### PR TITLE
Fix Codex review setup links

### DIFF
--- a/docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md
+++ b/docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md
@@ -3,7 +3,7 @@ status: ACTIVE
 last_updated: 2026-01-19
 ---
 
-# Codex Review Agent - Setup Complete! 🎉
+# Codex Review Agent - Setup Complete!
 
 ## What We Built
 
@@ -22,8 +22,8 @@ npm run review:watch
 You'll see:
 
 ```
-🚀 Starting Codex Review Agent...
-✅ Codex Review Agent is running!
+Starting Codex Review Agent...
+[OK] Codex Review Agent is running!
    Watching for file changes...
    Press Ctrl+C to stop
 ```
@@ -44,15 +44,15 @@ You'll get instant feedback like:
 
 ```
 ================================================================================
-📊 Codex Review: client/src/components/Dashboard.tsx
+Codex Review: client/src/components/Dashboard.tsx
 ================================================================================
 
-✅ GOOD: Code looks good with minimal issues
+[OK] GOOD: Code looks good with minimal issues
 
-🟡 MEDIUM (1):
+MEDIUM (1):
   1. [gemini] Avoid using "any" type - use specific types for better type safety
 
-🔵 LOW (1):
+LOW (1):
   1. [openai] Remove console.log statements before committing
 
 ================================================================================
@@ -60,10 +60,11 @@ You'll get instant feedback like:
 
 ## Key Features
 
-✅ **Real-time reviews** - Get feedback within 1 second of saving ✅ **Multi-AI
-consensus** - Reviews from 3 AI providers ✅ **Smart filtering** - Only reviews
-code files, skips node_modules ✅ **Severity levels** - Clear categorization
-(Critical → Info) ✅ **Debounced** - Won't spam if you save rapidly
+[x] **Real-time reviews** - Get feedback within 1 second of saving [x]
+**Multi-AI consensus** - Reviews from 3 AI providers [x] **Smart filtering** -
+Only reviews code files, skips node_modules [x] **Severity levels** - Clear
+categorization (Critical to Info) [x] **Debounced** - Won't spam if you save
+rapidly
 
 ## Configuration
 
@@ -82,7 +83,7 @@ Currently, the agent uses basic static analysis. To enable full AI reviews:
 
 1. Ensure your MCP multi-AI server is running
 2. Update
-   [CodexReviewAgent.ts:202](packages/codex-review-agent/src/CodexReviewAgent.ts#L202)
+   [CodexReviewAgent.ts:202](../../packages/codex-review-agent/src/CodexReviewAgent.ts#L202)
    to call the actual MCP server:
 
 ```typescript
@@ -102,7 +103,7 @@ private async callMCPCodeReview(
 
 ### Customize Watch Paths
 
-Edit [scripts/codex-review-watch.ts](scripts/codex-review-watch.ts):
+Edit [scripts/codex-review-watch.ts](../../scripts/codex-review-watch.ts):
 
 ```typescript
 const agent = new CodexReviewAgent({
@@ -200,23 +201,23 @@ cd packages/codex-review-agent && npm run build
 
 The GitHub Codex bot has already demonstrated massive value on your project:
 
-- ✅ Caught **$14M financial error** (management fee calculation)
-- ✅ Found **RS256 JWT security regression**
-- ✅ Detected **silent data loss** (wizard state)
-- ✅ Identified **dev environment blocker**
-- ✅ **100% accuracy** (0 false positives)
+- [x] Caught **$14M financial error** (management fee calculation)
+- [x] Found **RS256 JWT security regression**
+- [x] Detected **silent data loss** (wizard state)
+- [x] Identified **dev environment blocker**
+- [x] **100% accuracy** (0 false positives)
 
 Now you have that same quality of review **in real-time as you code**!
 
 ## Support
 
 - **Documentation**:
-  [packages/codex-review-agent/README.md](packages/codex-review-agent/README.md)
+  [packages/codex-review-agent/README.md](../../packages/codex-review-agent/README.md)
 - **Related**:
-  [CODEX-FIXES-EXECUTION-SUMMARY.md](docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md)
-- **Framework**: [BaseAgent](packages/agent-core/src/BaseAgent.ts)
+  [CODEX-FIXES-EXECUTION-SUMMARY.md](../action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md)
+- **Framework**: [BaseAgent](../../packages/agent-core/src/BaseAgent.ts)
 
 ---
 
-🎯 **Ready to use!** Just run `npm run review:watch` and start coding with
-instant AI feedback!
+**Ready to use!** Just run `npm run review:watch` and start coding with instant
+AI feedback!


### PR DESCRIPTION
## Summary

- retargeted five local links in `docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md` to existing root package, script, and action-plan files
- replaced existing emoji glyphs in the same staged doc with text equivalents so the repo no-emoji hook can accept the cleanup

## Why

The setup guide lives under `docs/ai-optimization`, so package and script links without the needed `../../` prefix resolved under the docs folder and showed up in the active docs link report.

## Validation

- `git diff --check`
- targeted `docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md` scan: 0 broken local links out of 5
- emoji-range scan for changed doc: no matches
- `npm run docs:check-links -- --report-only`: 388 broken links out of 1577, down from 393
- `npm run check`: 0 TypeScript errors
- `npm run lint`: pass, guardrail counts within baselines

## Not Tested

- inherited repo-wide broken-link backlog remains at 388 report-only failures