### PR TITLE
[codex] Keep pacing truth-source links navigable

### DIFF
--- a/docs/notebooklm-sources/pacing/01-overview.md
+++ b/docs/notebooklm-sources/pacing/01-overview.md
@@ -80,7 +80,7 @@ portfolio strategy.
 ### Real-World Impact
 
 From test case analysis
-([pacing-engine.test.ts:158-167](tests/unit/engines/pacing-engine.test.ts#L158)):
+([pacing-engine.test.ts:158-167](../../../tests/unit/engines/pacing-engine.test.ts#L158)):
 
 ```typescript
 // $50M fund deployed over 8 quarters
@@ -168,7 +168,7 @@ allocation timing:
 ### 3. Phase-Based Deployment
 
 Each 8-quarter schedule is divided into **three phases**
-([PacingEngine.ts:82-85](client/src/core/pacing/PacingEngine.ts#L82)):
+([PacingEngine.ts:82-85](../../../client/src/core/pacing/PacingEngine.ts#L82)):
 
 1. **Early-Stage Focus (Q1-3)**: Seed and Series A investments
    - Higher risk tolerance
@@ -186,7 +186,7 @@ Each 8-quarter schedule is divided into **three phases**
    - Reserve allocation
 
 **Test Evidence:**
-[pacing-engine.test.ts:113-143](tests/unit/engines/pacing-engine.test.ts#L113)
+[pacing-engine.test.ts:113-143](../../../tests/unit/engines/pacing-engine.test.ts#L113)
 validates phase note assignment across all strategies.
 
 ### 4. Deterministic Variability
@@ -208,11 +208,11 @@ const deployment = baseAmount * multiplier * variability;
 - **Deterministic**: Same inputs always produce same outputs (critical for
   testing)
 - **Reproducible**: Resets seed on each engine invocation
-  ([PacingEngine.ts:126](client/src/core/pacing/PacingEngine.ts#L126))
+  ([PacingEngine.ts:126](../../../client/src/core/pacing/PacingEngine.ts#L126))
 - **Realistic**: Mimics real-world unpredictability in deal flow
 
 **Edge Case:** Test
-[pacing-engine.test.ts:326-335](tests/unit/engines/pacing-engine.test.ts#L326)
+[pacing-engine.test.ts:326-335](../../../tests/unit/engines/pacing-engine.test.ts#L326)
 validates consistency across multiple runs with identical inputs.
 
 ### 5. Algorithm Modes
@@ -234,7 +234,7 @@ The PacingEngine supports two calculation modes:
 - Note suffix: "ML-optimized pacing"
 
 **Mode Detection:**
-[PacingEngine.ts:47-49](client/src/core/pacing/PacingEngine.ts#L47)
+[PacingEngine.ts:47-49](../../../client/src/core/pacing/PacingEngine.ts#L47)
 
 ```typescript
 function isAlgorithmModeEnabled(): boolean {
@@ -246,7 +246,7 @@ function isAlgorithmModeEnabled(): boolean {
 ```
 
 **Test Coverage:**
-[pacing-engine.test.ts:191-222](tests/unit/engines/pacing-engine.test.ts#L191)
+[pacing-engine.test.ts:191-222](../../../tests/unit/engines/pacing-engine.test.ts#L191)
 validates both modes.
 
 ---
@@ -264,7 +264,7 @@ graph LR
     E --> F[Engine Calculation]
 ```
 
-**Validation Schema:** [shared/types.ts:113-117](shared/types.ts#L113)
+**Validation Schema:** [shared/types.ts:113-117](../../../shared/types.ts#L113)
 
 ```typescript
 export const PacingInputSchema = z.object({
@@ -275,7 +275,7 @@ export const PacingInputSchema = z.object({
 ```
 
 **Test Coverage:**
-[pacing-engine.test.ts:24-53](tests/unit/engines/pacing-engine.test.ts#L24)
+[pacing-engine.test.ts:24-53](../../../tests/unit/engines/pacing-engine.test.ts#L24)
 validates rejection of invalid inputs.
 
 ### Core Calculation Flow
@@ -296,15 +296,16 @@ validates rejection of invalid inputs.
 ```
 
 **Implementation:**
-[PacingEngine.ts:52-95](client/src/core/pacing/PacingEngine.ts#L52) for
-rule-based, [PacingEngine.ts:98-113](client/src/core/pacing/PacingEngine.ts#L98)
+[PacingEngine.ts:52-95](../../../client/src/core/pacing/PacingEngine.ts#L52) for
+rule-based,
+[PacingEngine.ts:98-113](../../../client/src/core/pacing/PacingEngine.ts#L98)
 for ML-enhanced.
 
 ### Output Generation
 
 The primary function `PacingEngine()`
-([PacingEngine.ts:124](client/src/core/pacing/PacingEngine.ts#L124)) returns an
-array of `PacingOutput` objects:
+([PacingEngine.ts:124](../../../client/src/core/pacing/PacingEngine.ts#L124))
+returns an array of `PacingOutput` objects:
 
 ```typescript
 export function PacingEngine(input: unknown): PacingOutput[] {
@@ -322,7 +323,7 @@ export function PacingEngine(input: unknown): PacingOutput[] {
 
 **Summary Generation:** For comprehensive metadata, use
 `generatePacingSummary()`
-([PacingEngine.ts:144](client/src/core/pacing/PacingEngine.ts#L144)):
+([PacingEngine.ts:144](../../../client/src/core/pacing/PacingEngine.ts#L144)):
 
 ```typescript
 export function generatePacingSummary(input: PacingInput): PacingSummary {
@@ -343,7 +344,7 @@ export function generatePacingSummary(input: PacingInput): PacingSummary {
 ```
 
 **Test Coverage:**
-[pacing-engine.test.ts:255-293](tests/unit/engines/pacing-engine.test.ts#L255)
+[pacing-engine.test.ts:255-293](../../../tests/unit/engines/pacing-engine.test.ts#L255)
 validates summary generation.
 
 ---
@@ -369,7 +370,7 @@ validates summary generation.
 would deploy approximately $6.25M per quarter over 8 quarters.
 
 **Test Reference:**
-[pacing-engine.test.ts:81-94](tests/unit/engines/pacing-engine.test.ts#L81)
+[pacing-engine.test.ts:81-94](../../../tests/unit/engines/pacing-engine.test.ts#L81)
 
 ---
 
@@ -394,7 +395,7 @@ would front-load deployment to capture momentum and avoid being priced out
 later.
 
 **Test Reference:**
-[pacing-engine.test.ts:60-69](tests/unit/engines/pacing-engine.test.ts#L60)
+[pacing-engine.test.ts:60-69](../../../tests/unit/engines/pacing-engine.test.ts#L60)
 
 **Trade-off:** Higher exposure to early-period market corrections, but captures
 growth upside.
@@ -422,7 +423,7 @@ conserve capital early, waiting for valuations to stabilize before aggressive
 deployment in later quarters.
 
 **Test Reference:**
-[pacing-engine.test.ts:70-80](tests/unit/engines/pacing-engine.test.ts#L70)
+[pacing-engine.test.ts:70-80](../../../tests/unit/engines/pacing-engine.test.ts#L70)
 
 **Trade-off:** Risk of missing early recovery, but benefits from lower
 valuations later.
@@ -449,7 +450,7 @@ valuations later.
 running scenario analysis across multiple market conditions.
 
 **Test Reference:**
-[pacing-engine.test.ts:193-205](tests/unit/engines/pacing-engine.test.ts#L193)
+[pacing-engine.test.ts:193-205](../../../tests/unit/engines/pacing-engine.test.ts#L193)
 
 **Trade-off:** Higher complexity and less transparency, but captures nuanced
 market trends.
@@ -460,8 +461,9 @@ market trends.
 
 ### 1. Worker Integration
 
-The **pacing-worker** ([workers/pacing-worker.ts](workers/pacing-worker.ts))
-handles background calculations:
+The **pacing-worker**
+([workers/pacing-worker.ts](../../../workers/pacing-worker.ts)) handles
+background calculations:
 
 - Subscribes to BullMQ queue: `pacing:calc`
 - Loads fund data from PostgreSQL
@@ -513,7 +515,7 @@ Pacing schedules are used in multi-scenario analysis:
 - Stress-test portfolio construction under various pacing strategies
 
 **Test Evidence:**
-[pacing-engine.test.ts:299-336](tests/unit/engines/pacing-engine.test.ts#L299)
+[pacing-engine.test.ts:299-336](../../../tests/unit/engines/pacing-engine.test.ts#L299)
 validates edge cases across extreme fund sizes and quarters.
 
 ---
@@ -529,16 +531,17 @@ validates edge cases across extreme fund sizes and quarters.
 
 ## Related Documentation
 
-- **Type Definitions:** [shared/types.ts:113-132](shared/types.ts#L113) - Zod
-  schemas and TypeScript types
+- **Type Definitions:**
+  [shared/types.ts:113-132](../../../shared/types.ts#L113) - Zod schemas and
+  TypeScript types
 - **Test Suite:**
-  [tests/unit/engines/pacing-engine.test.ts](tests/unit/engines/pacing-engine.test.ts) -
+  [tests/unit/engines/pacing-engine.test.ts](../../../tests/unit/engines/pacing-engine.test.ts) -
   336 lines, 30+ test cases
 - **Worker Implementation:**
-  [workers/pacing-worker.ts](workers/pacing-worker.ts) - Background job
+  [workers/pacing-worker.ts](../../../workers/pacing-worker.ts) - Background job
   processing
 - **Validation Config:**
-  [scripts/validation/pacing-validation.yaml](scripts/validation/pacing-validation.yaml) -
+  [scripts/validation/pacing-validation.yaml](../../../scripts/validation/pacing-validation.yaml) -
   Promptfoo test cases
 
 ---

--- a/docs/notebooklm-sources/pacing/02-strategies.md
+++ b/docs/notebooklm-sources/pacing/02-strategies.md
@@ -48,7 +48,7 @@ Where:
 
 ### Hard Constraints
 
-**Implemented:** [PacingInputSchema validation](shared/types.ts#L113)
+**Implemented:** [PacingInputSchema validation](../../../shared/types.ts#L113)
 
 1. **Fund Size Constraint:**
 
@@ -81,7 +81,7 @@ Where:
    _Soft constraint due to variability; typically converges to ~F_
 
 **Test Evidence:**
-[pacing-engine.test.ts:157-167](tests/unit/engines/pacing-engine.test.ts#L157)
+[pacing-engine.test.ts:157-167](../../../tests/unit/engines/pacing-engine.test.ts#L157)
 validates total deployment is within 10% of fund size.
 
 ### Phase Determination
@@ -97,7 +97,7 @@ Phase(q) = {
 ```
 
 **Implementation:**
-[PacingEngine.ts:70-85](client/src/core/pacing/PacingEngine.ts#L70)
+[PacingEngine.ts:70-85](../../../client/src/core/pacing/PacingEngine.ts#L70)
 
 ```typescript
 if (i < 3) {
@@ -119,7 +119,7 @@ if (i < 3) {
 ### Algorithm Overview
 
 The **rule-based pacing** algorithm is the default mode
-([PacingEngine.ts:52-95](client/src/core/pacing/PacingEngine.ts#L52)):
+([PacingEngine.ts:52-95](../../../client/src/core/pacing/PacingEngine.ts#L52)):
 
 ```
 FOR each quarter q in [0, 7]:
@@ -222,10 +222,10 @@ Total: $50,312,500 (within 0.6% of fund size)
 ```
 
 **Test Coverage:**
-[pacing-engine.test.ts:81-94](tests/unit/engines/pacing-engine.test.ts#L81)
+[pacing-engine.test.ts:81-94](../../../tests/unit/engines/pacing-engine.test.ts#L81)
 
 **Validation Test Case:**
-[pacing-validation.yaml:10-24](scripts/validation/pacing-validation.yaml#L10) -
+[pacing-validation.yaml:10-24](../../../scripts/validation/pacing-validation.yaml#L10) -
 "Standard linear pacing calculation"
 
 ---
@@ -283,7 +283,7 @@ Total: $110,937,500
 | Q7        | ~$111M     | 100%      |
 
 **Implementation:**
-[PacingEngine.ts:56-62](client/src/core/pacing/PacingEngine.ts#L56)
+[PacingEngine.ts:56-62](../../../client/src/core/pacing/PacingEngine.ts#L56)
 
 ```typescript
 const marketAdjustments = {
@@ -293,7 +293,7 @@ const marketAdjustments = {
 ```
 
 **Test Coverage:**
-[pacing-engine.test.ts:60-69](tests/unit/engines/pacing-engine.test.ts#L60)
+[pacing-engine.test.ts:60-69](../../../tests/unit/engines/pacing-engine.test.ts#L60)
 
 ```typescript
 it('should front-load deployment in bull markets', () => {
@@ -312,7 +312,7 @@ it('should front-load deployment in bull markets', () => {
 ```
 
 **Validation Test Case:**
-[pacing-validation.yaml:27-41](scripts/validation/pacing-validation.yaml#L27) -
+[pacing-validation.yaml:27-41](../../../scripts/validation/pacing-validation.yaml#L27) -
 "Frontloaded deployment pattern (60% in year 1)"
 
 ---
@@ -374,7 +374,7 @@ valuations later. The 1.2× multiplier in late phase enables aggressive
 deployment when market has stabilized.
 
 **Test Coverage:**
-[pacing-engine.test.ts:70-80](tests/unit/engines/pacing-engine.test.ts#L70)
+[pacing-engine.test.ts:70-80](../../../tests/unit/engines/pacing-engine.test.ts#L70)
 
 ```typescript
 it('should back-load deployment in bear markets', () => {
@@ -393,7 +393,7 @@ it('should back-load deployment in bear markets', () => {
 ```
 
 **Validation Test Case:**
-[pacing-validation.yaml:43-57](scripts/validation/pacing-validation.yaml#L43) -
+[pacing-validation.yaml:43-57](../../../scripts/validation/pacing-validation.yaml#L43) -
 "Backend-loaded deployment pattern (delayed deployment)"
 
 ---
@@ -404,7 +404,7 @@ it('should back-load deployment in bear markets', () => {
 
 The **ML-enhanced** mode applies rule-based calculation first, then adds a
 simulated trend-based adjustment
-([PacingEngine.ts:98-113](client/src/core/pacing/PacingEngine.ts#L98)):
+([PacingEngine.ts:98-113](../../../client/src/core/pacing/PacingEngine.ts#L98)):
 
 ```
 FOR each quarter q:
@@ -474,7 +474,7 @@ function isAlgorithmModeEnabled(): boolean {
 ```
 
 **Test Coverage:**
-[pacing-engine.test.ts:193-205](tests/unit/engines/pacing-engine.test.ts#L193)
+[pacing-engine.test.ts:193-205](../../../tests/unit/engines/pacing-engine.test.ts#L193)
 
 ```typescript
 it('should apply ML enhancements when ALG_PACING is true', () => {
@@ -505,7 +505,7 @@ modeling of market unpredictability.
 
 The PacingEngine uses a **Pseudo-Random Number Generator (PRNG)** with fixed
 seed for deterministic randomness
-([PacingEngine.ts:22](client/src/core/pacing/PacingEngine.ts#L22)):
+([PacingEngine.ts:22](../../../client/src/core/pacing/PacingEngine.ts#L22)):
 
 ```typescript
 import { PRNG } from '@shared/utils/prng';
@@ -518,7 +518,7 @@ numbers.
 ### Seed Reset Mechanism
 
 Every invocation of `PacingEngine()` resets the PRNG seed
-([PacingEngine.ts:126](client/src/core/pacing/PacingEngine.ts#L126)):
+([PacingEngine.ts:126](../../../client/src/core/pacing/PacingEngine.ts#L126)):
 
 ```typescript
 export function PacingEngine(input: unknown): PacingOutput[] {
@@ -563,7 +563,7 @@ Range: [0.85, 1.15] (±15%)
 ### Test Evidence
 
 **Consistency Test:**
-[pacing-engine.test.ts:326-335](tests/unit/engines/pacing-engine.test.ts#L326)
+[pacing-engine.test.ts:326-335](../../../tests/unit/engines/pacing-engine.test.ts#L326)
 
 ```typescript
 it('should maintain consistency across multiple runs', () => {
@@ -618,7 +618,7 @@ const result = PacingEngine(input);
 - Variability has proportionally larger impact
 
 **Test Coverage:**
-[pacing-engine.test.ts:300-307](tests/unit/engines/pacing-engine.test.ts#L300)
+[pacing-engine.test.ts:300-307](../../../tests/unit/engines/pacing-engine.test.ts#L300)
 
 ```typescript
 it('should handle very small fund size', () => {
@@ -657,7 +657,7 @@ const result = PacingEngine(input);
 - Rounding errors are negligible relative to magnitude
 
 **Test Coverage:**
-[pacing-engine.test.ts:309-317](tests/unit/engines/pacing-engine.test.ts#L309)
+[pacing-engine.test.ts:309-317](../../../tests/unit/engines/pacing-engine.test.ts#L309)
 
 ```typescript
 it('should handle very large fund size', () => {
@@ -680,7 +680,7 @@ implementation)
 **Current Limitation:** Hardcoded 8-quarter schedule
 
 **Validation Test Case:**
-[pacing-validation.yaml:76-90](scripts/validation/pacing-validation.yaml#L76) -
+[pacing-validation.yaml:76-90](../../../scripts/validation/pacing-validation.yaml#L76) -
 "Edge case: Single-year full deployment"
 
 **Expected Behavior (if implemented):**
@@ -722,7 +722,7 @@ const result = PacingEngine(input);
 - No calendar date awareness
 
 **Test Coverage:**
-[pacing-engine.test.ts:318-324](tests/unit/engines/pacing-engine.test.ts#L318)
+[pacing-engine.test.ts:318-324](../../../tests/unit/engines/pacing-engine.test.ts#L318)
 
 ```typescript
 it('should handle high starting quarter', () => {
@@ -777,7 +777,7 @@ const result = PacingEngine(input);
 5. Therefore: `Deployment(q) = (F/8) × Multiplier × Variability ≥ 0` ∎
 
 **Test Evidence:**
-[pacing-engine.test.ts:178-185](tests/unit/engines/pacing-engine.test.ts#L178)
+[pacing-engine.test.ts:178-185](../../../tests/unit/engines/pacing-engine.test.ts#L178)
 
 ---
 
@@ -792,7 +792,7 @@ const result = PacingEngine(input);
 3. Therefore: `|deployments| = 8` ∎
 
 **Test Evidence:** Multiple test cases, e.g.,
-[pacing-engine.test.ts:151-156](tests/unit/engines/pacing-engine.test.ts#L151)
+[pacing-engine.test.ts:151-156](../../../tests/unit/engines/pacing-engine.test.ts#L151)
 
 ---
 
@@ -808,7 +808,7 @@ const result = PacingEngine(input);
 3. Therefore: `Quarter(q+1) = Quarter(q) + 1` ∎
 
 **Test Evidence:**
-[pacing-engine.test.ts:168-177](tests/unit/engines/pacing-engine.test.ts#L168)
+[pacing-engine.test.ts:168-177](../../../tests/unit/engines/pacing-engine.test.ts#L168)
 
 ---
 
@@ -843,7 +843,7 @@ converges to 1.
 6. For large `F`, rounding errors become negligible: `lim(F→∞) Total/F = 1` ∎
 
 **Test Evidence:**
-[pacing-engine.test.ts:157-167](tests/unit/engines/pacing-engine.test.ts#L157)
+[pacing-engine.test.ts:157-167](../../../tests/unit/engines/pacing-engine.test.ts#L157)
 shows total is within ±10% for $50M fund.
 
 ---
@@ -874,7 +874,7 @@ back-loads, neutral is balanced.
    ∎
 
 **Test Evidence:**
-[pacing-engine.test.ts:60-80](tests/unit/engines/pacing-engine.test.ts#L60)
+[pacing-engine.test.ts:60-80](../../../tests/unit/engines/pacing-engine.test.ts#L60)
 validates early vs late totals for bull and bear.
 
 ---
@@ -901,13 +901,13 @@ validates early vs late totals for bull and bear.
 ## Related Documentation
 
 - **Implementation:**
-  [PacingEngine.ts](client/src/core/pacing/PacingEngine.ts#L1)
+  [PacingEngine.ts](../../../client/src/core/pacing/PacingEngine.ts#L1)
 - **Test Suite:**
-  [pacing-engine.test.ts](tests/unit/engines/pacing-engine.test.ts#L1)
-- **Type Definitions:** [shared/types.ts:113-132](shared/types.ts#L113)
+  [pacing-engine.test.ts](../../../tests/unit/engines/pacing-engine.test.ts#L1)
+- **Type Definitions:** [shared/types.ts:113-132](../../../shared/types.ts#L113)
 - **PRNG Utility:** `@shared/utils/prng`
 - **Validation Config:**
-  [pacing-validation.yaml](scripts/validation/pacing-validation.yaml#L1)
+  [pacing-validation.yaml](../../../scripts/validation/pacing-validation.yaml#L1)
 
 ---
 

--- a/docs/notebooklm-sources/pacing/03-integration.md
+++ b/docs/notebooklm-sources/pacing/03-integration.md
@@ -53,7 +53,7 @@ const deployments = PacingEngine(input);
 ```
 
 **Code Reference:**
-[PacingEngine.ts:124-137](client/src/core/pacing/PacingEngine.ts#L124)
+[PacingEngine.ts:124-137](../../../client/src/core/pacing/PacingEngine.ts#L124)
 
 ---
 
@@ -87,10 +87,10 @@ const summary: PacingSummary = generatePacingSummary(input);
 **Use Case:** Dashboard displays, reporting, scenario comparison
 
 **Code Reference:**
-[PacingEngine.ts:144-159](client/src/core/pacing/PacingEngine.ts#L144)
+[PacingEngine.ts:144-159](../../../client/src/core/pacing/PacingEngine.ts#L144)
 
 **Test Evidence:**
-[pacing-engine.test.ts:255-293](tests/unit/engines/pacing-engine.test.ts#L255)
+[pacing-engine.test.ts:255-293](../../../tests/unit/engines/pacing-engine.test.ts#L255)
 
 ---
 
@@ -138,12 +138,12 @@ try {
 ```
 
 **Validation Logic:**
-[PacingEngine.ts:25-31](client/src/core/pacing/PacingEngine.ts#L25)
+[PacingEngine.ts:25-31](../../../client/src/core/pacing/PacingEngine.ts#L25)
 
-**Schema Definition:** [shared/types.ts:113-117](shared/types.ts#L113)
+**Schema Definition:** [shared/types.ts:113-117](../../../shared/types.ts#L113)
 
 **Test Coverage:**
-[pacing-engine.test.ts:24-53](tests/unit/engines/pacing-engine.test.ts#L24)
+[pacing-engine.test.ts:24-53](../../../tests/unit/engines/pacing-engine.test.ts#L24)
 
 ---
 
@@ -210,10 +210,10 @@ const result = PacingEngine(input);
 ```
 
 **Mode Detection:**
-[PacingEngine.ts:47-49](client/src/core/pacing/PacingEngine.ts#L47)
+[PacingEngine.ts:47-49](../../../client/src/core/pacing/PacingEngine.ts#L47)
 
 **Test Coverage:**
-[pacing-engine.test.ts:191-222](tests/unit/engines/pacing-engine.test.ts#L191)
+[pacing-engine.test.ts:191-222](../../../tests/unit/engines/pacing-engine.test.ts#L191)
 
 ---
 
@@ -225,7 +225,7 @@ The **pacing-worker** handles background calculations asynchronously via Redis
 queues.
 
 **Worker Setup:**
-[workers/pacing-worker.ts:31-152](workers/pacing-worker.ts#L31)
+[workers/pacing-worker.ts:31-152](../../../workers/pacing-worker.ts#L31)
 
 ```typescript
 import { Worker } from 'bullmq';
@@ -392,7 +392,7 @@ retrieval, but enables high-throughput API.
 ### Worker Health Monitoring
 
 **Health Check Server:**
-[workers/pacing-worker.ts:158-159](workers/pacing-worker.ts#L158)
+[workers/pacing-worker.ts:158-159](../../../workers/pacing-worker.ts#L158)
 
 ```bash
 # Health check endpoint
@@ -459,7 +459,7 @@ CREATE INDEX idx_pacing_history_fund ON pacing_history(fund_id);
 ```
 
 **Implementation:**
-[workers/pacing-worker.ts:62-80](workers/pacing-worker.ts#L62)
+[workers/pacing-worker.ts:62-80](../../../workers/pacing-worker.ts#L62)
 
 ---
 
@@ -849,7 +849,7 @@ const comparisonData = scenarios.map((s) => ({
 ```
 
 **Test Evidence:** Multi-scenario testing validated in
-[pacing-engine.test.ts:95-108](tests/unit/engines/pacing-engine.test.ts#L95)
+[pacing-engine.test.ts:95-108](../../../tests/unit/engines/pacing-engine.test.ts#L95)
 
 ---
 
@@ -887,7 +887,7 @@ export function PacingEngine(input: unknown): PacingOutput[] {
 deterministic results.
 
 **Code Reference:**
-[PacingEngine.ts:126](client/src/core/pacing/PacingEngine.ts#L126)
+[PacingEngine.ts:126](../../../client/src/core/pacing/PacingEngine.ts#L126)
 
 ---
 
@@ -918,7 +918,7 @@ const normalized = summary.deployments.map((d) => ({
 ```
 
 **Test Evidence:**
-[pacing-engine.test.ts:157-167](tests/unit/engines/pacing-engine.test.ts#L157)
+[pacing-engine.test.ts:157-167](../../../tests/unit/engines/pacing-engine.test.ts#L157)
 
 ---
 
@@ -1004,7 +1004,7 @@ if (!validateFundSizeForPacing(input.fundSize)) {
 ```
 
 **Test Evidence:** Edge cases validated in
-[pacing-engine.test.ts:299-336](tests/unit/engines/pacing-engine.test.ts#L299)
+[pacing-engine.test.ts:299-336](../../../tests/unit/engines/pacing-engine.test.ts#L299)
 
 ---
 
@@ -1145,7 +1145,7 @@ exceed benefit. Only cache if database lookups dominate.
 ### Unit Testing Pattern
 
 **Test Structure:**
-[pacing-engine.test.ts](tests/unit/engines/pacing-engine.test.ts#L1)
+[pacing-engine.test.ts](../../../tests/unit/engines/pacing-engine.test.ts#L1)
 
 ```typescript
 import { describe, it, expect } from 'vitest';
@@ -1249,7 +1249,7 @@ test.prop([
 ### Prometheus Metrics
 
 **Worker Metrics:**
-[workers/pacing-worker.ts:98-109](workers/pacing-worker.ts#L98)
+[workers/pacing-worker.ts:98-109](../../../workers/pacing-worker.ts#L98)
 
 ```typescript
 import { metrics } from '../lib/metrics';
@@ -1293,7 +1293,7 @@ rate(pacing_calculations_total[1m])
 ### Structured Logging
 
 **Logger Integration:**
-[workers/pacing-worker.ts:36](workers/pacing-worker.ts#L36)
+[workers/pacing-worker.ts:36](../../../workers/pacing-worker.ts#L36)
 
 ```typescript
 import { logger } from '../lib/logger';
@@ -1407,13 +1407,13 @@ logger.error('Pacing calculation failed', error, {
 ## Related Documentation
 
 - **Implementation:**
-  [PacingEngine.ts](client/src/core/pacing/PacingEngine.ts#L1)
-- **Worker:** [pacing-worker.ts](workers/pacing-worker.ts#L1)
+  [PacingEngine.ts](../../../client/src/core/pacing/PacingEngine.ts#L1)
+- **Worker:** [pacing-worker.ts](../../../workers/pacing-worker.ts#L1)
 - **Test Suite:**
-  [pacing-engine.test.ts](tests/unit/engines/pacing-engine.test.ts#L1)
-- **Type Definitions:** [shared/types.ts:113-132](shared/types.ts#L113)
+  [pacing-engine.test.ts](../../../tests/unit/engines/pacing-engine.test.ts#L1)
+- **Type Definitions:** [shared/types.ts:113-132](../../../shared/types.ts#L113)
 - **Validation Config:**
-  [pacing-validation.yaml](scripts/validation/pacing-validation.yaml#L1)
+  [pacing-validation.yaml](../../../scripts/validation/pacing-validation.yaml#L1)
 - **Database Schema:** `@shared/schema` (fundSnapshots, pacingHistory)
 
 ---


### PR DESCRIPTION
## Summary

Retargets the pacing NotebookLM truth-source links from their nested docs folder to the existing root-level pacing implementation, test, worker, shared type, and validation files.

Chosen bucket: `docs/notebooklm-sources/pacing/*.md` because the broken links were a coherent path-depth issue and every retargeted destination exists in the live repo.

## Scope

Changed files:
- `docs/notebooklm-sources/pacing/01-overview.md`
- `docs/notebooklm-sources/pacing/02-strategies.md`
- `docs/notebooklm-sources/pacing/03-integration.md`

No code, scripts, `.claude`, Phoenix protected paths, `tsconfig.eslint.json`, `.zap/rules.tsv`, or removed `docs/ai` material changed.

## Verification

- Targeted local-link scan:
  - `docs/notebooklm-sources/pacing/01-overview.md`: 0 broken local links out of 32 markdown links
  - `docs/notebooklm-sources/pacing/02-strategies.md`: 0 broken local links out of 38 markdown links
  - `docs/notebooklm-sources/pacing/03-integration.md`: 0 broken local links out of 34 markdown links
- `npm run docs:check-links -- --report-only`: before 383 broken links out of 1577; after 307 broken links out of 1577
- `git diff --check HEAD^ HEAD`: exit 0 with no output
- `npm run check`: Found 0 TypeScript errors; Current errors 0; New errors 0
- `npm run lint`: passed ESLint and guardrails

## Residual Risk

The inherited repo-wide broken-link backlog remains at 307 under report-only mode.