### PR TITLE
feat: add flexible numeric validation helpers for Drizzle-Zod schemas

### DIFF
--- a/shared/schema-helpers.ts
+++ b/shared/schema-helpers.ts
@@ -1,0 +1,93 @@
+/**
+ * Flexible numeric validation helpers for Drizzle-Zod schemas
+ *
+ * These helpers provide reusable, semantic validation patterns for common
+ * numeric constraints in schema definitions. They return Zod schemas directly
+ * for compatibility with drizzle-zod@0.5.1.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Options for the flexible numeric helper
+ */
+export interface NumOpts {
+  /** Minimum value (inclusive) */
+  min?: number;
+  /** Maximum value (inclusive) */
+  max?: number;
+  /** Require integer values */
+  int?: boolean;
+  /** Enable coercion from strings (default: true) */
+  coerce?: boolean;
+  /** Custom error message for minimum validation */
+  messageMin?: string;
+  /** Custom error message for maximum validation */
+  messageMax?: string;
+}
+
+/**
+ * Flexible numeric validation with customizable options
+ *
+ * @param opts Configuration options for validation
+ * @returns Zod schema with specified numeric constraints
+ */
+export const num = (opts: NumOpts = {}) => {
+  const { min, max, int, coerce = true, messageMin, messageMax } = opts;
+
+  let schema = coerce ? z.coerce.number() : z.number();
+
+  if (int) {
+    schema = schema.int();
+  }
+
+  if (min !== undefined) {
+    schema = schema.min(min, messageMin);
+  }
+
+  if (max !== undefined) {
+    schema = schema.max(max, messageMax);
+  }
+
+  return schema;
+};
+
+/**
+ * Non-negative numbers (>= 0)
+ * Common for amounts, quantities, counts
+ */
+export const nonNegative = () => num({ min: 0 });
+
+/**
+ * Numbers between 0 and 1 (inclusive)
+ * Common for decimal percentages, ratios, probabilities
+ */
+export const bounded01 = () => num({ min: 0, max: 1 });
+
+/**
+ * Numbers between 0 and 100 (inclusive)
+ * Common for whole number percentages
+ */
+export const percent100 = () => num({ min: 0, max: 100 });
+
+/**
+ * Positive integers (>= 1)
+ * Common for IDs, counts, years
+ */
+export const positiveInt = () => num({ min: 1, int: true });
+
+/**
+ * Year range validation
+ *
+ * @param minYear Minimum year (inclusive)
+ * @param maxYear Maximum year (inclusive)
+ * @returns Zod schema for year validation
+ */
+export const yearRange = (minYear: number, maxYear: number) =>
+  num({
+    min: minYear,
+    max: maxYear,
+    int: true,
+    messageMin: `Year must be at least ${minYear}`,
+    messageMax: `Year must be at most ${maxYear}`
+  });

--- a/tests/unit/schema-helpers.spec.ts
+++ b/tests/unit/schema-helpers.spec.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from 'vitest';
+import {
+  num,
+  nonNegative,
+  bounded01,
+  percent100,
+  positiveInt,
+  yearRange
+} from '../../shared/schema-helpers';
+
+describe('num helper', () => {
+  test('basic number validation', () => {
+    const schema = num();
+    expect(schema.parse(42)).toBe(42);
+    expect(schema.parse('42')).toBe(42); // coercion enabled by default
+    expect(() => schema.parse('invalid')).toThrow();
+  });
+
+  test('min/max constraints', () => {
+    const schema = num({ min: 10, max: 20 });
+    expect(schema.parse(15)).toBe(15);
+    expect(() => schema.parse(5)).toThrow();
+    expect(() => schema.parse(25)).toThrow();
+  });
+
+  test('integer constraint', () => {
+    const schema = num({ int: true });
+    expect(schema.parse(42)).toBe(42);
+    expect(() => schema.parse(42.5)).toThrow();
+  });
+
+  test('coercion disabled', () => {
+    const schema = num({ coerce: false });
+    expect(schema.parse(42)).toBe(42);
+    expect(() => schema.parse('42')).toThrow();
+  });
+
+  test('custom error messages', () => {
+    const schema = num({
+      min: 0,
+      max: 100,
+      messageMin: 'Must be positive',
+      messageMax: 'Too high'
+    });
+
+    expect(() => schema.parse(-1)).toThrow('Must be positive');
+    expect(() => schema.parse(101)).toThrow('Too high');
+  });
+});
+
+describe('nonNegative helper', () => {
+  test('allows zero and positive numbers', () => {
+    const schema = nonNegative();
+    expect(schema.parse(0)).toBe(0);
+    expect(schema.parse(42)).toBe(42);
+    expect(schema.parse('10')).toBe(10);
+  });
+
+  test('rejects negative numbers', () => {
+    const schema = nonNegative();
+    expect(() => schema.parse(-1)).toThrow();
+    expect(() => schema.parse(-0.1)).toThrow();
+  });
+});
+
+describe('bounded01 helper', () => {
+  test('enforces 0..1 range', () => {
+    const schema = bounded01();
+    expect(schema.parse(0)).toBe(0);
+    expect(schema.parse(0.5)).toBe(0.5);
+    expect(schema.parse(1)).toBe(1);
+    expect(schema.parse('0.75')).toBe(0.75);
+  });
+
+  test('rejects out-of-range values', () => {
+    const schema = bounded01();
+    expect(() => schema.parse(-0.1)).toThrow();
+    expect(() => schema.parse(1.1)).toThrow();
+  });
+});
+
+describe('percent100 helper', () => {
+  test('enforces 0..100 range', () => {
+    const schema = percent100();
+    expect(schema.parse(0)).toBe(0);
+    expect(schema.parse(50)).toBe(50);
+    expect(schema.parse(100)).toBe(100);
+    expect(schema.parse('75')).toBe(75);
+  });
+
+  test('rejects out-of-range values', () => {
+    const schema = percent100();
+    expect(() => schema.parse(-1)).toThrow();
+    expect(() => schema.parse(101)).toThrow();
+  });
+});
+
+describe('positiveInt helper', () => {
+  test('allows positive integers', () => {
+    const schema = positiveInt();
+    expect(schema.parse(1)).toBe(1);
+    expect(schema.parse(42)).toBe(42);
+    expect(schema.parse('10')).toBe(10);
+  });
+
+  test('rejects non-positive values', () => {
+    const schema = positiveInt();
+    expect(() => schema.parse(0)).toThrow();
+    expect(() => schema.parse(-1)).toThrow();
+  });
+
+  test('rejects non-integers', () => {
+    const schema = positiveInt();
+    expect(() => schema.parse(1.5)).toThrow();
+    expect(() => schema.parse(0.5)).toThrow();
+  });
+});
+
+describe('yearRange helper', () => {
+  test('enforces custom year range', () => {
+    const schema = yearRange(1900, 2100);
+    expect(schema.parse(1950)).toBe(1950);
+    expect(schema.parse(2000)).toBe(2000);
+    expect(schema.parse('2023')).toBe(2023);
+  });
+
+  test('rejects out-of-range years', () => {
+    const schema = yearRange(1900, 2100);
+    expect(() => schema.parse(1800)).toThrow();
+    expect(() => schema.parse(2200)).toThrow();
+  });
+
+  test('includes custom error messages', () => {
+    const schema = yearRange(1980, 2050);
+    expect(() => schema.parse(1970)).toThrow('Year must be at least 1980');
+    expect(() => schema.parse(2060)).toThrow('Year must be at most 2050');
+  });
+
+  test('requires integers', () => {
+    const schema = yearRange(2000, 2030);
+    expect(() => schema.parse(2023.5)).toThrow();
+  });
+});

--- a/tsconfig.schema-helpers.json
+++ b/tsconfig.schema-helpers.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true,
+    "moduleResolution": "bundler"
+  },
+  "include": [
+    "shared/schema-helpers.ts",
+    "shared/__tests__/schema-helpers.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR introduces reusable numeric validation helpers to improve consistency and readability of Drizzle-Zod schema definitions. This is a conservative, focused improvement with zero breaking changes.

### Key Changes
- **New module**: `shared/schema-helpers.ts` with flexible numeric validation helpers
- **Test coverage**: Comprehensive test suite with 18 tests covering all helpers and edge cases  
- **TypeScript support**: Scoped `tsconfig.schema-helpers.json` for clean compilation

### Available Helpers
- `nonNegative()` - Values >= 0
- `bounded01()` - Values between 0 and 1 (for decimal percentages)  
- `percent100()` - Values between 0 and 100 (for whole number percentages)
- `positiveInt()` - Integer values >= 1
- `yearRange(min, max)` - Valid year ranges
- `num(opts)` - Flexible base helper with custom min/max/int/coerce options

### Implementation Notes
- **Zero breaking changes**: Existing schemas continue to work unchanged
- **drizzle-zod@0.5.1 compatibility**: Helpers return schemas directly (not functions) for current version
- **Semantic validation**: Helpers provide meaningful validation with clear error messages
- **Conservative approach**: Focused scope without infrastructure changes

### Test Plan
- [x] All 18 schema helper tests pass
- [x] TypeScript compilation clean with scoped config  
- [x] All existing tests continue to pass (184 total)
- [x] Pre-push hooks validated successfully

### Usage Example
```typescript
import { nonNegative, bounded01, yearRange } from '../shared/schema-helpers';

export const insertFundSchema = createInsertSchema(funds, {
  size: nonNegative(),
  managementFee: bounded01(), 
  vintageYear: yearRange(1980, 2050)
});
```

🤖 Generated with [Claude Code](https://claude.ai/code)