### PR TITLE
Fix main CI after docs cleanup

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -13,6 +13,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   changes:
     name: Detect Changes

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -4196,66 +4196,6 @@
       "isStale": false,
       "lastUpdated": "2026-01-19",
       "owner": null,
-      "path": "docs/CLEANUP_PR_BODY.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/CLEANUP_PR_TEMPLATE.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/COMMIT_REVIEW.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/CONSOLIDATION_LEARNINGS.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
       "staleDays": 122,
       "status": "ACTIVE"
@@ -4302,21 +4242,6 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/DEPLOYMENT_RUNBOOK.md",
       "staleDays": 122,
       "status": "ACTIVE"
     },
@@ -4373,21 +4298,6 @@
       "path": "docs/DEVELOPMENT_STRATEGY.md",
       "staleDays": 122,
       "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "HISTORICAL"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/HANDOFF_JCURVE_IMPLEMENTATION.md",
-      "staleDays": 122,
-      "status": "HISTORICAL"
     },
     {
       "docType": "doc",
@@ -4595,66 +4505,6 @@
       "exists": true,
       "frontmatter": {
         "last_updated": "2026-01-19",
-        "status": "HISTORICAL"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/OSS_INTEGRATION_SUMMARY.md",
-      "staleDays": 122,
-      "status": "HISTORICAL"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/PHASE-1D-CHECKPOINT.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/PHASE-1D-STATUS.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/PHASE1A-XIRR-COMPLETE.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
@@ -4662,21 +4512,6 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/PHASE1B-FEES-COMPLETE.md",
       "staleDays": 122,
       "status": "ACTIVE"
     },
@@ -4709,21 +4544,6 @@
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
       "staleDays": 122,
       "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-04-20",
-        "status": "HISTORICAL"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-04-20",
-      "owner": null,
-      "path": "docs/PHASE1_INTEGRATION_SUMMARY.md",
-      "staleDays": 31,
-      "status": "HISTORICAL"
     },
     {
       "docType": "doc",
@@ -4935,51 +4755,6 @@
       "exists": true,
       "frontmatter": {
         "last_updated": "2026-01-19",
-        "status": "HISTORICAL"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/PROPOSAL_WORKFLOW_SUMMARY.md",
-      "staleDays": 122,
-      "status": "HISTORICAL"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/PR_DESCRIPTION.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/PR_INTEGRATION_PLAN.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
@@ -5031,21 +4806,6 @@
       "isStale": false,
       "lastUpdated": "2026-01-19",
       "owner": null,
-      "path": "docs/ROLLBACK.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
       "staleDays": 122,
       "status": "ACTIVE"
@@ -5064,21 +4824,6 @@
       "path": "docs/ROLLOUT_STRATEGY.md",
       "staleDays": 122,
       "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-04-20",
-        "status": "HISTORICAL"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-04-20",
-      "owner": null,
-      "path": "docs/SAFETY_CHECK_REPORT.md",
-      "staleDays": 31,
-      "status": "HISTORICAL"
     },
     {
       "docType": "doc",
@@ -5575,6 +5320,20 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
+        "last_updated": "2026-04-03"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-04-03",
+      "owner": null,
+      "path": "docs/adr/ADR-021-runtime-authority.md",
+      "staleDays": 48,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
         "last_updated": "2026-04-18",
         "status": "ACTIVE"
       },
@@ -5993,7 +5752,7 @@
       "isStale": false,
       "lastUpdated": "2026-01-19",
       "owner": null,
-      "path": "docs/chaos/catalog.md",
+      "path": "docs/chaos-engineering/catalog.md",
       "staleDays": 122,
       "status": "ACTIVE"
     },
@@ -6269,35 +6028,6 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-04-03"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-04-03",
-      "owner": null,
-      "path": "docs/decisions/adr-runtime-authority.md",
-      "staleDays": 48,
-      "status": "UNKNOWN"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/deployment-audit.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
         "last_updated": "2026-01-19",
         "status": "ACTIVE"
       },
@@ -6468,7 +6198,7 @@
       "isStale": false,
       "lastUpdated": "2026-01-19",
       "owner": null,
-      "path": "docs/dev/wsl2-quickstart.md",
+      "path": "docs/dev/windows-setup.md",
       "staleDays": 122,
       "status": "ACTIVE"
     },
@@ -6483,7 +6213,7 @@
       "isStale": false,
       "lastUpdated": "2026-01-19",
       "owner": null,
-      "path": "docs/development/windows-setup.md",
+      "path": "docs/dev/wsl2-quickstart.md",
       "staleDays": 122,
       "status": "ACTIVE"
     },
@@ -7910,66 +7640,6 @@
     {
       "docType": "doc",
       "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/phase2 docs/CHECKLIST-Phase2.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/phase2 docs/PR_BODY-Phase2.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/phase2 docs/README.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/phase2 docs/STRATEGY-Phase2-CapitalAllocation.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
       "frontmatter": {},
       "hasExecutionClaims": false,
       "isStale": true,
@@ -8695,21 +8365,6 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/production-deployment-checklist.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
         "last_updated": "2026-04-03"
       },
       "hasExecutionClaims": false,
@@ -9001,7 +8656,7 @@
       "isStale": false,
       "lastUpdated": "2026-01-19",
       "owner": null,
-      "path": "docs/release/compat-matrix.md",
+      "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
       "staleDays": 122,
       "status": "ACTIVE"
     },
@@ -9016,7 +8671,7 @@
       "isStale": false,
       "lastUpdated": "2026-01-19",
       "owner": null,
-      "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
+      "path": "docs/releases/compat-matrix.md",
       "staleDays": 122,
       "status": "ACTIVE"
     },
@@ -11342,111 +10997,6 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-04-03",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-04-03",
-      "owner": null,
-      "path": "docs/sprint-g2c-automation-kickoff.md",
-      "staleDays": 48,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/sprint-g2c-backlog.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/sprint-g2c-ceremony-calendar.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/sprint-g2c-master-checklist.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/sprint-g2c-planning-agenda.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "ACTIVE"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/sprint-g2c-sanity-check.md",
-      "staleDays": 122,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "HISTORICAL"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/sprint-g2c-stakeholder-summary.md",
-      "staleDays": 122,
-      "status": "HISTORICAL"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
         "last_updated": "2026-01-19",
         "status": "ACTIVE"
       },
@@ -11946,41 +11496,6 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "audience": "both",
-        "categories": [
-          "tech-debt",
-          "architecture",
-          "documentation"
-        ],
-        "keywords": [
-          "xirr",
-          "executive-summary",
-          "consolidation"
-        ],
-        "last_updated": "2026-04-03",
-        "owner": "Platform Developer",
-        "priority": 1,
-        "related_code": [
-          "client/src/lib/finance/xirr.ts"
-        ],
-        "review_cadence": "P90D",
-        "status": "ACTIVE",
-        "use_cases": [
-          "capability_discovery"
-        ]
-      },
-      "hasExecutionClaims": true,
-      "isStale": false,
-      "lastUpdated": "2026-04-03",
-      "owner": "Platform Developer",
-      "path": "docs/xirr-consolidation-summary.md",
-      "staleDays": 48,
-      "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
         "last_updated": "2026-01-19",
         "status": "ACTIVE"
       },
@@ -11991,21 +11506,6 @@
       "path": "docs/xirr-excel-validation.md",
       "staleDays": 122,
       "status": "ACTIVE"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {
-        "last_updated": "2026-01-19",
-        "status": "HISTORICAL"
-      },
-      "hasExecutionClaims": false,
-      "isStale": false,
-      "lastUpdated": "2026-01-19",
-      "owner": null,
-      "path": "docs/xirr-golden-set-addition-summary.md",
-      "staleDays": 122,
-      "status": "HISTORICAL"
     },
     {
       "docType": "doc",
@@ -13204,12 +12704,12 @@
   "stats": {
     "by_status": {
       "ACCEPTED": 1,
-      "ACTIVE": 465,
+      "ACTIVE": 440,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETED": 1,
       "DRAFT": 31,
-      "HISTORICAL": 34,
+      "HISTORICAL": 27,
       "HISTORICAL-FRAMEWORK": 1,
       "HISTORICAL-SNAPSHOT": 1,
       "IMPLEMENTED": 1,
@@ -13224,7 +12724,7 @@
     },
     "missing_frontmatter": 15,
     "stale_docs": 96,
-    "total_docs": 688
+    "total_docs": 656
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-05-21
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 688 |
+| Total Documents | 656 |
 | Stale Documents | 96 |
 | Missing Frontmatter | 15 |
 
@@ -19,10 +19,10 @@ last_updated: 2026-05-21
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 465 |
+| ACTIVE | 440 |
 | UNKNOWN | 123 |
-| HISTORICAL | 34 |
 | DRAFT | 31 |
+| HISTORICAL | 27 |
 | VERIFIED | 9 |
 | INDEXED | 6 |
 | REFERENCE | 6 |


### PR DESCRIPTION
## Summary
- Regenerate discovery routing artifacts after docs cleanup removed archived document paths.
- Add explicit `contents: read` and `security-events: write` permissions to `security-scan.yml` so SARIF uploads can publish to code scanning.

## Failure evidence
- `Documentation Routing Check` failed on `npm run docs:routing:check` because generated router artifacts still referenced deleted docs.
- `Security Deep Scan` scanners completed, but SARIF upload steps failed with `Resource not accessible by integration` / missing CodeQL Action API access.

## Verification
- `npm run docs:routing:check`
- Deterministic routing regeneration hash check
- `security-scan.yml` YAML parse
- `git diff --check`
- Pre-commit hook passed staged-file checks