### PR TITLE
docs: Keep archived April 5 plans from reopening settled lanes

### DIFF
--- a/docs/archive/2026-q2/2026-04-05-todo-report-remediation-strategy.md
+++ b/docs/archive/2026-q2/2026-04-05-todo-report-remediation-strategy.md
@@ -1,16 +1,22 @@
 # To-Do Report Remediation Strategy
 
-Date: `2026-04-05` Status: `actionable`
+Date: `2026-04-05` Status: `archived-reference`
+
+Superseded for execution by the current approved priority development queue
+handoff.
 
 ## Objective
 
-Convert the corrected accuracy review into a current-main execution strategy
-without replaying already-landed work or preserving stale backlog claims.
+Record the April 5 current-main rebaseline without replaying already-landed
+work or preserving stale backlog claims. This file is retained as archived
+evidence for P0 reconciliation, not as the active execution queue.
 
-## Source Of Truth
+## Archive Boundary
 
-This document is the repo-native strategy record for the remediation queue on
-current `main`. It supersedes the PR-only draft strategy from PR `#563`.
+For execution, defer to the current approved priority development queue handoff.
+This archived document preserves the April 5 rationale and evidence commands
+that informed that queue. It superseded the PR-only draft strategy from PR
+`#563` at the time, but it no longer authorizes work from zero.
 
 ## Re-Baselined Worktracks
 
@@ -59,7 +65,10 @@ Definition of done:
   fallback semantics
 - no same-label local IRR algorithm remains in the touched residual path
 
-### Worktrack C2: LP Benchmark Hardening
+### Worktrack C2: LP Benchmark Hardening Reference
+
+Status: closed/reference on current `main`; do not treat this as an open
+greenfield implementation lane.
 
 Scope:
 
@@ -76,7 +85,10 @@ Definition of done:
 - any future C2 work is triggered by regression or contradictory evidence, not
   by the stale PR baseline
 
-### Worktrack D: Snapshot Governance Closure
+### Worktrack D: Snapshot Governance Closure Reference
+
+Status: closed/reference on current `main`; `ADR-014` is the governing boundary
+unless future contradictory evidence appears.
 
 Scope:
 
@@ -106,7 +118,11 @@ rg -n "xirrNewtonBisection|shared canonical XIRR" server/services/actual-metrics
 rg -n "targetIRR|expectedIRR" server/services/metrics-aggregator.ts
 ```
 
-## Execution Order
+## Historical Execution Order
+
+Use this order only as historical context for the archived April 5 tranche. The
+current approved queue starts with P0 closeout/reconciliation and then moves
+through the approved priority lanes.
 
 1. Worktrack `A` first.
 2. Then run one bounded open worktrack at a time:
@@ -129,14 +145,13 @@ rg -n "targetIRR|expectedIRR" server/services/metrics-aggregator.ts
 - Worktrack C1:
   - canonical XIRR truth cases + touched service tests
 - Worktrack C2:
-  - if reopened, prove the route no longer serves persisted/fallback truthful
-    benchmark data
+  - remains closed/reference unless future evidence proves the route no longer
+    serves persisted/fallback truthful benchmark data
 - Worktrack D:
-  - if reopened, prove `ADR-014` is no longer the canonical referenced boundary
+  - remains closed/reference unless future evidence proves `ADR-014` is no
+    longer the canonical referenced boundary
 
 ## References
 
 - `docs/archive/2026-q2/todo-report-accuracy-review-2026-04-05.md`
 - `docs/adr/ADR-014-snapshot-governance.md`
-- `.omx/plans/prd-next-development-goal-current-main-rebaseline.md`
-- `.omx/plans/test-spec-next-development-goal-current-main-rebaseline.md`

--- a/docs/archive/2026-q2/todo-report-accuracy-review-2026-04-05.md
+++ b/docs/archive/2026-q2/todo-report-accuracy-review-2026-04-05.md
@@ -1,6 +1,9 @@
 # To-Do Report Accuracy Review
 
-Date: `2026-04-05` Status: `active`
+Date: `2026-04-05` Status: `archived-reference`
+
+Superseded for execution by the current approved priority development queue
+handoff.
 
 ## Verdict
 
@@ -8,12 +11,14 @@ The original to-do report was directionally useful but materially stale. It
 mixed validated remaining gaps with claims that current `main` had already
 closed or had never matched literally.
 
-This review is the current-main source of truth for the remediation queue. It
-supersedes the PR-only draft review from PR `#563`.
+This archived review records the April 5 current-main rebaseline that later fed
+the approved priority development queue. It superseded the PR-only draft review
+from PR `#563` at the time, but it is no longer the active execution source of
+truth.
 
 ## Current-Main Findings
 
-### Validated remaining gaps
+### Validated remaining gaps at the April 5 rebaseline
 
 1. Construction-vs-actual detailed breakdown remains explicitly deferred.
 2. Residual IRR follow-through remains a later audit lane outside the
@@ -21,6 +26,9 @@ supersedes the PR-only draft review from PR `#563`.
    current `main` instead of assumed from the earlier PR draft.
 
 ### Current-main closures that active docs must respect
+
+These closures are not open-from-zero worktracks. They are reference boundaries
+for future docs or code touched by newer plans.
 
 1. LP benchmark comparison no longer returns placeholder-only example data; the
    route serves persisted benchmark-derived series when present and an explicit
@@ -76,10 +84,11 @@ rg -n "targetIRR|expectedIRR" server/services/metrics-aggregator.ts
 
 ## Follow-Through
 
-The April 5 remediation queue has been re-baselined on current `main`. Use the
-archived strategy plus the current OMX handoff artifacts for bounded doc + UI
-truthfulness follow-through; do not re-execute the old active `docs/plans` path:
+The April 5 remediation queue has been re-baselined on current `main`. Use this
+archived strategy as evidence for the current approved priority queue handoff;
+do not re-execute the old active `docs/plans` path or treat snapshot
+governance, `C2`, or `D` as unresolved greenfield work.
+
+Related archive:
 
 - `docs/archive/2026-q2/2026-04-05-todo-report-remediation-strategy.md`
-- `.omx/plans/prd-next-development-goal-current-main-rebaseline.md`
-- `.omx/plans/test-spec-next-development-goal-current-main-rebaseline.md`


### PR DESCRIPTION
The priority queue now treats the April 5 planning docs as archived evidence, so their wording needs to defer execution to the current approved queue handoff and avoid implying C2, snapshot governance, or Worktrack D are active greenfield lanes.

Constraint: Root worktree contains unrelated fund-header/layout/audit changes, so this commit was made from isolated worktree C:\tmp\Updog_restore_p0

Rejected: Commit explicit .omx plan paths into tracked archive docs | those plan artifacts are workflow inputs and absent from a clean checkout

Confidence: high

Scope-risk: narrow

Directive: Do not point tracked archived docs at untracked .omx handoff files unless those artifacts are intentionally versioned

Tested: npx vitest run --config vitest.config.mjs --configLoader native --project=server --project=client tests/unit/pages/sensitivity-analysis.test.tsx tests/unit/pages/time-travel.test.tsx tests/unit/pages/fund-basics-bootstrap.test.tsx tests/unit/pages/review-step-finalize.test.tsx tests/unit/pages/fund-model-results.test.tsx tests/unit/pages/model-results.test.tsx tests/unit/contract/fund-finalize.test.ts tests/unit/services/funds.idempotency.test.tsx

Tested: npm run check

Tested: npx eslint . --max-warnings 0 --no-cache

Tested: npm run guardrails:check