### PR TITLE
refactor(ui): purge page hero chrome and internal-team microcopy

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -11,19 +11,11 @@ import {
   type NavigationContext,
   type NavigationItem,
 } from './navigation-config';
-import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
+import { Plus } from 'lucide-react';
 
 interface SidebarProps {
   activeModule: string;
 }
-
-const chartCategories = [
-  { id: 'basic', label: 'Basic Charts' },
-  { id: 'statistical', label: 'Statistical' },
-  { id: 'hierarchical', label: 'Hierarchical' },
-  { id: 'flow', label: 'Flow Charts' },
-  { id: 'advanced', label: 'Advanced' },
-];
 
 function baseNavClassName(isHovered: boolean, isActive: boolean, isDisabled: boolean): string {
   return cn(
@@ -163,7 +155,6 @@ function NavigationButton({
 }
 
 export default function Sidebar({ activeModule }: SidebarProps) {
-  const [isChartsExpanded, setIsChartsExpanded] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [location] = useLocation();
   const { needsSetup, currentFund } = useFundContext();
@@ -248,34 +239,6 @@ export default function Sidebar({ activeModule }: SidebarProps) {
             );
           })}
         </ul>
-
-        {isHovered && (
-          <div className="mt-6 pt-4 border-t border-lightGray">
-            <button
-              onClick={() => setIsChartsExpanded(!isChartsExpanded)}
-              className="w-full flex items-center justify-between px-2 py-2 text-xs font-medium text-charcoal/70 uppercase tracking-wider hover:text-charcoal transition-colors"
-            >
-              <span>Chart Types</span>
-              {isChartsExpanded ? (
-                <ChevronDown className="h-4 w-4" />
-              ) : (
-                <ChevronRight className="h-4 w-4" />
-              )}
-            </button>
-
-            {isChartsExpanded && (
-              <ul className="mt-3 space-y-1">
-                {chartCategories.map((category) => (
-                  <li key={category.id}>
-                    <button className="w-full text-left px-2 py-1 text-sm text-charcoal/70 hover:text-charcoal hover:bg-lightGray rounded-md transition-colors">
-                      {category.label}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )}
       </nav>
 
       {footerItems.length > 0 && (

--- a/client/src/components/metrics/TargetMetricsSnapshot.tsx
+++ b/client/src/components/metrics/TargetMetricsSnapshot.tsx
@@ -5,7 +5,7 @@ import { useFundMetrics } from '@/hooks/useFundMetrics';
 
 interface TargetMetricsSnapshotProps {
   title: string;
-  subtitle: string;
+  subtitle?: string;
 }
 
 function getPortfolioConstructionStatus(actual: number, target: number) {
@@ -16,7 +16,7 @@ function getPortfolioConstructionStatus(actual: number, target: number) {
   return actual / target >= 0.9 ? 'on-track' : 'behind';
 }
 
-export function TargetMetricsSnapshot({ title, subtitle }: TargetMetricsSnapshotProps) {
+export function TargetMetricsSnapshot({ title }: TargetMetricsSnapshotProps) {
   const { data, isLoading, error } = useFundMetrics({ skipProjections: true });
 
   if (isLoading) {
@@ -54,14 +54,9 @@ export function TargetMetricsSnapshot({ title, subtitle }: TargetMetricsSnapshot
 
   return (
     <section aria-label={title} className="space-y-4">
-      <div>
-        <h2 className="text-xl font-semibold text-[#292929]">{title}</h2>
-        <p className="text-sm text-[#292929]/70">{subtitle}</p>
-      </div>
       <div className="grid gap-4 md:grid-cols-3">
         <MetricsCard
           title="Deployment vs Plan"
-          description="Actual deployed capital against age-adjusted plan."
           actual={data.actual.totalDeployed}
           target={data.variance.deploymentVariance.target}
           format="currency"
@@ -70,7 +65,6 @@ export function TargetMetricsSnapshot({ title, subtitle }: TargetMetricsSnapshot
         />
         <MetricsCard
           title="TVPI vs Target"
-          description="Actual multiple versus configured target multiple."
           actual={data.actual.tvpi}
           target={data.target.targetTVPI}
           format="multiple"
@@ -78,7 +72,6 @@ export function TargetMetricsSnapshot({ title, subtitle }: TargetMetricsSnapshot
         />
         <MetricsCard
           title="Companies vs Target"
-          description="Current company count against construction target."
           actual={data.actual.totalCompanies}
           target={data.target.targetCompanyCount}
           format="number"

--- a/client/src/components/ui/POVLogo.tsx
+++ b/client/src/components/ui/POVLogo.tsx
@@ -1,8 +1,3 @@
- 
- 
- 
- 
- 
 import React from 'react';
 
 interface POVLogoProps {
@@ -11,23 +6,21 @@ interface POVLogoProps {
   className?: string;
 }
 
-export function POVLogo({
-  variant = 'dark',
-  size = 'md',
-  className = ''
-}: POVLogoProps) {
+export function POVLogo({ variant = 'dark', size = 'md', className = '' }: POVLogoProps) {
   const sizeClasses = {
     sm: 'h-8',
     md: 'h-12',
     lg: 'h-16',
-    xl: 'h-20'
+    xl: 'h-20',
   };
 
   // Official Press On Ventures brand assets
   const logoVariants = {
-    dark: "https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2F2e9c074662e8408c8bf0fd2e6f62254f?format=webp&width=800", // Black text logo
-    light: "https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Ff49ea40289bd4c9f935555b532cb6506?format=webp&width=800", // Beige text logo
-    white: "https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Fb3de3760e5924b7caf12011c893cbadd?format=webp&width=800" // White text logo
+    dark: 'https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2F2e9c074662e8408c8bf0fd2e6f62254f?format=webp&width=800', // Black text logo
+    light:
+      'https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Ff49ea40289bd4c9f935555b532cb6506?format=webp&width=800', // Beige text logo
+    white:
+      'https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Fb3de3760e5924b7caf12011c893cbadd?format=webp&width=800', // White text logo
   };
 
   return (
@@ -42,23 +35,21 @@ export function POVLogo({
 }
 
 // Icon-only version for smaller spaces
-export function POVIcon({
-  variant = 'dark',
-  size = 'md',
-  className = ''
-}: POVLogoProps) {
+export function POVIcon({ variant = 'dark', size = 'md', className = '' }: POVLogoProps) {
   const sizeClasses = {
     sm: 'w-6 h-6',
     md: 'w-8 h-8',
     lg: 'w-10 h-10',
-    xl: 'w-12 h-12'
+    xl: 'w-12 h-12',
   };
 
   // Official Press On Ventures icon assets
   const iconVariants = {
-    dark: "https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Fbe1ff0f489c346bb87e5a21a3de55ae4?format=webp&width=800", // Black icon
-    light: "https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Fa02554ba930546fa8bb20213ec027712?format=webp&width=800", // Beige icon
-    white: "https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2F832e7518a4a94541bf981160d3e94afd?format=webp&width=800" // White icon
+    dark: 'https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Fbe1ff0f489c346bb87e5a21a3de55ae4?format=webp&width=800', // Black icon
+    light:
+      'https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2Fa02554ba930546fa8bb20213ec027712?format=webp&width=800', // Beige icon
+    white:
+      'https://cdn.builder.io/api/v1/image/assets%2Fad9cb6f2f4a54f5aa9ea2c391202901f%2F832e7518a4a94541bf981160d3e94afd?format=webp&width=800', // White icon
   };
 
   return (
@@ -72,51 +63,24 @@ export function POVIcon({
   );
 }
 
-// Brand-compliant header component
+// Slim page header. Title + optional one-line subtitle, left-aligned.
+// Brand chrome lives in the sidebar; we don't repeat it on every page.
+// Props preserved for backward compat with existing call sites.
 export function POVBrandHeader({
   title,
   subtitle,
-  showLogo = true,
-  variant = 'light' // light background by default
 }: {
   title: string;
   subtitle?: string;
   showLogo?: boolean;
   variant?: 'light' | 'dark' | 'beige';
 }) {
-  const backgroundClasses = {
-    light: 'bg-white text-slate-900 border-gray-300',
-    dark: 'bg-slate-900 text-white border-slate-700',
-    beige: 'bg-slate-50 text-slate-900 border-slate-300'
-  };
-
-  const logoVariant = variant === 'dark' ? 'white' : 'dark';
-
   return (
-    <div className={`border-b-2 shadow-lg ${backgroundClasses[variant]}`}>
-      <div className="max-w-6xl mx-auto px-6 py-16">
-        <div className="text-center">
-          {showLogo && (
-            <div className="mb-8">
-              <POVLogo variant={logoVariant} size="lg" />
-            </div>
-          )}
-          <h1 className="font-inter font-bold text-5xl mb-6 tracking-tight">
-            {title}
-          </h1>
-          {subtitle && (
-            <p className="font-poppins text-xl max-w-4xl mx-auto leading-relaxed text-slate-600">
-              {subtitle}
-            </p>
-          )}
-          <div className="mt-8 flex items-center justify-center space-x-3 text-sm text-slate-500">
-            <div className="w-2 h-2 rounded-full bg-slate-400"></div>
-            <span className="font-poppins">Powered by Press On Ventures</span>
-            <div className="w-2 h-2 rounded-full bg-slate-400"></div>
-          </div>
-        </div>
+    <div className="border-b border-slate-200 bg-white">
+      <div className="px-6 py-4">
+        <h1 className="font-inter text-2xl font-semibold tracking-tight text-slate-900">{title}</h1>
+        {subtitle && <p className="mt-1 text-sm text-slate-600">{subtitle}</p>}
       </div>
     </div>
   );
 }
-

--- a/client/src/pages/DistributionsStep.tsx
+++ b/client/src/pages/DistributionsStep.tsx
@@ -1,13 +1,18 @@
 import React, { useState } from 'react';
 import { useLocation } from 'wouter';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
-import { Button } from "@/components/ui/button";
-import { Plus, Trash2, AlertCircle, ArrowLeft, ArrowRight } from "lucide-react";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Plus, Trash2, ArrowLeft, ArrowRight } from 'lucide-react';
 import { spreadIfDefined } from '@/lib/ts/spreadIfDefined';
 import { useFundTuple, useFundAction } from '@/stores/useFundSelector';
 import { useFundContext } from '@/contexts/FundContext';
@@ -27,7 +32,7 @@ interface WaterfallTier {
 
 export default function DistributionsStep() {
   const [, navigate] = useLocation();
-  const [activeTab, setActiveTab] = useState("waterfall");
+  const [activeTab, setActiveTab] = useState('waterfall');
 
   // Get fund size from context
   const { currentFund } = useFundContext();
@@ -44,8 +49,8 @@ export default function DistributionsStep() {
     mgmtFeeRecyclingRate,
     allowFutureRecycling,
     feeProfiles,
-    fundExpenses
-  ] = useFundTuple(s => [
+    fundExpenses,
+  ] = useFundTuple((s) => [
     s.waterfallTiers || [],
     s.recyclingEnabled || false,
     s.recyclingType || 'exits',
@@ -55,27 +60,27 @@ export default function DistributionsStep() {
     s.mgmtFeeRecyclingRate || 0,
     s.allowFutureRecycling || false,
     s.feeProfiles || [],
-    s.fundExpenses || []
+    s.fundExpenses || [],
   ]);
 
   // Actions
-  const updateDistributions = useFundAction(s => s.updateDistributions);
-  const addWaterfallTier = useFundAction(s => s.addWaterfallTier);
-  const updateWaterfallTier = useFundAction(s => s.updateWaterfallTier);
-  const removeWaterfallTier = useFundAction(s => s.removeWaterfallTier);
+  const updateDistributions = useFundAction((s) => s.updateDistributions);
+  const addWaterfallTier = useFundAction((s) => s.addWaterfallTier);
+  const updateWaterfallTier = useFundAction((s) => s.updateWaterfallTier);
+  const removeWaterfallTier = useFundAction((s) => s.removeWaterfallTier);
 
   // Fee Profile actions
-  const addFeeProfile = useFundAction(s => s.addFeeProfile);
-  const updateFeeProfile = useFundAction(s => s.updateFeeProfile);
-  const removeFeeProfile = useFundAction(s => s.removeFeeProfile);
-  const addFeeTier = useFundAction(s => s.addFeeTier);
-  const updateFeeTier = useFundAction(s => s.updateFeeTier);
-  const removeFeeTier = useFundAction(s => s.removeFeeTier);
+  const addFeeProfile = useFundAction((s) => s.addFeeProfile);
+  const updateFeeProfile = useFundAction((s) => s.updateFeeProfile);
+  const removeFeeProfile = useFundAction((s) => s.removeFeeProfile);
+  const addFeeTier = useFundAction((s) => s.addFeeTier);
+  const updateFeeTier = useFundAction((s) => s.updateFeeTier);
+  const removeFeeTier = useFundAction((s) => s.removeFeeTier);
 
   // Fund Expense actions
-  const addFundExpense = useFundAction(s => s.addFundExpense);
-  const updateFundExpense = useFundAction(s => s.updateFundExpense);
-  const removeFundExpense = useFundAction(s => s.removeFundExpense);
+  const addFundExpense = useFundAction((s) => s.addFundExpense);
+  const updateFundExpense = useFundAction((s) => s.updateFundExpense);
+  const removeFundExpense = useFundAction((s) => s.removeFundExpense);
 
   const handleAddTier = () => {
     const newTier: WaterfallTier = {
@@ -83,7 +88,7 @@ export default function DistributionsStep() {
       name: `Tier ${waterfallTiers.length + 1}`,
       gpSplit: 20,
       lpSplit: 80,
-      condition: 'none'
+      condition: 'none',
     };
     addWaterfallTier(newTier);
   };
@@ -93,7 +98,7 @@ export default function DistributionsStep() {
       recyclingEnabled: enabled,
       // Reset recycling values when disabled
       exitRecyclingRate: enabled ? exitRecyclingRate : 0,
-      mgmtFeeRecyclingRate: enabled ? mgmtFeeRecyclingRate : 0
+      mgmtFeeRecyclingRate: enabled ? mgmtFeeRecyclingRate : 0,
     });
   };
 
@@ -102,7 +107,7 @@ export default function DistributionsStep() {
     const newProfile: FeeProfile = {
       id: `profile-${Date.now()}`,
       name: `Fee Profile ${feeProfiles.length + 1}`,
-      feeTiers: []
+      feeTiers: [],
     };
     addFeeProfile(newProfile);
   };
@@ -114,7 +119,7 @@ export default function DistributionsStep() {
       percentage: 2.0,
       feeBasis: 'committed_capital',
       startMonth: 1,
-      endMonth: 120
+      endMonth: 120,
     };
     addFeeTier(profileId, newTier);
   };
@@ -125,7 +130,7 @@ export default function DistributionsStep() {
       category: 'Operating Expense',
       monthlyAmount: 10000,
       startMonth: 1,
-      endMonth: 120
+      endMonth: 120,
     };
     addFundExpense(newExpense);
   };
@@ -135,45 +140,42 @@ export default function DistributionsStep() {
     {
       value: 'committed_capital',
       label: 'Committed Capital',
-      description: 'Fee charged on total committed capital by LPs'
+      description: 'Fee charged on total committed capital by LPs',
     },
     {
       value: 'called_capital_period',
       label: 'Called Capital Each Period',
-      description: 'Fee charged on called capital in that period'
+      description: 'Fee charged on called capital in that period',
     },
     {
       value: 'gross_cumulative_called',
       label: 'Gross Cumulative Called Capital',
-      description: 'Fee charged on cumulative called capital to date'
+      description: 'Fee charged on cumulative called capital to date',
     },
     {
       value: 'net_cumulative_called',
       label: 'Net Cumulative Called Capital',
-      description: 'Fee charged on cumulative called capital less capital returned to LPs'
+      description: 'Fee charged on cumulative called capital less capital returned to LPs',
     },
     {
       value: 'cumulative_invested',
       label: 'Cumulative Invested Capital',
-      description: 'Fee charged on cumulative invested capital (initial + follow-on) to date'
+      description: 'Fee charged on cumulative invested capital (initial + follow-on) to date',
     },
     {
       value: 'fair_market_value',
       label: 'Fair Market Value',
-      description: 'Fee charged on fair market value of active investments each period'
+      description: 'Fee charged on fair market value of active investments each period',
     },
     {
       value: 'unrealized_investments',
       label: 'Unrealized Investments',
-      description: 'Fee charged on total cost basis of unrealized active investments'
-    }
+      description: 'Fee charged on total cost basis of unrealized active investments',
+    },
   ];
 
   return (
-    <ModernStepContainer
-      title="Exit Recycling"
-      description="Proceeds recycling configuration"
-    >
+    <ModernStepContainer title="Exit Recycling" description="Proceeds recycling configuration">
       <div className="space-y-8">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
           <TabsList className="grid w-full grid-cols-3">
@@ -185,17 +187,13 @@ export default function DistributionsStep() {
           <TabsContent value="waterfall" className="space-y-6">
             <div className="space-y-6">
               <div className="pb-4 border-b border-[#E0D8D1]">
-                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">Distribution Waterfall</h3>
-                <p className="text-[#292929]/70 font-poppins">Define how distributions flow between LPs and GP</p>
+                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+                  Distribution Waterfall
+                </h3>
+                <p className="text-[#292929]/70 font-poppins">
+                  Define how distributions flow between LPs and GP
+                </p>
               </div>
-
-              <Alert>
-                <AlertCircle className="h-4 w-4" />
-                <AlertDescription>
-                  American waterfall calculates carry on each individual deal.
-                  Consider clawback provisions to protect LPs.
-                </AlertDescription>
-              </Alert>
 
               <div className="space-y-4">
                 <h4 className="font-inter font-bold text-[#292929]">Waterfall Tiers</h4>
@@ -217,21 +215,32 @@ export default function DistributionsStep() {
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">Tier Name</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            Tier Name
+                          </Label>
                           <Input
                             value={tier.name}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateWaterfallTier(tier.id, { name: e.target.value })}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              updateWaterfallTier(tier.id, { name: e.target.value })
+                            }
                             placeholder="e.g., Preferred Return"
                             className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">Condition</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            Condition
+                          </Label>
                           <Select
                             value={tier.condition || 'none'}
                             onValueChange={(value: string) =>
-                              updateWaterfallTier(tier.id, { ...spreadIfDefined("condition", value as WaterfallTier['condition']) })
+                              updateWaterfallTier(tier.id, {
+                                ...spreadIfDefined(
+                                  'condition',
+                                  value as WaterfallTier['condition']
+                                ),
+                              })
                             }
                           >
                             <SelectTrigger className="h-12">
@@ -254,12 +263,16 @@ export default function DistributionsStep() {
                           <Input
                             type="number"
                             min="0"
-                            step={tier.condition === 'irr' ? "0.1" : "0.01"}
+                            step={tier.condition === 'irr' ? '0.1' : '0.01'}
                             value={tier.conditionValue || ''}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateWaterfallTier(tier.id, {
-                              ...(parseFloat(e.target.value) ? { conditionValue: parseFloat(e.target.value) } : {})
-                            })}
-                            placeholder={tier.condition === 'irr' ? "e.g., 8.0" : "e.g., 1.5"}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              updateWaterfallTier(tier.id, {
+                                ...(parseFloat(e.target.value)
+                                  ? { conditionValue: parseFloat(e.target.value) }
+                                  : {}),
+                              })
+                            }
+                            placeholder={tier.condition === 'irr' ? 'e.g., 8.0' : 'e.g., 1.5'}
                             className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                           />
                         </div>
@@ -267,7 +280,9 @@ export default function DistributionsStep() {
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">LP Split (%)</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            LP Split (%)
+                          </Label>
                           <Input
                             type="number"
                             min="0"
@@ -277,7 +292,7 @@ export default function DistributionsStep() {
                               const lpSplit = parseFloat(e.target.value) || 0;
                               updateWaterfallTier(tier.id, {
                                 lpSplit,
-                                gpSplit: 100 - lpSplit
+                                gpSplit: 100 - lpSplit,
                               });
                             }}
                             className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
@@ -285,19 +300,22 @@ export default function DistributionsStep() {
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">GP Split (%)</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            GP Split (%)
+                          </Label>
                           <div className="p-3 bg-[#F2F2F2] rounded-xl h-12 flex items-center">
-                            <span className="text-[#292929] font-poppins">
-                              {tier.gpSplit}%
-                            </span>
+                            <span className="text-[#292929] font-poppins">{tier.gpSplit}%</span>
                           </div>
                         </div>
                       </div>
-
                     </div>
                   ))}
 
-                  <Button onClick={handleAddTier} variant="outline" className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium">
+                  <Button
+                    onClick={handleAddTier}
+                    variant="outline"
+                    className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+                  >
                     <Plus className="h-4 w-4 mr-2" />
                     Add Waterfall Tier
                   </Button>
@@ -310,7 +328,9 @@ export default function DistributionsStep() {
             {/* Management Fees Section */}
             <div className="space-y-6">
               <div className="pb-4 border-b border-[#E0D8D1]">
-                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">Management Fees</h3>
+                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+                  Management Fees
+                </h3>
                 <p className="text-[#292929]/70 font-poppins">
                   Configure fee structures with different basis methods and step-downs
                 </p>
@@ -318,13 +338,20 @@ export default function DistributionsStep() {
 
               <div className="space-y-6">
                 {feeProfiles.map((profile: FeeProfile) => (
-                  <div key={profile.id} className="border border-[#E0D8D1] rounded-xl p-4 space-y-4">
+                  <div
+                    key={profile.id}
+                    className="border border-[#E0D8D1] rounded-xl p-4 space-y-4"
+                  >
                     <div className="flex items-center justify-between">
                       <div className="space-y-3 flex-1">
-                        <Label className="text-sm font-poppins font-medium text-[#292929]">Fee Profile Name</Label>
+                        <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          Fee Profile Name
+                        </Label>
                         <Input
                           value={profile.name}
-                          onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFeeProfile(profile.id, { name: e.target.value })}
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                            updateFeeProfile(profile.id, { name: e.target.value })
+                          }
                           placeholder="e.g., Default Fee Profile"
                           className="max-w-md h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                         />
@@ -370,44 +397,56 @@ export default function DistributionsStep() {
 
                           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">Fee Name</Label>
+                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                                Fee Name
+                              </Label>
                               <Input
                                 value={tier.name}
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFeeTier(profile.id, tier.id, { name: e.target.value })}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  updateFeeTier(profile.id, tier.id, { name: e.target.value })
+                                }
                                 placeholder="e.g., Management Fee"
                                 className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">Fee Percentage (%)</Label>
+                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                                Fee Percentage (%)
+                              </Label>
                               <Input
                                 type="number"
                                 min="0"
                                 max="10"
                                 step="0.1"
                                 value={tier.percentage}
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFeeTier(profile.id, tier.id, {
-                                  percentage: parseFloat(e.target.value) || 0
-                                })}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  updateFeeTier(profile.id, tier.id, {
+                                    percentage: parseFloat(e.target.value) || 0,
+                                  })
+                                }
                                 placeholder="2.0"
                                 className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">Fee Basis</Label>
+                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                                Fee Basis
+                              </Label>
                               <Select
                                 value={tier.feeBasis}
-                                onValueChange={(value: string) => updateFeeTier(profile.id, tier.id, {
-                                  feeBasis: value as FeeBasis
-                                })}
+                                onValueChange={(value: string) =>
+                                  updateFeeTier(profile.id, tier.id, {
+                                    feeBasis: value as FeeBasis,
+                                  })
+                                }
                               >
                                 <SelectTrigger className="h-12">
                                   <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
-                                  {feeBasisOptions.map(option => (
+                                  {feeBasisOptions.map((option) => (
                                     <SelectItem key={option.value} value={option.value}>
                                       {option.label}
                                     </SelectItem>
@@ -415,47 +454,66 @@ export default function DistributionsStep() {
                                 </SelectContent>
                               </Select>
                               <p className="text-xs text-[#292929]/60 font-poppins">
-                                {feeBasisOptions.find(opt => opt.value === tier.feeBasis)?.description}
+                                {
+                                  feeBasisOptions.find((opt) => opt.value === tier.feeBasis)
+                                    ?.description
+                                }
                               </p>
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">Start Month</Label>
+                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                                Start Month
+                              </Label>
                               <Input
                                 type="number"
                                 min="1"
                                 value={tier.startMonth}
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFeeTier(profile.id, tier.id, {
-                                  startMonth: parseInt(e.target.value) || 1
-                                })}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  updateFeeTier(profile.id, tier.id, {
+                                    startMonth: parseInt(e.target.value) || 1,
+                                  })
+                                }
                                 className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">End Month (Optional)</Label>
+                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                                End Month (Optional)
+                              </Label>
                               <Input
                                 type="number"
                                 min="1"
                                 value={tier.endMonth || ''}
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFeeTier(profile.id, tier.id, {
-                                  ...(parseInt(e.target.value) ? { endMonth: parseInt(e.target.value) } : {})
-                                })}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  updateFeeTier(profile.id, tier.id, {
+                                    ...(parseInt(e.target.value)
+                                      ? { endMonth: parseInt(e.target.value) }
+                                      : {}),
+                                  })
+                                }
                                 placeholder="120"
                                 className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">Management Fee Recycling (%)</Label>
+                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                                Management Fee Recycling (%)
+                              </Label>
                               <Input
                                 type="number"
                                 min="0"
                                 max="100"
                                 value={tier.recyclingPercentage || ''}
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFeeTier(profile.id, tier.id, {
-                                  ...(parseFloat(e.target.value) ? { recyclingPercentage: parseFloat(e.target.value) } : {})
-                                })}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  updateFeeTier(profile.id, tier.id, {
+                                    ...(parseFloat(e.target.value)
+                                      ? { recyclingPercentage: parseFloat(e.target.value) }
+                                      : {}),
+                                  })
+                                }
                                 placeholder="0"
                                 className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                               />
@@ -470,7 +528,11 @@ export default function DistributionsStep() {
                   </div>
                 ))}
 
-                <Button onClick={handleAddFeeProfile} variant="outline" className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium">
+                <Button
+                  onClick={handleAddFeeProfile}
+                  variant="outline"
+                  className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+                >
                   <Plus className="h-4 w-4 mr-2" />
                   Add Fee Profile
                 </Button>
@@ -479,7 +541,9 @@ export default function DistributionsStep() {
               {/* Fund Expenses Section */}
               <div className="space-y-6 border-t border-[#E0D8D1] pt-8">
                 <div className="pb-4 border-b border-[#E0D8D1]">
-                  <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">Fund Expenses</h3>
+                  <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+                    Fund Expenses
+                  </h3>
                   <p className="text-[#292929]/70 font-poppins">
                     Define line-item fund expenses with monthly amounts and terms
                   </p>
@@ -487,7 +551,10 @@ export default function DistributionsStep() {
 
                 <div className="space-y-4">
                   {fundExpenses.map((expense: FundExpense) => (
-                    <div key={expense.id} className="border border-[#E0D8D1] rounded-xl p-4 space-y-4">
+                    <div
+                      key={expense.id}
+                      className="border border-[#E0D8D1] rounded-xl p-4 space-y-4"
+                    >
                       <div className="flex items-center justify-between">
                         <h4 className="font-medium">Expense: {expense.category}</h4>
                         <Button
@@ -502,51 +569,69 @@ export default function DistributionsStep() {
 
                       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">Expense Category</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            Expense Category
+                          </Label>
                           <Input
                             value={expense.category}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFundExpense(expense.id, { category: e.target.value })}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              updateFundExpense(expense.id, { category: e.target.value })
+                            }
                             placeholder="e.g., Legal Fees"
                             className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">Monthly Amount ($)</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            Monthly Amount ($)
+                          </Label>
                           <Input
                             type="number"
                             min="0"
                             value={expense.monthlyAmount}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFundExpense(expense.id, {
-                              monthlyAmount: parseFloat(e.target.value) || 0
-                            })}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              updateFundExpense(expense.id, {
+                                monthlyAmount: parseFloat(e.target.value) || 0,
+                              })
+                            }
                             placeholder="10000"
                             className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">Start Month</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            Start Month
+                          </Label>
                           <Input
                             type="number"
                             min="1"
                             value={expense.startMonth}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFundExpense(expense.id, {
-                              startMonth: parseInt(e.target.value) || 1
-                            })}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              updateFundExpense(expense.id, {
+                                startMonth: parseInt(e.target.value) || 1,
+                              })
+                            }
                             className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">End Month (Optional)</Label>
+                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            End Month (Optional)
+                          </Label>
                           <Input
                             type="number"
                             min="1"
                             value={expense.endMonth || ''}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateFundExpense(expense.id, {
-                              ...(parseInt(e.target.value) ? { endMonth: parseInt(e.target.value) } : {})
-                            })}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              updateFundExpense(expense.id, {
+                                ...(parseInt(e.target.value)
+                                  ? { endMonth: parseInt(e.target.value) }
+                                  : {}),
+                              })
+                            }
                             placeholder="120"
                             className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                           />
@@ -555,7 +640,11 @@ export default function DistributionsStep() {
                     </div>
                   ))}
 
-                  <Button onClick={handleAddExpense} variant="outline" className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium">
+                  <Button
+                    onClick={handleAddExpense}
+                    variant="outline"
+                    className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+                  >
                     <Plus className="h-4 w-4 mr-2" />
                     Add Expense
                   </Button>
@@ -567,14 +656,21 @@ export default function DistributionsStep() {
           <TabsContent value="recycling" className="space-y-6">
             <div className="space-y-6">
               <div className="pb-4 border-b border-[#E0D8D1]">
-                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">Recycling Provisions</h3>
-                <p className="text-[#292929]/70 font-poppins">Configure exit proceeds recycling for new investments</p>
+                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+                  Recycling Provisions
+                </h3>
+                <p className="text-[#292929]/70 font-poppins">
+                  Configure exit proceeds recycling for new investments
+                </p>
               </div>
 
               <div className="space-y-6">
                 <div className="flex items-center justify-between p-4 border border-[#E0D8D1] rounded-xl">
                   <div className="space-y-1">
-                    <Label htmlFor="recycling-enabled" className="cursor-pointer font-poppins font-medium text-[#292929]">
+                    <Label
+                      htmlFor="recycling-enabled"
+                      className="cursor-pointer font-poppins font-medium text-[#292929]"
+                    >
                       Enable Exit Recycling
                     </Label>
                     <p className="text-sm text-[#292929]/60 font-poppins">
@@ -592,10 +688,17 @@ export default function DistributionsStep() {
                 {recyclingEnabled && (
                   <div className="space-y-6">
                     <div className="space-y-3">
-                      <Label htmlFor="recycling-type" className="text-sm font-poppins font-medium text-[#292929]">Recycling Type</Label>
+                      <Label
+                        htmlFor="recycling-type"
+                        className="text-sm font-poppins font-medium text-[#292929]"
+                      >
+                        Recycling Type
+                      </Label>
                       <Select
                         value={recyclingType}
-                        onValueChange={(value: string) => updateDistributions({ recyclingType: value as 'exits' | 'fees' | 'both' })}
+                        onValueChange={(value: string) =>
+                          updateDistributions({ recyclingType: value as 'exits' | 'fees' | 'both' })
+                        }
                       >
                         <SelectTrigger id="recycling-type" className="h-12">
                           <SelectValue />
@@ -608,34 +711,46 @@ export default function DistributionsStep() {
                       <p className="text-sm text-[#292929]/60 font-poppins">
                         {recyclingType === 'exits'
                           ? 'Fund can recycle exit proceeds up to a cap (% of committed capital)'
-                          : 'Fund can recycle exit proceeds up to the level of management fees earned to date'
-                        }
+                          : 'Fund can recycle exit proceeds up to the level of management fees earned to date'}
                       </p>
                     </div>
 
                     <div className="space-y-3">
-                      <Label htmlFor="exit-recycling" className="text-sm font-poppins font-medium text-[#292929]">Exit Proceeds Recycling Rate (%)</Label>
+                      <Label
+                        htmlFor="exit-recycling"
+                        className="text-sm font-poppins font-medium text-[#292929]"
+                      >
+                        Exit Proceeds Recycling Rate (%)
+                      </Label>
                       <Input
                         id="exit-recycling"
                         type="number"
                         min="0"
                         max="100"
                         value={exitRecyclingRate}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateDistributions({
-                          exitRecyclingRate: parseFloat(e.target.value) || 0
-                        })}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                          updateDistributions({
+                            exitRecyclingRate: parseFloat(e.target.value) || 0,
+                          })
+                        }
                         data-testid="exit-recycling-rate"
                         placeholder="100"
                         className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                       />
                       <p className="text-sm text-[#292929]/60 font-poppins">
-                        Percentage of exit proceeds that can be recycled each period (typically 100%)
+                        Percentage of exit proceeds that can be recycled each period (typically
+                        100%)
                       </p>
                     </div>
 
                     {recyclingType === 'exits' && (
                       <div className="space-y-3">
-                        <Label htmlFor="recycling-cap-pct" className="text-sm font-poppins font-medium text-[#292929]">Recycling Cap (% of Committed Capital)</Label>
+                        <Label
+                          htmlFor="recycling-cap-pct"
+                          className="text-sm font-poppins font-medium text-[#292929]"
+                        >
+                          Recycling Cap (% of Committed Capital)
+                        </Label>
                         <Input
                           id="recycling-cap-pct"
                           type="number"
@@ -646,29 +761,39 @@ export default function DistributionsStep() {
                           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                             const pct = parseFloat(e.target.value) || 0;
                             updateDistributions({
-                              recyclingCap: (pct / 100) * fundSize
+                              recyclingCap: (pct / 100) * fundSize,
                             });
                           }}
                           placeholder="50"
                           className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                         />
                         <p className="text-sm text-[#292929]/60 font-poppins">
-                          Maximum amount that can be recycled as % of committed capital (e.g., 50% cap = half the committed capital)
+                          Maximum amount that can be recycled as % of committed capital (e.g., 50%
+                          cap = half the committed capital)
                         </p>
                       </div>
                     )}
 
                     <div className="space-y-3">
-                      <Label htmlFor="recycling-period" className="text-sm font-poppins font-medium text-[#292929]">Recycling Term (years)</Label>
+                      <Label
+                        htmlFor="recycling-period"
+                        className="text-sm font-poppins font-medium text-[#292929]"
+                      >
+                        Recycling Term (years)
+                      </Label>
                       <Input
                         id="recycling-period"
                         type="number"
                         min="0"
                         max="10"
                         value={recyclingPeriod || ''}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateDistributions({
-                          ...(parseFloat(e.target.value) ? { recyclingPeriod: parseFloat(e.target.value) } : {})
-                        })}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                          updateDistributions({
+                            ...(parseFloat(e.target.value)
+                              ? { recyclingPeriod: parseFloat(e.target.value) }
+                              : {}),
+                          })
+                        }
                         placeholder="3"
                         className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
                       />
@@ -681,14 +806,20 @@ export default function DistributionsStep() {
                       <Switch
                         id="allow-future-recycling"
                         checked={allowFutureRecycling || false}
-                        onCheckedChange={(checked: boolean) => updateDistributions({ allowFutureRecycling: checked })}
+                        onCheckedChange={(checked: boolean) =>
+                          updateDistributions({ allowFutureRecycling: checked })
+                        }
                       />
                       <div>
-                        <Label htmlFor="allow-future-recycling" className="cursor-pointer text-sm font-poppins font-medium text-[#292929]">
+                        <Label
+                          htmlFor="allow-future-recycling"
+                          className="cursor-pointer text-sm font-poppins font-medium text-[#292929]"
+                        >
                           Allow fund to recycle future exit proceeds ahead of time
                         </Label>
                         <p className="text-sm text-[#292929]/60 font-poppins mt-1">
-                          If enabled, fund will aggressively invest in anticipation of future exits. If disabled, fund waits for exits before recycling.
+                          If enabled, fund will aggressively invest in anticipation of future exits.
+                          If disabled, fund waits for exits before recycling.
                         </p>
                       </div>
                     </div>

--- a/client/src/pages/FundBasicsStep.tsx
+++ b/client/src/pages/FundBasicsStep.tsx
@@ -194,7 +194,7 @@ export default function FundBasicsStep() {
           </div>
 
           <NumericInput
-            label="Capital Committed ($M) *"
+            label="Capital Committed ($M)"
             value={fundSize}
             onChange={(value: number | undefined) => handleInputChange('fundSize', value)}
             mode="number"

--- a/client/src/pages/dashboard-modern.tsx
+++ b/client/src/pages/dashboard-modern.tsx
@@ -76,7 +76,7 @@ function OverviewMetricsPanel({
       <MetricTile
         label="Total committed"
         value={formatDollars(metrics.actual.totalCommitted)}
-        detail="Fund commitments from the unified metrics layer"
+        detail="Fund commitments"
       />
       <MetricTile
         label="Capital deployed"
@@ -186,11 +186,7 @@ export default function ModernDashboard() {
   if (isLoading || !currentFund) {
     return (
       <div className="min-h-screen bg-pov-gray">
-        <POVBrandHeader
-          title="Dashboard"
-          subtitle="Real-time fund performance and portfolio analytics"
-          variant="light"
-        />
+        <POVBrandHeader title="Dashboard" />
         <div className="max-w-7xl mx-auto px-6 py-8">
           <div className="animate-pulse space-y-6">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
@@ -207,18 +203,11 @@ export default function ModernDashboard() {
 
   return (
     <div className="min-h-screen bg-slate-100">
-      <POVBrandHeader
-        title="Dashboard"
-        subtitle="Fund workspace and truthful live surfaces"
-        variant="light"
-      />
+      <POVBrandHeader title="Dashboard" />
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-6 py-8">
-        <TargetMetricsSnapshot
-          title="Target-Aware Snapshot"
-          subtitle="Truthful live metrics sourced from the unified metrics layer."
-        />
+        <TargetMetricsSnapshot title="Snapshot" />
 
         {/* Top Controls */}
         <div className="mt-8 flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">

--- a/tests/unit/components/metrics/target-metrics-snapshot.test.tsx
+++ b/tests/unit/components/metrics/target-metrics-snapshot.test.tsx
@@ -53,14 +53,9 @@ describe('TargetMetricsSnapshot', () => {
       staleOnTrack: false,
     });
 
-    render(
-      <TargetMetricsSnapshot
-        title="Target-Aware Snapshot"
-        subtitle="Truthful live metrics sourced from the unified metrics layer."
-      />
-    );
+    render(<TargetMetricsSnapshot title="Target-Aware Snapshot" />);
 
-    expect(screen.getByText('Target-Aware Snapshot')).toBeInTheDocument();
+    expect(screen.getByLabelText('Target-Aware Snapshot')).toBeInTheDocument();
     expect(screen.getByText('Deployment vs Plan')).toBeInTheDocument();
     expect(screen.getByText('TVPI vs Target')).toBeInTheDocument();
     expect(screen.getByText('Companies vs Target')).toBeInTheDocument();
@@ -73,12 +68,7 @@ describe('TargetMetricsSnapshot', () => {
       staleOnTrack: true,
     });
 
-    render(
-      <TargetMetricsSnapshot
-        title="Target-Aware Snapshot"
-        subtitle="Truthful live metrics sourced from the unified metrics layer."
-      />
-    );
+    render(<TargetMetricsSnapshot title="Target-Aware Snapshot" />);
 
     expect(screen.getByText('Behind Plan')).toBeInTheDocument();
   });
@@ -90,12 +80,7 @@ describe('TargetMetricsSnapshot', () => {
       staleOnTrack: false,
     });
 
-    render(
-      <TargetMetricsSnapshot
-        title="Target-Aware Snapshot"
-        subtitle="Truthful live metrics sourced from the unified metrics layer."
-      />
-    );
+    render(<TargetMetricsSnapshot title="Target-Aware Snapshot" />);
 
     expect(screen.getAllByText('On Track').length).toBeGreaterThanOrEqual(1);
   });
@@ -115,12 +100,7 @@ describe('TargetMetricsSnapshot', () => {
       error: null,
     });
 
-    render(
-      <TargetMetricsSnapshot
-        title="Target-Aware Snapshot"
-        subtitle="Truthful live metrics sourced from the unified metrics layer."
-      />
-    );
+    render(<TargetMetricsSnapshot title="Target-Aware Snapshot" />);
 
     expect(
       screen.getByText(/require a published target snapshot before plan comparisons can be shown/i)

--- a/tests/unit/pages/dashboard-modern.test.tsx
+++ b/tests/unit/pages/dashboard-modern.test.tsx
@@ -81,7 +81,6 @@ describe('ModernDashboard', () => {
   it('renders supported overview metrics instead of broad deferred copy', () => {
     render(<ModernDashboard />);
 
-    expect(screen.getByText('Target-Aware Snapshot')).toBeInTheDocument();
     expect(screen.getByText(/supported overview metrics/i)).toBeInTheDocument();
     expect(screen.getByText('Total committed')).toBeInTheDocument();
     expect(screen.getByText('$50.0M')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Strip the marketing-style hero block (`PRESS ON VENTURES / Page Title / Powered by Press On Ventures`) from every page that used `POVBrandHeader` — reclaims ~30% of viewport above the fold on every screen.
- Drop the engineering-vocabulary subtitles (`unified metrics layer`, `construction target`, `age-adjusted plan`, `configured target multiple`) from the dashboard and remove the condescending American-waterfall callout from the wizard.
- Remove the `Chart Types` placeholder section from the sidebar (no items, no nav targets, pure dead UI) and fix the duplicate asterisk on the `Capital Committed ($M)` field.

## Why
This branch is a small slice of the QA pass logged at `~/.claude/plans/parsed-tumbling-cocoa.md`. The page hero block was rendering on every primary route, eating substantial vertical real estate and forcing the GP to scroll past brand chrome to reach work. Internal-team vocabulary like *"Truthful live metrics sourced from the unified metrics layer"* doesn't belong above a GP-facing variance card. The `Capital Committed ($M)` label rendered `**` because the parent string included a literal `*` and `NumericInput` adds its own asterisk via the `required` prop.

## Changes
- `client/src/components/ui/POVLogo.tsx` — `POVBrandHeader` rewritten as slim left-aligned `<h1>` + optional subtitle; props kept for backward compat with 7+ call sites.
- `client/src/components/metrics/TargetMetricsSnapshot.tsx` — drop title h2, subtitle p, and three card description subtitles; `subtitle` prop is now optional.
- `client/src/pages/dashboard-modern.tsx` — drop subtitles passed to `POVBrandHeader` and `TargetMetricsSnapshot`; shorten one MetricTile detail.
- `client/src/components/layout/sidebar.tsx` — remove `Chart Types` collapsible + supporting `chartCategories` array + `isChartsExpanded` state.
- `client/src/pages/DistributionsStep.tsx` — remove the American waterfall info callout (formatter cleaned up the now-unused Alert imports).
- `client/src/pages/FundBasicsStep.tsx` — remove the literal `*` from the `Capital Committed ($M)` label.
- `tests/unit/components/metrics/target-metrics-snapshot.test.tsx` and `tests/unit/pages/dashboard-modern.test.tsx` — update assertions to match new component output (title now lives in `aria-label`, not visible text).

## Test plan
- [x] `npm run check` — TypeScript baseline: 0 new errors
- [x] `npx eslint <changed files>` — clean
- [x] `npx vitest run --project=client tests/unit/components/metrics/target-metrics-snapshot.test.tsx tests/unit/pages/dashboard-modern.test.tsx` — 9/9 pass
- [x] Pre-push gates: 88/88 client tests pass
- [x] `npm run build` — production build succeeded
- [x] Manual visual verification at `localhost:5000/dashboard`, `/portfolio`, `/pipeline`, `/settings`, `/help`, and all 7 wizard steps after rebuild

## Out of scope (deferred follow-ups)
- F1: Wizard `Next` button should block when required fields are empty.
- F4: HeaderKpis stale data and fake "Live metrics" badge.
- F7: Dashboard variance cards should be actual variance charts (bullet/gauge), not static numbers.
- F10: Carry vs Carried Interest terminology unification.
- D1-D5: Design system lockdown (4 fonts, 11 grays, 2 dark primaries, no tabular-nums) — multi-day, dedicated `tokens-cleanup` branch.
- The `Fund Construction Wizard` page hero is rendered by a separate `WizardHeader` component (not `POVBrandHeader`) and still shows the bloated brand chrome — easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)