### PR TITLE
Fix vercel preview api routing

### DIFF
--- a/client/src/lib/api-url.ts
+++ b/client/src/lib/api-url.ts
@@ -1,5 +1,21 @@
-const API_BASE_URL =
-  (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/+$/, '') || '';
+function getConfiguredApiBaseUrl(): string {
+  return (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/+$/, '') || '';
+}
+
+export function resolveApiBaseUrl(hostname: string | null, configuredApiBaseUrl: string): string {
+  // Vercel deployments expose frontend assets and API routes from the same host.
+  // For previews, forcing an absolute API base points requests at the production
+  // apex domain and turns same-origin calls into CORS preflights.
+  if (hostname?.endsWith('.vercel.app')) {
+    return '';
+  }
+
+  return configuredApiBaseUrl;
+}
+
+export function getApiBaseUrl(): string {
+  return resolveApiBaseUrl(globalThis.location?.hostname?.toLowerCase() ?? null, getConfiguredApiBaseUrl());
+}
 
 function normalizePath(path: string): string {
   if (!path.startsWith('/')) {
@@ -9,10 +25,14 @@ function normalizePath(path: string): string {
   return path;
 }
 
-export function withApiBase(path: string): string {
+export function joinApiBaseUrl(path: string, apiBaseUrl: string): string {
   if (/^https?:\/\//.test(path)) {
     return path;
   }
 
-  return `${API_BASE_URL}${normalizePath(path)}`;
+  return `${apiBaseUrl}${normalizePath(path)}`;
+}
+
+export function withApiBase(path: string): string {
+  return joinApiBaseUrl(path, getApiBaseUrl());
 }

--- a/client/src/lib/resilient-api-client.ts
+++ b/client/src/lib/resilient-api-client.ts
@@ -5,6 +5,7 @@
 
 import type { EngineAllocation } from '@/core/reserves/types';
 import type { ParityDataset, ParityValidationResult } from '@/lib/excel-parity-validator';
+import { getApiBaseUrl } from '@/lib/api-url';
 import { logger } from '@/lib/logger';
 
 interface ApiClientConfig {
@@ -89,7 +90,7 @@ export class ResilientApiClient {
 
   constructor(config: ApiClientConfig = {}) {
     this.config = {
-      baseUrl: config.baseUrl || (import.meta.env.VITE_API_BASE_URL as string | undefined) || '',
+      baseUrl: config.baseUrl || getApiBaseUrl(),
       timeoutMs: config.timeoutMs || 15000,
       maxRetries: config.maxRetries || 3,
       baseDelayMs: config.baseDelayMs || 1000,

--- a/client/src/vitals.ts
+++ b/client/src/vitals.ts
@@ -1,5 +1,6 @@
 import type { Metric } from 'web-vitals';
 import { onLCP, onINP, onCLS, onFCP, onTTFB } from 'web-vitals';
+import { withApiBase } from '@/lib/api-url';
 import { Sentry } from '@/monitoring';
 import { logger } from '@/lib/logger';
 
@@ -106,6 +107,7 @@ function sendToAnalytics(metric: VitalMetric) {
     env: import.meta.env.MODE,
     cid,
   };
+  const rumEndpoint = withApiBase('/api/metrics/rum');
 
   // Send to Sentry as custom measurement (if privacy allows)
   Sentry.withScope((scope) => {
@@ -124,12 +126,11 @@ function sendToAnalytics(metric: VitalMetric) {
 
   // Send to backend RUM endpoint
   if (typeof navigator.sendBeacon === 'function') {
-    const url = '/metrics/rum';
     const blob = new Blob([JSON.stringify(body)], { type: 'application/json' });
-    navigator.sendBeacon(url, blob);
+    navigator.sendBeacon(rumEndpoint, blob);
   } else {
     // Fallback for older browsers
-    fetch('/metrics/rum', {
+    fetch(rumEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/server/app.ts
+++ b/server/app.ts
@@ -27,6 +27,9 @@ import allocationScenariosRouter from './routes/allocation-scenarios.js';
 import { dealPipelineRouter } from './routes/deal-pipeline.js';
 import cohortAnalysisRouter from './routes/cohort-analysis.js';
 import sensitivityRouter from './routes/sensitivity.js';
+import metricsRouter from './routes/metrics-endpoint.js';
+import { metricsRumRouter } from './routes/metrics-rum.js';
+import { rumOriginGuard, rumSamplingGuard, rumLimiter } from './routes/metrics-rum.guard.js';
 import { swaggerSpec } from './config/swagger.js';
 import { cspDirectives, securityHeaders } from './config/csp.js';
 
@@ -148,6 +151,12 @@ export function makeApp() {
 
   // Health endpoints (must be before other routes for /healthz)
   app.use(healthRouter);
+
+  // Metrics endpoints (public, no auth required)
+  app.use('/metrics', metricsRouter);
+  app.use('/api', metricsRouter);
+  app.use(rumOriginGuard, rumLimiter, rumSamplingGuard, metricsRumRouter);
+  app.use('/api', rumOriginGuard, rumLimiter, rumSamplingGuard, metricsRumRouter);
 
   // Feature flags API
   app.use('/api/flags', flagsRouter);

--- a/server/server.ts
+++ b/server/server.ts
@@ -213,6 +213,7 @@ export async function createServer(
 
   // Metrics endpoints (public, no auth required)
   app.use('/metrics', metricsRouter);
+  app.use('/api', metricsRouter);
 
   // RUM metrics endpoint (public, for browser telemetry)
   const { metricsRumRouter } = await import('./routes/metrics-rum.js');
@@ -222,6 +223,7 @@ export async function createServer(
   // Apply guards and router together at the same path to prevent path resolution issues
   // Guards run in order: origin check -> rate limit -> sampling -> privacy (in router)
   app.use(rumOriginGuard, rumLimiter, rumSamplingGuard, metricsRumRouter);
+  app.use('/api', rumOriginGuard, rumLimiter, rumSamplingGuard, metricsRumRouter);
 
   // Centralized public-route matcher (mount-relative, no /api prefix).
   // Keep this boundary narrow: canonical /api/funds* endpoints stay behind

--- a/tests/unit/lib/api-url.test.tsx
+++ b/tests/unit/lib/api-url.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { joinApiBaseUrl, resolveApiBaseUrl } from '../../../client/src/lib/api-url';
+
+describe('api-url routing', () => {
+  it('uses the configured API base outside Vercel deployments', () => {
+    const apiBaseUrl = resolveApiBaseUrl('localhost', 'https://updog-restore.vercel.app');
+
+    expect(apiBaseUrl).toBe('https://updog-restore.vercel.app');
+    expect(joinApiBaseUrl('/api/funds', apiBaseUrl)).toBe(
+      'https://updog-restore.vercel.app/api/funds'
+    );
+  });
+
+  it('prefers same-origin API routes on Vercel deployments', () => {
+    const apiBaseUrl = resolveApiBaseUrl(
+      'updog-restore-preview-123.vercel.app',
+      'https://updog-restore.vercel.app'
+    );
+
+    expect(apiBaseUrl).toBe('');
+    expect(joinApiBaseUrl('/api/funds', apiBaseUrl)).toBe('/api/funds');
+  });
+
+  it('leaves absolute URLs untouched', () => {
+    expect(joinApiBaseUrl('https://example.com/api/funds', '')).toBe(
+      'https://example.com/api/funds'
+    );
+  });
+});

--- a/tests/unit/routes/metrics-rum-api.test.ts
+++ b/tests/unit/routes/metrics-rum-api.test.ts
@@ -42,6 +42,7 @@ describe('RUM metrics routes', () => {
     app = express();
     app.use(express.json());
     app.use(metricsRumRouter);
+    app.use('/api', metricsRumRouter);
 
     vi.clearAllMocks();
     executeMock.mockImplementation(async (fn: () => Promise<boolean>) => fn());
@@ -76,6 +77,25 @@ describe('RUM metrics routes', () => {
       expect.objectContaining({
         pathname: '/funds/:id',
         timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  it('accepts the api-prefixed alias used by browser telemetry on Vercel', async () => {
+    await request(app)
+      .post('/api/metrics/rum')
+      .send({
+        name: 'INP',
+        value: 180,
+        pathname: '/fund-setup',
+      })
+      .expect(204);
+
+    expect(processMetricMock).toHaveBeenCalledWith(
+      'INP',
+      180,
+      expect.objectContaining({
+        pathname: '/fund-setup',
       })
     );
   });

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
   
   "rewrites": [
     {
+      "source": "/metrics/:path*",
+      "destination": "/api/metrics/:path*"
+    },
+    {
       "source": "/api/:path*",
       "destination": "/api/:path*"
     },


### PR DESCRIPTION
 Remote branch contains exactly these files:
  - /abs/path/C:/dev/Updog_restore/client/src/lib/resilient-api-client.ts:1
  - /abs/path/C:/dev/Updog_restore/client/src/vitals.ts:1
  - /abs/path/C:/dev/Updog_restore/server/app.ts:1
  - /abs/path/C:/dev/Updog_restore/server/server.ts:1
  - /abs/path/C:/dev/Updog_restore/vercel.json:1
  - /abs/path/C:/dev/Updog_restore/tests/unit/lib/api-url.test.tsx:1
  - /abs/path/C:/dev/Updog_restore/tests/unit/routes/metrics-rum-api.test.ts:1

  Verification before publishing:

  - npm run check
  - npm run lint
  - npm test
  - targeted Vitest regression tests for api-url and metrics-rum