### PR TITLE
test: Protect metric-run evidence provenance guarantees

### DIFF
--- a/tests/unit/pages/lp-reporting/metrics.test.tsx
+++ b/tests/unit/pages/lp-reporting/metrics.test.tsx
@@ -845,6 +845,74 @@ describe('LpReportingMetricsPage', () => {
     );
   });
 
+  it('renders duplicate evidence create responses without duplicate rows', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/metric-runs/dry-run')) {
+        return new Response(JSON.stringify(makeDryRunResponse()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/commit')) {
+        return new Response(JSON.stringify(makeCommitResponse()), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/metric-runs/latest')) {
+        return new Response(
+          JSON.stringify({ metricRun: makeMetricRunDetail({ evidenceCount: 1 }) }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      if (url.endsWith('/metric-runs/17')) {
+        return new Response(JSON.stringify(makeMetricRunDetail({ evidenceCount: 1 })), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/evidence-records') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ record: makeEvidenceRecord(), inserted: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/metric-runs/17/evidence-records')) {
+        return new Response(JSON.stringify({ records: [makeEvidenceRecord()] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ error: 'UNEXPECTED_URL' }), { status: 500 });
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /run metrics/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-commit-button')).toBeEnabled();
+    });
+    fireEvent.click(screen.getByTestId('metrics-commit-button'));
+    await waitFor(() => {
+      expect(screen.getAllByTestId('metric-run-evidence-record')).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByTestId('metric-run-evidence-submit'));
+
+    await waitFor(() => {
+      const duplicateCall = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          String(url).endsWith('/metric-runs/17/evidence-records') && init?.method === 'POST'
+      );
+      expect(duplicateCall).toBeTruthy();
+    });
+    expect(screen.getAllByTestId('metric-run-evidence-record')).toHaveLength(1);
+  });
+
   it('approves after evidence and then locks the metric run', async () => {
     let latestStatus: MetricRunDetailResponse = makeMetricRunDetail({ evidenceCount: 1 });
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {

--- a/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
+++ b/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
@@ -1167,6 +1167,44 @@ describe('POST /api/funds/:fundId/metric-runs/commit', () => {
 });
 
 describe('metric-run evidence routes', () => {
+  it('POST returns 401 when unauthenticated', async () => {
+    authState.authenticated = false;
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/evidence-records')
+      .send(evidenceBody());
+
+    expect(res.status).toBe(401);
+    expect(dbState.insertedEvidenceRows).toHaveLength(0);
+  });
+
+  it('POST requires fund access', async () => {
+    authState.fundIds = [2];
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/evidence-records')
+      .send(evidenceBody());
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Forbidden');
+    expect(dbState.insertedEvidenceRows).toHaveLength(0);
+  });
+
+  it('POST rejects invalid route params', async () => {
+    const invalidFund = await request(buildApp())
+      .post('/api/funds/not-a-fund/metric-runs/500/evidence-records')
+      .send(evidenceBody());
+    const invalidMetricRun = await request(buildApp())
+      .post('/api/funds/1/metric-runs/not-a-run/evidence-records')
+      .send(evidenceBody());
+
+    expect(invalidFund.status).toBe(400);
+    expect(invalidFund.body.error).toBe('INVALID_FUND_ID');
+    expect(invalidMetricRun.status).toBe(400);
+    expect(invalidMetricRun.body.error).toBe('INVALID_METRIC_RUN_ID');
+    expect(dbState.insertedEvidenceRows).toHaveLength(0);
+  });
+
   it('POST creates metadata-only evidence for a draft metric run', async () => {
     dbState.metricRuns.push({
       id: 500,
@@ -1195,6 +1233,29 @@ describe('metric-run evidence routes', () => {
       idempotencyKey: 'metric-run-500-evidence-0',
       attachments: [],
     });
+  });
+
+  it('POST duplicate idempotency returns the existing row with 200', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 1,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'draft',
+      inputsHash: 'a'.repeat(64),
+    });
+    seedMetricRunEvidence({ idempotencyKey: 'metric-run-500-evidence-0' });
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/evidence-records')
+      .send(evidenceBody());
+
+    expect(res.status).toBe(200);
+    const parsed = MetricRunEvidenceCreateResponseSchema.parse(res.body);
+    expect(parsed.inserted).toBe(false);
+    expect(parsed.record.id).toBe(1000);
+    expect(dbState.insertedEvidenceRows).toHaveLength(0);
   });
 
   it('POST rejects route-owned fields in the request body', async () => {
@@ -1237,6 +1298,49 @@ describe('metric-run evidence routes', () => {
     expect(dbState.insertedEvidenceRows).toHaveLength(0);
   });
 
+  it.each(['locked', 'exported', 'superseded'])(
+    'POST returns 409 METRIC_RUN_NOT_EDITABLE for %s metric runs',
+    async (status) => {
+      dbState.metricRuns.push({
+        id: 500,
+        fundId: 1,
+        runType: 'quarterly_report',
+        perspective: 'lp_net',
+        asOfDate: '2026-03-31',
+        status,
+        inputsHash: 'a'.repeat(64),
+      });
+
+      const res = await request(buildApp())
+        .post('/api/funds/1/metric-runs/500/evidence-records')
+        .send(evidenceBody());
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('METRIC_RUN_NOT_EDITABLE');
+      expect(dbState.insertedEvidenceRows).toHaveLength(0);
+    }
+  );
+
+  it('POST returns 404 for cross-fund metric-run targets', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 2,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'draft',
+      inputsHash: 'a'.repeat(64),
+    });
+
+    const res = await request(buildApp())
+      .post('/api/funds/1/metric-runs/500/evidence-records')
+      .send(evidenceBody());
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('METRIC_RUN_NOT_FOUND');
+    expect(dbState.insertedEvidenceRows).toHaveLength(0);
+  });
+
   it('GET lists evidence for locked metric runs', async () => {
     dbState.metricRuns.push({
       id: 500,
@@ -1275,6 +1379,12 @@ describe('metric-run evidence routes', () => {
       createdAt: new Date('2026-05-10T00:00:00Z'),
       updatedAt: new Date('2026-05-10T00:00:00Z'),
     });
+    dbState.evidenceRecords.push({
+      ...dbState.evidenceRecords[0]!,
+      id: 1001,
+      metricRunId: 501,
+      idempotencyKey: 'metric-run-501-evidence-0',
+    });
 
     const res = await request(buildApp()).get('/api/funds/1/metric-runs/500/evidence-records');
 
@@ -1282,6 +1392,23 @@ describe('metric-run evidence routes', () => {
     const parsed = MetricRunEvidenceListResponseSchema.parse(res.body);
     expect(parsed.records).toHaveLength(1);
     expect(parsed.records[0]?.idempotencyKey).toBe('metric-run-500-evidence-0');
+  });
+
+  it('GET returns 404 for cross-fund metric-run targets', async () => {
+    dbState.metricRuns.push({
+      id: 500,
+      fundId: 2,
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      asOfDate: '2026-03-31',
+      status: 'locked',
+      inputsHash: 'a'.repeat(64),
+    });
+
+    const res = await request(buildApp()).get('/api/funds/1/metric-runs/500/evidence-records');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('METRIC_RUN_NOT_FOUND');
   });
 });
 

--- a/tests/unit/schema/lp-reporting-evidence-schema.test.ts
+++ b/tests/unit/schema/lp-reporting-evidence-schema.test.ts
@@ -270,6 +270,48 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
     });
   });
 
+  describe('Metric-run evidence idempotency migration', () => {
+    it('adds the idempotency key column and fund/metric-run/key unique index', () => {
+      const up = fs.readFileSync(
+        path.join(
+          process.cwd(),
+          'server',
+          'migrations',
+          '20260510_lp_reporting_metric_run_evidence_idempotency_v1.up.sql'
+        ),
+        'utf8'
+      );
+
+      expect(up).toMatch(/ADD COLUMN IF NOT EXISTS idempotency_key varchar\(128\)/i);
+      expect(up).toMatch(
+        /CREATE UNIQUE INDEX IF NOT EXISTS evidence_records_metric_run_idempotency_unique/i
+      );
+      expect(up).toMatch(
+        /ON evidence_records\s*\(\s*fund_id\s*,\s*metric_run_id\s*,\s*idempotency_key\s*\)/i
+      );
+      expect(up).toMatch(/WHERE idempotency_key IS NOT NULL/i);
+    });
+
+    it('rolls back only the metric-run evidence idempotency surface', () => {
+      const down = fs.readFileSync(
+        path.join(
+          process.cwd(),
+          'server',
+          'migrations',
+          '20260510_lp_reporting_metric_run_evidence_idempotency_v1.down.sql'
+        ),
+        'utf8'
+      );
+
+      expect(down).toMatch(/DROP INDEX IF EXISTS evidence_records_metric_run_idempotency_unique/i);
+      expect(down).toMatch(/DROP COLUMN IF EXISTS idempotency_key/i);
+      expect(down).not.toMatch(/DROP TABLE/i);
+      expect(down).not.toMatch(
+        /DROP COLUMN IF EXISTS (valuation_mark_id|company_id|metric_run_id|narrative_run_id)/i
+      );
+    });
+  });
+
   describe('Narrative-run uniqueness migration', () => {
     it('declares the one-draft-per-type unique index in schema and migrations', () => {
       const narrativeConfig = getTableConfig(schema.narrativeRuns);

--- a/tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts
+++ b/tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts
@@ -8,6 +8,7 @@ import {
   listMetricRunEvidence,
 } from '../../../../server/services/lp-reporting/metric-run-evidence-service';
 import type { MetricRunCommitError } from '../../../../server/services/lp-reporting/metric-run-commit-service';
+import type { MetricRunEvidenceCreateRequest } from '@shared/contracts/lp-reporting';
 import type { db } from '../../../../server/db';
 import {
   evidenceRecords,
@@ -25,6 +26,7 @@ interface State {
   insertValues: InsertEvidenceRecord[];
   nextEvidenceId: number;
   dropNextInsert: boolean;
+  raceExistingOnInsertDrop: boolean;
   operations: string[];
 }
 
@@ -35,6 +37,7 @@ const state: State = {
   insertValues: [],
   nextEvidenceId: 1000,
   dropNextInsert: false,
+  raceExistingOnInsertDrop: false,
   operations: [],
 };
 
@@ -91,6 +94,29 @@ function queryResult<T>(rows: T[]): Promise<T[]> & { limit: (count: number) => P
   return promise;
 }
 
+function evidenceRowFromInsert(row: InsertEvidenceRecord): EvidenceRecord {
+  return evidenceRow({
+    id: state.nextEvidenceId++,
+    fundId: row.fundId,
+    metricRunId: row.metricRunId ?? null,
+    idempotencyKey: row.idempotencyKey ?? null,
+    evidenceSource: row.evidenceSource,
+    sourceDate: row.sourceDate,
+    receivedDate: row.receivedDate ?? null,
+    expirationDate: row.expirationDate ?? null,
+    confidenceLevel: row.confidenceLevel ?? 'medium',
+    materialityLevel: row.materialityLevel ?? 'medium',
+    confidentiality: row.confidentiality ?? 'internal',
+    redactionRequired: row.redactionRequired ?? false,
+    documentHash: row.documentHash ?? null,
+    valuationPolicyVersion: row.valuationPolicyVersion ?? null,
+    description: row.description ?? null,
+    internalNotes: row.internalNotes ?? null,
+    lpObjection: row.lpObjection ?? null,
+    uploadedBy: row.uploadedBy ?? null,
+  });
+}
+
 function makeDatabase(): typeof db {
   return {
     transaction: async (callback: (tx: typeof db) => Promise<unknown>) => {
@@ -112,29 +138,17 @@ function makeDatabase(): typeof db {
           returning: async () => {
             state.insertValues.push(row);
             if (state.dropNextInsert || table !== evidenceRecords) {
+              if (
+                state.dropNextInsert &&
+                state.raceExistingOnInsertDrop &&
+                table === evidenceRecords
+              ) {
+                state.evidence.push(evidenceRowFromInsert(row));
+              }
               state.dropNextInsert = false;
               return [];
             }
-            const inserted = evidenceRow({
-              id: state.nextEvidenceId++,
-              fundId: row.fundId,
-              metricRunId: row.metricRunId ?? null,
-              idempotencyKey: row.idempotencyKey ?? null,
-              evidenceSource: row.evidenceSource,
-              sourceDate: row.sourceDate,
-              receivedDate: row.receivedDate ?? null,
-              expirationDate: row.expirationDate ?? null,
-              confidenceLevel: row.confidenceLevel ?? 'medium',
-              materialityLevel: row.materialityLevel ?? 'medium',
-              confidentiality: row.confidentiality ?? 'internal',
-              redactionRequired: row.redactionRequired ?? false,
-              documentHash: row.documentHash ?? null,
-              valuationPolicyVersion: row.valuationPolicyVersion ?? null,
-              description: row.description ?? null,
-              internalNotes: row.internalNotes ?? null,
-              lpObjection: row.lpObjection ?? null,
-              uploadedBy: row.uploadedBy ?? null,
-            });
+            const inserted = evidenceRowFromInsert(row);
             state.evidence.push(inserted);
             return [inserted];
           },
@@ -151,6 +165,7 @@ beforeEach(() => {
   state.insertValues = [];
   state.nextEvidenceId = 1000;
   state.dropNextInsert = false;
+  state.raceExistingOnInsertDrop = false;
   state.operations = [];
 });
 
@@ -213,8 +228,59 @@ describe('createMetricRunEvidence', () => {
     expect(state.insertValues).toHaveLength(0);
   });
 
-  it('rejects create for non-draft metric runs', async () => {
-    state.metricRuns = [{ id: 11, fundId: 1, status: 'approved' }];
+  it('returns the raced existing row when DB idempotency wins the insert race', async () => {
+    state.dropNextInsert = true;
+    state.raceExistingOnInsertDrop = true;
+
+    const result = await createMetricRunEvidence(
+      {
+        fundId: 1,
+        metricRunId: 11,
+        userId: 7,
+        body: {
+          idempotencyKey: 'metric-run-11-evidence-0',
+          evidenceSource: 'board_update',
+          sourceDate: '2026-03-31',
+        },
+      },
+      { database: makeDatabase() }
+    );
+
+    expect(result.inserted).toBe(false);
+    expect(result.record.idempotencyKey).toBe('metric-run-11-evidence-0');
+    expect(state.insertValues).toHaveLength(1);
+    expect(state.evidence).toHaveLength(1);
+  });
+
+  it.each(['approved', 'locked', 'exported', 'superseded'])(
+    'rejects create for %s metric runs',
+    async (status) => {
+      state.metricRuns = [{ id: 11, fundId: 1, status }];
+
+      await expect(
+        createMetricRunEvidence(
+          {
+            fundId: 1,
+            metricRunId: 11,
+            userId: 7,
+            body: {
+              idempotencyKey: 'metric-run-11-evidence-0',
+              evidenceSource: 'board_update',
+              sourceDate: '2026-03-31',
+            },
+          },
+          { database: makeDatabase() }
+        )
+      ).rejects.toMatchObject({
+        status: 409,
+        code: 'METRIC_RUN_NOT_EDITABLE',
+      } satisfies Partial<MetricRunCommitError>);
+      expect(state.insertValues).toHaveLength(0);
+    }
+  );
+
+  it('rejects cross-fund metric-run targets', async () => {
+    state.metricRuns = [{ id: 11, fundId: 2, status: 'draft' }];
 
     await expect(
       createMetricRunEvidence(
@@ -231,24 +297,120 @@ describe('createMetricRunEvidence', () => {
         { database: makeDatabase() }
       )
     ).rejects.toMatchObject({
-      status: 409,
-      code: 'METRIC_RUN_NOT_EDITABLE',
+      status: 404,
+      code: 'METRIC_RUN_NOT_FOUND',
     } satisfies Partial<MetricRunCommitError>);
+    expect(state.insertValues).toHaveLength(0);
+  });
+
+  it('rejects missing metric-run targets', async () => {
+    state.metricRuns = [];
+
+    await expect(
+      createMetricRunEvidence(
+        {
+          fundId: 1,
+          metricRunId: 11,
+          userId: 7,
+          body: {
+            idempotencyKey: 'metric-run-11-evidence-0',
+            evidenceSource: 'board_update',
+            sourceDate: '2026-03-31',
+          },
+        },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject({
+      status: 404,
+      code: 'METRIC_RUN_NOT_FOUND',
+    } satisfies Partial<MetricRunCommitError>);
+    expect(state.insertValues).toHaveLength(0);
+  });
+
+  it('rejects unresolved uploadedBy users before insert', async () => {
+    state.users = [];
+
+    await expect(
+      createMetricRunEvidence(
+        {
+          fundId: 1,
+          metricRunId: 11,
+          userId: 7,
+          body: {
+            idempotencyKey: 'metric-run-11-evidence-0',
+            evidenceSource: 'board_update',
+            sourceDate: '2026-03-31',
+          },
+        },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject({
+      status: 401,
+      code: 'AUTH_USER_ID_UNRESOLVED',
+    } satisfies Partial<MetricRunCommitError>);
+    expect(state.insertValues).toHaveLength(0);
+  });
+
+  it('rejects forbidden client fields before they reach the insert shape', async () => {
+    const bodyWithForbiddenFields = {
+      idempotencyKey: 'metric-run-11-evidence-0',
+      evidenceSource: 'board_update',
+      sourceDate: '2026-03-31',
+      uploadedBy: 99,
+      attachments: [],
+    } as unknown as MetricRunEvidenceCreateRequest;
+
+    await expect(
+      createMetricRunEvidence(
+        {
+          fundId: 1,
+          metricRunId: 11,
+          userId: 7,
+          body: bodyWithForbiddenFields,
+        },
+        { database: makeDatabase() }
+      )
+    ).rejects.toThrow();
     expect(state.insertValues).toHaveLength(0);
   });
 });
 
 describe('listMetricRunEvidence', () => {
-  it('lists evidence for non-draft metric runs without applying editability checks', async () => {
-    state.metricRuns = [{ id: 11, fundId: 1, status: 'locked' }];
-    state.evidence = [evidenceRow(), evidenceRow({ id: 1001, metricRunId: 12 })];
+  it.each(['draft', 'approved', 'locked', 'exported', 'superseded'])(
+    'lists evidence for %s metric runs without editability checks',
+    async (status) => {
+      state.metricRuns = [{ id: 11, fundId: 1, status }];
+      state.evidence = [evidenceRow(), evidenceRow({ id: 1001, metricRunId: 12 })];
 
-    const result = await listMetricRunEvidence(
-      { fundId: 1, metricRunId: 11 },
-      { database: makeDatabase() }
-    );
+      const result = await listMetricRunEvidence(
+        { fundId: 1, metricRunId: 11 },
+        { database: makeDatabase() }
+      );
 
-    expect(result.records).toHaveLength(1);
-    expect(result.records[0]?.id).toBe(1000);
+      expect(result.records).toHaveLength(1);
+      expect(result.records[0]?.id).toBe(1000);
+    }
+  );
+
+  it('rejects cross-fund metric-run targets', async () => {
+    state.metricRuns = [{ id: 11, fundId: 2, status: 'locked' }];
+
+    await expect(
+      listMetricRunEvidence({ fundId: 1, metricRunId: 11 }, { database: makeDatabase() })
+    ).rejects.toMatchObject({
+      status: 404,
+      code: 'METRIC_RUN_NOT_FOUND',
+    } satisfies Partial<MetricRunCommitError>);
+  });
+
+  it('rejects missing metric-run targets', async () => {
+    state.metricRuns = [];
+
+    await expect(
+      listMetricRunEvidence({ fundId: 1, metricRunId: 11 }, { database: makeDatabase() })
+    ).rejects.toMatchObject({
+      status: 404,
+      code: 'METRIC_RUN_NOT_FOUND',
+    } satisfies Partial<MetricRunCommitError>);
   });
 });


### PR DESCRIPTION
The metric-run evidence foundation already existed on the fresh base, so this commit tightens the regression net around the guarantees that make it safe to build on: route-scoped identity, DB-backed idempotency, lifecycle editability, cross-fund rejection, migration DDL, and duplicate UI rendering.

Constraint: S0 branch gate required feature work to start from a known base; main was even with origin/main after fetch.

Rejected: Add new production code | existing implementation already satisfied the slice and only needed stronger evidence.

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Do not widen metric-run evidence into generic uploads, narrative, export, approval, or share workflows without a separate PRD.

Tested: npx vitest run tests/unit/services/lp-reporting/metric-run-evidence-service.test.ts tests/unit/routes/lp-reporting/metric-runs-routes.test.ts tests/unit/schema/lp-reporting-evidence-schema.test.ts tests/unit/pages/lp-reporting/metrics.test.tsx (4 files, 164 tests)

Tested: focused LP Reporting suite (27 files, 627 tests, 2 skipped); metric-run regression suite (5 files, 187 tests); npm run check; npm run lint; npm test; git diff --check