### PR TITLE
fix(ci): use size-limit for bundle size checks

### DIFF
--- a/.github/workflows/performance-gates.yml
+++ b/.github/workflows/performance-gates.yml
@@ -23,30 +23,35 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build and check bundle
+      - name: Build application
+        run: npm run build:web
+
+      - name: Check bundle size with size-limit
         run: |
-          npm run build:web
+          # Use size-limit with .size-limit.json config
+          # This checks per-bundle limits (initial load, charts, etc.)
+          # instead of naively summing all chunks including lazy-loaded ones
+          echo "Running size-limit check..."
+          npx size-limit --json > size-limit-results.json
 
-          # Check bundle size (400KB target)
-          MAX_SIZE=409600  # 400KB in bytes
-          ACTUAL_SIZE=$(du -b dist/assets/*.js | awk '{sum+=$1} END {print sum}')
+          # Display results
+          echo ""
+          echo "Bundle Size Results:"
+          cat size-limit-results.json | npx -y json -a name size limit passed || cat size-limit-results.json
+          echo ""
 
-          echo "Bundle size: $ACTUAL_SIZE bytes (max: $MAX_SIZE)"
-
-          if [ $ACTUAL_SIZE -gt $MAX_SIZE ]; then
-            echo "[FAIL] Bundle size exceeds limit!"
-            echo "Actual: $ACTUAL_SIZE bytes"
-            echo "Max allowed: $MAX_SIZE bytes"
+          # Check if any limits exceeded
+          if npx size-limit; then
+            echo "[PASS] All bundle size limits within bounds"
+          else
+            echo "[FAIL] Bundle size limits exceeded!"
             exit 1
           fi
-
-          echo "[PASS] Bundle size within limits"
 
       - name: Save bundle metrics
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          echo "$ACTUAL_SIZE" > bundle-size.txt
-          echo "{ \"size\": $ACTUAL_SIZE, \"timestamp\": \"$(date -Iseconds)\" }" > bundle-metrics.json
+          cp size-limit-results.json bundle-metrics.json
 
       - name: Upload metrics
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,25 +2,25 @@
   {
     "name": "Initial Load (Critical Path)",
     "path": "dist/assets/index-*.js",
-    "limit": "150 KB",
-    "gzip": true
-  },
-  {
-    "name": "Deterministic Engine",
-    "path": "dist/assets/DeterministicEngine-*.js",
-    "limit": "50 KB",
-    "gzip": true
-  },
-  {
-    "name": "Math/Crypto Vendor",
-    "path": "dist/assets/math-crypto-vendor-*.js",
-    "limit": "30 KB",
+    "limit": "200 KB",
     "gzip": true
   },
   {
     "name": "Chart Components (Recharts)",
     "path": "dist/assets/ActiveShapeUtils-*.js",
     "limit": "300 KB",
+    "gzip": true
+  },
+  {
+    "name": "Fund Setup Page",
+    "path": "dist/assets/fund-setup-*.js",
+    "limit": "150 KB",
+    "gzip": true
+  },
+  {
+    "name": "PDF Tearsheet (lazy-loaded)",
+    "path": "dist/assets/tear-sheet-dashboard-*.js",
+    "limit": "1500 KB",
     "gzip": true
   }
 ]


### PR DESCRIPTION
## Summary

Replace the naive bundle size check with the proper `size-limit` tool.

## Problem

The old check in `performance-gates.yml` used:
```bash
ACTUAL_SIZE=$(du -b dist/assets/*.js | awk '{sum+=$1} END {print sum}')
```

This summed **ALL** JS chunks including lazy-loaded ones:
- **Total:** 3.18 MB
- **Limit:** 400 KB
- **Result:** Always failing

The PDF tearsheet alone is 1.35MB (correctly lazy-loaded at runtime).

## Solution

Use `size-limit` with `.size-limit.json` config to check per-bundle limits:

| Bundle | Limit | Actual (gzipped) | Status |
|--------|-------|------------------|--------|
| Initial Load | 200 KB | 71 KB | PASS |
| Chart Components | 300 KB | 87 KB | PASS |
| Fund Setup | 150 KB | 30 KB | PASS |
| PDF Tearsheet | 1.5 MB | 442 KB | PASS |

## Changes

- **performance-gates.yml:** Use `npx size-limit` instead of `du -b`
- **.size-limit.json:** Remove obsolete entries, add current bundles with appropriate limits

## Verification

```bash
$ npx size-limit
Initial Load (Critical Path)     71.27 kB (limit 200 kB) ✓
Chart Components (Recharts)      87.27 kB (limit 300 kB) ✓
Fund Setup Page                  30.46 kB (limit 150 kB) ✓
PDF Tearsheet (lazy-loaded)     441.91 kB (limit 1.5 MB) ✓
```

## Test plan

- [x] `npx size-limit` passes locally
- [x] Config validates all critical bundles
- [x] Lazy-loaded chunks tracked but not blocking
