### PR TITLE
Fix AI optimization decisions link

### DIFF
--- a/docs/ai-optimization/AI_COLLABORATION_GUIDE.md
+++ b/docs/ai-optimization/AI_COLLABORATION_GUIDE.md
@@ -627,7 +627,7 @@ cat .env.local | grep -E "ANTHROPIC|OPENAI|GOOGLE|DEEPSEEK"
   Core orchestrator guide
 - **[CODEX_AGENT_MIGRATION.md](./CODEX_AGENT_MIGRATION.md)** - Codex Review
   Agent integration
-- **[DECISIONS.md](./DECISIONS.md)** - Architecture decisions
+- **[DECISIONS.md](../../DECISIONS.md)** - Architecture decisions
 
 ---
 


### PR DESCRIPTION
## Summary
- Retarget `docs/ai-optimization/AI_COLLABORATION_GUIDE.md` to the repo-root `DECISIONS.md` source of truth.
- Keep the docs-link cleanup to one active documentation file after PR #681 merged.

## Verification
- `git diff --check`
- `npm run docs:check-links -- --report-only` -> 393 broken links out of 1577 total in 386 files
- Targeted `docs/ai-optimization/AI_COLLABORATION_GUIDE.md` scan -> 0 broken local links out of 3
- `npm run check`
- `npm run lint`

## Scope
- Changed only `docs/ai-optimization/AI_COLLABORATION_GUIDE.md`.
- Did not touch Phoenix protected paths, `.claude`, scripts, `tsconfig.eslint.json`, or `.zap/rules.tsv`.
- Did not recreate stale docs or start product work.