### PR TITLE
chore: harden Hermes routing gates

### DIFF
--- a/docs/DISCOVERY-MAP.source.yaml
+++ b/docs/DISCOVERY-MAP.source.yaml
@@ -30,6 +30,7 @@ configuration:
     - 'docs/forecasting/*.md' # Monte Carlo, power law
     - 'cheatsheets/**/*.md'
     - '.claude/**/*.md'
+    - '.claude/**/*.json'
     - '.claude/agents/*.md'
     - '.claude/skills/**/*.md'
     - '.claude/commands/*.md'

--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-05-20T06:02:57.970Z",
+  "generatedAt": "2026-05-20T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": ["CLAUDE.md"],
     "adr": ["docs/adr/", ".claude/commands/log-decision.md"],

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -1473,6 +1473,18 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/hermes/model-routing.json",
+      "staleDays": 0,
+      "status": "INDEXED"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {
         "last_updated": "2026-01-19",
         "status": "HISTORICAL"
@@ -1544,6 +1556,18 @@
       "path": ".claude/integration-test-reenable-plan.md",
       "staleDays": 121,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/large-file-allowlist.json",
+      "staleDays": 0,
+      "status": "INDEXED"
     },
     {
       "docType": "doc",
@@ -1902,6 +1926,30 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/schemas/handoff.schema.json",
+      "staleDays": 0,
+      "status": "INDEXED"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/schemas/telemetry-event.schema.json",
+      "staleDays": 0,
+      "status": "INDEXED"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {
         "last_updated": "2026-01-19",
         "status": "HISTORICAL"
@@ -1945,6 +1993,18 @@
       "status": "ACTIVE"
     },
     {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/settings.json",
+      "staleDays": 0,
+      "status": "INDEXED"
+    },
+    {
       "docType": "skill",
       "exists": true,
       "frontmatter": {
@@ -1972,6 +2032,18 @@
       "path": ".claude/skills/README.md",
       "staleDays": 121,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "skill",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/skills/_index.json",
+      "staleDays": 0,
+      "status": "INDEXED"
     },
     {
       "docType": "skill",
@@ -2611,6 +2683,30 @@
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
       "staleDays": 47,
       "status": "UNKNOWN"
+    },
+    {
+      "docType": "skill",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/skills/planning-with-files/.claude-plugin/marketplace.json",
+      "staleDays": 0,
+      "status": "INDEXED"
+    },
+    {
+      "docType": "skill",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": null,
+      "owner": null,
+      "path": ".claude/skills/planning-with-files/.claude-plugin/plugin.json",
+      "staleDays": 0,
+      "status": "INDEXED"
     },
     {
       "docType": "skill",
@@ -11759,14 +11855,19 @@
     {
       "docType": "doc",
       "exists": true,
-      "frontmatter": {},
+      "frontmatter": {
+        "categories": ["planning", "hermes", "orchestration"],
+        "last_updated": "2026-05-20",
+        "owner": "Platform Team",
+        "status": "ACTIVE"
+      },
       "hasExecutionClaims": false,
-      "isStale": true,
-      "lastUpdated": null,
-      "owner": null,
+      "isStale": false,
+      "lastUpdated": "2026-05-20",
+      "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-20-hermes-integration.md",
-      "staleDays": 999,
-      "status": "UNKNOWN"
+      "staleDays": 0,
+      "status": "ACTIVE"
     },
     {
       "docType": "doc",
@@ -12224,7 +12325,7 @@
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-05-20T06:02:57.970Z",
+  "generatedAt": "2026-05-20T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -13327,7 +13428,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED": 1,
-      "ACTIVE": 493,
+      "ACTIVE": 494,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETED": 1,
@@ -13336,17 +13437,18 @@
       "HISTORICAL-FRAMEWORK": 1,
       "HISTORICAL-SNAPSHOT": 1,
       "IMPLEMENTED": 1,
+      "INDEXED": 8,
       "REFERENCE": 6,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 136,
+      "UNKNOWN": 135,
       "VERIFIED": 9,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 16,
-    "stale_docs": 98,
-    "total_docs": 723
+    "missing_frontmatter": 15,
+    "stale_docs": 97,
+    "total_docs": 731
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -4,25 +4,26 @@ last_updated: 2026-05-20
 
 # Staleness Report
 
-_Generated: 2026-05-20T06:02:57.970Z_ _Source: docs/DISCOVERY-MAP.source.yaml_
+_Generated: 2026-05-20T00:00:00.000Z_ _Source: docs/DISCOVERY-MAP.source.yaml_
 
 ## Summary
 
 | Metric              | Value |
 | ------------------- | ----- |
-| Total Documents     | 723   |
-| Stale Documents     | 98    |
-| Missing Frontmatter | 16    |
+| Total Documents     | 731   |
+| Stale Documents     | 97    |
+| Missing Frontmatter | 15    |
 
 ### By Status
 
 | Status                  | Count |
 | ----------------------- | ----- |
-| ACTIVE                  | 493   |
-| UNKNOWN                 | 136   |
+| ACTIVE                  | 494   |
+| UNKNOWN                 | 135   |
 | HISTORICAL              | 34    |
 | DRAFT                   | 31    |
 | VERIFIED                | 9     |
+| INDEXED                 | 8     |
 | REFERENCE               | 6     |
 | ready                   | 3     |
 | active                  | 2     |
@@ -77,7 +78,6 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/plans/2026-05-15-term-conflict-tier2-fixes.md`            | Never        | 999      | YES - verify!        | Unassigned |
 | `docs/superpowers/plans/2026-05-16-variance-calculation-extraction.md`      | Never        | 999      | YES - verify!        | Unassigned |
 | `docs/superpowers/plans/2026-05-19-ca-period-truth-harness-remediation.md`  | Never        | 999      | No                   | Unassigned |
-| `docs/superpowers/plans/2026-05-20-hermes-integration.md`                   | Never        | 999      | No                   | Unassigned |
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md`   | Never        | 999      | YES - verify!        | Unassigned |
 | `.claude/skills/planning-with-files/CHANGELOG.md`                           | 2026-01-19   | 121      | No                   | Unassigned |
 | `cheatsheets/agent-architecture.md`                                         | 2026-01-19   | 121      | No                   | Unassigned |
@@ -92,8 +92,9 @@ Documents that need review (older than their cadence threshold):
 | `cheatsheets/codex-collaboration-protocol.md`                               | 2026-01-19   | 121      | No                   | Unassigned |
 | `cheatsheets/coding-pairs-playbook.md`                                      | 2026-01-19   | 121      | No                   | Unassigned |
 | `cheatsheets/command-summary.md`                                            | 2026-01-19   | 121      | No                   | Unassigned |
+| `cheatsheets/correct-workflow-example.md`                                   | 2026-01-19   | 121      | No                   | Unassigned |
 
-_...and 48 more stale documents._
+_...and 47 more stale documents._
 
 ## Documents with Execution Claims (Need Verification)
 
@@ -137,7 +138,6 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/superpowers/plans/2026-05-15-term-conflict-tier2-fixes.md`
 - [ ] `docs/superpowers/plans/2026-05-16-variance-calculation-extraction.md`
 - [ ] `docs/superpowers/plans/2026-05-19-ca-period-truth-harness-remediation.md`
-- [ ] `docs/superpowers/plans/2026-05-20-hermes-integration.md`
 - [ ] `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md`
 
 ---

--- a/docs/superpowers/plans/2026-05-20-hermes-integration.md
+++ b/docs/superpowers/plans/2026-05-20-hermes-integration.md
@@ -1,3 +1,10 @@
+---
+status: ACTIVE
+last_updated: 2026-05-20
+owner: Platform Team
+categories: [planning, hermes, orchestration]
+---
+
 # Hermes Integration Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
@@ -450,3 +457,24 @@ Expected: PASS or no new baseline regression.
   executable tasks.
 - Type consistency: test imports match planned `orchestrate.js` exports, and
   routing plan fields match CLI JSON output.
+
+## Hardening Follow-ups
+
+Approved follow-ups after the landed MVP:
+
+- Enforce Hermes gates in `orchestrate.js` around real model execution.
+- Keep the escape hatch limited to `--skip-preflight-gate --skip-reason`.
+- Never skip production-financial postflight gates.
+- Add `.claude/**/*.json` to discovery scanning so Hermes routing config is
+  discoverable.
+- Keep exactly one `hermes_dev_coop` discovery pattern.
+- Do not add `dev-pipeline.ts` as part of this MVP hardening pass.
+- Do not rewrite `orchestrate.js` wholesale; preserve the thin task-bus shape.
+- Do not touch financial calculation code.
+
+## Prune-Policy Reassessment
+
+`DEV_BRAIN.md` and `.claude/hermes/SOUL.md` remain intentionally small runtime
+prompt inputs. Their model-lane guidance, handoff rules, and Hermes identity are
+not fully derivable from code, and `orchestrate.js` loads them into spawned
+model prompts. Keep them unless a future change removes that runtime dependency.

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -37,6 +37,8 @@ function parseArgs(argv = []) {
     dryRun: false,
     json: false,
     help: false,
+    skipPreflightGate: false,
+    gateSkipReason: null,
     manualModel: null,
     legacyCommand: null,
   };
@@ -55,6 +57,13 @@ function parseArgs(argv = []) {
       options.dryRun = true;
     } else if (arg === '--json') {
       options.json = true;
+    } else if (arg === '--skip-gates') {
+      throw new Error('Use --skip-preflight-gate with --skip-reason instead of --skip-gates.');
+    } else if (arg === '--skip-preflight-gate') {
+      options.skipPreflightGate = true;
+    } else if (arg === '--skip-reason') {
+      options.gateSkipReason = argv[index + 1] || '';
+      index += 1;
     } else if (arg === '--phase') {
       options.phase = argv[index + 1] || options.phase;
       index += 1;
@@ -71,6 +80,12 @@ function parseArgs(argv = []) {
   }
 
   options.task = options.task.trim();
+  options.gateSkipReason = options.gateSkipReason?.trim() || null;
+
+  if (options.skipPreflightGate && !options.gateSkipReason) {
+    throw new Error('--skip-preflight-gate requires --skip-reason <reason>.');
+  }
+
   return options;
 }
 
@@ -151,12 +166,19 @@ function resolveGate(phase, specialist, gates = {}) {
   return gates[phase] || null;
 }
 
-function createRoutingPlan({ phase, task, routing, manualModel = null }) {
+function createRoutingPlan({
+  phase,
+  task,
+  routing,
+  manualModel = null,
+  skipPreflightGate = false,
+  gateSkipReason = null,
+}) {
   const specialist = scoreSpecialist(task, routing.specialists || {}, routing.scoring || {});
   const model = chooseModel(task, phase, routing, manualModel);
   const gate = resolveGate(phase, specialist, routing.gates || {});
 
-  return {
+  const plan = {
     phase,
     task,
     model,
@@ -165,6 +187,15 @@ function createRoutingPlan({ phase, task, routing, manualModel = null }) {
     score: specialist?.score || 0,
     gate,
   };
+
+  if (skipPreflightGate) {
+    plan.gateSkip = {
+      preflight: true,
+      reason: gateSkipReason || 'unspecified',
+    };
+  }
+
+  return plan;
 }
 
 function buildPrompt({ plan, brain, soul = '' }) {
@@ -240,6 +271,50 @@ function executeModel(model, prompt, routing, env = process.env) {
   });
 }
 
+function runGate(
+  gate,
+  { runner = spawnSync, env = process.env, stdio = 'inherit', throwOnFailure = true } = {}
+) {
+  const command = String(gate || '').trim();
+  if (!command) {
+    return { command: null, skipped: true, status: 0 };
+  }
+
+  const [bin, ...args] = command.split(/\s+/);
+  const result = runner(bin, args, {
+    env,
+    shell: process.platform === 'win32',
+    stdio,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const status = result.status ?? 0;
+  if (status !== 0 && throwOnFailure) {
+    throw new Error(`Gate failed (${command}) with exit code ${status}`);
+  }
+
+  return { command, skipped: false, status };
+}
+
+function getGateRunPlan(plan, { skipPreflightGate = false } = {}) {
+  const hasGate = Boolean(plan.gate);
+  return {
+    preflight: hasGate && !skipPreflightGate,
+    postflight: hasGate,
+  };
+}
+
+function isProductionFinancial(plan) {
+  return plan.phase === 'production' && plan.risk === 'financial';
+}
+
+function shouldRunPostflightGate(plan, code, gates) {
+  return gates.postflight && (code === 0 || isProductionFinancial(plan));
+}
+
 function printHelp(stdout = process.stdout) {
   stdout.write(`Usage:
   node orchestrate.js --phase <phase> --task "<description>"
@@ -247,7 +322,7 @@ function printHelp(stdout = process.stdout) {
   node orchestrate.js --dry-run --phase research --task "trace reserve engine flow"
 
 Phases: research | production | distribution
-Options: --claude | --codex | --kimi | --dry-run | --json | --help
+Options: --claude | --codex | --kimi | --dry-run | --json | --skip-preflight-gate --skip-reason "<reason>" | --help
 Legacy commands: bootstrap | smoke | enable-algorithms
 `);
 }
@@ -334,8 +409,10 @@ class Orchestrator {
   }
 }
 
-async function main(argv = process.argv.slice(2), env = process.env, io = process) {
+async function main(argv = process.argv.slice(2), env = process.env, io = process, deps = {}) {
   const options = parseArgs(argv);
+  const runModel = deps.executeModel || executeModel;
+  const gateRunner = deps.gateRunner || spawnSync;
 
   if (options.help) {
     printHelp(io.stdout);
@@ -358,14 +435,16 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
     env.HERMES_MODEL_ROUTING_FILE || join(ROOT, '.claude', 'hermes', 'model-routing.json');
   const brainPath = env.HERMES_DEV_BRAIN_FILE || join(ROOT, 'DEV_BRAIN.md');
   const soulPath = env.HERMES_SOUL_FILE || join(ROOT, '.claude', 'hermes', 'SOUL.md');
-  const routing = loadJSON(routingPath);
-  const brain = loadText(brainPath);
-  const soul = loadText(soulPath, { optional: true });
+  const routing = deps.routing || loadJSON(routingPath);
+  const brain = deps.brain ?? loadText(brainPath);
+  const soul = deps.soul ?? loadText(soulPath, { optional: true });
   const plan = createRoutingPlan({
     phase: options.phase,
     task: options.task,
     routing,
     manualModel: options.manualModel,
+    skipPreflightGate: options.skipPreflightGate,
+    gateSkipReason: options.gateSkipReason,
   });
   const prompt = buildPrompt({ plan, brain, soul });
 
@@ -382,7 +461,42 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
     return 0;
   }
 
-  return executeModel(plan.model, prompt, routing, env);
+  const gates = getGateRunPlan(plan, options);
+
+  if (gates.preflight) {
+    const preflight = runGate(plan.gate, {
+      env,
+      runner: gateRunner,
+      throwOnFailure: false,
+    });
+    if (preflight.status !== 0) {
+      return preflight.status;
+    }
+  } else if (plan.gate && options.skipPreflightGate) {
+    io.stderr.write(
+      `[hermes] WARNING: skipping preflight gate "${plan.gate}"; reason: ${options.gateSkipReason}\n`
+    );
+  }
+
+  const code = await runModel(plan.model, prompt, routing, env);
+
+  if (shouldRunPostflightGate(plan, code, gates)) {
+    const postflight = runGate(plan.gate, {
+      env,
+      runner: gateRunner,
+      throwOnFailure: false,
+    });
+    if (postflight.status !== 0) {
+      if (code !== 0) {
+        io.stderr.write(
+          `[hermes] WARNING: model exited ${code} and postflight gate exited ${postflight.status}\n`
+        );
+      }
+      return postflight.status;
+    }
+  }
+
+  return code;
 }
 
 if (isCliEntryPoint(import.meta.url, process.argv)) {
@@ -401,9 +515,13 @@ export {
   buildPrompt,
   chooseModel,
   createRoutingPlan,
+  getGateRunPlan,
   isCliEntryPoint,
+  isProductionFinancial,
   main,
   parseArgs,
   resolveGate,
+  runGate,
+  shouldRunPostflightGate,
   scoreSpecialist,
 };

--- a/scripts/generate-discovery-map.ts
+++ b/scripts/generate-discovery-map.ts
@@ -404,12 +404,26 @@ function pathMatchesGlob(filePath: string, pattern: string): boolean {
   return globPatternToRegExp(pattern).test(normalizePath(filePath));
 }
 
+function getIncludedExtensions(patterns: string[]): Set<string> {
+  const extensions = new Set<string>();
+
+  for (const pattern of patterns) {
+    const extension = path.extname(pattern).toLowerCase();
+    if (extension) {
+      extensions.add(extension);
+    }
+  }
+
+  return extensions.size > 0 ? extensions : new Set(['.md']);
+}
+
 function validateGlobSentinels(): void {
   const expectedMatches: Array<[string, string]> = [
     ['cheatsheets/**/*.md', 'cheatsheets/daily-workflow.md'],
     ['cheatsheets/**/*.md', 'cheatsheets/nested/example.md'],
     ['.claude/**/*.md', '.claude/AGENT-DIRECTORY.md'],
     ['.claude/**/*.md', '.claude/agents/code-reviewer.md'],
+    ['.claude/**/*.json', '.claude/hermes/model-routing.json'],
     ['docs/**/archive/**', 'docs/archive/2026-q2/example.md'],
     ['docs/**/archive/**', 'docs/observability/archive/example.md'],
     ['**/node_modules/**', 'node_modules/pkg/README.md'],
@@ -420,6 +434,7 @@ function validateGlobSentinels(): void {
     ['cheatsheets/**/*.md', 'cheatsheets/daily-workflow.txt'],
     ['cheatsheets/**/*.md', 'docs/cheatsheets/daily-workflow.md'],
     ['.claude/**/*.md', 'docs/.claude/AGENT-DIRECTORY.md'],
+    ['.claude/**/*.json', '.claude/hermes/model-routing.md'],
   ];
 
   for (const [pattern, filePath] of expectedMatches) {
@@ -460,6 +475,7 @@ function getTrackedFileSet(): Set<string> {
 async function globFiles(patterns: string[], excludes: string[]): Promise<string[]> {
   const includeRegexes = patterns.map(globPatternToRegExp);
   const excludeRegexes = excludes.map(globPatternToRegExp);
+  const includeExtensions = getIncludedExtensions(patterns);
   const results: string[] = [];
 
   async function walkDir(dir: string): Promise<void> {
@@ -476,7 +492,7 @@ async function globFiles(patterns: string[], excludes: string[]): Promise<string
 
         if (entry.isDirectory()) {
           await walkDir(fullPath);
-        } else if (entry.name.endsWith('.md')) {
+        } else if (includeExtensions.has(path.extname(entry.name).toLowerCase())) {
           // Check if matches any pattern
           const matches = includeRegexes.some((regex) => regex.test(relativePath));
           if (matches) {
@@ -508,7 +524,7 @@ async function globFiles(patterns: string[], excludes: string[]): Promise<string
       const entries = await fs.readdir('.', { withFileTypes: true });
       entries.sort((a, b) => compareStrings(a.name, b.name));
       for (const entry of entries) {
-        if (!entry.isDirectory() && entry.name.endsWith('.md')) {
+        if (!entry.isDirectory() && includeExtensions.has(path.extname(entry.name).toLowerCase())) {
           const matches = patterns.some((pat) => {
             return pathMatchesGlob(entry.name, pat);
           });
@@ -805,7 +821,9 @@ function extractField(content: string, field: string): string | null {
 async function main(): Promise<void> {
   const isCheckMode = process.argv.includes('--check');
   const isVerbose = process.argv.includes('--verbose');
-  const generatedAt = isCheckMode ? '1970-01-01T00:00:00.000Z' : new Date().toISOString();
+  const generatedAt = isCheckMode
+    ? '1970-01-01T00:00:00.000Z'
+    : `${new Date().toISOString().split('T')[0]}T00:00:00.000Z`;
 
   console.log(`Discovery Map Generator ${isCheckMode ? '(check mode)' : '(generate mode)'}`);
   console.log('---');
@@ -896,9 +914,10 @@ async function main(): Promise<void> {
     try {
       const normalizedFile = normalizePath(file);
       const content = normalizeLineEndings(await fs.readFile(normalizedFile, 'utf8'));
-      const parsed = parseFrontmatter(content);
+      const isMarkdown = path.extname(normalizedFile).toLowerCase() === '.md';
+      const parsed = isMarkdown ? parseFrontmatter(content) : { data: {}, content };
 
-      const lastUpdatedStr = parsed.data.last_updated as string | undefined;
+      const lastUpdatedStr = isMarkdown ? (parsed.data.last_updated as string | undefined) : null;
       const lastUpdated = lastUpdatedStr ? new Date(lastUpdatedStr) : null;
 
       const cadence = getStaleCadence(
@@ -909,15 +928,23 @@ async function main(): Promise<void> {
 
       // Cross-platform determinism: freeze "now" during check mode.
       const now = isCheckMode ? new Date('2000-01-01T00:00:00.000Z').getTime() : Date.now();
-      const staleDays = lastUpdated
-        ? Math.floor((now - lastUpdated.getTime()) / (24 * 60 * 60 * 1000))
-        : 999;
+      const staleDays = isMarkdown
+        ? lastUpdated
+          ? Math.floor((now - lastUpdated.getTime()) / (24 * 60 * 60 * 1000))
+          : 999
+        : 0;
 
-      const isStale = lastUpdated ? now - lastUpdated.getTime() > cadence : true;
+      const isStale = isMarkdown
+        ? lastUpdated
+          ? now - lastUpdated.getTime() > cadence
+          : true
+        : false;
 
-      const execClaims = hasExecutionClaims(content, config.staleness.execution_claim_patterns);
+      const execClaims = isMarkdown
+        ? hasExecutionClaims(content, config.staleness.execution_claim_patterns)
+        : false;
 
-      const status = (parsed.data.status as string) || 'UNKNOWN';
+      const status = isMarkdown ? (parsed.data.status as string) || 'UNKNOWN' : 'INDEXED';
 
       docsData.push({
         path: normalizedFile,
@@ -934,7 +961,7 @@ async function main(): Promise<void> {
 
       stats.total_docs++;
       if (isStale) stats.stale_docs++;
-      if (Object.keys(parsed.data).length === 0) stats.missing_frontmatter++;
+      if (isMarkdown && Object.keys(parsed.data).length === 0) stats.missing_frontmatter++;
       stats.by_status[status] = (stats.by_status[status] || 0) + 1;
     } catch {
       if (isVerbose) {
@@ -1089,7 +1116,9 @@ Documents without proper YAML frontmatter:
 
 `;
 
-  const missingFm = docsData.filter((d) => Object.keys(d.frontmatter).length === 0);
+  const missingFm = docsData.filter(
+    (d) => path.extname(d.path).toLowerCase() === '.md' && Object.keys(d.frontmatter).length === 0
+  );
   if (missingFm.length === 0) {
     mdOutput += '*All documents have frontmatter.*\n';
   } else {

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, test } from 'vitest';
 import {
   chooseModel,
   createRoutingPlan,
+  getGateRunPlan,
   isCliEntryPoint,
+  main,
   parseArgs,
   resolveGate,
+  runGate,
   scoreSpecialist,
 } from '../../../orchestrate.js';
 
@@ -59,6 +62,27 @@ describe('Hermes routing helpers', () => {
     expect(chooseModel(args.task, args.phase, routing, args.manualModel)).toBe('kimi');
   });
 
+  test('parseArgs rejects the broad gate skip flag', () => {
+    expect(() => parseArgs(['--task', 'fix gate', '--skip-gates'])).toThrow(
+      'Use --skip-preflight-gate'
+    );
+  });
+
+  test('parseArgs recognizes preflight gate skip reason', () => {
+    const args = parseArgs([
+      '--phase',
+      'production',
+      '--task',
+      'fix xirr calculation',
+      '--skip-preflight-gate',
+      '--skip-reason',
+      'repairing calc-gate',
+    ]);
+
+    expect(args.skipPreflightGate).toBe(true);
+    expect(args.gateSkipReason).toBe('repairing calc-gate');
+  });
+
   test('xirr production work routes to financial specialist and calc gate', () => {
     const specialist = scoreSpecialist(
       'fix xirr calculation with management fees',
@@ -109,6 +133,22 @@ describe('Hermes routing helpers', () => {
     });
   });
 
+  test('createRoutingPlan includes preflight skip reason when requested', () => {
+    const plan = createRoutingPlan({
+      phase: 'research',
+      task: 'repair doctor gate',
+      routing,
+      manualModel: null,
+      skipPreflightGate: true,
+      gateSkipReason: 'repairing doctor gate',
+    });
+
+    expect(plan.gateSkip).toEqual({
+      preflight: true,
+      reason: 'repairing doctor gate',
+    });
+  });
+
   test('entrypoint guard distinguishes imports from direct CLI execution', () => {
     expect(isCliEntryPoint('file:///repo/orchestrate.js', ['node', '/repo/orchestrate.js'])).toBe(
       true
@@ -116,5 +156,240 @@ describe('Hermes routing helpers', () => {
     expect(
       isCliEntryPoint('file:///repo/orchestrate.js', ['node', '/repo/tests/importer.js'])
     ).toBe(false);
+  });
+
+  test('runGate skips empty gate commands', () => {
+    let calls = 0;
+
+    const result = runGate('', {
+      runner: () => {
+        calls += 1;
+        return { status: 0 };
+      },
+    });
+
+    expect(result).toEqual({ command: null, skipped: true, status: 0 });
+    expect(calls).toBe(0);
+  });
+
+  test('runGate parses npm script gates', () => {
+    const calls: Array<{ bin: string; args: string[] }> = [];
+
+    const result = runGate('npm run check', {
+      runner: (bin, args) => {
+        calls.push({ bin, args });
+        return { status: 0 };
+      },
+    });
+
+    expect(result).toEqual({ command: 'npm run check', skipped: false, status: 0 });
+    expect(calls).toEqual([{ bin: 'npm', args: ['run', 'check'] }]);
+  });
+
+  test('runGate reports non-zero exits', () => {
+    expect(() =>
+      runGate('npm run check', {
+        runner: () => ({ status: 2 }),
+      })
+    ).toThrow('Gate failed (npm run check) with exit code 2');
+  });
+
+  test('getGateRunPlan never skips financial production postflight gate', () => {
+    expect(
+      getGateRunPlan(
+        {
+          phase: 'production',
+          risk: 'financial',
+          gate: 'npm run calc-gate',
+        },
+        { skipPreflightGate: true }
+      )
+    ).toEqual({
+      preflight: false,
+      postflight: true,
+    });
+  });
+
+  test('main warns when preflight gate is skipped', async () => {
+    const stderr: string[] = [];
+    const stdout: string[] = [];
+
+    await main(
+      [
+        '--phase',
+        'research',
+        '--task',
+        'trace reserve engine flow',
+        '--skip-preflight-gate',
+        '--skip-reason',
+        'repairing doctor gate',
+      ],
+      {
+        ...process.env,
+        HERMES_MODEL_ROUTING_FILE: `${process.cwd()}/.claude/hermes/model-routing.json`,
+        HERMES_DEV_BRAIN_FILE: `${process.cwd()}/DEV_BRAIN.md`,
+        HERMES_SOUL_FILE: `${process.cwd()}/.claude/hermes/SOUL.md`,
+      },
+      {
+        stdout: { write: (message: string) => stdout.push(message) },
+        stderr: { write: (message: string) => stderr.push(message) },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => 1,
+        gateRunner: () => ({ status: 0 }),
+      }
+    );
+
+    expect(stdout.join('')).toBe('');
+    expect(stderr.join('')).toContain(
+      '[hermes] WARNING: skipping preflight gate "npm run doctor:quick"; reason: repairing doctor gate'
+    );
+  });
+
+  test('main still runs financial postflight gate when preflight is skipped', async () => {
+    const gateCalls: string[] = [];
+    const code = await main(
+      [
+        '--phase',
+        'production',
+        '--task',
+        'fix xirr calculation regression',
+        '--skip-preflight-gate',
+        '--skip-reason',
+        'repairing calc-gate',
+      ],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => 1,
+        gateRunner: (bin, args) => {
+          gateCalls.push([bin, ...args].join(' '));
+          return { status: 0 };
+        },
+      }
+    );
+
+    expect(code).toBe(1);
+    expect(gateCalls).toEqual(['npm run calc-gate']);
+  });
+
+  test('main returns preflight gate status without executing model', async () => {
+    let modelCalls = 0;
+    const code = await main(
+      ['--phase', 'research', '--task', 'trace reserve engine flow'],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => {
+          modelCalls += 1;
+          return 0;
+        },
+        gateRunner: () => ({ status: 2 }),
+      }
+    );
+
+    expect(code).toBe(2);
+    expect(modelCalls).toBe(0);
+  });
+
+  test('main returns postflight status when model succeeds but postflight fails', async () => {
+    const code = await main(
+      [
+        '--phase',
+        'production',
+        '--task',
+        'fix xirr calculation regression',
+        '--skip-preflight-gate',
+        '--skip-reason',
+        'repairing calc-gate',
+      ],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => 0,
+        gateRunner: () => ({ status: 7 }),
+      }
+    );
+
+    expect(code).toBe(7);
+  });
+
+  test('main returns model status when model fails and financial postflight passes', async () => {
+    const code = await main(
+      [
+        '--phase',
+        'production',
+        '--task',
+        'fix xirr calculation regression',
+        '--skip-preflight-gate',
+        '--skip-reason',
+        'repairing calc-gate',
+      ],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => 5,
+        gateRunner: () => ({ status: 0 }),
+      }
+    );
+
+    expect(code).toBe(5);
+  });
+
+  test('main returns postflight status and logs both when model and postflight fail', async () => {
+    const stderr: string[] = [];
+    const code = await main(
+      [
+        '--phase',
+        'production',
+        '--task',
+        'fix xirr calculation regression',
+        '--skip-preflight-gate',
+        '--skip-reason',
+        'repairing calc-gate',
+      ],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: (message: string) => stderr.push(message) },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => 5,
+        gateRunner: () => ({ status: 7 }),
+      }
+    );
+
+    expect(code).toBe(7);
+    expect(stderr.join('')).toContain('model exited 5 and postflight gate exited 7');
   });
 });


### PR DESCRIPTION
## Summary

- Replaces broad Hermes gate skipping with explicit preflight-only skip support.
- Requires `--skip-preflight-gate --skip-reason "<reason>"`.
- Removes `HERMES_SKIP_GATES=1` behavior and rejects legacy `--skip-gates` with replacement guidance.
- Keeps production-financial postflight gates enforced, including when preflight is skipped or model execution fails.
- Preserves exit-code precedence so model failures are not hidden by passing postflight gates.
- Adds JSON discovery scanning for `.claude/**/*.json`.
- Updates discovery generation to index JSON without frontmatter/staleness noise and keeps generated artifacts deterministic.
- Adds gate behavior tests.
- Regenerates discovery artifacts.
- Adds hardening/prune notes to the Hermes integration plan.

## Verification

- `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routing/hermes-routing.test.ts`
- `npm run docs:routing:check`
- `npm run check`
- `npm run lint`
- `npm test`
- `git diff --check`
- Generated artifact determinism check using before/after router diffs and `Compare-Object`.
- CLI JSON with `--skip-preflight-gate --skip-reason "repairing calc-gate"` includes the skip reason.
- CLI with `--skip-gates` exits 1 with replacement guidance.
- Pre-push hook reran TypeScript baseline and the targeted Hermes routing test.

## Notes

No financial calculation files were touched.

Pre-push reported existing stale/missing-date documentation and default-branch Dependabot findings; those are outside this PR scope.