### PR TITLE
docs(resilience): add ADR, SLOs & policy

### DIFF
--- a/docs/ADR-00X-resilience-circuit-breaker.md
+++ b/docs/ADR-00X-resilience-circuit-breaker.md
@@ -1,0 +1,32 @@
+# ADR-00X: Application-Level Circuit Breaker & Resilience Program
+
+## Status
+Accepted
+
+## Context
+Key dependencies (cache, HTTP partners, read replicas) can fail or degrade. We need graceful
+degradation and guardrails to keep p95 latency ≤ 400 ms under normal load while preventing
+cascading failures.
+
+## Decision
+Introduce an application-level Circuit Breaker with:
+- **Serialized transitions** (mutex-protected), **N-successes to close**
+- **Exponential backoff with jitter** from OPEN → HALF_OPEN
+- **Timeout-bounded operations** and **fallbacks**
+- Optional **adaptive thresholds**
+- **Observability-first**: metrics, logs, traces, admin endpoints, readiness checks
+- **Progressive delivery**: flags, shadow mode, canaries, rollback runbook
+
+## Consequences
++ Faster recovery and safer failure handling
++ Clear operating signals for on-call
+− Slight code complexity; small overhead from instrumentation
+
+## Alternatives Considered
+Infra-only breakers (Envoy/NGINX) — still valuable but lack business-aware fallbacks.
+Retries alone — risk amplifying load on unhealthy services.
+
+## Links
+- `docs/SLO.md`
+- `server/infra/circuit-breaker/CircuitBreaker.ts`
+- `perf/k6-regression-guard.js`

--- a/docs/DELIVERY_PLAYBOOK.md
+++ b/docs/DELIVERY_PLAYBOOK.md
@@ -1,0 +1,7 @@
+# Delivery Playbook
+
+1. Merge code behind flags
+2. Staging chaos drills (timeouts, connection resets)
+3. Shadow mode evaluation (no enforcement)
+4. Canary release with guardrails
+5. Post-canary tuning; update ADR; set defaults

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -1,0 +1,18 @@
+# SLOs & Error Budgets
+
+**Primary SLO**: p95 end-to-end latency ≤ 400 ms in normal conditions.
+
+## SLIs
+- Request latency (p50/p95/p99)
+- Error rate (5xx + degraded-failed fallbacks)
+- Fallback rate (% of requests served via fallback)
+
+## Alerts (multi-window burn rates)
+- p95 > 400 ms for 5 min (critical)
+- Fallback rate > 10% for 5 min (warning)
+- Circuit stuck OPEN > 5 min (critical)
+
+## Dashboards
+- State over time (CLOSED / HALF_OPEN / OPEN)
+- Success/failure/fallback counts
+- Time in OPEN / time-to-half-open

--- a/docs/circuit-notion-checklist.md
+++ b/docs/circuit-notion-checklist.md
@@ -1,0 +1,8 @@
+# Circuit Breaker Rollout Checklist
+
+- [ ] Flags defined per dependency
+- [ ] Shadow mode on staging with fault injection
+- [ ] Canary 5% → 25% → 50% → 100%
+- [ ] Dashboards live; alerts firing in tests
+- [ ] Runbook validated in game day
+- [ ] ADR + SLO docs reviewed & approved

--- a/docs/fail-open-close-matrix.md
+++ b/docs/fail-open-close-matrix.md
@@ -1,0 +1,9 @@
+# Fail–Open–Close Policy Matrix (Per Route/Dependency)
+
+| Route | Dependency | Policy | Fallback | Data Risk Notes |
+|------|------------|--------|----------|-----------------|
+| /api/cache-get | Redis | **Fail-OPEN** | In-memory LRU | TTL parity, eventual reconcile |
+| /api/partner | Partner HTTP | **Fail-OPEN** | Stale cache snapshot | Mark response `X-Circuit-State` |
+| /admin/report | DB RO | **Fail-CLOSED** | HTTP 503 | No stale admin data |
+
+> Each entry must declare: breaker preset, timeouts, retries (<=1), and fallback semantics.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,20 @@
+# Resilience Runbook
+
+## Symptoms
+- Latency spikes, fallback rate rising, breaker OPEN / flapping
+
+## Quick Triage
+1) Check dashboards → is dependency down? error rate? time-to-half-open?
+2) Inspect logs for `stateChange`, `probeDenied`, `circuitOpen`
+
+## Actions
+- Force HALF_OPEN via admin endpoint if upstream is healthy
+- If flapping: increase `successesToClose` or loosen HALF_OPEN rate/concurrency caps
+- Reduce client retries or increase `operationTimeout` within SLO budgets
+
+## Tuning Presets
+See `shared/config/env.circuit.ts` for knobs: `failureThreshold`, `successesToClose`,
+`operationTimeout`, `maxHalfOpenRequests`, `halfOpenRateLimit`, `adaptiveThreshold`.
+
+## Rollback
+Disable feature flag `CB_<NAME>_ENABLED` and redeploy.


### PR DESCRIPTION
Adds ADR, SLOs, fail-open/closed matrix, runbook, rollout checklist, delivery playbook.