### PR TITLE
feat(db): implement Phase 1 database schema for portfolio optimization

### DIFF
--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -20,5 +20,8 @@ export * from './portfolio-route';
 // Stage normalization utilities
 export * from './parse-stage-distribution';
 
+// Portfolio optimization schemas
+export * from './portfolio-optimization';
+
 // Re-export Decimal for convenience
 export { Decimal } from 'decimal.js';

--- a/shared/schemas/portfolio-optimization.ts
+++ b/shared/schemas/portfolio-optimization.ts
@@ -1,0 +1,331 @@
+/**
+ * Portfolio Optimization Schemas
+ * Zod validation schemas for job_outbox, scenario_matrices, and optimization_sessions
+ */
+
+import { z } from 'zod';
+
+// =============================================================================
+// JOB OUTBOX SCHEMAS
+// =============================================================================
+
+/**
+ * Valid status values for job outbox entries
+ */
+export const jobOutboxStatusSchema = z.enum([
+  'pending',
+  'processing',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+export type JobOutboxStatus = z.infer<typeof jobOutboxStatusSchema>;
+
+/**
+ * Schema for creating a new job outbox entry
+ */
+export const insertJobOutboxSchema = z.object({
+  jobType: z.string().min(1, 'Job type is required'),
+  payload: z.record(z.unknown()).refine(
+    (val) => val !== null && typeof val === 'object',
+    'Payload must be a valid object'
+  ),
+  priority: z.number().int().min(0, 'Priority must be non-negative').default(0),
+  maxAttempts: z.number().int().min(1, 'Max attempts must be at least 1').default(3),
+  scheduledFor: z.date().optional(),
+});
+
+export type InsertJobOutboxInput = z.infer<typeof insertJobOutboxSchema>;
+
+/**
+ * Schema for updating a job outbox entry
+ */
+export const updateJobOutboxSchema = z
+  .object({
+    status: jobOutboxStatusSchema,
+    attemptCount: z.number().int().min(0),
+    priority: z.number().int().min(0),
+    scheduledFor: z.date().nullable(),
+  })
+  .partial();
+
+export type UpdateJobOutboxInput = z.infer<typeof updateJobOutboxSchema>;
+
+// =============================================================================
+// SCENARIO MATRICES SCHEMAS
+// =============================================================================
+
+/**
+ * Valid status values for scenario matrices
+ */
+export const scenarioMatrixStatusSchema = z.enum([
+  'pending',
+  'processing',
+  'complete',
+  'failed',
+]);
+
+export type ScenarioMatrixStatus = z.infer<typeof scenarioMatrixStatusSchema>;
+
+/**
+ * Valid matrix types
+ */
+export const matrixTypeSchema = z.enum(['moic', 'tvpi', 'dpi', 'irr']);
+
+export type MatrixType = z.infer<typeof matrixTypeSchema>;
+
+/**
+ * Schema for scenario states within a matrix
+ */
+export const scenarioStatesSchema = z.object({
+  scenarios: z.array(
+    z.object({
+      id: z.number().int(),
+      params: z.record(z.unknown()),
+    })
+  ),
+});
+
+export type ScenarioStates = z.infer<typeof scenarioStatesSchema>;
+
+/**
+ * Schema for bucket parameters
+ */
+export const bucketParamsSchema = z.object({
+  min: z.number(),
+  max: z.number(),
+  count: z.number().int().positive(),
+  distribution: z.string(),
+});
+
+export type BucketParams = z.infer<typeof bucketParamsSchema>;
+
+/**
+ * Schema for optimization configuration (s_opt)
+ */
+export const sOptSchema = z.object({
+  algorithm: z.string(),
+  params: z.record(z.unknown()),
+  convergence: z.record(z.unknown()),
+});
+
+export type SOpt = z.infer<typeof sOptSchema>;
+
+/**
+ * Schema for creating a new scenario matrix
+ */
+export const insertScenarioMatrixSchema = z.object({
+  scenarioId: z.string().uuid('Scenario ID must be a valid UUID'),
+  matrixType: matrixTypeSchema,
+  moicMatrix: z.string().optional(), // Base64 encoded
+  scenarioStates: scenarioStatesSchema.optional(),
+  bucketParams: bucketParamsSchema.optional(),
+  compressionCodec: z.enum(['zstd', 'lz4', 'none']).optional(),
+  matrixLayout: z.enum(['row-major', 'column-major']).optional(),
+  bucketCount: z.number().int().positive().optional(),
+  sOpt: sOptSchema.optional(),
+  status: scenarioMatrixStatusSchema.default('pending'),
+});
+
+export type InsertScenarioMatrixInput = z.infer<typeof insertScenarioMatrixSchema>;
+
+/**
+ * Schema for a complete scenario matrix (all fields required)
+ */
+export const completeScenarioMatrixSchema = z.object({
+  scenarioId: z.string().uuid(),
+  matrixType: matrixTypeSchema,
+  moicMatrix: z.string().min(1),
+  scenarioStates: scenarioStatesSchema,
+  bucketParams: bucketParamsSchema,
+  compressionCodec: z.enum(['zstd', 'lz4', 'none']),
+  matrixLayout: z.enum(['row-major', 'column-major']),
+  bucketCount: z.number().int().positive(),
+  sOpt: sOptSchema,
+  status: z.literal('complete'),
+});
+
+export type CompleteScenarioMatrix = z.infer<typeof completeScenarioMatrixSchema>;
+
+// =============================================================================
+// OPTIMIZATION SESSIONS SCHEMAS
+// =============================================================================
+
+/**
+ * Valid status values for optimization sessions
+ */
+export const optimizationSessionStatusSchema = z.enum([
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+export type OptimizationSessionStatus = z.infer<typeof optimizationSessionStatusSchema>;
+
+/**
+ * Valid optimization objectives
+ */
+export const optimizationObjectiveSchema = z.enum([
+  'maximize_return',
+  'minimize_risk',
+  'risk_adjusted',
+]);
+
+export type OptimizationObjective = z.infer<typeof optimizationObjectiveSchema>;
+
+/**
+ * Schema for optimization configuration
+ */
+export const optimizationConfigSchema = z.object({
+  objective: optimizationObjectiveSchema,
+  constraints: z.record(z.unknown()),
+  algorithm: z.string(),
+  maxIterations: z.number().int().positive().optional(),
+  convergenceTolerance: z.number().positive().optional(),
+});
+
+export type OptimizationConfig = z.infer<typeof optimizationConfigSchema>;
+
+/**
+ * Schema for optimization result metrics
+ */
+export const resultMetricsSchema = z.object({
+  expectedReturn: z.number(),
+  risk: z.number(),
+  sharpeRatio: z.number().optional(),
+  cvar: z.number().optional(),
+});
+
+export type ResultMetrics = z.infer<typeof resultMetricsSchema>;
+
+/**
+ * Schema for creating a new optimization session
+ */
+export const insertOptimizationSessionSchema = z.object({
+  matrixId: z.string().uuid('Matrix ID must be a valid UUID'),
+  optimizationConfig: optimizationConfigSchema,
+  pass1EStar: z.string().optional(), // Decimal as string
+  primaryLockEpsilon: z.string().optional(), // Decimal as string
+  status: optimizationSessionStatusSchema.default('pending'),
+});
+
+export type InsertOptimizationSessionInput = z.infer<typeof insertOptimizationSessionSchema>;
+
+/**
+ * Schema for updating an optimization session
+ */
+export const updateOptimizationSessionSchema = z
+  .object({
+    status: optimizationSessionStatusSchema,
+    pass1EStar: z.string(),
+    primaryLockEpsilon: z.string(),
+    resultWeights: z.record(z.number()),
+    resultMetrics: resultMetricsSchema,
+    errorMessage: z.string().nullable(),
+    currentIteration: z.number().int().min(0),
+    totalIterations: z.number().int().positive(),
+    startedAt: z.date(),
+    completedAt: z.date(),
+  })
+  .partial();
+
+export type UpdateOptimizationSessionInput = z.infer<typeof updateOptimizationSessionSchema>;
+
+// =============================================================================
+// VALIDATION HELPERS
+// =============================================================================
+
+/**
+ * Validates that a scenario matrix has all required fields when status is 'complete'
+ */
+export function validateCompleteMatrix(matrix: InsertScenarioMatrixInput): boolean {
+  if (matrix.status !== 'complete') {
+    return true; // Non-complete matrices don't need all fields
+  }
+
+  return (
+    matrix.moicMatrix !== undefined &&
+    matrix.scenarioStates !== undefined &&
+    matrix.bucketParams !== undefined &&
+    matrix.compressionCodec !== undefined &&
+    matrix.matrixLayout !== undefined &&
+    matrix.bucketCount !== undefined &&
+    matrix.sOpt !== undefined
+  );
+}
+
+/**
+ * Validates job outbox input and returns parsed data or errors
+ */
+export function validateJobOutboxInput(raw: unknown) {
+  const result = insertJobOutboxSchema.safeParse(raw);
+  if (!result.success) {
+    return {
+      ok: false as const,
+      status: 400,
+      issues: result.error.issues.map((i) => ({
+        code: i.code,
+        path: i.path.join('.'),
+        message: i.message,
+      })),
+    };
+  }
+  return { ok: true as const, data: result.data };
+}
+
+/**
+ * Validates scenario matrix input and returns parsed data or errors
+ */
+export function validateScenarioMatrixInput(raw: unknown) {
+  const result = insertScenarioMatrixSchema.safeParse(raw);
+  if (!result.success) {
+    return {
+      ok: false as const,
+      status: 400,
+      issues: result.error.issues.map((i) => ({
+        code: i.code,
+        path: i.path.join('.'),
+        message: i.message,
+      })),
+    };
+  }
+
+  // Additional validation for complete matrices
+  if (!validateCompleteMatrix(result.data)) {
+    return {
+      ok: false as const,
+      status: 422,
+      issues: [
+        {
+          code: 'missing_fields',
+          path: '',
+          message: 'Complete matrices require all payload fields to be set',
+        },
+      ],
+    };
+  }
+
+  return { ok: true as const, data: result.data };
+}
+
+/**
+ * Validates optimization session input and returns parsed data or errors
+ */
+export function validateOptimizationSessionInput(raw: unknown) {
+  const result = insertOptimizationSessionSchema.safeParse(raw);
+  if (!result.success) {
+    return {
+      ok: false as const,
+      status: 400,
+      issues: result.error.issues.map((i) => ({
+        code: i.code,
+        path: i.path.join('.'),
+        message: i.message,
+      })),
+    };
+  }
+  return { ok: true as const, data: result.data };
+}

--- a/tests/portfolio-optimization-schemas.test.ts
+++ b/tests/portfolio-optimization-schemas.test.ts
@@ -1,0 +1,511 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type {
+  JobOutbox,
+  InsertJobOutbox,
+  ScenarioMatrix,
+  InsertScenarioMatrix,
+  OptimizationSession,
+  InsertOptimizationSession,
+} from '../shared/schema';
+import {
+  jobOutboxStatusSchema,
+  insertJobOutboxSchema,
+  updateJobOutboxSchema,
+  scenarioMatrixStatusSchema,
+  matrixTypeSchema,
+  insertScenarioMatrixSchema,
+  optimizationSessionStatusSchema,
+  insertOptimizationSessionSchema,
+  updateOptimizationSessionSchema,
+  validateJobOutboxInput,
+  validateScenarioMatrixInput,
+  validateOptimizationSessionInput,
+  validateCompleteMatrix,
+} from '../shared/schemas/portfolio-optimization';
+
+describe('Portfolio Optimization Schema Types', () => {
+  describe('JobOutbox Types', () => {
+    it('should export correct select types', () => {
+      expectTypeOf<JobOutbox>().toHaveProperty('id');
+      expectTypeOf<JobOutbox>().toHaveProperty('jobType');
+      expectTypeOf<JobOutbox>().toHaveProperty('payload');
+      expectTypeOf<JobOutbox>().toHaveProperty('status');
+      expectTypeOf<JobOutbox>().toHaveProperty('priority');
+      expectTypeOf<JobOutbox>().toHaveProperty('maxAttempts');
+      expectTypeOf<JobOutbox>().toHaveProperty('attemptCount');
+      expectTypeOf<JobOutbox>().toHaveProperty('scheduledFor');
+      expectTypeOf<JobOutbox>().toHaveProperty('createdAt');
+      expectTypeOf<JobOutbox>().toHaveProperty('updatedAt');
+    });
+
+    it('should export correct insert types', () => {
+      expectTypeOf<InsertJobOutbox>().toHaveProperty('jobType');
+      expectTypeOf<InsertJobOutbox>().toHaveProperty('payload');
+    });
+  });
+
+  describe('ScenarioMatrix Types', () => {
+    it('should export correct select types', () => {
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('id');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('scenarioId');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('matrixType');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('moicMatrix');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('scenarioStates');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('bucketParams');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('compressionCodec');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('matrixLayout');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('bucketCount');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('sOpt');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('status');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('createdAt');
+      expectTypeOf<ScenarioMatrix>().toHaveProperty('updatedAt');
+    });
+
+    it('should export correct insert types', () => {
+      expectTypeOf<InsertScenarioMatrix>().toHaveProperty('scenarioId');
+      expectTypeOf<InsertScenarioMatrix>().toHaveProperty('matrixType');
+    });
+  });
+
+  describe('OptimizationSession Types', () => {
+    it('should export correct select types', () => {
+      expectTypeOf<OptimizationSession>().toHaveProperty('id');
+      expectTypeOf<OptimizationSession>().toHaveProperty('matrixId');
+      expectTypeOf<OptimizationSession>().toHaveProperty('optimizationConfig');
+      expectTypeOf<OptimizationSession>().toHaveProperty('pass1EStar');
+      expectTypeOf<OptimizationSession>().toHaveProperty('primaryLockEpsilon');
+      expectTypeOf<OptimizationSession>().toHaveProperty('resultWeights');
+      expectTypeOf<OptimizationSession>().toHaveProperty('resultMetrics');
+      expectTypeOf<OptimizationSession>().toHaveProperty('status');
+      expectTypeOf<OptimizationSession>().toHaveProperty('errorMessage');
+      expectTypeOf<OptimizationSession>().toHaveProperty('currentIteration');
+      expectTypeOf<OptimizationSession>().toHaveProperty('totalIterations');
+      expectTypeOf<OptimizationSession>().toHaveProperty('startedAt');
+      expectTypeOf<OptimizationSession>().toHaveProperty('completedAt');
+      expectTypeOf<OptimizationSession>().toHaveProperty('createdAt');
+      expectTypeOf<OptimizationSession>().toHaveProperty('updatedAt');
+    });
+
+    it('should export correct insert types', () => {
+      expectTypeOf<InsertOptimizationSession>().toHaveProperty('matrixId');
+      expectTypeOf<InsertOptimizationSession>().toHaveProperty('optimizationConfig');
+    });
+  });
+});
+
+describe('Portfolio Optimization Zod Schemas', () => {
+  describe('jobOutboxStatusSchema', () => {
+    it('should accept valid status values', () => {
+      const validStatuses = ['pending', 'processing', 'completed', 'failed', 'cancelled'];
+      validStatuses.forEach((status) => {
+        expect(() => jobOutboxStatusSchema.parse(status)).not.toThrow();
+      });
+    });
+
+    it('should reject invalid status values', () => {
+      expect(() => jobOutboxStatusSchema.parse('invalid')).toThrow();
+      expect(() => jobOutboxStatusSchema.parse('')).toThrow();
+      expect(() => jobOutboxStatusSchema.parse(null)).toThrow();
+    });
+  });
+
+  describe('insertJobOutboxSchema', () => {
+    it('should validate valid job outbox insert', () => {
+      const valid = {
+        jobType: 'calculate-reserves',
+        payload: { fundId: 'fund-123', scenarioId: 'scenario-456' },
+        priority: 5,
+        maxAttempts: 3,
+      };
+
+      expect(() => insertJobOutboxSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should accept minimal required fields', () => {
+      const minimal = {
+        jobType: 'calculate-pacing',
+        payload: { fundId: 'fund-789' },
+      };
+
+      const result = insertJobOutboxSchema.parse(minimal);
+      expect(result.jobType).toBe('calculate-pacing');
+      expect(result.payload).toEqual({ fundId: 'fund-789' });
+      expect(result.priority).toBe(0); // default
+      expect(result.maxAttempts).toBe(3); // default
+    });
+
+    it('should accept optional scheduledFor date', () => {
+      const withScheduled = {
+        jobType: 'monte-carlo-simulation',
+        payload: { scenarioId: 'scenario-999' },
+        scheduledFor: new Date('2026-01-05T00:00:00Z'),
+      };
+
+      const result = insertJobOutboxSchema.parse(withScheduled);
+      expect(result.scheduledFor).toBeInstanceOf(Date);
+    });
+
+    it('should reject missing required fields', () => {
+      expect(() => insertJobOutboxSchema.parse({ jobType: 'test' })).toThrow();
+      expect(() => insertJobOutboxSchema.parse({ payload: {} })).toThrow();
+      expect(() => insertJobOutboxSchema.parse({})).toThrow();
+    });
+
+    it('should reject empty job type', () => {
+      const invalid = {
+        jobType: '',
+        payload: { test: true },
+      };
+
+      expect(() => insertJobOutboxSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject negative priority values', () => {
+      const invalid = {
+        jobType: 'test-job',
+        payload: { test: true },
+        priority: -5,
+      };
+
+      expect(() => insertJobOutboxSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject invalid maxAttempts values', () => {
+      const invalid = {
+        jobType: 'test-job',
+        payload: { test: true },
+        maxAttempts: 0,
+      };
+
+      expect(() => insertJobOutboxSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe('updateJobOutboxSchema', () => {
+    it('should allow partial updates', () => {
+      const partial = {
+        status: 'processing' as const,
+        attemptCount: 1,
+      };
+
+      const result = updateJobOutboxSchema.parse(partial);
+      expect(result.status).toBe('processing');
+      expect(result.attemptCount).toBe(1);
+    });
+
+    it('should allow updating only status', () => {
+      const statusOnly = { status: 'completed' as const };
+      const result = updateJobOutboxSchema.parse(statusOnly);
+      expect(result.status).toBe('completed');
+    });
+
+    it('should accept empty update object', () => {
+      expect(() => updateJobOutboxSchema.parse({})).not.toThrow();
+    });
+
+    it('should reject invalid status in update', () => {
+      expect(() => updateJobOutboxSchema.parse({ status: 'invalid' })).toThrow();
+    });
+  });
+
+  describe('scenarioMatrixStatusSchema', () => {
+    it('should accept valid status values', () => {
+      const validStatuses = ['pending', 'processing', 'complete', 'failed'];
+      validStatuses.forEach((status) => {
+        expect(() => scenarioMatrixStatusSchema.parse(status)).not.toThrow();
+      });
+    });
+
+    it('should reject invalid status values', () => {
+      expect(() => scenarioMatrixStatusSchema.parse('completed')).toThrow(); // Note: 'complete' not 'completed'
+      expect(() => scenarioMatrixStatusSchema.parse('invalid')).toThrow();
+    });
+  });
+
+  describe('matrixTypeSchema', () => {
+    it('should accept valid matrix types', () => {
+      const validTypes = ['moic', 'tvpi', 'dpi', 'irr'];
+      validTypes.forEach((type) => {
+        expect(() => matrixTypeSchema.parse(type)).not.toThrow();
+      });
+    });
+
+    it('should reject invalid matrix types', () => {
+      expect(() => matrixTypeSchema.parse('invalid')).toThrow();
+      expect(() => matrixTypeSchema.parse('MOIC')).toThrow(); // case sensitive
+    });
+  });
+
+  describe('insertScenarioMatrixSchema', () => {
+    it('should validate minimal scenario matrix insert', () => {
+      const valid = {
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'moic' as const,
+      };
+
+      expect(() => insertScenarioMatrixSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should validate complete scenario matrix insert', () => {
+      const valid = {
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'moic' as const,
+        moicMatrix: 'base64encodeddata',
+        scenarioStates: { scenarios: [{ id: 1, params: { test: true } }] },
+        bucketParams: { min: 0, max: 10, count: 100, distribution: 'normal' },
+        compressionCodec: 'zstd' as const,
+        matrixLayout: 'row-major' as const,
+        bucketCount: 100,
+        sOpt: { algorithm: 'gradient', params: {}, convergence: {} },
+        status: 'complete' as const,
+      };
+
+      expect(() => insertScenarioMatrixSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should reject invalid UUID for scenarioId', () => {
+      const invalid = {
+        scenarioId: 'not-a-uuid',
+        matrixType: 'moic' as const,
+      };
+
+      expect(() => insertScenarioMatrixSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject invalid matrix type', () => {
+      const invalid = {
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'invalid',
+      };
+
+      expect(() => insertScenarioMatrixSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe('optimizationSessionStatusSchema', () => {
+    it('should accept valid status values', () => {
+      const validStatuses = ['pending', 'running', 'completed', 'failed', 'cancelled'];
+      validStatuses.forEach((status) => {
+        expect(() => optimizationSessionStatusSchema.parse(status)).not.toThrow();
+      });
+    });
+  });
+
+  describe('insertOptimizationSessionSchema', () => {
+    it('should validate valid optimization session insert', () => {
+      const valid = {
+        matrixId: '123e4567-e89b-12d3-a456-426614174000',
+        optimizationConfig: {
+          objective: 'maximize_return' as const,
+          constraints: { maxRisk: 0.2 },
+          algorithm: 'gradient-descent',
+        },
+      };
+
+      expect(() => insertOptimizationSessionSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should accept optional tie-break parameters', () => {
+      const valid = {
+        matrixId: '123e4567-e89b-12d3-a456-426614174000',
+        optimizationConfig: {
+          objective: 'risk_adjusted' as const,
+          constraints: {},
+          algorithm: 'monte-carlo',
+          maxIterations: 10000,
+          convergenceTolerance: 0.0001,
+        },
+        pass1EStar: '0.1234567890',
+        primaryLockEpsilon: '0.0000000001',
+      };
+
+      const result = insertOptimizationSessionSchema.parse(valid);
+      expect(result.pass1EStar).toBe('0.1234567890');
+      expect(result.primaryLockEpsilon).toBe('0.0000000001');
+    });
+
+    it('should reject invalid UUID for matrixId', () => {
+      const invalid = {
+        matrixId: 'not-a-uuid',
+        optimizationConfig: {
+          objective: 'maximize_return' as const,
+          constraints: {},
+          algorithm: 'test',
+        },
+      };
+
+      expect(() => insertOptimizationSessionSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject invalid optimization objective', () => {
+      const invalid = {
+        matrixId: '123e4567-e89b-12d3-a456-426614174000',
+        optimizationConfig: {
+          objective: 'invalid_objective',
+          constraints: {},
+          algorithm: 'test',
+        },
+      };
+
+      expect(() => insertOptimizationSessionSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe('updateOptimizationSessionSchema', () => {
+    it('should allow updating status', () => {
+      const update = { status: 'running' as const };
+      const result = updateOptimizationSessionSchema.parse(update);
+      expect(result.status).toBe('running');
+    });
+
+    it('should allow updating result metrics', () => {
+      const update = {
+        resultMetrics: {
+          expectedReturn: 0.15,
+          risk: 0.12,
+          sharpeRatio: 1.25,
+        },
+      };
+
+      const result = updateOptimizationSessionSchema.parse(update);
+      expect(result.resultMetrics?.expectedReturn).toBe(0.15);
+    });
+
+    it('should allow updating iteration tracking', () => {
+      const update = {
+        currentIteration: 500,
+        totalIterations: 1000,
+      };
+
+      const result = updateOptimizationSessionSchema.parse(update);
+      expect(result.currentIteration).toBe(500);
+      expect(result.totalIterations).toBe(1000);
+    });
+  });
+});
+
+describe('Validation Helpers', () => {
+  describe('validateJobOutboxInput', () => {
+    it('should return ok for valid input', () => {
+      const result = validateJobOutboxInput({
+        jobType: 'test-job',
+        payload: { data: 'value' },
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.jobType).toBe('test-job');
+      }
+    });
+
+    it('should return errors for invalid input', () => {
+      const result = validateJobOutboxInput({
+        jobType: '', // empty
+        payload: null, // invalid
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(400);
+        expect(result.issues.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('validateCompleteMatrix', () => {
+    it('should return true for non-complete matrices', () => {
+      const matrix = {
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'moic' as const,
+        status: 'pending' as const,
+      };
+
+      expect(validateCompleteMatrix(matrix)).toBe(true);
+    });
+
+    it('should return true for complete matrices with all fields', () => {
+      const matrix = {
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'moic' as const,
+        moicMatrix: 'data',
+        scenarioStates: { scenarios: [] },
+        bucketParams: { min: 0, max: 10, count: 100, distribution: 'normal' },
+        compressionCodec: 'zstd' as const,
+        matrixLayout: 'row-major' as const,
+        bucketCount: 100,
+        sOpt: { algorithm: 'test', params: {}, convergence: {} },
+        status: 'complete' as const,
+      };
+
+      expect(validateCompleteMatrix(matrix)).toBe(true);
+    });
+
+    it('should return false for complete matrices missing fields', () => {
+      const matrix = {
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'moic' as const,
+        status: 'complete' as const,
+        // missing all payload fields
+      };
+
+      expect(validateCompleteMatrix(matrix)).toBe(false);
+    });
+  });
+
+  describe('validateScenarioMatrixInput', () => {
+    it('should return ok for valid input', () => {
+      const result = validateScenarioMatrixInput({
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'moic',
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('should return 422 for incomplete complete matrix', () => {
+      const result = validateScenarioMatrixInput({
+        scenarioId: '123e4567-e89b-12d3-a456-426614174000',
+        matrixType: 'moic',
+        status: 'complete',
+        // missing required payload fields
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(422);
+        expect(result.issues[0].code).toBe('missing_fields');
+      }
+    });
+  });
+
+  describe('validateOptimizationSessionInput', () => {
+    it('should return ok for valid input', () => {
+      const result = validateOptimizationSessionInput({
+        matrixId: '123e4567-e89b-12d3-a456-426614174000',
+        optimizationConfig: {
+          objective: 'maximize_return',
+          constraints: {},
+          algorithm: 'gradient',
+        },
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('should return errors for invalid input', () => {
+      const result = validateOptimizationSessionInput({
+        matrixId: 'not-a-uuid',
+        optimizationConfig: {
+          objective: 'invalid',
+          constraints: {},
+          algorithm: 'test',
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(400);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add three new database tables for portfolio construction and optimization system:
  - `job_outbox` - Transactional outbox pattern for reliable BullMQ job queue integration
  - `scenario_matrices` - Monte Carlo simulation results with MOIC matrix storage
  - `optimization_sessions` - Optimization workflow state with tie-break support
- Add Zod validation schemas with validation helpers for all new tables
- Add comprehensive unit tests for schema types and validation

## Key Design Decisions

- `scenario_matrices` references existing `portfolioScenarios` table (adapted from design doc)
- MOIC matrix stored as base64-encoded text for Drizzle ORM compatibility
- Applied critical corrections: #6 (index order), #7 (no NOW() in partial indexes), #8 (BullMQ dedup), #9 (deterministic tie-break)

## Test plan

- [x] TypeScript compilation passes with no new errors
- [ ] Run `npm test -- portfolio-optimization-schemas.test.ts` to verify Zod schema validation
- [ ] Run `npm run db:push` to generate and apply migrations
- [ ] Verify tables created correctly in database with expected constraints and indexes