### PR TITLE
Restore GP QA workflow trust

### DIFF
--- a/client/src/components/layout/dynamic-fund-header.tsx
+++ b/client/src/components/layout/dynamic-fund-header.tsx
@@ -20,9 +20,9 @@ interface FundMetrics {
   totalCommitted: number;
   totalInvested: number;
   totalValue: number;
-  irr: number;
+  irr: number | null;
   moic: number;
-  dpi: number;
+  dpi: number | null;
   tvpi: number;
   activeInvestments: number;
   exited: number;
@@ -44,9 +44,9 @@ function toHeaderMetrics(
     totalCommitted,
     totalInvested,
     totalValue,
-    irr: actual?.irr ?? 0,
+    irr: actual?.irr ?? null,
     moic: totalInvested > 0 ? totalValue / totalInvested : 0,
-    dpi: actual?.dpi ?? 0,
+    dpi: actual?.dpi ?? null,
     tvpi: actual?.tvpi ?? 0,
     activeInvestments: actual?.activeCompanies ?? 0,
     exited: actual?.exitedCompanies ?? 0,
@@ -91,10 +91,10 @@ export default function DynamicFundHeader() {
   const formatMetricCurrency = (value: number | undefined) =>
     metricUnavailable || metricsLoading ? 'N/A' : formatCurrency(value);
 
-  const formatPercentage = (value: number | undefined) => {
-    if (!value && value !== 0) return '0.0%';
+  const formatPercentage = (value: number | null | undefined) => {
+    if (value === null || value === undefined) return 'N/A';
     const num = Number(value);
-    if (isNaN(num)) return '0.0%';
+    if (isNaN(num)) return 'N/A';
     const percent = Math.abs(num) <= 1 ? num * 100 : num;
     return `${percent.toFixed(1)}%`;
   };

--- a/client/src/components/layout/navigation-config.ts
+++ b/client/src/components/layout/navigation-config.ts
@@ -1,6 +1,7 @@
 import { extractFundResultsRouteId, getLocationPathname } from '@/lib/fund-routes';
 import {
   FileText,
+  Activity,
   Settings,
   Calculator,
   Briefcase,
@@ -69,6 +70,12 @@ const CORE_NAV: readonly NavigationItem[] = [
   },
   { id: 'portfolio', label: 'Portfolio', icon: Briefcase, target: staticTarget('/portfolio') },
   { id: 'pipeline', label: 'Pipeline', icon: LineChart, target: staticTarget('/pipeline') },
+  {
+    id: 'performance',
+    label: 'Performance',
+    icon: Activity,
+    target: staticTarget('/performance'),
+  },
   {
     id: 'financial-modeling',
     label: 'Forecasting',

--- a/client/src/contexts/FundContext.tsx
+++ b/client/src/contexts/FundContext.tsx
@@ -73,9 +73,9 @@ export function FundProvider({ children }: FundProviderProps) {
     if (funds && Array.isArray(funds) && funds.length > 0) {
       // Keep route-addressed or explicitly chosen funds, but ignore any carried
       // implicit first-fund selection on the canonical deterministic route.
-      const preferredFundId =
-        routeFundId ??
-        (suppressImplicitFundSelection && fundSelectionSource === 'implicit' ? null : fundId);
+      const suppressesImplicitFirstFund =
+        suppressImplicitFundSelection && fundSelectionSource === 'implicit' && funds.length > 1;
+      const preferredFundId = routeFundId ?? (suppressesImplicitFirstFund ? null : fundId);
 
       if (preferredFundId) {
         // Find specific fund by ID
@@ -95,7 +95,7 @@ export function FundProvider({ children }: FundProviderProps) {
             return;
           }
 
-          if (suppressImplicitFundSelection) {
+          if (suppressImplicitFundSelection && funds.length > 1) {
             setCurrentFund(null);
             setFundId(null);
             setFundSelectionSource(null);
@@ -107,7 +107,7 @@ export function FundProvider({ children }: FundProviderProps) {
           setFundSelectionSource('implicit');
         }
       } else {
-        if (suppressImplicitFundSelection) {
+        if (suppressImplicitFundSelection && funds.length > 1) {
           setCurrentFund(null);
           setFundId(null);
           setFundSelectionSource(null);
@@ -150,7 +150,11 @@ export function FundProvider({ children }: FundProviderProps) {
   const awaitingResolvedFundSelection =
     hasResolvedFunds && !currentFund && routeFundId == null && !suppressImplicitFundSelection;
   const allowsMissingActiveFund =
-    hasResolvedFunds && !currentFund && routeFundId == null && suppressImplicitFundSelection;
+    hasResolvedFunds &&
+    !currentFund &&
+    routeFundId == null &&
+    suppressImplicitFundSelection &&
+    funds.length > 1;
 
   // Consider "loading" until the first resolved fund has been copied into context
   // or demo mode has fully initialized. This prevents ProtectedRoute/HomeRoute from

--- a/client/src/hooks/useBacktesting.ts
+++ b/client/src/hooks/useBacktesting.ts
@@ -89,6 +89,23 @@ export function useBacktestAsyncRun() {
   });
 }
 
+export function useBacktestSyncRun() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (config: BacktestConfig) => {
+      return apiRequest<{ result: BacktestResult }>('POST', '/api/backtesting/run', config);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.all });
+    },
+  });
+}
+
+function isQueueUnavailableError(error: unknown): boolean {
+  return toSubmitErrorViewModel(error)?.errorCode === 'QUEUE_UNAVAILABLE';
+}
+
 /**
  * Poll job status. Refetches every 2s while non-terminal.
  * Automatically stops polling when job reaches terminal state.
@@ -196,7 +213,9 @@ export function useBacktestLifecycle(fundId: number | null) {
   const searchString = useSearch();
   const resumeJobId = useResumeJobId();
   const asyncRun = useBacktestAsyncRun();
+  const syncRun = useBacktestSyncRun();
   const [localJob, setLocalJob] = useState<{ jobId: string; fundId: number } | null>(null);
+  const [syncResult, setSyncResult] = useState<BacktestResult | null>(null);
   const [dismissedResumeJobId, setDismissedResumeJobId] = useState<string | null>(null);
   const [resumeMismatch, setResumeMismatch] = useState<{
     jobId: string;
@@ -259,20 +278,43 @@ export function useBacktestLifecycle(fundId: number | null) {
   // Auto-fetch result when job completes
   const backtestId = hasResumeMismatch ? null : effectiveJobViewModel.backtestId;
   const result = useBacktestResult(backtestId);
-  const submitError = useMemo(() => toSubmitErrorViewModel(asyncRun.error), [asyncRun.error]);
+  const syncResultViewModel = useMemo(
+    () => (syncResult ? toResultViewModel(syncResult) : null),
+    [syncResult]
+  );
+  const submitError = useMemo(() => {
+    if (syncRun.isPending || syncResult) {
+      return null;
+    }
+
+    return toSubmitErrorViewModel(syncRun.error ?? asyncRun.error);
+  }, [asyncRun.error, syncRun.error, syncRun.isPending, syncResult]);
 
   const startBacktest = useCallback(
     (config: BacktestConfig) => {
       setResumeMismatch(null);
       setLocalJob(null);
+      setSyncResult(null);
       asyncRun.reset();
+      syncRun.reset();
       asyncRun.mutate(config, {
         onSuccess: (response) => {
           setLocalJob({ jobId: response.jobId, fundId: config.fundId });
         },
+        onError: (error) => {
+          if (!isQueueUnavailableError(error)) {
+            return;
+          }
+
+          syncRun.mutate(config, {
+            onSuccess: (response) => {
+              setSyncResult(response.result);
+            },
+          });
+        },
       });
     },
-    [asyncRun]
+    [asyncRun, syncRun]
   );
 
   const isRunning =
@@ -282,10 +324,10 @@ export function useBacktestLifecycle(fundId: number | null) {
     startBacktest,
     activeJobId: hasResumeMismatch ? null : activeJobId,
     jobStatus: effectiveJobViewModel,
-    result: result.viewModel,
-    rawResult: result.data?.result ?? null,
+    result: syncResultViewModel ?? result.viewModel,
+    rawResult: syncResult ?? result.data?.result ?? null,
     isRunning,
-    isSubmitting: asyncRun.isPending,
+    isSubmitting: asyncRun.isPending || syncRun.isPending,
     submitError,
     resumeMismatch,
   };

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -11,8 +11,15 @@
  */
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import { useRoute, useLocation } from 'wouter';
-import { AlertCircle, ArrowLeft, ChevronDown, ChevronRight, History, RefreshCw } from 'lucide-react';
+import { Link, useRoute, useLocation } from 'wouter';
+import {
+  AlertCircle,
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  History,
+  RefreshCw,
+} from 'lucide-react';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -24,9 +31,7 @@ import type {
   WaterfallSetupSection,
 } from '@shared/contracts/fund-results-v1.contract';
 import type { FundStateReadV1 } from '@shared/contracts/fund-state-read-v1.contract';
-import type {
-  FundLifecycleHistoryV1,
-} from '@shared/contracts/fund-lifecycle-history-v1.contract';
+import type { FundLifecycleHistoryV1 } from '@shared/contracts/fund-lifecycle-history-v1.contract';
 import type {
   FundResultsComparisonV1,
   MetricDelta,
@@ -172,96 +177,99 @@ function useFundResults(fundId: string | null) {
     stateRef.current = state;
   }, [state]);
 
-  const fetchResults = useCallback(async (options: FetchOptions = {}) => {
-    if (!fundId || fundId === 'latest') return;
+  const fetchResults = useCallback(
+    async (options: FetchOptions = {}) => {
+      if (!fundId || fundId === 'latest') return;
 
-    if (options.resetBackoff) {
-      attemptRef.current = 0;
-      clearScheduledPoll();
-    }
-
-    if (abortRef.current) {
-      if (options.background) {
-        return;
+      if (options.resetBackoff) {
+        attemptRef.current = 0;
+        clearScheduledPoll();
       }
-      cancelInFlight();
-    }
 
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    try {
-      const res = await fetch(`/api/funds/${fundId}/results`, {
-        signal: controller.signal,
-      });
-
-      if (res.status === 404) {
-        if (stateRef.current.kind !== 'data' || options.initial) {
-          setState({ kind: 'error', message: 'Fund not found' });
+      if (abortRef.current) {
+        if (options.background) {
+          return;
         }
-        return;
+        cancelInFlight();
       }
-      if (!res.ok) {
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const res = await fetch(`/api/funds/${fundId}/results`, {
+          signal: controller.signal,
+        });
+
+        if (res.status === 404) {
+          if (stateRef.current.kind !== 'data' || options.initial) {
+            setState({ kind: 'error', message: 'Fund not found' });
+          }
+          return;
+        }
+        if (!res.ok) {
+          if (stateRef.current.kind !== 'data' || options.initial) {
+            setState({ kind: 'error', message: `Server error (${res.status})` });
+          } else if (
+            stateRef.current.kind === 'data' &&
+            isActiveCalculationStatus(stateRef.current.results.lifecycle.calculationState.status)
+          ) {
+            scheduleNextPoll();
+          }
+          return;
+        }
+
+        const data = (await res.json()) as FundResultsReadV1;
+        setState({ kind: 'data', results: data });
+
+        const currentLifecycleKey: LifecyclePollingKey = {
+          fundId,
+          status: data.lifecycle.calculationState.status,
+          runId: data.lifecycle.calculationState.runId,
+          configVersion: data.lifecycle.calculationState.configVersion,
+        };
+        const previousLifecycleKey = lastLifecycleKeyRef.current;
+        const shouldResetBackoff =
+          options.resetBackoff === true ||
+          previousLifecycleKey == null ||
+          previousLifecycleKey.fundId !== currentLifecycleKey.fundId ||
+          previousLifecycleKey.runId !== currentLifecycleKey.runId ||
+          previousLifecycleKey.configVersion !== currentLifecycleKey.configVersion ||
+          (!isActiveCalculationStatus(previousLifecycleKey.status) &&
+            isActiveCalculationStatus(currentLifecycleKey.status));
+
+        lastLifecycleKeyRef.current = currentLifecycleKey;
+
+        if (isActiveCalculationStatus(currentLifecycleKey.status)) {
+          if (shouldResetBackoff) {
+            attemptRef.current = 0;
+          }
+          scheduleNextPoll();
+        } else {
+          attemptRef.current = 0;
+          clearScheduledPoll();
+        }
+      } catch (error) {
+        if (controller.signal.aborted) return;
+
         if (stateRef.current.kind !== 'data' || options.initial) {
-          setState({ kind: 'error', message: `Server error (${res.status})` });
+          setState({ kind: 'error', message: 'Network error' });
         } else if (
           stateRef.current.kind === 'data' &&
           isActiveCalculationStatus(stateRef.current.results.lifecycle.calculationState.status)
         ) {
           scheduleNextPoll();
+        } else if (error instanceof Error) {
+          void error;
         }
-        return;
-      }
-
-      const data = (await res.json()) as FundResultsReadV1;
-      setState({ kind: 'data', results: data });
-
-      const currentLifecycleKey: LifecyclePollingKey = {
-        fundId,
-        status: data.lifecycle.calculationState.status,
-        runId: data.lifecycle.calculationState.runId,
-        configVersion: data.lifecycle.calculationState.configVersion,
-      };
-      const previousLifecycleKey = lastLifecycleKeyRef.current;
-      const shouldResetBackoff =
-        options.resetBackoff === true ||
-        previousLifecycleKey == null ||
-        previousLifecycleKey.fundId !== currentLifecycleKey.fundId ||
-        previousLifecycleKey.runId !== currentLifecycleKey.runId ||
-        previousLifecycleKey.configVersion !== currentLifecycleKey.configVersion ||
-        (!isActiveCalculationStatus(previousLifecycleKey.status) &&
-          isActiveCalculationStatus(currentLifecycleKey.status));
-
-      lastLifecycleKeyRef.current = currentLifecycleKey;
-
-      if (isActiveCalculationStatus(currentLifecycleKey.status)) {
-        if (shouldResetBackoff) {
-          attemptRef.current = 0;
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
         }
-        scheduleNextPoll();
-      } else {
-        attemptRef.current = 0;
-        clearScheduledPoll();
       }
-    } catch (error) {
-      if (controller.signal.aborted) return;
-
-      if (stateRef.current.kind !== 'data' || options.initial) {
-        setState({ kind: 'error', message: 'Network error' });
-      } else if (
-        stateRef.current.kind === 'data' &&
-        isActiveCalculationStatus(stateRef.current.results.lifecycle.calculationState.status)
-      ) {
-        scheduleNextPoll();
-      } else if (error instanceof Error) {
-        void error;
-      }
-    } finally {
-      if (abortRef.current === controller) {
-        abortRef.current = null;
-      }
-    }
-  }, [cancelInFlight, clearScheduledPoll, fundId, scheduleNextPoll]);
+    },
+    [cancelInFlight, clearScheduledPoll, fundId, scheduleNextPoll]
+  );
 
   fetchResultsRef.current = fetchResults;
 
@@ -395,10 +403,7 @@ function useFundResultsComparison(fundId: string | null) {
   return { state, refresh: fetchComparison };
 }
 
-function useRecalculatePublished(
-  fundId: string | null,
-  onSuccess: () => void
-) {
+function useRecalculatePublished(fundId: string | null, onSuccess: () => void) {
   const [state, setState] = useState<RecalculateState>({ kind: 'idle' });
 
   const recalculate = useCallback(async () => {
@@ -408,17 +413,15 @@ function useRecalculatePublished(
       const res = await fetch(`/api/funds/${fundId}/recalculate`, {
         method: 'POST',
       });
-      const payload = (await res.json().catch(() => null)) as
-        | { message?: string; error?: string }
-        | null;
+      const payload = (await res.json().catch(() => null)) as {
+        message?: string;
+        error?: string;
+      } | null;
 
       if (!res.ok) {
         setState({
           kind: 'error',
-          message:
-            payload?.message ??
-            payload?.error ??
-            `Failed to recalculate (${res.status})`,
+          message: payload?.message ?? payload?.error ?? `Failed to recalculate (${res.status})`,
         });
         return;
       }
@@ -702,9 +705,7 @@ function hasStaleEvidence(lifecycle: FundStateReadV1) {
   const publishedVersion = lifecycle.configState.publishedVersion;
   const calculationVersion = lifecycle.calculationState.configVersion;
   return (
-    publishedVersion != null &&
-    calculationVersion != null &&
-    calculationVersion < publishedVersion
+    publishedVersion != null && calculationVersion != null && calculationVersion < publishedVersion
   );
 }
 
@@ -724,7 +725,9 @@ function diagnosticAlertClasses(tone: 'neutral' | 'warning' | 'danger' | 'succes
 function getLifecycleDiagnostic(lifecycle: FundStateReadV1) {
   const { configState, calculationState } = lifecycle;
   const publishedVersion =
-    configState.publishedVersion != null ? `v${configState.publishedVersion}` : 'an unpublished draft';
+    configState.publishedVersion != null
+      ? `v${configState.publishedVersion}`
+      : 'an unpublished draft';
   const runLabel =
     calculationState.runId != null ? `run ${calculationState.runId}` : 'the next calculation run';
 
@@ -784,9 +787,9 @@ function ConfigDiffBanner({ lifecycle }: { lifecycle: FundStateReadV1 }) {
       <AlertCircle className="h-4 w-4 text-amber-700" />
       <AlertTitle>Results are stale</AlertTitle>
       <AlertDescription className="font-poppins text-amber-900">
-        Latest published configuration is v{lifecycle.configState.publishedVersion}, but the
-        current calculation is still on v{lifecycle.calculationState.configVersion}. Recalculate
-        to refresh the published results.
+        Latest published configuration is v{lifecycle.configState.publishedVersion}, but the current
+        calculation is still on v{lifecycle.calculationState.configVersion}. Recalculate to refresh
+        the published results.
       </AlertDescription>
     </Alert>
   );
@@ -795,7 +798,9 @@ function ConfigDiffBanner({ lifecycle }: { lifecycle: FundStateReadV1 }) {
 function PublishHistoryCard({ historyState }: { historyState: LifecycleHistoryState }) {
   const [isOpen, setIsOpen] = useState(false);
   const entryCount =
-    historyState.kind === 'data' ? historyState.history.entries.length : historyState.history?.entries.length ?? 0;
+    historyState.kind === 'data'
+      ? historyState.history.entries.length
+      : (historyState.history?.entries.length ?? 0);
 
   return (
     <div
@@ -818,11 +823,7 @@ function PublishHistoryCard({ historyState }: { historyState: LifecycleHistorySt
 
           <CollapsibleTrigger asChild>
             <Button variant="outline" size="sm" disabled={entryCount === 0}>
-              {isOpen ? (
-                <ChevronDown className="h-4 w-4" />
-              ) : (
-                <ChevronRight className="h-4 w-4" />
-              )}
+              {isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
               {isOpen ? 'Hide history' : 'Show history'}
             </Button>
           </CollapsibleTrigger>
@@ -877,11 +878,7 @@ function PublishHistoryCard({ historyState }: { historyState: LifecycleHistorySt
   );
 }
 
-function PublishComparisonCard({
-  comparisonState,
-}: {
-  comparisonState: ResultsComparisonState;
-}) {
+function PublishComparisonCard({ comparisonState }: { comparisonState: ResultsComparisonState }) {
   return (
     <div
       className="bg-white rounded-lg border border-beige-200 p-6 space-y-4"
@@ -1101,6 +1098,23 @@ function LifecycleStatusCard({
           {diagnostic.description}
         </AlertDescription>
       </Alert>
+
+      {!configState.hasPublished && (
+        <div className="rounded-md border border-beige-200 bg-white p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-medium text-charcoal">Publish the fund configuration</p>
+              <p className="mt-1 text-sm text-charcoal-500 font-poppins">
+                Review the current setup, publish it, then return here to request lifecycle-backed
+                calculations.
+              </p>
+            </div>
+            <Button asChild>
+              <Link href={`/fund-setup?fundId=${lifecycle.fundId}`}>Review and publish</Link>
+            </Button>
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <FactTile

--- a/server/app.ts
+++ b/server/app.ts
@@ -24,6 +24,7 @@ import interleavedThinkingRouter from './routes/interleaved-thinking.js';
 import scenarioAnalysisRouter from './routes/scenario-analysis.js';
 import allocationsRouter from './routes/allocations.js';
 import allocationScenariosRouter from './routes/allocation-scenarios.js';
+import backtestingRouter from './routes/backtesting.js';
 import fundsRouter from './routes/funds.js';
 import varianceRouter from './routes/variance.js';
 import { registerFundConfigRoutes } from './routes/fund-config.js';
@@ -215,6 +216,9 @@ export function makeApp() {
 
   // Sensitivity Analysis API (Phase 1A - one-way sweeps; fund-scoped)
   app.use('/api', sensitivityRouter);
+
+  // Backtesting API (Monte Carlo validation)
+  app.use('/api/backtesting', backtestingRouter);
 
   // API version endpoint for deployment verification
   app['get']('/api/version', (_req: Request, res: Response) =>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -43,6 +43,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   const allocationScenarioRoutes = await import('./routes/allocation-scenarios.js');
   app.use('/api', allocationScenarioRoutes.default);
 
+  const allocationsRoutes = await import('./routes/allocations.js');
+  app.use('/api', allocationsRoutes.default);
+
   const activitiesRoutes = await import('./routes/activities.js');
   app.use('/api', activitiesRoutes.default);
 
@@ -67,6 +70,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Backtesting routes (Monte Carlo validation)
   const backtestingRoutes = await import('./routes/backtesting.js');
   app.use('/api/backtesting', backtestingRoutes.default);
+
+  const sensitivityRoutes = await import('./routes/sensitivity.js');
+  app.use('/api', sensitivityRoutes.default);
 
   // MOIC Calculator routes
   const moicRoutes = await import('./routes/moic.js');
@@ -174,6 +180,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
     const devDashboardRoutes = await import('./routes/dev-dashboard.js');
     app.use('/api/dev-dashboard', devDashboardRoutes.default);
   }
+
+  app.use('/api', (_req: Request, res: Response) => {
+    res.status(404).json({
+      error: 'not_found',
+      message: 'API route not found',
+    });
+  });
 
   // Express app is compatible with http.RequestListener
   const httpServer = createServer(app as unknown as RequestListener);

--- a/server/services/actual-metrics-calculator.ts
+++ b/server/services/actual-metrics-calculator.ts
@@ -64,9 +64,9 @@ export class ActualMetricsCalculator {
     const rvpi = totalCalled.gt(0) ? currentNAV.div(totalCalled) : new Decimal(0);
 
     // Calculate portfolio composition
-    const activeCompanies = companies.filter((c) => c.status === 'active').length;
-    const exitedCompanies = companies.filter((c) => c.status === 'exited').length;
-    const writtenOffCompanies = companies.filter((c) => c.status === 'written-off').length;
+    const activeCompanies = companies.filter((c) => this.isLivePortfolioCompany(c)).length;
+    const exitedCompanies = companies.filter((c) => this.isExitedCompany(c)).length;
+    const writtenOffCompanies = companies.filter((c) => this.isWrittenOffCompany(c)).length;
     const totalCompanies = companies.length;
 
     // Calculate deployment metrics
@@ -112,13 +112,43 @@ export class ActualMetricsCalculator {
     companies: Pick<PortfolioCompany, 'status' | 'currentValuation'>[]
   ): Decimal {
     return companies
-      .filter((c) => c.status === 'active')
+      .filter((c) => this.isLivePortfolioCompany(c))
       .reduce((sum, company) => {
         const valuation = company.currentValuation
           ? this.parseDecimal(company.currentValuation)
           : new Decimal(0);
         return sum.plus(valuation);
       }, new Decimal(0));
+  }
+
+  private normalizeCompanyStatus(status: string | null | undefined): string {
+    return (status ?? 'active')
+      .trim()
+      .toLowerCase()
+      .replace(/[\s_]+/g, '-');
+  }
+
+  private isExitedCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
+    const status = this.normalizeCompanyStatus(company.status);
+    return (
+      status === 'exited' || status === 'exit' || status === 'realized' || status === 'realised'
+    );
+  }
+
+  private isWrittenOffCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
+    const status = this.normalizeCompanyStatus(company.status);
+    return (
+      status === 'written-off' ||
+      status === 'write-off' ||
+      status === 'writtenoff' ||
+      status === 'failed' ||
+      status === 'lost' ||
+      status === 'inactive'
+    );
+  }
+
+  private isLivePortfolioCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
+    return !this.isExitedCompany(company) && !this.isWrittenOffCompany(company);
   }
 
   /**

--- a/server/services/variance-calculator.ts
+++ b/server/services/variance-calculator.ts
@@ -184,12 +184,8 @@ export class VarianceCalculator {
     const targetCompanies = target.targetCompanyCount;
     const variance = actualCompanies - targetCompanies;
 
-    // Determine if on track based on deployment progress
-    const deploymentProgress =
-      target.targetFundSize > 0 ? actual.totalDeployed / target.targetFundSize : 0;
-
-    const expectedCompanies = Math.round(targetCompanies * deploymentProgress);
-    const onTrack = Math.abs(actualCompanies - expectedCompanies) <= 2; // Allow 2 company tolerance
+    const completionRatio = targetCompanies > 0 ? actualCompanies / targetCompanies : 1;
+    const onTrack = completionRatio >= 0.9;
 
     return {
       actualCompanies,

--- a/tests/unit/components/layout/navigation-config.test.ts
+++ b/tests/unit/components/layout/navigation-config.test.ts
@@ -37,3 +37,17 @@ describe('navigation-config sensitivity item', () => {
     }
   });
 });
+
+describe('navigation-config performance item', () => {
+  it('exposes the Performance sidebar item for the live performance route', () => {
+    const items = getNavigationItems();
+    const item = items.find((i) => i.id === 'performance');
+
+    expect(item).toBeDefined();
+    expect(item?.label).toBe('Performance');
+    expect(item?.target.kind).toBe('static');
+    if (item?.target.kind === 'static') {
+      expect(item.target.path).toBe('/performance');
+    }
+  });
+});

--- a/tests/unit/components/layout/sidebar-navigation.test.tsx
+++ b/tests/unit/components/layout/sidebar-navigation.test.tsx
@@ -67,6 +67,7 @@ describe('sidebar results navigation', () => {
       'dashboard',
       'portfolio',
       'pipeline',
+      'performance',
       'financial-modeling',
       'model-results',
       'sensitivity-analysis',

--- a/tests/unit/contexts/fund-context-route-selection.test.tsx
+++ b/tests/unit/contexts/fund-context-route-selection.test.tsx
@@ -129,6 +129,27 @@ describe('FundProvider route-aware selection', () => {
     });
   });
 
+  it('uses the only available fund on /forecasting', async () => {
+    mockUseQuery.mockReturnValue({
+      data: [mockFunds[0]],
+      isLoading: false,
+      error: null,
+    });
+    const { Wrapper } = createWouterWrapper('/forecasting');
+
+    render(
+      <Wrapper>
+        <FundProvider>
+          <Consumer />
+        </FundProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('1:First Fund:false:false')).toBeInTheDocument();
+    });
+  });
+
   it('uses an explicit route-scoped fund ID on /forecasting', async () => {
     const { Wrapper } = createWouterWrapper('/forecasting?fundId=2');
 
@@ -174,6 +195,27 @@ describe('FundProvider route-aware selection', () => {
 
     await waitFor(() => {
       expect(screen.getByText('none:none:false:false')).toBeInTheDocument();
+    });
+  });
+
+  it('uses the only available fund on /model-results', async () => {
+    mockUseQuery.mockReturnValue({
+      data: [mockFunds[0]],
+      isLoading: false,
+      error: null,
+    });
+    const { Wrapper } = createWouterWrapper('/model-results');
+
+    render(
+      <Wrapper>
+        <FundProvider>
+          <Consumer />
+        </FundProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('1:First Fund:false:false')).toBeInTheDocument();
     });
   });
 

--- a/tests/unit/hooks/useBacktesting.test.tsx
+++ b/tests/unit/hooks/useBacktesting.test.tsx
@@ -188,13 +188,21 @@ describe('useBacktestLifecycle', () => {
     expect(result.current.resumeMismatch).toBeNull();
   });
 
-  it('surfaces queue-unavailable submit failures without creating an active job', async () => {
-    apiRequestMock.mockRejectedValue(
-      Object.assign(new Error('Backtesting queue is unavailable'), {
-        status: 503,
-        errorCode: 'QUEUE_UNAVAILABLE',
-      })
-    );
+  it('falls back to a sync run when the async queue is unavailable', async () => {
+    apiRequestMock.mockImplementation(async (_method: string, url: string) => {
+      if (url === '/api/backtesting/run/async') {
+        throw Object.assign(new Error('Backtesting queue is unavailable'), {
+          status: 503,
+          errorCode: 'QUEUE_UNAVAILABLE',
+        });
+      }
+
+      if (url === '/api/backtesting/run') {
+        return { result: makeBacktestResult() };
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    });
 
     const { Wrapper } = createHookWrapper('/sensitivity-analysis');
     const { result } = renderHook(() => useBacktestLifecycle(7), { wrapper: Wrapper });
@@ -210,15 +218,21 @@ describe('useBacktestLifecycle', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.submitError).toMatchObject({
-        status: 503,
-        errorCode: 'QUEUE_UNAVAILABLE',
-        errorMessage: 'Backtesting queue is unavailable',
-        isRetryable: true,
-      });
+      expect(result.current.result?.backtestId).toBe('bt-123');
     });
 
+    expect(result.current.submitError).toBeNull();
     expect(result.current.activeJobId).toBeNull();
     expect(result.current.jobStatus.phase).toBe('idle');
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      'POST',
+      '/api/backtesting/run/async',
+      expect.objectContaining({ fundId: 7 })
+    );
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      'POST',
+      '/api/backtesting/run',
+      expect.objectContaining({ fundId: 7 })
+    );
   });
 });

--- a/tests/unit/server/routes-startup-automation.test.ts
+++ b/tests/unit/server/routes-startup-automation.test.ts
@@ -61,4 +61,23 @@ describe('registerRoutes automation startup', () => {
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty('error', 'validation_error');
   }, 30_000);
+
+  it('mounts reserve allocation and sensitivity JSON routes on the registerRoutes surface', async () => {
+    const app = express();
+    app.set('trust proxy', false);
+    app.use(express.json({ limit: '1mb' }));
+
+    const { registerRoutes } = await import('../../../server/routes');
+    server = await registerRoutes(app);
+
+    const allocationRes = await request(app).get('/api/funds/not-a-number/allocations/latest');
+    const sensitivityRes = await request(app).get('/api/funds/not-a-number/sensitivity/runs');
+
+    expect(allocationRes.status).toBe(400);
+    expect(allocationRes.type).toMatch(/json/);
+    expect(allocationRes.body).toHaveProperty('error', 'Invalid fund ID');
+    expect(sensitivityRes.status).toBe(400);
+    expect(sensitivityRes.type).toMatch(/json/);
+    expect(sensitivityRes.body).toHaveProperty('code', 'INVALID_FUND_ID');
+  }, 30_000);
 });

--- a/tests/unit/services/actual-metrics-calculator-live-status.test.ts
+++ b/tests/unit/services/actual-metrics-calculator-live-status.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { storageMock } = vi.hoisted(() => ({
+  storageMock: {
+    getFund: vi.fn(),
+    getPortfolioCompanies: vi.fn(),
+  },
+}));
+
+vi.mock('../../../server/storage', () => ({
+  storage: storageMock,
+}));
+
+import { ActualMetricsCalculator } from '../../../server/services/actual-metrics-calculator';
+
+describe('ActualMetricsCalculator live company status semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageMock.getFund.mockResolvedValue({
+      id: 1,
+      name: 'Test Fund I',
+      size: '100000000',
+      vintageYear: 2025,
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+    });
+    storageMock.getPortfolioCompanies.mockResolvedValue([
+      {
+        id: 1,
+        fundId: 1,
+        name: 'TechCorp',
+        sector: 'Fintech',
+        stage: 'Series B',
+        investmentAmount: '5000000',
+        currentValuation: '12500000',
+        status: 'Growing',
+        createdAt: new Date('2025-02-01T00:00:00.000Z'),
+      },
+      {
+        id: 2,
+        fundId: 1,
+        name: 'HealthAI',
+        sector: 'Healthcare',
+        stage: 'Series A',
+        investmentAmount: '3200000',
+        currentValuation: '8100000',
+        status: 'Growing',
+        createdAt: new Date('2025-03-01T00:00:00.000Z'),
+      },
+      {
+        id: 3,
+        fundId: 1,
+        name: 'DataFlow',
+        sector: 'SaaS',
+        stage: 'Series C',
+        investmentAmount: '8500000',
+        currentValuation: '25500000',
+        status: 'Scaling',
+        createdAt: new Date('2025-04-01T00:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('counts non-exited operating statuses as live for NAV and active companies', async () => {
+    const metrics = await new ActualMetricsCalculator().calculate(1);
+
+    expect(metrics.totalDeployed).toBe(16_700_000);
+    expect(metrics.currentNAV).toBe(46_100_000);
+    expect(metrics.totalValue).toBe(46_100_000);
+    expect(metrics.activeCompanies).toBe(3);
+    expect(metrics.exitedCompanies).toBe(0);
+    expect(metrics.writtenOffCompanies).toBe(0);
+    expect(metrics.averageCheckSize).toBeCloseTo(5_566_666.67, 2);
+    expect(metrics.dpi).toBeNull();
+    expect(metrics.tvpi).toBeCloseTo(46_100_000 / 16_700_000, 6);
+  });
+});

--- a/tests/unit/services/variance-calculator.test.ts
+++ b/tests/unit/services/variance-calculator.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { ActualMetrics, ProjectedMetrics, TargetMetrics } from '@shared/types/metrics';
+import { VarianceCalculator } from '../../../server/services/variance-calculator';
+
+function makeActual(overrides: Partial<ActualMetrics> = {}): ActualMetrics {
+  return {
+    asOfDate: '2026-04-25T00:00:00.000Z',
+    totalCommitted: 100_000_000,
+    totalCalled: 16_700_000,
+    totalDeployed: 16_700_000,
+    totalUncalled: 83_300_000,
+    currentNAV: 46_100_000,
+    totalDistributions: 0,
+    totalValue: 46_100_000,
+    irr: null,
+    tvpi: 2.76,
+    dpi: null,
+    rvpi: 2.76,
+    activeCompanies: 3,
+    exitedCompanies: 0,
+    writtenOffCompanies: 0,
+    totalCompanies: 3,
+    deploymentRate: 16.7,
+    averageCheckSize: 5_566_666.67,
+    fundAgeMonths: 12,
+    ...overrides,
+  };
+}
+
+function makeProjected(): ProjectedMetrics {
+  return {
+    asOfDate: '2026-04-25T00:00:00.000Z',
+    projectionDate: '2026-04-25T00:00:00.000Z',
+    projectedDeployment: [],
+    projectedDistributions: [],
+    projectedNAV: [],
+    expectedTVPI: 2.5,
+    expectedIRR: 0.25,
+    expectedDPI: 0,
+    totalReserveNeeds: 0,
+    allocatedReserves: 0,
+    unallocatedReserves: 0,
+    reserveAllocationRate: 0,
+    deploymentPace: 'behind',
+    quartersRemaining: 8,
+    recommendedQuarterlyDeployment: 5_000_000,
+  };
+}
+
+function makeTarget(): TargetMetrics {
+  return {
+    targetFundSize: 100_000_000,
+    targetIRR: 0.25,
+    targetTVPI: 2.5,
+    targetDeploymentYears: 3,
+    targetCompanyCount: 20,
+    targetAverageCheckSize: 5_000_000,
+  };
+}
+
+describe('VarianceCalculator portfolio construction status', () => {
+  it('does not report 3 of 20 companies as on track', () => {
+    const variance = new VarianceCalculator().calculate(
+      makeActual(),
+      makeProjected(),
+      makeTarget()
+    );
+
+    expect(variance.portfolioVariance).toMatchObject({
+      actualCompanies: 3,
+      targetCompanies: 20,
+      variance: -17,
+      onTrack: false,
+    });
+  });
+
+  it('allows near-complete company counts to remain on track', () => {
+    const variance = new VarianceCalculator().calculate(
+      makeActual({ totalCompanies: 18 }),
+      makeProjected(),
+      makeTarget()
+    );
+
+    expect(variance.portfolioVariance.onTrack).toBe(true);
+  });
+});


### PR DESCRIPTION
The QA pass showed core GP surfaces were reachable but untrustworthy: reserve planning received HTML for JSON, KPI metrics disagreed with portfolio detail, deterministic modeling routes lost the active fund, and backtesting stopped at queue availability. This tightens the canonical localhost route contract, reuses existing metric and backtest services, and adds focused regression coverage around the report failures.

Constraint: localhost:5000 QA is served by server/routes.ts registerRoutes(app); server/app.ts stays parity-only for UI-visible APIs

Constraint: No new dependencies or deferred product expansion

Rejected: Build new reporting, cap-table, or edit workflows | outside the QA revision and deferred surface contract

Rejected: Keep company-count target tied to deployment progress | labeled 3/20 companies on track

Confidence: high

Scope-risk: moderate

Directive: Do not reintroduce route mounts on only one server entrypoint without smoke coverage on the canonical registerRoutes path

Tested: Targeted Vitest 28 tests; npm run check; npm run lint; npm run build; npm run test:smoke

Not-tested: Full live browser QA against seeded Test Fund I