### PR TITLE
refactor: Route cohort XIRR through canonical solver

### DIFF
--- a/shared/core/cohorts/analysis/metrics.ts
+++ b/shared/core/cohorts/analysis/metrics.ts
@@ -6,10 +6,11 @@
  */
 
 import type { CashFlowEvent, CohortRow, CoverageSummaryType } from '@shared/types';
+import { xirrNewtonBisection, type CashFlow as XirrCashFlow } from '@shared/lib/finance/xirr';
 import { aggregateCashFlowsByDate, calculateCashFlowTotals, hasResidualValue } from './cash-flows';
 
 /**
- * Newton-Raphson XIRR implementation
+ * XIRR adapter for cohort cash flows.
  *
  * @param cashFlows Array of {date, amount} where negative = outflow, positive = inflow
  * @param guess Initial guess for rate (default 0.1 = 10%)
@@ -23,127 +24,12 @@ export function calculateXIRR(
   maxIterations = 100,
   tolerance = 1e-7
 ): number | null {
-  if (cashFlows.length < 2) {
-    return null;
-  }
-
-  // Check for at least one positive and one negative cash flow
-  const hasPositive = cashFlows.some((cf) => cf.amount > 0);
-  const hasNegative = cashFlows.some((cf) => cf.amount < 0);
-
-  if (!hasPositive || !hasNegative) {
-    return null;
-  }
-
-  // Sort by date
-  const sorted = [...cashFlows].sort((a, b) => a.date.getTime() - b.date.getTime());
-  const firstDate = sorted[0]?.date;
-  if (!firstDate) {
-    return null;
-  }
-
-  // Calculate days from first date
-  const daysFromStart = sorted.map((cf) => ({
-    amount: cf.amount,
-    days: (cf.date.getTime() - firstDate.getTime()) / (1000 * 60 * 60 * 24),
+  const canonicalFlows: XirrCashFlow[] = cashFlows.map(({ date, amount }) => ({
+    date,
+    amount,
   }));
 
-  // NPV function
-  const npv = (rate: number): number => {
-    return daysFromStart.reduce((sum, cf) => {
-      return sum + cf.amount / Math.pow(1 + rate, cf.days / 365);
-    }, 0);
-  };
-
-  // NPV derivative function
-  const npvDerivative = (rate: number): number => {
-    return daysFromStart.reduce((sum, cf) => {
-      return sum + ((-cf.days / 365) * cf.amount) / Math.pow(1 + rate, cf.days / 365 + 1);
-    }, 0);
-  };
-
-  let rate = guess;
-
-  for (let i = 0; i < maxIterations; i++) {
-    const currentNPV = npv(rate);
-    const currentDerivative = npvDerivative(rate);
-
-    if (Math.abs(currentDerivative) < 1e-10) {
-      // Derivative too small, try different approach
-      break;
-    }
-
-    const newRate = rate - currentNPV / currentDerivative;
-
-    if (Math.abs(newRate - rate) < tolerance) {
-      // Converged
-      if (newRate < -1 || !isFinite(newRate)) {
-        return null; // Invalid result
-      }
-      return newRate;
-    }
-
-    // Guard against runaway rates
-    if (newRate > 10 || newRate < -0.99) {
-      break;
-    }
-
-    rate = newRate;
-  }
-
-  // Did not converge, try bisection as fallback
-  return bisectionXIRR(sorted, -0.99, 5.0, tolerance, maxIterations);
-}
-
-/**
- * Bisection method for XIRR as fallback
- */
-function bisectionXIRR(
-  cashFlows: Array<{ date: Date; amount: number }>,
-  lowerBound: number,
-  upperBound: number,
-  tolerance: number,
-  maxIterations: number
-): number | null {
-  const firstDate = cashFlows[0]?.date;
-  if (!firstDate) {
-    return null;
-  }
-
-  const daysFromStart = cashFlows.map((cf) => ({
-    amount: cf.amount,
-    days: (cf.date.getTime() - firstDate.getTime()) / (1000 * 60 * 60 * 24),
-  }));
-
-  const npv = (rate: number): number => {
-    return daysFromStart.reduce((sum, cf) => {
-      return sum + cf.amount / Math.pow(1 + rate, cf.days / 365);
-    }, 0);
-  };
-
-  let low = lowerBound;
-  let high = upperBound;
-
-  for (let i = 0; i < maxIterations; i++) {
-    const mid = (low + high) / 2;
-    const npvMid = npv(mid);
-
-    if (Math.abs(npvMid) < tolerance) {
-      return mid;
-    }
-
-    if (npv(low) * npvMid < 0) {
-      high = mid;
-    } else {
-      low = mid;
-    }
-
-    if (high - low < tolerance) {
-      return mid;
-    }
-  }
-
-  return null;
+  return xirrNewtonBisection(canonicalFlows, guess, tolerance, maxIterations).irr;
 }
 
 /**

--- a/tests/unit/cohorts/advanced-cohort-analysis.test.ts
+++ b/tests/unit/cohorts/advanced-cohort-analysis.test.ts
@@ -11,7 +11,12 @@
 
 import { describe, it, expect } from 'vitest';
 import { calculateXIRR, calculateDPI, calculateTVPI } from '@/core/cohorts/metrics';
-import { normalizeSector, slugifySector, BLANK_SECTOR_TOKEN } from '@shared/utils/sector-normalization';
+import { xirrNewtonBisection, type CashFlow } from '@shared/lib/finance/xirr';
+import {
+  normalizeSector,
+  slugifySector,
+  BLANK_SECTOR_TOKEN,
+} from '@shared/utils/sector-normalization';
 import { resolveVintageKey, compareVintageKeys } from '@shared/utils/vintage-resolution';
 import {
   calculateCoverage,
@@ -94,6 +99,38 @@ describe('XIRR Calculations', () => {
       ]);
       expect(result).not.toBeNull();
       expect(result).toBeLessThan(0);
+    });
+
+    it('matches the canonical XIRR solver for irregular dated cash flows', () => {
+      const flows: CashFlow[] = [
+        { date: new Date('2020-01-01T00:00:00.000Z'), amount: -1000 },
+        { date: new Date('2020-07-01T00:00:00.000Z'), amount: -500 },
+        { date: new Date('2022-03-15T00:00:00.000Z'), amount: 1900 },
+      ];
+
+      const canonical = xirrNewtonBisection(flows);
+      expect(canonical.irr).not.toBeNull();
+
+      const result = calculateXIRR(flows);
+
+      expect(result).not.toBeNull();
+      expect(result).toBeCloseTo(canonical.irr!, 10);
+    });
+
+    it('matches the canonical XIRR solver for high short-hold returns', () => {
+      const flows: CashFlow[] = [
+        { date: new Date('2020-01-01T00:00:00.000Z'), amount: -100 },
+        { date: new Date('2020-07-01T00:00:00.000Z'), amount: 1000 },
+      ];
+
+      const canonical = xirrNewtonBisection(flows);
+      expect(canonical.irr).not.toBeNull();
+      expect(canonical.irr).toBeGreaterThan(5);
+
+      const result = calculateXIRR(flows);
+
+      expect(result).not.toBeNull();
+      expect(result).toBeCloseTo(canonical.irr!, 10);
     });
   });
 });


### PR DESCRIPTION
Cohort metrics carried a separate Newton/bisection XIRR implementation with a 365-day denominator and narrower rate bounds. Routing calculateXIRR through the shared solver aligns cohort analysis with ADR-010 without changing the public cohort metrics API.

Constraint: ADR-010 locks XIRR policy to Actual/365.25 and bounds [-0.999999, 200]

Rejected: Keep the local cohort solver and tune constants | maintaining two financial solvers preserves divergence risk

Confidence: high

Scope-risk: moderate

Directive: Do not reintroduce cohort-local XIRR math; add options to shared/lib/finance/xirr if cohort analysis needs solver behavior changes

Tested: npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/cohorts/advanced-cohort-analysis.test.ts

Tested: npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/xirr-golden-set.test.ts tests/unit/xirr-edge-cases.test.ts tests/unit/xirr-safe-wrappers.test.ts tests/unit/analytics-xirr.test.ts

Tested: npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/truth-cases/xirr.test.ts tests/unit/truth-cases/runner.test.ts

Tested: npm run phoenix:truth

Tested: npm run check

Tested: npm run lint

Tested: npx vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/app/route-perimeter-governance.test.tsx tests/unit/pages/variance-tracking.test.tsx tests/unit/components/layout/sidebar-navigation.test.tsx

Tested: npm test (rerun after one transient unrelated client timeout run)

Not-tested: Browser-rendered cohort analysis dashboard