### PR TITLE
[codex] Retarget Vitest governance links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2998,7 +2998,7 @@ and Phase 1D (Capital Allocation).
 
 - ❌ **`environmentMatchGlobs` Deprecated:** Vitest configuration uses
   deprecated `environmentMatchGlobs` option (lines 76-88 in
-  [vitest.config.ts](vitest.config.ts#L76-L88))
+  [vitest.config.mjs](vitest.config.mjs#L98-L141))
 - **Impact:** Server-side tests continue running in `jsdom` environment instead
   of `node`
 - **Errors:** `default.randomUUID is not a function`,
@@ -3020,7 +3020,7 @@ and Phase 1D (Capital Allocation).
 - [tests/unit/wizard-reserve-bridge.test.ts](tests/unit/wizard-reserve-bridge.test.ts)
 - `tests/unit/setup.ts` (since reorganized into `tests/setup/`; attempted
   environment-agnostic changes, reverted)
-- [vitest.config.ts](vitest.config.ts) (deprecated `environmentMatchGlobs`
+- [vitest.config.mjs](vitest.config.mjs) (deprecated `environmentMatchGlobs`
   configuration)
 
 ---

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -637,7 +637,7 @@ logic issues. Initial plan was to treat symptoms in phases by failure count.
 
 **Phase 1: Configuration (22 fixes)**
 
-- Added `@shared/` path alias to [`vitest.config.ts`](vitest.config.ts#L17)
+- Added `@shared/` path alias to [`vitest.config.mjs`](vitest.config.mjs#L23)
 - Created
   [`tests/utils/mock-shared-schema.ts`](tests/utils/mock-shared-schema.ts) -
   centralized mock factory using `importOriginal` pattern
@@ -730,7 +730,7 @@ misconfiguration:
 **Current Configuration Issue:**
 
 - Using deprecated `environmentMatchGlobs` in
-  [vitest.config.ts](vitest.config.ts#L76-L88)
+  [vitest.config.mjs](vitest.config.mjs#L98-L141)
 - Vitest silently ignores this option (removed in recent versions)
 - **Result:** All tests run in `jsdom` environment (default), including
   server-side tests
@@ -862,8 +862,8 @@ export default defineConfig({
 ### References
 
 - **Vitest Projects Documentation:** https://vitest.dev/guide/workspace.html
-- **Current Config:** [vitest.config.ts](vitest.config.ts#L76-L88) (deprecated
-  `environmentMatchGlobs`)
+- **Current Config:** [vitest.config.mjs](vitest.config.mjs#L98-L141)
+  (deprecated `environmentMatchGlobs`)
 - **Test Failures:** See CHANGELOG.md → Test Suite Environment Debugging
   (2025-10-19)
 - **Related Files:**


### PR DESCRIPTION
## Summary

- Retargeted five root-governance Markdown links from `vitest.config.ts` to the active `vitest.config.mjs`.
- Kept the slice to `DECISIONS.md` and `CHANGELOG.md`; no code, scripts, Phoenix paths, `.claude`, `tsconfig.eslint.json`, or `.zap/rules.tsv` were touched.

## Why

The docs-link report still counted stale links to the retired Vitest config filename. The active test command uses `vitest.config.mjs`, and that file contains the referenced alias and project configuration.

## Validation

- Targeted local-link scan: `DECISIONS.md` 0 broken local links out of 34 Markdown links; `CHANGELOG.md` 0 broken local links out of 31 Markdown links.
- `git diff --check`
- `npm run docs:check-links -- --report-only`: 388 -> 383 broken links out of 1577; remaining failures are inherited backlog.
- `npm run check`: 0 TypeScript errors.
- `npm run lint`: ESLint and guardrails passed.