### PR TITLE
Introduce API base helper and standardize fetch usage; refactor cap-table and portfolio chart UI logic

### DIFF
--- a/client/src/adapters/fund-store-adapters.ts
+++ b/client/src/adapters/fund-store-adapters.ts
@@ -190,7 +190,9 @@ export function fundStoreToCreateV1(state: FundStateSlice): FundCreateV1 {
   if (state.vintageYear == null) defaultedFields.push('vintageYear');
 
   if (defaultedFields.length > 0) {
-    console.warn('create-defaults-applied', { defaultedFields });
+    if (import.meta.env.DEV) {
+      console.warn('create-defaults-applied', { defaultedFields });
+    }
   }
 
   return {

--- a/client/src/components/cap-table/cap-table-calculator.tsx
+++ b/client/src/components/cap-table/cap-table-calculator.tsx
@@ -16,7 +16,6 @@ import {
   TableRow,
 } from '@/components/ui/table';
 
-
 import { Plus, Calculator, Download, Users, TrendingUp, DollarSign, Percent } from 'lucide-react';
 import SAFENoteEditor from './safe-note-editor';
 
@@ -63,9 +62,9 @@ const SAMPLE_SAFES_NOTES: SAFENote[] = [
     type: 'safe',
     principal: 500000,
     valuationCap: 8000000,
-    discount: 0.20,
+    discount: 0.2,
     holderName: 'Angel Investor 1',
-    investmentDate: '2024-01-15'
+    investmentDate: '2024-01-15',
   },
   {
     id: 'safe-2',
@@ -74,7 +73,7 @@ const SAMPLE_SAFES_NOTES: SAFENote[] = [
     valuationCap: 10000000,
     discount: 0.15,
     holderName: 'Angel Investor 2',
-    investmentDate: '2024-02-01'
+    investmentDate: '2024-02-01',
   },
   {
     id: 'note-1',
@@ -83,8 +82,8 @@ const SAMPLE_SAFES_NOTES: SAFENote[] = [
     valuationCap: 12000000,
     discount: 0.25,
     holderName: 'Convertible Note Holder',
-    investmentDate: '2024-03-10'
-  }
+    investmentDate: '2024-03-10',
+  },
 ];
 
 export default function CapTableCalculator() {
@@ -92,7 +91,7 @@ export default function CapTableCalculator() {
   const [safesNotes, setSafesNotes] = useState<SAFENote[]>(SAMPLE_SAFES_NOTES);
   const [proFormaCapTable, setProFormaCapTable] = useState<Shareholder[]>([]);
   const [consolidate, setConsolidate] = useState(true);
-  
+
   // Next Round Parameters
   const [preMoneyValuation, setPreMoneyValuation] = useState(15000000);
   const [roundSize, setRoundSize] = useState(5000000);
@@ -101,11 +100,12 @@ export default function CapTableCalculator() {
   // Calculate cap table metrics
   const calculateMetrics = () => {
     const totalShares = currentCapTable.reduce<number>((sum, sh) => sum + sh.shares, 0);
-    const totalOptions = currentCapTable.find(sh => sh.type === 'option-pool')?.shares ?? 0;
+    const totalOptions = currentCapTable.find((sh) => sh.type === 'option-pool')?.shares ?? 0;
     const fullyDilutedShares = totalShares;
 
     // Calculate price per share for next round
-    const pricePerShare = (preMoneyValuation + optionPoolIncrease) / (fullyDilutedShares + optionPoolIncrease);
+    const pricePerShare =
+      (preMoneyValuation + optionPoolIncrease) / (fullyDilutedShares + optionPoolIncrease);
     const newInvestorShares = roundSize / pricePerShare;
     const postMoneyValuation = preMoneyValuation + roundSize;
 
@@ -115,66 +115,62 @@ export default function CapTableCalculator() {
       fullyDilutedShares,
       pricePerShare,
       newInvestorShares,
-      postMoneyValuation
+      postMoneyValuation,
     };
   };
 
-  // Convert SAFEs and Notes
-  const convertSafesNotes = (pricePerShare: number) => {
-    return safesNotes.map(instrument => {
-      // Calculate cap-based price
-      const fullyDilutedShares = currentCapTable.reduce((sum, sh) => sum + sh.shares, 0);
-      const capBasedPrice = instrument.valuationCap ? 
-        instrument.valuationCap / fullyDilutedShares : Infinity;
-      
-      // Calculate discount-based price
-      const discountBasedPrice = instrument.discount ? 
-        pricePerShare * (1 - instrument.discount) : Infinity;
-      
-      // Take the lower of the two (better for investor)
+  // Generate pro-forma cap table
+  useEffect(() => {
+    const totalShares = currentCapTable.reduce<number>((sum, sh) => sum + sh.shares, 0);
+    const fullyDilutedShares = totalShares;
+    const pricePerShare =
+      (preMoneyValuation + optionPoolIncrease) / (fullyDilutedShares + optionPoolIncrease);
+    const newInvestorShares = roundSize / pricePerShare;
+
+    const convertedInstruments = safesNotes.map((instrument) => {
+      const capBasedPrice = instrument.valuationCap
+        ? instrument.valuationCap / fullyDilutedShares
+        : Infinity;
+      const discountBasedPrice = instrument.discount
+        ? pricePerShare * (1 - instrument.discount)
+        : Infinity;
       const conversionPrice = Math.min(capBasedPrice, discountBasedPrice);
       const shares = instrument.principal / conversionPrice;
 
       return {
         ...instrument,
         conversionPrice,
-        shares
+        shares,
       };
     });
-  };
 
-  // Generate pro-forma cap table
-  const generateProForma = () => {
-    const metrics = calculateMetrics();
-    const convertedInstruments = convertSafesNotes(metrics.pricePerShare);
-    
     // Start with current cap table
     let proForma = [...currentCapTable];
-    
+
     // Add new investor
     proForma.push({
       id: 'new-investor',
       name: 'New Investor',
       type: 'investor',
-      shares: metrics.newInvestorShares,
-      percentage: 0
+      shares: newInvestorShares,
+      percentage: 0,
     });
 
     // Add converted SAFEs/Notes
-    forEach(convertedInstruments, instrument => {
+    forEach(convertedInstruments, (instrument) => {
       proForma.push({
         id: instrument.id,
         name: instrument.holderName,
         type: instrument.type === 'safe' ? 'safe' : 'note',
         shares: instrument.shares || 0,
         percentage: 0,
-        isConverted: true
+        isConverted: true,
       });
     });
 
     // Add option pool increase if any
     if (optionPoolIncrease > 0) {
-      const optionPoolIndex = proForma.findIndex(sh => sh.type === 'option-pool');
+      const optionPoolIndex = proForma.findIndex((sh) => sh.type === 'option-pool');
       if (optionPoolIndex >= 0 && proForma[optionPoolIndex]) {
         proForma[optionPoolIndex].shares += optionPoolIncrease;
       }
@@ -184,9 +180,9 @@ export default function CapTableCalculator() {
     const newTotalShares = proForma.reduce((sum, sh) => sum + sh.shares, 0);
 
     // Recalculate all percentages
-    proForma = proForma.map(shareholder => ({
+    proForma = proForma.map((shareholder) => ({
       ...shareholder,
-      percentage: (shareholder.shares / newTotalShares) * 100
+      percentage: (shareholder.shares / newTotalShares) * 100,
     }));
 
     // Sort by percentage (descending)
@@ -194,11 +190,6 @@ export default function CapTableCalculator() {
 
     setProFormaCapTable(proForma);
     setSafesNotes(convertedInstruments);
-  };
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    generateProForma();
   }, [preMoneyValuation, roundSize, optionPoolIncrease, currentCapTable, safesNotes]);
 
   const metrics = calculateMetrics();
@@ -223,13 +214,20 @@ export default function CapTableCalculator() {
 
   const getShareholderTypeColor = (type: string) => {
     switch (type) {
-      case 'founder': return 'bg-blue-100 text-blue-800';
-      case 'employee': return 'bg-green-100 text-green-800';
-      case 'investor': return 'bg-purple-100 text-purple-800';
-      case 'safe': return 'bg-orange-100 text-orange-800';
-      case 'note': return 'bg-red-100 text-red-800';
-      case 'option-pool': return 'bg-gray-100 text-gray-800';
-      default: return 'bg-gray-100 text-gray-800';
+      case 'founder':
+        return 'bg-blue-100 text-blue-800';
+      case 'employee':
+        return 'bg-green-100 text-green-800';
+      case 'investor':
+        return 'bg-purple-100 text-purple-800';
+      case 'safe':
+        return 'bg-orange-100 text-orange-800';
+      case 'note':
+        return 'bg-red-100 text-red-800';
+      case 'option-pool':
+        return 'bg-gray-100 text-gray-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
     }
   };
 
@@ -320,29 +318,29 @@ export default function CapTableCalculator() {
                 id="pre-money"
                 type="number"
                 value={preMoneyValuation}
-                onChange={e => setPreMoneyValuation(Number(e.target.value))}
+                onChange={(e) => setPreMoneyValuation(Number(e.target.value))}
                 className="border-yellow-300 bg-yellow-50"
               />
             </div>
-            
+
             <div>
               <Label htmlFor="round-size">Round Size</Label>
               <Input
                 id="round-size"
                 type="number"
                 value={roundSize}
-                onChange={e => setRoundSize(Number(e.target.value))}
+                onChange={(e) => setRoundSize(Number(e.target.value))}
                 className="border-yellow-300 bg-yellow-50"
               />
             </div>
-            
+
             <div>
               <Label htmlFor="option-pool">Option Pool Increase</Label>
               <Input
                 id="option-pool"
                 type="number"
                 value={optionPoolIncrease}
-                onChange={e => setOptionPoolIncrease(Number(e.target.value))}
+                onChange={(e) => setOptionPoolIncrease(Number(e.target.value))}
                 className="border-yellow-300 bg-yellow-50"
               />
             </div>
@@ -400,11 +398,15 @@ export default function CapTableCalculator() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {currentCapTable.map(shareholder => (
+                  {currentCapTable.map((shareholder) => (
                     <TableRow key={shareholder.id}>
                       <TableCell className="font-medium">{shareholder.name}</TableCell>
-                      <TableCell className="text-right">{formatShares(shareholder.shares)}</TableCell>
-                      <TableCell className="text-right">{formatPercentage(shareholder.percentage)}</TableCell>
+                      <TableCell className="text-right">
+                        {formatShares(shareholder.shares)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatPercentage(shareholder.percentage)}
+                      </TableCell>
                       <TableCell>
                         <Badge className={getShareholderTypeColor(shareholder.type)}>
                           {shareholder.type}
@@ -432,11 +434,7 @@ export default function CapTableCalculator() {
                   <p className="text-sm text-gray-600">Pro Forma Cap Table after conversions.</p>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setConsolidate(!consolidate)}
-                  >
+                  <Button variant="outline" size="sm" onClick={() => setConsolidate(!consolidate)}>
                     Consolidate {consolidate ? '✓' : ''}
                   </Button>
                   <Button size="sm">
@@ -457,11 +455,15 @@ export default function CapTableCalculator() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {proFormaCapTable.map(shareholder => (
+                  {proFormaCapTable.map((shareholder) => (
                     <TableRow key={shareholder.id}>
                       <TableCell className="font-medium">{shareholder.name}</TableCell>
-                      <TableCell className="text-right">{formatShares(shareholder.shares)}</TableCell>
-                      <TableCell className="text-right">{formatPercentage(shareholder.percentage)}</TableCell>
+                      <TableCell className="text-right">
+                        {formatShares(shareholder.shares)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatPercentage(shareholder.percentage)}
+                      </TableCell>
                       <TableCell>
                         <Button size="sm" variant="ghost">
                           + Ownership Update
@@ -469,30 +471,42 @@ export default function CapTableCalculator() {
                       </TableCell>
                     </TableRow>
                   ))}
-                  
+
                   {/* Summary Rows */}
                   <TableRow className="border-t-2 border-gray-300">
                     <TableCell className="font-bold">Total Shares Excluding Options</TableCell>
                     <TableCell className="text-right font-bold">
-                      {formatShares(proFormaCapTable.filter(sh => sh.type !== 'option-pool').reduce((sum, sh) => sum + sh.shares, 0))}
+                      {formatShares(
+                        proFormaCapTable
+                          .filter((sh) => sh.type !== 'option-pool')
+                          .reduce((sum, sh) => sum + sh.shares, 0)
+                      )}
                     </TableCell>
                     <TableCell className="text-right font-bold">
-                      {formatPercentage(proFormaCapTable.filter(sh => sh.type !== 'option-pool').reduce((sum, sh) => sum + sh.percentage, 0))}
+                      {formatPercentage(
+                        proFormaCapTable
+                          .filter((sh) => sh.type !== 'option-pool')
+                          .reduce((sum, sh) => sum + sh.percentage, 0)
+                      )}
                     </TableCell>
                     <TableCell></TableCell>
                   </TableRow>
-                  
+
                   <TableRow>
                     <TableCell>Unallocated Options</TableCell>
                     <TableCell className="text-right">
-                      {formatShares(proFormaCapTable.find(sh => sh.type === 'option-pool')?.shares || 0)}
+                      {formatShares(
+                        proFormaCapTable.find((sh) => sh.type === 'option-pool')?.shares || 0
+                      )}
                     </TableCell>
                     <TableCell className="text-right">
-                      {formatPercentage(proFormaCapTable.find(sh => sh.type === 'option-pool')?.percentage || 0)}
+                      {formatPercentage(
+                        proFormaCapTable.find((sh) => sh.type === 'option-pool')?.percentage || 0
+                      )}
                     </TableCell>
                     <TableCell></TableCell>
                   </TableRow>
-                  
+
                   <TableRow className="border-t border-gray-300">
                     <TableCell className="font-bold">Total</TableCell>
                     <TableCell className="text-right font-bold">

--- a/client/src/components/forecasting/portfolio-flow-chart.tsx
+++ b/client/src/components/forecasting/portfolio-flow-chart.tsx
@@ -1,16 +1,10 @@
-import { useState, useEffect } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
-import { Separator } from "@/components/ui/separator";
-import { 
-  ArrowRight,
-  TrendingUp,
-  Play,
-  Pause,
-  RotateCcw
-} from "lucide-react";
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Separator } from '@/components/ui/separator';
+import { ArrowRight, TrendingUp, Play, Pause, RotateCcw } from 'lucide-react';
 
 interface PortfolioFlowChartProps {
   fundData: {
@@ -41,77 +35,76 @@ interface FlowStep {
   totalExits: number;
 }
 
+const STAGES: Stage[] = [
+  {
+    id: 'pre-seed',
+    name: 'Pre-Seed',
+    color: 'bg-gray-500',
+    graduationRate: 35, // 35% graduate to Seed
+    exitRate: 0, // No exits at pre-seed
+    currentDeals: 54,
+    monthlyGraduations: 0.5,
+    monthlyExits: 0,
+  },
+  {
+    id: 'seed',
+    name: 'Seed',
+    color: 'bg-blue-500',
+    graduationRate: 50, // 50% graduate to Series A
+    exitRate: 5, // 5% exit at seed
+    currentDeals: 18,
+    monthlyGraduations: 0.25,
+    monthlyExits: 0.05,
+  },
+  {
+    id: 'series-a',
+    name: 'Series A',
+    color: 'bg-green-500',
+    graduationRate: 60, // 60% graduate to Series B
+    exitRate: 15, // 15% exit at Series A
+    currentDeals: 9,
+    monthlyGraduations: 0.15,
+    monthlyExits: 0.15,
+  },
+  {
+    id: 'series-b',
+    name: 'Series B',
+    color: 'bg-purple-500',
+    graduationRate: 0, // Final stage
+    exitRate: 25, // 25% exit at Series B
+    currentDeals: 5,
+    monthlyGraduations: 0,
+    monthlyExits: 0.25,
+  },
+];
+
 export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps) {
   const [currentMonth, setCurrentMonth] = useState(1);
   const [isRunning, setIsRunning] = useState(false);
   const [flowData, setFlowData] = useState<FlowStep[]>([]);
 
-  const stages: Stage[] = [
-    {
-      id: "pre-seed",
-      name: "Pre-Seed",
-      color: "bg-gray-500",
-      graduationRate: 35, // 35% graduate to Seed
-      exitRate: 0, // No exits at pre-seed
-      currentDeals: 54,
-      monthlyGraduations: 0.5,
-      monthlyExits: 0
-    },
-    {
-      id: "seed",
-      name: "Seed", 
-      color: "bg-blue-500",
-      graduationRate: 50, // 50% graduate to Series A
-      exitRate: 5, // 5% exit at seed
-      currentDeals: 18,
-      monthlyGraduations: 0.25,
-      monthlyExits: 0.05
-    },
-    {
-      id: "series-a",
-      name: "Series A",
-      color: "bg-green-500", 
-      graduationRate: 60, // 60% graduate to Series B
-      exitRate: 15, // 15% exit at Series A
-      currentDeals: 9,
-      monthlyGraduations: 0.15,
-      monthlyExits: 0.15
-    },
-    {
-      id: "series-b",
-      name: "Series B",
-      color: "bg-purple-500",
-      graduationRate: 0, // Final stage
-      exitRate: 25, // 25% exit at Series B
-      currentDeals: 5,
-      monthlyGraduations: 0,
-      monthlyExits: 0.25
-    }
-  ];
-
   // Simulate portfolio flow over time
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (isRunning && currentMonth <= 36) {
       const timer = setTimeout(() => {
         const newStep: FlowStep = {
           month: currentMonth,
           preSeedInvestments: fundData.monthlyInvestmentRate,
-          seedGraduations: stages[0]?.monthlyGraduations ?? 0,
-          seriesAGraduations: stages[1]?.monthlyGraduations ?? 0, 
-          seriesBGraduations: stages[2]?.monthlyGraduations ?? 0,
-          totalExits: stages.reduce((sum, stage) => sum + stage.monthlyExits, 0)
+          seedGraduations: STAGES[0]?.monthlyGraduations ?? 0,
+          seriesAGraduations: STAGES[1]?.monthlyGraduations ?? 0,
+          seriesBGraduations: STAGES[2]?.monthlyGraduations ?? 0,
+          totalExits: STAGES.reduce((sum, stage) => sum + stage.monthlyExits, 0),
         };
-        
-        setFlowData(prev => [...prev, newStep]);
-        setCurrentMonth(prev => prev + 1);
+
+        setFlowData((prev) => [...prev, newStep]);
+        setCurrentMonth((prev) => prev + 1);
       }, 500); // 500ms per month for demo
 
       return () => clearTimeout(timer);
     } else if (currentMonth > 36) {
       setIsRunning(false);
     }
-  }, [currentMonth, isRunning, fundData.monthlyInvestmentRate, stages]);
+  }, [currentMonth, isRunning, fundData.monthlyInvestmentRate]);
 
   const resetFlow = () => {
     setCurrentMonth(1);
@@ -126,9 +119,11 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
   const calculateCumulativeStats = () => {
     const totalInvested = flowData.reduce((sum, step) => sum + step.preSeedInvestments, 0);
     const totalExits = flowData.reduce((sum, step) => sum + step.totalExits, 0);
-    const totalGraduations = flowData.reduce((sum, step) => 
-      sum + step.seedGraduations + step.seriesAGraduations + step.seriesBGraduations, 0);
-    
+    const totalGraduations = flowData.reduce(
+      (sum, step) => sum + step.seedGraduations + step.seriesAGraduations + step.seriesBGraduations,
+      0
+    );
+
     return { totalInvested, totalExits, totalGraduations };
   };
 
@@ -188,7 +183,8 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
         <CardHeader>
           <CardTitle>Investment Flow Visualization</CardTitle>
           <CardDescription>
-            {fundData.totalDeals} pre-seed deals • {fundData.monthlyInvestmentRate} deals/month • Repeated for 36 months
+            {fundData.totalDeals} pre-seed deals • {fundData.monthlyInvestmentRate} deals/month •
+            Repeated for 36 months
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -204,12 +200,12 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
             <div className="relative">
               {/* Stages Row */}
               <div className="grid grid-cols-4 gap-6">
-                {stages.map((stage, index) => (
+                {STAGES.map((stage, index) => (
                   <div key={stage.id} className="text-center space-y-4">
                     {/* Stage Header */}
                     <div>
                       <h3 className="font-semibold text-lg">{stage.name}</h3>
-                      {index < stages.length - 1 && (
+                      {index < STAGES.length - 1 && (
                         <div className="text-sm text-muted-foreground mt-1">
                           <span className="text-blue-600">{stage.name} Graduation %</span>
                         </div>
@@ -219,21 +215,25 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
                     {/* Stage Card */}
                     <Card className="border-2 hover:shadow-md transition-shadow">
                       <CardContent className="p-4">
-                        <div className={`w-full h-16 ${stage.color} rounded-lg flex items-center justify-center text-white font-bold text-lg mb-3`}>
-                          {index === 0 ? `${fundData.monthlyInvestmentRate} deals` : 
-                           index === stages.length - 1 ? `${stage.monthlyExits.toFixed(2)} exits` :
-                           `${stage.monthlyGraduations.toFixed(2)} grads`}
+                        <div
+                          className={`w-full h-16 ${stage.color} rounded-lg flex items-center justify-center text-white font-bold text-lg mb-3`}
+                        >
+                          {index === 0
+                            ? `${fundData.monthlyInvestmentRate} deals`
+                            : index === STAGES.length - 1
+                              ? `${stage.monthlyExits.toFixed(2)} exits`
+                              : `${stage.monthlyGraduations.toFixed(2)} grads`}
                         </div>
 
                         <div className="space-y-2 text-sm">
-                          {index < stages.length - 1 && (
+                          {index < STAGES.length - 1 && (
                             <div className="text-center">
                               <Badge variant="secondary" className="bg-blue-100 text-blue-800">
                                 {stage.graduationRate}% grad rate
                               </Badge>
                             </div>
                           )}
-                          
+
                           {stage.exitRate > 0 && (
                             <div className="text-center">
                               <Badge variant="secondary" className="bg-green-100 text-green-800">
@@ -251,7 +251,7 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
                     </Card>
 
                     {/* Arrow to next stage */}
-                    {index < stages.length - 1 && (
+                    {index < STAGES.length - 1 && (
                       <div className="flex justify-center">
                         <ArrowRight className="h-6 w-6 text-muted-foreground" />
                       </div>
@@ -269,10 +269,12 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
 
                 <div className="grid grid-cols-12 gap-1">
                   {Array.from({ length: 36 }, (_, i) => (
-                    <div 
+                    <div
                       key={i}
                       className={`h-8 rounded flex items-center justify-center text-xs font-medium ${
-                        i + 1 <= currentMonth ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-600'
+                        i + 1 <= currentMonth
+                          ? 'bg-blue-500 text-white'
+                          : 'bg-gray-200 text-gray-600'
                       }`}
                     >
                       {i + 1}
@@ -290,7 +292,9 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
         <Card>
           <CardHeader>
             <CardTitle>Portfolio Flow Statistics</CardTitle>
-            <CardDescription>Cumulative metrics from {flowData.length} months of investments</CardDescription>
+            <CardDescription>
+              Cumulative metrics from {flowData.length} months of investments
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
@@ -298,17 +302,19 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
                 <div className="text-2xl font-bold text-blue-600">{totalInvested.toFixed(1)}</div>
                 <div className="text-sm text-muted-foreground">Total Deals Invested</div>
               </div>
-              
+
               <div className="text-center">
-                <div className="text-2xl font-bold text-green-600">{totalGraduations.toFixed(1)}</div>
+                <div className="text-2xl font-bold text-green-600">
+                  {totalGraduations.toFixed(1)}
+                </div>
                 <div className="text-sm text-muted-foreground">Total Graduations</div>
               </div>
-              
+
               <div className="text-center">
                 <div className="text-2xl font-bold text-purple-600">{totalExits.toFixed(2)}</div>
                 <div className="text-sm text-muted-foreground">Total Exits</div>
               </div>
-              
+
               <div className="text-center">
                 <div className="text-2xl font-bold text-orange-600">
                   {totalInvested > 0 ? ((totalExits / totalInvested) * 100).toFixed(1) : 0}%
@@ -323,15 +329,21 @@ export default function PortfolioFlowChart({ fundData }: PortfolioFlowChartProps
             <div className="space-y-2">
               <h5 className="font-medium">Recent Monthly Activity</h5>
               <div className="max-h-32 overflow-y-auto space-y-1">
-                {flowData.slice(-6).reverse().map((step) => (
-                  <div key={step.month} className="flex justify-between items-center text-sm p-2 bg-gray-50 rounded">
-                    <span className="font-medium">Month {step.month}</span>
-                    <div className="flex space-x-4">
-                      <span className="text-blue-600">{step.preSeedInvestments} invested</span>
-                      <span className="text-green-600">{step.totalExits.toFixed(2)} exits</span>
+                {flowData
+                  .slice(-6)
+                  .reverse()
+                  .map((step) => (
+                    <div
+                      key={step.month}
+                      className="flex justify-between items-center text-sm p-2 bg-gray-50 rounded"
+                    >
+                      <span className="font-medium">Month {step.month}</span>
+                      <div className="flex space-x-4">
+                        <span className="text-blue-600">{step.preSeedInvestments} invested</span>
+                        <span className="text-green-600">{step.totalExits.toFixed(2)} exits</span>
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  ))}
               </div>
             </div>
           </CardContent>

--- a/client/src/lib/api-url.ts
+++ b/client/src/lib/api-url.ts
@@ -1,0 +1,17 @@
+const API_BASE_URL =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/+$/, '') || '';
+
+function normalizePath(path: string): string {
+  if (!path.startsWith('/')) {
+    return `/${path}`;
+  }
+  return path;
+}
+
+export function withApiBase(path: string): string {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  return `${API_BASE_URL}${normalizePath(path)}`;
+}

--- a/client/src/lib/env-detection.ts
+++ b/client/src/lib/env-detection.ts
@@ -1,3 +1,5 @@
+import { withApiBase } from '@/lib/api-url';
+
 // Simple runtime detection for demo mode
 function isStubModeResponse(value: unknown): value is { stubMode?: boolean } {
   return typeof value === 'object' && value !== null && 'stubMode' in value;
@@ -5,7 +7,7 @@ function isStubModeResponse(value: unknown): value is { stubMode?: boolean } {
 
 export async function isStubMode(): Promise<boolean> {
   try {
-    const response = await fetch('/api/stub-status');
+    const response = await fetch(withApiBase('/api/stub-status'));
     if (!response.ok) return false;
     const data: unknown = await response.json();
     return isStubModeResponse(data) && data.stubMode === true;

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,6 @@
 import type { QueryFunction } from '@tanstack/react-query';
 import { QueryClient } from '@tanstack/react-query';
+import { withApiBase } from '@/lib/api-url';
 
 /**
  * Structured API error that preserves server response details.
@@ -69,7 +70,7 @@ export async function apiRequest<TResponse = unknown>(
     options.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url, options);
+  const response = await fetch(withApiBase(url), options);
 
   if (!response.ok) {
     type ErrorBody = {
@@ -89,7 +90,7 @@ export async function apiRequest<TResponse = unknown>(
 type UnauthorizedBehavior = 'returnNull' | 'throw';
 export function getQueryFn<T>(options: { on401: UnauthorizedBehavior }): QueryFunction<T | null> {
   return async ({ queryKey }) => {
-    const res = await fetch(queryKey.join('/') as string, {
+    const res = await fetch(withApiBase(queryKey.join('/') as string), {
       credentials: 'include',
     });
 

--- a/client/src/lib/wizard-telemetry.ts
+++ b/client/src/lib/wizard-telemetry.ts
@@ -1,4 +1,7 @@
-import { logger } from "@/lib/logger";
+import { logger } from '@/lib/logger';
+import { withApiBase } from '@/lib/api-url';
+
+const WIZARD_TELEMETRY_ENDPOINT = withApiBase('/api/telemetry/wizard');
 
 export function emitWizard(event: Record<string, unknown>) {
   const enriched = {
@@ -15,23 +18,28 @@ export function emitWizard(event: Record<string, unknown>) {
     const beaconsSupported =
       typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function';
     const ok = beaconsSupported
-      ? navigator.sendBeacon('/api/telemetry/wizard', new Blob([body], { type: 'application/json' }))
+      ? navigator.sendBeacon(
+          WIZARD_TELEMETRY_ENDPOINT,
+          new Blob([body], { type: 'application/json' })
+        )
       : false;
 
     if (!ok) {
-      fetch('/api/telemetry/wizard', {
+      fetch(WIZARD_TELEMETRY_ENDPOINT, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body,
         keepalive: true,
       }).catch((fetchError) => {
         // Log telemetry failures for observability but don't block user flow
-        logger.debug("wizard_telemetry_fetch_failed", { error: fetchError instanceof Error ? fetchError.message : String(fetchError) });
+        logger.debug('wizard_telemetry_fetch_failed', {
+          error: fetchError instanceof Error ? fetchError.message : String(fetchError),
+        });
       });
     }
 
-    logger.info("wizard_telemetry", enriched);
+    logger.info('wizard_telemetry', enriched);
   } catch (err) {
-    logger.error("wizard_telemetry_error", err instanceof Error ? err : new Error(String(err)));
+    logger.error('wizard_telemetry_error', err instanceof Error ? err : new Error(String(err)));
   }
 }

--- a/client/src/machines/modeling-wizard.machine.ts
+++ b/client/src/machines/modeling-wizard.machine.ts
@@ -16,6 +16,7 @@
 
 import { setup, assign, fromPromise } from 'xstate';
 import { z } from 'zod';
+import { withApiBase } from '@/lib/api-url';
 import {
   calculateReservesForWizard,
   validateWizardPortfolio,
@@ -600,7 +601,7 @@ const submitFundModel = fromPromise(async ({ input }: { input: ModelingWizardCon
   };
 
   try {
-    const response = await fetch('/api/funds', {
+    const response = await fetch(withApiBase('/api/funds'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/services/fund-drafts.ts
+++ b/client/src/services/fund-drafts.ts
@@ -1,4 +1,5 @@
 import type { FundDraftWriteV1 } from '@shared/contracts/fund-draft-write-v1.contract';
+import { withApiBase } from '@/lib/api-url';
 
 type DraftApiErrorBody = {
   error?: string;
@@ -21,7 +22,7 @@ export async function saveFundDraft(
   fundId: number,
   payload: FundDraftWriteV1
 ): Promise<DraftRecordResponse> {
-  const response = await fetch(`/api/funds/${fundId}/draft`, {
+  const response = await fetch(withApiBase(`/api/funds/${fundId}/draft`), {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -35,7 +36,7 @@ export async function saveFundDraft(
 }
 
 export async function fetchFundDraft(fundId: number): Promise<FundDraftWriteV1> {
-  const response = await fetch(`/api/funds/${fundId}/draft`);
+  const response = await fetch(withApiBase(`/api/funds/${fundId}/draft`));
 
   if (!response.ok) {
     throw await readDraftApiError(response, 'Draft load failed');

--- a/client/src/services/funds.ts
+++ b/client/src/services/funds.ts
@@ -5,6 +5,7 @@
 import { clampPct, clampInt } from '../lib/coerce';
 import * as Telemetry from '../lib/telemetry';
 import { startInFlight, isInFlight, cancelInFlight } from '../lib/inflight';
+import { withApiBase } from '../lib/api-url';
 
 type Json = Record<string, unknown> | unknown[] | string | number | boolean | null | undefined;
 
@@ -40,7 +41,7 @@ export interface CreateFundResult {
   durationMs: number;
 }
 
-const DEFAULT_ENDPOINT = '/api/funds';
+const DEFAULT_ENDPOINT = withApiBase('/api/funds');
 const DEFAULT_TIMEOUT = 10_000;
 
 // ---------- Stable stringify + FNV-1a hash (deterministic) ----------
@@ -315,6 +316,11 @@ export function normalizeCreateFundResponse(raw: unknown): NormalizedFundRespons
 export async function createFund(payload: Json, options?: CreateFundOptions): Promise<unknown> {
   const result = await startCreateFund(payload, options);
   if (!result.res.ok) {
+    if (result.res.status === 404) {
+      throw new Error(
+        'Fund creation endpoint not found (HTTP 404). Verify API routing or VITE_API_BASE_URL.'
+      );
+    }
     throw new Error(`Fund creation failed: ${result.res.status}`);
   }
   const data: unknown = await result.res.json();
@@ -369,7 +375,7 @@ export async function createFundWithToast(payload: Json, options?: CreateFundOpt
 export async function finalizeFund(
   payload: import('@shared/contracts/fund-finalize-v1.contract').FundFinalizeV1
 ): Promise<import('@shared/contracts/fund-finalize-v1.contract').FundFinalizeResponseV1> {
-  const response = await fetch('/api/funds/finalize', {
+  const response = await fetch(withApiBase('/api/funds/finalize'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/client/src/vitals.ts
+++ b/client/src/vitals.ts
@@ -2,6 +2,7 @@ import type { Metric } from 'web-vitals';
 import { onLCP, onINP, onCLS, onFCP, onTTFB } from 'web-vitals';
 import { Sentry } from '@/monitoring';
 import { logger } from '@/lib/logger';
+import { withApiBase } from '@/lib/api-url';
 
 interface VitalMetric extends Omit<Metric, 'navigationType'> {
   navigationType?: string;
@@ -75,6 +76,37 @@ function isTelemetryAllowed(): boolean {
   return true;
 }
 
+const RUM_ENDPOINT = withApiBase('/metrics/rum');
+let rumEndpointDisabled = false;
+
+function sendRumMetric(body: Record<string, unknown>): void {
+  if (rumEndpointDisabled) {
+    return;
+  }
+
+  fetch(RUM_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    keepalive: true,
+  })
+    .then((response) => {
+      if (response.status === 404 || response.status === 405) {
+        rumEndpointDisabled = true;
+        logger.warn('rum_endpoint_disabled', {
+          endpoint: RUM_ENDPOINT,
+          status: response.status,
+        });
+      }
+    })
+    .catch((error: unknown) => {
+      logger.warn('web_vital_transport_failed', {
+        endpoint: RUM_ENDPOINT,
+        error: getErrorMessage(error),
+      });
+    });
+}
+
 /**
  * Send Core Web Vitals to monitoring backends
  */
@@ -122,25 +154,7 @@ function sendToAnalytics(metric: VitalMetric) {
     });
   });
 
-  // Send to backend RUM endpoint
-  if (typeof navigator.sendBeacon === 'function') {
-    const url = '/metrics/rum';
-    const blob = new Blob([JSON.stringify(body)], { type: 'application/json' });
-    navigator.sendBeacon(url, blob);
-  } else {
-    // Fallback for older browsers
-    fetch('/metrics/rum', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      keepalive: true,
-    }).catch((error: unknown) => {
-      logger.warn('web_vital_transport_failed', {
-        name: metric.name,
-        error: getErrorMessage(error),
-      });
-    });
-  }
+  sendRumMetric(body);
 
   // Log to console in development
   if (import.meta.env.DEV) {


### PR DESCRIPTION
### Motivation
- Centralize API base URL handling to support deployments behind custom `VITE_API_BASE_URL` and avoid hardcoded routes. 
- Standardize client-side network calls and telemetry endpoints to improve reliability and error diagnostics. 
- Refactor UI components (`CapTableCalculator`, `PortfolioFlowChart`) to fix minor bugs, improve conversions/pro-forma generation, and tidy formatting. 

### Description
- Add `client/src/lib/api-url.ts` with `withApiBase(path: string)` to normalize API paths and respect `VITE_API_BASE_URL`.
- Replace direct `fetch('/...')` calls with `withApiBase(...)` across the codebase (query client, env detection, wizard submission, fund services, fund drafts, wizard telemetry, vitals) to route requests consistently.
- Update telemetry/vitals: introduce `RUM_ENDPOINT` and `sendRumMetric` with 404/405 disabling and better logging, and use `withApiBase` for the wizard telemetry beacon/fallback `fetch` calls.
- Cap table and portfolio UI updates: refactor `CapTableCalculator` to compute pro-forma via `useEffect`, convert SAFEs/notes inline, fix numeric literals (e.g. `0.2`), add consistent formatting/commas and trailing commas; `PortfolioFlowChart` extracts `STAGES` constant, uses it throughout, cleans up effect dependencies and formatting, and improves flow rendering.
- Minor runtime behavior change: defaults applied warning in fund creation is now logged only in development (`import.meta.env.DEV`).
- Various code style and stability tweaks (arrow function parentheses, trailing commas, safer reductions, and small logging message normalizations).

### Testing
- Verified TypeScript typecheck and project build via `yarn build` (local) to ensure no compilation errors. 
- Ran unit test suite via `yarn test` (local) and lint checks; both completed successfully without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0888cbe348326989a9943d9a4abf7)