### PR TITLE
Capture draft metric-run evidence before reporting hardens

### DIFF
--- a/client/src/hooks/lp-reporting/index.ts
+++ b/client/src/hooks/lp-reporting/index.ts
@@ -5,11 +5,16 @@
  */
 
 export {
+  useMetricRunEvidenceCreate,
+  useMetricRunEvidenceList,
   useMetricRunCommit,
   useMetricsDryRun,
   type MetricsDryRunRequest,
   type DryRunErrorBody,
   type LpReportingHookError,
+  type MetricRunEvidenceCreateRequest,
+  type MetricRunEvidenceCreateResponse,
+  type MetricRunEvidenceListResponse,
 } from './useMetricsDryRun';
 export { useLedgerImportDryRun } from './useLedgerImportDryRun';
 export { useValuationMarkImportDryRun } from './useValuationMarkImportDryRun';

--- a/client/src/hooks/lp-reporting/useMetricsDryRun.ts
+++ b/client/src/hooks/lp-reporting/useMetricsDryRun.ts
@@ -8,15 +8,21 @@
  * @module client/hooks/lp-reporting/useMetricsDryRun
  */
 
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   MetricRunCommitRequestSchema,
   MetricRunCommitResponseSchema,
   MetricRunDryRunResponseSchema,
+  MetricRunEvidenceCreateRequestSchema,
+  MetricRunEvidenceCreateResponseSchema,
+  MetricRunEvidenceListResponseSchema,
   type MetricRunCommitRequest,
   type MetricRunCommitResponse,
   type MetricRunDryRunRequest,
   type MetricRunDryRunResponse,
+  type MetricRunEvidenceCreateRequest,
+  type MetricRunEvidenceCreateResponse,
+  type MetricRunEvidenceListResponse,
 } from '@shared/contracts/lp-reporting';
 
 export type MetricsDryRunRequest = MetricRunDryRunRequest;
@@ -105,6 +111,71 @@ async function postMetricRunCommit(
   return parsed.data;
 }
 
+function metricRunEvidenceQueryKey(fundId: number | null, metricRunId: number | null) {
+  return ['lp-reporting', 'metric-run-evidence', fundId, metricRunId] as const;
+}
+
+async function getMetricRunEvidenceList(
+  fundId: number,
+  metricRunId: number
+): Promise<MetricRunEvidenceListResponse> {
+  const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/evidence-records`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    const errorBody = (await res.json().catch(() => ({}))) as Partial<DryRunErrorBody>;
+    throw buildHookError(res.status, errorBody, `HTTP ${res.status}`);
+  }
+
+  const raw = (await res.json()) as unknown;
+  const parsed = MetricRunEvidenceListResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    const error = new Error(
+      'Metric-run evidence list response did not match the locked contract.'
+    ) as LpReportingHookError;
+    error.code = 'CONTRACT_PARSE_ERROR';
+    error.status = res.status;
+    throw error;
+  }
+
+  return parsed.data;
+}
+
+async function postMetricRunEvidence(
+  fundId: number,
+  metricRunId: number,
+  body: MetricRunEvidenceCreateRequest
+): Promise<MetricRunEvidenceCreateResponse> {
+  MetricRunEvidenceCreateRequestSchema.parse(body);
+
+  const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/evidence-records`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errorBody = (await res.json().catch(() => ({}))) as Partial<DryRunErrorBody>;
+    throw buildHookError(res.status, errorBody, `HTTP ${res.status}`);
+  }
+
+  const raw = (await res.json()) as unknown;
+  const parsed = MetricRunEvidenceCreateResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    const error = new Error(
+      'Metric-run evidence create response did not match the locked contract.'
+    ) as LpReportingHookError;
+    error.code = 'CONTRACT_PARSE_ERROR';
+    error.status = res.status;
+    throw error;
+  }
+
+  return parsed.data;
+}
+
 export function useMetricsDryRun(fundId: number | null) {
   return useMutation<MetricRunDryRunResponse, LpReportingHookError, MetricsDryRunRequest>({
     mutationFn: async (request) => {
@@ -138,3 +209,48 @@ export function useMetricRunCommit(fundId: number | null) {
     },
   });
 }
+
+export function useMetricRunEvidenceList(fundId: number | null, metricRunId: number | null) {
+  return useQuery<MetricRunEvidenceListResponse, LpReportingHookError>({
+    queryKey: metricRunEvidenceQueryKey(fundId, metricRunId),
+    enabled: fundId !== null && metricRunId !== null,
+    queryFn: async () => {
+      if (fundId === null || metricRunId === null) {
+        const error = new Error('fundId and metricRunId are required') as LpReportingHookError;
+        error.code = 'MISSING_METRIC_RUN_EVIDENCE_SCOPE';
+        throw error;
+      }
+
+      return getMetricRunEvidenceList(fundId, metricRunId);
+    },
+  });
+}
+
+export function useMetricRunEvidenceCreate(fundId: number | null, metricRunId: number | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    MetricRunEvidenceCreateResponse,
+    LpReportingHookError,
+    MetricRunEvidenceCreateRequest
+  >({
+    mutationFn: async (request) => {
+      if (fundId === null || metricRunId === null) {
+        const error = new Error('fundId and metricRunId are required') as LpReportingHookError;
+        error.code = 'MISSING_METRIC_RUN_EVIDENCE_SCOPE';
+        throw error;
+      }
+
+      return postMetricRunEvidence(fundId, metricRunId, request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: metricRunEvidenceQueryKey(fundId, metricRunId) });
+    },
+  });
+}
+
+export type {
+  MetricRunEvidenceCreateRequest,
+  MetricRunEvidenceCreateResponse,
+  MetricRunEvidenceListResponse,
+};

--- a/client/src/pages/lp-reporting/metrics.tsx
+++ b/client/src/pages/lp-reporting/metrics.tsx
@@ -20,7 +20,7 @@
  * @module client/pages/lp-reporting/metrics
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useState, type FormEvent } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -32,11 +32,18 @@ import { useFundContext } from '@/contexts/FundContext';
 import {
   LpMetricRunResultsSchema,
   MetricRunDryRunResponseSchema,
+  type ConfidenceLevel,
   type MetricRunCommitResponse,
   type MetricRunDryRunRequest,
   type MetricRunDryRunResponse,
+  type MetricRunEvidenceCreateRequest,
 } from '@shared/contracts/lp-reporting';
-import { useMetricRunCommit, type LpReportingHookError } from '@/hooks/lp-reporting';
+import {
+  useMetricRunCommit,
+  useMetricRunEvidenceCreate,
+  useMetricRunEvidenceList,
+  type LpReportingHookError,
+} from '@/hooks/lp-reporting';
 
 interface ErrorEnvelope {
   title: string;
@@ -45,7 +52,65 @@ interface ErrorEnvelope {
 
 const XIRR_PANEL_DOM_ID = 'lp-reporting-xirr-diagnostic-panel';
 
+type EvidenceSource =
+  | 'financing_round'
+  | 'signed_loi'
+  | 'revenue_milestone'
+  | 'strategic_partnership'
+  | 'audited_financials'
+  | 'board_update'
+  | 'gp_estimate'
+  | 'third_party_priced'
+  | 'secondary_transaction'
+  | 'customer_contract'
+  | 'management_report'
+  | 'auditor_confirmation';
+
+type MaterialityLevel = 'high' | 'medium' | 'low';
+type Confidentiality = 'internal' | 'lp_shareable' | 'restricted';
+
+interface EvidenceFormState {
+  evidenceSource: EvidenceSource;
+  sourceDate: string;
+  confidenceLevel: ConfidenceLevel;
+  materialityLevel: MaterialityLevel;
+  confidentiality: Confidentiality;
+  redactionRequired: boolean;
+  description: string;
+}
+
+function makeEvidenceFormState(sourceDate = ''): EvidenceFormState {
+  return {
+    evidenceSource: 'board_update',
+    sourceDate,
+    confidenceLevel: 'medium',
+    materialityLevel: 'medium',
+    confidentiality: 'internal',
+    redactionRequired: false,
+    description: '',
+  };
+}
+
+function optionalText(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function createEvidenceIdempotencyKey(metricRunId: number): string {
+  const token =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `metric-run-${metricRunId}-evidence-${token}`;
+}
+
 function envelopeFor(err: LpReportingHookError): ErrorEnvelope {
+  if (err.code === 'METRIC_RUN_NOT_EDITABLE') {
+    return {
+      title: 'Metric run not editable',
+      description: 'Evidence records can only be added while the metric run is still draft.',
+    };
+  }
   if (err.code === 'PREVIEW_HASH_MISMATCH') {
     return {
       title: 'Preview changed',
@@ -99,6 +164,14 @@ export default function LpReportingMetricsPage() {
   const [dryRunError, setDryRunError] = useState<LpReportingHookError | null>(null);
   const [commitResult, setCommitResult] = useState<MetricRunCommitResponse | null>(null);
   const [commitError, setCommitError] = useState<LpReportingHookError | null>(null);
+  const [evidenceForm, setEvidenceForm] = useState<EvidenceFormState>(() =>
+    makeEvidenceFormState()
+  );
+  const [evidenceIdempotencyKey, setEvidenceIdempotencyKey] = useState<string | null>(null);
+  const [evidenceError, setEvidenceError] = useState<LpReportingHookError | null>(null);
+  const committedMetricRunId = commitResult?.metricRunId ?? null;
+  const evidenceListQuery = useMetricRunEvidenceList(fundId, committedMetricRunId);
+  const evidenceCreateMutation = useMetricRunEvidenceCreate(fundId, committedMetricRunId);
 
   const handleSuccess = useCallback(
     (response: MetricRunDryRunResponse, request: MetricRunDryRunRequest) => {
@@ -112,6 +185,9 @@ export default function LpReportingMetricsPage() {
       setDryRunError(null);
       setCommitError(null);
       setCommitResult(null);
+      setEvidenceError(null);
+      setEvidenceIdempotencyKey(null);
+      setEvidenceForm(makeEvidenceFormState(parsedResults.asOfDate));
     },
     []
   );
@@ -120,6 +196,7 @@ export default function LpReportingMetricsPage() {
     setDryRunError(err);
     setCommitError(null);
     setCommitResult(null);
+    setEvidenceError(null);
   }, []);
 
   const handleCommit = useCallback(async () => {
@@ -133,6 +210,9 @@ export default function LpReportingMetricsPage() {
       });
       setCommitResult(result);
       setCommitError(null);
+      setEvidenceError(null);
+      setEvidenceIdempotencyKey(createEvidenceIdempotencyKey(result.metricRunId));
+      setEvidenceForm(makeEvidenceFormState(dryRun.results.asOfDate));
     } catch (err) {
       if (err && typeof err === 'object') {
         setCommitError(err as LpReportingHookError);
@@ -140,9 +220,59 @@ export default function LpReportingMetricsPage() {
     }
   }, [commitMutation, dryRun, dryRunRequest]);
 
+  const handleEvidenceSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (committedMetricRunId === null) {
+        return;
+      }
+      const idempotencyKey =
+        evidenceIdempotencyKey ?? createEvidenceIdempotencyKey(committedMetricRunId);
+
+      const request: MetricRunEvidenceCreateRequest = {
+        idempotencyKey,
+        evidenceSource: evidenceForm.evidenceSource,
+        sourceDate: evidenceForm.sourceDate,
+        confidenceLevel: evidenceForm.confidenceLevel,
+        materialityLevel: evidenceForm.materialityLevel,
+        confidentiality: evidenceForm.confidentiality,
+        redactionRequired: evidenceForm.redactionRequired,
+        ...(optionalText(evidenceForm.description) !== undefined && {
+          description: optionalText(evidenceForm.description),
+        }),
+      };
+
+      try {
+        await evidenceCreateMutation.mutateAsync(request);
+        setEvidenceError(null);
+        setEvidenceIdempotencyKey(createEvidenceIdempotencyKey(committedMetricRunId));
+        setEvidenceForm(makeEvidenceFormState(dryRun?.results.asOfDate ?? ''));
+      } catch (err) {
+        if (err && typeof err === 'object') {
+          setEvidenceError(err as LpReportingHookError);
+        }
+      }
+    },
+    [
+      committedMetricRunId,
+      dryRun?.results.asOfDate,
+      evidenceCreateMutation,
+      evidenceForm,
+      evidenceIdempotencyKey,
+    ]
+  );
+
   const results = dryRun?.results ?? null;
   const envelope = dryRunError ? envelopeFor(dryRunError) : null;
   const commitEnvelope = commitError ? envelopeFor(commitError) : null;
+  const evidenceQueryError =
+    evidenceListQuery.error && committedMetricRunId !== null ? evidenceListQuery.error : null;
+  const evidenceEnvelope = evidenceError
+    ? envelopeFor(evidenceError)
+    : evidenceQueryError
+      ? envelopeFor(evidenceQueryError)
+      : null;
+  const evidenceRecords = evidenceListQuery.data?.records ?? [];
 
   return (
     <div className="p-8 space-y-6">
@@ -238,6 +368,205 @@ export default function LpReportingMetricsPage() {
               ) : null}
             </CardContent>
           </Card>
+
+          {commitResult ? (
+            <Card data-testid="metric-run-evidence-card">
+              <CardHeader>
+                <CardTitle>Metric-run evidence</CardTitle>
+                <CardDescription>
+                  Metadata records attached to draft metric run #{commitResult.metricRunId}.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {evidenceEnvelope ? (
+                  <Alert
+                    variant="destructive"
+                    data-testid="metric-run-evidence-error-envelope"
+                    data-error-status={evidenceError?.status ?? evidenceQueryError?.status ?? ''}
+                  >
+                    <AlertTitle>{evidenceEnvelope.title}</AlertTitle>
+                    <AlertDescription>{evidenceEnvelope.description}</AlertDescription>
+                  </Alert>
+                ) : null}
+
+                <form
+                  className="grid gap-4 md:grid-cols-2"
+                  onSubmit={(event) => void handleEvidenceSubmit(event)}
+                  data-testid="metric-run-evidence-form"
+                >
+                  <label className="space-y-1 text-sm font-medium text-charcoal">
+                    Evidence source
+                    <select
+                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                      value={evidenceForm.evidenceSource}
+                      onChange={(event) =>
+                        setEvidenceForm((current) => ({
+                          ...current,
+                          evidenceSource: event.target.value as EvidenceSource,
+                        }))
+                      }
+                    >
+                      <option value="board_update">Board update</option>
+                      <option value="audited_financials">Audited financials</option>
+                      <option value="financing_round">Financing round</option>
+                      <option value="management_report">Management report</option>
+                      <option value="gp_estimate">GP estimate</option>
+                      <option value="third_party_priced">Third-party priced</option>
+                      <option value="signed_loi">Signed LOI</option>
+                      <option value="revenue_milestone">Revenue milestone</option>
+                      <option value="strategic_partnership">Strategic partnership</option>
+                      <option value="secondary_transaction">Secondary transaction</option>
+                      <option value="customer_contract">Customer contract</option>
+                      <option value="auditor_confirmation">Auditor confirmation</option>
+                    </select>
+                  </label>
+
+                  <label className="space-y-1 text-sm font-medium text-charcoal">
+                    Source date
+                    <input
+                      className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                      type="date"
+                      required
+                      value={evidenceForm.sourceDate}
+                      onChange={(event) =>
+                        setEvidenceForm((current) => ({
+                          ...current,
+                          sourceDate: event.target.value,
+                        }))
+                      }
+                    />
+                  </label>
+
+                  <label className="space-y-1 text-sm font-medium text-charcoal">
+                    Confidence
+                    <select
+                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                      value={evidenceForm.confidenceLevel}
+                      onChange={(event) =>
+                        setEvidenceForm((current) => ({
+                          ...current,
+                          confidenceLevel: event.target.value as ConfidenceLevel,
+                        }))
+                      }
+                    >
+                      <option value="high">High</option>
+                      <option value="medium">Medium</option>
+                      <option value="low">Low</option>
+                    </select>
+                  </label>
+
+                  <label className="space-y-1 text-sm font-medium text-charcoal">
+                    Materiality
+                    <select
+                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                      value={evidenceForm.materialityLevel}
+                      onChange={(event) =>
+                        setEvidenceForm((current) => ({
+                          ...current,
+                          materialityLevel: event.target.value as MaterialityLevel,
+                        }))
+                      }
+                    >
+                      <option value="high">High</option>
+                      <option value="medium">Medium</option>
+                      <option value="low">Low</option>
+                    </select>
+                  </label>
+
+                  <label className="space-y-1 text-sm font-medium text-charcoal">
+                    Confidentiality
+                    <select
+                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                      value={evidenceForm.confidentiality}
+                      onChange={(event) =>
+                        setEvidenceForm((current) => ({
+                          ...current,
+                          confidentiality: event.target.value as Confidentiality,
+                        }))
+                      }
+                    >
+                      <option value="internal">Internal</option>
+                      <option value="lp_shareable">LP shareable</option>
+                      <option value="restricted">Restricted</option>
+                    </select>
+                  </label>
+
+                  <label className="flex items-center gap-2 text-sm font-medium text-charcoal md:mt-7">
+                    <input
+                      type="checkbox"
+                      checked={evidenceForm.redactionRequired}
+                      onChange={(event) =>
+                        setEvidenceForm((current) => ({
+                          ...current,
+                          redactionRequired: event.target.checked,
+                        }))
+                      }
+                    />
+                    Redaction required
+                  </label>
+
+                  <label className="space-y-1 text-sm font-medium text-charcoal md:col-span-2">
+                    Description
+                    <textarea
+                      className="min-h-24 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                      maxLength={2000}
+                      value={evidenceForm.description}
+                      onChange={(event) =>
+                        setEvidenceForm((current) => ({
+                          ...current,
+                          description: event.target.value,
+                        }))
+                      }
+                    />
+                  </label>
+
+                  <div className="md:col-span-2">
+                    <Button
+                      type="submit"
+                      disabled={evidenceCreateMutation.isPending}
+                      data-testid="metric-run-evidence-submit"
+                    >
+                      {evidenceCreateMutation.isPending ? 'Saving...' : 'Add evidence'}
+                    </Button>
+                  </div>
+                </form>
+
+                <div className="space-y-3" data-testid="metric-run-evidence-list">
+                  {evidenceListQuery.isLoading ? (
+                    <p className="text-sm text-charcoal/70 font-poppins">Loading evidence...</p>
+                  ) : null}
+                  {!evidenceListQuery.isLoading && evidenceRecords.length === 0 ? (
+                    <p
+                      className="text-sm text-charcoal/70 font-poppins"
+                      data-testid="metric-run-evidence-empty"
+                    >
+                      No evidence records yet.
+                    </p>
+                  ) : null}
+                  {evidenceRecords.map((record) => (
+                    <div
+                      key={record.id}
+                      className="rounded-md border border-slate-200 px-3 py-2"
+                      data-testid="metric-run-evidence-record"
+                    >
+                      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                        <p className="text-sm font-medium text-charcoal">
+                          {record.evidenceSource.replaceAll('_', ' ')}
+                        </p>
+                        <p className="text-xs text-charcoal/60">{record.sourceDate}</p>
+                      </div>
+                      {record.description ? (
+                        <p className="mt-1 text-sm text-charcoal/70">{record.description}</p>
+                      ) : null}
+                      <p className="mt-1 text-xs text-charcoal/60">
+                        {record.confidenceLevel} confidence | {record.materialityLevel} materiality
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
 
           <Card>
             <CardHeader>

--- a/server/migrations/20260510_lp_reporting_metric_run_evidence_idempotency_v1.down.sql
+++ b/server/migrations/20260510_lp_reporting_metric_run_evidence_idempotency_v1.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS evidence_records_metric_run_idempotency_unique;
+
+ALTER TABLE evidence_records
+  DROP COLUMN IF EXISTS idempotency_key;

--- a/server/migrations/20260510_lp_reporting_metric_run_evidence_idempotency_v1.up.sql
+++ b/server/migrations/20260510_lp_reporting_metric_run_evidence_idempotency_v1.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE evidence_records
+  ADD COLUMN IF NOT EXISTS idempotency_key varchar(128);
+
+CREATE UNIQUE INDEX IF NOT EXISTS evidence_records_metric_run_idempotency_unique
+  ON evidence_records (fund_id, metric_run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;

--- a/server/routes/lp-reporting/metric-runs.ts
+++ b/server/routes/lp-reporting/metric-runs.ts
@@ -3,6 +3,8 @@
  *
  *   POST /api/funds/:fundId/metric-runs/dry-run
  *   POST /api/funds/:fundId/metric-runs/commit
+ *   GET  /api/funds/:fundId/metric-runs/:metricRunId/evidence-records
+ *   POST /api/funds/:fundId/metric-runs/:metricRunId/evidence-records
  *
  * Dry-run returns the full metric envelope plus a server-owned preview hash.
  * Commit re-runs the calculation from persisted source rows and only writes a
@@ -23,12 +25,19 @@ import {
   MetricRunCommitResponseSchema,
   MetricRunDryRunRequestSchema,
   MetricRunDryRunResponseSchema,
+  MetricRunEvidenceCreateRequestSchema,
+  MetricRunEvidenceCreateResponseSchema,
+  MetricRunEvidenceListResponseSchema,
 } from '@shared/contracts/lp-reporting';
 import {
   buildMetricRunDryRun,
   commitMetricRun,
   MetricRunCommitError,
 } from '../../services/lp-reporting/metric-run-commit-service';
+import {
+  createMetricRunEvidence,
+  listMetricRunEvidence,
+} from '../../services/lp-reporting/metric-run-evidence-service';
 
 const router = Router();
 
@@ -55,6 +64,18 @@ function parseFundId(req: Request): number {
     throw new MetricRunCommitError(400, 'INVALID_FUND_ID', 'fundId must be a positive integer.');
   }
   return fundId;
+}
+
+function parseMetricRunId(req: Request): number {
+  const metricRunId = Number.parseInt(firstString(req.params['metricRunId']) ?? '', 10);
+  if (!Number.isFinite(metricRunId) || metricRunId <= 0) {
+    throw new MetricRunCommitError(
+      400,
+      'INVALID_METRIC_RUN_ID',
+      'metricRunId must be a positive integer.'
+    );
+  }
+  return metricRunId;
 }
 
 function numericIdentity(value: unknown): number | null {
@@ -86,7 +107,11 @@ function resolveAuthenticatedUserId(req: Request): number {
 function sendMetricRunError(
   res: Response,
   err: unknown,
-  fallbackCode: 'METRIC_RUN_DRY_RUN_FAILED' | 'METRIC_RUN_COMMIT_FAILED'
+  fallbackCode:
+    | 'METRIC_RUN_DRY_RUN_FAILED'
+    | 'METRIC_RUN_COMMIT_FAILED'
+    | 'METRIC_RUN_EVIDENCE_CREATE_FAILED'
+    | 'METRIC_RUN_EVIDENCE_LIST_FAILED'
 ): Response {
   if (err instanceof MetricRunCommitError) {
     return res.status(err.status).json({
@@ -153,6 +178,54 @@ router.post(
       return res.status(validated.inserted ? 201 : 200).json(validated);
     } catch (err) {
       return sendMetricRunError(res, err, 'METRIC_RUN_COMMIT_FAILED');
+    }
+  }
+);
+
+router.get(
+  '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
+  requireAuth(),
+  requireFundAccess,
+  metricRunLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const result = await listMetricRunEvidence({
+        fundId: parseFundId(req),
+        metricRunId: parseMetricRunId(req),
+      });
+      const validated = MetricRunEvidenceListResponseSchema.parse(result);
+      return res.status(200).json(validated);
+    } catch (err) {
+      return sendMetricRunError(res, err, 'METRIC_RUN_EVIDENCE_LIST_FAILED');
+    }
+  }
+);
+
+router.post(
+  '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
+  requireAuth(),
+  requireFundAccess,
+  metricRunLimiter,
+  async (req: Request, res: Response) => {
+    const parsed = MetricRunEvidenceCreateRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST_BODY',
+        issues: parsed.error.issues,
+      });
+    }
+
+    try {
+      const result = await createMetricRunEvidence({
+        fundId: parseFundId(req),
+        metricRunId: parseMetricRunId(req),
+        userId: resolveAuthenticatedUserId(req),
+        body: parsed.data,
+      });
+      const validated = MetricRunEvidenceCreateResponseSchema.parse(result);
+      return res.status(validated.inserted ? 201 : 200).json(validated);
+    } catch (err) {
+      return sendMetricRunError(res, err, 'METRIC_RUN_EVIDENCE_CREATE_FAILED');
     }
   }
 );

--- a/server/services/lp-reporting/metric-run-evidence-service.ts
+++ b/server/services/lp-reporting/metric-run-evidence-service.ts
@@ -1,0 +1,298 @@
+/**
+ * LP Reporting -- metric-run evidence metadata service.
+ *
+ * Evidence records here are scoped to committed metric runs only. The route
+ * owns fundId/metricRunId/uploadedBy, and the client supplies only metadata
+ * plus an idempotency key for retry-safe creates.
+ *
+ * @module server/services/lp-reporting/metric-run-evidence-service
+ */
+
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '../../db';
+import {
+  EvidenceRecordCreateSchema,
+  MetricRunEvidenceCreateRequestSchema,
+  MetricRunEvidenceRecordSchema,
+  type MetricRunEvidenceCreateRequest,
+  type MetricRunEvidenceCreateResponse,
+  type MetricRunEvidenceListResponse,
+  type MetricRunEvidenceRecord,
+} from '@shared/contracts/lp-reporting';
+import {
+  evidenceRecords,
+  lpMetricRuns,
+  type EvidenceRecord,
+  type InsertEvidenceRecord,
+  type LpMetricRun,
+} from '@shared/schema/lp-reporting-evidence';
+import { users } from '@shared/schema/user';
+import { MetricRunCommitError } from './metric-run-commit-service';
+
+type MetricRunEvidenceDatabase = typeof db;
+
+export interface MetricRunEvidenceCreateInput {
+  fundId: number;
+  metricRunId: number;
+  userId: number;
+  body: MetricRunEvidenceCreateRequest;
+}
+
+export interface MetricRunEvidenceListInput {
+  fundId: number;
+  metricRunId: number;
+}
+
+interface MetricRunEvidenceServiceOptions {
+  database?: MetricRunEvidenceDatabase;
+}
+
+type MetricRunLookupRow = Pick<LpMetricRun, 'id' | 'fundId' | 'status'>;
+
+const EDITABLE_METRIC_RUN_STATUSES = new Set(['draft']);
+
+function isoDateTime(value: Date | string | null | undefined, field: string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  throw new MetricRunCommitError(
+    500,
+    'EVIDENCE_ROW_INVALID',
+    `${field} is required on evidence_records responses.`
+  );
+}
+
+function isoDay(value: Date | string | null | undefined): string | null {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string') {
+    return value.slice(0, 10);
+  }
+  return null;
+}
+
+async function assertUserExists(
+  database: MetricRunEvidenceDatabase,
+  userId: number
+): Promise<void> {
+  const rows = await database
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!rows[0]) {
+    throw new MetricRunCommitError(
+      401,
+      'AUTH_USER_ID_UNRESOLVED',
+      'Authenticated user could not be resolved to a numeric users.id.'
+    );
+  }
+}
+
+async function loadMetricRun(
+  database: MetricRunEvidenceDatabase,
+  fundId: number,
+  metricRunId: number
+): Promise<MetricRunLookupRow> {
+  const rows = await database
+    .select({
+      id: lpMetricRuns.id,
+      fundId: lpMetricRuns.fundId,
+      status: lpMetricRuns.status,
+    })
+    .from(lpMetricRuns)
+    .where(and(eq(lpMetricRuns.fundId, fundId), eq(lpMetricRuns.id, metricRunId)))
+    .limit(1);
+  const row = rows.find((candidate) => candidate.id === metricRunId && candidate.fundId === fundId);
+  if (!row) {
+    throw new MetricRunCommitError(
+      404,
+      'METRIC_RUN_NOT_FOUND',
+      'Metric run was not found for this fund.'
+    );
+  }
+  return row as MetricRunLookupRow;
+}
+
+function assertMetricRunEditable(metricRun: MetricRunLookupRow): void {
+  if (!EDITABLE_METRIC_RUN_STATUSES.has(metricRun.status)) {
+    throw new MetricRunCommitError(
+      409,
+      'METRIC_RUN_NOT_EDITABLE',
+      'Evidence records can only be added to draft metric runs.',
+      { status: metricRun.status }
+    );
+  }
+}
+
+function toMetricRunEvidenceRecord(row: EvidenceRecord): MetricRunEvidenceRecord {
+  return MetricRunEvidenceRecordSchema.parse({
+    id: row.id,
+    fundId: row.fundId,
+    metricRunId: row.metricRunId,
+    idempotencyKey: row.idempotencyKey,
+    evidenceSource: row.evidenceSource,
+    sourceDate: isoDay(row.sourceDate),
+    receivedDate: isoDay(row.receivedDate),
+    expirationDate: isoDay(row.expirationDate),
+    confidenceLevel: row.confidenceLevel,
+    materialityLevel: row.materialityLevel,
+    confidentiality: row.confidentiality,
+    redactionRequired: row.redactionRequired,
+    documentHash: row.documentHash ?? null,
+    valuationPolicyVersion: row.valuationPolicyVersion ?? null,
+    description: row.description ?? null,
+    internalNotes: row.internalNotes ?? null,
+    lpObjection: row.lpObjection ?? null,
+    uploadedBy: row.uploadedBy ?? null,
+    createdAt: isoDateTime(row.createdAt, 'createdAt'),
+    updatedAt: isoDateTime(row.updatedAt, 'updatedAt'),
+  });
+}
+
+async function findEvidenceByIdempotencyKey(
+  database: MetricRunEvidenceDatabase,
+  fundId: number,
+  metricRunId: number,
+  idempotencyKey: string
+): Promise<EvidenceRecord | null> {
+  const rows = await database
+    .select()
+    .from(evidenceRecords)
+    .where(
+      and(
+        eq(evidenceRecords.fundId, fundId),
+        eq(evidenceRecords.metricRunId, metricRunId),
+        eq(evidenceRecords.idempotencyKey, idempotencyKey)
+      )
+    )
+    .limit(1);
+  return (
+    (rows as EvidenceRecord[]).find(
+      (row) =>
+        row.fundId === fundId &&
+        row.metricRunId === metricRunId &&
+        row.idempotencyKey === idempotencyKey
+    ) ?? null
+  );
+}
+
+function evidenceInsertValues(input: MetricRunEvidenceCreateInput): InsertEvidenceRecord {
+  const body = MetricRunEvidenceCreateRequestSchema.parse(input.body);
+  const create = EvidenceRecordCreateSchema.parse({
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    evidenceSource: body.evidenceSource,
+    sourceDate: body.sourceDate,
+    receivedDate: body.receivedDate,
+    expirationDate: body.expirationDate,
+    confidenceLevel: body.confidenceLevel,
+    materialityLevel: body.materialityLevel,
+    confidentiality: body.confidentiality,
+    redactionRequired: body.redactionRequired,
+    documentHash: body.documentHash,
+    valuationPolicyVersion: body.valuationPolicyVersion,
+    description: body.description,
+    internalNotes: body.internalNotes,
+    lpObjection: body.lpObjection,
+    attachments: [],
+  });
+
+  return {
+    fundId: create.fundId,
+    metricRunId: create.metricRunId,
+    idempotencyKey: body.idempotencyKey,
+    evidenceSource: create.evidenceSource,
+    sourceDate: create.sourceDate,
+    confidenceLevel: create.confidenceLevel,
+    materialityLevel: create.materialityLevel,
+    confidentiality: create.confidentiality,
+    redactionRequired: create.redactionRequired,
+    attachments: [],
+    uploadedBy: input.userId,
+    ...(create.receivedDate !== undefined && { receivedDate: create.receivedDate }),
+    ...(create.expirationDate !== undefined && { expirationDate: create.expirationDate }),
+    ...(create.documentHash !== undefined && { documentHash: create.documentHash }),
+    ...(create.valuationPolicyVersion !== undefined && {
+      valuationPolicyVersion: create.valuationPolicyVersion,
+    }),
+    ...(create.description !== undefined && { description: create.description }),
+    ...(create.internalNotes !== undefined && { internalNotes: create.internalNotes }),
+    ...(create.lpObjection !== undefined && { lpObjection: create.lpObjection }),
+  };
+}
+
+export async function createMetricRunEvidence(
+  input: MetricRunEvidenceCreateInput,
+  options: MetricRunEvidenceServiceOptions = {}
+): Promise<MetricRunEvidenceCreateResponse> {
+  const database = options.database ?? db;
+  const body = MetricRunEvidenceCreateRequestSchema.parse(input.body);
+  const metricRun = await loadMetricRun(database, input.fundId, input.metricRunId);
+  assertMetricRunEditable(metricRun);
+  await assertUserExists(database, input.userId);
+
+  const existing = await findEvidenceByIdempotencyKey(
+    database,
+    input.fundId,
+    input.metricRunId,
+    body.idempotencyKey
+  );
+  if (existing) {
+    return { record: toMetricRunEvidenceRecord(existing), inserted: false };
+  }
+
+  const inserted = await database
+    .insert(evidenceRecords)
+    .values(evidenceInsertValues({ ...input, body }))
+    .onConflictDoNothing()
+    .returning();
+  const insertedRow = (inserted as EvidenceRecord[])[0];
+  if (insertedRow) {
+    return { record: toMetricRunEvidenceRecord(insertedRow), inserted: true };
+  }
+
+  const racedExisting = await findEvidenceByIdempotencyKey(
+    database,
+    input.fundId,
+    input.metricRunId,
+    body.idempotencyKey
+  );
+  if (racedExisting) {
+    return { record: toMetricRunEvidenceRecord(racedExisting), inserted: false };
+  }
+
+  throw new MetricRunCommitError(
+    409,
+    'METRIC_RUN_EVIDENCE_CONFLICT',
+    'Evidence create conflicted but no existing row could be loaded.'
+  );
+}
+
+export async function listMetricRunEvidence(
+  input: MetricRunEvidenceListInput,
+  options: MetricRunEvidenceServiceOptions = {}
+): Promise<MetricRunEvidenceListResponse> {
+  const database = options.database ?? db;
+  await loadMetricRun(database, input.fundId, input.metricRunId);
+
+  const rows = await database
+    .select()
+    .from(evidenceRecords)
+    .where(
+      and(
+        eq(evidenceRecords.fundId, input.fundId),
+        eq(evidenceRecords.metricRunId, input.metricRunId)
+      )
+    );
+  return {
+    records: (rows as EvidenceRecord[])
+      .filter((row) => row.fundId === input.fundId && row.metricRunId === input.metricRunId)
+      .map(toMetricRunEvidenceRecord),
+  };
+}

--- a/shared/contracts/lp-reporting/evidence-record.contract.ts
+++ b/shared/contracts/lp-reporting/evidence-record.contract.ts
@@ -108,3 +108,73 @@ export const EvidenceRecordCreateSchema = z
   });
 
 export type EvidenceRecordCreate = z.infer<typeof EvidenceRecordCreateSchema>;
+
+export const MetricRunEvidenceIdempotencyKeySchema = z.string().trim().min(1).max(128);
+
+export const MetricRunEvidenceCreateRequestSchema = z
+  .object({
+    idempotencyKey: MetricRunEvidenceIdempotencyKeySchema,
+    evidenceSource: EvidenceSourceSchema,
+    sourceDate: z.string().date(),
+    receivedDate: z.string().date().optional(),
+    expirationDate: z.string().date().optional(),
+    confidenceLevel: ConfidenceLevelSchema.default('medium'),
+    materialityLevel: MaterialityLevelSchema.default('medium'),
+    confidentiality: ConfidentialitySchema.default('internal'),
+    redactionRequired: z.boolean().default(false),
+    documentHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/i)
+      .optional(),
+    valuationPolicyVersion: z.string().max(64).optional(),
+    description: z.string().max(2000).optional(),
+    internalNotes: z.string().max(5000).optional(),
+    lpObjection: z.string().max(2000).optional(),
+  })
+  .strict();
+
+export const MetricRunEvidenceRecordSchema = z
+  .object({
+    id: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    metricRunId: z.number().int().positive(),
+    idempotencyKey: MetricRunEvidenceIdempotencyKeySchema,
+    evidenceSource: EvidenceSourceSchema,
+    sourceDate: z.string().date(),
+    receivedDate: z.string().date().nullable(),
+    expirationDate: z.string().date().nullable(),
+    confidenceLevel: ConfidenceLevelSchema,
+    materialityLevel: MaterialityLevelSchema,
+    confidentiality: ConfidentialitySchema,
+    redactionRequired: z.boolean(),
+    documentHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/i)
+      .nullable(),
+    valuationPolicyVersion: z.string().max(64).nullable(),
+    description: z.string().max(2000).nullable(),
+    internalNotes: z.string().max(5000).nullable(),
+    lpObjection: z.string().max(2000).nullable(),
+    uploadedBy: z.number().int().positive().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const MetricRunEvidenceCreateResponseSchema = z
+  .object({
+    record: MetricRunEvidenceRecordSchema,
+    inserted: z.boolean(),
+  })
+  .strict();
+
+export const MetricRunEvidenceListResponseSchema = z
+  .object({
+    records: z.array(MetricRunEvidenceRecordSchema),
+  })
+  .strict();
+
+export type MetricRunEvidenceCreateRequest = z.infer<typeof MetricRunEvidenceCreateRequestSchema>;
+export type MetricRunEvidenceRecord = z.infer<typeof MetricRunEvidenceRecordSchema>;
+export type MetricRunEvidenceCreateResponse = z.infer<typeof MetricRunEvidenceCreateResponseSchema>;
+export type MetricRunEvidenceListResponse = z.infer<typeof MetricRunEvidenceListResponseSchema>;

--- a/shared/schema/lp-reporting-evidence.ts
+++ b/shared/schema/lp-reporting-evidence.ts
@@ -392,6 +392,7 @@ export const evidenceRecords = pgTable(
     narrativeRunId: integer('narrative_run_id').references(() => narrativeRuns.id, {
       onDelete: 'cascade',
     }),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }),
 
     evidenceSource: varchar('evidence_source', { length: 64 }).notNull(),
     sourceDate: date('source_date').notNull(),
@@ -443,6 +444,9 @@ export const evidenceRecords = pgTable(
     valuationMarkIdx: index('idx_evidence_valuation_mark').on(table.valuationMarkId),
     companyIdx: index('idx_evidence_company').on(table.companyId),
     metricRunIdx: index('idx_evidence_metric_run').on(table.metricRunId),
+    metricRunIdempotencyUniqueIdx: uniqueIndex('evidence_records_metric_run_idempotency_unique')
+      .on(table.fundId, table.metricRunId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
     narrativeRunIdx: index('idx_evidence_narrative_run').on(table.narrativeRunId),
     expirationIdx: index('idx_evidence_expiration_date').on(table.expirationDate),
     confidenceIdx: index('idx_evidence_confidence').on(table.confidenceLevel),

--- a/tests/unit/contract/lp-reporting/evidence-record.contract.test.ts
+++ b/tests/unit/contract/lp-reporting/evidence-record.contract.test.ts
@@ -14,6 +14,9 @@ import {
   EvidenceRecordCreateSchema,
   EvidenceSourceSchema,
   MaterialityLevelSchema,
+  MetricRunEvidenceCreateRequestSchema,
+  MetricRunEvidenceCreateResponseSchema,
+  MetricRunEvidenceListResponseSchema,
 } from '@shared/contracts/lp-reporting/evidence-record.contract';
 
 const baseFields = {
@@ -158,6 +161,94 @@ describe('Defaults applied', () => {
   it('redactionRequired defaults to false', () => {
     const parsed = EvidenceRecordCreateSchema.parse({ ...baseFields, companyId: 42 });
     expect(parsed.redactionRequired).toBe(false);
+  });
+});
+
+describe('MetricRunEvidenceCreateRequestSchema -- route-scoped metadata only', () => {
+  const metricRunEvidenceBase = {
+    idempotencyKey: 'metric-run-11-evidence-0',
+    evidenceSource: 'board_update' as const,
+    sourceDate: '2026-03-31',
+  };
+
+  it('accepts metadata with an explicit idempotency key', () => {
+    const parsed = MetricRunEvidenceCreateRequestSchema.parse(metricRunEvidenceBase);
+    expect(parsed.confidenceLevel).toBe('medium');
+    expect(parsed.materialityLevel).toBe('medium');
+    expect(parsed.confidentiality).toBe('internal');
+    expect(parsed.redactionRequired).toBe(false);
+  });
+
+  it('rejects empty and oversized idempotency keys', () => {
+    expect(() =>
+      MetricRunEvidenceCreateRequestSchema.parse({
+        ...metricRunEvidenceBase,
+        idempotencyKey: '',
+      })
+    ).toThrow();
+    expect(() =>
+      MetricRunEvidenceCreateRequestSchema.parse({
+        ...metricRunEvidenceBase,
+        idempotencyKey: 'x'.repeat(129),
+      })
+    ).toThrow();
+  });
+
+  it('rejects route-owned IDs, target FKs, approvals, locks, exports, narratives, and attachments', () => {
+    for (const key of [
+      'fundId',
+      'metricRunId',
+      'valuationMarkId',
+      'companyId',
+      'narrativeRunId',
+      'uploadedBy',
+      'approvedBy',
+      'approvedAt',
+      'lockedBy',
+      'lockedAt',
+      'exportedAt',
+      'narrative',
+      'attachments',
+    ]) {
+      expect(() =>
+        MetricRunEvidenceCreateRequestSchema.parse({
+          ...metricRunEvidenceBase,
+          [key]: key === 'attachments' ? [] : 1,
+        })
+      ).toThrow();
+    }
+  });
+
+  it('parses create and list response envelopes', () => {
+    const record = {
+      id: 1001,
+      fundId: 1,
+      metricRunId: 11,
+      idempotencyKey: 'metric-run-11-evidence-0',
+      evidenceSource: 'board_update',
+      sourceDate: '2026-03-31',
+      receivedDate: null,
+      expirationDate: null,
+      confidenceLevel: 'medium',
+      materialityLevel: 'medium',
+      confidentiality: 'internal',
+      redactionRequired: false,
+      documentHash: null,
+      valuationPolicyVersion: null,
+      description: null,
+      internalNotes: null,
+      lpObjection: null,
+      uploadedBy: 7,
+      createdAt: '2026-05-10T00:00:00.000Z',
+      updatedAt: '2026-05-10T00:00:00.000Z',
+    };
+
+    expect(MetricRunEvidenceCreateResponseSchema.parse({ record, inserted: true }).record.id).toBe(
+      1001
+    );
+    expect(MetricRunEvidenceListResponseSchema.parse({ records: [record] }).records).toHaveLength(
+      1
+    );
   });
 });
 

--- a/tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx
+++ b/tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx
@@ -16,12 +16,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 
-import { useMetricRunCommit, useMetricsDryRun } from '@/hooks/lp-reporting';
+import {
+  useMetricRunCommit,
+  useMetricRunEvidenceCreate,
+  useMetricRunEvidenceList,
+  useMetricsDryRun,
+} from '@/hooks/lp-reporting';
 import type { MetricsDryRunRequest } from '@/hooks/lp-reporting';
 import type {
   LpMetricRunResults,
   MetricRunCommitResponse,
   MetricRunDryRunResponse,
+  MetricRunEvidenceCreateResponse,
+  MetricRunEvidenceListResponse,
 } from '@shared/contracts/lp-reporting';
 
 function makeWrapper() {
@@ -98,6 +105,44 @@ function makeCommitResponse(): MetricRunCommitResponse {
     status: 'draft',
     inputsHash: 'a'.repeat(64),
     previewHash: 'b'.repeat(64),
+    inserted: true,
+  };
+}
+
+function makeEvidenceRecord() {
+  return {
+    id: 1000,
+    fundId: 7,
+    metricRunId: 17,
+    idempotencyKey: 'metric-run-17-evidence-0',
+    evidenceSource: 'board_update' as const,
+    sourceDate: '2026-03-31',
+    receivedDate: null,
+    expirationDate: null,
+    confidenceLevel: 'medium' as const,
+    materialityLevel: 'high' as const,
+    confidentiality: 'internal' as const,
+    redactionRequired: false,
+    documentHash: null,
+    valuationPolicyVersion: null,
+    description: 'Q1 board materials',
+    internalNotes: null,
+    lpObjection: null,
+    uploadedBy: 7,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+  };
+}
+
+function makeEvidenceListResponse(): MetricRunEvidenceListResponse {
+  return {
+    records: [makeEvidenceRecord()],
+  };
+}
+
+function makeEvidenceCreateResponse(): MetricRunEvidenceCreateResponse {
+  return {
+    record: makeEvidenceRecord(),
     inserted: true,
   };
 }
@@ -258,5 +303,111 @@ describe('useMetricRunCommit', () => {
 
     expect(result.current.error?.status).toBe(409);
     expect(result.current.error?.code).toBe('PREVIEW_HASH_MISMATCH');
+  });
+});
+
+describe('metric-run evidence hooks', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /api/funds/:id/metric-runs/:metricRunId/evidence-records and parses the response', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(makeEvidenceListResponse()), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMetricRunEvidenceList(7, 17), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('/api/funds/7/metric-runs/17/evidence-records');
+    expect(init?.method).toBe('GET');
+    expect(result.current.data?.records[0]?.idempotencyKey).toBe('metric-run-17-evidence-0');
+  });
+
+  it('does not fetch the evidence list until both fundId and metricRunId exist', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMetricRunEvidenceList(7, null), { wrapper: Wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('POSTs metric-run evidence metadata with the explicit idempotency key', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(makeEvidenceCreateResponse()), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMetricRunEvidenceCreate(7, 17), { wrapper: Wrapper });
+
+    result.current.mutate({
+      idempotencyKey: 'metric-run-17-evidence-0',
+      evidenceSource: 'board_update',
+      sourceDate: '2026-03-31',
+      materialityLevel: 'high',
+      description: 'Q1 board materials',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('/api/funds/7/metric-runs/17/evidence-records');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(init?.body as string)).toEqual({
+      idempotencyKey: 'metric-run-17-evidence-0',
+      evidenceSource: 'board_update',
+      sourceDate: '2026-03-31',
+      materialityLevel: 'high',
+      description: 'Q1 board materials',
+    });
+    expect(result.current.data?.record.metricRunId).toBe(17);
+  });
+
+  it('surfaces METRIC_RUN_NOT_EDITABLE evidence create errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'METRIC_RUN_NOT_EDITABLE',
+          message: 'Evidence records can only be added to draft metric runs.',
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMetricRunEvidenceCreate(7, 17), { wrapper: Wrapper });
+
+    result.current.mutate({
+      idempotencyKey: 'metric-run-17-evidence-0',
+      evidenceSource: 'board_update',
+      sourceDate: '2026-03-31',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.status).toBe(409);
+    expect(result.current.error?.code).toBe('METRIC_RUN_NOT_EDITABLE');
   });
 });

--- a/tests/unit/pages/lp-reporting/metrics.test.tsx
+++ b/tests/unit/pages/lp-reporting/metrics.test.tsx
@@ -118,6 +118,31 @@ function makeCommitResponse(): MetricRunCommitResponse {
   };
 }
 
+function makeEvidenceRecord() {
+  return {
+    id: 1000,
+    fundId: 7,
+    metricRunId: 17,
+    idempotencyKey: 'metric-run-17-evidence-0',
+    evidenceSource: 'board_update',
+    sourceDate: '2026-03-31',
+    receivedDate: null,
+    expirationDate: null,
+    confidenceLevel: 'medium',
+    materialityLevel: 'high',
+    confidentiality: 'internal',
+    redactionRequired: false,
+    documentHash: null,
+    valuationPolicyVersion: null,
+    description: 'Q1 board materials',
+    internalNotes: null,
+    lpObjection: null,
+    uploadedBy: 7,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+  };
+}
+
 describe('LpReportingMetricsPage', () => {
   beforeEach(() => {
     fundContextMock.fundId = 7;
@@ -193,6 +218,12 @@ describe('LpReportingMetricsPage', () => {
           status: 201,
           headers: { 'Content-Type': 'application/json' },
         })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ records: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
       );
 
     renderPage();
@@ -218,6 +249,93 @@ describe('LpReportingMetricsPage', () => {
       previewHash: 'b'.repeat(64),
     });
     expect(screen.getByTestId('metrics-commit-result').textContent).toMatch(/metric run #17/i);
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-evidence-card')).toBeInTheDocument();
+    });
+  });
+
+  it('adds evidence metadata after a draft metric run is committed', async () => {
+    let evidenceListCalls = 0;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/metric-runs/dry-run')) {
+        return new Response(JSON.stringify(makeDryRunResponse()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/commit')) {
+        return new Response(JSON.stringify(makeCommitResponse()), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/evidence-records') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ record: makeEvidenceRecord(), inserted: true }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/evidence-records')) {
+        evidenceListCalls += 1;
+        return new Response(
+          JSON.stringify({
+            records: evidenceListCalls === 1 ? [] : [makeEvidenceRecord()],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      return new Response(JSON.stringify({ error: 'UNEXPECTED_URL' }), { status: 500 });
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /run metrics/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-commit-button')).toBeEnabled();
+    });
+    fireEvent.click(screen.getByTestId('metrics-commit-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-evidence-card')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-evidence-empty')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/^description/i), {
+      target: { value: 'Q1 board materials' },
+    });
+    fireEvent.click(screen.getByTestId('metric-run-evidence-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-evidence-record')).toBeInTheDocument();
+    });
+
+    const postCall = fetchSpy.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith('/metric-runs/17/evidence-records') && init?.method === 'POST'
+    );
+    expect(postCall).toBeTruthy();
+    const body = JSON.parse(postCall?.[1]?.body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      evidenceSource: 'board_update',
+      sourceDate: '2026-03-31',
+      confidenceLevel: 'medium',
+      materialityLevel: 'medium',
+      confidentiality: 'internal',
+      redactionRequired: false,
+      description: 'Q1 board materials',
+    });
+    expect(body.idempotencyKey).toEqual(expect.stringMatching(/^metric-run-17-evidence-/));
+    expect(body).not.toHaveProperty('fundId');
+    expect(body).not.toHaveProperty('metricRunId');
+    expect(body).not.toHaveProperty('attachments');
+    expect(screen.getByTestId('metric-run-evidence-record').textContent).toMatch(
+      /q1 board materials/i
+    );
   });
 
   it('renders the commit error envelope on preview mismatch', async () => {

--- a/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
+++ b/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
@@ -10,6 +10,8 @@ import request from 'supertest';
 import {
   MetricRunCommitResponseSchema,
   MetricRunDryRunResponseSchema,
+  MetricRunEvidenceCreateResponseSchema,
+  MetricRunEvidenceListResponseSchema,
 } from '@shared/contracts/lp-reporting';
 
 const authState = vi.hoisted(() => ({
@@ -21,10 +23,13 @@ const dbState = vi.hoisted(() => ({
   events: [] as MockEventRow[],
   marks: [] as MockMarkRow[],
   metricRuns: [] as MockMetricRunRow[],
+  evidenceRecords: [] as MockEvidenceRow[],
   users: [7] as number[],
   insertedMetricRows: [] as unknown[],
+  insertedEvidenceRows: [] as unknown[],
   insertCalls: 0,
   nextMetricRunId: 500,
+  nextEvidenceId: 1000,
   dropNextInsert: false,
 }));
 let nextUserId = 800;
@@ -97,6 +102,35 @@ interface MockMetricRunRow {
   inputsHash: string;
 }
 
+interface MockEvidenceRow {
+  id: number;
+  fundId: number;
+  valuationMarkId: number | null;
+  companyId: number | null;
+  metricRunId: number | null;
+  narrativeRunId: number | null;
+  idempotencyKey: string | null;
+  evidenceSource: string;
+  sourceDate: string;
+  receivedDate: string | null;
+  expirationDate: string | null;
+  confidenceLevel: string;
+  materialityLevel: string;
+  confidentiality: string;
+  redactionRequired: boolean;
+  documentHash: string | null;
+  valuationPolicyVersion: string | null;
+  description: string | null;
+  internalNotes: string | null;
+  lpObjection: string | null;
+  attachments: unknown[];
+  uploadedBy: number | null;
+  approvedBy: number | null;
+  approvedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 vi.mock('@shared/schema/lp-reporting-evidence', () => ({
   cashFlowEvents: { _kind: 'cashFlowEvents', id: 'cashFlowEvents.id' },
   valuationMarks: { _kind: 'valuationMarks', id: 'valuationMarks.id' },
@@ -109,6 +143,13 @@ vi.mock('@shared/schema/lp-reporting-evidence', () => ({
     asOfDate: 'lpMetricRuns.asOfDate',
     status: 'lpMetricRuns.status',
     inputsHash: 'lpMetricRuns.inputsHash',
+  },
+  evidenceRecords: {
+    _kind: 'evidenceRecords',
+    id: 'evidenceRecords.id',
+    fundId: 'evidenceRecords.fundId',
+    metricRunId: 'evidenceRecords.metricRunId',
+    idempotencyKey: 'evidenceRecords.idempotencyKey',
   },
 }));
 
@@ -137,9 +178,13 @@ function rowsFor(table: { _kind?: string }): Array<Record<string, unknown>> {
   if (table?._kind === 'lpMetricRuns') {
     return dbState.metricRuns.map((row) => ({
       id: row.id,
+      fundId: row.fundId,
       status: row.status,
       inputsHash: row.inputsHash,
     }));
+  }
+  if (table?._kind === 'evidenceRecords') {
+    return [...dbState.evidenceRecords] as unknown as Array<Record<string, unknown>>;
   }
   return [];
 }
@@ -152,8 +197,46 @@ vi.mock('../../../../server/db', () => ({
         values: vi.fn((row: Record<string, unknown>) => ({
           onConflictDoNothing: vi.fn(() => ({
             returning: vi.fn(async () => {
-              if (table?._kind !== 'lpMetricRuns' || dbState.dropNextInsert) {
+              if (dbState.dropNextInsert) {
                 dbState.dropNextInsert = false;
+                return [];
+              }
+              if (table?._kind === 'evidenceRecords') {
+                const id = dbState.nextEvidenceId++;
+                const evidenceRow: MockEvidenceRow = {
+                  id,
+                  fundId: row['fundId'] as number,
+                  valuationMarkId: (row['valuationMarkId'] as number | undefined) ?? null,
+                  companyId: (row['companyId'] as number | undefined) ?? null,
+                  metricRunId: (row['metricRunId'] as number | undefined) ?? null,
+                  narrativeRunId: (row['narrativeRunId'] as number | undefined) ?? null,
+                  idempotencyKey: (row['idempotencyKey'] as string | undefined) ?? null,
+                  evidenceSource: row['evidenceSource'] as string,
+                  sourceDate: row['sourceDate'] as string,
+                  receivedDate: (row['receivedDate'] as string | undefined) ?? null,
+                  expirationDate: (row['expirationDate'] as string | undefined) ?? null,
+                  confidenceLevel: row['confidenceLevel'] as string,
+                  materialityLevel: row['materialityLevel'] as string,
+                  confidentiality: row['confidentiality'] as string,
+                  redactionRequired: row['redactionRequired'] as boolean,
+                  documentHash: (row['documentHash'] as string | undefined) ?? null,
+                  valuationPolicyVersion:
+                    (row['valuationPolicyVersion'] as string | undefined) ?? null,
+                  description: (row['description'] as string | undefined) ?? null,
+                  internalNotes: (row['internalNotes'] as string | undefined) ?? null,
+                  lpObjection: (row['lpObjection'] as string | undefined) ?? null,
+                  attachments: (row['attachments'] as unknown[] | undefined) ?? [],
+                  uploadedBy: (row['uploadedBy'] as number | undefined) ?? null,
+                  approvedBy: null,
+                  approvedAt: null,
+                  createdAt: new Date('2026-05-10T00:00:00Z'),
+                  updatedAt: new Date('2026-05-10T00:00:00Z'),
+                };
+                dbState.evidenceRecords.push(evidenceRow);
+                dbState.insertedEvidenceRows.push(row);
+                return [evidenceRow];
+              }
+              if (table?._kind !== 'lpMetricRuns') {
                 return [];
               }
               const id = dbState.nextMetricRunId++;
@@ -258,6 +341,16 @@ function dryRunBody(eventIds: number[] = [], markIds: number[] = []) {
   };
 }
 
+function evidenceBody() {
+  return {
+    idempotencyKey: 'metric-run-500-evidence-0',
+    evidenceSource: 'board_update',
+    sourceDate: '2026-03-31',
+    materialityLevel: 'high',
+    description: 'Q1 board materials',
+  };
+}
+
 beforeEach(() => {
   authState.authenticated = true;
   authState.userId = nextUserId++;
@@ -265,10 +358,13 @@ beforeEach(() => {
   dbState.events = [];
   dbState.marks = [];
   dbState.metricRuns = [];
+  dbState.evidenceRecords = [];
   dbState.users = [authState.userId];
   dbState.insertedMetricRows = [];
+  dbState.insertedEvidenceRows = [];
   dbState.insertCalls = 0;
   dbState.nextMetricRunId = 500;
+  dbState.nextEvidenceId = 1000;
   dbState.dropNextInsert = false;
 });
 
@@ -499,13 +595,132 @@ describe('POST /api/funds/:fundId/metric-runs/commit', () => {
   });
 });
 
+describe('metric-run evidence routes', () => {
+  it('POST creates metadata-only evidence for a draft metric run', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'draft',
+      inputsHash: 'a'.repeat(64),
+    });
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/evidence-records')
+      .send(evidenceBody());
+
+    expect(res.status).toBe(201);
+    const parsed = MetricRunEvidenceCreateResponseSchema.parse(res.body);
+    expect(parsed.inserted).toBe(true);
+    expect(parsed.record.metricRunId).toBe(500);
+    expect(parsed.record.uploadedBy).toBe(authState.userId);
+    expect(dbState.insertedEvidenceRows).toHaveLength(1);
+    expect(dbState.insertedEvidenceRows[0]).toMatchObject({
+      fundId: 1,
+      metricRunId: 500,
+      uploadedBy: authState.userId,
+      idempotencyKey: 'metric-run-500-evidence-0',
+      attachments: [],
+    });
+  });
+
+  it('POST rejects route-owned fields in the request body', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'draft',
+      inputsHash: 'a'.repeat(64),
+    });
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/evidence-records')
+      .send({ ...evidenceBody(), metricRunId: 500 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_REQUEST_BODY');
+    expect(dbState.insertedEvidenceRows).toHaveLength(0);
+  });
+
+  it('POST returns 409 METRIC_RUN_NOT_EDITABLE for approved metric runs', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'approved',
+      inputsHash: 'a'.repeat(64),
+    });
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/evidence-records')
+      .send(evidenceBody());
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('METRIC_RUN_NOT_EDITABLE');
+    expect(dbState.insertedEvidenceRows).toHaveLength(0);
+  });
+
+  it('GET lists evidence for locked metric runs', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'locked',
+      inputsHash: 'a'.repeat(64),
+    });
+    dbState.evidenceRecords.push({
+      id: 1000,
+      fundId: 1,
+      valuationMarkId: null,
+      companyId: null,
+      metricRunId: 500,
+      narrativeRunId: null,
+      idempotencyKey: 'metric-run-500-evidence-0',
+      evidenceSource: 'board_update',
+      sourceDate: '2026-03-31',
+      receivedDate: null,
+      expirationDate: null,
+      confidenceLevel: 'medium',
+      materialityLevel: 'high',
+      confidentiality: 'internal',
+      redactionRequired: false,
+      documentHash: null,
+      valuationPolicyVersion: null,
+      description: 'Q1 board materials',
+      internalNotes: null,
+      lpObjection: null,
+      attachments: [],
+      uploadedBy: authState.userId,
+      approvedBy: null,
+      approvedAt: null,
+      createdAt: new Date('2026-05-10T00:00:00Z'),
+      updatedAt: new Date('2026-05-10T00:00:00Z'),
+    });
+
+    const res = await request(buildApp()).get('/api/funds/1/metric-runs/500/evidence-records');
+
+    expect(res.status).toBe(200);
+    const parsed = MetricRunEvidenceListResponseSchema.parse(res.body);
+    expect(parsed.records).toHaveLength(1);
+    expect(parsed.records[0]?.idempotencyKey).toBe('metric-run-500-evidence-0');
+  });
+});
+
 describe('Source grep -- metric-run route boundaries', () => {
   const routerSource = fs.readFileSync(
     path.join(process.cwd(), 'server', 'routes', 'lp-reporting', 'metric-runs.ts'),
     'utf8'
   );
 
-  it('declares dry-run and commit endpoints only', () => {
+  it('declares scoped metric-run endpoints only', () => {
     const paths =
       routerSource
         .match(/router\.post\(\s*['"]([^'"]+)['"]/g)
@@ -514,7 +729,15 @@ describe('Source grep -- metric-run route boundaries', () => {
     expect(paths).toEqual([
       '/api/funds/:fundId/metric-runs/dry-run',
       '/api/funds/:fundId/metric-runs/commit',
+      '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
     ]);
+
+    const getPaths =
+      routerSource
+        .match(/router\.get\(\s*['"]([^'"]+)['"]/g)
+        ?.map((match) => match.replace(/router\.get\(\s*['"]/, '').replace(/['"]$/, '')) ?? [];
+
+    expect(getPaths).toEqual(['/api/funds/:fundId/metric-runs/:metricRunId/evidence-records']);
   });
 
   it('does not add any /api/public route', () => {

--- a/tests/unit/schema/lp-reporting-evidence-schema.test.ts
+++ b/tests/unit/schema/lp-reporting-evidence-schema.test.ts
@@ -163,6 +163,7 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       expect(names).toContain('company_id');
       expect(names).toContain('metric_run_id');
       expect(names).toContain('narrative_run_id');
+      expect(names).toContain('idempotency_key');
       expect(names).not.toContain('target_type');
       expect(names).not.toContain('target_id');
     });
@@ -176,6 +177,7 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       expect(names).toContain('idx_evidence_company');
       expect(names).toContain('idx_evidence_metric_run');
       expect(names).toContain('idx_evidence_narrative_run');
+      expect(names).toContain('evidence_records_metric_run_idempotency_unique');
     });
 
     it('indexes parent FKs used by narrative and participation history flows', () => {

--- a/tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts
+++ b/tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for metric-run evidence metadata service.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createMetricRunEvidence,
+  listMetricRunEvidence,
+} from '../../../../server/services/lp-reporting/metric-run-evidence-service';
+import type { MetricRunCommitError } from '../../../../server/services/lp-reporting/metric-run-commit-service';
+import type { db } from '../../../../server/db';
+import {
+  evidenceRecords,
+  lpMetricRuns,
+  type EvidenceRecord,
+  type InsertEvidenceRecord,
+  type LpMetricRun,
+} from '@shared/schema/lp-reporting-evidence';
+import { users } from '@shared/schema/user';
+
+interface State {
+  metricRuns: Array<Pick<LpMetricRun, 'id' | 'fundId' | 'status'>>;
+  evidence: EvidenceRecord[];
+  users: number[];
+  insertValues: InsertEvidenceRecord[];
+  nextEvidenceId: number;
+  dropNextInsert: boolean;
+}
+
+const state: State = {
+  metricRuns: [],
+  evidence: [],
+  users: [],
+  insertValues: [],
+  nextEvidenceId: 1000,
+  dropNextInsert: false,
+};
+
+function evidenceRow(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  return {
+    id: 1000,
+    fundId: 1,
+    valuationMarkId: null,
+    companyId: null,
+    metricRunId: 11,
+    narrativeRunId: null,
+    idempotencyKey: 'metric-run-11-evidence-0',
+    evidenceSource: 'board_update',
+    sourceDate: '2026-03-31',
+    receivedDate: null,
+    expirationDate: null,
+    confidenceLevel: 'medium',
+    materialityLevel: 'medium',
+    confidentiality: 'internal',
+    redactionRequired: false,
+    documentHash: null,
+    valuationPolicyVersion: null,
+    description: 'Q1 board materials',
+    internalNotes: null,
+    lpObjection: null,
+    attachments: [],
+    uploadedBy: 7,
+    approvedBy: null,
+    approvedAt: null,
+    createdAt: new Date('2026-05-10T00:00:00Z'),
+    updatedAt: new Date('2026-05-10T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function rowsFor(table: unknown): unknown[] {
+  if (table === lpMetricRuns) {
+    return state.metricRuns;
+  }
+  if (table === evidenceRecords) {
+    return state.evidence;
+  }
+  if (table === users) {
+    return state.users.map((id) => ({ id }));
+  }
+  return [];
+}
+
+function queryResult<T>(rows: T[]): Promise<T[]> & { limit: (count: number) => Promise<T[]> } {
+  const promise = Promise.resolve(rows) as Promise<T[]> & {
+    limit: (count: number) => Promise<T[]>;
+  };
+  promise.limit = (count: number) => Promise.resolve(rows.slice(0, count));
+  return promise;
+}
+
+function makeDatabase(): typeof db {
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => queryResult(rowsFor(table)),
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (row: InsertEvidenceRecord) => ({
+        onConflictDoNothing: () => ({
+          returning: async () => {
+            state.insertValues.push(row);
+            if (state.dropNextInsert || table !== evidenceRecords) {
+              state.dropNextInsert = false;
+              return [];
+            }
+            const inserted = evidenceRow({
+              id: state.nextEvidenceId++,
+              fundId: row.fundId,
+              metricRunId: row.metricRunId ?? null,
+              idempotencyKey: row.idempotencyKey ?? null,
+              evidenceSource: row.evidenceSource,
+              sourceDate: row.sourceDate,
+              receivedDate: row.receivedDate ?? null,
+              expirationDate: row.expirationDate ?? null,
+              confidenceLevel: row.confidenceLevel ?? 'medium',
+              materialityLevel: row.materialityLevel ?? 'medium',
+              confidentiality: row.confidentiality ?? 'internal',
+              redactionRequired: row.redactionRequired ?? false,
+              documentHash: row.documentHash ?? null,
+              valuationPolicyVersion: row.valuationPolicyVersion ?? null,
+              description: row.description ?? null,
+              internalNotes: row.internalNotes ?? null,
+              lpObjection: row.lpObjection ?? null,
+              uploadedBy: row.uploadedBy ?? null,
+            });
+            state.evidence.push(inserted);
+            return [inserted];
+          },
+        }),
+      }),
+    }),
+  } as unknown as typeof db;
+}
+
+beforeEach(() => {
+  state.metricRuns = [{ id: 11, fundId: 1, status: 'draft' }];
+  state.evidence = [];
+  state.users = [7];
+  state.insertValues = [];
+  state.nextEvidenceId = 1000;
+  state.dropNextInsert = false;
+});
+
+describe('createMetricRunEvidence', () => {
+  it('inserts metadata-only evidence for a draft metric run', async () => {
+    const result = await createMetricRunEvidence(
+      {
+        fundId: 1,
+        metricRunId: 11,
+        userId: 7,
+        body: {
+          idempotencyKey: 'metric-run-11-evidence-0',
+          evidenceSource: 'board_update',
+          sourceDate: '2026-03-31',
+          materialityLevel: 'high',
+          description: 'Q1 board materials',
+        },
+      },
+      { database: makeDatabase() }
+    );
+
+    expect(result.inserted).toBe(true);
+    expect(result.record.metricRunId).toBe(11);
+    expect(result.record.uploadedBy).toBe(7);
+    expect(state.insertValues).toHaveLength(1);
+    expect(state.insertValues[0]).toMatchObject({
+      fundId: 1,
+      metricRunId: 11,
+      uploadedBy: 7,
+      idempotencyKey: 'metric-run-11-evidence-0',
+      attachments: [],
+      materialityLevel: 'high',
+    });
+    expect(state.insertValues[0]?.valuationMarkId).toBeUndefined();
+    expect(state.insertValues[0]?.companyId).toBeUndefined();
+    expect(state.insertValues[0]?.narrativeRunId).toBeUndefined();
+    expect(state.insertValues[0]?.approvedBy).toBeUndefined();
+  });
+
+  it('returns an existing row without inserting when the idempotency key was already used', async () => {
+    state.evidence = [evidenceRow()];
+
+    const result = await createMetricRunEvidence(
+      {
+        fundId: 1,
+        metricRunId: 11,
+        userId: 7,
+        body: {
+          idempotencyKey: 'metric-run-11-evidence-0',
+          evidenceSource: 'board_update',
+          sourceDate: '2026-03-31',
+        },
+      },
+      { database: makeDatabase() }
+    );
+
+    expect(result.inserted).toBe(false);
+    expect(result.record.id).toBe(1000);
+    expect(state.insertValues).toHaveLength(0);
+  });
+
+  it('rejects create for non-draft metric runs', async () => {
+    state.metricRuns = [{ id: 11, fundId: 1, status: 'approved' }];
+
+    await expect(
+      createMetricRunEvidence(
+        {
+          fundId: 1,
+          metricRunId: 11,
+          userId: 7,
+          body: {
+            idempotencyKey: 'metric-run-11-evidence-0',
+            evidenceSource: 'board_update',
+            sourceDate: '2026-03-31',
+          },
+        },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'METRIC_RUN_NOT_EDITABLE',
+    } satisfies Partial<MetricRunCommitError>);
+    expect(state.insertValues).toHaveLength(0);
+  });
+});
+
+describe('listMetricRunEvidence', () => {
+  it('lists evidence for non-draft metric runs without applying editability checks', async () => {
+    state.metricRuns = [{ id: 11, fundId: 1, status: 'locked' }];
+    state.evidence = [evidenceRow(), evidenceRow({ id: 1001, metricRunId: 12 })];
+
+    const result = await listMetricRunEvidence(
+      { fundId: 1, metricRunId: 11 },
+      { database: makeDatabase() }
+    );
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]?.id).toBe(1000);
+  });
+});


### PR DESCRIPTION
Metric-run reporting needs a small evidence trail before later approval/export states make snapshots immutable. This adds a route-scoped metadata-only evidence create/list path, the idempotency index needed for retries, and the metrics-page panel that appears only after a draft run is committed.

Constraint: Evidence create is scoped to draft metric runs and route-owned fund/metric/user IDs
Rejected: Generic evidence API and attachment handling | outside sprint scope and would widen approvals/storage surface
Rejected: Deterministic UI idempotency keys | reload collisions would return stale records
Confidence: high
Scope-risk: moderate
Directive: Do not add non-metric evidence targets to these routes without a new contract and lifecycle decision
Tested: npx vitest run tests/unit/contract/lp-reporting/evidence-record.contract.test.ts tests/unit/schema/lp-reporting-evidence-schema.test.ts tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts tests/unit/routes/lp-reporting/metric-runs-routes.test.ts tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx tests/unit/pages/lp-reporting/metrics.test.tsx; npm run check; npm run lint; npm test; npm run build
Not-tested: Live database migration against production data