### PR TITLE
Investigate TypeScript error count deviation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,7 @@ PR_CREATED*.md
 .claude/settings.local.json
 
 # TypeScript cache files
-.tscache
+.tscache*
 
 # Code quality and analysis tools
 .codacy/


### PR DESCRIPTION
Changed .tscache to .tscache* to ignore all TypeScript cache variants including .tscache-strict created by tsconfig.strict.json.