### PR TITLE
Codex/parallel professional deal integration

### DIFF
--- a/client/src/lib/fund-header-metric-calculations.ts
+++ b/client/src/lib/fund-header-metric-calculations.ts
@@ -152,6 +152,7 @@ function emptyHeaderMetrics(currentFundSize: number): HeaderMetrics {
     deploymentRate: null,
     remainingDeployableCapital: null,
     availability: {
+      nav: unavailableMetric('portfolio_nav', 'Metrics unavailable'),
       irr: unavailableMetric('cashflows', 'Metrics unavailable'),
       dpi: unavailableMetric('distributions', 'Metrics unavailable'),
     },
@@ -161,8 +162,10 @@ function emptyHeaderMetrics(currentFundSize: number): HeaderMetrics {
 function actualHeaderMetrics(currentFundSize: number, actual: ActualMetrics): HeaderMetrics {
   const totalCommitted = numberWithFallback(actual.totalCommitted, currentFundSize);
   const totalInvested = nullableNumber(actual.totalDeployed);
-  const currentNAV = nullableNumber(actual.currentNAV);
-  const totalValue = getTotalValue(actual);
+  const navAvailability = getNavAvailability(actual, totalInvested);
+  const currentNAV =
+    navAvailability.status === 'available' ? nullableNumber(actual.currentNAV) : null;
+  const totalValue = navAvailability.status === 'available' ? getTotalValue(actual) : null;
 
   return {
     totalCommitted,
@@ -179,10 +182,32 @@ function actualHeaderMetrics(currentFundSize: number, actual: ActualMetrics): He
     deploymentRate: nullableNumber(actual.deploymentRate),
     remainingDeployableCapital: calculateRemainingDeployableCapital(totalCommitted, totalInvested),
     availability: {
+      nav: navAvailability,
       irr: getIrrAvailability(actual),
       dpi: getDpiAvailability(actual),
     },
   };
+}
+
+function getNavAvailability(
+  actual: ActualMetrics,
+  totalInvested: number | null
+): MetricAvailabilityDetail {
+  const currentNAV = nullableNumber(actual.currentNAV);
+  const totalValue = getTotalValue(actual);
+  if ((currentNAV ?? 0) <= 0 && (totalValue ?? 0) <= 0) {
+    return { status: 'available', source: 'portfolio_nav' };
+  }
+
+  if (totalInvested == null || totalInvested <= 0) {
+    return unavailableMetric(
+      'portfolio_nav',
+      'Needs investment facts',
+      'investment_facts_missing'
+    );
+  }
+
+  return { status: 'available', source: 'portfolio_nav' };
 }
 
 function getIrrAvailability(actual: ActualMetrics): MetricAvailabilityDetail {
@@ -277,7 +302,13 @@ function buildHeaderMetricCards(
     {
       key: 'totalValue',
       title: 'Current Value',
-      displayValue: formatMetricCurrency(metrics.totalValue, metricDisplayUnavailable),
+      displayValue: formatPerformanceMetric(
+        metrics.totalValue,
+        metrics.availability.nav,
+        formatCurrency,
+        metricDisplayUnavailable
+      ),
+      titleText: metrics.availability.nav.message,
       theme: 'white',
       icon: 'target',
     },
@@ -398,6 +429,9 @@ function getCompactKpiExplanation(
     return 'Metrics unavailable because the live metrics source is unavailable.';
   }
   if (availability?.status === 'unavailable') {
+    if (availability.reason === 'investment_facts_missing') {
+      return 'NAV is unavailable until investment facts are recorded for valued portfolio companies.';
+    }
     if (availability.reason === 'no_distributions_recorded') {
       return 'DPI is unavailable because no distributions have been recorded.';
     }
@@ -440,6 +474,7 @@ function getCompactKpiValue(metrics: HeaderMetrics, selectedKpi: CompactKpiKey) 
 }
 
 function getCompactKpiAvailability(metrics: HeaderMetrics, selectedKpi: CompactKpiKey) {
+  if (selectedKpi === 'nav') return metrics.availability.nav;
   if (selectedKpi === 'dpi') return metrics.availability.dpi;
   if (selectedKpi === 'netIrr') return metrics.availability.irr;
   return undefined;

--- a/client/src/types/fund-header-metrics.ts
+++ b/client/src/types/fund-header-metrics.ts
@@ -75,6 +75,7 @@ export interface HeaderMetrics {
   deploymentRate: number | null;
   remainingDeployableCapital: number | null;
   availability: {
+    nav: MetricAvailabilityDetail;
     irr: MetricAvailabilityDetail;
     dpi: MetricAvailabilityDetail;
   };

--- a/server/routes/deal-pipeline.ts
+++ b/server/routes/deal-pipeline.ts
@@ -20,20 +20,13 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { firstString } from '../lib/request-values';
 import { z } from 'zod';
-import { db } from '../db';
-import {
-  dealOpportunities,
-  pipelineStages,
-  dueDiligenceItems,
-  scoringModels,
-  pipelineActivities,
-} from '@shared/schema';
 import { CompanySectorSchema, CompanyStageSchema } from '@shared/company-taxonomy';
-import { eq, and, desc, asc, lt, or, sql, inArray } from 'drizzle-orm';
 import { idempotency } from '../middleware/idempotency';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import * as dealPipelineService from '../services/deal-pipeline-service';
 
 const router = Router();
+const idempotent = idempotency();
 
 // ============================================================
 // ZOD VALIDATION SCHEMAS
@@ -107,6 +100,10 @@ const PaginationSchema = z.object({
   sortDir: SortDirEnum,
 });
 
+const PipelineQuerySchema = z.object({
+  fundId: z.coerce.number().int().positive().optional(),
+});
+
 // Stage Change Schema
 const StageChangeSchema = z.object({
   status: DealStatusEnum,
@@ -146,6 +143,10 @@ function decodeCursor(cursor: string): CursorData | null {
     if (!data.createdAt || typeof data.id !== 'number') {
       return null;
     }
+    const createdAt = new Date(data.createdAt);
+    if (Number.isNaN(createdAt.getTime())) {
+      return null;
+    }
     return data;
   } catch {
     return null;
@@ -160,7 +161,7 @@ function decodeCursor(cursor: string): CursorData | null {
  * POST /api/deals/opportunities - Create new deal
  * Idempotency-enabled for safe retries
  */
-router['post']('/opportunities', idempotency, async (req: Request, res: Response) => {
+router['post']('/opportunities', idempotent, async (req: Request, res: Response) => {
   const validation = CreateDealSchema.safeParse(req.body);
   if (!validation.success) {
     return res.status(400).json({
@@ -175,46 +176,13 @@ router['post']('/opportunities', idempotency, async (req: Request, res: Response
       return;
     }
 
-    const [deal] = await db
-      .insert(dealOpportunities)
-      .values({
-        fundId: data.fundId ?? null,
-        companyName: data.companyName,
-        sector: data.sector,
-        stage: data.stage,
-        sourceType: data.sourceType,
-        dealSize: data.dealSize ? String(data.dealSize) : null,
-        valuation: data.valuation ? String(data.valuation) : null,
-        status: data.status,
-        priority: data.priority,
-        foundedYear: data.foundedYear ?? null,
-        employeeCount: data.employeeCount ?? null,
-        revenue: data.revenue ? String(data.revenue) : null,
-        description: data.description ?? null,
-        website: data.website || null,
-        contactName: data.contactName ?? null,
-        contactEmail: data.contactEmail || null,
-        contactPhone: data.contactPhone ?? null,
-        sourceNotes: data.sourceNotes ?? null,
-        nextAction: data.nextAction ?? null,
-      })
-      .returning();
-
+    const deal = await dealPipelineService.createDeal(data);
     if (!deal) {
       return res.status(500).json({
         error: 'internal_error',
         message: 'Failed to create deal - no result returned',
       });
     }
-
-    // Log activity for deal creation
-    await db.insert(pipelineActivities).values({
-      opportunityId: deal.id,
-      type: 'stage_change',
-      title: 'Deal Created',
-      description: `New deal "${data.companyName}" added to pipeline`,
-      completedDate: new Date(),
-    });
 
     return res.status(201).json({
       success: true,
@@ -250,82 +218,40 @@ router['get']('/opportunities', async (req: Request, res: Response) => {
       return;
     }
 
-    // Build filter conditions
-    const conditions = [];
-
-    if (status) {
-      conditions.push(eq(dealOpportunities.status, status));
-    }
-    if (priority) {
-      conditions.push(eq(dealOpportunities.priority, priority));
-    }
-    if (fundId) {
-      conditions.push(eq(dealOpportunities.fundId, fundId));
-    }
-    if (search) {
-      conditions.push(
-        or(
-          sql`${dealOpportunities.companyName} ILIKE ${`%${search}%`}`,
-          sql`${dealOpportunities.sector} ILIKE ${`%${search}%`}`,
-          sql`${dealOpportunities.description} ILIKE ${`%${search}%`}`
-        )
-      );
-    }
-
-    // Cursor pagination only works with default sort (createdAt DESC)
     const isDefaultSort = sortBy === 'createdAt' && sortDir === 'desc';
+    let cursorData: CursorData | undefined;
     if (cursor && isDefaultSort) {
-      const cursorData = decodeCursor(cursor);
-      if (!cursorData) {
+      const decodedCursor = decodeCursor(cursor);
+      if (!decodedCursor) {
         return res.status(400).json({
           error: 'invalid_cursor',
           message: 'The provided cursor is invalid or expired',
         });
       }
-      conditions.push(
-        or(
-          lt(dealOpportunities.createdAt, new Date(cursorData.createdAt)),
-          and(
-            eq(dealOpportunities.createdAt, new Date(cursorData.createdAt)),
-            lt(dealOpportunities.id, cursorData.id)
-          )
-        )
-      );
+      cursorData = decodedCursor;
     }
 
-    // Build dynamic orderBy
-    const sortFn = sortDir === 'asc' ? asc : desc;
-    const sortColumn = {
-      updatedAt: dealOpportunities.updatedAt,
-      companyName: dealOpportunities.companyName,
-      dealSize: dealOpportunities.dealSize,
-      createdAt: dealOpportunities.createdAt,
-    }[sortBy];
-
-    const deals = await db
-      .select()
-      .from(dealOpportunities)
-      .where(conditions.length > 0 ? and(...conditions) : undefined)
-      .orderBy(sortFn(sortColumn), desc(dealOpportunities.id))
-      .limit(limit + 1);
-
-    // Determine pagination info
-    const hasMore = deals.length > limit;
-    const items = hasMore ? deals.slice(0, limit) : deals;
-    const lastItem = items[items.length - 1];
-    // Only provide cursor for default sort
-    const nextCursor =
-      hasMore && isDefaultSort && lastItem?.createdAt
-        ? encodeCursor(lastItem.createdAt, lastItem.id)
-        : null;
+    const result = await dealPipelineService.listDeals({
+      cursor: cursorData,
+      limit,
+      status,
+      priority,
+      fundId,
+      search,
+      sortBy,
+      sortDir,
+    });
+    const nextCursor = result.pagination.nextCursor
+      ? encodeCursor(result.pagination.nextCursor.createdAt, result.pagination.nextCursor.id)
+      : null;
 
     return res.json({
       success: true,
-      data: items,
+      data: result.items,
       pagination: {
-        hasMore,
+        hasMore: result.pagination.hasMore,
         nextCursor,
-        count: items.length,
+        count: result.pagination.count,
       },
     });
   } catch (error) {
@@ -351,44 +277,14 @@ router['get']('/opportunities/:id', async (req: Request, res: Response) => {
   }
 
   try {
-    const [deal] = await db
-      .select()
-      .from(dealOpportunities)
-      .where(eq(dealOpportunities.id, id))
-      .limit(1);
-
+    const deal = await dealPipelineService.getDeal(id);
     if (!deal) {
       return res.status(404).json({ error: 'not_found', message: 'Deal not found' });
     }
 
-    // Fetch related data
-    const [ddItems, activities, scores] = await Promise.all([
-      db
-        .select()
-        .from(dueDiligenceItems)
-        .where(eq(dueDiligenceItems.opportunityId, id))
-        .orderBy(desc(dueDiligenceItems.createdAt)),
-      db
-        .select()
-        .from(pipelineActivities)
-        .where(eq(pipelineActivities.opportunityId, id))
-        .orderBy(desc(pipelineActivities.createdAt))
-        .limit(20),
-      db
-        .select()
-        .from(scoringModels)
-        .where(eq(scoringModels.opportunityId, id))
-        .orderBy(desc(scoringModels.scoredAt)),
-    ]);
-
     return res.json({
       success: true,
-      data: {
-        ...deal,
-        dueDiligence: ddItems,
-        activities,
-        scores,
-      },
+      data: deal,
     });
   } catch (error) {
     console.error('Deal fetch error:', error);
@@ -403,7 +299,7 @@ router['get']('/opportunities/:id', async (req: Request, res: Response) => {
  * PUT /api/deals/opportunities/:id - Update deal
  * Idempotency-enabled
  */
-router['put']('/opportunities/:id', idempotency, async (req: Request, res: Response) => {
+router['put']('/opportunities/:id', idempotent, async (req: Request, res: Response) => {
   const paramId = firstString(req.params['id']);
   if (!paramId) {
     return res.status(400).json({ error: 'invalid_id', message: 'Deal ID is required' });
@@ -422,48 +318,15 @@ router['put']('/opportunities/:id', idempotency, async (req: Request, res: Respo
   }
 
   try {
-    // Check if deal exists
-    const [existing] = await db
-      .select()
-      .from(dealOpportunities)
-      .where(eq(dealOpportunities.id, id))
-      .limit(1);
-
-    if (!existing) {
-      return res.status(404).json({ error: 'not_found', message: 'Deal not found' });
+    const data = validation.data;
+    if (data.fundId !== undefined && !(await enforceProvidedFundScope(req, res, data.fundId))) {
+      return;
     }
 
-    const data = validation.data;
-    const updateData: Record<string, unknown> = {
-      updatedAt: new Date(),
-    };
-
-    // Only include provided fields - use bracket notation for index signature access
-    if (data.fundId !== undefined) updateData['fundId'] = data.fundId;
-    if (data.companyName !== undefined) updateData['companyName'] = data.companyName;
-    if (data.sector !== undefined) updateData['sector'] = data.sector;
-    if (data.stage !== undefined) updateData['stage'] = data.stage;
-    if (data.sourceType !== undefined) updateData['sourceType'] = data.sourceType;
-    if (data.dealSize !== undefined) updateData['dealSize'] = String(data.dealSize);
-    if (data.valuation !== undefined) updateData['valuation'] = String(data.valuation);
-    if (data.status !== undefined) updateData['status'] = data.status;
-    if (data.priority !== undefined) updateData['priority'] = data.priority;
-    if (data.foundedYear !== undefined) updateData['foundedYear'] = data.foundedYear;
-    if (data.employeeCount !== undefined) updateData['employeeCount'] = data.employeeCount;
-    if (data.revenue !== undefined) updateData['revenue'] = String(data.revenue);
-    if (data.description !== undefined) updateData['description'] = data.description;
-    if (data.website !== undefined) updateData['website'] = data.website || null;
-    if (data.contactName !== undefined) updateData['contactName'] = data.contactName;
-    if (data.contactEmail !== undefined) updateData['contactEmail'] = data.contactEmail || null;
-    if (data.contactPhone !== undefined) updateData['contactPhone'] = data.contactPhone;
-    if (data.sourceNotes !== undefined) updateData['sourceNotes'] = data.sourceNotes;
-    if (data.nextAction !== undefined) updateData['nextAction'] = data.nextAction;
-
-    const [updated] = await db
-      .update(dealOpportunities)
-      .set(updateData)
-      .where(eq(dealOpportunities.id, id))
-      .returning();
+    const updated = await dealPipelineService.updateDeal(id, data);
+    if (!updated) {
+      return res.status(404).json({ error: 'not_found', message: 'Deal not found' });
+    }
 
     return res.json({
       success: true,
@@ -482,7 +345,7 @@ router['put']('/opportunities/:id', idempotency, async (req: Request, res: Respo
 /**
  * DELETE /api/deals/opportunities/:id - Archive deal (soft delete)
  */
-router['delete']('/opportunities/:id', idempotency, async (req: Request, res: Response) => {
+router['delete']('/opportunities/:id', idempotent, async (req: Request, res: Response) => {
   const paramId = firstString(req.params['id']);
   if (!paramId) {
     return res.status(400).json({ error: 'invalid_id', message: 'Deal ID is required' });
@@ -493,34 +356,10 @@ router['delete']('/opportunities/:id', idempotency, async (req: Request, res: Re
   }
 
   try {
-    const [existing] = await db
-      .select()
-      .from(dealOpportunities)
-      .where(eq(dealOpportunities.id, id))
-      .limit(1);
-
-    if (!existing) {
+    const archived = await dealPipelineService.archiveDeal(id);
+    if (!archived) {
       return res.status(404).json({ error: 'not_found', message: 'Deal not found' });
     }
-
-    // Soft delete by setting status to 'passed'
-    const [archived] = await db
-      .update(dealOpportunities)
-      .set({
-        status: 'passed',
-        updatedAt: new Date(),
-      })
-      .where(eq(dealOpportunities.id, id))
-      .returning();
-
-    // Log activity
-    await db.insert(pipelineActivities).values({
-      opportunityId: id,
-      type: 'stage_change',
-      title: 'Deal Archived',
-      description: `Deal "${existing.companyName}" was archived`,
-      completedDate: new Date(),
-    });
 
     return res.json({
       success: true,
@@ -539,7 +378,7 @@ router['delete']('/opportunities/:id', idempotency, async (req: Request, res: Re
 /**
  * POST /api/deals/:id/stage - Move deal to new stage
  */
-router['post']('/:id/stage', idempotency, async (req: Request, res: Response) => {
+router['post']('/:id/stage', idempotent, async (req: Request, res: Response) => {
   const paramId = firstString(req.params['id']);
   if (!paramId) {
     return res.status(400).json({ error: 'invalid_id', message: 'Deal ID is required' });
@@ -558,42 +397,16 @@ router['post']('/:id/stage', idempotency, async (req: Request, res: Response) =>
   }
 
   try {
-    const [existing] = await db
-      .select()
-      .from(dealOpportunities)
-      .where(eq(dealOpportunities.id, id))
-      .limit(1);
-
-    if (!existing) {
+    const result = await dealPipelineService.changeDealStage(id, validation.data);
+    if (!result) {
       return res.status(404).json({ error: 'not_found', message: 'Deal not found' });
     }
 
-    const { status, notes } = validation.data;
-    const previousStatus = existing.status;
-
-    const [updated] = await db
-      .update(dealOpportunities)
-      .set({
-        status,
-        updatedAt: new Date(),
-      })
-      .where(eq(dealOpportunities.id, id))
-      .returning();
-
-    // Log stage change activity
-    await db.insert(pipelineActivities).values({
-      opportunityId: id,
-      type: 'stage_change',
-      title: `Stage Changed: ${previousStatus} -> ${status}`,
-      description: notes ?? `Deal moved from ${previousStatus} to ${status}`,
-      completedDate: new Date(),
-    });
-
     return res.json({
       success: true,
-      data: updated,
-      previousStatus,
-      newStatus: status,
+      data: result.updated,
+      previousStatus: result.previousStatus,
+      newStatus: result.newStatus,
       message: 'Deal stage updated successfully',
     });
   } catch (error) {
@@ -609,58 +422,25 @@ router['post']('/:id/stage', idempotency, async (req: Request, res: Response) =>
  * GET /api/deals/pipeline - Pipeline view (grouped by status)
  */
 router['get']('/pipeline', async (req: Request, res: Response) => {
-  const fundIdParam = req['query']['fundId'];
-  const fundId = fundIdParam ? parseInt(fundIdParam as string, 10) : undefined;
+  const validation = PipelineQuerySchema.safeParse(req.query);
+  if (!validation.success) {
+    return res.status(400).json({
+      error: 'validation_error',
+      issues: validation.error.issues,
+    });
+  }
 
   try {
-    const conditions = fundId ? eq(dealOpportunities['fundId'], fundId) : undefined;
-
-    const deals = await db
-      .select()
-      .from(dealOpportunities)
-      .where(conditions)
-      .orderBy(desc(dealOpportunities.priority), desc(dealOpportunities.updatedAt));
-
-    // Group by status for Kanban view
-    type DealArray = typeof deals;
-    const pipeline: { [key: string]: DealArray } = {
-      lead: [],
-      qualified: [],
-      pitch: [],
-      dd: [],
-      committee: [],
-      term_sheet: [],
-      closed: [],
-      passed: [],
-    };
-
-    for (const deal of deals) {
-      const status = deal.status;
-      if (status && pipeline[status]) {
-        pipeline[status].push(deal);
-      }
+    const { fundId } = validation.data;
+    if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
     }
 
-    // Get stage configuration
-    const stages = await db.select().from(pipelineStages).orderBy(pipelineStages.orderIndex);
+    const data = await dealPipelineService.getPipeline(fundId);
 
     return res.json({
       success: true,
-      data: {
-        pipeline,
-        stages,
-        totalDeals: deals.length,
-        summary: {
-          lead: pipeline['lead']?.length ?? 0,
-          qualified: pipeline['qualified']?.length ?? 0,
-          pitch: pipeline['pitch']?.length ?? 0,
-          dd: pipeline['dd']?.length ?? 0,
-          committee: pipeline['committee']?.length ?? 0,
-          term_sheet: pipeline['term_sheet']?.length ?? 0,
-          closed: pipeline['closed']?.length ?? 0,
-          passed: pipeline['passed']?.length ?? 0,
-        },
-      },
+      data,
     });
   } catch (error) {
     console.error('Pipeline fetch error:', error);
@@ -676,11 +456,7 @@ router['get']('/pipeline', async (req: Request, res: Response) => {
  */
 router['get']('/stages', async (_req: Request, res: Response) => {
   try {
-    const stages = await db
-      .select()
-      .from(pipelineStages)
-      .where(eq(pipelineStages.isActive, true))
-      .orderBy(pipelineStages.orderIndex);
+    const stages = await dealPipelineService.getPipelineStages();
 
     return res.json({
       success: true,
@@ -698,7 +474,7 @@ router['get']('/stages', async (_req: Request, res: Response) => {
 /**
  * POST /api/deals/:id/diligence - Add due diligence item
  */
-router['post']('/:id/diligence', idempotency, async (req: Request, res: Response) => {
+router['post']('/:id/diligence', idempotent, async (req: Request, res: Response) => {
   const paramId = firstString(req.params['id']);
   if (!paramId) {
     return res.status(400).json({ error: 'invalid_id', message: 'Deal ID is required' });
@@ -717,31 +493,10 @@ router['post']('/:id/diligence', idempotency, async (req: Request, res: Response
   }
 
   try {
-    // Verify deal exists
-    const [deal] = await db
-      .select()
-      .from(dealOpportunities)
-      .where(eq(dealOpportunities.id, dealId))
-      .limit(1);
-
-    if (!deal) {
+    const item = await dealPipelineService.createDiligenceItem(dealId, validation.data);
+    if (!item) {
       return res.status(404).json({ error: 'not_found', message: 'Deal not found' });
     }
-
-    const data = validation.data;
-    const [item] = await db
-      .insert(dueDiligenceItems)
-      .values({
-        opportunityId: dealId,
-        category: data.category,
-        item: data.item,
-        description: data.description ?? null,
-        status: data.status,
-        priority: data.priority,
-        assignedTo: data.assignedTo ?? null,
-        dueDate: data.dueDate ? new Date(data.dueDate) : null,
-      })
-      .returning();
 
     return res.status(201).json({
       success: true,
@@ -771,46 +526,11 @@ router['get']('/:id/diligence', async (req: Request, res: Response) => {
   }
 
   try {
-    const items = await db
-      .select()
-      .from(dueDiligenceItems)
-      .where(eq(dueDiligenceItems.opportunityId, dealId))
-      .orderBy(dueDiligenceItems.category, desc(dueDiligenceItems.createdAt));
-
-    // Group by category
-    const grouped: Record<string, typeof items> = {
-      Financial: [],
-      Legal: [],
-      Technical: [],
-      Market: [],
-      Team: [],
-    };
-
-    for (const item of items) {
-      const category = item.category as keyof typeof grouped;
-      if (grouped[category]) {
-        grouped[category].push(item);
-      }
-    }
-
-    // Calculate completion stats
-    const total = items.length;
-    const completed = items.filter((i) => i.status === 'completed').length;
-    const inProgress = items.filter((i) => i.status === 'in_progress').length;
+    const data = await dealPipelineService.getDiligenceItems(dealId);
 
     return res.json({
       success: true,
-      data: {
-        items,
-        grouped,
-        stats: {
-          total,
-          completed,
-          inProgress,
-          pending: total - completed - inProgress,
-          completionRate: total > 0 ? Math.round((completed / total) * 100) : 0,
-        },
-      },
+      data,
     });
   } catch (error) {
     console.error('DD items fetch error:', error);
@@ -876,8 +596,12 @@ router['post']('/opportunities/import/preview', async (req: Request, res: Respon
 
   try {
     const { rows: rawRows, fundId } = validation.data;
-    const valid: Array<{ index: number; data: z.infer<typeof ImportRowSchema> }> = [];
-    const invalid: Array<{ index: number; errors: string[] }> = [];
+    if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+
+    const valid: dealPipelineService.ImportPreviewRow[] = [];
+    const invalid: dealPipelineService.InvalidImportPreviewRow[] = [];
 
     for (let i = 0; i < rawRows.length; i++) {
       const result = ImportRowSchema.safeParse(rawRows[i]);
@@ -891,59 +615,16 @@ router['post']('/opportunities/import/preview', async (req: Request, res: Respon
       }
     }
 
-    // Check for duplicates among valid rows
-    const duplicates: Array<{ index: number; existingId: number; companyName: string }> = [];
-    if (valid.length > 0) {
-      const companyNames = valid.map((v) => v.data.companyName.trim().toLowerCase());
-      const conditions = [
-        sql`LOWER(TRIM(${dealOpportunities.companyName})) IN (${sql.join(
-          companyNames.map((n) => sql`${n}`),
-          sql`, `
-        )})`,
-      ];
-      if (fundId) {
-        conditions.push(eq(dealOpportunities.fundId, fundId));
-      }
-
-      const existing = await db
-        .select({
-          id: dealOpportunities.id,
-          companyName: dealOpportunities.companyName,
-          stage: dealOpportunities.stage,
-          fundId: dealOpportunities.fundId,
-        })
-        .from(dealOpportunities)
-        .where(and(...conditions));
-
-      const existingMap = new Map(existing.map((e) => [e.companyName.trim().toLowerCase(), e]));
-
-      for (const v of valid) {
-        const key = v.data.companyName.trim().toLowerCase();
-        const match = existingMap.get(key);
-        if (match) {
-          duplicates.push({
-            index: v.index,
-            existingId: match.id,
-            companyName: v.data.companyName,
-          });
-        }
-      }
-    }
-
-    const duplicateIndices = new Set(duplicates.map((d) => d.index));
-    const toImport = valid.filter((v) => !duplicateIndices.has(v.index));
+    const data = await dealPipelineService.previewImport({
+      rawRowCount: rawRows.length,
+      valid,
+      invalid,
+      fundId,
+    });
 
     return res.json({
       success: true,
-      data: {
-        total: rawRows.length,
-        valid: valid.length,
-        invalid: invalid.length,
-        duplicates: duplicates.length,
-        toImport: toImport.length,
-        invalidRows: invalid,
-        duplicateRows: duplicates,
-      },
+      data,
     });
   } catch (error) {
     console.error('Import preview error:', error);
@@ -958,7 +639,7 @@ router['post']('/opportunities/import/preview', async (req: Request, res: Respon
  * POST /api/deals/opportunities/import
  * Bulk import validated rows. Supports skip_duplicates mode.
  */
-router['post']('/opportunities/import', idempotency, async (req: Request, res: Response) => {
+router['post']('/opportunities/import', idempotent, async (req: Request, res: Response) => {
   const validation = ImportConfirmSchema.safeParse(req.body);
   if (!validation.success) {
     return res.status(400).json({
@@ -969,81 +650,15 @@ router['post']('/opportunities/import', idempotency, async (req: Request, res: R
 
   try {
     const { rows, fundId, mode } = validation.data;
-
-    // Build skip set for duplicates if needed
-    const skipSet = new Set<number>();
-    if (mode === 'skip_duplicates' && rows.length > 0) {
-      const companyNames = rows.map((r) => r.companyName.trim().toLowerCase());
-      const conditions = [
-        sql`LOWER(TRIM(${dealOpportunities.companyName})) IN (${sql.join(
-          companyNames.map((n) => sql`${n}`),
-          sql`, `
-        )})`,
-      ];
-      if (fundId) {
-        conditions.push(eq(dealOpportunities.fundId, fundId));
-      }
-
-      const existing = await db
-        .select({ companyName: dealOpportunities.companyName })
-        .from(dealOpportunities)
-        .where(and(...conditions));
-
-      const existingNames = new Set(existing.map((e) => e.companyName.trim().toLowerCase()));
-      rows.forEach((r, i) => {
-        if (existingNames.has(r.companyName.trim().toLowerCase())) {
-          skipSet.add(i);
-        }
-      });
+    if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
     }
 
-    let imported = 0;
-    const skipped = skipSet.size;
-    const failed: Array<{ index: number; message: string }> = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      if (skipSet.has(i)) continue;
-      const row = rows[i]!;
-      try {
-        await db.insert(dealOpportunities).values({
-          fundId: fundId ?? null,
-          companyName: row.companyName,
-          sector: row.sector,
-          stage: row.stage,
-          sourceType: row.sourceType,
-          dealSize: row.dealSize ? String(row.dealSize) : null,
-          valuation: row.valuation ? String(row.valuation) : null,
-          status: row.status ?? 'lead',
-          priority: row.priority ?? 'medium',
-          foundedYear: row.foundedYear ?? null,
-          employeeCount: row.employeeCount ?? null,
-          revenue: row.revenue ? String(row.revenue) : null,
-          description: row.description ?? null,
-          website: row.website || null,
-          contactName: row.contactName ?? null,
-          contactEmail: row.contactEmail || null,
-          contactPhone: row.contactPhone ?? null,
-          sourceNotes: row.sourceNotes ?? null,
-          nextAction: row.nextAction ?? null,
-        });
-        imported++;
-      } catch (err) {
-        failed.push({
-          index: i,
-          message: err instanceof Error ? err.message : 'Insert failed',
-        });
-      }
-    }
+    const data = await dealPipelineService.confirmImport({ rows, fundId, mode });
 
     return res.json({
-      success: failed.length === 0,
-      data: {
-        imported,
-        skipped,
-        failed: failed.length,
-        failedRows: failed,
-        total: rows.length,
-      },
+      success: data.failed === 0,
+      data,
     });
   } catch (error) {
     console.error('Import error:', error);
@@ -1076,7 +691,7 @@ const BulkArchiveSchema = z.object({
  * POST /api/deals/opportunities/bulk/status
  * Bulk update deal statuses. Idempotent per dealId+status pair.
  */
-router['post']('/opportunities/bulk/status', idempotency, async (req: Request, res: Response) => {
+router['post']('/opportunities/bulk/status', idempotent, async (req: Request, res: Response) => {
   const validation = BulkStatusSchema.safeParse(req.body);
   if (!validation.success) {
     return res.status(400).json({
@@ -1086,54 +701,11 @@ router['post']('/opportunities/bulk/status', idempotency, async (req: Request, r
   }
 
   try {
-    const { dealIds, status, notes } = validation.data;
-    const updatedIds: number[] = [];
-    const failed: Array<{ id: number; reason: string }> = [];
-
-    // Verify all deals exist first
-    const existing = await db
-      .select({ id: dealOpportunities.id, status: dealOpportunities.status })
-      .from(dealOpportunities)
-      .where(inArray(dealOpportunities.id, dealIds));
-
-    const existingMap = new Map(existing.map((e) => [e.id, e]));
-
-    for (const dealId of dealIds) {
-      const deal = existingMap.get(dealId);
-      if (!deal) {
-        failed.push({ id: dealId, reason: 'Deal not found' });
-        continue;
-      }
-      if (deal.status === status) {
-        updatedIds.push(dealId); // Already in target status = idempotent success
-        continue;
-      }
-      try {
-        await db
-          .update(dealOpportunities)
-          .set({ status, updatedAt: new Date() })
-          .where(eq(dealOpportunities.id, dealId));
-
-        await db.insert(pipelineActivities).values({
-          opportunityId: dealId,
-          type: 'stage_change',
-          title: `Bulk Status Change: ${deal.status} -> ${status}`,
-          description: notes ?? `Bulk status change to ${status}`,
-          completedDate: new Date(),
-        });
-
-        updatedIds.push(dealId);
-      } catch (err) {
-        failed.push({
-          id: dealId,
-          reason: err instanceof Error ? err.message : 'Update failed',
-        });
-      }
-    }
+    const data = await dealPipelineService.bulkUpdateStatus(validation.data);
 
     return res.json({
-      success: failed.length === 0,
-      data: { updatedIds, failed },
+      success: data.failed.length === 0,
+      data,
     });
   } catch (error) {
     console.error('Bulk status error:', error);
@@ -1148,7 +720,7 @@ router['post']('/opportunities/bulk/status', idempotency, async (req: Request, r
  * POST /api/deals/opportunities/bulk/archive
  * Bulk archive deals (soft delete to 'passed' status). Idempotent.
  */
-router['post']('/opportunities/bulk/archive', idempotency, async (req: Request, res: Response) => {
+router['post']('/opportunities/bulk/archive', idempotent, async (req: Request, res: Response) => {
   const validation = BulkArchiveSchema.safeParse(req.body);
   if (!validation.success) {
     return res.status(400).json({
@@ -1158,57 +730,11 @@ router['post']('/opportunities/bulk/archive', idempotency, async (req: Request, 
   }
 
   try {
-    const { dealIds } = validation.data;
-    const updatedIds: number[] = [];
-    const failed: Array<{ id: number; reason: string }> = [];
-
-    const existing = await db
-      .select({
-        id: dealOpportunities.id,
-        companyName: dealOpportunities.companyName,
-        status: dealOpportunities.status,
-      })
-      .from(dealOpportunities)
-      .where(inArray(dealOpportunities.id, dealIds));
-
-    const existingMap = new Map(existing.map((e) => [e.id, e]));
-
-    for (const dealId of dealIds) {
-      const deal = existingMap.get(dealId);
-      if (!deal) {
-        failed.push({ id: dealId, reason: 'Deal not found' });
-        continue;
-      }
-      if (deal.status === 'passed') {
-        updatedIds.push(dealId); // Already archived = idempotent success
-        continue;
-      }
-      try {
-        await db
-          .update(dealOpportunities)
-          .set({ status: 'passed', updatedAt: new Date() })
-          .where(eq(dealOpportunities.id, dealId));
-
-        await db.insert(pipelineActivities).values({
-          opportunityId: dealId,
-          type: 'stage_change',
-          title: 'Bulk Archive',
-          description: `Deal "${deal.companyName}" archived via bulk action`,
-          completedDate: new Date(),
-        });
-
-        updatedIds.push(dealId);
-      } catch (err) {
-        failed.push({
-          id: dealId,
-          reason: err instanceof Error ? err.message : 'Archive failed',
-        });
-      }
-    }
+    const data = await dealPipelineService.bulkArchive(validation.data);
 
     return res.json({
-      success: failed.length === 0,
-      data: { updatedIds, failed },
+      success: data.failed.length === 0,
+      data,
     });
   } catch (error) {
     console.error('Bulk archive error:', error);

--- a/server/services/deal-pipeline-service.ts
+++ b/server/services/deal-pipeline-service.ts
@@ -1,0 +1,719 @@
+import { and, asc, desc, eq, inArray, lt, or, sql, type SQL } from 'drizzle-orm';
+
+import { db } from '../db';
+import {
+  dealOpportunities,
+  dueDiligenceItems,
+  pipelineActivities,
+  pipelineStages,
+  scoringModels,
+} from '@shared/schema';
+
+export type DealStatus =
+  | 'lead'
+  | 'qualified'
+  | 'pitch'
+  | 'dd'
+  | 'committee'
+  | 'term_sheet'
+  | 'closed'
+  | 'passed';
+
+export type DealPriority = 'high' | 'medium' | 'low';
+export type DealSortBy = 'updatedAt' | 'companyName' | 'dealSize' | 'createdAt';
+export type DealSortDir = 'asc' | 'desc';
+
+export interface DealCursor {
+  createdAt: string;
+  id: number;
+}
+
+export interface CreateDealInput {
+  fundId?: number | undefined;
+  companyName: string;
+  sector: string;
+  stage: string;
+  sourceType: string;
+  dealSize?: number | undefined;
+  valuation?: number | undefined;
+  status: DealStatus;
+  priority: DealPriority;
+  foundedYear?: number | undefined;
+  employeeCount?: number | undefined;
+  revenue?: number | undefined;
+  description?: string | undefined;
+  website?: string | undefined;
+  contactName?: string | undefined;
+  contactEmail?: string | undefined;
+  contactPhone?: string | undefined;
+  sourceNotes?: string | undefined;
+  nextAction?: string | undefined;
+}
+
+export type UpdateDealInput = {
+  [K in keyof CreateDealInput]?: CreateDealInput[K] | undefined;
+};
+
+export interface ListDealsInput {
+  cursor?: DealCursor | undefined;
+  limit: number;
+  status?: DealStatus | undefined;
+  priority?: DealPriority | undefined;
+  fundId?: number | undefined;
+  search?: string | undefined;
+  sortBy: DealSortBy;
+  sortDir: DealSortDir;
+}
+
+export interface StageChangeInput {
+  status: DealStatus;
+  notes?: string | undefined;
+}
+
+export interface CreateDiligenceItemInput {
+  category: 'Financial' | 'Legal' | 'Technical' | 'Market' | 'Team';
+  item: string;
+  description?: string | undefined;
+  status: 'pending' | 'in_progress' | 'completed' | 'not_applicable';
+  priority: DealPriority;
+  assignedTo?: string | undefined;
+  dueDate?: string | undefined;
+}
+
+export interface ImportDealRowInput extends Omit<CreateDealInput, 'status' | 'priority'> {
+  status?: DealStatus | undefined;
+  priority?: DealPriority | undefined;
+}
+
+export interface ImportPreviewRow {
+  index: number;
+  data: ImportDealRowInput;
+}
+
+export interface InvalidImportPreviewRow {
+  index: number;
+  errors: string[];
+}
+
+export interface PreviewImportInput {
+  rawRowCount: number;
+  valid: ImportPreviewRow[];
+  invalid: InvalidImportPreviewRow[];
+  fundId?: number | undefined;
+}
+
+export interface ConfirmImportInput {
+  rows: ImportDealRowInput[];
+  fundId?: number | undefined;
+  mode: 'skip_duplicates' | 'import_all';
+}
+
+export interface BulkStatusInput {
+  dealIds: number[];
+  status: DealStatus;
+  notes?: string | undefined;
+}
+
+export interface BulkArchiveInput {
+  dealIds: number[];
+}
+
+type DealRow = typeof dealOpportunities.$inferSelect;
+type DiligenceItemRow = typeof dueDiligenceItems.$inferSelect;
+
+function toDealInsertValues(data: CreateDealInput) {
+  return {
+    fundId: data.fundId ?? null,
+    companyName: data.companyName,
+    sector: data.sector,
+    stage: data.stage,
+    sourceType: data.sourceType,
+    dealSize: data.dealSize ? String(data.dealSize) : null,
+    valuation: data.valuation ? String(data.valuation) : null,
+    status: data.status,
+    priority: data.priority,
+    foundedYear: data.foundedYear ?? null,
+    employeeCount: data.employeeCount ?? null,
+    revenue: data.revenue ? String(data.revenue) : null,
+    description: data.description ?? null,
+    website: data.website || null,
+    contactName: data.contactName ?? null,
+    contactEmail: data.contactEmail || null,
+    contactPhone: data.contactPhone ?? null,
+    sourceNotes: data.sourceNotes ?? null,
+    nextAction: data.nextAction ?? null,
+  };
+}
+
+function toDealUpdateValues(data: UpdateDealInput): Record<string, unknown> {
+  const updateData: Record<string, unknown> = {
+    updatedAt: new Date(),
+  };
+
+  if (data.fundId !== undefined) updateData['fundId'] = data.fundId;
+  if (data.companyName !== undefined) updateData['companyName'] = data.companyName;
+  if (data.sector !== undefined) updateData['sector'] = data.sector;
+  if (data.stage !== undefined) updateData['stage'] = data.stage;
+  if (data.sourceType !== undefined) updateData['sourceType'] = data.sourceType;
+  if (data.dealSize !== undefined) updateData['dealSize'] = String(data.dealSize);
+  if (data.valuation !== undefined) updateData['valuation'] = String(data.valuation);
+  if (data.status !== undefined) updateData['status'] = data.status;
+  if (data.priority !== undefined) updateData['priority'] = data.priority;
+  if (data.foundedYear !== undefined) updateData['foundedYear'] = data.foundedYear;
+  if (data.employeeCount !== undefined) updateData['employeeCount'] = data.employeeCount;
+  if (data.revenue !== undefined) updateData['revenue'] = String(data.revenue);
+  if (data.description !== undefined) updateData['description'] = data.description;
+  if (data.website !== undefined) updateData['website'] = data.website || null;
+  if (data.contactName !== undefined) updateData['contactName'] = data.contactName;
+  if (data.contactEmail !== undefined) updateData['contactEmail'] = data.contactEmail || null;
+  if (data.contactPhone !== undefined) updateData['contactPhone'] = data.contactPhone;
+  if (data.sourceNotes !== undefined) updateData['sourceNotes'] = data.sourceNotes;
+  if (data.nextAction !== undefined) updateData['nextAction'] = data.nextAction;
+
+  return updateData;
+}
+
+function dealNameCondition(companyNames: string[]): SQL<unknown> {
+  return sql`LOWER(TRIM(${dealOpportunities.companyName})) IN (${sql.join(
+    companyNames.map((name) => sql`${name}`),
+    sql`, `
+  )})`;
+}
+
+async function findDealById(id: number): Promise<DealRow | undefined> {
+  const [deal] = await db
+    .select()
+    .from(dealOpportunities)
+    .where(eq(dealOpportunities.id, id))
+    .limit(1);
+
+  return deal;
+}
+
+export async function createDeal(data: CreateDealInput) {
+  const [deal] = await db.insert(dealOpportunities).values(toDealInsertValues(data)).returning();
+
+  if (!deal) {
+    return undefined;
+  }
+
+  await db.insert(pipelineActivities).values({
+    opportunityId: deal.id,
+    type: 'stage_change',
+    title: 'Deal Created',
+    description: `New deal "${data.companyName}" added to pipeline`,
+    completedDate: new Date(),
+  });
+
+  return deal;
+}
+
+export async function listDeals(input: ListDealsInput) {
+  const { cursor, limit, status, priority, fundId, search, sortBy, sortDir } = input;
+  const conditions: SQL<unknown>[] = [];
+
+  if (status) {
+    conditions.push(eq(dealOpportunities.status, status));
+  }
+  if (priority) {
+    conditions.push(eq(dealOpportunities.priority, priority));
+  }
+  if (fundId) {
+    conditions.push(eq(dealOpportunities.fundId, fundId));
+  }
+  if (search) {
+    const searchCondition = or(
+      sql`${dealOpportunities.companyName} ILIKE ${`%${search}%`}`,
+      sql`${dealOpportunities.sector} ILIKE ${`%${search}%`}`,
+      sql`${dealOpportunities.description} ILIKE ${`%${search}%`}`
+    );
+    if (searchCondition) {
+      conditions.push(searchCondition);
+    }
+  }
+
+  const isDefaultSort = sortBy === 'createdAt' && sortDir === 'desc';
+  if (cursor && isDefaultSort) {
+    const cursorCondition = or(
+      lt(dealOpportunities.createdAt, new Date(cursor.createdAt)),
+      and(
+        eq(dealOpportunities.createdAt, new Date(cursor.createdAt)),
+        lt(dealOpportunities.id, cursor.id)
+      )
+    );
+    if (cursorCondition) {
+      conditions.push(cursorCondition);
+    }
+  }
+
+  const sortFn = sortDir === 'asc' ? asc : desc;
+  const sortColumn = {
+    updatedAt: dealOpportunities.updatedAt,
+    companyName: dealOpportunities.companyName,
+    dealSize: dealOpportunities.dealSize,
+    createdAt: dealOpportunities.createdAt,
+  }[sortBy];
+
+  const deals = await db
+    .select()
+    .from(dealOpportunities)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(sortFn(sortColumn), desc(dealOpportunities.id))
+    .limit(limit + 1);
+
+  const hasMore = deals.length > limit;
+  const items = hasMore ? deals.slice(0, limit) : deals;
+  const lastItem = items[items.length - 1];
+  const nextCursor =
+    hasMore && isDefaultSort && lastItem?.createdAt
+      ? {
+          createdAt: lastItem.createdAt,
+          id: lastItem.id,
+        }
+      : null;
+
+  return {
+    items,
+    pagination: {
+      hasMore,
+      nextCursor,
+      count: items.length,
+    },
+  };
+}
+
+export async function getDeal(id: number) {
+  const deal = await findDealById(id);
+
+  if (!deal) {
+    return undefined;
+  }
+
+  const [ddItems, activities, scores] = await Promise.all([
+    db
+      .select()
+      .from(dueDiligenceItems)
+      .where(eq(dueDiligenceItems.opportunityId, id))
+      .orderBy(desc(dueDiligenceItems.createdAt)),
+    db
+      .select()
+      .from(pipelineActivities)
+      .where(eq(pipelineActivities.opportunityId, id))
+      .orderBy(desc(pipelineActivities.createdAt))
+      .limit(20),
+    db
+      .select()
+      .from(scoringModels)
+      .where(eq(scoringModels.opportunityId, id))
+      .orderBy(desc(scoringModels.scoredAt)),
+  ]);
+
+  return {
+    ...deal,
+    dueDiligence: ddItems,
+    activities,
+    scores,
+  };
+}
+
+export async function updateDeal(id: number, data: UpdateDealInput) {
+  const existing = await findDealById(id);
+
+  if (!existing) {
+    return undefined;
+  }
+
+  const [updated] = await db
+    .update(dealOpportunities)
+    .set(toDealUpdateValues(data))
+    .where(eq(dealOpportunities.id, id))
+    .returning();
+
+  return updated;
+}
+
+export async function archiveDeal(id: number) {
+  const existing = await findDealById(id);
+
+  if (!existing) {
+    return undefined;
+  }
+
+  const [archived] = await db
+    .update(dealOpportunities)
+    .set({
+      status: 'passed',
+      updatedAt: new Date(),
+    })
+    .where(eq(dealOpportunities.id, id))
+    .returning();
+
+  await db.insert(pipelineActivities).values({
+    opportunityId: id,
+    type: 'stage_change',
+    title: 'Deal Archived',
+    description: `Deal "${existing.companyName}" was archived`,
+    completedDate: new Date(),
+  });
+
+  return archived;
+}
+
+export async function changeDealStage(id: number, input: StageChangeInput) {
+  const existing = await findDealById(id);
+
+  if (!existing) {
+    return undefined;
+  }
+
+  const previousStatus = existing.status;
+  const [updated] = await db
+    .update(dealOpportunities)
+    .set({
+      status: input.status,
+      updatedAt: new Date(),
+    })
+    .where(eq(dealOpportunities.id, id))
+    .returning();
+
+  await db.insert(pipelineActivities).values({
+    opportunityId: id,
+    type: 'stage_change',
+    title: `Stage Changed: ${previousStatus} -> ${input.status}`,
+    description: input.notes ?? `Deal moved from ${previousStatus} to ${input.status}`,
+    completedDate: new Date(),
+  });
+
+  return {
+    updated,
+    previousStatus,
+    newStatus: input.status,
+  };
+}
+
+export async function getPipeline(fundId?: number) {
+  const conditions = fundId ? eq(dealOpportunities.fundId, fundId) : undefined;
+
+  const deals = await db
+    .select()
+    .from(dealOpportunities)
+    .where(conditions)
+    .orderBy(desc(dealOpportunities.priority), desc(dealOpportunities.updatedAt));
+
+  const pipeline: Record<string, DealRow[]> = {
+    lead: [],
+    qualified: [],
+    pitch: [],
+    dd: [],
+    committee: [],
+    term_sheet: [],
+    closed: [],
+    passed: [],
+  };
+
+  for (const deal of deals) {
+    const status = deal.status;
+    if (status && pipeline[status]) {
+      pipeline[status].push(deal);
+    }
+  }
+
+  const stages = await db.select().from(pipelineStages).orderBy(pipelineStages.orderIndex);
+
+  return {
+    pipeline,
+    stages,
+    totalDeals: deals.length,
+    summary: {
+      lead: pipeline['lead']?.length ?? 0,
+      qualified: pipeline['qualified']?.length ?? 0,
+      pitch: pipeline['pitch']?.length ?? 0,
+      dd: pipeline['dd']?.length ?? 0,
+      committee: pipeline['committee']?.length ?? 0,
+      term_sheet: pipeline['term_sheet']?.length ?? 0,
+      closed: pipeline['closed']?.length ?? 0,
+      passed: pipeline['passed']?.length ?? 0,
+    },
+  };
+}
+
+export async function getPipelineStages() {
+  return db
+    .select()
+    .from(pipelineStages)
+    .where(eq(pipelineStages.isActive, true))
+    .orderBy(pipelineStages.orderIndex);
+}
+
+export async function createDiligenceItem(dealId: number, data: CreateDiligenceItemInput) {
+  const deal = await findDealById(dealId);
+
+  if (!deal) {
+    return undefined;
+  }
+
+  const [item] = await db
+    .insert(dueDiligenceItems)
+    .values({
+      opportunityId: dealId,
+      category: data.category,
+      item: data.item,
+      description: data.description ?? null,
+      status: data.status,
+      priority: data.priority,
+      assignedTo: data.assignedTo ?? null,
+      dueDate: data.dueDate ? new Date(data.dueDate) : null,
+    })
+    .returning();
+
+  return item;
+}
+
+export async function getDiligenceItems(dealId: number) {
+  const items = await db
+    .select()
+    .from(dueDiligenceItems)
+    .where(eq(dueDiligenceItems.opportunityId, dealId))
+    .orderBy(dueDiligenceItems.category, desc(dueDiligenceItems.createdAt));
+
+  const grouped: Record<string, DiligenceItemRow[]> = {
+    Financial: [],
+    Legal: [],
+    Technical: [],
+    Market: [],
+    Team: [],
+  };
+
+  for (const item of items) {
+    const category = item.category as keyof typeof grouped;
+    if (grouped[category]) {
+      grouped[category].push(item);
+    }
+  }
+
+  const total = items.length;
+  const completed = items.filter((item) => item.status === 'completed').length;
+  const inProgress = items.filter((item) => item.status === 'in_progress').length;
+
+  return {
+    items,
+    grouped,
+    stats: {
+      total,
+      completed,
+      inProgress,
+      pending: total - completed - inProgress,
+      completionRate: total > 0 ? Math.round((completed / total) * 100) : 0,
+    },
+  };
+}
+
+export async function previewImport(input: PreviewImportInput) {
+  const duplicates: Array<{ index: number; existingId: number; companyName: string }> = [];
+
+  if (input.valid.length > 0) {
+    const companyNames = input.valid.map((row) => row.data.companyName.trim().toLowerCase());
+    const conditions = [dealNameCondition(companyNames)];
+    if (input.fundId) {
+      conditions.push(eq(dealOpportunities.fundId, input.fundId));
+    }
+
+    const existing = await db
+      .select({
+        id: dealOpportunities.id,
+        companyName: dealOpportunities.companyName,
+        stage: dealOpportunities.stage,
+        fundId: dealOpportunities.fundId,
+      })
+      .from(dealOpportunities)
+      .where(and(...conditions));
+
+    const existingMap = new Map(
+      existing.map((deal) => [deal.companyName.trim().toLowerCase(), deal])
+    );
+
+    for (const row of input.valid) {
+      const key = row.data.companyName.trim().toLowerCase();
+      const match = existingMap.get(key);
+      if (match) {
+        duplicates.push({
+          index: row.index,
+          existingId: match.id,
+          companyName: row.data.companyName,
+        });
+      }
+    }
+  }
+
+  const duplicateIndices = new Set(duplicates.map((duplicate) => duplicate.index));
+  const toImport = input.valid.filter((row) => !duplicateIndices.has(row.index));
+
+  return {
+    total: input.rawRowCount,
+    valid: input.valid.length,
+    invalid: input.invalid.length,
+    duplicates: duplicates.length,
+    toImport: toImport.length,
+    invalidRows: input.invalid,
+    duplicateRows: duplicates,
+  };
+}
+
+export async function confirmImport(input: ConfirmImportInput) {
+  const skipSet = new Set<number>();
+  if (input.mode === 'skip_duplicates' && input.rows.length > 0) {
+    const companyNames = input.rows.map((row) => row.companyName.trim().toLowerCase());
+    const conditions = [dealNameCondition(companyNames)];
+    if (input.fundId) {
+      conditions.push(eq(dealOpportunities.fundId, input.fundId));
+    }
+
+    const existing = await db
+      .select({ companyName: dealOpportunities.companyName })
+      .from(dealOpportunities)
+      .where(and(...conditions));
+
+    const existingNames = new Set(existing.map((deal) => deal.companyName.trim().toLowerCase()));
+    input.rows.forEach((row, index) => {
+      if (existingNames.has(row.companyName.trim().toLowerCase())) {
+        skipSet.add(index);
+      }
+    });
+  }
+
+  let imported = 0;
+  const skipped = skipSet.size;
+  const failed: Array<{ index: number; message: string }> = [];
+
+  for (let index = 0; index < input.rows.length; index++) {
+    if (skipSet.has(index)) continue;
+    const row = input.rows[index];
+    if (!row) continue;
+
+    try {
+      const createInput: CreateDealInput = {
+        ...row,
+        status: row.status ?? 'lead',
+        priority: row.priority ?? 'medium',
+      };
+      if (input.fundId !== undefined) {
+        createInput.fundId = input.fundId;
+      }
+      await db.insert(dealOpportunities).values(toDealInsertValues(createInput));
+      imported++;
+    } catch (error) {
+      failed.push({
+        index,
+        message: error instanceof Error ? error.message : 'Insert failed',
+      });
+    }
+  }
+
+  return {
+    imported,
+    skipped,
+    failed: failed.length,
+    failedRows: failed,
+    total: input.rows.length,
+  };
+}
+
+export async function bulkUpdateStatus(input: BulkStatusInput) {
+  const updatedIds: number[] = [];
+  const failed: Array<{ id: number; reason: string }> = [];
+
+  const existing = await db
+    .select({ id: dealOpportunities.id, status: dealOpportunities.status })
+    .from(dealOpportunities)
+    .where(inArray(dealOpportunities.id, input.dealIds));
+
+  const existingMap = new Map(existing.map((deal) => [deal.id, deal]));
+
+  for (const dealId of input.dealIds) {
+    const deal = existingMap.get(dealId);
+    if (!deal) {
+      failed.push({ id: dealId, reason: 'Deal not found' });
+      continue;
+    }
+    if (deal.status === input.status) {
+      updatedIds.push(dealId);
+      continue;
+    }
+
+    try {
+      await db
+        .update(dealOpportunities)
+        .set({ status: input.status, updatedAt: new Date() })
+        .where(eq(dealOpportunities.id, dealId));
+
+      await db.insert(pipelineActivities).values({
+        opportunityId: dealId,
+        type: 'stage_change',
+        title: `Bulk Status Change: ${deal.status} -> ${input.status}`,
+        description: input.notes ?? `Bulk status change to ${input.status}`,
+        completedDate: new Date(),
+      });
+
+      updatedIds.push(dealId);
+    } catch (error) {
+      failed.push({
+        id: dealId,
+        reason: error instanceof Error ? error.message : 'Update failed',
+      });
+    }
+  }
+
+  return { updatedIds, failed };
+}
+
+export async function bulkArchive(input: BulkArchiveInput) {
+  const updatedIds: number[] = [];
+  const failed: Array<{ id: number; reason: string }> = [];
+
+  const existing = await db
+    .select({
+      id: dealOpportunities.id,
+      companyName: dealOpportunities.companyName,
+      status: dealOpportunities.status,
+    })
+    .from(dealOpportunities)
+    .where(inArray(dealOpportunities.id, input.dealIds));
+
+  const existingMap = new Map(existing.map((deal) => [deal.id, deal]));
+
+  for (const dealId of input.dealIds) {
+    const deal = existingMap.get(dealId);
+    if (!deal) {
+      failed.push({ id: dealId, reason: 'Deal not found' });
+      continue;
+    }
+    if (deal.status === 'passed') {
+      updatedIds.push(dealId);
+      continue;
+    }
+
+    try {
+      await db
+        .update(dealOpportunities)
+        .set({ status: 'passed', updatedAt: new Date() })
+        .where(eq(dealOpportunities.id, dealId));
+
+      await db.insert(pipelineActivities).values({
+        opportunityId: dealId,
+        type: 'stage_change',
+        title: 'Bulk Archive',
+        description: `Deal "${deal.companyName}" archived via bulk action`,
+        completedDate: new Date(),
+      });
+
+      updatedIds.push(dealId);
+    } catch (error) {
+      failed.push({
+        id: dealId,
+        reason: error instanceof Error ? error.message : 'Archive failed',
+      });
+    }
+  }
+
+  return { updatedIds, failed };
+}

--- a/tests/unit/components/layout/dynamic-fund-header.test.tsx
+++ b/tests/unit/components/layout/dynamic-fund-header.test.tsx
@@ -257,6 +257,34 @@ describe('DynamicFundHeader', () => {
     expect(metricLabel('Remaining').parentElement).toHaveTextContent('$50M');
   });
 
+  it('does not pair zero invested capital with a positive current value when investment facts are missing', () => {
+    mockUseFundMetrics.mockReturnValue({
+      data: makeMetrics({
+        totalCalled: 0,
+        totalDeployed: 0,
+        totalUncalled: 50_000_000,
+        currentNAV: 46_000_000,
+        totalDistributions: 0,
+        totalValue: 46_000_000,
+        tvpi: 0,
+        deploymentRate: 0,
+        activeCompanies: 3,
+        totalCompanies: 3,
+        averageCheckSize: 0,
+      }),
+      isLoading: false,
+      error: null,
+    });
+
+    render(<DynamicFundHeader />);
+
+    expect(screen.getByText('Awaiting deployment')).toBeInTheDocument();
+    expect(metricLabel('Total Invested').parentElement).toHaveTextContent('$0');
+    expect(metricLabel('Current Value').parentElement).toHaveTextContent('Needs investment facts');
+    expect(metricLabel('Current Value').parentElement).not.toHaveTextContent('$46M');
+    expect(screen.queryByText('$46M')).not.toBeInTheDocument();
+  });
+
   it('renders calculated IRR and DPI when actual cash-flow metrics are available', () => {
     mockUseFundMetrics.mockReturnValue({
       data: makeMetrics({
@@ -342,6 +370,33 @@ describe('DynamicFundHeader', () => {
     expect(navCard).toHaveTextContent('NAV');
     expect(navCard).toHaveTextContent('$40.0M');
     expect(navCard).not.toHaveTextContent('$46.0M');
+  });
+
+  it('keeps compact NAV truthful when valuations exist without investment facts', () => {
+    mockUseFlag.mockReturnValue(true);
+    mockUseFundMetrics.mockReturnValue({
+      data: makeMetrics({
+        totalCalled: 0,
+        totalDeployed: 0,
+        currentNAV: 46_000_000,
+        totalValue: 46_000_000,
+        tvpi: 0,
+        deploymentRate: 0,
+      }),
+      isLoading: false,
+      error: null,
+    });
+
+    render(<DynamicFundHeader />);
+
+    const navCard = screen.getByTestId('compact-kpi-nav');
+    expect(navCard).toHaveTextContent('NAV');
+    expect(navCard).toHaveTextContent('Needs investment facts');
+    expect(navCard).toHaveAttribute(
+      'title',
+      'NAV is unavailable until investment facts are recorded for valued portfolio companies.'
+    );
+    expect(screen.queryByText('$46.0M')).not.toBeInTheDocument();
   });
 
   it('renders compact KPI items in the canonical truth-line order', () => {

--- a/tests/unit/routes/deal-pipeline.contract.test.ts
+++ b/tests/unit/routes/deal-pipeline.contract.test.ts
@@ -1,0 +1,468 @@
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requestId } from '../../../server/middleware/requestId';
+import { clearIdempotencyCache } from '../../../server/middleware/idempotency';
+
+type QueryChain = PromiseLike<unknown[]> & {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+};
+
+type MutationChain = PromiseLike<unknown[]> & {
+  values: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+};
+
+const mockState = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+    insertReturningResults: [] as unknown[][],
+    updateReturningResults: [] as unknown[][],
+    insertValues: [] as unknown[],
+    updateSets: [] as unknown[],
+  };
+
+  function next(queue: unknown[][]): unknown[] {
+    return queue.shift() ?? [];
+  }
+
+  function thenFor(result: unknown[]): QueryChain['then'] {
+    return (onfulfilled, onrejected) => Promise.resolve(result).then(onfulfilled, onrejected);
+  }
+
+  function makeQuery(result: unknown[]): QueryChain {
+    const query = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => Promise.resolve(result)),
+      then: thenFor(result),
+    } as QueryChain;
+
+    return query;
+  }
+
+  function makeInsertMutation(table: unknown): MutationChain {
+    const result: unknown[] = [];
+    const mutation = {
+      values: vi.fn((payload: unknown) => {
+        state.insertValues.push({ table, payload });
+        return mutation;
+      }),
+      set: vi.fn(() => mutation),
+      where: vi.fn(() => mutation),
+      returning: vi.fn(() => Promise.resolve(next(state.insertReturningResults))),
+      then: thenFor(result),
+    } as MutationChain;
+
+    return mutation;
+  }
+
+  function makeUpdateMutation(table: unknown): MutationChain {
+    const result: unknown[] = [];
+    const mutation = {
+      values: vi.fn(() => mutation),
+      set: vi.fn((payload: unknown) => {
+        state.updateSets.push({ table, payload });
+        return mutation;
+      }),
+      where: vi.fn(() => mutation),
+      returning: vi.fn(() => Promise.resolve(next(state.updateReturningResults))),
+      then: thenFor(result),
+    } as MutationChain;
+
+    return mutation;
+  }
+
+  const db = {
+    select: vi.fn(() => makeQuery(next(state.selectResults))),
+    insert: vi.fn((table: unknown) => makeInsertMutation(table)),
+    update: vi.fn((table: unknown) => makeUpdateMutation(table)),
+  };
+
+  return { db, state };
+});
+
+const redisState = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  const redis = {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    setex: vi.fn(async (key: string, _ttl: number, value: string | number | Buffer) => {
+      store.set(key, String(value));
+      return 'OK';
+    }),
+    del: vi.fn(async (key: string) => (store.delete(key) ? 1 : 0)),
+  };
+
+  return { redis, store };
+});
+
+vi.mock('../../../server/db', () => ({
+  db: mockState.db,
+}));
+
+vi.mock('../../../server/db/redis-circuit', () => ({
+  redis: redisState.redis,
+}));
+
+import dealPipelineRouter from '../../../server/routes/deal-pipeline';
+
+function resetDbMock() {
+  mockState.state.selectResults = [];
+  mockState.state.insertReturningResults = [];
+  mockState.state.updateReturningResults = [];
+  mockState.state.insertValues = [];
+  mockState.state.updateSets = [];
+  mockState.db.select.mockClear();
+  mockState.db.insert.mockClear();
+  mockState.db.update.mockClear();
+}
+
+function resetRedisMock() {
+  redisState.store.clear();
+  redisState.redis.get.mockClear();
+  redisState.redis.setex.mockClear();
+  redisState.redis.del.mockClear();
+}
+
+function makeUser(fundIds: number[] = [1]): Express.User {
+  return {
+    id: 'test-user',
+    sub: 'test-user',
+    email: 'test@example.com',
+    role: 'admin',
+    roles: ['admin'],
+    fundIds,
+    ip: '127.0.0.1',
+    userAgent: 'vitest',
+  };
+}
+
+function makeApp(fundIds: number[] = [1]) {
+  const app = express();
+  app.use(requestId());
+  app.use(express.json());
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    req.user = makeUser(fundIds);
+    next();
+  });
+  app.use('/api/deals', dealPipelineRouter);
+  app.use((_req, res) => {
+    res.status(404).json({ error: 'not_found' });
+  });
+  return app;
+}
+
+function validDealPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    companyName: 'Contract Co',
+    sector: 'SaaS',
+    stage: 'Seed',
+    sourceType: 'Referral',
+    status: 'lead',
+    priority: 'medium',
+    ...overrides,
+  };
+}
+
+function dealRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 101,
+    fundId: 1,
+    companyName: 'Contract Co',
+    sector: 'SaaS',
+    stage: 'Seed',
+    sourceType: 'Referral',
+    status: 'lead',
+    priority: 'medium',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function cursorFor(payload: Record<string, unknown>) {
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+async function waitForIdempotencyCache() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+async function expectIdempotentReplay({
+  key,
+  arrange,
+  act,
+  expectedInsertCount,
+  expectedUpdateCount,
+}: {
+  key: string;
+  arrange: () => void;
+  act: () => request.Test;
+  expectedInsertCount: number;
+  expectedUpdateCount: number;
+}) {
+  arrange();
+
+  const first = await act().set('Idempotency-Key', key);
+
+  expect(first.status).toBeGreaterThanOrEqual(200);
+  expect(first.status).toBeLessThan(300);
+  expect(first.headers['idempotency-replay']).toBeUndefined();
+  expect(mockState.state.insertValues).toHaveLength(expectedInsertCount);
+  expect(mockState.state.updateSets).toHaveLength(expectedUpdateCount);
+
+  await waitForIdempotencyCache();
+
+  const second = await act().set('Idempotency-Key', key);
+
+  expect(second.status).toBe(first.status);
+  expect(second.body).toEqual(first.body);
+  expect(second.headers['idempotency-replay']).toBe('true');
+  expect(mockState.state.insertValues).toHaveLength(expectedInsertCount);
+  expect(mockState.state.updateSets).toHaveLength(expectedUpdateCount);
+}
+
+describe('deal pipeline route contracts', () => {
+  beforeEach(() => {
+    clearIdempotencyCache();
+    resetDbMock();
+    resetRedisMock();
+  });
+
+  afterEach(() => {
+    clearIdempotencyCache();
+    resetDbMock();
+    resetRedisMock();
+  });
+
+  it('rejects invalid opportunity IDs before DB access', async () => {
+    const app = makeApp();
+
+    const getResponse = await request(app).get('/api/deals/opportunities/not-a-number');
+    const putResponse = await request(app)
+      .put('/api/deals/opportunities/not-a-number')
+      .send(validDealPayload());
+    const deleteResponse = await request(app).delete('/api/deals/opportunities/not-a-number');
+    const stageResponse = await request(app)
+      .post('/api/deals/not-a-number/stage')
+      .send({ status: 'qualified' });
+
+    for (const response of [getResponse, putResponse, deleteResponse, stageResponse]) {
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: 'invalid_id',
+        message: 'Deal ID must be a number',
+      });
+    }
+    expect(mockState.db.select).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+    expect(mockState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed cursors without querying deals', async () => {
+    const response = await request(makeApp()).get('/api/deals/opportunities?cursor=not-json');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: 'invalid_cursor',
+      message: 'The provided cursor is invalid or expired',
+    });
+    expect(mockState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects structurally valid cursors with invalid timestamps without querying deals', async () => {
+    const cursor = cursorFor({ createdAt: 'not-a-date', id: 101 });
+    const response = await request(makeApp()).get(`/api/deals/opportunities?cursor=${cursor}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: 'invalid_cursor',
+      message: 'The provided cursor is invalid or expired',
+    });
+    expect(mockState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 with request id propagation for missing deal reads and mutations', async () => {
+    mockState.state.selectResults.push([], [], []);
+    const app = makeApp();
+
+    const getResponse = await request(app).get('/api/deals/opportunities/404');
+    const putResponse = await request(app)
+      .put('/api/deals/opportunities/404')
+      .send({ companyName: 'Missing Co' });
+    const deleteResponse = await request(app).delete('/api/deals/opportunities/404');
+
+    for (const response of [getResponse, putResponse, deleteResponse]) {
+      expect(response.status).toBe(404);
+      expect(response.headers['x-request-id']).toEqual(expect.any(String));
+      expect(response.body).toEqual({
+        error: 'not_found',
+        message: 'Deal not found',
+      });
+    }
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid import and bulk payloads before DB access', async () => {
+    const app = makeApp();
+
+    const preview = await request(app)
+      .post('/api/deals/opportunities/import/preview')
+      .send({ rows: [{ companyName: '', sector: 'Nope' }] });
+    const confirm = await request(app)
+      .post('/api/deals/opportunities/import')
+      .send({ rows: [{ companyName: '', sector: 'Nope' }] });
+    const bulkStatus = await request(app)
+      .post('/api/deals/opportunities/bulk/status')
+      .send({ dealIds: [], status: 'qualified' });
+    const bulkArchive = await request(app)
+      .post('/api/deals/opportunities/bulk/archive')
+      .send({ dealIds: [] });
+
+    expect(preview.status).toBe(200);
+    expect(preview.body.data).toMatchObject({
+      total: 1,
+      valid: 0,
+      invalid: 1,
+      toImport: 0,
+    });
+    expect(confirm.status).toBe(400);
+    expect(confirm.body).toMatchObject({ error: 'validation_error' });
+    expect(bulkStatus.status).toBe(400);
+    expect(bulkStatus.body).toMatchObject({ error: 'validation_error' });
+    expect(bulkArchive.status).toBe(400);
+    expect(bulkArchive.body).toMatchObject({ error: 'validation_error' });
+    expect(mockState.db.insert).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects provided fund scope across body and query surfaces before DB access', async () => {
+    const app = makeApp([1]);
+
+    const createBodyScope = await request(app)
+      .post('/api/deals/opportunities')
+      .send(validDealPayload({ fundId: 2 }));
+    const listQueryScope = await request(app).get('/api/deals/opportunities?fundId=2');
+    const updateBodyScope = await request(app)
+      .put('/api/deals/opportunities/101')
+      .send({ fundId: 2 });
+    const pipelineQueryScope = await request(app).get('/api/deals/pipeline?fundId=2');
+    const previewBodyScope = await request(app)
+      .post('/api/deals/opportunities/import/preview')
+      .send({ fundId: 2, rows: [validDealPayload({ companyName: 'Preview Co' })] });
+    const confirmBodyScope = await request(app)
+      .post('/api/deals/opportunities/import')
+      .send({ fundId: 2, rows: [validDealPayload({ companyName: 'Import Co' })] });
+
+    for (const response of [
+      createBodyScope,
+      listQueryScope,
+      updateBodyScope,
+      pipelineQueryScope,
+      previewBodyScope,
+      confirmBodyScope,
+    ]) {
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        error: 'Forbidden',
+        code: 'FUND_ACCESS_DENIED',
+      });
+    }
+    expect(mockState.db.select).not.toHaveBeenCalled();
+    expect(mockState.db.insert).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('replays create without duplicate deal or activity inserts', async () => {
+    await expectIdempotentReplay({
+      key: 'deal-create-once',
+      arrange: () => {
+        mockState.state.insertReturningResults.push([dealRow({ id: 201 })]);
+      },
+      act: () => request(makeApp()).post('/api/deals/opportunities').send(validDealPayload()),
+      expectedInsertCount: 2,
+      expectedUpdateCount: 0,
+    });
+  });
+
+  it('replays import without duplicate row inserts', async () => {
+    await expectIdempotentReplay({
+      key: 'deal-import-once',
+      arrange: () => {
+        mockState.state.selectResults.push([]);
+      },
+      act: () =>
+        request(makeApp())
+          .post('/api/deals/opportunities/import')
+          .send({ rows: [validDealPayload({ companyName: 'Import Co' })] }),
+      expectedInsertCount: 1,
+      expectedUpdateCount: 0,
+    });
+  });
+
+  it('replays stage change without duplicate update or activity insert', async () => {
+    await expectIdempotentReplay({
+      key: 'deal-stage-once',
+      arrange: () => {
+        mockState.state.selectResults.push([dealRow({ id: 202, status: 'lead' })]);
+        mockState.state.updateReturningResults.push([dealRow({ id: 202, status: 'qualified' })]);
+      },
+      act: () =>
+        request(makeApp())
+          .post('/api/deals/202/stage')
+          .send({ status: 'qualified', notes: 'contract pin' }),
+      expectedInsertCount: 1,
+      expectedUpdateCount: 1,
+    });
+  });
+
+  it('replays delete without duplicate archive update or activity insert', async () => {
+    await expectIdempotentReplay({
+      key: 'deal-delete-once',
+      arrange: () => {
+        mockState.state.selectResults.push([dealRow({ id: 203, status: 'lead' })]);
+        mockState.state.updateReturningResults.push([dealRow({ id: 203, status: 'passed' })]);
+      },
+      act: () => request(makeApp()).delete('/api/deals/opportunities/203'),
+      expectedInsertCount: 1,
+      expectedUpdateCount: 1,
+    });
+  });
+
+  it('replays bulk status without duplicate updates or activity inserts', async () => {
+    await expectIdempotentReplay({
+      key: 'deal-bulk-status-once',
+      arrange: () => {
+        mockState.state.selectResults.push([dealRow({ id: 204, status: 'lead' })]);
+      },
+      act: () =>
+        request(makeApp())
+          .post('/api/deals/opportunities/bulk/status')
+          .send({ dealIds: [204], status: 'qualified', notes: 'contract pin' }),
+      expectedInsertCount: 1,
+      expectedUpdateCount: 1,
+    });
+  });
+
+  it('replays bulk archive without duplicate updates or activity inserts', async () => {
+    await expectIdempotentReplay({
+      key: 'deal-bulk-archive-once',
+      arrange: () => {
+        mockState.state.selectResults.push([dealRow({ id: 205, status: 'lead' })]);
+      },
+      act: () =>
+        request(makeApp())
+          .post('/api/deals/opportunities/bulk/archive')
+          .send({ dealIds: [205] }),
+      expectedInsertCount: 1,
+      expectedUpdateCount: 1,
+    });
+  });
+});

--- a/tests/unit/server/route-surface-inventory.test.ts
+++ b/tests/unit/server/route-surface-inventory.test.ts
@@ -28,13 +28,35 @@ type SurfaceStatus =
   | 'registerRoutes-only-intentional'
   | 'registerRoutes-only-defect'
   | 'makeApp-only-intentional'
+  | 'makeApp-and-createServer-intentional'
   | 'makeApp-only-defect';
+
+type RouteSurface = 'registerRoutes' | 'makeApp' | 'createServer';
+type AuthPosture = 'protected' | 'public-pre-auth';
+type HttpMethod = 'DELETE' | 'GET' | 'POST' | 'PUT';
+
+type RouteSurfaceEndpoint = {
+  method: HttpMethod;
+  path: string;
+  mountSurfaces: readonly RouteSurface[];
+  authPosture: AuthPosture;
+  aliasOf?: string;
+};
+
+type ExternalOwnership = {
+  owner: string;
+  consumers: readonly string[];
+  evidenceFiles: readonly string[];
+};
 
 type RouteSurfaceInventoryEntry = {
   surfaceStatus: SurfaceStatus;
   registerRoutesMount?: string;
   makeAppMount?: string;
-  exposure: 'protected' | 'public-pre-auth';
+  createServerMount?: string;
+  exposure: AuthPosture;
+  endpoints: readonly RouteSurfaceEndpoint[];
+  externalOwnership?: ExternalOwnership;
   intent: string;
 };
 
@@ -44,12 +66,52 @@ const routeSurfaceInventory = {
     registerRoutesMount: '/api/deals',
     makeAppMount: '/api/deals',
     exposure: 'protected',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/api/deals/opportunities',
+        mountSurfaces: ['registerRoutes', 'makeApp'],
+        authPosture: 'protected',
+      },
+      {
+        method: 'POST',
+        path: '/api/deals/opportunities',
+        mountSurfaces: ['registerRoutes', 'makeApp'],
+        authPosture: 'protected',
+      },
+      {
+        method: 'PUT',
+        path: '/api/deals/opportunities/:id',
+        mountSurfaces: ['registerRoutes', 'makeApp'],
+        authPosture: 'protected',
+      },
+      {
+        method: 'DELETE',
+        path: '/api/deals/opportunities/:id',
+        mountSurfaces: ['registerRoutes', 'makeApp'],
+        authPosture: 'protected',
+      },
+      {
+        method: 'POST',
+        path: '/api/deals/:id/stage',
+        mountSurfaces: ['registerRoutes', 'makeApp'],
+        authPosture: 'protected',
+      },
+    ],
     intent: 'Core API route available through both active app bootstrap surfaces.',
   },
   reallocation: {
     surfaceStatus: 'registerRoutes-only-defect',
     registerRoutesMount: '/api/funds/:fundId/reallocation/*',
     exposure: 'protected',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/api/funds/:fundId/reallocation/preview',
+        mountSurfaces: ['registerRoutes'],
+        authPosture: 'protected',
+      },
+    ],
     intent:
       'Current route gap: full-path router is registerRoutes-only and must not be silently blessed before extraction.',
   },
@@ -57,21 +119,187 @@ const routeSurfaceInventory = {
     surfaceStatus: 'makeApp-only-intentional',
     makeAppMount: '/api-docs',
     exposure: 'public-pre-auth',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/api-docs',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api-docs.json',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+    ],
     intent: 'Developer documentation mount that is installed before the makeApp auth boundary.',
+  },
+  health: {
+    surfaceStatus: 'makeApp-only-intentional',
+    makeAppMount: '/',
+    exposure: 'public-pre-auth',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/healthz',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/readyz',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/health',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/health',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/health/ready',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/health/live',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/health/detailed-json',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/health/inflight',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/health/db',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/health/cache',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/health/queues',
+        mountSurfaces: ['makeApp'],
+        authPosture: 'public-pre-auth',
+      },
+    ],
+    intent:
+      'Health probes are mounted before the makeApp auth boundary for platform readiness checks.',
   },
   metrics: {
     surfaceStatus: 'both',
-    registerRoutesMount: '/api/metrics',
-    makeAppMount: '/api/metrics',
+    registerRoutesMount: '/metrics',
+    makeAppMount: '/metrics + /api/metrics',
+    createServerMount: '/metrics + /api/metrics',
     exposure: 'public-pre-auth',
-    intent: 'Operational telemetry endpoint mounted before auth in both app surfaces.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/metrics',
+        mountSurfaces: ['registerRoutes', 'makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/metrics',
+        mountSurfaces: ['makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+        aliasOf: '/metrics',
+      },
+    ],
+    externalOwnership: {
+      owner: 'Platform observability',
+      consumers: ['Prometheus scrapers', 'Grafana and alerting runbooks'],
+      evidenceFiles: ['docs/observability.md', 'docs/production-deployment-checklist.md'],
+    },
+    intent:
+      'Operational telemetry endpoint mounted before auth; /api/metrics is a compatibility alias for serverless/API-base consumers.',
   },
   rum: {
-    surfaceStatus: 'both',
-    registerRoutesMount: '/api/rum',
-    makeAppMount: '/api/rum',
+    surfaceStatus: 'makeApp-and-createServer-intentional',
+    makeAppMount: '/metrics/rum + /api/metrics/rum',
+    createServerMount: '/metrics/rum + /api/metrics/rum',
     exposure: 'public-pre-auth',
-    intent: 'Operational telemetry endpoint mounted before auth in both app surfaces.',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/metrics/rum',
+        mountSurfaces: ['makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'POST',
+        path: '/api/metrics/rum',
+        mountSurfaces: ['makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+        aliasOf: '/metrics/rum',
+      },
+      {
+        method: 'GET',
+        path: '/metrics/rum',
+        mountSurfaces: ['makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/metrics/rum',
+        mountSurfaces: ['makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+        aliasOf: '/metrics/rum',
+      },
+      {
+        method: 'GET',
+        path: '/metrics/rum/health',
+        mountSurfaces: ['makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+      },
+      {
+        method: 'GET',
+        path: '/api/metrics/rum/health',
+        mountSurfaces: ['makeApp', 'createServer'],
+        authPosture: 'public-pre-auth',
+        aliasOf: '/metrics/rum/health',
+      },
+    ],
+    externalOwnership: {
+      owner: 'Frontend performance observability',
+      consumers: [
+        'Browser Web Vitals beacons',
+        'Synthetic RUM health checks',
+        'Prometheus RUM scrape',
+      ],
+      evidenceFiles: [
+        'client/src/vitals.ts',
+        'docs/observability/rum.md',
+        'docs/production-deployment-checklist.md',
+      ],
+    },
+    intent:
+      'Browser telemetry ingress and RUM scrape endpoints are intentionally public before auth with /api aliases for API-base clients.',
   },
 } as const satisfies Record<string, RouteSurfaceInventoryEntry>;
 
@@ -185,6 +413,22 @@ describe('route surface inventory', () => {
       makeAppMount: '/api/deals',
       exposure: 'protected',
     });
+    expect(routeSurfaceInventory['deal-pipeline'].endpoints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          method: 'POST',
+          path: '/api/deals/opportunities',
+          mountSurfaces: ['registerRoutes', 'makeApp'],
+          authPosture: 'protected',
+        }),
+        expect.objectContaining({
+          method: 'POST',
+          path: '/api/deals/:id/stage',
+          mountSurfaces: ['registerRoutes', 'makeApp'],
+          authPosture: 'protected',
+        }),
+      ])
+    );
 
     expect(routeSurfaceInventory.reallocation).toMatchObject({
       surfaceStatus: 'registerRoutes-only-defect',
@@ -196,6 +440,78 @@ describe('route surface inventory', () => {
       surfaceStatus: 'makeApp-only-intentional',
       makeAppMount: '/api-docs',
       exposure: 'public-pre-auth',
+    });
+
+    expect(routeSurfaceInventory.health.endpoints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          method: 'GET',
+          path: '/healthz',
+          authPosture: 'public-pre-auth',
+        }),
+        expect.objectContaining({
+          method: 'GET',
+          path: '/api/health/ready',
+          authPosture: 'public-pre-auth',
+        }),
+      ])
+    );
+  });
+
+  it('pins public telemetry aliases to owners, consumers, and auth posture', () => {
+    expect(routeSurfaceInventory.metrics.endpoints).toEqual(
+      expect.arrayContaining([
+        {
+          method: 'GET',
+          path: '/metrics',
+          mountSurfaces: ['registerRoutes', 'makeApp', 'createServer'],
+          authPosture: 'public-pre-auth',
+        },
+        {
+          method: 'GET',
+          path: '/api/metrics',
+          mountSurfaces: ['makeApp', 'createServer'],
+          authPosture: 'public-pre-auth',
+          aliasOf: '/metrics',
+        },
+      ])
+    );
+    expect(routeSurfaceInventory.metrics.externalOwnership).toMatchObject({
+      owner: 'Platform observability',
+      consumers: ['Prometheus scrapers', 'Grafana and alerting runbooks'],
+    });
+
+    expect(routeSurfaceInventory.rum.endpoints).toEqual(
+      expect.arrayContaining([
+        {
+          method: 'POST',
+          path: '/metrics/rum',
+          mountSurfaces: ['makeApp', 'createServer'],
+          authPosture: 'public-pre-auth',
+        },
+        {
+          method: 'POST',
+          path: '/api/metrics/rum',
+          mountSurfaces: ['makeApp', 'createServer'],
+          authPosture: 'public-pre-auth',
+          aliasOf: '/metrics/rum',
+        },
+        {
+          method: 'GET',
+          path: '/api/metrics/rum/health',
+          mountSurfaces: ['makeApp', 'createServer'],
+          authPosture: 'public-pre-auth',
+          aliasOf: '/metrics/rum/health',
+        },
+      ])
+    );
+    expect(routeSurfaceInventory.rum.externalOwnership).toMatchObject({
+      owner: 'Frontend performance observability',
+      consumers: [
+        'Browser Web Vitals beacons',
+        'Synthetic RUM health checks',
+        'Prometheus RUM scrape',
+      ],
     });
   });
 
@@ -217,11 +533,59 @@ describe('route surface inventory', () => {
     expect(serverTs).not.toContain('/api-docs');
   });
 
+  it('matches telemetry alias inventory to source files and consumer evidence', async () => {
+    const [
+      routesTs,
+      appTs,
+      serverTs,
+      metricsEndpointTs,
+      rumTs,
+      rumIngressTs,
+      vitalsTs,
+      observabilityDoc,
+      rumDoc,
+      productionChecklist,
+    ] = await Promise.all([
+      readRepoFile('server/routes.ts'),
+      readRepoFile('server/app.ts'),
+      readRepoFile('server/server.ts'),
+      readRepoFile('server/routes/metrics-endpoint.ts'),
+      readRepoFile('server/routes/metrics-rum.ts'),
+      readRepoFile('server/routes/metrics-rum-ingress.ts'),
+      readRepoFile('client/src/vitals.ts'),
+      readRepoFile('docs/observability.md'),
+      readRepoFile('docs/observability/rum.md'),
+      readRepoFile('docs/production-deployment-checklist.md'),
+    ]);
+
+    expect(routesTs).toContain('app.use(metricsRouter)');
+    expect(routesTs).not.toContain('metricsRumRouter');
+    expect(metricsEndpointTs).toContain("metricsRouter['get']('/metrics'");
+
+    for (const source of [appTs, serverTs]) {
+      expect(source).toContain("app.use('/metrics', metricsRouter)");
+      expect(source).toContain("app.use('/api', metricsRouter)");
+      expect(source).toContain('installRumIngressGuards(app)');
+      expect(source).toContain('app.use(metricsRumRouter)');
+      expect(source).toContain("app.use('/api', metricsRumRouter)");
+    }
+
+    expect(rumIngressTs).toContain("['/metrics/rum', '/api/metrics/rum']");
+    expect(rumTs).toContain("'/metrics/rum'");
+    expect(rumTs).toContain("metricsRumRouter['get']('/metrics/rum'");
+    expect(rumTs).toContain("metricsRumRouter['get']('/metrics/rum/health'");
+    expect(vitalsTs).toContain("withApiBase('/api/metrics/rum')");
+
+    expect(observabilityDoc).toContain('| `/metrics` | Prometheus metrics |');
+    expect(rumDoc).toContain('# Real User Monitoring (RUM)');
+    expect(productionChecklist).toContain('RUM metrics flowing to Prometheus');
+  });
+
   it('keeps public telemetry and docs out of the protected API allowlist', () => {
     expect(isPublicApiPath('GET', '/deals/opportunities')).toBe(false);
     expect(isPublicApiPath('POST', '/funds/1/reallocation/preview')).toBe(false);
     expect(isPublicApiPath('GET', '/metrics')).toBe(false);
-    expect(isPublicApiPath('POST', '/rum')).toBe(false);
+    expect(isPublicApiPath('POST', '/metrics/rum')).toBe(false);
     expect(isPublicApiPath('GET', '/api-docs')).toBe(false);
   });
 

--- a/tests/unit/services/deal-pipeline-service.test.ts
+++ b/tests/unit/services/deal-pipeline-service.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type QueryChain = PromiseLike<unknown[]> & {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+};
+
+type MutationChain = PromiseLike<unknown[]> & {
+  values: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+};
+
+const mockState = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+    insertReturningResults: [] as unknown[][],
+    updateReturningResults: [] as unknown[][],
+    insertValues: [] as unknown[],
+    updateSets: [] as unknown[],
+  };
+
+  function next(queue: unknown[][]): unknown[] {
+    return queue.shift() ?? [];
+  }
+
+  function thenFor(result: unknown[]): QueryChain['then'] {
+    return (onfulfilled, onrejected) => Promise.resolve(result).then(onfulfilled, onrejected);
+  }
+
+  function makeQuery(result: unknown[]): QueryChain {
+    const query = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => Promise.resolve(result)),
+      then: thenFor(result),
+    } as QueryChain;
+
+    return query;
+  }
+
+  function makeInsertMutation(table: unknown): MutationChain {
+    const result: unknown[] = [];
+    const mutation = {
+      values: vi.fn((payload: unknown) => {
+        state.insertValues.push({ table, payload });
+        return mutation;
+      }),
+      set: vi.fn(() => mutation),
+      where: vi.fn(() => mutation),
+      returning: vi.fn(() => Promise.resolve(next(state.insertReturningResults))),
+      then: thenFor(result),
+    } as MutationChain;
+
+    return mutation;
+  }
+
+  function makeUpdateMutation(table: unknown): MutationChain {
+    const result: unknown[] = [];
+    const mutation = {
+      values: vi.fn(() => mutation),
+      set: vi.fn((payload: unknown) => {
+        state.updateSets.push({ table, payload });
+        return mutation;
+      }),
+      where: vi.fn(() => mutation),
+      returning: vi.fn(() => Promise.resolve(next(state.updateReturningResults))),
+      then: thenFor(result),
+    } as MutationChain;
+
+    return mutation;
+  }
+
+  const db = {
+    select: vi.fn(() => makeQuery(next(state.selectResults))),
+    insert: vi.fn((table: unknown) => makeInsertMutation(table)),
+    update: vi.fn((table: unknown) => makeUpdateMutation(table)),
+  };
+
+  return { db, state };
+});
+
+vi.mock('../../../server/db', () => ({
+  db: mockState.db,
+}));
+
+import {
+  bulkUpdateStatus,
+  confirmImport,
+  previewImport,
+  type ImportDealRowInput,
+} from '../../../server/services/deal-pipeline-service';
+
+function resetDbMock() {
+  mockState.state.selectResults = [];
+  mockState.state.insertReturningResults = [];
+  mockState.state.updateReturningResults = [];
+  mockState.state.insertValues = [];
+  mockState.state.updateSets = [];
+  mockState.db.select.mockClear();
+  mockState.db.insert.mockClear();
+  mockState.db.update.mockClear();
+}
+
+function importRow(companyName: string): ImportDealRowInput {
+  return {
+    companyName,
+    sector: 'SaaS',
+    stage: 'Seed',
+    sourceType: 'Referral',
+  };
+}
+
+function payloadAt(index: number) {
+  const entry = mockState.state.insertValues[index] as { payload?: unknown } | undefined;
+  return entry?.payload;
+}
+
+describe('deal pipeline service', () => {
+  beforeEach(() => {
+    resetDbMock();
+  });
+
+  it('previews import duplicates without writing deals', async () => {
+    mockState.state.selectResults.push([
+      { id: 11, companyName: 'Acme AI', stage: 'Seed', fundId: 1 },
+    ]);
+
+    const result = await previewImport({
+      rawRowCount: 2,
+      valid: [
+        { index: 0, data: importRow('Acme AI') },
+        { index: 1, data: importRow('Beta Cloud') },
+      ],
+      invalid: [],
+      fundId: 1,
+    });
+
+    expect(result).toMatchObject({
+      total: 2,
+      valid: 2,
+      invalid: 0,
+      duplicates: 1,
+      toImport: 1,
+      duplicateRows: [{ index: 0, existingId: 11, companyName: 'Acme AI' }],
+    });
+    expect(mockState.db.insert).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('confirms import with skip-duplicates while inserting only new rows', async () => {
+    mockState.state.selectResults.push([{ companyName: 'Acme AI' }]);
+
+    const result = await confirmImport({
+      rows: [importRow('Acme AI'), importRow('Beta Cloud')],
+      fundId: 1,
+      mode: 'skip_duplicates',
+    });
+
+    expect(result).toMatchObject({
+      imported: 1,
+      skipped: 1,
+      failed: 0,
+      total: 2,
+    });
+    expect(mockState.state.insertValues).toHaveLength(1);
+    expect(payloadAt(0)).toMatchObject({
+      fundId: 1,
+      companyName: 'Beta Cloud',
+      status: 'lead',
+      priority: 'medium',
+    });
+  });
+
+  it('bulk-updates status idempotently and reports missing deals', async () => {
+    mockState.state.selectResults.push([
+      { id: 1, status: 'qualified' },
+      { id: 2, status: 'lead' },
+    ]);
+
+    const result = await bulkUpdateStatus({
+      dealIds: [1, 2, 3],
+      status: 'qualified',
+      notes: 'service contract',
+    });
+
+    expect(result).toEqual({
+      updatedIds: [1, 2],
+      failed: [{ id: 3, reason: 'Deal not found' }],
+    });
+    expect(mockState.state.updateSets).toHaveLength(1);
+    expect(mockState.state.insertValues).toHaveLength(1);
+    expect(payloadAt(0)).toMatchObject({
+      opportunityId: 2,
+      title: 'Bulk Status Change: lead -> qualified',
+      description: 'service contract',
+    });
+  });
+});


### PR DESCRIPTION
### Summary

This PR introduces a significant refactoring of the POVC Fund-Modeling Platform by decoupling the deal-pipeline persistence logic from the route handlers and migrating it to a dedicated service layer. Additionally, it addresses a critical data presentation issue in the fund header to prevent contradictory Net Asset Value (NAV) metrics from rendering when foundational investment facts are missing.

### Key Changes

* **Deal Pipeline Architecture Refactor:** Migrated heavy database operations and business logic out of `server/routes/deal-pipeline.ts` (removing ~570 lines) and centralized it within a newly created `server/services/deal-pipeline-service.ts` module.
* **NAV Metric Integrity:** Updated `client/src/lib/fund-header-metric-calculations.ts` to enforce strict NAV availability checks via the new `getNavAvailability` function. The UI will now suppress current NAV valuations and display an explicit "Needs investment facts" warning if total invested capital is missing or zero.
* **Type Definitions Update:** Expanded the `HeaderMetrics` interface in `client/src/types/fund-header-metrics.ts` to include `nav` inside the `availability` object, standardizing how NAV edge cases are tracked alongside IRR and DPI.
* **Test Coverage Expansion:** * Added a robust unit test suite (`tests/unit/services/deal-pipeline-service.test.ts`) to validate the new service layer's handling of `previewImport`, `confirmImport`, and `bulkUpdateStatus`.
* Updated `tests/unit/components/layout/dynamic-fund-header.test.tsx` to verify that compact and full metric cards successfully default to the truthful fallback state when valuations exist without underlying investment facts.



### Impact

* **Maintainability:** Thinning out the API route layer firmly separates concerns, making the deal pipeline's core logic highly testable, isolated, and easier to extend for future features.
* **User Trust & Data Accuracy:** Prevents LP and GP users from viewing mathematically contradictory performance states (e.g., a positive fund valuation with $0 deployed), ensuring the platform strictly enforces chronological data entry.

### Testing

* **Unit & Contract Tests:** Execute the test suite to ensure the newly added backend tests (`deal-pipeline-service.test.ts`, `deal-pipeline.contract.test.ts`) and UI component tests pass successfully.
* **Pipeline Regression Validation:** Manually execute the deal pipeline CSV import flow (validating the preview calculation, confirmation, and skip-duplicates logic) as well as the bulk status update functionality to ensure exact parity with pre-refactor behavior.
* **Fund Header UI Edge Cases:** Load a fund scenario in the application containing $0 total deployed capital but possessing a positive `currentNAV`. Confirm that both the primary metric card and the compact KPI item display "Needs investment facts" and completely obscure the $46M (or equivalent) monetary figure.