### PR TITLE
[codex] Make NotebookLM Windows source links repo-relative

### DIFF
--- a/docs/notebooklm-sources/cohorts/01-overview.md
+++ b/docs/notebooklm-sources/cohorts/01-overview.md
@@ -91,7 +91,7 @@ vintage cohort.
 ### Real-World Context
 
 From validation test cases
-([cohorts-validation.yaml:10-28](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L10)):
+([cohorts-validation.yaml:10-28](../../../scripts/validation/cohorts-validation.yaml#L10)):
 
 ```yaml
 # Standard vintage cohort analysis
@@ -231,7 +231,7 @@ const maturityFactor = Math.min(yearsActive / 5, 1.0);
   5-year cohorts directly)
 
 **Example from tests**
-([cohort-engine.test.ts:81-86](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L81)):
+([cohort-engine.test.ts:81-86](../../../tests/unit/engines/cohort-engine.test.ts#L81)):
 
 ```typescript
 const recentCohort = CohortEngine({ vintageYear: 2023, cohortSize: 10 });
@@ -249,7 +249,7 @@ The engine applies **market condition adjustments** based on historical venture
 capital market data:
 
 **Adjustment Factors**
-([CohortEngine.ts:87-93](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L87)):
+([CohortEngine.ts:87-93](../../../client/src/core/cohorts/CohortEngine.ts#L87)):
 
 ```typescript
 const vintageAdjustments: Record<number, number> = {
@@ -275,7 +275,7 @@ baseIRR += vintageAdjustments[vintageYear] || 0;
 - **2024:** AI-driven growth, partial IPO market recovery, M&A acceleration
 
 **Test Validation**
-([cohort-engine.test.ts:64-70](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L64)):
+([cohort-engine.test.ts:64-70](../../../tests/unit/engines/cohort-engine.test.ts#L64)):
 
 ```typescript
 // COVID impact validation
@@ -303,7 +303,7 @@ The CohortEngine operates in **two modes**: rule-based (default) and ML-enhanced
 **Processing Steps:**
 
 1. **Validation**
-   ([CohortEngine.ts:26-32](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L26))
+   ([CohortEngine.ts:26-32](../../../client/src/core/cohorts/CohortEngine.ts#L26))
 
    ```typescript
    const result = CohortInputSchema.safeParse(input);
@@ -317,7 +317,7 @@ The CohortEngine operates in **two modes**: rule-based (default) and ML-enhanced
    - Validates cohortSize (positive integer)
 
 2. **Generate Mock Companies**
-   ([CohortEngine.ts:48-64](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L48))
+   ([CohortEngine.ts:48-64](../../../client/src/core/cohorts/CohortEngine.ts#L48))
    - Creates `cohortSize` portfolio companies
    - Assigns realistic valuations ($1M-$51M base range)
    - Applies growth factors (1.0x-3.375x)
@@ -325,7 +325,7 @@ The CohortEngine operates in **two modes**: rule-based (default) and ML-enhanced
    - Generates unique names and IDs
 
 3. **Calculate Maturity**
-   ([CohortEngine.ts:80-81](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L80))
+   ([CohortEngine.ts:80-81](../../../client/src/core/cohorts/CohortEngine.ts#L80))
 
    ```typescript
    const yearsActive = new Date().getFullYear() - vintageYear;
@@ -333,7 +333,7 @@ The CohortEngine operates in **two modes**: rule-based (default) and ML-enhanced
    ```
 
 4. **Compute Performance Metrics**
-   ([CohortEngine.ts:84-103](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L84))
+   ([CohortEngine.ts:84-103](../../../client/src/core/cohorts/CohortEngine.ts#L84))
    - Start with base IRR (15%)
    - Apply vintage-specific adjustment (-5% to +8%)
    - Scale by maturity factor (newer = lower realized returns)
@@ -342,7 +342,7 @@ The CohortEngine operates in **two modes**: rule-based (default) and ML-enhanced
    - Round to appropriate precision (IRR: 4 decimals, TVPI/DPI: 2 decimals)
 
 5. **Package Output**
-   ([CohortEngine.ts:111-118](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L111))
+   ([CohortEngine.ts:111-118](../../../client/src/core/cohorts/CohortEngine.ts#L111))
    ```typescript
    const output: CohortOutput = {
      cohortId: `cohort-${fundId}-${vintageYear}`,
@@ -359,7 +359,7 @@ The CohortEngine operates in **two modes**: rule-based (default) and ML-enhanced
 **Activation:** Set `ALG_COHORT=true` or `NODE_ENV=development`
 
 **Enhancement Logic**
-([CohortEngine.ts:122-148](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L122)):
+([CohortEngine.ts:122-148](../../../client/src/core/cohorts/CohortEngine.ts#L122)):
 
 1. Start with rule-based calculation
 2. Apply ML adjustment multiplier (0.9-1.1x)

--- a/docs/notebooklm-sources/cohorts/02-metrics.md
+++ b/docs/notebooklm-sources/cohorts/02-metrics.md
@@ -42,7 +42,7 @@ standards):
 and unrealized value)
 
 **Validation Source:**
-[cohorts-validation.yaml:10-28](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L10)
+[cohorts-validation.yaml:10-28](../../../scripts/validation/cohorts-validation.yaml#L10)
 defines 5 test scenarios covering standard, multi-cohort, total loss, 10x
 return, and mixed performance cases.
 
@@ -78,7 +78,7 @@ TVPI = (Distributions + Residual Value) / Paid-In Capital
    gains/losses)
 
 **Example from validation**
-([cohorts-validation.yaml:10-28](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L10)):
+([cohorts-validation.yaml:10-28](../../../scripts/validation/cohorts-validation.yaml#L10)):
 
 ```yaml
 vintage: 2023
@@ -86,6 +86,7 @@ companies: 5
 totalInvested: 25000000 # Paid-In Capital = $25M
 totalValue: 40000000 # Current portfolio value = $40M
 realized: 15000000 # Distributions = $15M
+
 
 # Calculation:
 # Residual Value = $40M - $15M = $25M
@@ -101,7 +102,7 @@ realized: 15000000 # Distributions = $15M
 ### Implementation in Code
 
 The engine calculates TVPI via the `multiple` field
-([CohortEngine.ts:98-100](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L98)):
+([CohortEngine.ts:98-100](../../../client/src/core/cohorts/CohortEngine.ts#L98)):
 
 ```typescript
 // Base multiple calculation (TVPI)
@@ -132,7 +133,7 @@ const multiple = Math.max(1.0, baseMultiple + (Math.random() * 0.5 - 0.25));
 **Scenario:** All companies in cohort write down to zero value
 
 **Validation Test**
-([cohorts-validation.yaml:59-75](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L59)):
+([cohorts-validation.yaml:59-75](../../../scripts/validation/cohorts-validation.yaml#L59)):
 
 ```yaml
 vintage: 2020
@@ -140,6 +141,7 @@ companies: 3
 totalInvested: 15000000
 totalValue: 0 # Complete write-off
 realized: 0 # No distributions
+
 
 # Expected: TVPI = 0x (0 / 15M = 0)
 ```
@@ -155,7 +157,7 @@ Series A)
 **Scenario:** "Unicorn cohort" with multiple successful exits
 
 **Validation Test**
-([cohorts-validation.yaml:77-93](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L77)):
+([cohorts-validation.yaml:77-93](../../../scripts/validation/cohorts-validation.yaml#L77)):
 
 ```yaml
 vintage: 2019
@@ -163,6 +165,7 @@ companies: 10
 totalInvested: 50000000
 totalValue: 500000000 # 10x portfolio value
 realized: 450000000 # 9x cash returned
+
 
 # Expected: TVPI = 10.0x (500M / 50M = 10.0)
 ```
@@ -192,7 +195,7 @@ realized: 450000000 # 9x cash returned
 ### Precision & Rounding
 
 **Implementation**
-([CohortEngine.ts:106-108](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L106)):
+([CohortEngine.ts:106-108](../../../client/src/core/cohorts/CohortEngine.ts#L106)):
 
 ```typescript
 performance: {
@@ -232,11 +235,12 @@ DPI = Distributions / Paid-In Capital
 2. **Paid-In Capital:** Total amount invested in the cohort
 
 **Example from validation**
-([cohorts-validation.yaml:10-28](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L10)):
+([cohorts-validation.yaml:10-28](../../../scripts/validation/cohorts-validation.yaml#L10)):
 
 ```yaml
 totalInvested: 25000000 # Paid-In Capital = $25M
 realized: 15000000 # Distributions = $15M
+
 
 # DPI = $15M / $25M = 0.60x (60 cents returned per dollar invested)
 ```
@@ -249,7 +253,7 @@ realized: 15000000 # Distributions = $15M
 ### Implementation in Code
 
 The engine calculates DPI based on maturity
-([CohortEngine.ts:102-103](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L102)):
+([CohortEngine.ts:102-103](../../../client/src/core/cohorts/CohortEngine.ts#L102)):
 
 ```typescript
 // DPI calculation (distributions to paid-in)
@@ -282,7 +286,7 @@ const dpi = Math.max(0, multiple * maturityFactor * 0.4);
 value)
 
 **Validation**
-([cohort-engine.test.ts:117-120](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L117)):
+([cohort-engine.test.ts:117-120](../../../tests/unit/engines/cohort-engine.test.ts#L117)):
 
 ```typescript
 it('should ensure DPI <= Multiple', () => {
@@ -306,7 +310,7 @@ it('should ensure DPI <= Multiple', () => {
 **Scenario:** Early-stage cohort with no exits yet
 
 **Validation Test**
-([cohorts-validation.yaml:44-48](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L44)):
+([cohorts-validation.yaml:44-48](../../../scripts/validation/cohorts-validation.yaml#L44)):
 
 ```yaml
 vintage: 2024
@@ -314,6 +318,7 @@ companies: 4
 totalInvested: 20000000
 totalValue: 22000000
 realized: 0 # No distributions yet
+
 
 # Expected: DPI = 0x (0 / 20M = 0)
 ```
@@ -325,12 +330,13 @@ realized: 0 # No distributions yet
 **Scenario:** Unicorn cohort with major exits
 
 **Validation Test**
-([cohorts-validation.yaml:77-93](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L77)):
+([cohorts-validation.yaml:77-93](../../../scripts/validation/cohorts-validation.yaml#L77)):
 
 ```yaml
 vintage: 2019
 totalInvested: 50000000
 realized: 450000000 # $450M cash returned
+
 
 # Expected: DPI = 9.0x (450M / 50M = 9.0)
 ```
@@ -341,7 +347,7 @@ distributions
 #### 3. DPI vs Maturity Correlation
 
 **Test Validation**
-([cohort-engine.test.ts:81-86](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L81)):
+([cohort-engine.test.ts:81-86](../../../tests/unit/engines/cohort-engine.test.ts#L81)):
 
 ```typescript
 it('should apply maturity factor to performance', () => {
@@ -365,7 +371,7 @@ it('should apply maturity factor to performance', () => {
 ### Precision & Rounding
 
 **Implementation**
-([CohortEngine.ts:106-108](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L106)):
+([CohortEngine.ts:106-108](../../../client/src/core/cohorts/CohortEngine.ts#L106)):
 
 ```typescript
 performance: {
@@ -409,12 +415,13 @@ RVPI = TVPI - DPI
 2. **Paid-In Capital:** Total amount invested
 
 **Example from validation**
-([cohorts-validation.yaml:10-28](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L10)):
+([cohorts-validation.yaml:10-28](../../../scripts/validation/cohorts-validation.yaml#L10)):
 
 ```yaml
 totalInvested: 25000000 # Paid-In Capital = $25M
 totalValue: 40000000 # Total Value = $40M
 realized: 15000000 # Distributions = $15M
+
 
 # Method 1: Direct calculation
 # Residual Value = $40M - $15M = $25M
@@ -441,7 +448,7 @@ const rvpi = performance.multiple - performance.dpi;
 ```
 
 **Validation Relationship**
-([cohorts-validation.yaml:24-26](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L24)):
+([cohorts-validation.yaml:24-26](../../../scripts/validation/cohorts-validation.yaml#L24)):
 
 ```yaml
 # Validation test expects this relationship:
@@ -472,7 +479,7 @@ result.cohorts[0].rvpi === 1.0 # RVPI = TVPI - DPI
 **Scenario:** Young cohort with minimal distributions
 
 **Validation Test**
-([cohorts-validation.yaml:44-48](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L44)):
+([cohorts-validation.yaml:44-48](../../../scripts/validation/cohorts-validation.yaml#L44)):
 
 ```yaml
 vintage: 2024
@@ -584,7 +591,7 @@ years.
 ### Implementation in Code
 
 The engine uses a **simplified rule-based IRR calculation**
-([CohortEngine.ts:84-96](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L84)):
+([CohortEngine.ts:84-96](../../../client/src/core/cohorts/CohortEngine.ts#L84)):
 
 ```typescript
 // Base IRR calculation with vintage year effects
@@ -628,7 +635,7 @@ baseIRR *= maturityFactor; // Scale by fund maturity
 ### XIRR Calculation (Full Implementation)
 
 For **actual IRR calculation** with cash flow timing, the codebase uses **XIRR**
-([client/src/lib/finance/xirr.ts](c:\dev\Updog_restore\client\src\lib\finance\xirr.ts)):
+([client/src/lib/finance/xirr.ts](../../../client/src/lib/finance/xirr.ts)):
 
 ```typescript
 import { xirrNewtonBisection } from '@/lib/finance/xirr';
@@ -644,7 +651,7 @@ console.log(result.irr); // 0.185 (18.5%)
 ```
 
 **Test Validation**
-([xirr-golden-set.test.ts:30-34](c:\dev\Updog_restore\tests\unit\xirr-golden-set.test.ts#L30)):
+([xirr-golden-set.test.ts:30-34](../../../tests/unit/xirr-golden-set.test.ts#L30)):
 
 ```typescript
 const flows = [
@@ -669,7 +676,7 @@ to 7 decimal places (±1e-7 tolerance).
 **Scenario:** Cohort returns capital with minimal gain
 
 **Validation Test**
-([cohorts-validation.yaml:112](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L112)):
+([cohorts-validation.yaml:112](../../../scripts/validation/cohorts-validation.yaml#L112)):
 
 ```yaml
 vintage: 2023
@@ -680,7 +687,7 @@ realized: 0
 ```
 
 **Test Case**
-([xirr-golden-set.test.ts:109-112](c:\dev\Updog_restore\tests\unit\xirr-golden-set.test.ts#L109)):
+([xirr-golden-set.test.ts:109-112](../../../tests/unit/xirr-golden-set.test.ts#L109)):
 
 ```typescript
 const flows = [
@@ -696,7 +703,7 @@ expect(result.irr).toBeCloseTo(0.000998, 6); // ~0.1% IRR
 **Scenario:** Cohort loses money, IRR < 0%
 
 **Validation Test**
-([cohorts-validation.yaml:59-75](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L59)):
+([cohorts-validation.yaml:59-75](../../../scripts/validation/cohorts-validation.yaml#L59)):
 
 ```yaml
 vintage: 2020
@@ -707,7 +714,7 @@ realized: 0
 ```
 
 **Test Case**
-([xirr-golden-set.test.ts:96-99](c:\dev\Updog_restore\tests\unit\xirr-golden-set.test.ts#L96)):
+([xirr-golden-set.test.ts:96-99](../../../tests/unit/xirr-golden-set.test.ts#L96)):
 
 ```typescript
 const flows = [
@@ -728,7 +735,7 @@ expect(result.irr).toBeCloseTo(-0.10091, 5); // -10.09% IRR (10% loss)
 **Scenario:** Unicorn cohort with rapid exits
 
 **Validation Test**
-([cohorts-validation.yaml:77-93](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L77)):
+([cohorts-validation.yaml:77-93](../../../scripts/validation/cohorts-validation.yaml#L77)):
 
 ```yaml
 vintage: 2019
@@ -736,11 +743,12 @@ totalInvested: 50000000
 totalValue: 500000000 # 10x return
 realized: 450000000 # 9x cash
 
+
 # Expected: IRR > 0.50 (>50% annualized)
 ```
 
 **Test Case**
-([xirr-golden-set.test.ts:136-139](c:\dev\Updog_restore\tests\unit\xirr-golden-set.test.ts#L136)):
+([xirr-golden-set.test.ts:136-139](../../../tests/unit/xirr-golden-set.test.ts#L136)):
 
 ```typescript
 const flows = [
@@ -756,7 +764,7 @@ expect(result.irr).toBeCloseTo(99.0, 1); // 9,900% IRR (100x in 6 months!)
 ### Precision & Rounding
 
 **Implementation**
-([CohortEngine.ts:106](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L106)):
+([CohortEngine.ts:106](../../../client/src/core/cohorts/CohortEngine.ts#L106)):
 
 ```typescript
 performance: {
@@ -768,7 +776,7 @@ performance: {
 standards
 
 **Test Validation**
-([cohort-engine.test.ts:127-128](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L127)):
+([cohort-engine.test.ts:127-128](../../../tests/unit/engines/cohort-engine.test.ts#L127)):
 
 ```typescript
 // IRR to 4 decimal places
@@ -793,7 +801,7 @@ Portfolio TVPI = (Sum of Total Values) / (Sum of Paid-In Capital)
 ```
 
 **Validation Test**
-([cohorts-validation.yaml:50-57](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L50)):
+([cohorts-validation.yaml:50-57](../../../scripts/validation/cohorts-validation.yaml#L50)):
 
 ```yaml
 cohorts:
@@ -813,7 +821,7 @@ cohorts:
 ```
 
 **Implementation**
-([CohortEngine.ts:238](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L238)):
+([CohortEngine.ts:238](../../../client/src/core/cohorts/CohortEngine.ts#L238)):
 
 ```typescript
 const avgMultiple =
@@ -847,7 +855,7 @@ Portfolio DPI = (Sum of Distributions) / (Sum of Paid-In Capital)
 ```
 
 **Validation Test**
-([cohorts-validation.yaml:55-56](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L55)):
+([cohorts-validation.yaml:55-56](../../../scripts/validation/cohorts-validation.yaml#L55)):
 
 ```yaml
 # From multi-cohort test:
@@ -896,7 +904,7 @@ const portfolioIRR = xirrNewtonBisection(allCashFlows).irr;
 ### Maturity Comparison
 
 **Validation Test**
-([cohorts-validation.yaml:57](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L57)):
+([cohorts-validation.yaml:57](../../../scripts/validation/cohorts-validation.yaml#L57)):
 
 ```yaml
 # Expect older cohorts to have higher maturity
@@ -922,7 +930,7 @@ const maturity = Math.min((currentYear - vintageYear) / 5, 1.0);
 ### Validation Test Suite
 
 The engine's metrics are validated against 5 comprehensive test scenarios
-([cohorts-validation.yaml](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml)):
+([cohorts-validation.yaml](../../../scripts/validation/cohorts-validation.yaml)):
 
 | Test Case  | Scenario          | Key Metric              | Expected Result       |
 | ---------- | ----------------- | ----------------------- | --------------------- |
@@ -988,10 +996,10 @@ const dpi = Math.max(0, calculatedDPI); // Floor at 0x
 **Scenario:** Newton-Raphson fails to converge
 
 **Fallback:** Use bisection method
-([brent-solver.ts](c:\dev\Updog_restore\client\src\lib\finance\brent-solver.ts))
+([brent-solver.ts](../../../client/src/lib/finance/brent-solver.ts))
 
 **Test Case**
-([xirr-golden-set.test.ts:268-275](c:\dev\Updog_restore\tests\unit\xirr-golden-set.test.ts#L268)):
+([xirr-golden-set.test.ts:268-275](../../../tests/unit/xirr-golden-set.test.ts#L268)):
 
 ```typescript
 describe('XIRR Method Fallbacks', () => {
@@ -1011,7 +1019,7 @@ describe('XIRR Method Fallbacks', () => {
 ### Tolerance & Precision
 
 **Excel XIRR Parity**
-([test-infrastructure.ts:258-261](c:\dev\Updog_restore\tests\setup\test-infrastructure.ts#L258)):
+([test-infrastructure.ts:258-261](../../../tests/setup/test-infrastructure.ts#L258)):
 
 ```typescript
 // Standard tolerance for XIRR/IRR comparisons

--- a/docs/notebooklm-sources/cohorts/03-analysis.md
+++ b/docs/notebooklm-sources/cohorts/03-analysis.md
@@ -32,7 +32,7 @@ implementing cohort features, AI agents, integration engineers **Last Updated:**
 **Simplest Use Case:** Analyze a single vintage cohort
 
 **Code Example**
-([CohortEngine.ts:159-169](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L159)):
+([CohortEngine.ts:159-169](../../../client/src/core/cohorts/CohortEngine.ts#L159)):
 
 ```typescript
 import { CohortEngine } from '@/core/cohorts/CohortEngine';
@@ -64,7 +64,7 @@ console.log(result);
 ```
 
 **Test Validation**
-([cohort-engine.test.ts:26-33](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L26)):
+([cohort-engine.test.ts:26-33](../../../tests/unit/engines/cohort-engine.test.ts#L26)):
 
 ```typescript
 it('should validate and process correct input', () => {
@@ -82,7 +82,7 @@ it('should validate and process correct input', () => {
 **Use Case:** Get aggregated statistics and metadata for a cohort
 
 **Code Example**
-([CohortEngine.ts:176-208](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L176)):
+([CohortEngine.ts:176-208](../../../client/src/core/cohorts/CohortEngine.ts#L176)):
 
 ```typescript
 import { generateCohortSummary } from '@/core/cohorts/CohortEngine';
@@ -118,7 +118,7 @@ console.log(summary);
 ```
 
 **Stage Distribution Calculation**
-([CohortEngine.ts:185-188](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L185)):
+([CohortEngine.ts:185-188](../../../client/src/core/cohorts/CohortEngine.ts#L185)):
 
 ```typescript
 // Calculate stage distribution
@@ -133,7 +133,7 @@ const stageDistribution = reduce(
 ```
 
 **Test Validation**
-([cohort-engine.test.ts:302-309](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L302)):
+([cohort-engine.test.ts:302-309](../../../tests/unit/engines/cohort-engine.test.ts#L302)):
 
 ```typescript
 it('should include stage distribution', () => {
@@ -170,7 +170,7 @@ try {
 ```
 
 **Test Validation**
-([cohort-engine.test.ts:36-38](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L36)):
+([cohort-engine.test.ts:36-38](../../../tests/unit/engines/cohort-engine.test.ts#L36)):
 
 ```typescript
 it('should reject invalid cohort input', () => {
@@ -180,7 +180,7 @@ it('should reject invalid cohort input', () => {
 ```
 
 **Validation Schema**
-([shared/types.ts:135-139](c:\dev\Updog_restore\shared\types.ts#L135)):
+([shared/types.ts:135-139](../../../shared/types.ts#L135)):
 
 ```typescript
 export const CohortInputSchema = z.object({
@@ -251,7 +251,7 @@ const chartData = {
 ```
 
 **Test Validation**
-([cohort-engine.test.ts:40-48](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L40)):
+([cohort-engine.test.ts:40-48](../../../tests/unit/engines/cohort-engine.test.ts#L40)):
 
 ```typescript
 it('should handle various vintage years', () => {
@@ -303,7 +303,7 @@ console.log(comparison);
 ```
 
 **Vintage Adjustments**
-([CohortEngine.ts:87-93](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L87)):
+([CohortEngine.ts:87-93](../../../client/src/core/cohorts/CohortEngine.ts#L87)):
 
 ```typescript
 const vintageAdjustments: Record<number, number> = {
@@ -316,7 +316,7 @@ const vintageAdjustments: Record<number, number> = {
 ```
 
 **Test Validation**
-([cohort-engine.test.ts:56-62](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L56)):
+([cohort-engine.test.ts:56-62](../../../tests/unit/engines/cohort-engine.test.ts#L56)):
 
 ```typescript
 it('should apply vintage year adjustments', () => {
@@ -337,7 +337,7 @@ it('should apply vintage year adjustments', () => {
 **Use Case:** Compare performance across multiple vintages simultaneously
 
 **Code Example**
-([CohortEngine.ts:215-250](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L215)):
+([CohortEngine.ts:215-250](../../../client/src/core/cohorts/CohortEngine.ts#L215)):
 
 ```typescript
 import { compareCohorts } from '@/core/cohorts/CohortEngine';
@@ -367,7 +367,7 @@ console.log(comparison);
 ```
 
 **Best Performer Identification**
-([CohortEngine.ts:231-234](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L231)):
+([CohortEngine.ts:231-234](../../../client/src/core/cohorts/CohortEngine.ts#L231)):
 
 ```typescript
 // Find best performing cohort by IRR
@@ -380,7 +380,7 @@ const bestPerforming = reduce(
 ```
 
 **Test Validation**
-([cohort-engine.test.ts:192-203](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L192)):
+([cohort-engine.test.ts:192-203](../../../tests/unit/engines/cohort-engine.test.ts#L192)):
 
 ```typescript
 it('should compare multiple cohorts', () => {
@@ -400,7 +400,7 @@ it('should compare multiple cohorts', () => {
 ### Validation Test: Multi-Cohort Aggregation
 
 **Real-World Scenario**
-([cohorts-validation.yaml:30-57](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L30)):
+([cohorts-validation.yaml:30-57](../../../scripts/validation/cohorts-validation.yaml#L30)):
 
 ```yaml
 scenario: 'Cross-vintage portfolio analysis'
@@ -423,6 +423,7 @@ cohorts:
     totalValue: 22000000 # 1.1x TVPI
     realized: 0 # 0x DPI (too early)
 
+
 # Expected aggregation:
 # Portfolio TVPI = (80M + 45M + 22M) / (40M + 30M + 20M)
 #                = 147M / 90M = 1.63x
@@ -444,7 +445,7 @@ result.cohorts.length === 3 &&
 ### Aggregate Metrics Calculation
 
 **Average IRR**
-([CohortEngine.ts:237](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L237)):
+([CohortEngine.ts:237](../../../client/src/core/cohorts/CohortEngine.ts#L237)):
 
 ```typescript
 const avgIRR =
@@ -453,7 +454,7 @@ const avgIRR =
 ```
 
 **Average TVPI**
-([CohortEngine.ts:238](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L238)):
+([CohortEngine.ts:238](../../../client/src/core/cohorts/CohortEngine.ts#L238)):
 
 ```typescript
 const avgMultiple =
@@ -465,7 +466,7 @@ const avgMultiple =
 ```
 
 **Total Companies**
-([CohortEngine.ts:239](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L239)):
+([CohortEngine.ts:239](../../../client/src/core/cohorts/CohortEngine.ts#L239)):
 
 ```typescript
 const totalCompanies = reduce(
@@ -476,7 +477,7 @@ const totalCompanies = reduce(
 ```
 
 **Test Validation**
-([cohort-engine.test.ts:243-254](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L243)):
+([cohort-engine.test.ts:243-254](../../../tests/unit/engines/cohort-engine.test.ts#L243)):
 
 ```typescript
 it('should calculate total companies across cohorts', () => {
@@ -795,7 +796,7 @@ years old)
 **Solution:** Use maturity-adjusted metrics or compare within similar age groups
 
 **Test Validation**
-([cohort-engine.test.ts:81-86](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L81)):
+([cohort-engine.test.ts:81-86](../../../tests/unit/engines/cohort-engine.test.ts#L81)):
 
 ```typescript
 it('should apply maturity factor to performance', () => {
@@ -854,7 +855,7 @@ const portfolioIRR = xirrNewtonBisection(allCashFlows).irr;
 - Leads to negative RVPI (unrealized value can't be negative)
 
 **Test Validation**
-([cohort-engine.test.ts:117-120](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L117)):
+([cohort-engine.test.ts:117-120](../../../tests/unit/engines/cohort-engine.test.ts#L117)):
 
 ```typescript
 it('should ensure DPI <= Multiple', () => {
@@ -868,7 +869,7 @@ it('should ensure DPI <= Multiple', () => {
 **Solution:** Enforce constraint in calculation
 
 **Implementation**
-([CohortEngine.ts:102-103](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L102)):
+([CohortEngine.ts:102-103](../../../client/src/core/cohorts/CohortEngine.ts#L102)):
 
 ```typescript
 const dpi = Math.max(0, Math.min(multiple, multiple * maturityFactor * 0.4));
@@ -885,7 +886,7 @@ const dpi = Math.max(0, Math.min(multiple, multiple * maturityFactor * 0.4));
 - Cannot be used for LP reporting or investment decisions
 
 **Current Status:** The engine generates mock companies for scaffolding
-([CohortEngine.ts:48-64](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L48))
+([CohortEngine.ts:48-64](../../../client/src/core/cohorts/CohortEngine.ts#L48))
 
 **Solution:** Replace mock generation with actual portfolio data integration
 
@@ -950,42 +951,42 @@ const scenario = CohortEngine({
 
 ### Core Engine Files
 
-| File                                                                                         | Lines   | Purpose                 | Key Functions                       |
-| -------------------------------------------------------------------------------------------- | ------- | ----------------------- | ----------------------------------- |
-| [CohortEngine.ts:159-169](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L159) | 159-169 | Main engine function    | `CohortEngine(input)`               |
-| [CohortEngine.ts:176-208](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L176) | 176-208 | Summary generation      | `generateCohortSummary(input)`      |
-| [CohortEngine.ts:215-250](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L215) | 215-250 | Multi-cohort comparison | `compareCohorts(cohorts)`           |
-| [CohortEngine.ts:72-119](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L72)   | 72-119  | Rule-based calculation  | `calculateRuleBasedCohortMetrics()` |
-| [CohortEngine.ts:122-148](c:\dev\Updog_restore\client\src\core\cohorts\CohortEngine.ts#L122) | 122-148 | ML-enhanced calculation | `calculateMLBasedCohortMetrics()`   |
+| File                                                                             | Lines   | Purpose                 | Key Functions                       |
+| -------------------------------------------------------------------------------- | ------- | ----------------------- | ----------------------------------- |
+| [CohortEngine.ts:159-169](../../../client/src/core/cohorts/CohortEngine.ts#L159) | 159-169 | Main engine function    | `CohortEngine(input)`               |
+| [CohortEngine.ts:176-208](../../../client/src/core/cohorts/CohortEngine.ts#L176) | 176-208 | Summary generation      | `generateCohortSummary(input)`      |
+| [CohortEngine.ts:215-250](../../../client/src/core/cohorts/CohortEngine.ts#L215) | 215-250 | Multi-cohort comparison | `compareCohorts(cohorts)`           |
+| [CohortEngine.ts:72-119](../../../client/src/core/cohorts/CohortEngine.ts#L72)   | 72-119  | Rule-based calculation  | `calculateRuleBasedCohortMetrics()` |
+| [CohortEngine.ts:122-148](../../../client/src/core/cohorts/CohortEngine.ts#L122) | 122-148 | ML-enhanced calculation | `calculateMLBasedCohortMetrics()`   |
 
 ### Validation & Testing
 
-| File                                                                                                  | Lines   | Purpose                   | Coverage        |
-| ----------------------------------------------------------------------------------------------------- | ------- | ------------------------- | --------------- |
-| [cohorts-validation.yaml:10-122](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L10) | 10-122  | Validation test cases     | 5 scenarios     |
-| [cohort-engine.test.ts:1-418](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L1)       | 1-418   | Unit test suite           | 335 lines, 100% |
-| [cohort-engine.test.ts:26-48](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L26)      | 26-48   | Input validation tests    | 3 test cases    |
-| [cohort-engine.test.ts:56-87](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L56)      | 56-87   | Vintage year tests        | 5 test cases    |
-| [cohort-engine.test.ts:94-133](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L94)     | 94-133  | Performance metrics tests | 6 test cases    |
-| [cohort-engine.test.ts:192-259](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L192)   | 192-259 | Multi-cohort tests        | 7 test cases    |
-| [cohort-engine.test.ts:376-418](c:\dev\Updog_restore\tests\unit\engines\cohort-engine.test.ts#L376)   | 376-418 | Edge case tests           | 5 test cases    |
+| File                                                                                      | Lines   | Purpose                   | Coverage        |
+| ----------------------------------------------------------------------------------------- | ------- | ------------------------- | --------------- |
+| [cohorts-validation.yaml:10-122](../../../scripts/validation/cohorts-validation.yaml#L10) | 10-122  | Validation test cases     | 5 scenarios     |
+| [cohort-engine.test.ts:1-418](../../../tests/unit/engines/cohort-engine.test.ts#L1)       | 1-418   | Unit test suite           | 335 lines, 100% |
+| [cohort-engine.test.ts:26-48](../../../tests/unit/engines/cohort-engine.test.ts#L26)      | 26-48   | Input validation tests    | 3 test cases    |
+| [cohort-engine.test.ts:56-87](../../../tests/unit/engines/cohort-engine.test.ts#L56)      | 56-87   | Vintage year tests        | 5 test cases    |
+| [cohort-engine.test.ts:94-133](../../../tests/unit/engines/cohort-engine.test.ts#L94)     | 94-133  | Performance metrics tests | 6 test cases    |
+| [cohort-engine.test.ts:192-259](../../../tests/unit/engines/cohort-engine.test.ts#L192)   | 192-259 | Multi-cohort tests        | 7 test cases    |
+| [cohort-engine.test.ts:376-418](../../../tests/unit/engines/cohort-engine.test.ts#L376)   | 376-418 | Edge case tests           | 5 test cases    |
 
 ### Type Definitions
 
-| File                                                                 | Lines   | Purpose          | Types                                          |
-| -------------------------------------------------------------------- | ------- | ---------------- | ---------------------------------------------- |
-| [shared/types.ts:135-139](c:\dev\Updog_restore\shared\types.ts#L135) | 135-139 | Input schema     | `CohortInputSchema`                            |
-| [shared/types.ts:141-155](c:\dev\Updog_restore\shared\types.ts#L141) | 141-155 | Output schema    | `CohortOutputSchema`                           |
-| [shared/types.ts:157-180](c:\dev\Updog_restore\shared\types.ts#L157) | 157-180 | Summary schema   | `CohortSummarySchema`                          |
-| [shared/types.ts:194-196](c:\dev\Updog_restore\shared\types.ts#L194) | 194-196 | TypeScript types | `CohortInput`, `CohortOutput`, `CohortSummary` |
+| File                                                     | Lines   | Purpose          | Types                                          |
+| -------------------------------------------------------- | ------- | ---------------- | ---------------------------------------------- |
+| [shared/types.ts:135-139](../../../shared/types.ts#L135) | 135-139 | Input schema     | `CohortInputSchema`                            |
+| [shared/types.ts:141-155](../../../shared/types.ts#L141) | 141-155 | Output schema    | `CohortOutputSchema`                           |
+| [shared/types.ts:157-180](../../../shared/types.ts#L157) | 157-180 | Summary schema   | `CohortSummarySchema`                          |
+| [shared/types.ts:194-196](../../../shared/types.ts#L194) | 194-196 | TypeScript types | `CohortInput`, `CohortOutput`, `CohortSummary` |
 
 ### XIRR/IRR Implementation
 
-| File                                                                                        | Lines  | Purpose             | Functions               |
-| ------------------------------------------------------------------------------------------- | ------ | ------------------- | ----------------------- |
-| [xirr.ts:39-134](c:\dev\Updog_restore\client\src\lib\finance\xirr.ts#L39)                   | 39-134 | Newton-Raphson XIRR | `xirrNewtonBisection()` |
-| [brent-solver.ts:1-150](c:\dev\Updog_restore\client\src\lib\finance\brent-solver.ts#L1)     | 1-150  | Bisection fallback  | `brentSolver()`         |
-| [xirr-golden-set.test.ts:1-290](c:\dev\Updog_restore\tests\unit\xirr-golden-set.test.ts#L1) | 1-290  | Excel validation    | 20 test cases           |
+| File                                                                            | Lines  | Purpose             | Functions               |
+| ------------------------------------------------------------------------------- | ------ | ------------------- | ----------------------- |
+| [xirr.ts:39-134](../../../client/src/lib/finance/xirr.ts#L39)                   | 39-134 | Newton-Raphson XIRR | `xirrNewtonBisection()` |
+| [brent-solver.ts:1-150](../../../client/src/lib/finance/brent-solver.ts#L1)     | 1-150  | Bisection fallback  | `brentSolver()`         |
+| [xirr-golden-set.test.ts:1-290](../../../tests/unit/xirr-golden-set.test.ts#L1) | 1-290  | Excel validation    | 20 test cases           |
 
 ### Integration Points
 
@@ -1005,7 +1006,7 @@ const scenario = CohortEngine({
 **Context:** A typical 2023 vintage cohort with 1.6x TVPI and 12% IRR
 
 **Test Case**
-([cohorts-validation.yaml:10-28](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L10)):
+([cohorts-validation.yaml:10-28](../../../scripts/validation/cohorts-validation.yaml#L10)):
 
 ```yaml
 vintage: 2023
@@ -1032,7 +1033,7 @@ realized: 15000000
 **Context:** A failed 2020 vintage cohort that wrote down to zero
 
 **Test Case**
-([cohorts-validation.yaml:59-75](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L59)):
+([cohorts-validation.yaml:59-75](../../../scripts/validation/cohorts-validation.yaml#L59)):
 
 ```yaml
 vintage: 2020
@@ -1040,6 +1041,7 @@ companies: 3
 totalInvested: 15000000
 totalValue: 0 # Complete write-off
 realized: 0 # No distributions
+
 
 # Expected:
 # TVPI = 0x (0 / 15M)
@@ -1059,7 +1061,7 @@ realized: 0 # No distributions
 **Context:** Exceptional 2019 vintage with 10x return and multiple exits
 
 **Test Case**
-([cohorts-validation.yaml:77-93](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L77)):
+([cohorts-validation.yaml:77-93](../../../scripts/validation/cohorts-validation.yaml#L77)):
 
 ```yaml
 vintage: 2019
@@ -1067,6 +1069,7 @@ companies: 10
 totalInvested: 50000000
 totalValue: 500000000 # 10x portfolio value
 realized: 450000000 # 9x cash returned
+
 
 # Expected:
 # TVPI = 10.0x (500M / 50M)
@@ -1086,7 +1089,7 @@ realized: 450000000 # 9x cash returned
 **Context:** Realistic portfolio with winners, losers, and average performers
 
 **Test Case**
-([cohorts-validation.yaml:95-122](c:\dev\Updog_restore\scripts\validation\cohorts-validation.yaml#L95)):
+([cohorts-validation.yaml:95-122](../../../scripts/validation/cohorts-validation.yaml#L95)):
 
 ```yaml
 cohorts:

--- a/docs/notebooklm-sources/reserves/02-algorithms.md
+++ b/docs/notebooklm-sources/reserves/02-algorithms.md
@@ -44,7 +44,7 @@ algorithm guarantees:
 ```
 
 **Reference:**
-[ConstrainedReserveEngine.ts:5-74](c:/dev/Updog_restore/client/src/core/reserves/ConstrainedReserveEngine.ts#L5-L74)
+[ConstrainedReserveEngine.ts:5-74](../../../client/src/core/reserves/ConstrainedReserveEngine.ts#L5-L74)
 
 ---
 
@@ -53,7 +53,7 @@ algorithm guarantees:
 ### Phase 1: Input Parsing and Constraint Setup
 
 **Code:**
-[ConstrainedReserveEngine.ts:6-18](c:/dev/Updog_restore/client/src/core/reserves/ConstrainedReserveEngine.ts#L6-L18)
+[ConstrainedReserveEngine.ts:6-18](../../../client/src/core/reserves/ConstrainedReserveEngine.ts#L6-L18)
 
 ```typescript
 calculate(input: ReserveInput) {
@@ -103,7 +103,7 @@ calculate(input: ReserveInput) {
 ### Phase 2: Company Scoring and Ranking
 
 **Code:**
-[ConstrainedReserveEngine.ts:21-41](c:/dev/Updog_restore/client/src/core/reserves/ConstrainedReserveEngine.ts#L21-L41)
+[ConstrainedReserveEngine.ts:21-41](../../../client/src/core/reserves/ConstrainedReserveEngine.ts#L21-L41)
 
 ```typescript
 const comps = input.companies.map((c) => {
@@ -209,7 +209,7 @@ This ensures **deterministic sorting** (no random ordering).
 ### Phase 3: Greedy Allocation with Constraint Satisfaction
 
 **Code:**
-[ConstrainedReserveEngine.ts:43-58](c:/dev/Updog_restore/client/src/core/reserves/ConstrainedReserveEngine.ts#L43-L58)
+[ConstrainedReserveEngine.ts:43-58](../../../client/src/core/reserves/ConstrainedReserveEngine.ts#L43-L58)
 
 ```typescript
 let remainingC = toCents(input.availableReserves);
@@ -353,7 +353,7 @@ stageAllocated.set(c.stage, stAlloc + roomC);
 ### Phase 4: Output Construction and Conservation Check
 
 **Code:**
-[ConstrainedReserveEngine.ts:60-74](c:/dev/Updog_restore/client/src/core/reserves/ConstrainedReserveEngine.ts#L60-L74)
+[ConstrainedReserveEngine.ts:60-74](../../../client/src/core/reserves/ConstrainedReserveEngine.ts#L60-L74)
 
 ```typescript
 const totalAllocatedC = comps.reduce((s, c) => addCents(s, c.allocatedC), 0n);
@@ -602,7 +602,7 @@ stagePolicies = [
 ### Validation Test Case
 
 **From:**
-[reserves-validation.yaml:86-113](c:/dev/Updog_restore/scripts/validation/reserves-validation.yaml#L86-L113)
+[reserves-validation.yaml:86-113](../../../scripts/validation/reserves-validation.yaml#L86-L113)
 
 ```yaml
 - description: 'Multi-vintage portfolio with different deployment stages'
@@ -776,7 +776,7 @@ assert(JSON.stringify(result1) === JSON.stringify(result2));
 ```
 
 **Test Coverage:** See
-[reserves.property.test.ts:217-255](c:/dev/Updog_restore/client/src/core/reserves/__tests__/reserves.property.test.ts#L217-L255)
+[reserves.property.test.ts:217-255](../../../client/src/core/reserves/__tests__/reserves.property.test.ts#L217-L255)
 (Idempotence test)
 
 ---
@@ -789,5 +789,5 @@ assert(JSON.stringify(result1) === JSON.stringify(result2));
 
 **Related:**
 
-- [Money utilities](c:/dev/Updog_restore/shared/money.ts) - BigInt arithmetic
-- [Schemas](c:/dev/Updog_restore/shared/schemas.ts) - Input validation
+- [Money utilities](../../../shared/money.ts) - BigInt arithmetic
+- [Schemas](../../../shared/schemas.ts) - Input validation

--- a/docs/notebooklm-sources/reserves/03-examples.md
+++ b/docs/notebooklm-sources/reserves/03-examples.md
@@ -318,7 +318,7 @@ allocated = $0 (no capital left)
 ### Edge Case 1: Zero Available Reserves
 
 **From:**
-[reserves-validation.yaml:32-49](c:/dev/Updog_restore/scripts/validation/reserves-validation.yaml#L32-L49)
+[reserves-validation.yaml:32-49](../../../scripts/validation/reserves-validation.yaml#L32-L49)
 
 **Scenario:** Fund is fully deployed, no capital available for reserves.
 
@@ -382,7 +382,7 @@ for (const c of comps) {
 ### Edge Case 2: 100% Reserve Utilization
 
 **From:**
-[reserves-validation.yaml:51-68](c:/dev/Updog_restore/scripts/validation/reserves-validation.yaml#L51-L68)
+[reserves-validation.yaml:51-68](../../../scripts/validation/reserves-validation.yaml#L51-L68)
 
 **Scenario:** Single high-reserve company can absorb all available capital.
 
@@ -455,7 +455,7 @@ utilizationRate = $50M / $50M = 1.0 (100%)
 ### Edge Case 3: Maximum Deployment (Fully Deployed Fund)
 
 **From:**
-[reserves-validation.yaml:70-84](c:/dev/Updog_restore/scripts/validation/reserves-validation.yaml#L70-L84)
+[reserves-validation.yaml:70-84](../../../scripts/validation/reserves-validation.yaml#L70-L84)
 
 **Scenario:** Fund has deployed all capital, including reserves.
 
@@ -827,7 +827,7 @@ stageAllocated['series_a'] = $7M (STAGE CAP REACHED)
 ### Example 1: Mixed Vintage, Different Stages
 
 **From:**
-[reserves-validation.yaml:86-113](c:/dev/Updog_restore/scripts/validation/reserves-validation.yaml#L86-L113)
+[reserves-validation.yaml:86-113](../../../scripts/validation/reserves-validation.yaml#L86-L113)
 
 **Setup:**
 
@@ -1100,8 +1100,8 @@ const validation = validateReserveInput(input);
 **Test Coverage:**
 
 - Unit tests:
-  [reserves.spec.ts](c:/dev/Updog_restore/client/src/core/reserves/__tests__/reserves.spec.ts)
+  [reserves.spec.ts](../../../client/src/core/reserves/__tests__/reserves.spec.ts)
 - Property tests:
-  [reserves.property.test.ts](c:/dev/Updog_restore/client/src/core/reserves/__tests__/reserves.property.test.ts)
+  [reserves.property.test.ts](../../../client/src/core/reserves/__tests__/reserves.property.test.ts)
 - Validation suite:
-  [reserves-validation.yaml](c:/dev/Updog_restore/scripts/validation/reserves-validation.yaml)
+  [reserves-validation.yaml](../../../scripts/validation/reserves-validation.yaml)

--- a/docs/notebooklm-sources/reserves/04-integration.md
+++ b/docs/notebooklm-sources/reserves/04-integration.md
@@ -894,7 +894,7 @@ describe('ConstrainedReserveEngine', () => {
 ### Property-Based Testing
 
 **From:**
-[reserves.property.test.ts](c:/dev/Updog_restore/client/src/core/reserves/__tests__/reserves.property.test.ts)
+[reserves.property.test.ts](../../../client/src/core/reserves/__tests__/reserves.property.test.ts)
 
 ```typescript
 import fc from 'fast-check';
@@ -994,7 +994,7 @@ describe('Reserve + Pacing Integration', () => {
 
 **References:**
 
-- [Implementation](c:/dev/Updog_restore/client/src/core/reserves/ConstrainedReserveEngine.ts)
-- [Schemas](c:/dev/Updog_restore/shared/schemas.ts)
-- [Tests](c:/dev/Updog_restore/client/src/core/reserves/__tests__)
-- [Validation](c:/dev/Updog_restore/scripts/validation/reserves-validation.yaml)
+- [Implementation](../../../client/src/core/reserves/ConstrainedReserveEngine.ts)
+- [Schemas](../../../shared/schemas.ts)
+- [Tests](../../../client/src/core/reserves/__tests__)
+- [Validation](../../../scripts/validation/reserves-validation.yaml)


### PR DESCRIPTION
## Summary

- Rewrites absolute Windows live-code links under `docs/notebooklm-sources/cohorts/**` and `docs/notebooklm-sources/reserves/**` to repo-relative Markdown links.
- Preserves existing link labels and anchors; no new source anchors were invented.
- Leaves unrelated broken-link classes untouched, including `docs/notebooklm-sources/xirr.md`, historical missing docs, templates, internal docs, Phoenix crosswalk references, and generated artifacts.

## Why

These NotebookLM docs pointed at `c:/dev/Updog_restore/...` or `c:\dev\Updog_restore\...`, which can resolve on this local Windows checkout but does not navigate correctly from GitHub or other clones. Repo-relative targets keep the links portable while preserving the original source references.

## Validation

- Baseline before cleanup: `npm run docs:check-links -- --report-only` reported 188 broken links out of 1570 total.
- Focused touched-doc scan: 172 links across the six touched docs, 0 broken.
- Full report after cleanup: `npm run docs:check-links -- --report-only` still reports 188 broken links out of 1570 total, with 0 report hits for touched docs; remaining NotebookLM report lines are only `docs\notebooklm-sources\xirr.md`.
- `rg -n -i "c:(\\|/)dev(\\|/)Updog_restore" docs/notebooklm-sources` returns no matches.
- `git diff --check HEAD^..HEAD`
- `npm run check`
- `npm run lint`

## Remaining Baseline

The full broken-link count remains 188 because the old absolute Windows links existed on the local checkout and were not part of the local missing-target baseline. This PR is a GitHub navigability cleanup for that failure class, not a reduction of unrelated missing historical/template/internal/Phoenix references.