### PR TITLE
Constrain public share access to immutable snapshots

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -15,6 +15,9 @@ exclude_paths:
   - 'dist/**'
   - 'build/**'
   - 'coverage/**'
+  # This is a PostgreSQL rollback migration; Codacy's SQL Server rules request
+  # T-SQL SET directives that would make the migration invalid.
+  - 'server/migrations/20260427_public_share_snapshots.down.sql'
   - '**/*.test.ts'
   - '**/*.test.tsx'
   - '**/*.spec.ts'

--- a/client/src/pages/dashboard-modern.tsx
+++ b/client/src/pages/dashboard-modern.tsx
@@ -19,6 +19,7 @@ import type { CreateShareLinkRequest } from '@shared/sharing-schema';
 import { useFundMetrics } from '@/hooks/useFundMetrics';
 import { dollarsToCents, formatCents } from '@/lib/units';
 import type { UnifiedFundMetrics } from '@shared/types/metrics';
+import { getErrorMessage } from '@/lib/http-response';
 
 function formatDollars(value: number): string {
   return formatCents(dollarsToCents(value), { compact: true });
@@ -154,20 +155,32 @@ export default function ModernDashboard() {
   const [activeView, setActiveView] = useState('overview');
   const metricsQuery = useFundMetrics({ enabled: Boolean(currentFund) });
 
-  // Mock function to create share links - replace with actual API call
   const handleCreateShare = async (
     config: CreateShareLinkRequest
   ): Promise<{ shareUrl: string; shareId: string }> => {
-    void config;
+    const response = await fetch('/api/shares', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': crypto.randomUUID(),
+      },
+      body: JSON.stringify(config),
+    });
 
-    // Simulate API call
-    const shareId = 'demo-share-123';
-    const shareUrl = `${window.location.origin}/shared/${shareId}`;
+    const body = (await response.json()) as unknown;
+    if (!response.ok) {
+      throw new Error(getErrorMessage(body) ?? 'Failed to create share link');
+    }
 
-    // Simulate delay
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const share = (body as { share?: { id?: string; shareUrl?: string } }).share;
+    if (!share?.id || !share.shareUrl) {
+      throw new Error('Share API returned an invalid response');
+    }
 
-    return { shareUrl, shareId };
+    return {
+      shareId: share.id,
+      shareUrl: `${window.location.origin}${share.shareUrl}`,
+    };
   };
 
   if (isLoading || !currentFund) {

--- a/client/src/pages/shared-dashboard.tsx
+++ b/client/src/pages/shared-dashboard.tsx
@@ -25,6 +25,34 @@ interface ShareApiResponse {
   share?: ShareData;
 }
 
+type ShareResponseState =
+  | { kind: 'error'; message: string }
+  | { kind: 'passkey'; share: ShareData }
+  | { kind: 'snapshot'; share: ShareData; snapshot: PublicShareSnapshotPayload };
+
+function shareResponseError(body: ShareApiResponse, fallback: string): string {
+  return body.message ?? body.error ?? fallback;
+}
+
+function classifyShareResponse(body: ShareApiResponse): ShareResponseState {
+  if (!body.success || !body.share) {
+    return { kind: 'error', message: shareResponseError(body, 'Failed to load share') };
+  }
+
+  const { share } = body;
+  const { snapshot } = share;
+
+  if (share.requirePasskey && !snapshot) {
+    return { kind: 'passkey', share };
+  }
+
+  if (!snapshot) {
+    return { kind: 'error', message: 'Public share snapshot is unavailable' };
+  }
+
+  return { kind: 'snapshot', share, snapshot };
+}
+
 const useSharedDashboard = (shareId: string) => {
   const [shareData, setShareData] = useState<ShareData | null>(null);
   const [snapshot, setSnapshot] = useState<PublicShareSnapshotPayload | null>(null);
@@ -33,25 +61,22 @@ const useSharedDashboard = (shareId: string) => {
   const [requiresPasskey, setRequiresPasskey] = useState(false);
 
   const applyShareResponse = useCallback((body: ShareApiResponse) => {
-    if (!body.success || !body.share) {
-      setError(body.message ?? body.error ?? 'Failed to load share');
+    const state = classifyShareResponse(body);
+
+    if (state.kind === 'error') {
+      setError(state.message);
       return false;
     }
 
-    setShareData(body.share);
-    if (body.share.requirePasskey && !body.share.snapshot) {
+    setShareData(state.share);
+    if (state.kind === 'passkey') {
       setRequiresPasskey(true);
       setSnapshot(null);
       return true;
     }
 
-    if (!body.share.snapshot) {
-      setError('Public share snapshot is unavailable');
-      return false;
-    }
-
     setRequiresPasskey(false);
-    setSnapshot(body.share.snapshot);
+    setSnapshot(state.snapshot);
     return true;
   }, []);
 
@@ -64,7 +89,7 @@ const useSharedDashboard = (shareId: string) => {
         const body = (await response.json()) as ShareApiResponse;
 
         if (!response.ok) {
-          setError(body.message ?? body.error ?? 'Failed to load share');
+          setError(shareResponseError(body, 'Failed to load share'));
           return;
         }
 
@@ -96,7 +121,7 @@ const useSharedDashboard = (shareId: string) => {
         const body = (await response.json()) as ShareApiResponse;
 
         if (!response.ok) {
-          setError(body.message ?? body.error ?? 'Verification failed');
+          setError(shareResponseError(body, 'Verification failed'));
           return false;
         }
 

--- a/client/src/pages/shared-dashboard.tsx
+++ b/client/src/pages/shared-dashboard.tsx
@@ -1,118 +1,74 @@
-/**
- * Shared Dashboard for LP Access
- * Displays fund metrics with LP-appropriate visibility controls
- *
- * Uses the shares API:
- * - GET /api/shares/:shareId - Get share details
- * - POST /api/shares/:shareId/verify - Verify passkey
- */
-
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useRoute } from 'wouter';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Shield, Eye, Clock, AlertCircle, CheckCircle, Printer } from 'lucide-react';
+import type {
+  PublicMetricValue,
+  PublicShareSnapshotPayload,
+} from '@shared/contracts/public-share-snapshot.contract';
 
 interface ShareData {
   id: string;
-  fundId?: string;
-  accessLevel?: string;
   requirePasskey: boolean;
-  hiddenMetrics?: string[];
   customTitle?: string | null;
   customMessage?: string | null;
+  expiresAt?: string | null;
+  snapshot?: PublicShareSnapshotPayload;
 }
 
 interface ShareApiResponse {
   success?: boolean;
   error?: string;
+  message?: string;
   share?: ShareData;
 }
 
-interface DashboardApiResponse {
-  fund?: {
-    name?: string;
-    size?: string;
-    deployedCapital?: string;
-  };
-  summary?: {
-    currentIRR?: number;
-    totalCompanies?: number;
-  };
-  metrics?: {
-    irr?: number;
-    moic?: number;
-    dpi?: number;
-    rvpi?: number;
-  };
-  portfolioCompanies?: Array<{
-    name: string;
-    stage?: string;
-    moic?: number;
-    status?: string;
-  }>;
-}
-
-interface DashboardData {
-  fundName: string;
-  totalCommitments: number;
-  totalCalled: number;
-  totalDistributed: number;
-  nav: number;
-  portfolioCompanies: number;
-  metrics: {
-    irr: number;
-    moic: number;
-    dpi: number;
-    rvpi: number;
-  };
-  topPerformers: Array<{
-    name: string;
-    stage: string;
-    moic: number;
-    status: string;
-  }>;
-}
-
-// Hook to fetch share data from API
 const useSharedDashboard = (shareId: string) => {
   const [shareData, setShareData] = useState<ShareData | null>(null);
-  const [dashboardData, setDashboardData] = useState<DashboardData | null>(null);
+  const [snapshot, setSnapshot] = useState<PublicShareSnapshotPayload | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [requiresPasskey, setRequiresPasskey] = useState(false);
 
-  // Initial fetch - get share info
+  const applyShareResponse = useCallback((body: ShareApiResponse) => {
+    if (!body.success || !body.share) {
+      setError(body.message ?? body.error ?? 'Failed to load share');
+      return false;
+    }
+
+    setShareData(body.share);
+    if (body.share.requirePasskey && !body.share.snapshot) {
+      setRequiresPasskey(true);
+      setSnapshot(null);
+      return true;
+    }
+
+    if (!body.share.snapshot) {
+      setError('Public share snapshot is unavailable');
+      return false;
+    }
+
+    setRequiresPasskey(false);
+    setSnapshot(body.share.snapshot);
+    return true;
+  }, []);
+
   useEffect(() => {
     const fetchShare = async () => {
       try {
         setIsLoading(true);
-        const response = await fetch(`/api/shares/${shareId}`);
+        setError(null);
+        const response = await fetch(`/api/public/shares/${shareId}`);
         const body = (await response.json()) as ShareApiResponse;
 
         if (!response.ok) {
-          if (response.status === 404) {
-            setError('Share link not found');
-          } else if (response.status === 410) {
-            setError(body.error ?? 'Share has expired or been revoked');
-          } else {
-            setError(body.error ?? 'Failed to load share');
-          }
+          setError(body.message ?? body.error ?? 'Failed to load share');
           return;
         }
 
-        if (body.success && body.share) {
-          setShareData(body.share);
-
-          // If passkey required and no fundId returned, need passkey verification
-          if (body.share.requirePasskey && !body.share.fundId) {
-            setRequiresPasskey(true);
-          } else if (body.share.fundId) {
-            // No passkey required - fetch dashboard data
-            await fetchDashboardData(body.share.fundId);
-          }
-        }
+        applyShareResponse(body);
       } catch {
         setError('Failed to connect to server');
       } finally {
@@ -123,16 +79,15 @@ const useSharedDashboard = (shareId: string) => {
     if (shareId) {
       fetchShare();
     }
-  }, [shareId]);
+  }, [applyShareResponse, shareId]);
 
-  // Verify passkey and get full share data
   const verifyPasskey = useCallback(
     async (passkey: string): Promise<boolean> => {
       try {
         setIsLoading(true);
         setError(null);
 
-        const response = await fetch(`/api/shares/${shareId}/verify`, {
+        const response = await fetch(`/api/public/shares/${shareId}/verify`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ passkey }),
@@ -141,22 +96,11 @@ const useSharedDashboard = (shareId: string) => {
         const body = (await response.json()) as ShareApiResponse;
 
         if (!response.ok) {
-          if (response.status === 401) {
-            setError('Invalid passkey');
-            return false;
-          }
-          setError(body.error ?? 'Verification failed');
+          setError(body.message ?? body.error ?? 'Verification failed');
           return false;
         }
 
-        if (body.success && body.share && body.share.fundId) {
-          setShareData(body.share);
-          setRequiresPasskey(false);
-          await fetchDashboardData(body.share.fundId);
-          return true;
-        }
-
-        return false;
+        return applyShareResponse(body);
       } catch {
         setError('Failed to verify passkey');
         return false;
@@ -164,70 +108,12 @@ const useSharedDashboard = (shareId: string) => {
         setIsLoading(false);
       }
     },
-    [shareId]
+    [applyShareResponse, shareId]
   );
-
-  // Fetch fund dashboard data
-  const fetchDashboardData = async (fundId: string) => {
-    try {
-      // Fetch fund metrics from the fund API
-      const response = await fetch(`/api/dashboard-summary/${fundId}`);
-
-      if (response.ok) {
-        const data = (await response.json()) as DashboardApiResponse;
-        // Transform API response to dashboard format
-        setDashboardData({
-          fundName: data.fund?.name ?? 'Fund',
-          totalCommitments: parseFloat(data.fund?.size ?? '0'),
-          totalCalled: parseFloat(data.fund?.deployedCapital ?? '0'),
-          totalDistributed: data.summary?.currentIRR ? parseFloat(data.fund?.size ?? '0') * 0.3 : 0,
-          nav: parseFloat(data.fund?.size ?? '0') * 1.2,
-          portfolioCompanies: data.summary?.totalCompanies ?? 0,
-          metrics: {
-            irr: data.metrics?.irr ?? data.summary?.currentIRR ?? 0,
-            moic: data.metrics?.moic ?? 1.0,
-            dpi: data.metrics?.dpi ?? 0,
-            rvpi: data.metrics?.rvpi ?? 1.0,
-          },
-          topPerformers:
-            data.portfolioCompanies?.slice(0, 5).map((c) => ({
-              name: c.name,
-              stage: c.stage ?? 'Active',
-              moic: c.moic ?? 1.0,
-              status: c.status ?? 'Active',
-            })) ?? [],
-        });
-      } else {
-        // Use placeholder data if fund API not available
-        setDashboardData({
-          fundName: 'Venture Fund',
-          totalCommitments: 50000000,
-          totalCalled: 35000000,
-          totalDistributed: 15000000,
-          nav: 45000000,
-          portfolioCompanies: 25,
-          metrics: { irr: 18.5, moic: 1.4, dpi: 0.43, rvpi: 1.29 },
-          topPerformers: [],
-        });
-      }
-    } catch {
-      // Use placeholder on error
-      setDashboardData({
-        fundName: 'Venture Fund',
-        totalCommitments: 50000000,
-        totalCalled: 35000000,
-        totalDistributed: 15000000,
-        nav: 45000000,
-        portfolioCompanies: 25,
-        metrics: { irr: 18.5, moic: 1.4, dpi: 0.43, rvpi: 1.29 },
-        topPerformers: [],
-      });
-    }
-  };
 
   return {
     shareConfig: shareData,
-    dashboardData,
+    snapshot,
     isLoading,
     error,
     requiresPasskey,
@@ -235,28 +121,68 @@ const useSharedDashboard = (shareId: string) => {
   };
 };
 
+function formatMetric(metric: PublicMetricValue): string {
+  if (metric.availability !== 'available' || metric.value === null) {
+    return 'Unavailable';
+  }
+
+  if (metric.unit === 'currency') {
+    return `$${(metric.value / 1000000).toFixed(1)}M`;
+  }
+
+  if (metric.unit === 'percent') {
+    return `${metric.value.toFixed(1)}%`;
+  }
+
+  if (metric.unit === 'multiple') {
+    return `${metric.value.toFixed(2)}x`;
+  }
+
+  return String(metric.value);
+}
+
+function MetricCard({ metric }: { metric: PublicMetricValue }) {
+  const unavailable = metric.availability !== 'available';
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium text-gray-600">{metric.label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className={`text-2xl font-bold ${unavailable ? 'text-gray-500' : 'text-gray-900'}`}>
+          {formatMetric(metric)}
+        </div>
+        <p className="mt-2 text-xs text-gray-500">
+          {unavailable
+            ? (metric.unavailableReason ?? 'Source data unavailable')
+            : `${metric.source} as of ${new Date(metric.asOfDate).toLocaleDateString()}`}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
 const SharedDashboard: React.FC = () => {
   const [, params] = useRoute('/shared/:shareId');
   const shareId = params?.shareId ?? '';
   const [enteredPasskey, setEnteredPasskey] = useState('');
   const [passkeyError, setPasskeyError] = useState<string | null>(null);
 
-  const { shareConfig, dashboardData, isLoading, error, requiresPasskey, verifyPasskey } =
+  const { shareConfig, snapshot, isLoading, error, requiresPasskey, verifyPasskey } =
     useSharedDashboard(shareId);
 
-  // Track view analytics (server-side via recordShareView)
   useEffect(() => {
-    if (shareConfig && dashboardData && !isLoading) {
+    if (shareConfig && snapshot && !isLoading) {
       const startTime = Date.now();
       return () => {
         const duration = Math.round((Date.now() - startTime) / 1000);
-        // Duration could be sent to analytics endpoint
         if (duration > 5) {
           // Duration is intentionally tracked for future analytics integration.
         }
       };
     }
-  }, [shareConfig, dashboardData, isLoading]);
+  }, [shareConfig, snapshot, isLoading]);
 
   const handlePasskeySubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -350,23 +276,18 @@ const SharedDashboard: React.FC = () => {
     );
   }
 
-  if (!shareConfig || !dashboardData) {
+  if (!snapshot) {
     return null;
   }
 
   return (
     <div className="min-h-screen bg-gray-50 print:bg-white">
-      {/* Header */}
       <div className="bg-white border-b print:border-0">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">
-                {shareConfig?.customTitle || `${dashboardData?.fundName || 'Fund'} Dashboard`}
-              </h1>
-              {shareConfig?.customMessage && (
-                <p className="text-gray-600 mt-1">{shareConfig.customMessage}</p>
-              )}
+              <h1 className="text-2xl font-bold text-gray-900">{snapshot.title}</h1>
+              {snapshot.message && <p className="text-gray-600 mt-1">{snapshot.message}</p>}
             </div>
             <div className="flex items-center gap-4 no-print">
               <Button
@@ -387,149 +308,60 @@ const SharedDashboard: React.FC = () => {
         </div>
       </div>
 
-      {/* Dashboard Content */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Fund Overview */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">Total Commitments</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                ${(dashboardData.totalCommitments / 1000000).toFixed(1)}M
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">Capital Called</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                ${(dashboardData.totalCalled / 1000000).toFixed(1)}M
-              </div>
-              <div className="text-sm text-gray-500">
-                {((dashboardData.totalCalled / dashboardData.totalCommitments) * 100).toFixed(1)}%
-                of commitments
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">Distributions</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                ${(dashboardData.totalDistributed / 1000000).toFixed(1)}M
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">Current NAV</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">${(dashboardData.nav / 1000000).toFixed(1)}M</div>
-            </CardContent>
-          </Card>
+          {snapshot.metrics.map((metric) => (
+            <MetricCard key={metric.id} metric={metric} />
+          ))}
         </div>
 
-        {/* Performance Metrics */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">IRR</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold text-green-600">
-                {dashboardData.metrics.irr.toFixed(1)}%
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">MOIC</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{dashboardData.metrics.moic.toFixed(1)}x</div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">DPI</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{dashboardData.metrics.dpi.toFixed(2)}x</div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600">RVPI</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{dashboardData.metrics.rvpi.toFixed(2)}x</div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Top Performers */}
         <Card>
           <CardHeader>
-            <CardTitle>Top Portfolio Companies</CardTitle>
+            <CardTitle>Public Portfolio Snapshot</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b">
-                    <th className="text-left py-2">Company</th>
-                    <th className="text-left py-2">Stage</th>
-                    <th className="text-left py-2">MOIC</th>
-                    <th className="text-left py-2">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {dashboardData.topPerformers.map((company, index) => (
-                    <tr key={index} className="border-b">
-                      <td className="py-3 font-medium">{company.name}</td>
-                      <td className="py-3">{company.stage}</td>
-                      <td className="py-3 font-bold">{company.moic.toFixed(1)}x</td>
-                      <td className="py-3">
-                        <span
-                          className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
-                            company.status === 'Active'
-                              ? 'bg-green-100 text-green-800'
-                              : 'bg-blue-100 text-blue-800'
-                          }`}
-                        >
-                          {company.status}
-                        </span>
-                      </td>
+            {snapshot.portfolioCompanies.length === 0 ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                Portfolio company details are unavailable in this public snapshot.
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-2">Company</th>
+                      <th className="text-left py-2">Stage</th>
+                      <th className="text-left py-2">MOIC</th>
+                      <th className="text-left py-2">Status</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                  </thead>
+                  <tbody>
+                    {snapshot.portfolioCompanies.map((company) => (
+                      <tr key={company.name} className="border-b">
+                        <td className="py-3 font-medium">{company.name}</td>
+                        <td className="py-3">{company.stage ?? 'Unavailable'}</td>
+                        <td className="py-3 font-bold">
+                          {company.moic === null ? 'Unavailable' : `${company.moic.toFixed(1)}x`}
+                        </td>
+                        <td className="py-3">{company.status ?? 'Unavailable'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </CardContent>
         </Card>
 
-        {/* Footer */}
         <div className="mt-12 pt-8 border-t text-center text-sm text-gray-500">
           <div className="flex items-center justify-center gap-4">
             <div className="flex items-center gap-1">
               <CheckCircle className="h-4 w-4 text-green-500" />
-              Secure Access
+              Server-authorized Snapshot
             </div>
             <div className="flex items-center gap-1">
               <Clock className="h-4 w-4" />
-              Last Updated: {new Date().toLocaleDateString()}
+              As of {new Date(snapshot.asOfDate).toLocaleDateString()}
             </div>
           </div>
           <p className="mt-2">

--- a/server/lib/public-api-boundary.ts
+++ b/server/lib/public-api-boundary.ts
@@ -9,10 +9,19 @@ function normalizeMountRelativePath(mountRelativePath: string): string {
   return mountRelativePath;
 }
 
-export function isPublicApiPath(_method: string, mountRelativePath: string): boolean {
+export function isPublicApiPath(method: string, mountRelativePath: string): boolean {
   const normalizedPath = normalizeMountRelativePath(mountRelativePath);
+  const normalizedMethod = method.toUpperCase();
 
   if (ALWAYS_PUBLIC_EXACT.has(normalizedPath)) {
+    return true;
+  }
+
+  if (normalizedMethod === 'GET' && /^\/public\/shares\/[^/]+$/.test(normalizedPath)) {
+    return true;
+  }
+
+  if (normalizedMethod === 'POST' && /^\/public\/shares\/[^/]+\/verify$/.test(normalizedPath)) {
     return true;
   }
 

--- a/server/lib/stable-json.ts
+++ b/server/lib/stable-json.ts
@@ -1,0 +1,24 @@
+export interface StableJsonOptions {
+  omitUndefinedObjectKeys?: boolean;
+}
+
+export function stableJson(value: unknown, options: StableJsonOptions = {}): string {
+  if (value === undefined) return 'null';
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item, options)).join(',')}]`;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record)
+      .filter((key) => !options.omitUndefinedObjectKeys || record[key] !== undefined)
+      .sort();
+
+    return `{${keys
+      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key], options)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}

--- a/server/migrations/20260427_public_share_snapshots.down.sql
+++ b/server/migrations/20260427_public_share_snapshots.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS share_snapshots_payload_hash_idx;
+DROP INDEX IF EXISTS share_snapshots_share_generated_idx;
+DROP TABLE IF EXISTS share_snapshots;
+DROP INDEX IF EXISTS shares_creator_idempotency_key_idx;
+ALTER TABLE shares
+  DROP COLUMN IF EXISTS idempotency_request_hash,
+  DROP COLUMN IF EXISTS idempotency_key,
+  DROP COLUMN IF EXISTS version;

--- a/server/migrations/20260427_public_share_snapshots.up.sql
+++ b/server/migrations/20260427_public_share_snapshots.up.sql
@@ -1,0 +1,30 @@
+ALTER TABLE shares
+  ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS idempotency_key text,
+  ADD COLUMN IF NOT EXISTS idempotency_request_hash text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS shares_creator_idempotency_key_idx
+  ON shares (created_by, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS share_snapshots (
+  id text PRIMARY KEY,
+  share_id text NOT NULL REFERENCES shares(id) ON DELETE CASCADE,
+  fund_id_internal text NOT NULL,
+  payload_version text NOT NULL DEFAULT 'public-share-snapshot.v1',
+  as_of_date timestamptz NOT NULL,
+  source_calculation_run_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  hidden_metric_policy jsonb NOT NULL,
+  generated_by text NOT NULL,
+  generated_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  payload_hash text NOT NULL,
+  payload jsonb NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS share_snapshots_share_generated_idx
+  ON share_snapshots (share_id, generated_at);
+
+CREATE INDEX IF NOT EXISTS share_snapshots_payload_hash_idx
+  ON share_snapshots (payload_hash);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -121,6 +121,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Shares routes (fund sharing system)
   const sharesRoutes = await import('./routes/shares.js');
   app.use('/api/shares', sharesRoutes.sharesRouter);
+  app.use('/api/public/shares', sharesRoutes.publicSharesRouter);
 
   // Middleware to record HTTP metrics
   app.use((req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -117,6 +117,8 @@ const VerifyPasskeySchema = z.object({
   passkey: z.string().min(1),
 });
 
+type CreateShareRequest = z.infer<typeof CreateShareRequestSchema>;
+
 function versionETag(share: Pick<Share, 'version'>): string {
   return `"${share.version}"`;
 }
@@ -197,6 +199,102 @@ function serializeManagementShare(share: Share) {
     createdAt: share.createdAt,
     updatedAt: share.updatedAt,
   };
+}
+
+function resolveCreateExpiresAt(expiresInDays: CreateShareRequest['expiresInDays']): Date | null {
+  if (!expiresInDays) return null;
+
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + expiresInDays);
+  return expiresAt;
+}
+
+function resolveCreatePasskeyHash(
+  body: Pick<CreateShareRequest, 'requirePasskey' | 'passkey'>
+): string | null {
+  if (!body.requirePasskey || !body.passkey) return null;
+  return hashPasskey(body.passkey);
+}
+
+function buildShareInsertValues(params: {
+  body: CreateShareRequest;
+  shareId: string;
+  userId: string;
+  expiresAt: Date | null;
+  idempotencyKey: string | undefined;
+  idempotencyRequestHash: string;
+  now: Date;
+}): typeof shares.$inferInsert {
+  const { body, shareId, userId, expiresAt, idempotencyKey, idempotencyRequestHash, now } = params;
+
+  return {
+    id: shareId,
+    fundId: body.fundId,
+    createdBy: userId,
+    accessLevel: body.accessLevel,
+    requirePasskey: body.requirePasskey,
+    passkeyHash: resolveCreatePasskeyHash(body),
+    expiresAt,
+    hiddenMetrics: body.hiddenMetrics,
+    customTitle: body.customTitle ?? null,
+    customMessage: body.customMessage ?? null,
+    idempotencyKey: idempotencyKey ?? null,
+    idempotencyRequestHash: idempotencyKey ? idempotencyRequestHash : null,
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function createShareWithSnapshot(
+  values: typeof shares.$inferInsert,
+  generatedBy: string
+): Promise<Share> {
+  return db.transaction(async (tx) => {
+    const [createdShare] = await tx.insert(shares).values(values).returning();
+
+    if (!createdShare) {
+      throw new Error('Failed to create share');
+    }
+
+    await createShareSnapshot(createdShare, generatedBy, tx);
+    return createdShare;
+  });
+}
+
+async function findIdempotentShare(
+  userId: string,
+  idempotencyKey: string
+): Promise<Share | undefined> {
+  const [existingShare] = await db
+    .select()
+    .from(shares)
+    .where(and(eq(shares.createdBy, userId), eq(shares.idempotencyKey, idempotencyKey)))
+    .limit(1);
+
+  return existingShare;
+}
+
+function isIdempotencyConflict(existingShare: Share, requestHash: string): boolean {
+  return Boolean(
+    existingShare.idempotencyRequestHash && existingShare.idempotencyRequestHash !== requestHash
+  );
+}
+
+function sendIdempotentShareResponse(res: Response, existingShare: Share, requestHash: string) {
+  if (isIdempotencyConflict(existingShare, requestHash)) {
+    return res.status(409).json({
+      success: false,
+      error: 'idempotency_key_reused',
+      message: 'Idempotency key was already used with a different share request',
+    });
+  }
+
+  res.setHeader('ETag', versionETag(existingShare));
+  return res.status(200).json({
+    success: true,
+    share: serializeManagementShare(existingShare),
+  });
 }
 
 async function findShare(shareId: string): Promise<Share | undefined> {
@@ -309,73 +407,26 @@ managementRouter.post('/', async (req: Request, res: Response, next: NextFunctio
     const idempotencyKey = firstString(req.headers['idempotency-key']) ?? body.clientRequestId;
     const idempotencyRequestHash = createShareRequestHash(body);
     if (idempotencyKey) {
-      const [existingShare] = await db
-        .select()
-        .from(shares)
-        .where(and(eq(shares.createdBy, userId), eq(shares.idempotencyKey, idempotencyKey)))
-        .limit(1);
-
+      const existingShare = await findIdempotentShare(userId, idempotencyKey);
       if (existingShare) {
-        if (
-          existingShare.idempotencyRequestHash &&
-          existingShare.idempotencyRequestHash !== idempotencyRequestHash
-        ) {
-          return res.status(409).json({
-            success: false,
-            error: 'idempotency_key_reused',
-            message: 'Idempotency key was already used with a different share request',
-          });
-        }
-
-        res.setHeader('ETag', versionETag(existingShare));
-        return res.status(200).json({
-          success: true,
-          share: serializeManagementShare(existingShare),
-        });
+        return sendIdempotentShareResponse(res, existingShare, idempotencyRequestHash);
       }
-    }
-
-    let expiresAt: Date | null = null;
-    if (body.expiresInDays) {
-      expiresAt = new Date();
-      expiresAt.setDate(expiresAt.getDate() + body.expiresInDays);
     }
 
     const shareId = uuidv4();
     const now = new Date();
-    const share = await db.transaction(async (tx) => {
-      const [createdShare] = await tx
-        .insert(shares)
-        .values({
-          id: shareId,
-          fundId: body.fundId,
-          createdBy: userId,
-          accessLevel: body.accessLevel,
-          requirePasskey: body.requirePasskey,
-          passkeyHash: body.requirePasskey && body.passkey ? hashPasskey(body.passkey) : null,
-          expiresAt,
-          hiddenMetrics: body.hiddenMetrics,
-          customTitle: body.customTitle ?? null,
-          customMessage: body.customMessage ?? null,
-          idempotencyKey: idempotencyKey ?? null,
-          idempotencyRequestHash: idempotencyKey ? idempotencyRequestHash : null,
-          version: 1,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning();
-
-      if (!createdShare) {
-        throw new Error('Failed to create share');
-      }
-
-      await createShareSnapshot(createdShare, userId, tx);
-      return createdShare;
-    });
-
-    if (!share) {
-      return res.status(500).json({ success: false, error: 'Failed to create share' });
-    }
+    const share = await createShareWithSnapshot(
+      buildShareInsertValues({
+        body,
+        shareId,
+        userId,
+        expiresAt: resolveCreateExpiresAt(body.expiresInDays),
+        idempotencyKey,
+        idempotencyRequestHash,
+        now,
+      }),
+      userId
+    );
 
     res.setHeader('ETag', versionETag(share));
 

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -1,90 +1,340 @@
 /**
  * Shares API Routes
  *
- * Endpoints for creating and managing share links for fund dashboards.
- *
- * POST   /api/shares              - Create a share link
- * GET    /api/shares              - List shares for a fund
- * GET    /api/shares/:shareId     - Get share details (public, with passkey if required)
- * PATCH  /api/shares/:shareId     - Update share configuration
- * DELETE /api/shares/:shareId     - Revoke (deactivate) a share
- * POST   /api/shares/:shareId/verify - Verify passkey
- * GET    /api/shares/:shareId/analytics - Get share analytics
+ * /api/shares is authenticated share management.
+ * /api/public/shares is the anonymous public snapshot boundary.
  */
 
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import crypto from 'node:crypto';
+import { and, desc, eq, sql } from 'drizzle-orm';
 import { db } from '../db';
-import { shares, shareAnalytics, SHARE_ACCESS_LEVELS } from '@shared/schema/shares';
-import { eq, desc, sql } from 'drizzle-orm';
+import { shares, shareAnalytics, SHARE_ACCESS_LEVELS, type Share } from '@shared/schema/shares';
 import { LP_HIDDEN_METRICS } from '@shared/sharing-schema';
 import { firstString } from '../lib/request-values';
+import { parseETag } from '../lib/http-preconditions';
+import {
+  createShareSnapshot,
+  getLatestShareSnapshot,
+  markShareSnapshotsRevoked,
+} from '../services/share-snapshot-service';
+import { logger } from '../lib/logger.js';
+import { stableJson } from '../lib/stable-json.js';
 
-// Password hashing utilities using PBKDF2
 const HASH_ITERATIONS = 100000;
 const HASH_KEY_LENGTH = 64;
 const HASH_ALGORITHM = 'sha512';
 
 function hashPasskey(passkey: string): string {
   const salt = crypto.randomBytes(16).toString('hex');
-  const hash = crypto.pbkdf2Sync(passkey, salt, HASH_ITERATIONS, HASH_KEY_LENGTH, HASH_ALGORITHM).toString('hex');
+  const hash = crypto
+    .pbkdf2Sync(passkey, salt, HASH_ITERATIONS, HASH_KEY_LENGTH, HASH_ALGORITHM)
+    .toString('hex');
   return `${salt}:${hash}`;
 }
 
 function verifyPasskey(passkey: string, storedHash: string): boolean {
   const [salt, hash] = storedHash.split(':');
   if (!salt || !hash) return false;
-  const verifyHash = crypto.pbkdf2Sync(passkey, salt, HASH_ITERATIONS, HASH_KEY_LENGTH, HASH_ALGORITHM).toString('hex');
+  const verifyHash = crypto
+    .pbkdf2Sync(passkey, salt, HASH_ITERATIONS, HASH_KEY_LENGTH, HASH_ALGORITHM)
+    .toString('hex');
   return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(verifyHash));
 }
 
-const router = Router();
+const managementRouter = Router();
+const publicRouter = Router();
 
-// Validation schemas
-const CreateShareRequestSchema = z.object({
-  fundId: z.string().min(1),
-  accessLevel: z.enum(SHARE_ACCESS_LEVELS).default('view_only'),
-  requirePasskey: z.boolean().default(false),
-  passkey: z.string().min(4).max(50).optional(),
-  expiresInDays: z.number().min(1).max(365).optional(),
-  hiddenMetrics: z.array(z.string()).default([...LP_HIDDEN_METRICS]),
-  customTitle: z.string().max(100).optional(),
-  customMessage: z.string().max(500).optional(),
+function publicShareRateLimitKey(req: Request): string {
+  const ipKey = ipKeyGenerator(req.ip ?? req.socket.remoteAddress ?? 'unknown');
+  return `${ipKey}:share:${req.params['shareId'] ?? 'unknown'}`;
+}
+
+const publicShareReadLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: publicShareRateLimitKey,
+  message: {
+    success: false,
+    error: 'too_many_requests',
+    message: 'Too many public share requests. Please try again later.',
+  },
 });
 
-const UpdateShareRequestSchema = z.object({
-  accessLevel: z.enum(SHARE_ACCESS_LEVELS).optional(),
-  requirePasskey: z.boolean().optional(),
-  passkey: z.string().min(4).max(50).optional(),
-  expiresInDays: z.number().min(1).max(365).nullable().optional(),
-  hiddenMetrics: z.array(z.string()).optional(),
-  customTitle: z.string().max(100).nullable().optional(),
-  customMessage: z.string().max(500).nullable().optional(),
-  isActive: z.boolean().optional(),
+const publicShareVerifyLimiter = rateLimit({
+  windowMs: 5 * 60_000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: publicShareRateLimitKey,
+  message: {
+    success: false,
+    error: 'too_many_requests',
+    message: 'Too many passkey attempts. Please try again later.',
+  },
 });
+
+const CreateShareRequestSchema = z
+  .object({
+    fundId: z.string().min(1),
+    accessLevel: z.enum(SHARE_ACCESS_LEVELS).default('view_only'),
+    requirePasskey: z.boolean().default(false),
+    passkey: z.string().min(4).max(50).optional(),
+    expiresInDays: z.number().min(1).max(365).optional(),
+    hiddenMetrics: z.array(z.string()).default([...LP_HIDDEN_METRICS]),
+    customTitle: z.string().max(100).optional(),
+    customMessage: z.string().max(500).optional(),
+    clientRequestId: z.string().min(1).max(128).optional(),
+  })
+  .refine((value) => !value.requirePasskey || Boolean(value.passkey), {
+    path: ['passkey'],
+    message: 'passkey is required when requirePasskey is true',
+  });
+
+const UpdateShareRequestSchema = z
+  .object({
+    accessLevel: z.enum(SHARE_ACCESS_LEVELS).optional(),
+    requirePasskey: z.boolean().optional(),
+    passkey: z.string().min(4).max(50).optional(),
+    expiresInDays: z.number().min(1).max(365).nullable().optional(),
+    hiddenMetrics: z.array(z.string()).optional(),
+    customTitle: z.string().max(100).nullable().optional(),
+    customMessage: z.string().max(500).nullable().optional(),
+    isActive: z.boolean().optional(),
+  })
+  .refine((value) => value.requirePasskey !== true || Boolean(value.passkey), {
+    path: ['passkey'],
+    message: 'passkey is required when enabling passkey protection',
+  });
 
 const VerifyPasskeySchema = z.object({
   passkey: z.string().min(1),
 });
 
-/**
- * POST /api/shares - Create a share link
- */
-router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const body = CreateShareRequestSchema.parse(req.body);
-    const userId = (req as Request & { user?: { id: string } }).user?.id ?? 'anonymous';
+function versionETag(share: Pick<Share, 'version'>): string {
+  return `"${share.version}"`;
+}
 
-    // Hash passkey if provided
-    let passkeyHash: string | null = null;
-    if (body.requirePasskey && body.passkey) {
-      passkeyHash = hashPasskey(body.passkey);
+function createShareRequestHash(body: z.infer<typeof CreateShareRequestSchema>): string {
+  // Passkey is intentionally part of the fingerprint: retrying with a new
+  // passkey is a different effective create request and needs a new key.
+  const { clientRequestId: _clientRequestId, ...fingerprintBody } = body;
+  return crypto
+    .createHash('sha256')
+    .update(stableJson(fingerprintBody, { omitUndefinedObjectKeys: true }))
+    .digest('hex');
+}
+
+function getAuthenticatedUserId(req: Request): string | undefined {
+  return req.context?.userId ?? req.user?.id;
+}
+
+function requireAuthenticatedUser(req: Request, res: Response): string | undefined {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) {
+    res.status(401).json({ success: false, error: 'Authentication required' });
+    return undefined;
+  }
+  return userId;
+}
+
+function canManageFund(req: Request, fundId: string): boolean {
+  if (req.context?.role === 'admin' || req.user?.isAdmin) return true;
+  if (req.context?.fundId && req.context.fundId === fundId) return true;
+
+  const numericFundId = Number(fundId);
+  if (Number.isFinite(numericFundId) && req.user?.fundIds?.includes(numericFundId)) {
+    return true;
+  }
+
+  return false;
+}
+
+function requireShareVersion(req: Request, res: Response, share: Share): boolean {
+  const ifMatch = firstString(req.headers['if-match']);
+  if (!ifMatch) {
+    res.status(428).json({
+      success: false,
+      error: 'precondition_required',
+      message: 'If-Match header is required for share mutations',
+      current: versionETag(share),
+    });
+    return false;
+  }
+
+  if (parseETag(ifMatch) !== String(share.version)) {
+    res.status(412).json({
+      success: false,
+      error: 'precondition_failed',
+      message: 'Share has been modified',
+      current: versionETag(share),
+    });
+    return false;
+  }
+
+  return true;
+}
+
+function serializeManagementShare(share: Share) {
+  return {
+    id: share.id,
+    fundId: share.fundId,
+    accessLevel: share.accessLevel,
+    requirePasskey: share.requirePasskey,
+    expiresAt: share.expiresAt,
+    hiddenMetrics: share.hiddenMetrics,
+    customTitle: share.customTitle,
+    customMessage: share.customMessage,
+    isActive: share.isActive,
+    version: share.version,
+    shareUrl: `/shared/${share.id}`,
+    createdAt: share.createdAt,
+    updatedAt: share.updatedAt,
+  };
+}
+
+async function findShare(shareId: string): Promise<Share | undefined> {
+  const [share] = await db.select().from(shares).where(eq(shares.id, shareId)).limit(1);
+  return share;
+}
+
+async function recordShareView(shareId: string, req: Request) {
+  const viewerIp = req.ip ?? req.socket.remoteAddress ?? null;
+  const userAgent = req.get('user-agent') ?? null;
+
+  await db
+    .update(shares)
+    .set({
+      viewCount: sql`${shares.viewCount} + 1`,
+      lastViewedAt: new Date(),
+    })
+    .where(eq(shares.id, shareId));
+
+  await db.insert(shareAnalytics).values({
+    id: uuidv4(),
+    shareId,
+    viewerIp,
+    userAgent,
+    viewedAt: new Date(),
+  });
+}
+
+async function sendPublicSharePayload(
+  req: Request,
+  res: Response,
+  share: Share,
+  verified: boolean
+) {
+  if (!share.isActive) {
+    return res.status(410).json({ success: false, error: 'Share has been revoked' });
+  }
+
+  if (share.expiresAt && new Date() > share.expiresAt) {
+    return res.status(410).json({ success: false, error: 'Share has expired' });
+  }
+
+  if (share.requirePasskey && !verified) {
+    return res.json({
+      success: true,
+      share: {
+        id: share.id,
+        requirePasskey: true,
+        customTitle: share.customTitle,
+        customMessage: share.customMessage,
+        expiresAt: share.expiresAt?.toISOString() ?? null,
+      },
+    });
+  }
+
+  const snapshot = await getLatestShareSnapshot(share.id);
+  if (!snapshot) {
+    return res.status(503).json({
+      success: false,
+      error: 'snapshot_unavailable',
+      message: 'Public share snapshot is unavailable',
+    });
+  }
+
+  if (snapshot.revokedAt) {
+    return res.status(410).json({ success: false, error: 'Share has been revoked' });
+  }
+
+  const responseETag = `"${snapshot.payloadHash}"`;
+  res.setHeader('ETag', responseETag);
+  res.setHeader('Cache-Control', 'private, no-cache, must-revalidate');
+
+  if (
+    req.method === 'GET' &&
+    parseETag(firstString(req.headers['if-none-match'])) === parseETag(responseETag)
+  ) {
+    return res.status(304).end();
+  }
+
+  void recordShareView(share.id, req).catch((error: unknown) => {
+    logger.warn({ err: error, shareId: share.id }, 'Failed to record public share view');
+  });
+
+  return res.json({
+    success: true,
+    share: {
+      id: share.id,
+      requirePasskey: share.requirePasskey,
+      customTitle: share.customTitle,
+      customMessage: share.customMessage,
+      expiresAt: share.expiresAt?.toISOString() ?? null,
+      snapshot: snapshot.payload,
+    },
+  });
+}
+
+/**
+ * POST /api/shares - Create a share link and immutable public snapshot.
+ */
+managementRouter.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = requireAuthenticatedUser(req, res);
+    if (!userId) return;
+
+    const body = CreateShareRequestSchema.parse(req.body);
+    if (!canManageFund(req, body.fundId)) {
+      return res.status(403).json({ success: false, error: 'Fund access denied' });
     }
 
-    // Calculate expiration date
+    const idempotencyKey = firstString(req.headers['idempotency-key']) ?? body.clientRequestId;
+    const idempotencyRequestHash = createShareRequestHash(body);
+    if (idempotencyKey) {
+      const [existingShare] = await db
+        .select()
+        .from(shares)
+        .where(and(eq(shares.createdBy, userId), eq(shares.idempotencyKey, idempotencyKey)))
+        .limit(1);
+
+      if (existingShare) {
+        if (
+          existingShare.idempotencyRequestHash &&
+          existingShare.idempotencyRequestHash !== idempotencyRequestHash
+        ) {
+          return res.status(409).json({
+            success: false,
+            error: 'idempotency_key_reused',
+            message: 'Idempotency key was already used with a different share request',
+          });
+        }
+
+        res.setHeader('ETag', versionETag(existingShare));
+        return res.status(200).json({
+          success: true,
+          share: serializeManagementShare(existingShare),
+        });
+      }
+    }
+
     let expiresAt: Date | null = null;
     if (body.expiresInDays) {
       expiresAt = new Date();
@@ -93,83 +343,81 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
 
     const shareId = uuidv4();
     const now = new Date();
+    const share = await db.transaction(async (tx) => {
+      const [createdShare] = await tx
+        .insert(shares)
+        .values({
+          id: shareId,
+          fundId: body.fundId,
+          createdBy: userId,
+          accessLevel: body.accessLevel,
+          requirePasskey: body.requirePasskey,
+          passkeyHash: body.requirePasskey && body.passkey ? hashPasskey(body.passkey) : null,
+          expiresAt,
+          hiddenMetrics: body.hiddenMetrics,
+          customTitle: body.customTitle ?? null,
+          customMessage: body.customMessage ?? null,
+          idempotencyKey: idempotencyKey ?? null,
+          idempotencyRequestHash: idempotencyKey ? idempotencyRequestHash : null,
+          version: 1,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
 
-    const [share] = await db
-      .insert(shares)
-      .values({
-        id: shareId,
-        fundId: body.fundId,
-        createdBy: userId,
-        accessLevel: body.accessLevel,
-        requirePasskey: body.requirePasskey,
-        passkeyHash,
-        expiresAt,
-        hiddenMetrics: body.hiddenMetrics,
-        customTitle: body.customTitle ?? null,
-        customMessage: body.customMessage ?? null,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
+      if (!createdShare) {
+        throw new Error('Failed to create share');
+      }
+
+      await createShareSnapshot(createdShare, userId, tx);
+      return createdShare;
+    });
 
     if (!share) {
       return res.status(500).json({ success: false, error: 'Failed to create share' });
     }
 
-    res.status(201).json({
+    res.setHeader('ETag', versionETag(share));
+
+    return res.status(201).json({
       success: true,
-      share: {
-        id: share.id,
-        fundId: share.fundId,
-        accessLevel: share.accessLevel,
-        requirePasskey: share.requirePasskey,
-        expiresAt: share.expiresAt,
-        hiddenMetrics: share.hiddenMetrics,
-        customTitle: share.customTitle,
-        customMessage: share.customMessage,
-        shareUrl: `/share/${share.id}`,
-        createdAt: share.createdAt,
-      },
+      share: serializeManagementShare(share),
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+      return res
+        .status(400)
+        .json({ success: false, error: 'Validation error', details: error.errors });
     }
     next(error);
   }
 });
 
 /**
- * GET /api/shares - List shares for a fund
+ * GET /api/shares - List shares for a fund.
  */
-router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+managementRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const userId = requireAuthenticatedUser(req, res);
+    if (!userId) return;
+
     const fundId = firstString(req.query['fundId']);
     if (!fundId) {
       return res.status(400).json({ success: false, error: 'fundId query parameter required' });
     }
+    if (!canManageFund(req, fundId)) {
+      return res.status(403).json({ success: false, error: 'Fund access denied' });
+    }
 
     const fundShares = await db
-      .select({
-        id: shares.id,
-        fundId: shares.fundId,
-        accessLevel: shares.accessLevel,
-        requirePasskey: shares.requirePasskey,
-        expiresAt: shares.expiresAt,
-        hiddenMetrics: shares.hiddenMetrics,
-        customTitle: shares.customTitle,
-        viewCount: shares.viewCount,
-        lastViewedAt: shares.lastViewedAt,
-        isActive: shares.isActive,
-        createdAt: shares.createdAt,
-      })
+      .select()
       .from(shares)
       .where(eq(shares.fundId, fundId))
       .orderBy(desc(shares.createdAt));
 
-    res.json({
+    return res.json({
       success: true,
-      shares: fundShares,
+      shares: fundShares.map(serializeManagementShare),
     });
   } catch (error) {
     next(error);
@@ -177,156 +425,39 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 });
 
 /**
- * GET /api/shares/:shareId - Get share details (public endpoint)
+ * PATCH /api/shares/:shareId - Update share configuration.
  */
-router.get('/:shareId', async (req: Request, res: Response, next: NextFunction) => {
+managementRouter.patch('/:shareId', async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const userId = requireAuthenticatedUser(req, res);
+    if (!userId) return;
+
     const shareId = firstString(req.params['shareId']);
     if (!shareId) {
       return res.status(400).json({ success: false, error: 'Share ID is required' });
     }
 
-    const [share] = await db
-      .select()
-      .from(shares)
-      .where(eq(shares.id, shareId))
-      .limit(1);
-
-    if (!share) {
-      return res.status(404).json({ success: false, error: 'Share not found' });
-    }
-
-    if (!share.isActive) {
-      return res.status(410).json({ success: false, error: 'Share has been revoked' });
-    }
-
-    if (share.expiresAt && new Date() > share.expiresAt) {
-      return res.status(410).json({ success: false, error: 'Share has expired' });
-    }
-
-    // If passkey required, don't return full details
-    if (share.requirePasskey) {
-      return res.json({
-        success: true,
-        share: {
-          id: share.id,
-          requirePasskey: true,
-          customTitle: share.customTitle,
-          customMessage: share.customMessage,
-        },
-      });
-    }
-
-    // Record view
-    await recordShareView(shareId, req);
-
-    res.json({
-      success: true,
-      share: {
-        id: share.id,
-        fundId: share.fundId,
-        accessLevel: share.accessLevel,
-        hiddenMetrics: share.hiddenMetrics,
-        customTitle: share.customTitle,
-        customMessage: share.customMessage,
-      },
-    });
-  } catch (error) {
-    next(error);
-  }
-});
-
-/**
- * POST /api/shares/:shareId/verify - Verify passkey
- */
-router.post('/:shareId/verify', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const shareId = firstString(req.params['shareId']);
-    if (!shareId) {
-      return res.status(400).json({ success: false, error: 'Share ID is required' });
-    }
-    const { passkey } = VerifyPasskeySchema.parse(req.body);
-
-    const [share] = await db
-      .select()
-      .from(shares)
-      .where(eq(shares.id, shareId))
-      .limit(1);
-
-    if (!share) {
-      return res.status(404).json({ success: false, error: 'Share not found' });
-    }
-
-    if (!share.isActive) {
-      return res.status(410).json({ success: false, error: 'Share has been revoked' });
-    }
-
-    if (share.expiresAt && new Date() > share.expiresAt) {
-      return res.status(410).json({ success: false, error: 'Share has expired' });
-    }
-
-    if (!share.passkeyHash) {
-      return res.status(400).json({ success: false, error: 'Share does not require passkey' });
-    }
-
-    const isValid = verifyPasskey(passkey, share.passkeyHash);
-    if (!isValid) {
-      return res.status(401).json({ success: false, error: 'Invalid passkey' });
-    }
-
-    // Record view
-    await recordShareView(shareId, req);
-
-    res.json({
-      success: true,
-      share: {
-        id: share.id,
-        fundId: share.fundId,
-        accessLevel: share.accessLevel,
-        hiddenMetrics: share.hiddenMetrics,
-        customTitle: share.customTitle,
-        customMessage: share.customMessage,
-      },
-    });
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
-    }
-    next(error);
-  }
-});
-
-/**
- * PATCH /api/shares/:shareId - Update share configuration
- */
-router.patch('/:shareId', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const shareId = firstString(req.params['shareId']);
-    if (!shareId) {
-      return res.status(400).json({ success: false, error: 'Share ID is required' });
-    }
-    const body = UpdateShareRequestSchema.parse(req.body);
-
-    const [existingShare] = await db
-      .select()
-      .from(shares)
-      .where(eq(shares.id, shareId))
-      .limit(1);
-
+    const existingShare = await findShare(shareId);
     if (!existingShare) {
       return res.status(404).json({ success: false, error: 'Share not found' });
     }
+    if (!canManageFund(req, existingShare.fundId)) {
+      return res.status(403).json({ success: false, error: 'Fund access denied' });
+    }
+    if (!requireShareVersion(req, res, existingShare)) return;
 
-    // Build update object
+    const body = UpdateShareRequestSchema.parse(req.body);
     const updates: Partial<typeof shares.$inferInsert> = {
       updatedAt: new Date(),
+      version: existingShare.version + 1,
     };
 
     if (body.accessLevel !== undefined) updates.accessLevel = body.accessLevel;
-    if (body.requirePasskey !== undefined) updates.requirePasskey = body.requirePasskey;
-    if (body.passkey !== undefined) {
-      updates.passkeyHash = hashPasskey(body.passkey);
+    if (body.requirePasskey !== undefined) {
+      updates.requirePasskey = body.requirePasskey;
+      if (!body.requirePasskey) updates.passkeyHash = null;
     }
+    if (body.passkey !== undefined) updates.passkeyHash = hashPasskey(body.passkey);
     if (body.expiresInDays !== undefined) {
       if (body.expiresInDays === null) {
         updates.expiresAt = null;
@@ -341,129 +472,203 @@ router.patch('/:shareId', async (req: Request, res: Response, next: NextFunction
     if (body.customMessage !== undefined) updates.customMessage = body.customMessage;
     if (body.isActive !== undefined) updates.isActive = body.isActive;
 
-    const [updatedShare] = await db
-      .update(shares)
-      .set(updates)
-      .where(eq(shares.id, shareId))
-      .returning();
+    const updatedShare = await db.transaction(async (tx) => {
+      const [share] = await tx
+        .update(shares)
+        .set(updates)
+        .where(and(eq(shares.id, shareId), eq(shares.version, existingShare.version)))
+        .returning();
+
+      if (!share) return undefined;
+
+      if (share.isActive) {
+        await createShareSnapshot(share, userId, tx);
+      } else {
+        await markShareSnapshotsRevoked(share.id, new Date(), tx);
+      }
+
+      return share;
+    });
 
     if (!updatedShare) {
-      return res.status(404).json({ success: false, error: 'Share not found' });
+      return res.status(412).json({
+        success: false,
+        error: 'precondition_failed',
+        message: 'Share has been modified',
+      });
     }
 
-    res.json({
+    res.setHeader('ETag', versionETag(updatedShare));
+    return res.json({
       success: true,
-      share: {
-        id: updatedShare.id,
-        fundId: updatedShare.fundId,
-        accessLevel: updatedShare.accessLevel,
-        requirePasskey: updatedShare.requirePasskey,
-        expiresAt: updatedShare.expiresAt,
-        hiddenMetrics: updatedShare.hiddenMetrics,
-        customTitle: updatedShare.customTitle,
-        customMessage: updatedShare.customMessage,
-        isActive: updatedShare.isActive,
-        updatedAt: updatedShare.updatedAt,
-      },
+      share: serializeManagementShare(updatedShare),
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+      return res
+        .status(400)
+        .json({ success: false, error: 'Validation error', details: error.errors });
     }
     next(error);
   }
 });
 
 /**
- * DELETE /api/shares/:shareId - Revoke (deactivate) a share
+ * DELETE /api/shares/:shareId - Revoke a share.
  */
-router.delete('/:shareId', async (req: Request, res: Response, next: NextFunction) => {
+managementRouter.delete('/:shareId', async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const userId = requireAuthenticatedUser(req, res);
+    if (!userId) return;
+
     const shareId = firstString(req.params['shareId']);
     if (!shareId) {
       return res.status(400).json({ success: false, error: 'Share ID is required' });
     }
 
-    const [share] = await db
-      .update(shares)
-      .set({ isActive: false, updatedAt: new Date() })
-      .where(eq(shares.id, shareId))
-      .returning();
-
-    if (!share) {
+    const existingShare = await findShare(shareId);
+    if (!existingShare) {
       return res.status(404).json({ success: false, error: 'Share not found' });
     }
-
-    res.json({ success: true, message: 'Share revoked successfully' });
-  } catch (error) {
-    next(error);
-  }
-});
-
-/**
- * GET /api/shares/:shareId/analytics - Get share analytics
- */
-router.get('/:shareId/analytics', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const shareId = firstString(req.params['shareId']);
-    if (!shareId) {
-      return res.status(400).json({ success: false, error: 'Share ID is required' });
+    if (!canManageFund(req, existingShare.fundId)) {
+      return res.status(403).json({ success: false, error: 'Fund access denied' });
     }
+    if (!requireShareVersion(req, res, existingShare)) return;
 
-    const [share] = await db
-      .select()
-      .from(shares)
-      .where(eq(shares.id, shareId))
-      .limit(1);
+    const revokedAt = new Date();
+    const share = await db.transaction(async (tx) => {
+      const [revokedShare] = await tx
+        .update(shares)
+        .set({ isActive: false, updatedAt: revokedAt, version: existingShare.version + 1 })
+        .where(and(eq(shares.id, shareId), eq(shares.version, existingShare.version)))
+        .returning();
 
-    if (!share) {
-      return res.status(404).json({ success: false, error: 'Share not found' });
-    }
+      if (!revokedShare) return undefined;
 
-    const analytics = await db
-      .select()
-      .from(shareAnalytics)
-      .where(eq(shareAnalytics.shareId, shareId))
-      .orderBy(desc(shareAnalytics.viewedAt))
-      .limit(100);
-
-    res.json({
-      success: true,
-      summary: {
-        totalViews: share.viewCount,
-        lastViewedAt: share.lastViewedAt,
-      },
-      views: analytics,
+      await markShareSnapshotsRevoked(shareId, revokedAt, tx);
+      return revokedShare;
     });
+
+    if (!share) {
+      return res.status(412).json({
+        success: false,
+        error: 'precondition_failed',
+        message: 'Share has been modified',
+      });
+    }
+
+    return res.json({ success: true, message: 'Share revoked successfully' });
   } catch (error) {
     next(error);
   }
 });
 
 /**
- * Helper: Record share view
+ * GET /api/shares/:shareId/analytics - Get share analytics.
  */
-async function recordShareView(shareId: string, req: Request) {
-  const viewerIp = req.ip ?? req.socket.remoteAddress ?? null;
-  const userAgent = req.get('user-agent') ?? null;
+managementRouter.get(
+  '/:shareId/analytics',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = requireAuthenticatedUser(req, res);
+      if (!userId) return;
 
-  // Update share view count
-  await db
-    .update(shares)
-    .set({
-      viewCount: sql`${shares.viewCount} + 1`,
-      lastViewedAt: new Date(),
-    })
-    .where(eq(shares.id, shareId));
+      const shareId = firstString(req.params['shareId']);
+      if (!shareId) {
+        return res.status(400).json({ success: false, error: 'Share ID is required' });
+      }
 
-  // Record analytics
-  await db.insert(shareAnalytics).values({
-    id: uuidv4(),
-    shareId,
-    viewerIp,
-    userAgent,
-    viewedAt: new Date(),
-  });
-}
+      const share = await findShare(shareId);
+      if (!share) {
+        return res.status(404).json({ success: false, error: 'Share not found' });
+      }
+      if (!canManageFund(req, share.fundId)) {
+        return res.status(403).json({ success: false, error: 'Fund access denied' });
+      }
 
-export const sharesRouter = router;
+      const analytics = await db
+        .select()
+        .from(shareAnalytics)
+        .where(eq(shareAnalytics.shareId, shareId))
+        .orderBy(desc(shareAnalytics.viewedAt))
+        .limit(100);
+
+      return res.json({
+        success: true,
+        summary: {
+          totalViews: share.viewCount,
+          lastViewedAt: share.lastViewedAt,
+        },
+        views: analytics,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * GET /api/public/shares/:shareId - Anonymous public snapshot read.
+ */
+publicRouter.get(
+  '/:shareId',
+  publicShareReadLimiter,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const shareId = firstString(req.params['shareId']);
+      if (!shareId) {
+        return res.status(400).json({ success: false, error: 'Share ID is required' });
+      }
+
+      const share = await findShare(shareId);
+      if (!share) {
+        return res.status(404).json({ success: false, error: 'Share not found' });
+      }
+
+      return sendPublicSharePayload(req, res, share, false);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * POST /api/public/shares/:shareId/verify - Verify passkey and return public snapshot.
+ */
+publicRouter.post(
+  '/:shareId/verify',
+  publicShareVerifyLimiter,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const shareId = firstString(req.params['shareId']);
+      if (!shareId) {
+        return res.status(400).json({ success: false, error: 'Share ID is required' });
+      }
+
+      const { passkey } = VerifyPasskeySchema.parse(req.body);
+      const share = await findShare(shareId);
+      if (!share) {
+        return res.status(404).json({ success: false, error: 'Share not found' });
+      }
+
+      if (!share.passkeyHash) {
+        return res.status(400).json({ success: false, error: 'Share does not require passkey' });
+      }
+      if (!verifyPasskey(passkey, share.passkeyHash)) {
+        return res.status(401).json({ success: false, error: 'Invalid passkey' });
+      }
+
+      return sendPublicSharePayload(req, res, share, true);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res
+          .status(400)
+          .json({ success: false, error: 'Validation error', details: error.errors });
+      }
+      next(error);
+    }
+  }
+);
+
+export const sharesRouter = managementRouter;
+export const publicSharesRouter = publicRouter;

--- a/server/services/share-snapshot-service.ts
+++ b/server/services/share-snapshot-service.ts
@@ -1,0 +1,315 @@
+import crypto from 'node:crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { desc, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { storage } from '../storage';
+import { getDashboardSummaryReadModel } from './dashboard-summary-read-service';
+import { shareSnapshots, type Share, type ShareSnapshotRecord } from '@shared/schema/shares';
+import { stableJson } from '../lib/stable-json.js';
+import type {
+  PublicMetricValue,
+  PublicPortfolioCompany,
+  PublicShareSnapshotPayload,
+} from '@shared/contracts/public-share-snapshot.contract';
+
+const SNAPSHOT_PAYLOAD_VERSION = 'public-share-snapshot.v1';
+const SNAPSHOT_CALCULATION_VERSION = 'dashboard-summary-read-model.v1';
+type SnapshotDb = Pick<typeof db, 'insert' | 'select' | 'update'>;
+
+function numberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function dateToIso(value: Date | string | null | undefined, fallback: Date): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  return fallback.toISOString();
+}
+
+function availableMetric(
+  id: string,
+  label: string,
+  value: number | null,
+  unit: PublicMetricValue['unit'],
+  source: string,
+  asOfDate: string
+): PublicMetricValue {
+  if (value === null) {
+    return unavailableMetric(id, label, unit, source, asOfDate, 'source_value_missing');
+  }
+
+  return {
+    id,
+    label,
+    value,
+    unit,
+    availability: 'available',
+    source,
+    asOfDate,
+    calculationVersion: SNAPSHOT_CALCULATION_VERSION,
+  };
+}
+
+function unavailableMetric(
+  id: string,
+  label: string,
+  unit: PublicMetricValue['unit'],
+  source: string,
+  asOfDate: string,
+  unavailableReason: string
+): PublicMetricValue {
+  return {
+    id,
+    label,
+    value: null,
+    unit,
+    availability: 'unavailable',
+    source,
+    asOfDate,
+    calculationVersion: SNAPSHOT_CALCULATION_VERSION,
+    unavailableReason,
+  };
+}
+
+function redactMetrics(
+  metrics: PublicMetricValue[],
+  hiddenMetrics: readonly string[] | null | undefined
+): { metrics: PublicMetricValue[]; applied: string[] } {
+  // Hidden metrics must be removed from top-level metrics and any per-row
+  // surfaces that expose the same value, such as portfolioCompanies[*].moic.
+  const hidden = new Set(hiddenMetrics ?? []);
+  const applied = metrics.filter((metric) => hidden.has(metric.id)).map((metric) => metric.id);
+
+  return {
+    metrics: metrics.filter((metric) => !hidden.has(metric.id)),
+    applied,
+  };
+}
+
+function payloadContentFingerprint(payload: PublicShareSnapshotPayload): unknown {
+  const { generatedAt: _generatedAt, snapshotId: _snapshotId, ...content } = payload;
+  return content;
+}
+
+function hashPayload(payload: PublicShareSnapshotPayload): string {
+  return crypto
+    .createHash('sha256')
+    .update(stableJson(payloadContentFingerprint(payload)))
+    .digest('hex');
+}
+
+function portfolioCompanyMoic(company: Record<string, unknown>): number | null {
+  const exitMoicBps = numberOrNull(company['exitMoicBps']);
+  if (exitMoicBps !== null) {
+    return exitMoicBps / 10000;
+  }
+
+  const currentValuation = numberOrNull(company['currentValuation']);
+  const investmentAmount = numberOrNull(company['investmentAmount']);
+  if (currentValuation !== null && investmentAmount !== null && investmentAmount > 0) {
+    return currentValuation / investmentAmount;
+  }
+
+  return null;
+}
+
+export async function buildPublicShareSnapshotPayload(
+  share: Share,
+  _generatedBy: string,
+  snapshotId = uuidv4()
+): Promise<{ payload: PublicShareSnapshotPayload; payloadHash: string }> {
+  const generatedAt = new Date();
+  const fundId = numberOrNull(share.fundId);
+  const readModel =
+    fundId === null ? undefined : await getDashboardSummaryReadModel(storage, fundId);
+  const latestMetrics = readModel?.metrics ?? null;
+  const fallbackAsOfDate = share.updatedAt ?? share.createdAt ?? generatedAt;
+  const asOfDate = dateToIso(
+    latestMetrics?.asOfDate ?? latestMetrics?.metricDate,
+    fallbackAsOfDate
+  );
+
+  const allMetrics: PublicMetricValue[] = [
+    availableMetric(
+      'total_commitments',
+      'Total commitments',
+      numberOrNull(readModel?.fund?.size),
+      'currency',
+      readModel ? 'funds.size' : 'fund_read_model',
+      asOfDate
+    ),
+    unavailableMetric(
+      'capital_called',
+      'Capital called',
+      'currency',
+      'capital_activity_ledger',
+      asOfDate,
+      'capital_call_source_not_yet_persisted'
+    ),
+    availableMetric(
+      'capital_deployed',
+      'Capital deployed',
+      numberOrNull(readModel?.fund?.deployedCapital),
+      'currency',
+      readModel ? 'funds.deployed_capital' : 'fund_read_model',
+      asOfDate
+    ),
+    unavailableMetric(
+      'total_distributions',
+      'Distributions',
+      'currency',
+      'fund_distributions',
+      asOfDate,
+      'distribution_source_not_in_snapshot_read_model'
+    ),
+    availableMetric(
+      'total_value',
+      'Total value',
+      numberOrNull(latestMetrics?.totalValue),
+      'currency',
+      latestMetrics ? 'fund_metrics.totalvalue' : 'fund_metrics',
+      asOfDate
+    ),
+    availableMetric(
+      'irr',
+      'IRR',
+      readModel ? numberOrNull(readModel.summary.currentIRR) : null,
+      'percent',
+      latestMetrics ? 'fund_metrics.irr' : 'fund_metrics',
+      asOfDate
+    ),
+    availableMetric(
+      'moic',
+      'MOIC',
+      numberOrNull(latestMetrics?.multiple),
+      'multiple',
+      latestMetrics ? 'fund_metrics.multiple' : 'fund_metrics',
+      asOfDate
+    ),
+    availableMetric(
+      'dpi',
+      'DPI',
+      numberOrNull(latestMetrics?.dpi),
+      'multiple',
+      latestMetrics ? 'fund_metrics.dpi' : 'fund_metrics',
+      asOfDate
+    ),
+    availableMetric(
+      'tvpi',
+      'TVPI',
+      numberOrNull(latestMetrics?.tvpi),
+      'multiple',
+      latestMetrics ? 'fund_metrics.tvpi' : 'fund_metrics',
+      asOfDate
+    ),
+    availableMetric(
+      'portfolio_companies',
+      'Portfolio companies',
+      readModel ? readModel.summary.totalCompanies : null,
+      'count',
+      readModel ? 'portfolio_companies.count' : 'portfolio_companies',
+      asOfDate
+    ),
+  ];
+
+  const { metrics, applied } = redactMetrics(allMetrics, share.hiddenMetrics);
+  const hidden = new Set(share.hiddenMetrics ?? []);
+  const portfolioCompanies: PublicPortfolioCompany[] = (readModel?.portfolioCompanies ?? [])
+    .slice(0, 5)
+    .map((company) => ({
+      name: company.name,
+      stage: company.stage ?? null,
+      moic: hidden.has('moic') ? null : portfolioCompanyMoic(company as Record<string, unknown>),
+      status: company.status ?? null,
+    }));
+
+  const sourceCalculationRunIds =
+    latestMetrics?.runId === null || latestMetrics?.runId === undefined
+      ? []
+      : [String(latestMetrics.runId)];
+
+  const payload: PublicShareSnapshotPayload = {
+    payloadVersion: SNAPSHOT_PAYLOAD_VERSION,
+    snapshotId,
+    shareId: share.id,
+    title: share.customTitle ?? readModel?.fund?.name ?? 'Fund dashboard',
+    message: share.customMessage ?? null,
+    asOfDate,
+    generatedAt: generatedAt.toISOString(),
+    metrics,
+    portfolioCompanies,
+    hiddenMetricPolicy: {
+      requested: share.hiddenMetrics ?? [],
+      applied,
+    },
+    sourceCalculationRunIds,
+  };
+
+  return { payload, payloadHash: hashPayload(payload) };
+}
+
+export async function createShareSnapshot(
+  share: Share,
+  generatedBy: string,
+  database: SnapshotDb = db
+): Promise<ShareSnapshotRecord> {
+  const snapshotId = uuidv4();
+  const { payload, payloadHash } = await buildPublicShareSnapshotPayload(
+    share,
+    generatedBy,
+    snapshotId
+  );
+
+  const [snapshot] = await database
+    .insert(shareSnapshots)
+    .values({
+      id: snapshotId,
+      shareId: share.id,
+      fundIdInternal: share.fundId,
+      payloadVersion: payload.payloadVersion,
+      asOfDate: new Date(payload.asOfDate),
+      sourceCalculationRunIds: payload.sourceCalculationRunIds,
+      hiddenMetricPolicy: payload.hiddenMetricPolicy,
+      generatedBy,
+      generatedAt: new Date(payload.generatedAt),
+      expiresAt: share.expiresAt,
+      payloadHash,
+      payload,
+    })
+    .returning();
+
+  if (!snapshot) {
+    throw new Error('Failed to create share snapshot');
+  }
+
+  return snapshot;
+}
+
+export async function getLatestShareSnapshot(
+  shareId: string
+): Promise<ShareSnapshotRecord | undefined> {
+  const [snapshot] = await db
+    .select()
+    .from(shareSnapshots)
+    .where(eq(shareSnapshots.shareId, shareId))
+    .orderBy(desc(shareSnapshots.generatedAt))
+    .limit(1);
+
+  return snapshot;
+}
+
+export async function markShareSnapshotsRevoked(
+  shareId: string,
+  revokedAt: Date,
+  database: SnapshotDb = db
+): Promise<void> {
+  await database
+    .update(shareSnapshots)
+    .set({ revokedAt })
+    .where(eq(shareSnapshots.shareId, shareId));
+}

--- a/shared/contracts/public-share-snapshot.contract.ts
+++ b/shared/contracts/public-share-snapshot.contract.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+export const PublicMetricAvailabilitySchema = z.enum(['available', 'unavailable']);
+export type PublicMetricAvailability = z.infer<typeof PublicMetricAvailabilitySchema>;
+
+export const PublicMetricValueSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  value: z.number().nullable(),
+  unit: z.enum(['currency', 'percent', 'multiple', 'count']),
+  availability: PublicMetricAvailabilitySchema,
+  source: z.string(),
+  asOfDate: z.string(),
+  calculationVersion: z.string(),
+  unavailableReason: z.string().optional(),
+});
+
+export type PublicMetricValue = z.infer<typeof PublicMetricValueSchema>;
+
+export const PublicPortfolioCompanySchema = z.object({
+  name: z.string(),
+  stage: z.string().nullable(),
+  moic: z.number().nullable(),
+  status: z.string().nullable(),
+});
+
+export type PublicPortfolioCompany = z.infer<typeof PublicPortfolioCompanySchema>;
+
+export const PublicShareSnapshotPayloadSchema = z.object({
+  payloadVersion: z.literal('public-share-snapshot.v1'),
+  snapshotId: z.string(),
+  shareId: z.string(),
+  title: z.string(),
+  message: z.string().nullable(),
+  asOfDate: z.string(),
+  generatedAt: z.string(),
+  metrics: z.array(PublicMetricValueSchema),
+  portfolioCompanies: z.array(PublicPortfolioCompanySchema),
+  hiddenMetricPolicy: z.object({
+    requested: z.array(z.string()),
+    applied: z.array(z.string()),
+  }),
+  sourceCalculationRunIds: z.array(z.string()),
+});
+
+export type PublicShareSnapshotPayload = z.infer<typeof PublicShareSnapshotPayloadSchema>;
+
+export const PublicShareResponseSchema = z.object({
+  success: z.literal(true),
+  share: z.object({
+    id: z.string(),
+    requirePasskey: z.boolean(),
+    customTitle: z.string().nullable(),
+    customMessage: z.string().nullable(),
+    expiresAt: z.string().nullable(),
+    snapshot: PublicShareSnapshotPayloadSchema.optional(),
+  }),
+});
+
+export type PublicShareResponse = z.infer<typeof PublicShareResponseSchema>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -29,6 +29,7 @@ import { createInsertSchema } from 'drizzle-zod';
 export * from './schema/fund';
 export * from './schema/portfolio';
 export * from './schema/scenario';
+export * from './schema/shares';
 
 // Import tables for FK references and schema definitions
 import { funds, fundConfigs, fundSnapshots, calcRuns } from './schema/fund';

--- a/shared/schema/shares.ts
+++ b/shared/schema/shares.ts
@@ -5,14 +5,30 @@
  * Enables secure sharing of fund dashboards with Limited Partners.
  */
 
-import { pgTable, text, timestamp, boolean, integer, jsonb, index } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import {
+  pgTable,
+  text,
+  timestamp,
+  boolean,
+  integer,
+  jsonb,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 import { funds } from './fund';
+import type { PublicShareSnapshotPayload } from '../contracts/public-share-snapshot.contract';
 
 // Access level enum values
-export const SHARE_ACCESS_LEVELS = ['view_only', 'view_with_details', 'collaborator', 'admin'] as const;
-export type ShareAccessLevel = typeof SHARE_ACCESS_LEVELS[number];
+export const SHARE_ACCESS_LEVELS = [
+  'view_only',
+  'view_with_details',
+  'collaborator',
+  'admin',
+] as const;
+export type ShareAccessLevel = (typeof SHARE_ACCESS_LEVELS)[number];
 
 /**
  * Shares table - stores share link configurations
@@ -43,6 +59,9 @@ export const shares = pgTable(
 
     // Status
     isActive: boolean('is_active').notNull().default(true),
+    version: integer('version').notNull().default(1),
+    idempotencyKey: text('idempotency_key'),
+    idempotencyRequestHash: text('idempotency_request_hash'),
 
     // Timestamps
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
@@ -52,6 +71,48 @@ export const shares = pgTable(
     fundIdIdx: index('shares_fund_id_idx').on(table.fundId),
     createdByIdx: index('shares_created_by_idx').on(table.createdBy),
     activeIdx: index('shares_active_idx').on(table.isActive),
+    idempotencyUniqueIdx: uniqueIndex('shares_creator_idempotency_key_idx')
+      .on(table.createdBy, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
+  })
+);
+
+/**
+ * Immutable public payloads generated from private fund read models.
+ *
+ * Public routes must return this payload, not the private fund id or private
+ * dashboard API response that was used to generate it.
+ */
+export const shareSnapshots = pgTable(
+  'share_snapshots',
+  {
+    id: text('id').primaryKey(), // UUID
+    shareId: text('share_id')
+      .notNull()
+      .references(() => shares.id, { onDelete: 'cascade' }),
+    fundIdInternal: text('fund_id_internal').notNull(),
+    payloadVersion: text('payload_version').notNull().default('public-share-snapshot.v1'),
+    asOfDate: timestamp('as_of_date', { withTimezone: true }).notNull(),
+    sourceCalculationRunIds: jsonb('source_calculation_run_ids')
+      .$type<string[]>()
+      .notNull()
+      .default([]),
+    hiddenMetricPolicy: jsonb('hidden_metric_policy')
+      .$type<{ requested: string[]; applied: string[] }>()
+      .notNull(),
+    generatedBy: text('generated_by').notNull(),
+    generatedAt: timestamp('generated_at', { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    payloadHash: text('payload_hash').notNull(),
+    payload: jsonb('payload').$type<PublicShareSnapshotPayload>().notNull(),
+  },
+  (table) => ({
+    shareGeneratedIdx: index('share_snapshots_share_generated_idx').on(
+      table.shareId,
+      table.generatedAt
+    ),
+    payloadHashIdx: index('share_snapshots_payload_hash_idx').on(table.payloadHash),
   })
 );
 
@@ -85,6 +146,8 @@ export const selectShareSchema = createSelectSchema(shares);
 
 export const insertShareAnalyticsSchema = createInsertSchema(shareAnalytics);
 export const selectShareAnalyticsSchema = createSelectSchema(shareAnalytics);
+export const insertShareSnapshotSchema = createInsertSchema(shareSnapshots);
+export const selectShareSnapshotSchema = createSelectSchema(shareSnapshots);
 
 // Extended validation schema with proper types
 export const createShareSchema = z.object({
@@ -103,3 +166,5 @@ export type Share = typeof shares.$inferSelect;
 export type NewShare = typeof shares.$inferInsert;
 export type ShareAnalyticsRecord = typeof shareAnalytics.$inferSelect;
 export type NewShareAnalyticsRecord = typeof shareAnalytics.$inferInsert;
+export type ShareSnapshotRecord = typeof shareSnapshots.$inferSelect;
+export type NewShareSnapshotRecord = typeof shareSnapshots.$inferInsert;

--- a/tests/e2e/report-sharing.spec.ts
+++ b/tests/e2e/report-sharing.spec.ts
@@ -15,7 +15,8 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Share API', () => {
   const baseUrl = '/api/shares';
-  const testFundId = 'test-fund-123';
+  const publicBaseUrl = '/api/public/shares';
+  const testFundId = '1';
 
   test.describe('Create Share', () => {
     test('creates a basic share link', async ({ request }) => {
@@ -24,6 +25,7 @@ test.describe('Share API', () => {
           fundId: testFundId,
           accessLevel: 'view_only',
           requirePasskey: false,
+          hiddenMetrics: ['irr'],
         },
       });
 
@@ -33,7 +35,8 @@ test.describe('Share API', () => {
       expect(body.share).toBeDefined();
       expect(body.share.fundId).toBe(testFundId);
       expect(body.share.accessLevel).toBe('view_only');
-      expect(body.share.shareUrl).toMatch(/^\/share\//);
+      expect(body.share.shareUrl).toMatch(/^\/shared\//);
+      expect(body.share.version).toBe(1);
     });
 
     test('creates a passkey-protected share', async ({ request }) => {
@@ -116,8 +119,8 @@ test.describe('Share API', () => {
     });
   });
 
-  test.describe('Get Share', () => {
-    test('returns share details for public access', async ({ request }) => {
+  test.describe('Public Share', () => {
+    test('returns public snapshot without private fund id', async ({ request }) => {
       // First create a share
       const createResponse = await request.post(baseUrl, {
         data: {
@@ -130,13 +133,17 @@ test.describe('Share API', () => {
       const shareId = created.share.id;
 
       // Then retrieve it
-      const response = await request.get(`${baseUrl}/${shareId}`);
+      const response = await request.get(`${publicBaseUrl}/${shareId}`);
 
       expect(response.status()).toBe(200);
       const body = await response.json();
       expect(body.success).toBe(true);
       expect(body.share.id).toBe(shareId);
-      expect(body.share.fundId).toBe(testFundId);
+      expect(body.share.fundId).toBeUndefined();
+      expect(body.share.snapshot).toBeDefined();
+      expect(
+        body.share.snapshot.metrics.every((metric: { id: string }) => metric.id !== 'irr')
+      ).toBe(true);
     });
 
     test('returns limited info for passkey-protected share', async ({ request }) => {
@@ -152,16 +159,17 @@ test.describe('Share API', () => {
       const shareId = created.share.id;
 
       // Get without passkey
-      const response = await request.get(`${baseUrl}/${shareId}`);
+      const response = await request.get(`${publicBaseUrl}/${shareId}`);
 
       expect(response.status()).toBe(200);
       const body = await response.json();
       expect(body.share.requirePasskey).toBe(true);
-      expect(body.share.fundId).toBeUndefined(); // Shouldn't expose fundId without passkey
+      expect(body.share.fundId).toBeUndefined();
+      expect(body.share.snapshot).toBeUndefined();
     });
 
     test('returns 404 for non-existent share', async ({ request }) => {
-      const response = await request.get(`${baseUrl}/non-existent-id`);
+      const response = await request.get(`${publicBaseUrl}/non-existent-id`);
 
       expect(response.status()).toBe(404);
     });
@@ -181,14 +189,15 @@ test.describe('Share API', () => {
       const shareId = created.share.id;
 
       // Verify with correct passkey
-      const response = await request.post(`${baseUrl}/${shareId}/verify`, {
+      const response = await request.post(`${publicBaseUrl}/${shareId}/verify`, {
         data: { passkey: 'correctpasskey' },
       });
 
       expect(response.status()).toBe(200);
       const body = await response.json();
       expect(body.success).toBe(true);
-      expect(body.share.fundId).toBe(testFundId); // Now fundId is exposed
+      expect(body.share.fundId).toBeUndefined();
+      expect(body.share.snapshot).toBeDefined();
     });
 
     test('rejects incorrect passkey', async ({ request }) => {
@@ -204,7 +213,7 @@ test.describe('Share API', () => {
       const shareId = created.share.id;
 
       // Verify with wrong passkey
-      const response = await request.post(`${baseUrl}/${shareId}/verify`, {
+      const response = await request.post(`${publicBaseUrl}/${shareId}/verify`, {
         data: { passkey: 'wrongpasskey' },
       });
 
@@ -225,9 +234,11 @@ test.describe('Share API', () => {
       });
       const created = await createResponse.json();
       const shareId = created.share.id;
+      const etag = createResponse.headers()['etag'];
 
       // Update it
       const response = await request.patch(`${baseUrl}/${shareId}`, {
+        headers: { 'If-Match': etag ?? '"1"' },
         data: {
           accessLevel: 'view_with_details',
           customTitle: 'Updated Title',
@@ -250,9 +261,11 @@ test.describe('Share API', () => {
       });
       const created = await createResponse.json();
       const shareId = created.share.id;
+      const etag = createResponse.headers()['etag'];
 
       // Add passkey
       const response = await request.patch(`${baseUrl}/${shareId}`, {
+        headers: { 'If-Match': etag ?? '"1"' },
         data: {
           requirePasskey: true,
           passkey: 'newpasskey',
@@ -275,16 +288,19 @@ test.describe('Share API', () => {
       });
       const created = await createResponse.json();
       const shareId = created.share.id;
+      const etag = createResponse.headers()['etag'];
 
       // Revoke it
-      const response = await request.delete(`${baseUrl}/${shareId}`);
+      const response = await request.delete(`${baseUrl}/${shareId}`, {
+        headers: { 'If-Match': etag ?? '"1"' },
+      });
 
       expect(response.status()).toBe(200);
       const body = await response.json();
       expect(body.success).toBe(true);
 
       // Verify it's no longer accessible
-      const getResponse = await request.get(`${baseUrl}/${shareId}`);
+      const getResponse = await request.get(`${publicBaseUrl}/${shareId}`);
       expect(getResponse.status()).toBe(410); // Gone
     });
   });

--- a/tests/unit/server/public-route-boundary.test.ts
+++ b/tests/unit/server/public-route-boundary.test.ts
@@ -7,11 +7,19 @@ describe('server public API route boundary', () => {
     ['GET', '/flags'],
     ['GET', '/flags/status'],
     ['GET', '/health/details'],
+    ['GET', '/public/shares/share-123'],
+    ['POST', '/public/shares/share-123/verify'],
   ])('treats %s %s as public', (method, path) => {
     expect(isPublicApiPath(method, path)).toBe(true);
   });
 
   it.each([
+    ['GET', '/shares/share-123'],
+    ['POST', '/shares/share-123/verify'],
+    ['POST', '/public/shares'],
+    ['PATCH', '/public/shares/share-123'],
+    ['DELETE', '/public/shares/share-123'],
+    ['GET', '/public/shares/share-123/analytics'],
     ['GET', '/funds'],
     ['POST', '/funds'],
     ['GET', '/funds/1'],

--- a/tests/unit/server/share-routes-error-paths.test.ts
+++ b/tests/unit/server/share-routes-error-paths.test.ts
@@ -1,0 +1,361 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Share, ShareSnapshotRecord } from '../../../shared/schema/shares';
+
+const routeMocks = vi.hoisted(() => {
+  type Row = Record<string, unknown>;
+  type State = {
+    shares: Row[];
+    shareAnalytics: Row[];
+    selectSharesQueue: Row[][];
+    transactionCalls: number;
+  };
+
+  const state: State = {
+    shares: [],
+    shareAnalytics: [],
+    selectSharesQueue: [],
+    transactionCalls: 0,
+  };
+  let activeState = state;
+
+  function cloneRows(rows: Row[]): Row[] {
+    return rows.map((row) => ({ ...row }));
+  }
+
+  function reset() {
+    state.shares = [];
+    state.shareAnalytics = [];
+    state.selectSharesQueue = [];
+    state.transactionCalls = 0;
+    activeState = state;
+  }
+
+  function getTableName(table: unknown): string {
+    if (typeof table === 'string') return table;
+    if (!table || typeof table !== 'object') return 'unknown';
+
+    const symbolName = (table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')];
+    if (typeof symbolName === 'string') return symbolName;
+
+    const candidate = table as { name?: unknown; _?: { name?: unknown; tableName?: unknown } };
+    if (typeof candidate._?.name === 'string') return candidate._.name;
+    if (typeof candidate._?.tableName === 'string') return candidate._.tableName;
+    if (typeof candidate.name === 'string') return candidate.name;
+    return 'unknown';
+  }
+
+  function rowsForTable(table: string): Row[] {
+    if (table === 'shares') {
+      return state.selectSharesQueue.shift() ?? activeState.shares;
+    }
+    if (table === 'share_analytics') return activeState.shareAnalytics;
+    return [];
+  }
+
+  function select() {
+    let selectedTable = 'unknown';
+    let limitValue: number | undefined;
+
+    const execute = async () => {
+      const rows = rowsForTable(selectedTable);
+      return limitValue === undefined ? rows : rows.slice(0, limitValue);
+    };
+
+    const builder = {
+      from(table: unknown) {
+        selectedTable = getTableName(table);
+        return builder;
+      },
+      where() {
+        return builder;
+      },
+      orderBy() {
+        return builder;
+      },
+      limit(value: number) {
+        limitValue = value;
+        return builder;
+      },
+      then(onFulfilled: (value: Row[]) => unknown, onRejected?: (reason: unknown) => unknown) {
+        return execute().then(onFulfilled, onRejected);
+      },
+      catch(onRejected: (reason: unknown) => unknown) {
+        return execute().catch(onRejected);
+      },
+    };
+
+    return builder;
+  }
+
+  function insert(table: unknown) {
+    const tableName = getTableName(table);
+    return {
+      values(value: Row | Row[]) {
+        const rows = Array.isArray(value) ? value : [value];
+        const target =
+          tableName === 'share_analytics' ? activeState.shareAnalytics : activeState.shares;
+        target.push(...rows.map((row) => ({ ...row })));
+
+        const execute = async () => rows;
+        return {
+          returning: execute,
+          then(onFulfilled: (value: Row[]) => unknown, onRejected?: (reason: unknown) => unknown) {
+            return execute().then(onFulfilled, onRejected);
+          },
+        };
+      },
+    };
+  }
+
+  function update(table: unknown) {
+    const tableName = getTableName(table);
+    return {
+      set(updateValue: Row) {
+        return {
+          where() {
+            const execute = async () => {
+              if (tableName !== 'shares' || activeState.shares.length === 0) return [];
+              const updated = { ...activeState.shares[0], ...updateValue };
+              activeState.shares[0] = updated;
+              return [updated];
+            };
+
+            return {
+              returning: execute,
+              then(
+                onFulfilled: (value: Row[]) => unknown,
+                onRejected?: (reason: unknown) => unknown
+              ) {
+                return execute().then(onFulfilled, onRejected);
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  const db = {
+    select,
+    insert,
+    update,
+    transaction: vi.fn(async <T>(callback: (tx: typeof db) => Promise<T>): Promise<T> => {
+      state.transactionCalls += 1;
+      const previous = activeState;
+      const draft: State = {
+        shares: cloneRows(state.shares),
+        shareAnalytics: cloneRows(state.shareAnalytics),
+        selectSharesQueue: state.selectSharesQueue,
+        transactionCalls: state.transactionCalls,
+      };
+      activeState = draft;
+
+      try {
+        const result = await callback(db);
+        // eslint-disable-next-line require-atomic-updates -- test transaction mock commits only after callback success
+        state.shares = draft.shares;
+        // eslint-disable-next-line require-atomic-updates -- test transaction mock commits only after callback success
+        state.shareAnalytics = draft.shareAnalytics;
+        return result;
+      } finally {
+        // eslint-disable-next-line require-atomic-updates -- restores the single active test transaction context
+        activeState = previous;
+      }
+    }),
+  };
+
+  return {
+    db,
+    state,
+    reset,
+    createShareSnapshot: vi.fn(),
+    getLatestShareSnapshot: vi.fn(),
+    markShareSnapshotsRevoked: vi.fn(),
+  };
+});
+
+vi.mock('../../../server/db', () => ({
+  db: routeMocks.db,
+  pool: null,
+}));
+
+vi.mock('../../../server/services/share-snapshot-service', () => ({
+  createShareSnapshot: routeMocks.createShareSnapshot,
+  getLatestShareSnapshot: routeMocks.getLatestShareSnapshot,
+  markShareSnapshotsRevoked: routeMocks.markShareSnapshotsRevoked,
+}));
+
+function makeShare(overrides: Partial<Share> = {}): Share {
+  const now = new Date('2026-04-27T12:00:00.000Z');
+  return {
+    id: 'share-1',
+    fundId: '1',
+    createdBy: 'user-1',
+    accessLevel: 'view_only',
+    requirePasskey: false,
+    passkeyHash: null,
+    expiresAt: null,
+    hiddenMetrics: [],
+    customTitle: null,
+    customMessage: null,
+    viewCount: 0,
+    lastViewedAt: null,
+    isActive: true,
+    version: 1,
+    idempotencyKey: null,
+    idempotencyRequestHash: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<ShareSnapshotRecord> = {}): ShareSnapshotRecord {
+  const now = new Date('2026-04-27T12:00:00.000Z');
+  return {
+    id: 'snapshot-1',
+    shareId: 'share-1',
+    fundIdInternal: '1',
+    payloadVersion: 'public-share-snapshot.v1',
+    asOfDate: now,
+    sourceCalculationRunIds: [],
+    hiddenMetricPolicy: { requested: [], applied: [] },
+    generatedBy: 'user-1',
+    generatedAt: now,
+    expiresAt: null,
+    revokedAt: null,
+    payloadHash: 'hash-1',
+    payload: {
+      payloadVersion: 'public-share-snapshot.v1',
+      snapshotId: 'snapshot-1',
+      shareId: 'share-1',
+      title: 'Investor snapshot',
+      message: null,
+      asOfDate: now.toISOString(),
+      generatedAt: now.toISOString(),
+      metrics: [],
+      portfolioCompanies: [],
+      hiddenMetricPolicy: { requested: [], applied: [] },
+      sourceCalculationRunIds: [],
+    },
+    ...overrides,
+  };
+}
+
+async function makeApp() {
+  const app = express();
+  app.set('trust proxy', 1);
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.context = {
+      userId: 'user-1',
+      email: 'user@example.com',
+      role: 'admin',
+      orgId: 'org-1',
+    };
+    next();
+  });
+
+  const { sharesRouter, publicSharesRouter } = await import('../../../server/routes/shares');
+  app.use('/api/shares', sharesRouter);
+  app.use('/api/public/shares', publicSharesRouter);
+  app.use(
+    (err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      res.status(500).json({ success: false, error: err instanceof Error ? err.message : 'error' });
+    }
+  );
+  return app;
+}
+
+describe('share routes error paths', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    routeMocks.reset();
+    routeMocks.createShareSnapshot.mockResolvedValue(makeSnapshot());
+    routeMocks.getLatestShareSnapshot.mockResolvedValue(makeSnapshot());
+    routeMocks.markShareSnapshotsRevoked.mockResolvedValue(undefined);
+  });
+
+  it('rejects idempotency-key reuse with a different request fingerprint', async () => {
+    const app = await makeApp();
+    routeMocks.state.selectSharesQueue.push([
+      makeShare({
+        idempotencyKey: 'share-create-1',
+        idempotencyRequestHash: 'original-request-hash',
+      }),
+    ]);
+
+    const response = await request(app)
+      .post('/api/shares')
+      .set('Idempotency-Key', 'share-create-1')
+      .send({
+        fundId: '1',
+        accessLevel: 'view_with_details',
+        requirePasskey: false,
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      success: false,
+      error: 'idempotency_key_reused',
+    });
+    expect(routeMocks.createShareSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('rolls back share creation when snapshot creation fails inside the transaction', async () => {
+    const app = await makeApp();
+    routeMocks.state.selectSharesQueue.push([]);
+    routeMocks.createShareSnapshot.mockRejectedValueOnce(new Error('snapshot write failed'));
+
+    const response = await request(app).post('/api/shares').send({
+      fundId: '1',
+      accessLevel: 'view_only',
+      requirePasskey: false,
+    });
+
+    expect(response.status).toBe(500);
+    expect(routeMocks.state.transactionCalls).toBe(1);
+    expect(routeMocks.state.shares).toHaveLength(0);
+  });
+
+  it('returns 304 for matching public snapshot ETags', async () => {
+    const app = await makeApp();
+    routeMocks.state.shares = [makeShare()];
+    routeMocks.getLatestShareSnapshot.mockResolvedValueOnce(
+      makeSnapshot({ payloadHash: 'hash-304' })
+    );
+
+    const response = await request(app)
+      .get('/api/public/shares/share-1')
+      .set('If-None-Match', '"hash-304"');
+
+    expect(response.status).toBe(304);
+    expect(response.headers['etag']).toBe('"hash-304"');
+    expect(routeMocks.state.shareAnalytics).toHaveLength(0);
+  });
+
+  it('rate-limits repeated public passkey verification attempts per share', async () => {
+    const app = await makeApp();
+    routeMocks.state.shares = [
+      makeShare({
+        requirePasskey: true,
+        passkeyHash: `${'a'.repeat(32)}:${'b'.repeat(128)}`,
+      }),
+    ];
+
+    const responses = [];
+    for (let index = 0; index < 6; index += 1) {
+      responses.push(
+        await request(app)
+          .post('/api/public/shares/share-1/verify')
+          .send({ passkey: 'wrong-passkey' })
+      );
+    }
+
+    expect(responses.slice(0, 5).every((response) => response.status === 401)).toBe(true);
+    expect(responses[5]?.status).toBe(429);
+  });
+});

--- a/tests/unit/server/share-snapshot-service.test.ts
+++ b/tests/unit/server/share-snapshot-service.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Share } from '../../../shared/schema/shares';
+import { buildPublicShareSnapshotPayload } from '../../../server/services/share-snapshot-service';
+
+const readModelState = vi.hoisted(() => ({
+  value: undefined as
+    | {
+        fund: { name: string; size: string; deployedCapital: string };
+        portfolioCompanies: Array<{
+          name: string;
+          stage: string;
+          status: string;
+          investmentAmount?: string;
+          currentValuation?: string | null;
+          exitMoicBps?: number | null;
+        }>;
+        recentActivities: unknown[];
+        metrics: {
+          asOfDate: Date;
+          metricDate?: Date;
+          totalValue: string;
+          multiple: string;
+          dpi: string;
+          tvpi: string;
+          runId: number;
+        };
+        summary: { totalCompanies: number; deploymentRate: number; currentIRR: number };
+      }
+    | undefined,
+}));
+
+vi.mock('../../../server/storage', () => ({ storage: {} }));
+vi.mock('../../../server/services/dashboard-summary-read-service', () => ({
+  getDashboardSummaryReadModel: vi.fn(async () => readModelState.value),
+}));
+
+function createShare(overrides: Partial<Share> = {}): Share {
+  const now = new Date('2026-04-27T12:00:00.000Z');
+  return {
+    id: 'share-1',
+    fundId: 'missing-fund',
+    createdBy: 'user-1',
+    accessLevel: 'view_only',
+    requirePasskey: false,
+    passkeyHash: null,
+    expiresAt: null,
+    hiddenMetrics: [],
+    customTitle: 'Investor snapshot',
+    customMessage: null,
+    viewCount: 0,
+    lastViewedAt: null,
+    isActive: true,
+    version: 1,
+    idempotencyKey: null,
+    idempotencyRequestHash: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function expectNoKey(value: unknown, forbiddenKey: string): void {
+  if (Array.isArray(value)) {
+    value.forEach((item) => expectNoKey(item, forbiddenKey));
+    return;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    Object.entries(value).forEach(([key, child]) => {
+      expect(key).not.toBe(forbiddenKey);
+      expectNoKey(child, forbiddenKey);
+    });
+  }
+}
+
+describe('public share snapshot service', () => {
+  beforeEach(() => {
+    readModelState.value = undefined;
+  });
+
+  it('redacts hidden metrics server-side', async () => {
+    const { payload } = await buildPublicShareSnapshotPayload(
+      createShare({ hiddenMetrics: ['irr'] }),
+      'user-1',
+      'snapshot-1'
+    );
+
+    expect(payload.metrics.map((metric) => metric.id)).not.toContain('irr');
+    expect(payload.hiddenMetricPolicy).toEqual({
+      requested: ['irr'],
+      applied: ['irr'],
+    });
+  });
+
+  it('redacts portfolio company MOIC when the metric is hidden', async () => {
+    readModelState.value = {
+      fund: { name: 'Fund I', size: '100000000', deployedCapital: '25000000' },
+      portfolioCompanies: [
+        {
+          name: 'Company A',
+          stage: 'Series A',
+          status: 'active',
+          investmentAmount: '1000000',
+          currentValuation: '4000000',
+          exitMoicBps: 35000,
+        },
+      ],
+      recentActivities: [],
+      metrics: {
+        asOfDate: new Date('2026-04-01T00:00:00.000Z'),
+        totalValue: '4000000',
+        multiple: '4',
+        dpi: '0.5',
+        tvpi: '4.5',
+        runId: 42,
+      },
+      summary: { totalCompanies: 1, deploymentRate: 25, currentIRR: 18.2 },
+    };
+
+    const visible = await buildPublicShareSnapshotPayload(
+      createShare({ fundId: '1', hiddenMetrics: [] }),
+      'user-1',
+      'snapshot-1'
+    );
+    const hidden = await buildPublicShareSnapshotPayload(
+      createShare({ fundId: '1', hiddenMetrics: ['moic'] }),
+      'user-1',
+      'snapshot-2'
+    );
+
+    expect(visible.payload.portfolioCompanies[0]?.moic).toBe(3.5);
+    expect(hidden.payload.metrics.map((metric) => metric.id)).not.toContain('moic');
+    expect(hidden.payload.portfolioCompanies[0]?.moic).toBeNull();
+  });
+
+  it('hashes content deterministically without snapshot audit fields', async () => {
+    readModelState.value = {
+      fund: { name: 'Fund I', size: '100000000', deployedCapital: '25000000' },
+      portfolioCompanies: [],
+      recentActivities: [],
+      metrics: {
+        asOfDate: new Date('2026-04-01T00:00:00.000Z'),
+        totalValue: '4000000',
+        multiple: '4',
+        dpi: '0.5',
+        tvpi: '4.5',
+        runId: 42,
+      },
+      summary: { totalCompanies: 0, deploymentRate: 25, currentIRR: 18.2 },
+    };
+
+    const first = await buildPublicShareSnapshotPayload(
+      createShare({ fundId: '1' }),
+      'user-1',
+      'snapshot-1'
+    );
+    const second = await buildPublicShareSnapshotPayload(
+      createShare({ fundId: '1' }),
+      'user-1',
+      'snapshot-2'
+    );
+
+    expect(first.payload.snapshotId).not.toBe(second.payload.snapshotId);
+    expect(first.payloadHash).toBe(second.payloadHash);
+  });
+
+  it('marks unsupported source data unavailable instead of fabricating values', async () => {
+    const { payload } = await buildPublicShareSnapshotPayload(
+      createShare(),
+      'user-1',
+      'snapshot-1'
+    );
+
+    const capitalCalled = payload.metrics.find((metric) => metric.id === 'capital_called');
+    const totalCommitments = payload.metrics.find((metric) => metric.id === 'total_commitments');
+
+    expect(capitalCalled).toMatchObject({
+      availability: 'unavailable',
+      value: null,
+      unavailableReason: 'capital_call_source_not_yet_persisted',
+    });
+    expect(totalCommitments).toMatchObject({
+      availability: 'unavailable',
+      value: null,
+    });
+    expectNoKey(payload, 'fundId');
+  });
+});


### PR DESCRIPTION
The share API previously exposed live fund read models through a public route boundary. This change splits anonymous snapshot reads from authenticated management, persists immutable public payloads, and adds defensive retry, caching, redaction, and rate-limit behavior around the new trust boundary.

Constraint: Anonymous viewers must never receive private fund IDs or live dashboard read models

Constraint: No new dependencies; reused existing express-rate-limit and Drizzle patterns

Rejected: Serve public shares from dashboard-summary endpoint | leaks fund-scoped live model and bypasses snapshot contract

Rejected: Bundle fundId type migration | pre-existing schema mismatch with broader migration risk

Confidence: high

Scope-risk: moderate

Directive: Do not expose /api/dashboard-summary or fundId from public share pages; public reads must go through snapshot payloads

Tested: npm run check; targeted ESLint; vitest 35 share tests; git diff --check

Not-tested: Full Playwright suite; report-sharing spec remains outside current Playwright testMatch