### PR TITLE
chore: Merge tsconfig.eslint.server.json into tsconfig.eslint.json (PR 3b)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -386,7 +386,7 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: './tsconfig.eslint.server.json',
+        project: './tsconfig.eslint.json',
         tsconfigRootDir: __dirname,
       },
     },

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,7 @@
     "noEmit": true
   },
   "include": [
+    "api/**/*",
     "client/src/**/*",
     "server/**/*",
     "shared/**/*",

--- a/tsconfig.eslint.server.json
+++ b/tsconfig.eslint.server.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["api/**/*", "server/**/*", "types/**/*"],
-  "exclude": ["dist", "node_modules", "build", "coverage"]
-}


### PR DESCRIPTION
## Summary

Second slice of config consolidation. Brings tsconfig count from **6 to 5**.

The two eslint tsconfigs were structurally identical (extends root, noEmit: true) and differed only in include scope. Merging into one config simplifies the lint setup with no behavioral change.

## Changes

- `tsconfig.eslint.json` — added `api/**/*` to includes (previously only in the server variant).
- `eslint.config.js:389` — switched the api/server-specific block from `./tsconfig.eslint.server.json` to `./tsconfig.eslint.json`.
- `tsconfig.eslint.server.json` — deleted.

## Why `types/**/*` was NOT added

The original `tsconfig.eslint.server.json` included `types/**/*`, but adding that to the unified config introduces **7 new no-unsafe-* warnings in `shared/lib/jcurve-fit.ts`**. Root cause: when ESLint's TypeScript service sees `types/ml-levenberg-marquardt.d.ts` (which declares the module as a bare `declare module 'ml-levenberg-marquardt';`), the import of that module gets explicit `any`, and type-aware ESLint flags every use of the result. Without `types/` in the project, the parser doesn't load the ambient declarations and can't detect the `any` propagation.

Verified the api/server files that import ambient-typed modules (`server/app.ts`, `server/lib/rateLimitStore.ts`, `server/middleware/rate-limit.ts`, `server/middleware/rateLimitDetailed.ts`, plus `api/[[...slug]].ts`) still lint clean **without** `types/` in the unified config. So leaving it out is safe.

## Verification

- `npm run lint` exits 0; `eslint-disable-ratchet` reports 1 file-level disable, well under the 29 baseline.
- `npm run check`: 0 TS errors, 0 new (baseline ratchet preserved).
- `npm run calc-gate`: 479 tests pass (phoenix:truth + test:wave4 + orphans).
- Individual lint of all 5 api/server files that import ambient-declared modules: all clean.

## Cumulative tally

Starting point of the refactor batch: 11 tsconfigs.
After PR 3a: 6 tsconfigs.
After this PR: **5 tsconfigs** (root, client, server, shared, eslint).

That hits the plan's target.

## Follow-up

- PR 3c: vitest config consolidation (8 → 4). The `.mjs` entry point referenced by `package.json:55` and `scripts/pre-push.mjs:167` needs care.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>