### PR TITLE
feat: protect approved metric-run evidence from drift

### DIFF
--- a/client/src/hooks/lp-reporting/index.ts
+++ b/client/src/hooks/lp-reporting/index.ts
@@ -5,16 +5,26 @@
  */
 
 export {
+  useLatestMetricRun,
+  useMetricRunApprove,
+  useMetricRunDetail,
   useMetricRunEvidenceCreate,
   useMetricRunEvidenceList,
   useMetricRunCommit,
+  useMetricRunLock,
   useMetricsDryRun,
   type MetricsDryRunRequest,
   type DryRunErrorBody,
   type LpReportingHookError,
+  type LatestMetricRunQuery,
+  type LatestMetricRunResponse,
+  type MetricRunApproveRequest,
+  type MetricRunDetailResponse,
   type MetricRunEvidenceCreateRequest,
   type MetricRunEvidenceCreateResponse,
   type MetricRunEvidenceListResponse,
+  type MetricRunLifecycleResponse,
+  type MetricRunLockRequest,
 } from './useMetricsDryRun';
 export { useLedgerImportDryRun } from './useLedgerImportDryRun';
 export { useValuationMarkImportDryRun } from './useValuationMarkImportDryRun';

--- a/client/src/hooks/lp-reporting/useMetricsDryRun.ts
+++ b/client/src/hooks/lp-reporting/useMetricsDryRun.ts
@@ -10,19 +10,30 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  LatestMetricRunResponseSchema,
+  MetricRunApproveRequestSchema,
   MetricRunCommitRequestSchema,
   MetricRunCommitResponseSchema,
+  MetricRunDetailResponseSchema,
   MetricRunDryRunResponseSchema,
   MetricRunEvidenceCreateRequestSchema,
   MetricRunEvidenceCreateResponseSchema,
   MetricRunEvidenceListResponseSchema,
+  MetricRunLifecycleResponseSchema,
+  MetricRunLockRequestSchema,
+  type LatestMetricRunQuery,
+  type LatestMetricRunResponse,
+  type MetricRunApproveRequest,
   type MetricRunCommitRequest,
   type MetricRunCommitResponse,
+  type MetricRunDetailResponse,
   type MetricRunDryRunRequest,
   type MetricRunDryRunResponse,
   type MetricRunEvidenceCreateRequest,
   type MetricRunEvidenceCreateResponse,
   type MetricRunEvidenceListResponse,
+  type MetricRunLifecycleResponse,
+  type MetricRunLockRequest,
 } from '@shared/contracts/lp-reporting';
 
 export type MetricsDryRunRequest = MetricRunDryRunRequest;
@@ -38,6 +49,10 @@ export type LpReportingHookError = Error & {
   status?: number;
 };
 
+interface ContractResponseSchema<TResponse> {
+  safeParse(raw: unknown): { success: true; data: TResponse } | { success: false };
+}
+
 function buildHookError(
   status: number,
   body: Partial<DryRunErrorBody>,
@@ -47,6 +62,28 @@ function buildHookError(
   error.code = body.code ?? body.error ?? 'UNKNOWN';
   error.status = status;
   return error;
+}
+
+async function readContractResponse<TResponse>(
+  res: Response,
+  schema: ContractResponseSchema<TResponse>,
+  contractErrorMessage: string
+): Promise<TResponse> {
+  if (!res.ok) {
+    const errorBody = (await res.json().catch(() => ({}))) as Partial<DryRunErrorBody>;
+    throw buildHookError(res.status, errorBody, `HTTP ${res.status}`);
+  }
+
+  const raw = (await res.json()) as unknown;
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    const error = new Error(contractErrorMessage) as LpReportingHookError;
+    error.code = 'CONTRACT_PARSE_ERROR';
+    error.status = res.status;
+    throw error;
+  }
+
+  return parsed.data;
 }
 
 async function postMetricsDryRun(
@@ -60,23 +97,11 @@ async function postMetricsDryRun(
     body: JSON.stringify(body),
   });
 
-  if (!res.ok) {
-    const errorBody = (await res.json().catch(() => ({}))) as Partial<DryRunErrorBody>;
-    throw buildHookError(res.status, errorBody, `HTTP ${res.status}`);
-  }
-
-  const raw = (await res.json()) as unknown;
-  const parsed = MetricRunDryRunResponseSchema.safeParse(raw);
-  if (!parsed.success) {
-    const error = new Error(
-      'Metric-run dry-run response did not match the locked contract.'
-    ) as LpReportingHookError;
-    error.code = 'CONTRACT_PARSE_ERROR';
-    error.status = res.status;
-    throw error;
-  }
-
-  return parsed.data;
+  return readContractResponse(
+    res,
+    MetricRunDryRunResponseSchema,
+    'Metric-run dry-run response did not match the locked contract.'
+  );
 }
 
 async function postMetricRunCommit(
@@ -92,27 +117,68 @@ async function postMetricRunCommit(
     body: JSON.stringify(body),
   });
 
-  if (!res.ok) {
-    const errorBody = (await res.json().catch(() => ({}))) as Partial<DryRunErrorBody>;
-    throw buildHookError(res.status, errorBody, `HTTP ${res.status}`);
-  }
-
-  const raw = (await res.json()) as unknown;
-  const parsed = MetricRunCommitResponseSchema.safeParse(raw);
-  if (!parsed.success) {
-    const error = new Error(
-      'Metric-run commit response did not match the locked contract.'
-    ) as LpReportingHookError;
-    error.code = 'CONTRACT_PARSE_ERROR';
-    error.status = res.status;
-    throw error;
-  }
-
-  return parsed.data;
+  return readContractResponse(
+    res,
+    MetricRunCommitResponseSchema,
+    'Metric-run commit response did not match the locked contract.'
+  );
 }
 
 function metricRunEvidenceQueryKey(fundId: number | null, metricRunId: number | null) {
   return ['lp-reporting', 'metric-run-evidence', fundId, metricRunId] as const;
+}
+
+function latestMetricRunQueryKey(fundId: number | null, query: LatestMetricRunQuery | null) {
+  return [
+    'lp-reporting',
+    'metric-runs',
+    'latest',
+    fundId,
+    query?.runType ?? null,
+    query?.perspective ?? null,
+    query?.asOfDate ?? null,
+  ] as const;
+}
+
+function metricRunDetailQueryKey(fundId: number | null, metricRunId: number | null) {
+  return ['lp-reporting', 'metric-runs', 'detail', fundId, metricRunId] as const;
+}
+
+async function getLatestMetricRun(
+  fundId: number,
+  query: LatestMetricRunQuery
+): Promise<LatestMetricRunResponse> {
+  const params = new URLSearchParams({
+    runType: query.runType,
+    perspective: query.perspective,
+    asOfDate: query.asOfDate,
+  });
+  const res = await fetch(`/api/funds/${fundId}/metric-runs/latest?${params.toString()}`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  return readContractResponse(
+    res,
+    LatestMetricRunResponseSchema,
+    'Latest metric-run response did not match the locked contract.'
+  );
+}
+
+async function getMetricRunDetail(
+  fundId: number,
+  metricRunId: number
+): Promise<MetricRunDetailResponse> {
+  const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  return readContractResponse(
+    res,
+    MetricRunDetailResponseSchema,
+    'Metric-run detail response did not match the locked contract.'
+  );
 }
 
 async function getMetricRunEvidenceList(
@@ -124,23 +190,53 @@ async function getMetricRunEvidenceList(
     credentials: 'include',
   });
 
-  if (!res.ok) {
-    const errorBody = (await res.json().catch(() => ({}))) as Partial<DryRunErrorBody>;
-    throw buildHookError(res.status, errorBody, `HTTP ${res.status}`);
-  }
+  return readContractResponse(
+    res,
+    MetricRunEvidenceListResponseSchema,
+    'Metric-run evidence list response did not match the locked contract.'
+  );
+}
 
-  const raw = (await res.json()) as unknown;
-  const parsed = MetricRunEvidenceListResponseSchema.safeParse(raw);
-  if (!parsed.success) {
-    const error = new Error(
-      'Metric-run evidence list response did not match the locked contract.'
-    ) as LpReportingHookError;
-    error.code = 'CONTRACT_PARSE_ERROR';
-    error.status = res.status;
-    throw error;
-  }
+async function postMetricRunApprove(
+  fundId: number,
+  metricRunId: number,
+  body: MetricRunApproveRequest
+): Promise<MetricRunLifecycleResponse> {
+  MetricRunApproveRequestSchema.parse(body);
 
-  return parsed.data;
+  const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+
+  return readContractResponse(
+    res,
+    MetricRunLifecycleResponseSchema,
+    'Metric-run approve response did not match the locked contract.'
+  );
+}
+
+async function postMetricRunLock(
+  fundId: number,
+  metricRunId: number,
+  body: MetricRunLockRequest
+): Promise<MetricRunLifecycleResponse> {
+  MetricRunLockRequestSchema.parse(body);
+
+  const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/lock`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+
+  return readContractResponse(
+    res,
+    MetricRunLifecycleResponseSchema,
+    'Metric-run lock response did not match the locked contract.'
+  );
 }
 
 async function postMetricRunEvidence(
@@ -157,23 +253,11 @@ async function postMetricRunEvidence(
     body: JSON.stringify(body),
   });
 
-  if (!res.ok) {
-    const errorBody = (await res.json().catch(() => ({}))) as Partial<DryRunErrorBody>;
-    throw buildHookError(res.status, errorBody, `HTTP ${res.status}`);
-  }
-
-  const raw = (await res.json()) as unknown;
-  const parsed = MetricRunEvidenceCreateResponseSchema.safeParse(raw);
-  if (!parsed.success) {
-    const error = new Error(
-      'Metric-run evidence create response did not match the locked contract.'
-    ) as LpReportingHookError;
-    error.code = 'CONTRACT_PARSE_ERROR';
-    error.status = res.status;
-    throw error;
-  }
-
-  return parsed.data;
+  return readContractResponse(
+    res,
+    MetricRunEvidenceCreateResponseSchema,
+    'Metric-run evidence create response did not match the locked contract.'
+  );
 }
 
 export function useMetricsDryRun(fundId: number | null) {
@@ -204,8 +288,41 @@ export function useMetricRunCommit(fundId: number | null) {
       return postMetricRunCommit(fundId, request);
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['lp-reporting', 'metric-runs'] });
       queryClient.invalidateQueries({ queryKey: ['lp-reporting', 'metric-runs', fundId] });
       queryClient.invalidateQueries({ queryKey: ['fund-metrics', fundId] });
+    },
+  });
+}
+
+export function useLatestMetricRun(fundId: number | null, query: LatestMetricRunQuery | null) {
+  return useQuery<LatestMetricRunResponse, LpReportingHookError>({
+    queryKey: latestMetricRunQueryKey(fundId, query),
+    enabled: fundId !== null && query !== null,
+    queryFn: async () => {
+      if (fundId === null || query === null) {
+        const error = new Error(
+          'fundId and latest metric-run filters are required'
+        ) as LpReportingHookError;
+        error.code = 'MISSING_LATEST_METRIC_RUN_SCOPE';
+        throw error;
+      }
+      return getLatestMetricRun(fundId, query);
+    },
+  });
+}
+
+export function useMetricRunDetail(fundId: number | null, metricRunId: number | null) {
+  return useQuery<MetricRunDetailResponse, LpReportingHookError>({
+    queryKey: metricRunDetailQueryKey(fundId, metricRunId),
+    enabled: fundId !== null && metricRunId !== null,
+    queryFn: async () => {
+      if (fundId === null || metricRunId === null) {
+        const error = new Error('fundId and metricRunId are required') as LpReportingHookError;
+        error.code = 'MISSING_METRIC_RUN_DETAIL_SCOPE';
+        throw error;
+      }
+      return getMetricRunDetail(fundId, metricRunId);
     },
   });
 }
@@ -222,6 +339,44 @@ export function useMetricRunEvidenceList(fundId: number | null, metricRunId: num
       }
 
       return getMetricRunEvidenceList(fundId, metricRunId);
+    },
+  });
+}
+
+export function useMetricRunApprove(fundId: number | null, metricRunId: number | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<MetricRunLifecycleResponse, LpReportingHookError, MetricRunApproveRequest>({
+    mutationFn: async (request) => {
+      if (fundId === null || metricRunId === null) {
+        const error = new Error('fundId and metricRunId are required') as LpReportingHookError;
+        error.code = 'MISSING_METRIC_RUN_LIFECYCLE_SCOPE';
+        throw error;
+      }
+      return postMetricRunApprove(fundId, metricRunId, request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['lp-reporting', 'metric-runs'] });
+      queryClient.invalidateQueries({ queryKey: metricRunEvidenceQueryKey(fundId, metricRunId) });
+    },
+  });
+}
+
+export function useMetricRunLock(fundId: number | null, metricRunId: number | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<MetricRunLifecycleResponse, LpReportingHookError, MetricRunLockRequest>({
+    mutationFn: async (request) => {
+      if (fundId === null || metricRunId === null) {
+        const error = new Error('fundId and metricRunId are required') as LpReportingHookError;
+        error.code = 'MISSING_METRIC_RUN_LIFECYCLE_SCOPE';
+        throw error;
+      }
+      return postMetricRunLock(fundId, metricRunId, request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['lp-reporting', 'metric-runs'] });
+      queryClient.invalidateQueries({ queryKey: metricRunEvidenceQueryKey(fundId, metricRunId) });
     },
   });
 }
@@ -244,13 +399,20 @@ export function useMetricRunEvidenceCreate(fundId: number | null, metricRunId: n
       return postMetricRunEvidence(fundId, metricRunId, request);
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['lp-reporting', 'metric-runs'] });
       queryClient.invalidateQueries({ queryKey: metricRunEvidenceQueryKey(fundId, metricRunId) });
     },
   });
 }
 
 export type {
+  LatestMetricRunQuery,
+  LatestMetricRunResponse,
+  MetricRunApproveRequest,
+  MetricRunDetailResponse,
   MetricRunEvidenceCreateRequest,
   MetricRunEvidenceCreateResponse,
   MetricRunEvidenceListResponse,
+  MetricRunLifecycleResponse,
+  MetricRunLockRequest,
 };

--- a/client/src/pages/lp-reporting/metrics.tsx
+++ b/client/src/pages/lp-reporting/metrics.tsx
@@ -23,6 +23,7 @@
 import { useCallback, useState, type FormEvent } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { MetricRunForm } from '@/components/lp-reporting/MetricRunForm';
 import { MetricsCards } from '@/components/lp-reporting/MetricsCards';
@@ -33,15 +34,21 @@ import {
   LpMetricRunResultsSchema,
   MetricRunDryRunResponseSchema,
   type ConfidenceLevel,
+  type MetricRunDetailResponse,
   type MetricRunCommitResponse,
   type MetricRunDryRunRequest,
   type MetricRunDryRunResponse,
   type MetricRunEvidenceCreateRequest,
+  type MetricRunLifecycleResponse,
 } from '@shared/contracts/lp-reporting';
 import {
+  useLatestMetricRun,
+  useMetricRunApprove,
   useMetricRunCommit,
+  useMetricRunDetail,
   useMetricRunEvidenceCreate,
   useMetricRunEvidenceList,
+  useMetricRunLock,
   type LpReportingHookError,
 } from '@/hooks/lp-reporting';
 
@@ -105,6 +112,24 @@ function createEvidenceIdempotencyKey(metricRunId: number): string {
 }
 
 function envelopeFor(err: LpReportingHookError): ErrorEnvelope {
+  if (err.code === 'METRIC_RUN_EVIDENCE_REQUIRED') {
+    return {
+      title: 'Evidence required',
+      description: 'Add at least one evidence record before approving this metric run.',
+    };
+  }
+  if (err.code === 'METRIC_RUN_VERSION_CONFLICT') {
+    return {
+      title: 'Metric run changed',
+      description: 'The metric run changed since this page loaded. Refresh the lifecycle state.',
+    };
+  }
+  if (err.code === 'METRIC_RUN_STATUS_CONFLICT') {
+    return {
+      title: 'Metric run status changed',
+      description: 'This lifecycle action is no longer valid for the metric run status.',
+    };
+  }
   if (err.code === 'METRIC_RUN_NOT_EDITABLE') {
     return {
       title: 'Metric run not editable',
@@ -164,12 +189,37 @@ export default function LpReportingMetricsPage() {
   const [dryRunError, setDryRunError] = useState<LpReportingHookError | null>(null);
   const [commitResult, setCommitResult] = useState<MetricRunCommitResponse | null>(null);
   const [commitError, setCommitError] = useState<LpReportingHookError | null>(null);
+  const [lifecycleResult, setLifecycleResult] = useState<MetricRunLifecycleResponse | null>(null);
+  const [lifecycleError, setLifecycleError] = useState<LpReportingHookError | null>(null);
   const [evidenceForm, setEvidenceForm] = useState<EvidenceFormState>(() =>
     makeEvidenceFormState()
   );
   const [evidenceIdempotencyKey, setEvidenceIdempotencyKey] = useState<string | null>(null);
   const [evidenceError, setEvidenceError] = useState<LpReportingHookError | null>(null);
   const committedMetricRunId = commitResult?.metricRunId ?? null;
+  const latestQuery = useLatestMetricRun(
+    fundId,
+    dryRunRequest
+      ? {
+          asOfDate: dryRunRequest.asOfDate,
+          runType: dryRunRequest.runType,
+          perspective: dryRunRequest.perspective,
+        }
+      : null
+  );
+  const latestMetricRun = latestQuery.data?.metricRun ?? null;
+  const committedMetricRunQuery = useMetricRunDetail(fundId, committedMetricRunId);
+  const committedMetricRun = committedMetricRunQuery.data ?? null;
+  const latestMatchesCommitted =
+    latestMetricRun !== null &&
+    (committedMetricRunId === null || latestMetricRun.metricRunId === committedMetricRunId);
+  const activeMetricRun: MetricRunDetailResponse | null =
+    lifecycleResult?.metricRun ??
+    committedMetricRun ??
+    (latestMatchesCommitted ? latestMetricRun : null);
+  const lifecycleMetricRunId = activeMetricRun?.metricRunId ?? committedMetricRunId;
+  const approveMutation = useMetricRunApprove(fundId, lifecycleMetricRunId);
+  const lockMutation = useMetricRunLock(fundId, lifecycleMetricRunId);
   const evidenceListQuery = useMetricRunEvidenceList(fundId, committedMetricRunId);
   const evidenceCreateMutation = useMetricRunEvidenceCreate(fundId, committedMetricRunId);
 
@@ -185,6 +235,8 @@ export default function LpReportingMetricsPage() {
       setDryRunError(null);
       setCommitError(null);
       setCommitResult(null);
+      setLifecycleResult(null);
+      setLifecycleError(null);
       setEvidenceError(null);
       setEvidenceIdempotencyKey(null);
       setEvidenceForm(makeEvidenceFormState(parsedResults.asOfDate));
@@ -196,6 +248,8 @@ export default function LpReportingMetricsPage() {
     setDryRunError(err);
     setCommitError(null);
     setCommitResult(null);
+    setLifecycleResult(null);
+    setLifecycleError(null);
     setEvidenceError(null);
   }, []);
 
@@ -210,6 +264,8 @@ export default function LpReportingMetricsPage() {
       });
       setCommitResult(result);
       setCommitError(null);
+      setLifecycleResult(null);
+      setLifecycleError(null);
       setEvidenceError(null);
       setEvidenceIdempotencyKey(createEvidenceIdempotencyKey(result.metricRunId));
       setEvidenceForm(makeEvidenceFormState(dryRun.results.asOfDate));
@@ -220,6 +276,42 @@ export default function LpReportingMetricsPage() {
     }
   }, [commitMutation, dryRun, dryRunRequest]);
 
+  const handleApprove = useCallback(async () => {
+    if (!activeMetricRun) {
+      return;
+    }
+    try {
+      const result = await approveMutation.mutateAsync({
+        expectedVersion: activeMetricRun.version,
+      });
+      setLifecycleResult(result);
+      setLifecycleError(null);
+      setEvidenceError(null);
+    } catch (err) {
+      if (err && typeof err === 'object') {
+        setLifecycleError(err as LpReportingHookError);
+      }
+    }
+  }, [activeMetricRun, approveMutation]);
+
+  const handleLock = useCallback(async () => {
+    if (!activeMetricRun) {
+      return;
+    }
+    try {
+      const result = await lockMutation.mutateAsync({
+        expectedVersion: activeMetricRun.version,
+      });
+      setLifecycleResult(result);
+      setLifecycleError(null);
+      setEvidenceError(null);
+    } catch (err) {
+      if (err && typeof err === 'object') {
+        setLifecycleError(err as LpReportingHookError);
+      }
+    }
+  }, [activeMetricRun, lockMutation]);
+
   const handleEvidenceSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -228,6 +320,7 @@ export default function LpReportingMetricsPage() {
       }
       const idempotencyKey =
         evidenceIdempotencyKey ?? createEvidenceIdempotencyKey(committedMetricRunId);
+      const description = optionalText(evidenceForm.description);
 
       const request: MetricRunEvidenceCreateRequest = {
         idempotencyKey,
@@ -237,9 +330,7 @@ export default function LpReportingMetricsPage() {
         materialityLevel: evidenceForm.materialityLevel,
         confidentiality: evidenceForm.confidentiality,
         redactionRequired: evidenceForm.redactionRequired,
-        ...(optionalText(evidenceForm.description) !== undefined && {
-          description: optionalText(evidenceForm.description),
-        }),
+        ...(description !== undefined && { description }),
       };
 
       try {
@@ -265,6 +356,7 @@ export default function LpReportingMetricsPage() {
   const results = dryRun?.results ?? null;
   const envelope = dryRunError ? envelopeFor(dryRunError) : null;
   const commitEnvelope = commitError ? envelopeFor(commitError) : null;
+  const lifecycleEnvelope = lifecycleError ? envelopeFor(lifecycleError) : null;
   const evidenceQueryError =
     evidenceListQuery.error && committedMetricRunId !== null ? evidenceListQuery.error : null;
   const evidenceEnvelope = evidenceError
@@ -273,6 +365,14 @@ export default function LpReportingMetricsPage() {
       ? envelopeFor(evidenceQueryError)
       : null;
   const evidenceRecords = evidenceListQuery.data?.records ?? [];
+  const activeEvidenceCount = Math.max(activeMetricRun?.evidenceCount ?? 0, evidenceRecords.length);
+  const canApprove =
+    activeMetricRun?.status === 'draft' &&
+    activeEvidenceCount > 0 &&
+    !approveMutation.isPending &&
+    !latestQuery.isFetching;
+  const canLock = activeMetricRun?.status === 'approved' && !lockMutation.isPending;
+  const isEvidenceEditable = activeMetricRun === null || activeMetricRun.status === 'draft';
 
   return (
     <div className="p-8 space-y-6">
@@ -370,11 +470,104 @@ export default function LpReportingMetricsPage() {
           </Card>
 
           {commitResult ? (
+            <Card data-testid="metric-run-lifecycle-card">
+              <CardHeader>
+                <CardTitle>Metric-run lifecycle</CardTitle>
+                <CardDescription>
+                  Approval and lock state for metric run #{commitResult.metricRunId}.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {lifecycleEnvelope ? (
+                  <Alert
+                    variant="destructive"
+                    data-testid="metric-run-lifecycle-error-envelope"
+                    data-error-status={lifecycleError?.status ?? ''}
+                  >
+                    <AlertTitle>{lifecycleEnvelope.title}</AlertTitle>
+                    <AlertDescription>{lifecycleEnvelope.description}</AlertDescription>
+                  </Alert>
+                ) : null}
+
+                {activeMetricRun ? (
+                  <div
+                    className="grid gap-3 rounded-md border border-slate-200 p-3 text-sm md:grid-cols-2"
+                    data-testid="metric-run-lifecycle-panel"
+                  >
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-charcoal/60">Status</p>
+                      <div className="mt-1 flex items-center gap-2">
+                        <Badge variant="outline" data-testid="metric-run-status-badge">
+                          {activeMetricRun.status}
+                        </Badge>
+                        <span className="text-xs text-charcoal/60">
+                          version {activeMetricRun.version}
+                        </span>
+                      </div>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-charcoal/60">Evidence</p>
+                      <p className="mt-1 font-medium" data-testid="metric-run-evidence-count">
+                        {activeEvidenceCount} record{activeEvidenceCount === 1 ? '' : 's'}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-charcoal/60">Approved</p>
+                      <p className="mt-1 text-charcoal/70" data-testid="metric-run-approved-at">
+                        {activeMetricRun.approvedAt ?? 'Not approved'}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-charcoal/60">Locked</p>
+                      <p className="mt-1 text-charcoal/70" data-testid="metric-run-locked-at">
+                        {activeMetricRun.lockedAt ?? 'Not locked'}
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm text-charcoal/70 font-poppins">
+                    Loading lifecycle status...
+                  </p>
+                )}
+
+                {activeMetricRun?.status === 'draft' && activeEvidenceCount === 0 ? (
+                  <Alert data-testid="metric-run-approval-blocked">
+                    <AlertTitle>Approval blocked</AlertTitle>
+                    <AlertDescription>
+                      Add at least one evidence record before approving this metric run.
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Button
+                    type="button"
+                    onClick={() => void handleApprove()}
+                    disabled={!canApprove}
+                    data-testid="metric-run-approve-button"
+                  >
+                    {approveMutation.isPending ? 'Approving...' : 'Approve'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void handleLock()}
+                    disabled={!canLock}
+                    data-testid="metric-run-lock-button"
+                  >
+                    {lockMutation.isPending ? 'Locking...' : 'Lock'}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {commitResult ? (
             <Card data-testid="metric-run-evidence-card">
               <CardHeader>
                 <CardTitle>Metric-run evidence</CardTitle>
                 <CardDescription>
-                  Metadata records attached to draft metric run #{commitResult.metricRunId}.
+                  Metadata records attached to metric run #{commitResult.metricRunId}.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -389,147 +582,156 @@ export default function LpReportingMetricsPage() {
                   </Alert>
                 ) : null}
 
-                <form
-                  className="grid gap-4 md:grid-cols-2"
-                  onSubmit={(event) => void handleEvidenceSubmit(event)}
-                  data-testid="metric-run-evidence-form"
-                >
-                  <label className="space-y-1 text-sm font-medium text-charcoal">
-                    Evidence source
-                    <select
-                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
-                      value={evidenceForm.evidenceSource}
-                      onChange={(event) =>
-                        setEvidenceForm((current) => ({
-                          ...current,
-                          evidenceSource: event.target.value as EvidenceSource,
-                        }))
-                      }
-                    >
-                      <option value="board_update">Board update</option>
-                      <option value="audited_financials">Audited financials</option>
-                      <option value="financing_round">Financing round</option>
-                      <option value="management_report">Management report</option>
-                      <option value="gp_estimate">GP estimate</option>
-                      <option value="third_party_priced">Third-party priced</option>
-                      <option value="signed_loi">Signed LOI</option>
-                      <option value="revenue_milestone">Revenue milestone</option>
-                      <option value="strategic_partnership">Strategic partnership</option>
-                      <option value="secondary_transaction">Secondary transaction</option>
-                      <option value="customer_contract">Customer contract</option>
-                      <option value="auditor_confirmation">Auditor confirmation</option>
-                    </select>
-                  </label>
+                {isEvidenceEditable ? (
+                  <form
+                    className="grid gap-4 md:grid-cols-2"
+                    onSubmit={(event) => void handleEvidenceSubmit(event)}
+                    data-testid="metric-run-evidence-form"
+                  >
+                    <label className="space-y-1 text-sm font-medium text-charcoal">
+                      Evidence source
+                      <select
+                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        value={evidenceForm.evidenceSource}
+                        onChange={(event) =>
+                          setEvidenceForm((current) => ({
+                            ...current,
+                            evidenceSource: event.target.value as EvidenceSource,
+                          }))
+                        }
+                      >
+                        <option value="board_update">Board update</option>
+                        <option value="audited_financials">Audited financials</option>
+                        <option value="financing_round">Financing round</option>
+                        <option value="management_report">Management report</option>
+                        <option value="gp_estimate">GP estimate</option>
+                        <option value="third_party_priced">Third-party priced</option>
+                        <option value="signed_loi">Signed LOI</option>
+                        <option value="revenue_milestone">Revenue milestone</option>
+                        <option value="strategic_partnership">Strategic partnership</option>
+                        <option value="secondary_transaction">Secondary transaction</option>
+                        <option value="customer_contract">Customer contract</option>
+                        <option value="auditor_confirmation">Auditor confirmation</option>
+                      </select>
+                    </label>
 
-                  <label className="space-y-1 text-sm font-medium text-charcoal">
-                    Source date
-                    <input
-                      className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
-                      type="date"
-                      required
-                      value={evidenceForm.sourceDate}
-                      onChange={(event) =>
-                        setEvidenceForm((current) => ({
-                          ...current,
-                          sourceDate: event.target.value,
-                        }))
-                      }
-                    />
-                  </label>
+                    <label className="space-y-1 text-sm font-medium text-charcoal">
+                      Source date
+                      <input
+                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                        type="date"
+                        required
+                        value={evidenceForm.sourceDate}
+                        onChange={(event) =>
+                          setEvidenceForm((current) => ({
+                            ...current,
+                            sourceDate: event.target.value,
+                          }))
+                        }
+                      />
+                    </label>
 
-                  <label className="space-y-1 text-sm font-medium text-charcoal">
-                    Confidence
-                    <select
-                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
-                      value={evidenceForm.confidenceLevel}
-                      onChange={(event) =>
-                        setEvidenceForm((current) => ({
-                          ...current,
-                          confidenceLevel: event.target.value as ConfidenceLevel,
-                        }))
-                      }
-                    >
-                      <option value="high">High</option>
-                      <option value="medium">Medium</option>
-                      <option value="low">Low</option>
-                    </select>
-                  </label>
+                    <label className="space-y-1 text-sm font-medium text-charcoal">
+                      Confidence
+                      <select
+                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        value={evidenceForm.confidenceLevel}
+                        onChange={(event) =>
+                          setEvidenceForm((current) => ({
+                            ...current,
+                            confidenceLevel: event.target.value as ConfidenceLevel,
+                          }))
+                        }
+                      >
+                        <option value="high">High</option>
+                        <option value="medium">Medium</option>
+                        <option value="low">Low</option>
+                      </select>
+                    </label>
 
-                  <label className="space-y-1 text-sm font-medium text-charcoal">
-                    Materiality
-                    <select
-                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
-                      value={evidenceForm.materialityLevel}
-                      onChange={(event) =>
-                        setEvidenceForm((current) => ({
-                          ...current,
-                          materialityLevel: event.target.value as MaterialityLevel,
-                        }))
-                      }
-                    >
-                      <option value="high">High</option>
-                      <option value="medium">Medium</option>
-                      <option value="low">Low</option>
-                    </select>
-                  </label>
+                    <label className="space-y-1 text-sm font-medium text-charcoal">
+                      Materiality
+                      <select
+                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        value={evidenceForm.materialityLevel}
+                        onChange={(event) =>
+                          setEvidenceForm((current) => ({
+                            ...current,
+                            materialityLevel: event.target.value as MaterialityLevel,
+                          }))
+                        }
+                      >
+                        <option value="high">High</option>
+                        <option value="medium">Medium</option>
+                        <option value="low">Low</option>
+                      </select>
+                    </label>
 
-                  <label className="space-y-1 text-sm font-medium text-charcoal">
-                    Confidentiality
-                    <select
-                      className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
-                      value={evidenceForm.confidentiality}
-                      onChange={(event) =>
-                        setEvidenceForm((current) => ({
-                          ...current,
-                          confidentiality: event.target.value as Confidentiality,
-                        }))
-                      }
-                    >
-                      <option value="internal">Internal</option>
-                      <option value="lp_shareable">LP shareable</option>
-                      <option value="restricted">Restricted</option>
-                    </select>
-                  </label>
+                    <label className="space-y-1 text-sm font-medium text-charcoal">
+                      Confidentiality
+                      <select
+                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        value={evidenceForm.confidentiality}
+                        onChange={(event) =>
+                          setEvidenceForm((current) => ({
+                            ...current,
+                            confidentiality: event.target.value as Confidentiality,
+                          }))
+                        }
+                      >
+                        <option value="internal">Internal</option>
+                        <option value="lp_shareable">LP shareable</option>
+                        <option value="restricted">Restricted</option>
+                      </select>
+                    </label>
 
-                  <label className="flex items-center gap-2 text-sm font-medium text-charcoal md:mt-7">
-                    <input
-                      type="checkbox"
-                      checked={evidenceForm.redactionRequired}
-                      onChange={(event) =>
-                        setEvidenceForm((current) => ({
-                          ...current,
-                          redactionRequired: event.target.checked,
-                        }))
-                      }
-                    />
-                    Redaction required
-                  </label>
+                    <label className="flex items-center gap-2 text-sm font-medium text-charcoal md:mt-7">
+                      <input
+                        type="checkbox"
+                        checked={evidenceForm.redactionRequired}
+                        onChange={(event) =>
+                          setEvidenceForm((current) => ({
+                            ...current,
+                            redactionRequired: event.target.checked,
+                          }))
+                        }
+                      />
+                      Redaction required
+                    </label>
 
-                  <label className="space-y-1 text-sm font-medium text-charcoal md:col-span-2">
-                    Description
-                    <textarea
-                      className="min-h-24 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
-                      maxLength={2000}
-                      value={evidenceForm.description}
-                      onChange={(event) =>
-                        setEvidenceForm((current) => ({
-                          ...current,
-                          description: event.target.value,
-                        }))
-                      }
-                    />
-                  </label>
+                    <label className="space-y-1 text-sm font-medium text-charcoal md:col-span-2">
+                      Description
+                      <textarea
+                        className="min-h-24 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                        maxLength={2000}
+                        value={evidenceForm.description}
+                        onChange={(event) =>
+                          setEvidenceForm((current) => ({
+                            ...current,
+                            description: event.target.value,
+                          }))
+                        }
+                      />
+                    </label>
 
-                  <div className="md:col-span-2">
-                    <Button
-                      type="submit"
-                      disabled={evidenceCreateMutation.isPending}
-                      data-testid="metric-run-evidence-submit"
-                    >
-                      {evidenceCreateMutation.isPending ? 'Saving...' : 'Add evidence'}
-                    </Button>
-                  </div>
-                </form>
+                    <div className="md:col-span-2">
+                      <Button
+                        type="submit"
+                        disabled={evidenceCreateMutation.isPending}
+                        data-testid="metric-run-evidence-submit"
+                      >
+                        {evidenceCreateMutation.isPending ? 'Saving...' : 'Add evidence'}
+                      </Button>
+                    </div>
+                  </form>
+                ) : (
+                  <Alert data-testid="metric-run-evidence-readonly">
+                    <AlertTitle>Evidence locked</AlertTitle>
+                    <AlertDescription>
+                      Evidence can be reviewed but not added after approval.
+                    </AlertDescription>
+                  </Alert>
+                )}
 
                 <div className="space-y-3" data-testid="metric-run-evidence-list">
                   {evidenceListQuery.isLoading ? (

--- a/server/migrations/20260510_lp_reporting_metric_run_lifecycle_v1.down.sql
+++ b/server/migrations/20260510_lp_reporting_metric_run_lifecycle_v1.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE lp_metric_runs
+  DROP COLUMN IF EXISTS locked_by,
+  DROP COLUMN IF EXISTS updated_at,
+  DROP COLUMN IF EXISTS version;

--- a/server/migrations/20260510_lp_reporting_metric_run_lifecycle_v1.up.sql
+++ b/server/migrations/20260510_lp_reporting_metric_run_lifecycle_v1.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE lp_metric_runs
+  ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS locked_by integer REFERENCES users(id);

--- a/server/routes/lp-reporting/metric-runs.ts
+++ b/server/routes/lp-reporting/metric-runs.ts
@@ -3,6 +3,10 @@
  *
  *   POST /api/funds/:fundId/metric-runs/dry-run
  *   POST /api/funds/:fundId/metric-runs/commit
+ *   GET  /api/funds/:fundId/metric-runs/latest
+ *   GET  /api/funds/:fundId/metric-runs/:metricRunId
+ *   POST /api/funds/:fundId/metric-runs/:metricRunId/approve
+ *   POST /api/funds/:fundId/metric-runs/:metricRunId/lock
  *   GET  /api/funds/:fundId/metric-runs/:metricRunId/evidence-records
  *   POST /api/funds/:fundId/metric-runs/:metricRunId/evidence-records
  *
@@ -23,11 +27,17 @@ import { firstString } from '../../lib/request-values';
 import {
   MetricRunCommitRequestSchema,
   MetricRunCommitResponseSchema,
+  MetricRunDetailResponseSchema,
   MetricRunDryRunRequestSchema,
   MetricRunDryRunResponseSchema,
+  LatestMetricRunQuerySchema,
+  LatestMetricRunResponseSchema,
+  MetricRunApproveRequestSchema,
   MetricRunEvidenceCreateRequestSchema,
   MetricRunEvidenceCreateResponseSchema,
   MetricRunEvidenceListResponseSchema,
+  MetricRunLifecycleResponseSchema,
+  MetricRunLockRequestSchema,
 } from '@shared/contracts/lp-reporting';
 import {
   buildMetricRunDryRun,
@@ -38,6 +48,12 @@ import {
   createMetricRunEvidence,
   listMetricRunEvidence,
 } from '../../services/lp-reporting/metric-run-evidence-service';
+import {
+  approveMetricRun,
+  getLatestMetricRun,
+  getMetricRunDetail,
+  lockMetricRun,
+} from '../../services/lp-reporting/metric-run-lifecycle-service';
 
 const router = Router();
 
@@ -110,6 +126,10 @@ function sendMetricRunError(
   fallbackCode:
     | 'METRIC_RUN_DRY_RUN_FAILED'
     | 'METRIC_RUN_COMMIT_FAILED'
+    | 'METRIC_RUN_DETAIL_FAILED'
+    | 'METRIC_RUN_LATEST_FAILED'
+    | 'METRIC_RUN_APPROVE_FAILED'
+    | 'METRIC_RUN_LOCK_FAILED'
     | 'METRIC_RUN_EVIDENCE_CREATE_FAILED'
     | 'METRIC_RUN_EVIDENCE_LIST_FAILED'
 ): Response {
@@ -178,6 +198,114 @@ router.post(
       return res.status(validated.inserted ? 201 : 200).json(validated);
     } catch (err) {
       return sendMetricRunError(res, err, 'METRIC_RUN_COMMIT_FAILED');
+    }
+  }
+);
+
+router.get(
+  '/api/funds/:fundId/metric-runs/latest',
+  requireAuth(),
+  requireFundAccess,
+  metricRunLimiter,
+  async (req: Request, res: Response) => {
+    const parsed = LatestMetricRunQuerySchema.safeParse({
+      runType: firstString(req.query['runType']),
+      perspective: firstString(req.query['perspective']),
+      asOfDate: firstString(req.query['asOfDate']),
+    });
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST_QUERY',
+        issues: parsed.error.issues,
+      });
+    }
+
+    try {
+      const result = await getLatestMetricRun({
+        fundId: parseFundId(req),
+        ...parsed.data,
+      });
+      const validated = LatestMetricRunResponseSchema.parse(result);
+      return res.status(200).json(validated);
+    } catch (err) {
+      return sendMetricRunError(res, err, 'METRIC_RUN_LATEST_FAILED');
+    }
+  }
+);
+
+router.get(
+  '/api/funds/:fundId/metric-runs/:metricRunId',
+  requireAuth(),
+  requireFundAccess,
+  metricRunLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const result = await getMetricRunDetail({
+        fundId: parseFundId(req),
+        metricRunId: parseMetricRunId(req),
+      });
+      const validated = MetricRunDetailResponseSchema.parse(result);
+      return res.status(200).json(validated);
+    } catch (err) {
+      return sendMetricRunError(res, err, 'METRIC_RUN_DETAIL_FAILED');
+    }
+  }
+);
+
+router.post(
+  '/api/funds/:fundId/metric-runs/:metricRunId/approve',
+  requireAuth(),
+  requireFundAccess,
+  metricRunLimiter,
+  async (req: Request, res: Response) => {
+    const parsed = MetricRunApproveRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST_BODY',
+        issues: parsed.error.issues,
+      });
+    }
+
+    try {
+      const result = await approveMetricRun({
+        fundId: parseFundId(req),
+        metricRunId: parseMetricRunId(req),
+        userId: resolveAuthenticatedUserId(req),
+        expectedVersion: parsed.data.expectedVersion,
+      });
+      const validated = MetricRunLifecycleResponseSchema.parse(result);
+      return res.status(200).json(validated);
+    } catch (err) {
+      return sendMetricRunError(res, err, 'METRIC_RUN_APPROVE_FAILED');
+    }
+  }
+);
+
+router.post(
+  '/api/funds/:fundId/metric-runs/:metricRunId/lock',
+  requireAuth(),
+  requireFundAccess,
+  metricRunLimiter,
+  async (req: Request, res: Response) => {
+    const parsed = MetricRunLockRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST_BODY',
+        issues: parsed.error.issues,
+      });
+    }
+
+    try {
+      const result = await lockMetricRun({
+        fundId: parseFundId(req),
+        metricRunId: parseMetricRunId(req),
+        userId: resolveAuthenticatedUserId(req),
+        expectedVersion: parsed.data.expectedVersion,
+      });
+      const validated = MetricRunLifecycleResponseSchema.parse(result);
+      return res.status(200).json(validated);
+    } catch (err) {
+      return sendMetricRunError(res, err, 'METRIC_RUN_LOCK_FAILED');
     }
   }
 );

--- a/server/services/lp-reporting/metric-run-evidence-service.ts
+++ b/server/services/lp-reporting/metric-run-evidence-service.ts
@@ -8,7 +8,7 @@
  * @module server/services/lp-reporting/metric-run-evidence-service
  */
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db';
 import {
@@ -46,11 +46,50 @@ export interface MetricRunEvidenceListInput {
 
 interface MetricRunEvidenceServiceOptions {
   database?: MetricRunEvidenceDatabase;
+  skipTransaction?: boolean;
 }
 
 type MetricRunLookupRow = Pick<LpMetricRun, 'id' | 'fundId' | 'status'>;
+type TransactionCapableDatabase = MetricRunEvidenceDatabase & {
+  transaction?: <TResult>(
+    callback: (tx: MetricRunEvidenceDatabase) => Promise<TResult>
+  ) => Promise<TResult>;
+};
+type ExecuteCapableDatabase = MetricRunEvidenceDatabase & {
+  execute?: (query: unknown) => Promise<unknown>;
+};
 
 const EDITABLE_METRIC_RUN_STATUSES = new Set(['draft']);
+
+function withTransaction<TResult>(
+  database: MetricRunEvidenceDatabase,
+  skipTransaction: boolean,
+  callback: (tx: MetricRunEvidenceDatabase) => Promise<TResult>
+): Promise<TResult> {
+  const transactionCapable = database as TransactionCapableDatabase;
+  if (!skipTransaction && typeof transactionCapable.transaction === 'function') {
+    return transactionCapable.transaction((tx) => callback(tx));
+  }
+  return callback(database);
+}
+
+async function lockMetricRunRow(
+  database: MetricRunEvidenceDatabase,
+  fundId: number,
+  metricRunId: number
+): Promise<void> {
+  const executeCapable = database as ExecuteCapableDatabase;
+  if (typeof executeCapable.execute !== 'function') {
+    return;
+  }
+  await executeCapable.execute(sql`
+    SELECT id
+      FROM lp_metric_runs
+     WHERE fund_id = ${fundId}
+       AND id = ${metricRunId}
+     FOR UPDATE
+  `);
+}
 
 function isoDateTime(value: Date | string | null | undefined, field: string): string {
   if (value instanceof Date) {
@@ -232,46 +271,49 @@ export async function createMetricRunEvidence(
   options: MetricRunEvidenceServiceOptions = {}
 ): Promise<MetricRunEvidenceCreateResponse> {
   const database = options.database ?? db;
-  const body = MetricRunEvidenceCreateRequestSchema.parse(input.body);
-  const metricRun = await loadMetricRun(database, input.fundId, input.metricRunId);
-  assertMetricRunEditable(metricRun);
-  await assertUserExists(database, input.userId);
+  return withTransaction(database, options.skipTransaction === true, async (tx) => {
+    const body = MetricRunEvidenceCreateRequestSchema.parse(input.body);
+    await lockMetricRunRow(tx, input.fundId, input.metricRunId);
+    const metricRun = await loadMetricRun(tx, input.fundId, input.metricRunId);
+    assertMetricRunEditable(metricRun);
+    await assertUserExists(tx, input.userId);
 
-  const existing = await findEvidenceByIdempotencyKey(
-    database,
-    input.fundId,
-    input.metricRunId,
-    body.idempotencyKey
-  );
-  if (existing) {
-    return { record: toMetricRunEvidenceRecord(existing), inserted: false };
-  }
+    const existing = await findEvidenceByIdempotencyKey(
+      tx,
+      input.fundId,
+      input.metricRunId,
+      body.idempotencyKey
+    );
+    if (existing) {
+      return { record: toMetricRunEvidenceRecord(existing), inserted: false };
+    }
 
-  const inserted = await database
-    .insert(evidenceRecords)
-    .values(evidenceInsertValues({ ...input, body }))
-    .onConflictDoNothing()
-    .returning();
-  const insertedRow = (inserted as EvidenceRecord[])[0];
-  if (insertedRow) {
-    return { record: toMetricRunEvidenceRecord(insertedRow), inserted: true };
-  }
+    const inserted = await tx
+      .insert(evidenceRecords)
+      .values(evidenceInsertValues({ ...input, body }))
+      .onConflictDoNothing()
+      .returning();
+    const insertedRow = (inserted as EvidenceRecord[])[0];
+    if (insertedRow) {
+      return { record: toMetricRunEvidenceRecord(insertedRow), inserted: true };
+    }
 
-  const racedExisting = await findEvidenceByIdempotencyKey(
-    database,
-    input.fundId,
-    input.metricRunId,
-    body.idempotencyKey
-  );
-  if (racedExisting) {
-    return { record: toMetricRunEvidenceRecord(racedExisting), inserted: false };
-  }
+    const racedExisting = await findEvidenceByIdempotencyKey(
+      tx,
+      input.fundId,
+      input.metricRunId,
+      body.idempotencyKey
+    );
+    if (racedExisting) {
+      return { record: toMetricRunEvidenceRecord(racedExisting), inserted: false };
+    }
 
-  throw new MetricRunCommitError(
-    409,
-    'METRIC_RUN_EVIDENCE_CONFLICT',
-    'Evidence create conflicted but no existing row could be loaded.'
-  );
+    throw new MetricRunCommitError(
+      409,
+      'METRIC_RUN_EVIDENCE_CONFLICT',
+      'Evidence create conflicted but no existing row could be loaded.'
+    );
+  });
 }
 
 export async function listMetricRunEvidence(

--- a/server/services/lp-reporting/metric-run-lifecycle-service.ts
+++ b/server/services/lp-reporting/metric-run-lifecycle-service.ts
@@ -1,0 +1,424 @@
+/**
+ * LP Reporting -- metric-run approval and lock lifecycle service.
+ *
+ * Lifecycle transitions serialize on the parent metric-run row before reading
+ * or snapshotting evidence so approved runs cannot drift after evidence create
+ * requests race with approval.
+ *
+ * @module server/services/lp-reporting/metric-run-lifecycle-service
+ */
+
+import { and, eq, sql } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../../db';
+import {
+  LatestMetricRunResponseSchema,
+  MetricRunDetailResponseSchema,
+  MetricRunLifecycleResponseSchema,
+  type LatestMetricRunQuery,
+  type LatestMetricRunResponse,
+  type MetricRunDetailResponse,
+  type MetricRunLifecycleResponse,
+} from '@shared/contracts/lp-reporting';
+import {
+  evidenceRecords,
+  lpMetricRuns,
+  type EvidenceRecord,
+  type LpMetricRun,
+} from '@shared/schema/lp-reporting-evidence';
+import { MetricRunCommitError } from './metric-run-commit-service';
+
+type MetricRunLifecycleDatabase = typeof db;
+
+export interface MetricRunLifecycleInput {
+  fundId: number;
+  metricRunId: number;
+  userId: number;
+  expectedVersion: number;
+}
+
+export interface LatestMetricRunInput extends LatestMetricRunQuery {
+  fundId: number;
+}
+
+export interface MetricRunDetailInput {
+  fundId: number;
+  metricRunId: number;
+}
+
+interface MetricRunLifecycleServiceOptions {
+  database?: MetricRunLifecycleDatabase;
+  skipTransaction?: boolean;
+}
+
+type TransactionCapableDatabase = MetricRunLifecycleDatabase & {
+  transaction?: <TResult>(
+    callback: (tx: MetricRunLifecycleDatabase) => Promise<TResult>
+  ) => Promise<TResult>;
+};
+
+type ExecuteCapableDatabase = MetricRunLifecycleDatabase & {
+  execute?: (query: unknown) => Promise<unknown>;
+};
+
+const IdArraySchema = z.array(z.number().int().positive());
+
+function withTransaction<TResult>(
+  database: MetricRunLifecycleDatabase,
+  skipTransaction: boolean,
+  callback: (tx: MetricRunLifecycleDatabase) => Promise<TResult>
+): Promise<TResult> {
+  const transactionCapable = database as TransactionCapableDatabase;
+  if (!skipTransaction && typeof transactionCapable.transaction === 'function') {
+    return transactionCapable.transaction((tx) => callback(tx));
+  }
+  return callback(database);
+}
+
+async function lockMetricRunRow(
+  database: MetricRunLifecycleDatabase,
+  fundId: number,
+  metricRunId: number
+): Promise<void> {
+  const executeCapable = database as ExecuteCapableDatabase;
+  if (typeof executeCapable.execute !== 'function') {
+    return;
+  }
+  await executeCapable.execute(sql`
+    SELECT id
+      FROM lp_metric_runs
+     WHERE fund_id = ${fundId}
+       AND id = ${metricRunId}
+     FOR UPDATE
+  `);
+}
+
+function isoDateTime(value: Date | string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? value : new Date(parsed).toISOString();
+}
+
+function isoDay(value: Date | string): string {
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return value.slice(0, 10);
+}
+
+function normalizeIdArray(value: unknown): number[] {
+  return IdArraySchema.parse(value ?? []);
+}
+
+function normalizeVersion(value: number | null | undefined): number {
+  if (value === null || value === undefined) return 1;
+  return Number.isInteger(value) && value > 0 ? value : 1;
+}
+
+function dateSortValue(value: Date | string | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  const parsed = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function toMetricRunDetail(metricRun: LpMetricRun, evidenceIds: number[]): MetricRunDetailResponse {
+  return MetricRunDetailResponseSchema.parse({
+    metricRunId: metricRun.id,
+    fundId: metricRun.fundId,
+    asOfDate: isoDay(metricRun.asOfDate),
+    runType: metricRun.runType,
+    perspective: metricRun.perspective,
+    status: metricRun.status,
+    inputsHash: metricRun.inputsHash,
+    sourceEventIds: normalizeIdArray(metricRun.sourceEventIds),
+    sourceMarkIds: normalizeIdArray(metricRun.sourceMarkIds),
+    sourceEvidenceIds: normalizeIdArray(metricRun.sourceEvidenceIds),
+    evidenceCount: evidenceIds.length,
+    generatedBy: metricRun.generatedBy ?? null,
+    approvedBy: metricRun.approvedBy ?? null,
+    approvedAt: isoDateTime(metricRun.approvedAt),
+    lockedBy: metricRun.lockedBy ?? null,
+    lockedAt: isoDateTime(metricRun.lockedAt),
+    exportedAt: isoDateTime(metricRun.exportedAt),
+    version: normalizeVersion(metricRun.version),
+    createdAt: isoDateTime(metricRun.createdAt),
+    updatedAt: isoDateTime(metricRun.updatedAt),
+  });
+}
+
+async function loadMetricRun(
+  database: MetricRunLifecycleDatabase,
+  fundId: number,
+  metricRunId: number
+): Promise<LpMetricRun> {
+  const rows = await database
+    .select()
+    .from(lpMetricRuns)
+    .where(and(eq(lpMetricRuns.fundId, fundId), eq(lpMetricRuns.id, metricRunId)))
+    .limit(1);
+  const row = (rows as LpMetricRun[]).find(
+    (candidate) => candidate.id === metricRunId && candidate.fundId === fundId
+  );
+  if (!row) {
+    throw new MetricRunCommitError(
+      404,
+      'METRIC_RUN_NOT_FOUND',
+      'Metric run was not found for this fund.'
+    );
+  }
+  return row;
+}
+
+async function loadEvidenceIds(
+  database: MetricRunLifecycleDatabase,
+  fundId: number,
+  metricRunId: number
+): Promise<number[]> {
+  const rows = await database
+    .select()
+    .from(evidenceRecords)
+    .where(and(eq(evidenceRecords.fundId, fundId), eq(evidenceRecords.metricRunId, metricRunId)));
+  return (rows as EvidenceRecord[])
+    .filter((row) => row.fundId === fundId && row.metricRunId === metricRunId)
+    .map((row) => row.id)
+    .sort((a, b) => a - b);
+}
+
+async function loadDetail(
+  database: MetricRunLifecycleDatabase,
+  fundId: number,
+  metricRunId: number
+): Promise<MetricRunDetailResponse> {
+  const metricRun = await loadMetricRun(database, fundId, metricRunId);
+  const evidenceIds = await loadEvidenceIds(database, fundId, metricRunId);
+  return toMetricRunDetail(metricRun, evidenceIds);
+}
+
+function assertExpectedVersion(actual: number, expected: number): void {
+  if (actual !== expected) {
+    throw new MetricRunCommitError(
+      409,
+      'METRIC_RUN_VERSION_CONFLICT',
+      'Metric run version no longer matches the request.',
+      { expectedVersion: expected, actualVersion: actual }
+    );
+  }
+}
+
+function statusConflict(actualStatus: string, expectedStatus: string): MetricRunCommitError {
+  return new MetricRunCommitError(
+    409,
+    'METRIC_RUN_STATUS_CONFLICT',
+    `Metric run must be ${expectedStatus} for this lifecycle transition.`,
+    { expectedStatus, actualStatus }
+  );
+}
+
+function isSameApproveRetry(metricRun: LpMetricRun, input: MetricRunLifecycleInput): boolean {
+  return (
+    metricRun.status === 'approved' &&
+    normalizeVersion(metricRun.version) === input.expectedVersion + 1 &&
+    metricRun.approvedBy === input.userId &&
+    metricRun.approvedAt !== null &&
+    normalizeIdArray(metricRun.sourceEvidenceIds).length > 0
+  );
+}
+
+function isSameLockRetry(metricRun: LpMetricRun, input: MetricRunLifecycleInput): boolean {
+  return (
+    metricRun.status === 'locked' &&
+    normalizeVersion(metricRun.version) === input.expectedVersion + 1 &&
+    metricRun.lockedBy === input.userId &&
+    metricRun.lockedAt !== null
+  );
+}
+
+export async function getLatestMetricRun(
+  input: LatestMetricRunInput,
+  options: MetricRunLifecycleServiceOptions = {}
+): Promise<LatestMetricRunResponse> {
+  const database = options.database ?? db;
+  const rows = await database
+    .select()
+    .from(lpMetricRuns)
+    .where(
+      and(
+        eq(lpMetricRuns.fundId, input.fundId),
+        eq(lpMetricRuns.runType, input.runType),
+        eq(lpMetricRuns.perspective, input.perspective),
+        eq(lpMetricRuns.asOfDate, input.asOfDate)
+      )
+    );
+  const exactRows = (rows as LpMetricRun[])
+    .filter(
+      (row) =>
+        row.fundId === input.fundId &&
+        row.runType === input.runType &&
+        row.perspective === input.perspective &&
+        isoDay(row.asOfDate) === input.asOfDate
+    )
+    .sort((left, right) => {
+      const createdDelta = dateSortValue(right.createdAt) - dateSortValue(left.createdAt);
+      return createdDelta !== 0 ? createdDelta : right.id - left.id;
+    });
+
+  const latest = exactRows[0] ?? null;
+  if (!latest) {
+    return LatestMetricRunResponseSchema.parse({ metricRun: null });
+  }
+  const evidenceIds = await loadEvidenceIds(database, input.fundId, latest.id);
+  return LatestMetricRunResponseSchema.parse({
+    metricRun: toMetricRunDetail(latest, evidenceIds),
+  });
+}
+
+export async function getMetricRunDetail(
+  input: MetricRunDetailInput,
+  options: MetricRunLifecycleServiceOptions = {}
+): Promise<MetricRunDetailResponse> {
+  const database = options.database ?? db;
+  return loadDetail(database, input.fundId, input.metricRunId);
+}
+
+export async function approveMetricRun(
+  input: MetricRunLifecycleInput,
+  options: MetricRunLifecycleServiceOptions = {}
+): Promise<MetricRunLifecycleResponse> {
+  const database = options.database ?? db;
+  return withTransaction(database, options.skipTransaction === true, async (tx) => {
+    await lockMetricRunRow(tx, input.fundId, input.metricRunId);
+    const metricRun = await loadMetricRun(tx, input.fundId, input.metricRunId);
+    if (isSameApproveRetry(metricRun, input)) {
+      return MetricRunLifecycleResponseSchema.parse({
+        metricRun: await loadDetail(tx, input.fundId, input.metricRunId),
+        changed: false,
+      });
+    }
+    if (metricRun.status !== 'draft') {
+      throw statusConflict(metricRun.status, 'draft');
+    }
+    assertExpectedVersion(normalizeVersion(metricRun.version), input.expectedVersion);
+
+    const evidenceIds = await loadEvidenceIds(tx, input.fundId, input.metricRunId);
+    if (evidenceIds.length === 0) {
+      throw new MetricRunCommitError(
+        409,
+        'METRIC_RUN_EVIDENCE_REQUIRED',
+        'At least one evidence record is required before approval.'
+      );
+    }
+
+    const now = new Date();
+    const updatedRows = await tx
+      .update(lpMetricRuns)
+      .set({
+        status: 'approved',
+        approvedBy: input.userId,
+        approvedAt: now,
+        sourceEvidenceIds: evidenceIds,
+        version: input.expectedVersion + 1,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(lpMetricRuns.fundId, input.fundId),
+          eq(lpMetricRuns.id, input.metricRunId),
+          eq(lpMetricRuns.status, 'draft'),
+          eq(lpMetricRuns.version, input.expectedVersion)
+        )
+      )
+      .returning();
+
+    const updated = (updatedRows as LpMetricRun[])[0];
+    if (!updated) {
+      const current = await loadMetricRun(tx, input.fundId, input.metricRunId);
+      if (isSameApproveRetry(current, input)) {
+        return MetricRunLifecycleResponseSchema.parse({
+          metricRun: await loadDetail(tx, input.fundId, input.metricRunId),
+          changed: false,
+        });
+      }
+      if (current.status !== 'draft') {
+        throw statusConflict(current.status, 'draft');
+      }
+      assertExpectedVersion(normalizeVersion(current.version), input.expectedVersion);
+      throw new MetricRunCommitError(
+        409,
+        'METRIC_RUN_STATUS_CONFLICT',
+        'Metric run approval conflicted with another lifecycle update.'
+      );
+    }
+
+    return MetricRunLifecycleResponseSchema.parse({
+      metricRun: toMetricRunDetail(updated, evidenceIds),
+      changed: true,
+    });
+  });
+}
+
+export async function lockMetricRun(
+  input: MetricRunLifecycleInput,
+  options: MetricRunLifecycleServiceOptions = {}
+): Promise<MetricRunLifecycleResponse> {
+  const database = options.database ?? db;
+  return withTransaction(database, options.skipTransaction === true, async (tx) => {
+    await lockMetricRunRow(tx, input.fundId, input.metricRunId);
+    const metricRun = await loadMetricRun(tx, input.fundId, input.metricRunId);
+    if (isSameLockRetry(metricRun, input)) {
+      return MetricRunLifecycleResponseSchema.parse({
+        metricRun: await loadDetail(tx, input.fundId, input.metricRunId),
+        changed: false,
+      });
+    }
+    if (metricRun.status !== 'approved') {
+      throw statusConflict(metricRun.status, 'approved');
+    }
+    assertExpectedVersion(normalizeVersion(metricRun.version), input.expectedVersion);
+
+    const now = new Date();
+    const updatedRows = await tx
+      .update(lpMetricRuns)
+      .set({
+        status: 'locked',
+        lockedBy: input.userId,
+        lockedAt: now,
+        version: input.expectedVersion + 1,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(lpMetricRuns.fundId, input.fundId),
+          eq(lpMetricRuns.id, input.metricRunId),
+          eq(lpMetricRuns.status, 'approved'),
+          eq(lpMetricRuns.version, input.expectedVersion)
+        )
+      )
+      .returning();
+
+    const updated = (updatedRows as LpMetricRun[])[0];
+    if (!updated) {
+      const current = await loadMetricRun(tx, input.fundId, input.metricRunId);
+      if (isSameLockRetry(current, input)) {
+        return MetricRunLifecycleResponseSchema.parse({
+          metricRun: await loadDetail(tx, input.fundId, input.metricRunId),
+          changed: false,
+        });
+      }
+      if (current.status !== 'approved') {
+        throw statusConflict(current.status, 'approved');
+      }
+      assertExpectedVersion(normalizeVersion(current.version), input.expectedVersion);
+      throw new MetricRunCommitError(
+        409,
+        'METRIC_RUN_STATUS_CONFLICT',
+        'Metric run lock conflicted with another lifecycle update.'
+      );
+    }
+
+    const evidenceIds = await loadEvidenceIds(tx, input.fundId, input.metricRunId);
+    return MetricRunLifecycleResponseSchema.parse({
+      metricRun: toMetricRunDetail(updated, evidenceIds),
+      changed: true,
+    });
+  });
+}

--- a/shared/contracts/lp-reporting/lp-metric-run.contract.ts
+++ b/shared/contracts/lp-reporting/lp-metric-run.contract.ts
@@ -187,6 +187,71 @@ export type MetricRunDryRunResponse = z.infer<typeof MetricRunDryRunResponseSche
 export type MetricRunCommitRequest = z.infer<typeof MetricRunCommitRequestSchema>;
 export type MetricRunCommitResponse = z.infer<typeof MetricRunCommitResponseSchema>;
 
+export const MetricRunDetailResponseSchema = z
+  .object({
+    metricRunId: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+    runType: LpMetricRunTypeSchema,
+    perspective: LpMetricRunPerspectiveSchema,
+    status: LpMetricRunStatusSchema,
+    inputsHash: z.string().min(1).max(128),
+    sourceEventIds: z.array(z.number().int().positive()),
+    sourceMarkIds: z.array(z.number().int().positive()),
+    sourceEvidenceIds: z.array(z.number().int().positive()),
+    evidenceCount: z.number().int().nonnegative(),
+    generatedBy: z.number().int().positive().nullable(),
+    approvedBy: z.number().int().positive().nullable(),
+    approvedAt: z.string().datetime().nullable(),
+    lockedBy: z.number().int().positive().nullable(),
+    lockedAt: z.string().datetime().nullable(),
+    exportedAt: z.string().datetime().nullable(),
+    version: z.number().int().positive(),
+    createdAt: z.string().datetime().nullable(),
+    updatedAt: z.string().datetime().nullable(),
+  })
+  .strict();
+
+export const MetricRunApproveRequestSchema = z
+  .object({
+    expectedVersion: z.number().int().positive(),
+  })
+  .strict();
+
+export const MetricRunLockRequestSchema = z
+  .object({
+    expectedVersion: z.number().int().positive(),
+  })
+  .strict();
+
+export const MetricRunLifecycleResponseSchema = z
+  .object({
+    metricRun: MetricRunDetailResponseSchema,
+    changed: z.boolean(),
+  })
+  .strict();
+
+export const LatestMetricRunQuerySchema = z
+  .object({
+    asOfDate: z.string().date(),
+    runType: LpMetricRunTypeSchema,
+    perspective: LpMetricRunPerspectiveSchema,
+  })
+  .strict();
+
+export const LatestMetricRunResponseSchema = z
+  .object({
+    metricRun: MetricRunDetailResponseSchema.nullable(),
+  })
+  .strict();
+
+export type MetricRunDetailResponse = z.infer<typeof MetricRunDetailResponseSchema>;
+export type MetricRunApproveRequest = z.infer<typeof MetricRunApproveRequestSchema>;
+export type MetricRunLockRequest = z.infer<typeof MetricRunLockRequestSchema>;
+export type MetricRunLifecycleResponse = z.infer<typeof MetricRunLifecycleResponseSchema>;
+export type LatestMetricRunQuery = z.infer<typeof LatestMetricRunQuerySchema>;
+export type LatestMetricRunResponse = z.infer<typeof LatestMetricRunResponseSchema>;
+
 // ---------------------------------------------------------------------------
 // CREATE request (mirrors lp_metric_runs row insert).
 // ---------------------------------------------------------------------------

--- a/shared/schema/lp-reporting-evidence.ts
+++ b/shared/schema/lp-reporting-evidence.ts
@@ -287,9 +287,12 @@ export const lpMetricRuns = pgTable(
     generatedBy: integer('generated_by').references(() => users.id),
     approvedBy: integer('approved_by').references(() => users.id),
     approvedAt: timestamp('approved_at', { withTimezone: true }),
+    lockedBy: integer('locked_by').references(() => users.id),
     lockedAt: timestamp('locked_at', { withTimezone: true }),
     exportedAt: timestamp('exported_at', { withTimezone: true }),
+    version: integer('version').notNull().default(1),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
   },
   (table) => ({
     runTypeCheck: check(

--- a/tests/unit/contract/lp-reporting/lp-metric-run.contract.test.ts
+++ b/tests/unit/contract/lp-reporting/lp-metric-run.contract.test.ts
@@ -9,10 +9,15 @@ import {
   LpMetricRunPerspectiveSchema,
   LpMetricRunStatusSchema,
   LpMetricRunTypeSchema,
+  LatestMetricRunResponseSchema,
+  MetricRunApproveRequestSchema,
   MetricRunCommitRequestSchema,
   MetricRunCommitResponseSchema,
+  MetricRunDetailResponseSchema,
   MetricRunDryRunRequestSchema,
   MetricRunDryRunResponseSchema,
+  MetricRunLifecycleResponseSchema,
+  MetricRunLockRequestSchema,
   type LpMetricRunResults,
   type XirrDiagnostic,
 } from '@shared/contracts/lp-reporting/lp-metric-run.contract';
@@ -202,6 +207,83 @@ describe('Metric-run dry-run and commit endpoint contracts', () => {
         unexpected: true,
       })
     ).toThrow();
+  });
+});
+
+describe('Metric-run lifecycle endpoint contracts', () => {
+  const detail = {
+    metricRunId: 17,
+    fundId: 7,
+    asOfDate: '2026-03-31',
+    runType: 'quarterly_report',
+    perspective: 'lp_net',
+    status: 'draft',
+    inputsHash: hex64,
+    sourceEventIds: [1, 2],
+    sourceMarkIds: [10],
+    sourceEvidenceIds: [],
+    evidenceCount: 0,
+    generatedBy: 7,
+    approvedBy: null,
+    approvedAt: null,
+    lockedBy: null,
+    lockedAt: null,
+    exportedAt: null,
+    version: 1,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+  };
+
+  it('approve request requires a positive expectedVersion and rejects unknown keys', () => {
+    expect(MetricRunApproveRequestSchema.parse({ expectedVersion: 1 })).toEqual({
+      expectedVersion: 1,
+    });
+    expect(() => MetricRunApproveRequestSchema.parse({ expectedVersion: 0 })).toThrow();
+    expect(() =>
+      MetricRunApproveRequestSchema.parse({ expectedVersion: 1, status: 'draft' })
+    ).toThrow();
+  });
+
+  it('lock request requires a positive expectedVersion and rejects unknown keys', () => {
+    expect(MetricRunLockRequestSchema.parse({ expectedVersion: 2 })).toEqual({
+      expectedVersion: 2,
+    });
+    expect(() => MetricRunLockRequestSchema.parse({ expectedVersion: -1 })).toThrow();
+    expect(() => MetricRunLockRequestSchema.parse({ expectedVersion: 2, lockedBy: 7 })).toThrow();
+  });
+
+  it('detail response includes lifecycle fields and evidence snapshot fields', () => {
+    const parsed = MetricRunDetailResponseSchema.parse({
+      ...detail,
+      status: 'approved',
+      sourceEvidenceIds: [1000],
+      evidenceCount: 1,
+      approvedBy: 7,
+      approvedAt: '2026-05-10T01:00:00.000Z',
+      version: 2,
+    });
+
+    expect(parsed.sourceEvidenceIds).toEqual([1000]);
+    expect(parsed.evidenceCount).toBe(1);
+    expect(parsed.version).toBe(2);
+    expect(parsed.lockedBy).toBeNull();
+  });
+
+  it('lifecycle response wraps detail plus changed flag', () => {
+    const parsed = MetricRunLifecycleResponseSchema.parse({
+      metricRun: detail,
+      changed: true,
+    });
+
+    expect(parsed.metricRun.metricRunId).toBe(17);
+    expect(parsed.changed).toBe(true);
+  });
+
+  it('latest response accepts null and strict detail payloads', () => {
+    expect(LatestMetricRunResponseSchema.parse({ metricRun: null })).toEqual({
+      metricRun: null,
+    });
+    expect(LatestMetricRunResponseSchema.parse({ metricRun: detail }).metricRun?.version).toBe(1);
   });
 });
 

--- a/tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx
+++ b/tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx
@@ -17,18 +17,24 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import {
+  useLatestMetricRun,
+  useMetricRunApprove,
   useMetricRunCommit,
+  useMetricRunDetail,
   useMetricRunEvidenceCreate,
   useMetricRunEvidenceList,
+  useMetricRunLock,
   useMetricsDryRun,
 } from '@/hooks/lp-reporting';
 import type { MetricsDryRunRequest } from '@/hooks/lp-reporting';
 import type {
   LpMetricRunResults,
   MetricRunCommitResponse,
+  MetricRunDetailResponse,
   MetricRunDryRunResponse,
   MetricRunEvidenceCreateResponse,
   MetricRunEvidenceListResponse,
+  MetricRunLifecycleResponse,
 } from '@shared/contracts/lp-reporting';
 
 function makeWrapper() {
@@ -144,6 +150,43 @@ function makeEvidenceCreateResponse(): MetricRunEvidenceCreateResponse {
   return {
     record: makeEvidenceRecord(),
     inserted: true,
+  };
+}
+
+function makeMetricRunDetail(
+  overrides: Partial<MetricRunDetailResponse> = {}
+): MetricRunDetailResponse {
+  return {
+    metricRunId: 17,
+    fundId: 7,
+    asOfDate: '2026-03-31',
+    runType: 'quarterly_report',
+    perspective: 'lp_net',
+    status: 'draft',
+    inputsHash: 'a'.repeat(64),
+    sourceEventIds: [],
+    sourceMarkIds: [],
+    sourceEvidenceIds: [],
+    evidenceCount: 0,
+    generatedBy: 7,
+    approvedBy: null,
+    approvedAt: null,
+    lockedBy: null,
+    lockedAt: null,
+    exportedAt: null,
+    version: 1,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeLifecycleResponse(
+  overrides: Partial<MetricRunDetailResponse> = {}
+): MetricRunLifecycleResponse {
+  return {
+    metricRun: makeMetricRunDetail(overrides),
+    changed: true,
   };
 }
 
@@ -303,6 +346,142 @@ describe('useMetricRunCommit', () => {
 
     expect(result.current.error?.status).toBe(409);
     expect(result.current.error?.code).toBe('PREVIEW_HASH_MISMATCH');
+  });
+});
+
+describe('metric-run lifecycle hooks', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs exact-context latest metric-run state', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ metricRun: makeMetricRunDetail() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useLatestMetricRun(7, {
+          asOfDate: '2026-03-31',
+          runType: 'quarterly_report',
+          perspective: 'lp_net',
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      '/api/funds/7/metric-runs/latest?runType=quarterly_report&perspective=lp_net&asOfDate=2026-03-31'
+    );
+    expect(init?.method).toBe('GET');
+    expect(result.current.data?.metricRun?.version).toBe(1);
+  });
+
+  it('does not fetch latest until all filters exist', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useLatestMetricRun(7, null), { wrapper: Wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('GETs metric-run detail by committed run ID', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(makeMetricRunDetail({ evidenceCount: 1 })), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMetricRunDetail(7, 17), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('/api/funds/7/metric-runs/17');
+    expect(init?.method).toBe('GET');
+    expect(result.current.data?.metricRunId).toBe(17);
+    expect(result.current.data?.evidenceCount).toBe(1);
+  });
+
+  it('POSTs expectedVersion to approve endpoint', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          makeLifecycleResponse({
+            status: 'approved',
+            approvedBy: 7,
+            approvedAt: '2026-05-10T01:00:00.000Z',
+            version: 2,
+          })
+        ),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMetricRunApprove(7, 17), { wrapper: Wrapper });
+
+    result.current.mutate({ expectedVersion: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('/api/funds/7/metric-runs/17/approve');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(init?.body as string)).toEqual({ expectedVersion: 1 });
+    expect(result.current.data?.metricRun.status).toBe('approved');
+  });
+
+  it('POSTs expectedVersion to lock endpoint and preserves 409 server code', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'METRIC_RUN_VERSION_CONFLICT',
+          message: 'Metric run version no longer matches the request.',
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMetricRunLock(7, 17), { wrapper: Wrapper });
+
+    result.current.mutate({ expectedVersion: 2 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('/api/funds/7/metric-runs/17/lock');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(init?.body as string)).toEqual({ expectedVersion: 2 });
+    expect(result.current.error?.status).toBe(409);
+    expect(result.current.error?.code).toBe('METRIC_RUN_VERSION_CONFLICT');
   });
 });
 

--- a/tests/unit/pages/lp-reporting/metrics.test.tsx
+++ b/tests/unit/pages/lp-reporting/metrics.test.tsx
@@ -43,7 +43,9 @@ import LpReportingMetricsPage from '@/pages/lp-reporting/metrics';
 import type {
   LpMetricRunResults,
   MetricRunCommitResponse,
+  MetricRunDetailResponse,
   MetricRunDryRunResponse,
+  MetricRunLifecycleResponse,
 } from '@shared/contracts/lp-reporting';
 
 function renderPage() {
@@ -143,6 +145,43 @@ function makeEvidenceRecord() {
   };
 }
 
+function makeMetricRunDetail(
+  overrides: Partial<MetricRunDetailResponse> = {}
+): MetricRunDetailResponse {
+  return {
+    metricRunId: 17,
+    fundId: 7,
+    asOfDate: '2026-03-31',
+    runType: 'internal_review',
+    perspective: 'lp_net',
+    status: 'draft',
+    inputsHash: 'a'.repeat(64),
+    sourceEventIds: [],
+    sourceMarkIds: [],
+    sourceEvidenceIds: [],
+    evidenceCount: 0,
+    generatedBy: 7,
+    approvedBy: null,
+    approvedAt: null,
+    lockedBy: null,
+    lockedAt: null,
+    exportedAt: null,
+    version: 1,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeLifecycleResponse(
+  overrides: Partial<MetricRunDetailResponse> = {}
+): MetricRunLifecycleResponse {
+  return {
+    metricRun: makeMetricRunDetail(overrides),
+    changed: true,
+  };
+}
+
 describe('LpReportingMetricsPage', () => {
   beforeEach(() => {
     fundContextMock.fundId = 7;
@@ -205,26 +244,40 @@ describe('LpReportingMetricsPage', () => {
   });
 
   it('commits the successful preview and renders the saved draft result', async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(makeDryRunResponse()), {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/metric-runs/dry-run')) {
+        return new Response(JSON.stringify(makeDryRunResponse()), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(makeCommitResponse()), {
+        });
+      }
+      if (url.includes('/metric-runs/latest')) {
+        return new Response(JSON.stringify({ metricRun: makeMetricRunDetail() }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/commit')) {
+        return new Response(JSON.stringify(makeCommitResponse()), {
           status: 201,
           headers: { 'Content-Type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ records: [] }), {
+        });
+      }
+      if (url.endsWith('/metric-runs/17')) {
+        return new Response(JSON.stringify(makeMetricRunDetail()), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
-        })
-      );
+        });
+      }
+      if (url.endsWith('/metric-runs/17/evidence-records')) {
+        return new Response(JSON.stringify({ records: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ error: 'UNEXPECTED_URL' }), { status: 500 });
+    });
 
     renderPage();
 
@@ -239,7 +292,11 @@ describe('LpReportingMetricsPage', () => {
       expect(screen.getByTestId('metrics-commit-result')).toBeInTheDocument();
     });
 
-    const [, commitInit] = fetchSpy.mock.calls[1]!;
+    const commitCall = fetchSpy.mock.calls.find(([url]) =>
+      String(url).endsWith('/metric-runs/commit')
+    );
+    expect(commitCall).toBeTruthy();
+    const [, commitInit] = commitCall!;
     expect(JSON.parse(commitInit?.body as string)).toMatchObject({
       asOfDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
       runType: 'internal_review',
@@ -252,6 +309,94 @@ describe('LpReportingMetricsPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('metric-run-evidence-card')).toBeInTheDocument();
     });
+  });
+
+  it('uses committed run detail when latest returns a newer same-context run', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/metric-runs/dry-run')) {
+        return new Response(JSON.stringify(makeDryRunResponse()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/metric-runs/latest')) {
+        return new Response(
+          JSON.stringify({
+            metricRun: makeMetricRunDetail({
+              metricRunId: 99,
+              evidenceCount: 2,
+              version: 4,
+            }),
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      if (url.endsWith('/metric-runs/commit')) {
+        return new Response(JSON.stringify({ ...makeCommitResponse(), inserted: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17')) {
+        return new Response(JSON.stringify(makeMetricRunDetail({ evidenceCount: 1 })), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/approve') && init?.method === 'POST') {
+        return new Response(
+          JSON.stringify(
+            makeLifecycleResponse({
+              status: 'approved',
+              evidenceCount: 1,
+              sourceEvidenceIds: [1000],
+              approvedBy: 7,
+              approvedAt: '2026-05-10T01:00:00.000Z',
+              version: 2,
+            })
+          ),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      if (url.endsWith('/metric-runs/17/evidence-records')) {
+        return new Response(JSON.stringify({ records: [makeEvidenceRecord()] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ error: 'UNEXPECTED_URL' }), { status: 500 });
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /run metrics/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-commit-button')).toBeEnabled();
+    });
+    fireEvent.click(screen.getByTestId('metrics-commit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-approve-button')).toBeEnabled();
+    });
+    fireEvent.click(screen.getByTestId('metric-run-approve-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-status-badge').textContent).toBe('approved');
+    });
+
+    const approveCall = fetchSpy.mock.calls.find(([url]) =>
+      String(url).endsWith('/metric-runs/17/approve')
+    );
+    expect(approveCall).toBeTruthy();
+    expect(JSON.parse(approveCall?.[1]?.body as string)).toEqual({ expectedVersion: 1 });
+    expect(screen.getByTestId('metrics-commit-result').textContent).toMatch(/metric run #17/i);
   });
 
   it('adds evidence metadata after a draft metric run is committed', async () => {
@@ -269,6 +414,26 @@ describe('LpReportingMetricsPage', () => {
           status: 201,
           headers: { 'Content-Type': 'application/json' },
         });
+      }
+      if (url.includes('/metric-runs/latest')) {
+        return new Response(
+          JSON.stringify({
+            metricRun: makeMetricRunDetail({ evidenceCount: evidenceListCalls > 1 ? 1 : 0 }),
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      if (url.endsWith('/metric-runs/17')) {
+        return new Response(
+          JSON.stringify(makeMetricRunDetail({ evidenceCount: evidenceListCalls > 1 ? 1 : 0 })),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
       }
       if (url.endsWith('/metric-runs/17/evidence-records') && init?.method === 'POST') {
         return new Response(JSON.stringify({ record: makeEvidenceRecord(), inserted: true }), {
@@ -338,16 +503,123 @@ describe('LpReportingMetricsPage', () => {
     );
   });
 
-  it('renders the commit error envelope on preview mismatch', async () => {
-    vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(makeDryRunResponse()), {
+  it('approves after evidence and then locks the metric run', async () => {
+    let latestStatus: MetricRunDetailResponse = makeMetricRunDetail({ evidenceCount: 1 });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/metric-runs/dry-run')) {
+        return new Response(JSON.stringify(makeDryRunResponse()), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(
+        });
+      }
+      if (url.endsWith('/metric-runs/commit')) {
+        return new Response(JSON.stringify(makeCommitResponse()), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/metric-runs/latest')) {
+        return new Response(JSON.stringify({ metricRun: latestStatus }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17')) {
+        return new Response(JSON.stringify(latestStatus), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/approve') && init?.method === 'POST') {
+        latestStatus = makeMetricRunDetail({
+          status: 'approved',
+          evidenceCount: 1,
+          sourceEvidenceIds: [1000],
+          approvedBy: 7,
+          approvedAt: '2026-05-10T01:00:00.000Z',
+          version: 2,
+        });
+        return new Response(JSON.stringify(makeLifecycleResponse(latestStatus)), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/lock') && init?.method === 'POST') {
+        latestStatus = makeMetricRunDetail({
+          ...latestStatus,
+          status: 'locked',
+          lockedBy: 7,
+          lockedAt: '2026-05-10T02:00:00.000Z',
+          version: 3,
+        });
+        return new Response(JSON.stringify(makeLifecycleResponse(latestStatus)), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/evidence-records')) {
+        return new Response(JSON.stringify({ records: [makeEvidenceRecord()] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ error: 'UNEXPECTED_URL' }), { status: 500 });
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /run metrics/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-commit-button')).toBeEnabled();
+    });
+    fireEvent.click(screen.getByTestId('metrics-commit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-approve-button')).toBeEnabled();
+    });
+    fireEvent.click(screen.getByTestId('metric-run-approve-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-status-badge').textContent).toBe('approved');
+    });
+    expect(screen.queryByTestId('metric-run-evidence-form')).toBeNull();
+    expect(screen.getByTestId('metric-run-evidence-readonly')).toBeInTheDocument();
+    expect(screen.getByTestId('metric-run-lock-button')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('metric-run-lock-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metric-run-status-badge').textContent).toBe('locked');
+    });
+
+    const approveCall = fetchSpy.mock.calls.find(([url]) =>
+      String(url).endsWith('/metric-runs/17/approve')
+    );
+    const lockCall = fetchSpy.mock.calls.find(([url]) =>
+      String(url).endsWith('/metric-runs/17/lock')
+    );
+    expect(JSON.parse(approveCall?.[1]?.body as string)).toEqual({ expectedVersion: 1 });
+    expect(JSON.parse(lockCall?.[1]?.body as string)).toEqual({ expectedVersion: 2 });
+  });
+
+  it('renders the commit error envelope on preview mismatch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/metric-runs/dry-run')) {
+        return new Response(JSON.stringify(makeDryRunResponse()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/metric-runs/latest')) {
+        return new Response(JSON.stringify({ metricRun: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/commit')) {
+        return new Response(
           JSON.stringify({
             error: 'PREVIEW_HASH_MISMATCH',
             message: 'Metric-run preview hash no longer matches.',
@@ -356,8 +628,10 @@ describe('LpReportingMetricsPage', () => {
             status: 409,
             headers: { 'Content-Type': 'application/json' },
           }
-        )
-      );
+        );
+      }
+      return new Response(JSON.stringify({ error: 'UNEXPECTED_URL' }), { status: 500 });
+    });
 
     renderPage();
 

--- a/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
+++ b/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
@@ -9,9 +9,11 @@ import request from 'supertest';
 
 import {
   MetricRunCommitResponseSchema,
+  MetricRunDetailResponseSchema,
   MetricRunDryRunResponseSchema,
   MetricRunEvidenceCreateResponseSchema,
   MetricRunEvidenceListResponseSchema,
+  MetricRunLifecycleResponseSchema,
 } from '@shared/contracts/lp-reporting';
 
 const authState = vi.hoisted(() => ({
@@ -100,6 +102,18 @@ interface MockMetricRunRow {
   asOfDate: string;
   status: string;
   inputsHash: string;
+  sourceEventIds?: number[];
+  sourceMarkIds?: number[];
+  sourceEvidenceIds?: number[];
+  generatedBy?: number | null;
+  approvedBy?: number | null;
+  approvedAt?: Date | null;
+  lockedBy?: number | null;
+  lockedAt?: Date | null;
+  exportedAt?: Date | null;
+  version?: number;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
 }
 
 interface MockEvidenceRow {
@@ -143,6 +157,18 @@ vi.mock('@shared/schema/lp-reporting-evidence', () => ({
     asOfDate: 'lpMetricRuns.asOfDate',
     status: 'lpMetricRuns.status',
     inputsHash: 'lpMetricRuns.inputsHash',
+    sourceEventIds: 'lpMetricRuns.sourceEventIds',
+    sourceMarkIds: 'lpMetricRuns.sourceMarkIds',
+    sourceEvidenceIds: 'lpMetricRuns.sourceEvidenceIds',
+    generatedBy: 'lpMetricRuns.generatedBy',
+    approvedBy: 'lpMetricRuns.approvedBy',
+    approvedAt: 'lpMetricRuns.approvedAt',
+    lockedBy: 'lpMetricRuns.lockedBy',
+    lockedAt: 'lpMetricRuns.lockedAt',
+    exportedAt: 'lpMetricRuns.exportedAt',
+    version: 'lpMetricRuns.version',
+    createdAt: 'lpMetricRuns.createdAt',
+    updatedAt: 'lpMetricRuns.updatedAt',
   },
   evidenceRecords: {
     _kind: 'evidenceRecords',
@@ -179,8 +205,27 @@ function rowsFor(table: { _kind?: string }): Array<Record<string, unknown>> {
     return dbState.metricRuns.map((row) => ({
       id: row.id,
       fundId: row.fundId,
+      runType: row.runType,
+      perspective: row.perspective,
+      asOfDate: row.asOfDate,
       status: row.status,
       inputsHash: row.inputsHash,
+      sourceEventIds: row.sourceEventIds ?? [],
+      sourceMarkIds: row.sourceMarkIds ?? [],
+      sourceEvidenceIds: row.sourceEvidenceIds ?? [],
+      resultsJson: {},
+      diagnosticsJson: {},
+      methodologyVersion: 'lp-reporting-methodology-v1',
+      calculationVersion: 'lp-reporting-metrics-engine-1.0.0',
+      generatedBy: row.generatedBy ?? authState.userId,
+      approvedBy: row.approvedBy ?? null,
+      approvedAt: row.approvedAt ?? null,
+      lockedBy: row.lockedBy ?? null,
+      lockedAt: row.lockedAt ?? null,
+      exportedAt: row.exportedAt ?? null,
+      version: row.version ?? 1,
+      createdAt: row.createdAt ?? new Date('2026-05-10T00:00:00Z'),
+      updatedAt: row.updatedAt ?? new Date('2026-05-10T00:00:00Z'),
     }));
   }
   if (table?._kind === 'evidenceRecords') {
@@ -189,8 +234,44 @@ function rowsFor(table: { _kind?: string }): Array<Record<string, unknown>> {
   return [];
 }
 
-vi.mock('../../../../server/db', () => ({
-  db: {
+vi.mock('../../../../server/db', () => {
+  const dbMock = {
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(dbMock)),
+    execute: vi.fn(async () => []),
+    update: vi.fn((table: { _kind?: string }) => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => {
+            if (table?._kind !== 'lpMetricRuns') {
+              return [];
+            }
+            const current = dbState.metricRuns.find((row) => row.id === 500 && row.fundId === 1);
+            if (!current) {
+              return [];
+            }
+            const nextVersion =
+              typeof values['version'] === 'number' ? (values['version'] as number) : undefined;
+            const expectedVersion = nextVersion !== undefined ? nextVersion - 1 : current.version;
+            const validApprove =
+              values['status'] === 'approved' &&
+              current.status === 'draft' &&
+              (current.version ?? 1) === expectedVersion;
+            const validLock =
+              values['status'] === 'locked' &&
+              current.status === 'approved' &&
+              (current.version ?? 1) === expectedVersion;
+            if (!validApprove && !validLock) {
+              return [];
+            }
+            const updated = { ...current, ...values } as MockMetricRunRow;
+            dbState.metricRuns = dbState.metricRuns.map((row) =>
+              row.id === updated.id ? updated : row
+            );
+            return rowsFor({ _kind: 'lpMetricRuns' }).filter((row) => row['id'] === updated.id);
+          }),
+        })),
+      })),
+    })),
     insert: vi.fn((table: { _kind?: string }) => {
       dbState.insertCalls += 1;
       return {
@@ -248,6 +329,13 @@ vi.mock('../../../../server/db', () => ({
                 asOfDate: row['asOfDate'] as string,
                 status: row['status'] as string,
                 inputsHash: row['inputsHash'] as string,
+                sourceEventIds: (row['sourceEventIds'] as number[] | undefined) ?? [],
+                sourceMarkIds: (row['sourceMarkIds'] as number[] | undefined) ?? [],
+                sourceEvidenceIds: (row['sourceEvidenceIds'] as number[] | undefined) ?? [],
+                generatedBy: (row['generatedBy'] as number | undefined) ?? authState.userId,
+                version: 1,
+                createdAt: new Date('2026-05-10T00:00:00Z'),
+                updatedAt: new Date('2026-05-10T00:00:00Z'),
               };
               dbState.metricRuns.push(metricRun);
               dbState.insertedMetricRows.push(row);
@@ -262,8 +350,9 @@ vi.mock('../../../../server/db', () => ({
         where: vi.fn(() => queryResult(rowsFor(table))),
       })),
     })),
-  },
-}));
+  };
+  return { db: dbMock };
+});
 
 vi.mock('drizzle-orm', async () => {
   const actual = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
@@ -714,6 +803,186 @@ describe('metric-run evidence routes', () => {
   });
 });
 
+describe('metric-run lifecycle routes', () => {
+  it('GET latest requires exact metric-run context filters', async () => {
+    const res = await request(buildApp()).get('/api/funds/1/metric-runs/latest');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_REQUEST_QUERY');
+  });
+
+  it('GET latest returns null when no exact context matches', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'fundraise_pack',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'draft',
+      inputsHash: 'a'.repeat(64),
+    });
+
+    const res = await request(buildApp()).get(
+      '/api/funds/1/metric-runs/latest?runType=quarterly_report&perspective=lp_net&asOfDate=2026-03-31'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.metricRun).toBeNull();
+  });
+
+  it('GET detail returns the requested committed metric run by ID', async () => {
+    dbState.metricRuns.push(
+      {
+        id: 500,
+        fundId: 1,
+        runType: 'quarterly_report',
+        perspective: 'lp_net',
+        asOfDate: '2026-03-31',
+        status: 'draft',
+        inputsHash: 'a'.repeat(64),
+        version: 1,
+      },
+      {
+        id: 501,
+        fundId: 1,
+        runType: 'quarterly_report',
+        perspective: 'lp_net',
+        asOfDate: '2026-03-31',
+        status: 'approved',
+        inputsHash: 'b'.repeat(64),
+        version: 2,
+        createdAt: new Date('2026-05-11T00:00:00Z'),
+      }
+    );
+    dbState.evidenceRecords.push({
+      ...evidenceBody(),
+      id: 1000,
+      fundId: 1,
+      valuationMarkId: null,
+      companyId: null,
+      metricRunId: 500,
+      narrativeRunId: null,
+      receivedDate: null,
+      expirationDate: null,
+      confidenceLevel: 'medium',
+      confidentiality: 'internal',
+      redactionRequired: false,
+      documentHash: null,
+      valuationPolicyVersion: null,
+      internalNotes: null,
+      lpObjection: null,
+      attachments: [],
+      uploadedBy: authState.userId,
+      approvedBy: null,
+      approvedAt: null,
+      createdAt: new Date('2026-05-10T00:00:00Z'),
+      updatedAt: new Date('2026-05-10T00:00:00Z'),
+    } as MockEvidenceRow);
+
+    const res = await request(buildApp()).get('/api/funds/1/metric-runs/500');
+
+    expect(res.status).toBe(200);
+    const parsed = MetricRunDetailResponseSchema.parse(res.body);
+    expect(parsed.metricRunId).toBe(500);
+    expect(parsed.status).toBe('draft');
+    expect(parsed.evidenceCount).toBe(1);
+  });
+
+  it('POST approve returns lifecycle response and snapshots evidence IDs', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'draft',
+      inputsHash: 'a'.repeat(64),
+      version: 1,
+    });
+    dbState.evidenceRecords.push({
+      ...evidenceBody(),
+      id: 1000,
+      fundId: 1,
+      valuationMarkId: null,
+      companyId: null,
+      metricRunId: 500,
+      narrativeRunId: null,
+      receivedDate: null,
+      expirationDate: null,
+      confidenceLevel: 'medium',
+      confidentiality: 'internal',
+      redactionRequired: false,
+      documentHash: null,
+      valuationPolicyVersion: null,
+      internalNotes: null,
+      lpObjection: null,
+      attachments: [],
+      uploadedBy: authState.userId,
+      approvedBy: null,
+      approvedAt: null,
+      createdAt: new Date('2026-05-10T00:00:00Z'),
+      updatedAt: new Date('2026-05-10T00:00:00Z'),
+    } as MockEvidenceRow);
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/approve')
+      .send({ expectedVersion: 1 });
+
+    expect(res.status).toBe(200);
+    const parsed = MetricRunLifecycleResponseSchema.parse(res.body);
+    expect(parsed.changed).toBe(true);
+    expect(parsed.metricRun.status).toBe('approved');
+    expect(parsed.metricRun.version).toBe(2);
+    expect(parsed.metricRun.sourceEvidenceIds).toEqual([1000]);
+  });
+
+  it('POST approve returns 409 when evidence is missing', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'draft',
+      inputsHash: 'a'.repeat(64),
+      version: 1,
+    });
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/approve')
+      .send({ expectedVersion: 1 });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('METRIC_RUN_EVIDENCE_REQUIRED');
+  });
+
+  it('POST lock returns lifecycle response for approved metric runs', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'approved',
+      inputsHash: 'a'.repeat(64),
+      sourceEvidenceIds: [1000],
+      approvedBy: authState.userId,
+      approvedAt: new Date('2026-05-10T00:00:00Z'),
+      version: 2,
+    });
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/lock')
+      .send({ expectedVersion: 2 });
+
+    expect(res.status).toBe(200);
+    const parsed = MetricRunLifecycleResponseSchema.parse(res.body);
+    expect(parsed.metricRun.status).toBe('locked');
+    expect(parsed.metricRun.lockedBy).toBe(authState.userId);
+    expect(parsed.metricRun.version).toBe(3);
+  });
+});
+
 describe('Source grep -- metric-run route boundaries', () => {
   const routerSource = fs.readFileSync(
     path.join(process.cwd(), 'server', 'routes', 'lp-reporting', 'metric-runs.ts'),
@@ -729,6 +998,8 @@ describe('Source grep -- metric-run route boundaries', () => {
     expect(paths).toEqual([
       '/api/funds/:fundId/metric-runs/dry-run',
       '/api/funds/:fundId/metric-runs/commit',
+      '/api/funds/:fundId/metric-runs/:metricRunId/approve',
+      '/api/funds/:fundId/metric-runs/:metricRunId/lock',
       '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
     ]);
 
@@ -737,7 +1008,11 @@ describe('Source grep -- metric-run route boundaries', () => {
         .match(/router\.get\(\s*['"]([^'"]+)['"]/g)
         ?.map((match) => match.replace(/router\.get\(\s*['"]/, '').replace(/['"]$/, '')) ?? [];
 
-    expect(getPaths).toEqual(['/api/funds/:fundId/metric-runs/:metricRunId/evidence-records']);
+    expect(getPaths).toEqual([
+      '/api/funds/:fundId/metric-runs/latest',
+      '/api/funds/:fundId/metric-runs/:metricRunId',
+      '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
+    ]);
   });
 
   it('does not add any /api/public route', () => {

--- a/tests/unit/schema/lp-reporting-evidence-schema.test.ts
+++ b/tests/unit/schema/lp-reporting-evidence-schema.test.ts
@@ -131,6 +131,14 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       expect(names).toContain('lp_metric_run_status_check');
     });
 
+    it('lp_metric_runs exposes lifecycle concurrency and lock audit columns', () => {
+      const config = getTableConfig(schema.lpMetricRuns);
+      const names = config.columns.map((c) => c.name);
+      expect(names).toContain('version');
+      expect(names).toContain('updated_at');
+      expect(names).toContain('locked_by');
+    });
+
     it('narrative_runs declares 2 CHECKs (type, status)', () => {
       const config = getTableConfig(schema.narrativeRuns);
       const names = config.checks.map((c) => c.name);

--- a/tests/unit/schema/lp-reporting-import-indexes.test.ts
+++ b/tests/unit/schema/lp-reporting-import-indexes.test.ts
@@ -69,3 +69,38 @@ describe('LP reporting metric-run idempotency index', () => {
     expect(schema).toMatch(/uniqueIndex\('lp_metric_runs_fund_run_inputs_unique'\)/);
   });
 });
+
+describe('LP reporting metric-run lifecycle migration', () => {
+  it('adds version, updated_at, and locked_by columns in the lifecycle migration', () => {
+    const migration = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        'server',
+        'migrations',
+        '20260510_lp_reporting_metric_run_lifecycle_v1.up.sql'
+      ),
+      'utf8'
+    );
+
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1/i);
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now\(\)/i);
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS locked_by integer REFERENCES users\(id\)/i);
+  });
+
+  it('rolls back only the lifecycle columns', () => {
+    const migration = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        'server',
+        'migrations',
+        '20260510_lp_reporting_metric_run_lifecycle_v1.down.sql'
+      ),
+      'utf8'
+    );
+
+    expect(migration).toMatch(/DROP COLUMN IF EXISTS locked_by/i);
+    expect(migration).toMatch(/DROP COLUMN IF EXISTS updated_at/i);
+    expect(migration).toMatch(/DROP COLUMN IF EXISTS version/i);
+    expect(migration).not.toMatch(/DROP TABLE/i);
+  });
+});

--- a/tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts
+++ b/tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts
@@ -25,6 +25,7 @@ interface State {
   insertValues: InsertEvidenceRecord[];
   nextEvidenceId: number;
   dropNextInsert: boolean;
+  operations: string[];
 }
 
 const state: State = {
@@ -34,6 +35,7 @@ const state: State = {
   insertValues: [],
   nextEvidenceId: 1000,
   dropNextInsert: false,
+  operations: [],
 };
 
 function evidenceRow(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
@@ -91,6 +93,14 @@ function queryResult<T>(rows: T[]): Promise<T[]> & { limit: (count: number) => P
 
 function makeDatabase(): typeof db {
   return {
+    transaction: async (callback: (tx: typeof db) => Promise<unknown>) => {
+      state.operations.push('transaction');
+      return callback(makeDatabase());
+    },
+    execute: async () => {
+      state.operations.push('lock-parent');
+      return [];
+    },
     select: () => ({
       from: (table: unknown) => ({
         where: () => queryResult(rowsFor(table)),
@@ -141,6 +151,7 @@ beforeEach(() => {
   state.insertValues = [];
   state.nextEvidenceId = 1000;
   state.dropNextInsert = false;
+  state.operations = [];
 });
 
 describe('createMetricRunEvidence', () => {
@@ -177,6 +188,7 @@ describe('createMetricRunEvidence', () => {
     expect(state.insertValues[0]?.companyId).toBeUndefined();
     expect(state.insertValues[0]?.narrativeRunId).toBeUndefined();
     expect(state.insertValues[0]?.approvedBy).toBeUndefined();
+    expect(state.operations).toEqual(['transaction', 'lock-parent']);
   });
 
   it('returns an existing row without inserting when the idempotency key was already used', async () => {

--- a/tests/unit/services/lp-reporting/metric-run-lifecycle-service.test.ts
+++ b/tests/unit/services/lp-reporting/metric-run-lifecycle-service.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit tests for LP Reporting metric-run approval and lock lifecycle.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  approveMetricRun,
+  getLatestMetricRun,
+  getMetricRunDetail,
+  lockMetricRun,
+} from '../../../../server/services/lp-reporting/metric-run-lifecycle-service';
+import type { MetricRunCommitError } from '../../../../server/services/lp-reporting/metric-run-commit-service';
+import type { db } from '../../../../server/db';
+import {
+  evidenceRecords,
+  lpMetricRuns,
+  type EvidenceRecord,
+  type LpMetricRun,
+} from '@shared/schema/lp-reporting-evidence';
+
+interface State {
+  metricRuns: LpMetricRun[];
+  evidence: EvidenceRecord[];
+  operations: string[];
+}
+
+const state: State = {
+  metricRuns: [],
+  evidence: [],
+  operations: [],
+};
+
+const hex64 = 'a'.repeat(64);
+const now = new Date('2026-05-10T00:00:00.000Z');
+
+function metricRun(overrides: Partial<LpMetricRun> = {}): LpMetricRun {
+  return {
+    id: 11,
+    fundId: 1,
+    vehicleId: null,
+    asOfDate: '2026-03-31',
+    runType: 'quarterly_report',
+    perspective: 'lp_net',
+    status: 'draft',
+    inputsHash: hex64,
+    sourceEventIds: [],
+    sourceMarkIds: [],
+    sourceEvidenceIds: [],
+    resultsJson: {},
+    diagnosticsJson: {},
+    methodologyVersion: 'lp-reporting-methodology-v1',
+    calculationVersion: 'lp-reporting-metrics-engine-1.0.0',
+    generatedBy: 7,
+    approvedBy: null,
+    approvedAt: null,
+    lockedBy: null,
+    lockedAt: null,
+    exportedAt: null,
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as LpMetricRun;
+}
+
+function evidenceRow(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  return {
+    id: 1000,
+    fundId: 1,
+    valuationMarkId: null,
+    companyId: null,
+    metricRunId: 11,
+    narrativeRunId: null,
+    idempotencyKey: 'metric-run-11-evidence-0',
+    evidenceSource: 'board_update',
+    sourceDate: '2026-03-31',
+    receivedDate: null,
+    expirationDate: null,
+    confidenceLevel: 'medium',
+    materialityLevel: 'high',
+    confidentiality: 'internal',
+    redactionRequired: false,
+    documentHash: null,
+    valuationPolicyVersion: null,
+    description: 'Q1 board materials',
+    internalNotes: null,
+    lpObjection: null,
+    attachments: [],
+    uploadedBy: 7,
+    approvedBy: null,
+    approvedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as EvidenceRecord;
+}
+
+function queryResult<T>(rows: T[]): Promise<T[]> & { limit: (count: number) => Promise<T[]> } {
+  const promise = Promise.resolve(rows) as Promise<T[]> & {
+    limit: (count: number) => Promise<T[]>;
+  };
+  promise.limit = (count: number) => Promise.resolve(rows.slice(0, count));
+  return promise;
+}
+
+function rowsFor(table: unknown): unknown[] {
+  if (table === lpMetricRuns) {
+    return [...state.metricRuns];
+  }
+  if (table === evidenceRecords) {
+    return [...state.evidence];
+  }
+  return [];
+}
+
+function makeDatabase(): typeof db {
+  return {
+    transaction: async (callback: (tx: typeof db) => Promise<unknown>) => {
+      state.operations.push('transaction');
+      return callback(makeDatabase());
+    },
+    execute: async () => {
+      state.operations.push('lock-parent');
+      return [];
+    },
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => queryResult(rowsFor(table)),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Partial<LpMetricRun>) => ({
+        where: () => ({
+          returning: async () => {
+            if (table !== lpMetricRuns) {
+              return [];
+            }
+            const current = state.metricRuns.find((row) => row.id === 11 && row.fundId === 1);
+            if (!current) {
+              return [];
+            }
+            const nextVersion = values.version;
+            const expectedVersion =
+              typeof nextVersion === 'number' && Number.isInteger(nextVersion)
+                ? nextVersion - 1
+                : current.version;
+            const validApprove =
+              values.status === 'approved' &&
+              current.status === 'draft' &&
+              current.version === expectedVersion;
+            const validLock =
+              values.status === 'locked' &&
+              current.status === 'approved' &&
+              current.version === expectedVersion;
+            if (!validApprove && !validLock) {
+              return [];
+            }
+            const updated = { ...current, ...values } as LpMetricRun;
+            state.metricRuns = state.metricRuns.map((row) =>
+              row.id === updated.id ? updated : row
+            );
+            return [updated];
+          },
+        }),
+      }),
+    }),
+  } as unknown as typeof db;
+}
+
+beforeEach(() => {
+  state.metricRuns = [metricRun()];
+  state.evidence = [
+    evidenceRow(),
+    evidenceRow({ id: 1001, idempotencyKey: 'metric-run-11-evidence-1' }),
+  ];
+  state.operations = [];
+});
+
+describe('approveMetricRun', () => {
+  it('approves a draft metric run with evidence and snapshots evidence IDs', async () => {
+    const result = await approveMetricRun(
+      { fundId: 1, metricRunId: 11, userId: 7, expectedVersion: 1 },
+      { database: makeDatabase() }
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.metricRun.status).toBe('approved');
+    expect(result.metricRun.version).toBe(2);
+    expect(result.metricRun.approvedBy).toBe(7);
+    expect(result.metricRun.sourceEvidenceIds).toEqual([1000, 1001]);
+    expect(result.metricRun.evidenceCount).toBe(2);
+    expect(state.operations).toEqual(['transaction', 'lock-parent']);
+  });
+
+  it('rejects approval without evidence', async () => {
+    state.evidence = [];
+
+    await expect(
+      approveMetricRun(
+        { fundId: 1, metricRunId: 11, userId: 7, expectedVersion: 1 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'METRIC_RUN_EVIDENCE_REQUIRED',
+    } satisfies Partial<MetricRunCommitError>);
+  });
+
+  it('rejects approval when expectedVersion is stale', async () => {
+    state.metricRuns = [metricRun({ version: 3 })];
+
+    await expect(
+      approveMetricRun(
+        { fundId: 1, metricRunId: 11, userId: 7, expectedVersion: 1 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'METRIC_RUN_VERSION_CONFLICT',
+    } satisfies Partial<MetricRunCommitError>);
+  });
+
+  it('returns changed=false only for a strict same-user retry', async () => {
+    state.metricRuns = [
+      metricRun({
+        status: 'approved',
+        approvedBy: 7,
+        approvedAt: now,
+        sourceEvidenceIds: [1000],
+        version: 2,
+      }),
+    ];
+
+    const result = await approveMetricRun(
+      { fundId: 1, metricRunId: 11, userId: 7, expectedVersion: 1 },
+      { database: makeDatabase() }
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.metricRun.status).toBe('approved');
+  });
+});
+
+describe('lockMetricRun', () => {
+  it('locks an approved metric run and records lock attribution', async () => {
+    state.metricRuns = [
+      metricRun({
+        status: 'approved',
+        approvedBy: 7,
+        approvedAt: now,
+        sourceEvidenceIds: [1000, 1001],
+        version: 2,
+      }),
+    ];
+
+    const result = await lockMetricRun(
+      { fundId: 1, metricRunId: 11, userId: 8, expectedVersion: 2 },
+      { database: makeDatabase() }
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.metricRun.status).toBe('locked');
+    expect(result.metricRun.lockedBy).toBe(8);
+    expect(result.metricRun.version).toBe(3);
+    expect(result.metricRun.sourceEvidenceIds).toEqual([1000, 1001]);
+  });
+
+  it('rejects lock before approval', async () => {
+    await expect(
+      lockMetricRun(
+        { fundId: 1, metricRunId: 11, userId: 8, expectedVersion: 1 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'METRIC_RUN_STATUS_CONFLICT',
+    } satisfies Partial<MetricRunCommitError>);
+  });
+});
+
+describe('getLatestMetricRun', () => {
+  it('returns the latest exact-context row and ignores other contexts', async () => {
+    state.metricRuns = [
+      metricRun({ id: 9, createdAt: new Date('2026-05-09T00:00:00.000Z') }),
+      metricRun({ id: 12, createdAt: new Date('2026-05-10T00:00:00.000Z') }),
+      metricRun({
+        id: 99,
+        runType: 'fundraise_pack',
+        createdAt: new Date('2026-05-11T00:00:00.000Z'),
+      }),
+    ];
+
+    const result = await getLatestMetricRun(
+      {
+        fundId: 1,
+        asOfDate: '2026-03-31',
+        runType: 'quarterly_report',
+        perspective: 'lp_net',
+      },
+      { database: makeDatabase() }
+    );
+
+    expect(result.metricRun?.metricRunId).toBe(12);
+  });
+
+  it('returns null when no exact context matches', async () => {
+    const result = await getLatestMetricRun(
+      {
+        fundId: 1,
+        asOfDate: '2026-03-31',
+        runType: 'fundraise_pack',
+        perspective: 'lp_net',
+      },
+      { database: makeDatabase() }
+    );
+
+    expect(result.metricRun).toBeNull();
+  });
+});
+
+describe('getMetricRunDetail', () => {
+  it('returns the requested metric run by ID even when a newer same-context run exists', async () => {
+    state.metricRuns = [
+      metricRun({ id: 11, createdAt: new Date('2026-05-09T00:00:00.000Z') }),
+      metricRun({
+        id: 12,
+        status: 'approved',
+        version: 2,
+        createdAt: new Date('2026-05-10T00:00:00.000Z'),
+      }),
+    ];
+
+    const result = await getMetricRunDetail(
+      {
+        fundId: 1,
+        metricRunId: 11,
+      },
+      { database: makeDatabase() }
+    );
+
+    expect(result.metricRunId).toBe(11);
+    expect(result.status).toBe('draft');
+    expect(result.evidenceCount).toBe(2);
+  });
+});


### PR DESCRIPTION
Metric-run approval needs to freeze the exact evidence set and prevent late evidence writes from racing lifecycle transitions. This adds versioned approve and lock transitions, serializes evidence create and lifecycle changes on the parent metric-run row, and makes the UI read committed lifecycle state by metricRunId instead of treating latest same-context runs as canonical.

Constraint: Approval must require at least one evidence record and snapshot sourceEvidenceIds before lock.

Constraint: Evidence create must remain draft-only and serialize against approve and lock.

Constraint: Committed-run UI state must be keyed by metricRunId, not latest context lookup.

Rejected: Use latest as lifecycle source after commit - it can return a newer same-context run after an idempotent commit.

Confidence: high

Scope-risk: moderate

Reversibility: clean

Directive: Keep approval and evidence-create paths serialized on lp_metric_runs before changing lifecycle states.

Tested: npm run check

Tested: npm run lint

Tested: npx vitest run tests/unit/services/lp-reporting/metric-run-lifecycle-service.test.ts tests/unit/routes/lp-reporting/metric-runs-routes.test.ts tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx tests/unit/pages/lp-reporting/metrics.test.tsx

Tested: npm test

Tested: git diff --check

Not-tested: Live Postgres row-lock integration test.