### PR TITLE
fix(husky): make pre-push hook POSIX-portable and committed-executable

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"


### PR DESCRIPTION
## Summary

- Replace `#!/usr/bin/env bash` + `set -euo pipefail` with POSIX `#!/bin/sh` + `set -eu` in `.husky/pre-push`.
- Mark the hook executable via `git update-index --chmod=+x` so the shebang is honored.
- One-line behavior change; Hermes-adjacent hygiene, not part of the Hermes feature surface.

## Why

Husky 9 invokes hooks via `/bin/sh`. On systems where `/bin/sh` is `dash` (Debian, many cloud containers), `set -o pipefail` errors out with `Illegal option -o pipefail` before reaching the `exec node scripts/pre-push.mjs` line. Compounding the issue, the hook was not committed as executable, so even on systems with bash the `#!/usr/bin/env bash` shebang was ignored. The net effect: cloud-container pushes had to bypass the hook with `--no-verify` despite the underlying `node scripts/pre-push.mjs` check being green.

This is a pre-existing portability bug, surfaced while pushing the P1 Hermes batch from a cloud container. The fix is independent of the Hermes feature work.

## Test plan

- [x] `sh -n .husky/pre-push` — clean
- [x] `bash -n .husky/pre-push` — clean
- [x] `git ls-files --stage .husky/pre-push` shows mode `100755`
- [x] `git diff --summary HEAD~1 .husky/pre-push` shows `mode change 100644 => 100755`
- [x] `.husky/pre-push` runs end-to-end on `main` post-fix: 0 new TypeScript errors, targeted tests clean
- [x] `git push -u origin claude/husky-pre-push-portability` succeeded **without** `--no-verify`

## Notes

The hook delegates to `node scripts/pre-push.mjs`, which is unchanged — the underlying gates (TS baseline, targeted Vitest) keep their semantics. Only the shell wrapper is touched.