### PR TITLE
fix(routes): comment out WIP scenario-comparison import

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -764,9 +764,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   const { engineAdminRoutes } = await import('./routes/admin/engine.js');
   app.use('/api/admin/engine', engineAdminRoutes);
 
-  // Scenario Comparison Tool routes
-  const scenarioComparisonRoutes = await import('./routes/scenario-comparison.js');
-  app.use(scenarioComparisonRoutes.default);
+  // Scenario Comparison Tool routes (WIP - file not yet implemented)
+  // const scenarioComparisonRoutes = await import('./routes/scenario-comparison.js');
+  // app.use(scenarioComparisonRoutes.default);
 
   // Development dashboard routes (development only)
   if (process.env["NODE_ENV"] === 'development') {


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation error in server/routes.ts caused by importing a file that doesn't exist yet.

## Changes
- Comment out scenario-comparison route import in server/routes.ts
- Add WIP note explaining the file isn't implemented yet

## Root Cause
The scenario-comparison.ts route file is referenced but doesn't exist, causing:
```
error TS2307: Cannot find module './routes/scenario-comparison.js'
```

## Resolution
Temporarily comment out the import until the scenario comparison feature is implemented.

## Testing
- `npm run check` passes without new TypeScript errors
e)