### PR TITLE
[codex] Repair active doc links before broader cleanup

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,12 +46,12 @@ Humans AND Agents **Last Updated**: 2026-05-20
 
 **Status**: [ACTIVE] **Audience**: Humans + Agents
 
-| Document                                               | Description                                       | When to Use                  |
-| ------------------------------------------------------ | ------------------------------------------------- | ---------------------------- |
-| [README.md](../README.md)                              | Project overview, tech stack, setup               | First time setup             |
-| [processes/clone-guide.md](processes/clone-guide.md)   | Blobless clone guidance and archive policy        | Size-sensitive local clones  |
-| [CLAUDE.md](../CLAUDE.md)                              | AI assistant guidelines, conventions              | Before ANY AI-assisted task  |
-| [CAPABILITIES.md](../CAPABILITIES.md)                  | Historical inventory of agents, tools, and skills | Historical capability lookup |
+| Document                                             | Description                                       | When to Use                  |
+| ---------------------------------------------------- | ------------------------------------------------- | ---------------------------- |
+| [README.md](../README.md)                            | Project overview, tech stack, setup               | First time setup             |
+| [processes/clone-guide.md](processes/clone-guide.md) | Blobless clone guidance and archive policy        | Size-sensitive local clones  |
+| [CLAUDE.md](../CLAUDE.md)                            | AI assistant guidelines, conventions              | Before ANY AI-assisted task  |
+| [CAPABILITIES.md](../CAPABILITIES.md)                | Historical inventory of agents, tools, and skills | Historical capability lookup |
 
 **Current Path**: CLAUDE.md -> repo search -> docs/INDEX.md -> README.md
 
@@ -111,7 +111,7 @@ Hardening baseline)
 | ------------------------------------------------------------------ | --------------------------------------------------------- | -------------------------------------------- |
 | [scripts/README.md](../scripts/README.md)                          | Deployment scripts (progressive rollout, smoke tests)     | Deploying to staging/production              |
 | [workflows/PRODUCTION_SCRIPTS.md](workflows/PRODUCTION_SCRIPTS.md) | Production deployment system details                      | Understanding deployment process             |
-| [DEPLOYMENT_RUNBOOK.md](DEPLOYMENT_RUNBOOK.md)                     | Step-by-step production deployment and rollback runbook   | Executing or supervising production rollout  |
+| [runbooks/rollback.md](runbooks/rollback.md)                       | Step-by-step rollback runbook                             | Executing or supervising production rollback |
 | [OPERATOR_RUNBOOK.md](OPERATOR_RUNBOOK.md)                         | Unified metrics diagnostic runbook                        | Investigating production metrics anomalies   |
 | [observability.md](observability.md)                               | Monitoring, health checks, metrics, and alerting overview | Understanding runtime observability surfaces |
 

--- a/docs/metrics-meanings.md
+++ b/docs/metrics-meanings.md
@@ -10,21 +10,25 @@ last_updated: 2026-01-19
 ### Core Metrics (Tactyc-aligned)
 
 **IRR (Internal Rate of Return)**
+
 - Annualized return accounting for cash flow timing
 - Computed from quarterly XIRR using Actual/365 day-count convention
 - Sign convention: LP view (investments negative, distributions positive)
 - Formula: Quarterly XIRR → annualized via `(1 + quarterly)^4 - 1`
 
 **TVPI (Total Value to Paid-In)**
+
 - `(DPI + RVPI)` = Total value (realized + residual) / invested capital
 - Invariant: `TVPI ≥ DPI` (always true for mark-to-market NAV)
 - Unitless multiple (2.5x TVPI = $2.50 returned per $1 invested)
 
 **DPI (Distributions to Paid-In)**
+
 - Cash returned to LPs / total invested capital
 - Realized returns only (distributions, not paper gains)
 
 **NAV (Net Asset Value)**
+
 - Current portfolio value (mark-to-market)
 - `NAV = unrealized value + cash - fees`
 - Always ≥ 0 (negative NAV is invalid)
@@ -32,12 +36,15 @@ last_updated: 2026-01-19
 ### Reserve-Specific Metrics
 
 **Exit MOIC on Planned Reserves**
+
 - Industry-standard metric for follow-on investment quality
 - Expected return (MOIC) on next dollar of follow-on capital
 - Used by `DeterministicReserveEngine` for ranking investments
-- Formula: `(exit value / (initial + planned reserves)) * graduation probability`
+- Formula:
+  `(exit value / (initial + planned reserves)) * graduation probability`
 
 **7-Flavor MOIC Vocabulary**
+
 1. **Current MOIC**: Current valuation / invested capital
 2. **Exit MOIC**: Expected exit valuation / total capital (initial + reserves)
 3. **Initial MOIC**: Calculated on initial investment only
@@ -49,32 +56,36 @@ last_updated: 2026-01-19
 ### Construction vs Current
 
 **Construction Scenario**
+
 - Pro-forma portfolio based on planned investments
 - Includes uncommitted capital, planned follow-ons
 - Used for forward-looking optimization
 
 **Current Scenario**
+
 - Actual portfolio as it stands today
 - Only committed/deployed capital
 - Baseline for measuring Construction improvements
 
 ## AI Evaluation Metrics
 
-**irrDelta**: `Construction IRR - Current IRR`
-**tvpiDelta**: `Construction TVPI - Current TVPI`
-**exitMoicOnPlannedReserves**: From `DeterministicReserveEngine.calculateOptimalReserveAllocation()`
+**irrDelta**: `Construction IRR - Current IRR` **tvpiDelta**:
+`Construction TVPI - Current TVPI` **exitMoicOnPlannedReserves**: From
+`DeterministicReserveEngine.calculateOptimalReserveAllocation()`
 
 ## Determinism Guarantees
 
 - **Fixed Decimal precision**: 28 digits, ROUND_HALF_UP mode
 - **No ambient Date.now()** or `Math.random()` in core evaluation paths
 - **Excel parity tolerance**: `|Δ IRR| ≤ 1e-6`, `|Δ TVPI| ≤ 1e-6`
-- **Prohibited in `ai/**` and `core/reserves/**`**: Ambient `Number` arithmetic, `Math.*` functions
+- **Prohibited in `ai/**`and`core/reserves/**`**: Ambient `Number` arithmetic,
+  `Math.*` functions
 - **Required**: Use `Decimal.js` (or equivalent) for all financial math
 
 ## Implementation Notes
 
 ### Decimal.js Configuration
+
 ```typescript
 import Decimal from 'decimal.js';
 
@@ -83,11 +94,12 @@ Decimal.set({
   precision: 28,
   rounding: Decimal.ROUND_HALF_UP,
   toExpNeg: -7,
-  toExpPos: 21
+  toExpPos: 21,
 });
 ```
 
 ### IRR Calculation
+
 ```typescript
 // Quarterly XIRR → Annualized IRR
 const quarterlyRate = xirr(cashFlows, dates);
@@ -95,6 +107,7 @@ const annualizedIRR = new Decimal(1).plus(quarterlyRate).pow(4).minus(1);
 ```
 
 ### TVPI Calculation
+
 ```typescript
 // Total Value to Paid-In
 const tvpi = (distributions + currentNAV) / capitalCalled;
@@ -104,6 +117,9 @@ assert(tvpi >= dpi, 'TVPI must be >= DPI');
 
 ## References
 
-- [Evaluator Metrics ADR](adr/003-evaluator-metrics.md) - Detailed rationale for metric selection
-- [Determinism ADR](adr/002-deterministic-computation.md) - Why we enforce deterministic math
-- [Observability Metrics](observability/ai-metrics.md) - Prometheus metrics for monitoring
+- [Evaluator Metrics ADR](adr/0001-evaluator-metrics.md) - Detailed rationale
+  for metric selection
+- [Capital Allocation Policy ADR](adr/ADR-008-capital-allocation-policy.md) -
+  Deterministic allocation policy and auditability rationale
+- [Observability Metrics](observability/ai-metrics.md) - Prometheus metrics for
+  monitoring


### PR DESCRIPTION
## Summary

This PR fixes the first narrow broken-link cleanup bucket in active docs only:

- Updates `docs/INDEX.md` to route the missing deployment runbook link to the existing rollback runbook.
- Updates `docs/metrics-meanings.md` ADR references to point at existing ADR files.

It intentionally does not touch Phoenix-protected paths, preserved config/tooling changes, template placeholders, NotebookLM/source docs, or historical/reference-doc link debt.

## Verification

- `git diff --check`
- `npm run docs:check-links` expected red: improved `400 -> 397`; changed docs have `0` remaining broken links
- `npm run check`
- `npm run lint`
- Pre-push hook: docs/config-only path, large-file and safety checks passed

## Remaining Scope

`npm run docs:check-links` still reports 397 inherited broken links outside this PR. Those should continue by small buckets on separate branches.