### PR TITLE
chore(hermes): keep guidance aligned with live routing assets

### DIFF
--- a/.claude/AGENT-METRICS.md
+++ b/.claude/AGENT-METRICS.md
@@ -1,7 +1,7 @@
 ---
 status: ACTIVE
 audience: agents
-last_updated: 2025-12-29
+last_updated: 2026-05-20
 owner: 'Platform Team'
 review_cadence: P7D
 categories: [agents, metrics, performance]
@@ -17,14 +17,14 @@ ecosystem and identify improvement opportunities.
 
 ### Core Metrics Per Agent
 
-| Metric | Description | Target |
-|--------|-------------|--------|
-| **Invocation Count** | Times agent was called | - |
-| **Success Rate** | % completing without errors | >95% |
-| **Avg Runtime** | Mean execution time | <5min |
-| **P95 Runtime** | 95th percentile runtime | <10min |
-| **Memory Usage** | Peak memory during execution | <500MB |
-| **Failure Categories** | Types of failures encountered | - |
+| Metric                 | Description                   | Target |
+| ---------------------- | ----------------------------- | ------ |
+| **Invocation Count**   | Times agent was called        | -      |
+| **Success Rate**       | % completing without errors   | >95%   |
+| **Avg Runtime**        | Mean execution time           | <5min  |
+| **P95 Runtime**        | 95th percentile runtime       | <10min |
+| **Memory Usage**       | Peak memory during execution  | <500MB |
+| **Failure Categories** | Types of failures encountered | -      |
 
 ### Tracking Method
 
@@ -53,31 +53,31 @@ interface AgentMetrics {
 
 ### High-Volume Agents (Weekly Metrics)
 
-| Agent | Invocations | Success Rate | Avg Runtime | Trend |
-|-------|-------------|--------------|-------------|-------|
-| code-reviewer | ~50/week | 98% | 45s | Stable |
-| test-repair | ~30/week | 92% | 2m 15s | Improving |
-| waterfall-specialist | ~20/week | 97% | 1m 30s | Stable |
-| perf-guard | ~15/week | 95% | 3m 00s | Stable |
-| schema-drift-checker | ~10/week | 99% | 30s | Stable |
+| Agent                | Invocations | Success Rate | Avg Runtime | Trend     |
+| -------------------- | ----------- | ------------ | ----------- | --------- |
+| code-reviewer        | ~50/week    | 98%          | 45s         | Stable    |
+| test-repair          | ~30/week    | 92%          | 2m 15s      | Improving |
+| waterfall-specialist | ~20/week    | 97%          | 1m 30s      | Stable    |
+| perf-guard           | ~15/week    | 95%          | 3m 00s      | Stable    |
+| schema-drift-checker | ~10/week    | 99%          | 30s         | Stable    |
 
 ### Phoenix Agents (Weekly Metrics)
 
-| Agent | Invocations | Success Rate | Avg Runtime | Trend |
-|-------|-------------|--------------|-------------|-------|
-| phoenix-truth-case-runner | ~25/week | 100% | 4m 00s | Stable |
-| phoenix-precision-guardian | ~10/week | 95% | 2m 00s | Stable |
-| xirr-fees-validator | ~15/week | 98% | 1m 45s | Improving |
-| phoenix-probabilistic-engineer | ~8/week | 90% | 5m 00s | New |
+| Agent                          | Invocations | Success Rate | Avg Runtime | Trend     |
+| ------------------------------ | ----------- | ------------ | ----------- | --------- |
+| phoenix-truth-case-runner      | ~25/week    | 100%         | 4m 00s      | Stable    |
+| phoenix-precision-guardian     | ~10/week    | 95%          | 2m 00s      | Stable    |
+| xirr-fees-validator            | ~15/week    | 98%          | 1m 45s      | Improving |
+| phoenix-probabilistic-engineer | ~8/week     | 90%          | 5m 00s      | New       |
 
 ### Low-Volume Agents (Monthly Metrics)
 
-| Agent | Invocations | Success Rate | Avg Runtime |
-|-------|-------------|--------------|-------------|
-| db-migration | ~5/month | 100% | 2m 00s |
-| incident-responder | ~2/month | 100% | 10m 00s |
-| chaos-engineer | ~1/month | 100% | 15m 00s |
-| playwright-test-author | ~3/month | 90% | 5m 00s |
+| Agent                  | Invocations | Success Rate | Avg Runtime |
+| ---------------------- | ----------- | ------------ | ----------- |
+| db-migration           | ~5/month    | 100%         | 2m 00s      |
+| incident-responder     | ~2/month    | 100%         | 10m 00s     |
+| chaos-engineer         | ~1/month    | 100%         | 15m 00s     |
+| playwright-test-author | ~3/month    | 90%          | 5m 00s      |
 
 ---
 
@@ -85,24 +85,27 @@ interface AgentMetrics {
 
 ### Common Failure Patterns
 
-| Pattern | Frequency | Typical Agent | Mitigation |
-|---------|-----------|---------------|------------|
-| Timeout | 15% of failures | test-repair | Increase timeout, add progress logging |
-| File not found | 10% of failures | code-reviewer | Validate paths before analysis |
-| Memory limit | 5% of failures | perf-guard | Streaming analysis for large bundles |
-| Rate limit | 3% of failures | Any | Exponential backoff, retry |
+| Pattern        | Frequency       | Typical Agent | Mitigation                             |
+| -------------- | --------------- | ------------- | -------------------------------------- |
+| Timeout        | 15% of failures | test-repair   | Increase timeout, add progress logging |
+| File not found | 10% of failures | code-reviewer | Validate paths before analysis         |
+| Memory limit   | 5% of failures  | perf-guard    | Streaming analysis for large bundles   |
+| Rate limit     | 3% of failures  | Any           | Exponential backoff, retry             |
 
 ### Agent-Specific Issues
 
 **test-repair:**
+
 - 60% of failures: Test still failing after 3 fix attempts
 - Mitigation: Escalate to human, log attempted fixes
 
 **phoenix-probabilistic-engineer:**
+
 - 70% of failures: Monte Carlo convergence issues
 - Mitigation: Increase iteration count, adjust seed
 
 **playwright-test-author:**
+
 - 50% of failures: Browser environment issues
 - Mitigation: Retry with fresh browser context
 
@@ -110,21 +113,27 @@ interface AgentMetrics {
 
 ## Performance Optimization Log
 
+### Pilot Metrics
+
+| Date       | Pilot   | Model lane      | Routing correct | Owner correct | Gate correct | Handoff clear | Human intervention reason           | Notes                                                                                                                                                       |
+| ---------- | ------- | --------------- | --------------- | ------------- | ------------ | ------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-20 | Pilot 1 | Claude research | Yes             | Yes           | Yes          | Mostly        | Write approval required for cleanup | Handoff mislabeled gate as skipped; gate execution passed, but the gate status field conflated write permission with Hermes preflight/postflight execution. |
+
 ### Recent Improvements
 
-| Date | Agent | Optimization | Impact |
-|------|-------|--------------|--------|
-| 2025-12-20 | code-reviewer | Parallel file analysis | -40% runtime |
-| 2025-12-15 | test-repair | Cached test discovery | -25% runtime |
-| 2025-12-10 | perf-guard | Incremental bundle analysis | -50% runtime |
+| Date       | Agent         | Optimization                | Impact       |
+| ---------- | ------------- | --------------------------- | ------------ |
+| 2025-12-20 | code-reviewer | Parallel file analysis      | -40% runtime |
+| 2025-12-15 | test-repair   | Cached test discovery       | -25% runtime |
+| 2025-12-10 | perf-guard    | Incremental bundle analysis | -50% runtime |
 
 ### Planned Optimizations
 
-| Agent | Planned Change | Expected Impact | Priority |
-|-------|----------------|-----------------|----------|
-| phoenix-truth-case-runner | Parallel test execution | -30% runtime | P1 |
-| waterfall-specialist | Memoized validation | -20% runtime | P2 |
-| schema-drift-checker | Incremental schema comparison | -40% runtime | P2 |
+| Agent                     | Planned Change                | Expected Impact | Priority |
+| ------------------------- | ----------------------------- | --------------- | -------- |
+| phoenix-truth-case-runner | Parallel test execution       | -30% runtime    | P1       |
+| waterfall-specialist      | Memoized validation           | -20% runtime    | P2       |
+| schema-drift-checker      | Incremental schema comparison | -40% runtime    | P2       |
 
 ---
 
@@ -151,12 +160,12 @@ Most common sequences:
 
 ### Files Per Invocation
 
-| Agent | Avg Files | Max Files |
-|-------|-----------|-----------|
-| code-reviewer | 8 | 50 |
-| test-repair | 3 | 15 |
-| waterfall-specialist | 2 | 5 |
-| perf-guard | 1 | 1 (bundle) |
+| Agent                | Avg Files | Max Files  |
+| -------------------- | --------- | ---------- |
+| code-reviewer        | 8         | 50         |
+| test-repair          | 3         | 15         |
+| waterfall-specialist | 2         | 5          |
+| perf-guard           | 1         | 1 (bundle) |
 
 ---
 
@@ -164,27 +173,27 @@ Most common sequences:
 
 ### Tier 1 Agents (Critical Path)
 
-| Agent | Availability SLO | Latency P95 SLO |
-|-------|------------------|-----------------|
-| code-reviewer | 99.9% | <2min |
-| test-repair | 99.5% | <5min |
-| waterfall-specialist | 99.9% | <3min |
+| Agent                | Availability SLO | Latency P95 SLO |
+| -------------------- | ---------------- | --------------- |
+| code-reviewer        | 99.9%            | <2min           |
+| test-repair          | 99.5%            | <5min           |
+| waterfall-specialist | 99.9%            | <3min           |
 
 ### Tier 2 Agents (Important)
 
-| Agent | Availability SLO | Latency P95 SLO |
-|-------|------------------|-----------------|
-| perf-guard | 99% | <5min |
-| phoenix-truth-case-runner | 99% | <10min |
-| schema-drift-checker | 99% | <2min |
+| Agent                     | Availability SLO | Latency P95 SLO |
+| ------------------------- | ---------------- | --------------- |
+| perf-guard                | 99%              | <5min           |
+| phoenix-truth-case-runner | 99%              | <10min          |
+| schema-drift-checker      | 99%              | <2min           |
 
 ### Tier 3 Agents (Best Effort)
 
-| Agent | Availability SLO | Latency P95 SLO |
-|-------|------------------|-----------------|
-| chaos-engineer | 95% | <30min |
-| playwright-test-author | 95% | <10min |
-| incident-responder | 99% (on demand) | <15min |
+| Agent                  | Availability SLO | Latency P95 SLO |
+| ---------------------- | ---------------- | --------------- |
+| chaos-engineer         | 95%              | <30min          |
+| playwright-test-author | 95%              | <10min          |
+| incident-responder     | 99% (on demand)  | <15min          |
 
 ---
 
@@ -192,18 +201,18 @@ Most common sequences:
 
 ### Critical Alerts
 
-| Condition | Alert | Action |
-|-----------|-------|--------|
-| Success rate <90% for 1 hour | Page on-call | Investigate immediately |
-| Avg runtime >2x normal | Slack notification | Review and optimize |
-| Memory usage >90% | Slack notification | Increase limits or fix leak |
+| Condition                    | Alert              | Action                      |
+| ---------------------------- | ------------------ | --------------------------- |
+| Success rate <90% for 1 hour | Page on-call       | Investigate immediately     |
+| Avg runtime >2x normal       | Slack notification | Review and optimize         |
+| Memory usage >90%            | Slack notification | Increase limits or fix leak |
 
 ### Warning Alerts
 
-| Condition | Alert | Action |
-|-----------|-------|--------|
-| Success rate <95% for 24 hours | Daily report | Review failure patterns |
-| Queue depth >10 pending | Dashboard update | Scale or prioritize |
+| Condition                      | Alert            | Action                  |
+| ------------------------------ | ---------------- | ----------------------- |
+| Success rate <95% for 24 hours | Daily report     | Review failure patterns |
+| Queue depth >10 pending        | Dashboard update | Scale or prioritize     |
 
 ---
 

--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,7 @@ CB_DB_HALF_OPEN_MAX_CONC=1
 # === Hermes Orchestration ===
 HERMES_MODEL_ROUTING_FILE=.claude/hermes/model-routing.json
 HERMES_DEV_BRAIN_FILE=DEV_BRAIN.md
+HERMES_SOUL_FILE=.claude/hermes/SOUL.md
 CLAUDE_CODE_BIN=claude
 CODEX_BIN=codex
 KIMI_CODE_BIN=kimi-code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 ---
 status: ACTIVE
-last_updated: 2026-04-18
+last_updated: 2026-05-20
 ---
 
 # AGENTS.md
 
 **Start here:** Read this file first, then use repo search plus `docs/INDEX.md`
-and `.Codex/DISCOVERY-MAP.md` to find existing solutions. Consult
+and `.claude/DISCOVERY-MAP.md` to find existing solutions. Consult
 `CAPABILITIES.md` only as a historical inventory.
 
 This file provides guidance to Codex (Codex.ai/code) when working with code in
@@ -189,7 +189,7 @@ npm install
 - `npm run lint` - ESLint code quality check
 - `npm run lint:fix` - Auto-fix linting issues
 - **Quality Gates**: See
-  [.Codex/WORKFLOW.md](.Codex/WORKFLOW.md#quality-gate-protocol) - MANDATORY
+  [.claude/WORKFLOW.md](.claude/WORKFLOW.md#quality-gate-protocol) - MANDATORY
   pre-commit validation
 
 ### Database
@@ -205,7 +205,7 @@ npm install
 
 ## Discovery Routing (Quick Reference)
 
-For detailed routing logic, see `.Codex/DISCOVERY-MAP.md`. Key patterns:
+For detailed routing logic, see `.claude/DISCOVERY-MAP.md`. Key patterns:
 
 | Task Type                       | Route To                                  |
 | ------------------------------- | ----------------------------------------- |
@@ -232,14 +232,14 @@ report**: `docs/_generated/staleness-report.md` **Regenerate**:
 - **Superpowers**: `/superpowers:brainstorm`, `/superpowers:write-plan`,
   `/superpowers:execute-plan` - See
   [obra/superpowers](https://github.com/obra/superpowers)
-- **Skills**: See [.Codex/skills/INDEX.md](.Codex/skills/INDEX.md)
+- **Skills**: See [.claude/skills/INDEX.md](.claude/skills/INDEX.md)
 
 ## MANDATORY WORKFLOW - START HERE
 
 1. **AGENTS.md** - Current operating guidance and governance
 2. **Repo search** - Check for existing code, commands, skills, and docs
 3. **docs/INDEX.md** - Human-facing documentation routing
-4. **.Codex/DISCOVERY-MAP.md** - Agent-facing discovery routing
+4. **.claude/DISCOVERY-MAP.md** - Agent-facing discovery routing
 5. **CHANGELOG.md** - Check for similar past work
 6. **DECISIONS.md** - Review architectural decisions
 7. **CAPABILITIES.md** - Historical inventory only, if helpful
@@ -250,7 +250,7 @@ report**: `docs/_generated/staleness-report.md` **Regenerate**:
 START HERE:
 - Read AGENTS.md
 - Search the repo for existing implementations
-- Use docs/INDEX.md and .Codex/DISCOVERY-MAP.md for routing
+- Use docs/INDEX.md and .claude/DISCOVERY-MAP.md for routing
 - Consult CAPABILITIES.md only if historical inventory context helps
 ```
 

--- a/DEV_BRAIN.md
+++ b/DEV_BRAIN.md
@@ -30,13 +30,13 @@ the model-specific governance files remain authoritative.
 
 ## Phase Routing
 
-| Phase                 | Default               | Handoff Artifact      | Required Gate                                    |
-| --------------------- | --------------------- | --------------------- | ------------------------------------------------ |
-| research              | Claude                | Implementation brief  | `npm run doctor:quick` plus repo search evidence |
-| research-long-context | Kimi                  | Audit memo            | Cite files read and uncertainty                  |
-| production            | Codex                 | Diff plus tests       | `npm run check` plus targeted tests              |
-| production-financial  | Codex plus specialist | Diff plus truth notes | `npm run calc-gate`                              |
-| distribution          | Claude                | PR-ready summary      | `npm run lint` plus relevant tests               |
+| Phase                          | Default               | Handoff Artifact      | Required Gate                                                                                 |
+| ------------------------------ | --------------------- | --------------------- | --------------------------------------------------------------------------------------------- |
+| research                       | Claude                | Implementation brief  | `npm run doctor:quick` plus repo search evidence                                              |
+| research long-context sub-path | Kimi                  | Audit memo            | Routed from `research` via `longContextTriggers` or `--kimi`; cite files read and uncertainty |
+| production                     | Codex                 | Diff plus tests       | `npm run check` plus targeted tests                                                           |
+| production-financial           | Codex plus specialist | Diff plus truth notes | `npm run calc-gate`                                                                           |
+| distribution                   | Claude                | PR-ready summary      | `npm run lint` plus relevant tests                                                            |
 
 ## Specialist Escalation
 

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -437,7 +437,7 @@ class Orchestrator {
     const tests = [
       {
         name: 'ReserveEngine API',
-        url: 'http://localhost:3000/api/reserves/1',
+        url: 'http://localhost:5000/api/reserves/1',
         validator: (data) =>
           Array.isArray(data) &&
           data.length > 0 &&
@@ -446,7 +446,7 @@ class Orchestrator {
       },
       {
         name: 'PacingEngine API',
-        url: 'http://localhost:3000/api/pacing/summary',
+        url: 'http://localhost:5000/api/pacing/summary',
         validator: (data) =>
           Array.isArray(data) &&
           data.length > 0 &&


### PR DESCRIPTION
Hermes Pilot 1 found stale Codex-era navigation paths and a legacy smoke-test port that no longer match the current repo contract. This cleanup keeps the implementation lane narrow: update broken guidance paths, document the Hermes soul file env var, clarify the long-context research sub-path, and record the Pilot 1 handoff metric without changing routing weights or financial logic.

Constraint: No financial calculation files, model-routing specialist weights, or automation changes.

Rejected: Tighten Hermes handoff schema now | one mislabeled gate field is not enough evidence for a parser or schema change.

Confidence: high

Scope-risk: narrow

Directive: Keep research-long-context as a research sub-path unless model-routing.json intentionally adds it as a phase.

Tested: npm run check; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routing/hermes-routing.test.ts; node orchestrate.js --json --phase research --task repo-wide-audit-of-Hermes-ownership; npm run hermes:dry -- --phase research --task audit-Hermes-docs-and-scripts-for-stale-references; git diff --check