### PR TITLE
docs: Keep closeout evidence truthful after archive pruning

### DIFF
--- a/docs/STABILIZATION-ROADMAP.md
+++ b/docs/STABILIZATION-ROADMAP.md
@@ -332,8 +332,9 @@ below, not a backlog.
   `2026-04-02-phase-2-scenario-comparison-consolidation-plan.md` and the
   2026-04-03 slice 3 / slice 4 follow-ups
 - Dual-forecast PR queue — `2026-04-03-phase-1b-single-owner-pr-queue.md`
-- Doc truthfulness remediation (CLOSED 2026-04-08, settled on main) —
-  `docs/archive/2026-q2/2026-04-05-todo-report-remediation-strategy.md`
+- Doc truthfulness remediation (CLOSED 2026-04-08, settled on main) — covered by
+  ADR-014, current product evidence, and git history after the April 5 archive
+  copy was pruned
 
 **Standing rules that outlast the program:**
 

--- a/docs/adr/ADR-014-snapshot-governance.md
+++ b/docs/adr/ADR-014-snapshot-governance.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-04-05
+last_updated: 2026-05-22
 ---
 
 # ADR-014: Snapshot Governance
@@ -104,5 +104,5 @@ The current-main remediation queue should:
 - `server/services/fund-state-read-service.ts`
 - `server/services/time-travel-analytics.ts`
 - `server/services/backtesting-service.ts`
-- `docs/archive/2026-q2/2026-04-05-todo-report-remediation-strategy.md`
-  (archived 2026-04-08 per Phase 3 close-via-archive)
+- `docs/plans/2026-03-31-variance-roadmap-revision.md` (historical sequencing
+  framework updated after the April 5 archive tree was pruned)

--- a/docs/plans/2026-03-31-variance-roadmap-revision.md
+++ b/docs/plans/2026-03-31-variance-roadmap-revision.md
@@ -33,11 +33,11 @@ statuses below are out of date:**
 - **Phase 0.P Cleanup**: settled on main as of 2026-04-08. The remaining items
   flagged below (`_reportsData`, `mockVarianceData`, restore UI) and the
   Worktrack A/B of the original strategy doc are no longer present in
-  `client/src` — see
-  `docs/archive/2026-q2/2026-04-05-todo-report-remediation-strategy.md`
-  (archived 2026-04-08 per
-  `.planning/phases/03-todo-report-remediation/03-CONTEXT.md` D-01
-  close-via-archive).
+  `client/src`. The April 5 archive copy was later pruned; current closeout
+  evidence is the accepted `docs/adr/ADR-014-snapshot-governance.md` boundary,
+  current product code/tests, and the archive-deletion history (archived
+  2026-04-08 per `.planning/phases/03-todo-report-remediation/03-CONTEXT.md`
+  D-01 close-via-archive).
 - **Phase 1A.1**: implementation recorded in
   `2026-04-01-variance-phase1a1c-implementation-plan.md`.
 - **Phase 1A.2**: hardening in


### PR DESCRIPTION
## Summary
- Replace stale tracked references to the pruned April 5 remediation archive doc with current tracked evidence.
- Keep ADR-014 as the active snapshot-governance boundary and point the historical variance roadmap at current closeout evidence.
- Preserve B truthfulness as a no-op code path: current sensitivity/time-travel pages and tests already prove the live four-tab sensitivity surface and restore-disabled UUID/version boundary.

## A-closeout evidence
- Old active paths are absent: `docs/plans/2026-04-05-todo-report-remediation-strategy.md`, `docs/todo-report-accuracy-review-2026-04-05.md`.
- Old archive paths are absent: `docs/archive/2026-q2/2026-04-05-todo-report-remediation-strategy.md`, `docs/archive/2026-q2/todo-report-accuracy-review-2026-04-05.md`.
- Git history shows archive-tree deletion at `1dfd80d6`.
- `docs/adr/ADR-014-snapshot-governance.md` remains accepted and names the `fund_snapshots` / `fund_state_snapshots` boundary.
- `server/routes/lp-api.ts` retains persisted benchmark-derived copy and explicit no-dataset fallback copy.

## B truthfulness evidence
- `client/src/pages/sensitivity-analysis.tsx` exposes Monte Carlo, One-Way, Two-Way, and Stress as live fund-scoped persisted surfaces.
- `client/src/pages/time-travel.tsx` keeps restore unavailable and describes the UUID snapshot/version identity boundary for server-side restore.
- No page/test code edits were needed.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `npm run check`
- `npm run lint`
- `npx vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/pages/sensitivity-analysis.test.tsx tests/unit/pages/time-travel.test.tsx` (2 files, 6 tests)
- Scoped touched-doc link scan: 3 files, 0 links, 0 broken links
- Pre-commit checks passed
- Pre-push checks passed; hook classified the branch as docs/config-only and skipped heavier tests

## Known gaps
- `npm run docs:check-links` still fails on the repo's pre-existing broad docs baseline: 400 broken links out of 1578. This PR does not add links in touched docs.
- Native child architect review attempts timed out twice, so final review was done locally against the three-file diff and verified by focused gates.
