### PR TITLE
feat(hermes): add role taxonomy, candidates, handoff schema, and run

### DIFF
--- a/.claude/hermes/model-routing.json
+++ b/.claude/hermes/model-routing.json
@@ -9,12 +9,14 @@
     "research": {
       "owner": "claude",
       "reviewer": "kimi",
+      "role": "leader-coordinator",
       "artifact": "implementation brief",
       "gate": "npm run doctor:quick"
     },
     "production": {
       "owner": "codex",
       "reviewer": "claude",
+      "role": "worker-executor",
       "artifact": "diff plus tests",
       "gate": "npm run check"
     },
@@ -22,6 +24,8 @@
       "owner": "codex",
       "reviewer": "claude",
       "audit": "kimi",
+      "role": "worker-executor",
+      "specialistRequired": true,
       "artifact": "diff plus truth-case notes",
       "gate": "npm run calc-gate",
       "humanApproval": true
@@ -29,6 +33,7 @@
     "distribution": {
       "owner": "claude",
       "repairOwner": "codex",
+      "role": "release-manager",
       "artifact": "PR-ready summary",
       "gate": "npm run lint"
     }

--- a/.gitignore
+++ b/.gitignore
@@ -268,6 +268,9 @@ _archive/
 # Babysitter orchestration state (ephemeral)
 .a5c/
 
+# Hermes run ledger (ephemeral runtime state)
+ai-logs/
+
 # Skill staging directories (source material, not deployed)
 uiux-skill/
 

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { spawn, spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -112,6 +112,8 @@ function scoreSpecialist(task, specialists = {}, scoring = {}) {
 
   for (const [name, config] of Object.entries(specialists)) {
     let score = 0;
+    let maxScore = 0;
+    const matched = [];
 
     for (const keyword of config.keywords || []) {
       const phrase = String(
@@ -119,8 +121,10 @@ function scoreSpecialist(task, specialists = {}, scoring = {}) {
       ).toLowerCase();
       const weight = typeof keyword === 'string' ? 1 : keyword.weight || 1;
 
+      maxScore += weight;
       if (phrase && input.includes(phrase)) {
         score += weight;
+        matched.push(phrase);
       }
     }
 
@@ -128,6 +132,9 @@ function scoreSpecialist(task, specialists = {}, scoring = {}) {
       candidates.push({
         name,
         score,
+        maxScore,
+        confidence: maxScore > 0 ? Math.round((score / maxScore) * 100) / 100 : 0,
+        matched,
         risk: config.risk || 'quality',
       });
     }
@@ -143,7 +150,8 @@ function scoreSpecialist(task, specialists = {}, scoring = {}) {
     return (leftRisk === -1 ? 99 : leftRisk) - (rightRisk === -1 ? 99 : rightRisk);
   });
 
-  return candidates[0];
+  const [selected] = candidates;
+  return { ...selected, candidates };
 }
 
 function chooseModel(task, phase, routing, manualModel = null) {
@@ -166,6 +174,20 @@ function resolveGate(phase, specialist, gates = {}) {
   return gates[phase] || null;
 }
 
+function resolveEffectivePhase(phase, specialist) {
+  if (phase === 'production' && specialist?.risk === 'financial') {
+    return 'production-financial';
+  }
+  return phase;
+}
+
+function resolveOwnership(phase, specialist, ownership = {}) {
+  const effective = resolveEffectivePhase(phase, specialist);
+  const entry = ownership[effective] || ownership[phase];
+  if (!entry) return null;
+  return { effectivePhase: effective, ...entry };
+}
+
 function createRoutingPlan({
   phase,
   task,
@@ -177,6 +199,7 @@ function createRoutingPlan({
   const specialist = scoreSpecialist(task, routing.specialists || {}, routing.scoring || {});
   const model = chooseModel(task, phase, routing, manualModel);
   const gate = resolveGate(phase, specialist, routing.gates || {});
+  const ownership = resolveOwnership(phase, specialist, routing.ownership || {});
 
   const plan = {
     phase,
@@ -185,8 +208,14 @@ function createRoutingPlan({
     specialist: specialist?.name || null,
     risk: specialist?.risk || 'standard',
     score: specialist?.score || 0,
+    confidence: specialist?.confidence ?? 0,
+    candidates: specialist?.candidates || [],
     gate,
   };
+
+  if (ownership) {
+    plan.ownership = ownership;
+  }
 
   if (skipPreflightGate) {
     plan.gateSkip = {
@@ -198,7 +227,7 @@ function createRoutingPlan({
   return plan;
 }
 
-function buildPrompt({ plan, brain, soul = '' }) {
+function buildPrompt({ plan, brain, soul = '', runId = null }) {
   const lines = [
     'You are operating inside Updog_restore.',
     '',
@@ -206,12 +235,33 @@ function buildPrompt({ plan, brain, soul = '' }) {
     `MODEL ROLE: ${plan.model}`,
   ];
 
+  if (plan.ownership) {
+    const own = plan.ownership;
+    const ownerLine = [
+      `OWNER: ${own.owner}`,
+      own.reviewer ? `reviewer: ${own.reviewer}` : null,
+      own.role ? `role: ${own.role}` : null,
+      own.artifact ? `artifact: ${own.artifact}` : null,
+      own.humanApproval ? 'human approval required' : null,
+    ]
+      .filter(Boolean)
+      .join('; ');
+    lines.push(ownerLine);
+  }
+
   if (plan.specialist) {
-    lines.push(`SPECIALIST: ${plan.specialist} (risk: ${plan.risk})`);
+    const confidencePct = Math.round((plan.confidence ?? 0) * 100);
+    lines.push(
+      `SPECIALIST: ${plan.specialist} (risk: ${plan.risk}; confidence: ${confidencePct}%)`
+    );
   }
 
   if (plan.gate) {
     lines.push(`REQUIRED GATE: ${plan.gate}`);
+  }
+
+  if (runId) {
+    lines.push(`RUN ID: ${runId}`);
   }
 
   lines.push('', '--- DEV_BRAIN ---', brain.trim(), '--- END DEV_BRAIN ---');
@@ -231,7 +281,10 @@ function buildPrompt({ plan, brain, soul = '' }) {
     '4. Prefer existing specialists before inventing new abstractions.',
     '5. Produce the smallest safe diff.',
     '6. If financial logic is touched, confirm calc-gate coverage.',
-    '7. Return: Summary, Affected Files, Changes or Plan, Verification, Risks.'
+    '7. Return: Summary, Affected Files, Changes or Plan, Verification, Risks.',
+    '8. End with a Handoff block using exactly these labels:',
+    '   Run ID, Phase, Owner, Reviewer, Task, Protected areas, Files touched,',
+    '   Commands run, Gate status, Decision needed, Next action.'
   );
 
   return lines.join('\n');
@@ -297,6 +350,19 @@ function runGate(
   }
 
   return { command, skipped: false, status };
+}
+
+function generateRunId(now = new Date()) {
+  const iso = now.toISOString().replace(/[:.]/g, '-').replace('Z', 'Z');
+  return `hermes-${iso}`;
+}
+
+function writeRunLedger(record, { root = ROOT, fs = { mkdirSync, writeFileSync } } = {}) {
+  const dir = join(root, 'ai-logs', 'hermes', 'runs');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${record.runId}.json`);
+  fs.writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`);
+  return file;
 }
 
 function getGateRunPlan(plan, { skipPreflightGate = false } = {}) {
@@ -413,6 +479,8 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
   const options = parseArgs(argv);
   const runModel = deps.executeModel || executeModel;
   const gateRunner = deps.gateRunner || spawnSync;
+  const ledgerWriter = deps.writeRunLedger === undefined ? writeRunLedger : deps.writeRunLedger;
+  const clock = deps.clock || (() => new Date());
 
   if (options.help) {
     printHelp(io.stdout);
@@ -438,6 +506,7 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
   const routing = deps.routing || loadJSON(routingPath);
   const brain = deps.brain ?? loadText(brainPath);
   const soul = deps.soul ?? loadText(soulPath, { optional: true });
+  const runId = generateRunId(clock());
   const plan = createRoutingPlan({
     phase: options.phase,
     task: options.task,
@@ -446,7 +515,7 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
     skipPreflightGate: options.skipPreflightGate,
     gateSkipReason: options.gateSkipReason,
   });
-  const prompt = buildPrompt({ plan, brain, soul });
+  const prompt = buildPrompt({ plan, brain, soul, runId });
 
   if (options.json) {
     io.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
@@ -461,6 +530,27 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
     return 0;
   }
 
+  const ledger = {
+    runId,
+    startedAt: clock().toISOString(),
+    plan,
+    preflight: null,
+    model: null,
+    postflight: null,
+    exitCode: null,
+  };
+
+  const finalizeLedger = (exitCode) => {
+    ledger.exitCode = exitCode;
+    ledger.completedAt = clock().toISOString();
+    if (!ledgerWriter) return;
+    try {
+      ledgerWriter(ledger);
+    } catch (error) {
+      io.stderr.write(`[hermes] WARNING: failed to write run ledger: ${error.message}\n`);
+    }
+  };
+
   const gates = getGateRunPlan(plan, options);
 
   if (gates.preflight) {
@@ -469,16 +559,25 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
       runner: gateRunner,
       throwOnFailure: false,
     });
+    ledger.preflight = { command: plan.gate, status: preflight.status, skipped: false };
     if (preflight.status !== 0) {
+      finalizeLedger(preflight.status);
       return preflight.status;
     }
   } else if (plan.gate && options.skipPreflightGate) {
+    ledger.preflight = {
+      command: plan.gate,
+      status: null,
+      skipped: true,
+      reason: options.gateSkipReason,
+    };
     io.stderr.write(
       `[hermes] WARNING: skipping preflight gate "${plan.gate}"; reason: ${options.gateSkipReason}\n`
     );
   }
 
   const code = await runModel(plan.model, prompt, routing, env);
+  ledger.model = { name: plan.model, exitCode: code };
 
   if (shouldRunPostflightGate(plan, code, gates)) {
     const postflight = runGate(plan.gate, {
@@ -486,16 +585,19 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
       runner: gateRunner,
       throwOnFailure: false,
     });
+    ledger.postflight = { command: plan.gate, status: postflight.status };
     if (postflight.status !== 0) {
       if (code !== 0) {
         io.stderr.write(
           `[hermes] WARNING: model exited ${code} and postflight gate exited ${postflight.status}\n`
         );
       }
+      finalizeLedger(postflight.status);
       return postflight.status;
     }
   }
 
+  finalizeLedger(code);
   return code;
 }
 
@@ -515,13 +617,17 @@ export {
   buildPrompt,
   chooseModel,
   createRoutingPlan,
+  generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
   isProductionFinancial,
   main,
   parseArgs,
+  resolveEffectivePhase,
   resolveGate,
+  resolveOwnership,
   runGate,
   shouldRunPostflightGate,
   scoreSpecialist,
+  writeRunLedger,
 };

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  buildPrompt,
   chooseModel,
   createRoutingPlan,
+  generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
   main,
   parseArgs,
+  resolveEffectivePhase,
   resolveGate,
+  resolveOwnership,
   runGate,
   scoreSpecialist,
 } from '../../../orchestrate.js';
@@ -24,6 +28,34 @@ const routing = {
     '--claude': 'claude',
     '--codex': 'codex',
     '--kimi': 'kimi',
+  },
+  ownership: {
+    research: {
+      owner: 'claude',
+      reviewer: 'kimi',
+      role: 'leader-coordinator',
+      artifact: 'implementation brief',
+    },
+    production: {
+      owner: 'codex',
+      reviewer: 'claude',
+      role: 'worker-executor',
+      artifact: 'diff plus tests',
+    },
+    'production-financial': {
+      owner: 'codex',
+      reviewer: 'claude',
+      audit: 'kimi',
+      role: 'worker-executor',
+      specialistRequired: true,
+      artifact: 'diff plus truth-case notes',
+      humanApproval: true,
+    },
+    distribution: {
+      owner: 'claude',
+      role: 'release-manager',
+      artifact: 'PR-ready summary',
+    },
   },
   specialists: {
     'waterfall-specialist': {
@@ -90,12 +122,26 @@ describe('Hermes routing helpers', () => {
       routing.scoring
     );
 
-    expect(specialist).toEqual({
-      name: 'xirr-fees-validator',
-      risk: 'financial',
-      score: 7,
-    });
+    expect(specialist?.name).toBe('xirr-fees-validator');
+    expect(specialist?.risk).toBe('financial');
+    expect(specialist?.score).toBe(7);
+    expect(specialist?.matched).toEqual(['xirr calculation', 'management fees']);
+    expect(specialist?.confidence).toBe(1);
     expect(resolveGate('production', specialist, routing.gates)).toBe('npm run calc-gate');
+  });
+
+  test('scoreSpecialist exposes maxScore and partial-match confidence', () => {
+    const specialist = scoreSpecialist(
+      'investigate management fees report',
+      routing.specialists,
+      routing.scoring
+    );
+
+    expect(specialist?.name).toBe('xirr-fees-validator');
+    expect(specialist?.score).toBe(3);
+    expect(specialist?.maxScore).toBe(7);
+    expect(specialist?.confidence).toBeCloseTo(0.43, 2);
+    expect(specialist?.matched).toEqual(['management fees']);
   });
 
   test('distribution phase summary does not false-positive to waterfall specialist', () => {
@@ -114,7 +160,7 @@ describe('Hermes routing helpers', () => {
     );
   });
 
-  test('createRoutingPlan combines model, specialist, risk, score, and gate', () => {
+  test('createRoutingPlan includes specialist, confidence, candidates, and ownership', () => {
     const plan = createRoutingPlan({
       phase: 'production',
       task: 'fix xirr calculation with management fees',
@@ -122,15 +168,57 @@ describe('Hermes routing helpers', () => {
       manualModel: null,
     });
 
-    expect(plan).toEqual({
-      phase: 'production',
-      task: 'fix xirr calculation with management fees',
-      model: 'codex',
-      specialist: 'xirr-fees-validator',
-      risk: 'financial',
+    expect(plan.phase).toBe('production');
+    expect(plan.task).toBe('fix xirr calculation with management fees');
+    expect(plan.model).toBe('codex');
+    expect(plan.specialist).toBe('xirr-fees-validator');
+    expect(plan.risk).toBe('financial');
+    expect(plan.score).toBe(7);
+    expect(plan.confidence).toBe(1);
+    expect(plan.gate).toBe('npm run calc-gate');
+    expect(plan.candidates).toHaveLength(1);
+    expect(plan.candidates[0]).toMatchObject({
+      name: 'xirr-fees-validator',
       score: 7,
-      gate: 'npm run calc-gate',
+      matched: ['xirr calculation', 'management fees'],
     });
+    expect(plan.ownership).toMatchObject({
+      effectivePhase: 'production-financial',
+      owner: 'codex',
+      reviewer: 'claude',
+      role: 'worker-executor',
+      humanApproval: true,
+    });
+  });
+
+  test('createRoutingPlan returns empty candidates when no specialist matches', () => {
+    const plan = createRoutingPlan({
+      phase: 'distribution',
+      task: 'prepare distribution summary for PR',
+      routing,
+      manualModel: null,
+    });
+
+    expect(plan.specialist).toBeNull();
+    expect(plan.candidates).toEqual([]);
+    expect(plan.confidence).toBe(0);
+    expect(plan.ownership).toMatchObject({
+      effectivePhase: 'distribution',
+      owner: 'claude',
+      role: 'release-manager',
+    });
+  });
+
+  test('resolveEffectivePhase promotes financial production work', () => {
+    expect(resolveEffectivePhase('production', { risk: 'financial' })).toBe('production-financial');
+    expect(resolveEffectivePhase('production', { risk: 'quality' })).toBe('production');
+    expect(resolveEffectivePhase('research', { risk: 'financial' })).toBe('research');
+  });
+
+  test('resolveOwnership prefers production-financial entry for financial work', () => {
+    const ownership = resolveOwnership('production', { risk: 'financial' }, routing.ownership);
+    expect(ownership?.effectivePhase).toBe('production-financial');
+    expect(ownership?.humanApproval).toBe(true);
   });
 
   test('createRoutingPlan includes preflight skip reason when requested', () => {
@@ -147,6 +235,34 @@ describe('Hermes routing helpers', () => {
       preflight: true,
       reason: 'repairing doctor gate',
     });
+  });
+
+  test('buildPrompt injects ownership context and handoff schema labels', () => {
+    const plan = createRoutingPlan({
+      phase: 'production',
+      task: 'fix xirr calculation with management fees',
+      routing,
+      manualModel: null,
+    });
+
+    const prompt = buildPrompt({ plan, brain: 'DEV_BRAIN', soul: 'SOUL', runId: 'hermes-test' });
+
+    expect(prompt).toContain('OWNER: codex');
+    expect(prompt).toContain('reviewer: claude');
+    expect(prompt).toContain('role: worker-executor');
+    expect(prompt).toContain('human approval required');
+    expect(prompt).toContain('SPECIALIST: xirr-fees-validator');
+    expect(prompt).toContain('confidence: 100%');
+    expect(prompt).toContain('RUN ID: hermes-test');
+    expect(prompt).toContain('Handoff block');
+    expect(prompt).toContain(
+      'Run ID, Phase, Owner, Reviewer, Task, Protected areas, Files touched'
+    );
+  });
+
+  test('generateRunId formats deterministically from a clock', () => {
+    const id = generateRunId(new Date('2026-05-20T18:30:45.123Z'));
+    expect(id).toBe('hermes-2026-05-20T18-30-45-123Z');
   });
 
   test('entrypoint guard distinguishes imports from direct CLI execution', () => {
@@ -240,6 +356,7 @@ describe('Hermes routing helpers', () => {
         soul: 'SOUL',
         executeModel: async () => 1,
         gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
       }
     );
 
@@ -275,6 +392,7 @@ describe('Hermes routing helpers', () => {
           gateCalls.push([bin, ...args].join(' '));
           return { status: 0 };
         },
+        writeRunLedger: null,
       }
     );
 
@@ -300,6 +418,7 @@ describe('Hermes routing helpers', () => {
           return 0;
         },
         gateRunner: () => ({ status: 2 }),
+        writeRunLedger: null,
       }
     );
 
@@ -329,6 +448,7 @@ describe('Hermes routing helpers', () => {
         soul: 'SOUL',
         executeModel: async () => 0,
         gateRunner: () => ({ status: 7 }),
+        writeRunLedger: null,
       }
     );
 
@@ -357,6 +477,7 @@ describe('Hermes routing helpers', () => {
         soul: 'SOUL',
         executeModel: async () => 5,
         gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
       }
     );
 
@@ -386,10 +507,79 @@ describe('Hermes routing helpers', () => {
         soul: 'SOUL',
         executeModel: async () => 5,
         gateRunner: () => ({ status: 7 }),
+        writeRunLedger: null,
       }
     );
 
     expect(code).toBe(7);
     expect(stderr.join('')).toContain('model exited 5 and postflight gate exited 7');
+  });
+
+  test('main writes a run ledger capturing plan, gates, and exit code', async () => {
+    const ledgerCalls: unknown[] = [];
+
+    const code = await main(
+      [
+        '--phase',
+        'production',
+        '--task',
+        'fix xirr calculation regression',
+        '--skip-preflight-gate',
+        '--skip-reason',
+        'repairing calc-gate',
+      ],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => 0,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: (record: unknown) => ledgerCalls.push(record),
+        clock: () => new Date('2026-05-20T18:30:45.123Z'),
+      }
+    );
+
+    expect(code).toBe(0);
+    expect(ledgerCalls).toHaveLength(1);
+    const record = ledgerCalls[0] as {
+      runId: string;
+      exitCode: number;
+      plan: { specialist: string };
+      preflight: { skipped: boolean; reason: string };
+      model: { name: string; exitCode: number };
+      postflight: { status: number };
+    };
+    expect(record.runId).toBe('hermes-2026-05-20T18-30-45-123Z');
+    expect(record.exitCode).toBe(0);
+    expect(record.plan.specialist).toBe('xirr-fees-validator');
+    expect(record.preflight).toMatchObject({ skipped: true, reason: 'repairing calc-gate' });
+    expect(record.model).toMatchObject({ name: 'codex', exitCode: 0 });
+    expect(record.postflight).toMatchObject({ status: 0 });
+  });
+
+  test('main skips ledger when writeRunLedger is null and does not throw', async () => {
+    const code = await main(
+      ['--phase', 'research', '--task', 'trace reserve engine flow'],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        executeModel: async () => 0,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      }
+    );
+
+    expect(code).toBe(0);
   });
 });


### PR DESCRIPTION
Incorporates the P1 batch from the Hermes integration recommendations:

- Add role fields (leader-coordinator, worker-executor, release-manager) and specialistRequired flag to ownership metadata in model-routing.json so the multi-agent role topology is machine-readable.
- Surface routing candidates with score, maxScore, confidence, and matched phrases in scoreSpecialist and createRoutingPlan output, making --json routing decisions auditable.
- Inject ownership context (owner, reviewer, role, artifact, humanApproval) and a required Handoff block schema into spawned prompts so model handoffs use a consistent format.
- Add gitignored run-ledger writer that records plan, preflight, model exit, and postflight status to ai-logs/hermes/runs/<runId>.json for each non-dry-run invocation. Tests inject a no-op writer to avoid disk writes.

No behavior change for existing flows: defaults, gates, and skip-reason semantics are preserved. 27 routing tests pass (19 original, 8 new).