### PR TITLE
fix(ops-webhook): add .ts extension to dynamic import paths

### DIFF
--- a/tests/integration/ops-webhook.test.ts
+++ b/tests/integration/ops-webhook.test.ts
@@ -26,7 +26,7 @@ describe('Ops Webhook: Auto-Downgrade', () => {
     process.env.REDIS_URL = 'redis://localhost:6379';
 
     // Re-import the route after setting env vars
-    const modulePath = '../../server/routes/_ops-stage-validation';
+    const modulePath = '../../server/routes/_ops-stage-validation.ts';
     delete require.cache[require.resolve(modulePath)];
     const opsRoute = (await import(modulePath)).default;
 
@@ -327,7 +327,7 @@ describe('Ops Webhook: Auto-Downgrade', () => {
       delete process.env.ALERTMANAGER_WEBHOOK_SECRET;
 
       await expect(async () => {
-        const modulePath = '../../server/routes/_ops-stage-validation';
+        const modulePath = '../../server/routes/_ops-stage-validation.ts';
         delete require.cache[require.resolve(modulePath)];
         await import(modulePath);
       }).rejects.toThrow('ALERTMANAGER_WEBHOOK_SECRET');
@@ -337,7 +337,7 @@ describe('Ops Webhook: Auto-Downgrade', () => {
       process.env.ALERTMANAGER_WEBHOOK_SECRET = 'short';
 
       await expect(async () => {
-        const modulePath = '../../server/routes/_ops-stage-validation';
+        const modulePath = '../../server/routes/_ops-stage-validation.ts';
         delete require.cache[require.resolve(modulePath)];
         await import(modulePath);
       }).rejects.toThrow('ALERTMANAGER_WEBHOOK_SECRET');


### PR DESCRIPTION
Resolves module resolution failure in ops-webhook integration tests by adding explicit .ts extension to 3 dynamic import paths. Node's require.resolve() requires explicit extensions for TypeScript files when used with dynamic imports and cache clearing.

Root cause: require.resolve() cannot resolve TypeScript files without explicit extension in dynamic import context, unlike static imports.

Changes:
- Line 29: beforeEach hook (re-imports route after setting env vars)
- Line 330: Startup validation test (missing secret)
- Line 340: Startup validation test (short secret)

Impact: +9 tests passing (0/17 → 9/17, +53% success rate)

Batch gate:
- Test gate: 9/17 passing
- Baseline gate: 0 new TypeScript errors
- Schema drift: No changes

Part of Foundation Hardening Sprint Phase 2.1 - Cluster A (ops-webhook)