### PR TITLE
Add To-Do report accuracy review (2026-04-05)

### DIFF
--- a/docs/plans/2026-04-05-todo-report-remediation-strategy.md
+++ b/docs/plans/2026-04-05-todo-report-remediation-strategy.md
@@ -1,0 +1,121 @@
+# To-Do Report Remediation Strategy (Updated Main)
+
+Date: 2026-04-05 Status: actionable
+
+## Objective
+
+Convert the corrected accuracy review into an execution strategy that can be
+implemented against current `main` without repeating stale assumptions.
+
+## Scope based on validated findings
+
+### Keep as active backlog (confirmed gaps)
+
+1. Construction-vs-actual detailed breakdown remains deferred.
+2. One-way/two-way/stress sensitivity tabs remain unimplemented.
+3. IRR unification to canonical shared XIRR is still needed.
+4. LP benchmark endpoint still returns placeholder data.
+5. Snapshot-table governance/ADR decision still needed.
+
+### Remove or reword (stale claims)
+
+1. Drift logic does **not** need to be built from scratch.
+2. Backtesting tests are **not** quarantined.
+3. Restore path mismatch is stale framing for active UX (restore currently
+   disabled in UI while route exists).
+4. Concentration analysis code exists (do not claim “no code exists”).
+
+## Implementation strategy
+
+## Track A — Correct planning source of truth (Day 0)
+
+- Replace stale statements in planning artifacts with validated wording.
+- Add “evidence command” lines beside each claim to prevent future drift.
+
+### Definition of done
+
+- No planning doc claims drift-from-scratch, quarantined backtesting, or missing
+  concentration code.
+- Each retained claim has at least one reproducible command.
+
+## Track B — Deliver low-risk product truthfulness updates (Days 1-3)
+
+### B1. Sensitivity tab messaging hardening
+
+- Keep disabled tabs, but add explicit expected API contract names and data
+  requirements in UI copy to reduce ambiguity for implementation handoff.
+
+### B2. Restore UX alignment
+
+- Keep restore disabled until end-to-end wiring is confirmed.
+- Add explicit pointer to versioned restore route contract in developer-facing
+  docs to avoid “route mismatch” regression in future status reports.
+
+### Definition of done
+
+- UI text consistently reflects current behavior and implementation gates.
+- Documentation uses route-accurate wording.
+
+## Track C — Backend execution slices (Days 3-10)
+
+### C1. IRR unification slice
+
+- Migrate `ActualMetricsCalculator` and `PerformanceCalculator` IRR paths to
+  canonical shared XIRR helpers where feasible.
+- Keep adapter wrappers if return-type semantics differ; avoid behavior changes
+  without explicit truth-case coverage.
+
+### C2. Benchmark endpoint hardening slice
+
+- Replace LP benchmark placeholder payload with a real data source path
+  (initially minimal but non-static).
+- Keep fallback semantics explicit when no benchmark dataset is available.
+
+### Definition of done
+
+- No production endpoint returns hardcoded benchmark example values.
+- IRR code paths document canonical source and avoid duplicate local algorithms.
+
+## Track D — Governance closure (parallel)
+
+### D1. Snapshot-table ADR
+
+- Decide canonical responsibility boundaries for `fund_snapshots` vs
+  `fund_state_snapshots` (analytics-read snapshots vs time-travel state
+  snapshots), including provenance and FK expectations.
+
+### Definition of done
+
+- ADR accepted and referenced by read/write services touching either table.
+
+## Sandbox validation protocol (required per slice)
+
+Use these commands as mandatory validation gates before claiming completion:
+
+1. Drift implementation evidence:
+   - `rg -n "toMetricDelta|driftCapable|driftReason" server/services/fund-results-comparison-service.ts`
+2. Deferred construction-vs-actual evidence:
+   - `rg -n "Construction vs\. actual comparison remains deferred|valuation-tier breakdowns stay deferred" client/src/components/forecasting/construction-actual-comparison.tsx`
+3. Sensitivity status evidence:
+   - `rg -n "COMING_SOON_TABS|planned but not yet wired" client/src/pages/sensitivity-analysis.tsx`
+4. Backtesting integration health:
+   - `npm run test:integration -- tests/integration/backtesting-api.test.ts`
+5. Restore route/UI alignment:
+   - `rg -n "Restore Unavailable|server route is wired" client/src/pages/time-travel.tsx`
+   - `rg -n "POST /api/snapshots/:snapshotId/versions/:versionId/restore|/:versionId/restore" server/routes/portfolio/versions.ts`
+6. Benchmark placeholder check:
+   - `rg -n "Benchmark data placeholder|Placeholder for benchmark comparison logic" server/routes/lp-api.ts`
+7. Concentration-code presence check:
+   - `rg -n "identifyConcentrationRisks|Sector concentration|Stage concentration" server/services/portfolio-performance-predictor.ts`
+
+## Exit criteria for “strategy complete”
+
+- Planning artifacts updated with corrected statuses and reproducible evidence.
+- At least one backend slice (IRR unification or benchmark hardening) lands with
+  tests.
+- Snapshot-table ADR accepted or explicitly timeboxed with owner and due date.
+
+## Notes
+
+This strategy intentionally avoids re-litigating already-implemented
+capabilities and focuses implementation effort on validated remaining gaps.

--- a/docs/todo-report-accuracy-review-2026-04-05.md
+++ b/docs/todo-report-accuracy-review-2026-04-05.md
@@ -125,3 +125,9 @@ unit script (`npm test`), which intentionally excludes integration paths.
   quarantined”, “concentration analysis no code exists”, and restore-route
   mismatch phrasing.
 - Mark as governance item: canonical snapshot table decision/ADR.
+
+## Follow-through
+
+Execution has been translated into an updated-main implementation strategy in:
+
+- `docs/plans/2026-04-05-todo-report-remediation-strategy.md`

--- a/docs/todo-report-accuracy-review-2026-04-05.md
+++ b/docs/todo-report-accuracy-review-2026-04-05.md
@@ -1,0 +1,127 @@
+# To-Do Report Accuracy Review (as of 2026-04-05)
+
+## Verdict
+
+The report is **partially accurate but materially stale**. Several items are
+correct at a high level, while others are now inaccurate (or overstate missing
+functionality).
+
+## Sandbox validation (implemented)
+
+Validated in the sandbox repo on `2026-04-05` using reproducible command checks:
+
+1. Drift implementation exists:
+   - `rg -n "toMetricDelta|driftCapable|driftReason" server/services/fund-results-comparison-service.ts`
+2. Deferred construction-vs-actual copy exists:
+   - `rg -n "Construction vs\\. actual comparison remains deferred|valuation-tier breakdowns stay deferred" client/src/components/forecasting/construction-actual-comparison.tsx`
+3. One-way/two-way/stress are marked coming soon and disabled:
+   - `rg -n "COMING_SOON_TABS|disabled|planned but not yet wired" client/src/pages/sensitivity-analysis.tsx`
+4. Backtesting tests are not quarantined:
+   - `rg -n "@quarantine" tests/integration/backtesting-api.test.ts`
+   - `npm run test:integration -- tests/integration/backtesting-api.test.ts`
+5. Restore route/UI status:
+   - `rg -n "Restore Unavailable|server route is wired" client/src/pages/time-travel.tsx`
+   - `rg -n "POST /api/snapshots/:snapshotId/versions/:versionId/restore|/:versionId/restore" server/routes/portfolio/versions.ts`
+6. LP benchmark endpoint still placeholder:
+   - `rg -n "Placeholder for benchmark comparison logic|Benchmark data placeholder" server/routes/lp-api.ts`
+7. Concentration analysis exists in backend:
+   - `rg -n "identifyConcentrationRisks|Sector concentration|Stage concentration" server/services/portfolio-performance-predictor.ts`
+
+Sandbox validation surfaced one wording improvement: the restore item should no
+longer be framed as a client/server path mismatch in active workflow because the
+current UI intentionally disables restore while a versioned restore route
+exists. It also surfaced one execution improvement: integration evidence should
+use the integration Vitest config (`test:integration`) rather than the default
+unit script (`npm test`), which intentionally excludes integration paths.
+
+## Findings by section
+
+### Phase 1 remainder
+
+1. **Drift calculation must be built from scratch** → **Inaccurate**
+   - A drift/delta implementation already exists in
+     `FundResultsComparisonService` (`toMetricDelta`, `driftCapable`,
+     `driftReason`, percentage delta logic).
+   - Drift statuses also exist in allocation scenario apply preview flows
+     (`exact_match`, `stale_but_mappable`, `company_set_changed`).
+
+2. **Scenario builder wiring: 486 lines, zero API calls, needs fund-data
+   endpoint** → **Partially accurate, specific details unverified/outdated**
+   - We can confirm at least one scenario manager surface is local-state driven
+     with no API wiring
+     (`client/src/components/cap-table/scenario-manager.tsx`).
+   - The precise “486 lines” figure does not match current files reviewed.
+
+3. **Construction-actual comparison shows deferral message** → **Accurate**
+   - This surface explicitly renders a deferred message and states
+     round/stage/valuation breakdowns are deferred until stable provenance
+     exists.
+
+### Phase 2 remainder
+
+1. **One-way/two-way/stress testing marked coming soon** → **Accurate**
+   - Sensitivity page marks those tabs as planned/coming soon and disabled.
+
+2. **Backtesting tests still quarantined** → **Inaccurate**
+   - The primary backtesting API test suite is active
+     (`tests/integration/backtesting-api.test.ts`) and does not carry
+     `@quarantine` markers.
+
+### Phase 3 remainder
+
+1. **Snapshot schema ADR and canonical table decision needed** → **Mostly
+   accurate (governance gap)**
+   - Both `fund_snapshots` and `fund_state_snapshots` coexist in schema
+     definitions.
+   - We did not find a current ADR that clearly resolves canonical ownership
+     between them.
+
+2. **Restore workflow route mismatch** → **Inaccurate for active flow (stale
+   claim)**
+   - The time-travel UI currently disables restore with explicit “Restore
+     Unavailable” copy.
+   - A server restore route does exist for snapshot versions
+     (`POST /api/snapshots/:snapshotId/versions/:versionId/restore`).
+
+3. **Audit trail UI missing despite fundEvents data** → **Plausibly accurate**
+   - `fundEvents` exists in shared schema.
+   - No direct client UI usage of `fundEvents` was found in `client/src`.
+
+### Phase 4
+
+1. **MOIC endpoint compute-only + sample-only UI needs adapter** → **Partially
+   accurate**
+   - `/api/moic/calculate` and `/api/moic/rank` routes exist.
+   - They compute from caller-supplied investments (no fundId lookup in route
+     logic).
+   - `pages/moic-analysis.tsx` appears sample/static-data oriented.
+
+2. **IRR unification needed across calculators to canonical shared XIRR** →
+   **Accurate**
+   - `ActualMetricsCalculator` contains deprecated local XIRR comments.
+   - `PerformanceCalculator` uses a simple CAGR-based IRR approximation.
+   - Canonical shared XIRR exists in `shared/lib/finance/xirr.ts`.
+
+3. **Performance attribution engine: no backend exists** → **Overstated /
+   partially inaccurate**
+   - There is at least placeholder backend attribution payload in
+     `portfolio-intelligence` backtest route.
+   - However, this does not appear to be a robust production attribution engine.
+
+4. **Benchmarking data feed: no data source exists** → **Mostly accurate for LP
+   benchmark endpoint**
+   - `/api/lp/performance/benchmark` explicitly returns placeholder benchmark
+     data with a note to implement real logic.
+
+5. **Concentration analysis: no code exists** → **Inaccurate**
+   - Concentration-risk analysis code exists in services (e.g.,
+     `portfolio-performance-predictor.ts`).
+
+## Suggested corrected summary
+
+- Keep: deferred construction-vs-actual, sensitivity tabs still coming soon, LP
+  benchmark feed still placeholder, IRR unification still needed.
+- Revise/remove: “drift must be built from scratch”, “backtesting tests
+  quarantined”, “concentration analysis no code exists”, and restore-route
+  mismatch phrasing.
+- Mark as governance item: canonical snapshot table decision/ADR.


### PR DESCRIPTION
### Motivation

- Provide a reconciled accuracy review of a previously published To-Do report as of `2026-04-05` to correct stale or overstated claims and surface current code status. 
- Capture sandbox validation evidence and recommend wording and execution improvements for future reviews.

### Description

- Add `docs/todo-report-accuracy-review-2026-04-05.md` which summarizes validation results, per-phase findings, and a suggested corrected summary of items to keep, revise, or escalate to governance. 
- Documented concrete evidence locations and code pointers such as `toMetricDelta`, `driftCapable`, and `driftReason` in `server/services/fund-results-comparison-service.ts`, deferred UI messages in `client/src/components/forecasting/construction-actual-comparison.tsx`, and the placeholder LP benchmark endpoint in `server/routes/lp-api.ts`.
- Noted a UX wording improvement around the restore workflow and recommended using the integration Vitest config for integration evidence instead of the default unit test runner.
- Classified each original To-Do claim as accurate, partially accurate, inaccurate, or overstated with references to supporting files and code paths.

### Testing

- Performed targeted source searches using ripgrep patterns such as `rg -n "toMetricDelta|driftCapable|driftReason" server/services/fund-results-comparison-service.ts` and similar `rg` checks across the repo to confirm presence or absence of artifacts. 
- Executed the integration test command `npm run test:integration -- tests/integration/backtesting-api.test.ts` to validate backtesting API test status and observed no quarantined markers or test failures. 
- Verified UI/server routes via `rg` for restore route and time-travel UI copy to confirm the client intentionally disables restore while a server restore route exists. 
- Confirmed presence of backend concentration-analysis helpers and placeholder benchmarking responses via `rg` checks against `server/services/portfolio-performance-predictor.ts` and `server/routes/lp-api.ts` respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2be78b490832694d3a5f6aaebc860)