### PR TITLE
docs: add analytics visualization truthfulness doctrine

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,32 @@
+---
+status: ACTIVE
+audience: both
+last_updated: 2026-05-24
+categories: [design, analytics, visualization, truthfulness]
+keywords: [design, charts, dashboards, provenance, evidence, visual-truthfulness]
+source_of_truth: false
+agent_routing:
+  priority: 2
+  route_hint: 'Start here for Updog presentation-layer doctrine for dashboards, charts, reports, and analytical displays.'
+  use_cases: [chart_review, dashboard_design, report_design, fund_results_ui, lp_reporting]
+maintenance:
+  owner: 'Product + Frontend'
+  review_cadence: 'P60D'
+---
+
+# Design Docs
+
+This folder captures presentation-layer doctrine for Updog. It does not define calculation semantics, database contracts, or worker behavior. Use it when designing or reviewing dashboards, charts, analytical reports, LP-facing views, and fund-model result screens.
+
+## Current docs
+
+| Document | Purpose | Use when |
+| --- | --- | --- |
+| [analytics-visualization-principles.md](analytics-visualization-principles.md) | House rules for truthful, comparison-rich analytical displays | Creating or reviewing charts, dashboards, fund results, LP reports, and scenario views |
+| [analytics-visualization-rollout.md](analytics-visualization-rollout.md) | Sequenced implementation plan for applying those rules inside `Updog_restore` | Planning PRs after the doctrine is accepted |
+
+## Design stance
+
+Updog should feel like a serious analytical operating system, not a collection of attractive but disconnected dashboards. The presentation layer must make model outputs easier to compare, audit, explain, and act on without racing ahead of the data layer.
+
+Use these docs alongside the broader Updog Design Philosophy v3.1.1: dashboard-first, action-near, provenance-first, and role-aware.

--- a/docs/design/analytics-visualization-principles.md
+++ b/docs/design/analytics-visualization-principles.md
@@ -1,0 +1,225 @@
+---
+status: ACTIVE
+audience: both
+last_updated: 2026-05-24
+categories: [design, analytics, visualization, truthfulness]
+keywords:
+  [charts, dashboards, tufte, evidence, provenance, comparison, small-multiples, sparklines, fund-results]
+source_of_truth: true
+agent_routing:
+  priority: 1
+  route_hint: 'Use for any Updog chart, dashboard, report, fund results, scenario comparison, reserve analysis, or LP-facing analytical display.'
+  use_cases:
+    [chart_review, dashboard_review, fund_model_results, scenario_builder, reserve_planning, lp_reporting, visual_truthfulness]
+maintenance:
+  owner: 'Product + Frontend'
+  review_cadence: 'P60D'
+---
+
+# Analytics Visualization Principles
+
+## Purpose
+
+This document converts the Tufte-style visualization guidance into Updog-specific presentation-layer rules. It is highly relevant to dashboards, charts, reports, fund-model results, scenario comparison, reserve planning, MOIC analysis, portfolio monitoring, and LP reporting.
+
+It is intentionally not a rewrite of the calculation engines, persistence layer, worker orchestration, schema contracts, or CI architecture. Those systems must continue to prioritize truthful first-run results, authoritative contracts, and deterministic validation. The presentation layer then makes those results understandable, comparable, and auditable.
+
+## The operating thesis
+
+Updog’s analytical UI is only valuable when users can answer four questions quickly:
+
+1. What changed?
+2. Compared to what?
+3. Why did it change?
+4. Can I trust the number?
+
+Every chart, KPI, table, report block, and dashboard panel should answer at least one of those questions. The best analytical surfaces answer all four without forcing the user into a separate explanation page.
+
+## Non-negotiables
+
+### 1. Truthfulness beats polish
+
+A polished chart with placeholder, stale, or mock-only data is worse than an empty state. Production-facing analytics must clearly distinguish live data, demo data, sample data, stale data, unavailable sections, and pending calculation states.
+
+Rules:
+
+- No production chart should silently import `SAMPLE_DATA`, mock fixtures, or placeholder records.
+- Demo/sample states must be visibly labeled in the surface, not only in code.
+- Stale results must show why they are stale and what action recalculates or republishs them.
+- Failed or unavailable sections must remain visible with an explanation rather than disappearing.
+
+### 2. Comparison is the default analytical act
+
+A single metric is rarely useful in venture modeling. A fund model is useful because it compares construction vs. current forecast, base vs. upside/downside, planned reserves vs. deployed reserves, initial allocation vs. follow-on demand, and current value vs. cost.
+
+Rules:
+
+- Every major number should answer “compared to what?”
+- Scenario views should show cases side by side before asking users to inspect one case deeply.
+- Use common scales when comparing cases, cohorts, years, companies, or scenarios.
+- Prefer small multiples when users need to compare patterns, not just totals.
+
+### 3. Evidence must travel with the number
+
+Every material output should carry enough evidence to make it inspectable. The UI does not need to show every field at full volume, but it must expose provenance near the number.
+
+Each major metric or result section should be able to show:
+
+- Fund or entity ID/name.
+- Published config version.
+- Calculation run ID or equivalent run marker.
+- Last calculated timestamp.
+- Source endpoint or contract section.
+- Current lifecycle state: ready, calculating, failed, stale, unavailable, demo.
+- Key assumptions or drivers behind the output.
+
+This is especially important for `/fund-model-results/:fundId`, LP reports, shared dashboards, scenario exports, and board/IC-ready summaries.
+
+### 4. Words, numbers, and graphics belong together
+
+Do not isolate the chart from the explanation. Labels, annotations, captions, source notes, and assumption callouts should live close to the visual evidence.
+
+Rules:
+
+- Place labels near the data they describe.
+- Use short interpretive captions under charts: “The fund is two quarters behind plan,” “Upside case depends on a higher Series C conversion rate,” etc.
+- Explain material assumptions inside the chart card or immediately adjacent rail.
+- Avoid making tooltips the only place where meaning appears.
+
+### 5. Reduce chart furniture
+
+Remove visual elements that do not carry analytical meaning. Gridlines, legends, borders, gradients, shadows, dual legends, and decorative colors should earn their presence.
+
+Rules:
+
+- Prefer direct labels over legends when the label can sit near the series.
+- Do not show a Recharts/Chart.js legend and then repeat a custom legend below the chart.
+- Use lighter gridlines or fewer gridlines unless the user needs precise reading.
+- Use color to encode meaning, not decoration.
+- Do not rely on color alone; pair it with labels, shapes, ordering, or text.
+
+### 6. Axis integrity is a product requirement
+
+Misleading scales are product bugs. Venture data can easily distort if charts change domains per scenario, truncate baselines without disclosure, or compare values with incompatible units.
+
+Rules:
+
+- Shared comparison charts must use shared scales unless the difference is clearly labeled.
+- Axis truncation must be intentional and disclosed.
+- Units must be visible: dollars, cents, %, x, bps, quarters, years.
+- Avoid mixing dollars and multiples on the same axis unless the design makes the encoding unmistakable.
+
+### 7. Compact trend cues should support scanning
+
+Tables are a primary interface for venture operations. Users often need to scan many companies, investments, LPs, reserves, calls, or assumptions before opening a detail view.
+
+Rules:
+
+- Use inline sparklines for row-level trends where a full chart would be excessive.
+- Sparklines should show shape, not decorative noise.
+- Pair sparklines with the current value and, when useful, a short delta.
+- Use them for portfolio-company tables, reserve rankings, KPI rows, LP reporting summaries, and watchlists.
+
+Example patterns:
+
+```text
+TVPI             2.1x   ▁▂▃▅▇
+Reserve need    $3.2M  ▇▆▅▃▂
+Ownership       8.4%   ▆▅▄▃▂
+Runway          9 mo   ▃▃▂▂▁
+```
+
+## Updog surface rules
+
+| Surface | Primary visualization job | Required evidence pattern |
+| --- | --- | --- |
+| `/fund-model-results/:fundId` | Explain authoritative published results | Evidence header per section: config version, run, timestamp, source, status |
+| Scenario builder | Compare changed assumptions and outcomes | Base vs. changed assumptions side by side; identical scales for outcome charts |
+| Reserve planning | Rank follow-on needs and explain why | Table with reserve need, current/planned/deployed reserve, ownership effect, trigger annotation |
+| MOIC / TVPI / DPI / IRR analysis | Show return mechanics, not only headline metrics | Direct labels, assumptions, time horizon, calculation version, stale state |
+| Construction vs. current forecasts | Reveal drift from the original plan | Small multiples or paired charts with shared scales and variance callouts |
+| Portfolio dashboards | Support scanning and triage | KPI tiles with provenance, company tables with sparklines, exception annotations |
+| LP reports / shared dashboards | Build trust with clear evidence | Integrated words/numbers/charts, source notes, export timestamp, version badge |
+| Wizard inputs | Explain effect of assumptions | Inline examples, micro-visualizations, and impact previews where possible |
+
+## Evidence header pattern
+
+Use an evidence header when a section presents material output.
+
+```text
+READY · CONFIG v12 · RUN #148 · CALCULATED 2026-05-24 09:41 PT · SOURCE /api/funds/:id/results · CURRENT
+```
+
+State language:
+
+- `READY`: result is current for the published config.
+- `CALCULATING`: result is in progress; keep previous output visible if available and label it as prior.
+- `STALE`: result belongs to an older config or underlying data version.
+- `FAILED`: calculation failed; show last known result only if clearly labeled.
+- `UNAVAILABLE`: the section is not supported by the server response.
+- `DEMO`: synthetic or fixture-backed data, visible to users.
+
+## Chart review checklist
+
+Before merging a chart or dashboard panel, answer:
+
+1. What decision does this chart support?
+2. What is the comparison baseline?
+3. Are the axes and units honest?
+4. Are labels close to the data?
+5. Are legends necessary, or can the series be directly labeled?
+6. Is color encoding meaning rather than decoration?
+7. Is any meaning color-only?
+8. Is the data source, run/version, and freshness visible?
+9. Does the chart use live data, and if not, is demo/sample data visibly labeled?
+10. Would a small multiple, table, or sparkline communicate the same evidence better?
+11. Is there a written takeaway or annotation that explains the main pattern?
+12. Can the chart survive empty, partial, loading, stale, and failed states?
+
+## Recommended component primitives
+
+These are conceptual names, not mandates for exact implementation names.
+
+- `EvidenceHeader`: status, run, version, timestamp, source, current/stale/demo state.
+- `MetricWithProvenance`: KPI value plus evidence trigger and supporting assumptions.
+- `ComparisonBand`: side-by-side base/upside/downside/current/plan snapshots.
+- `SmallMultipleGrid`: repeated charts with shared units and scales.
+- `InlineSparkline`: compact row-level trend cue.
+- `AssumptionCallout`: short explanation of what drove a chart or metric.
+- `SourceNote`: endpoint/contract/version note for LP/reporting contexts.
+- `UnavailableSection`: honest placeholder when the server does not support a section.
+
+## Anti-patterns
+
+Avoid these unless there is a documented reason:
+
+- Large single-number hero metrics with no baseline, source, or timestamp.
+- Charts that look production-ready while using sample data.
+- Tooltips that contain essential meaning unavailable elsewhere.
+- Scenario charts with different scales that make outcomes look more comparable than they are.
+- Duplicate legends.
+- Dense gridlines, shadows, gradients, or decoration that compete with the data.
+- Hiding failed or unavailable sections to make a page look cleaner.
+- Exporting LP-facing charts without version and timestamp evidence.
+
+## Testing implications
+
+This doctrine should produce testable guardrails over time. Start with lightweight assertions instead of screenshot-perfect tests.
+
+Suggested tests:
+
+- Production chart components do not import or render `SAMPLE_DATA` without a visible demo/sample label.
+- Each fund results section renders an evidence header when the server supplies provenance fields.
+- Comparison/small-multiple components share a common domain by default.
+- Stale results show a visible stale warning and recalculation action.
+- Charts with color encodings include text labels or non-color cues.
+- LP/report exports include source/version/timestamp evidence.
+
+## Relationship to Updog Design Philosophy v3.1.1
+
+The broader design philosophy says Updog is dashboard-first, action-near, multi-entity, and provenance-first. This document narrows that philosophy into analytical visualization rules:
+
+- Dashboard-first becomes evidence-first dashboards.
+- Action-near becomes decisions near the supporting comparison.
+- Provenance-first becomes visible run/version/source state.
+- Multi-entity becomes small multiples, ranked tables, and comparable views across funds, SPVs, sidecars, companies, LP groups, and scenarios.

--- a/docs/design/analytics-visualization-rollout.md
+++ b/docs/design/analytics-visualization-rollout.md
@@ -46,7 +46,7 @@ Do not launch a cosmetic analytics redesign ahead of the data layer. The correct
 
 **Exit criteria:**
 
-- The doc is linked from `docs/INDEX.md`.
+- The doctrine is discoverable through `docs/design/README.md`.
 - New chart PRs can cite the checklist.
 - Designers and engineers agree that visual truthfulness outranks decorative polish.
 
@@ -186,7 +186,7 @@ A reference implementation for Updog chart style: fewer decorations, clearer com
 
 ## Candidate implementation order
 
-1. `docs/design/*` doctrine and index links.
+1. `docs/design/*` doctrine and README entry point.
 2. `EvidenceHeader` component prototype.
 3. Fund results section evidence headers.
 4. Portfolio Cost and Value chart pilot refactor.

--- a/docs/design/analytics-visualization-rollout.md
+++ b/docs/design/analytics-visualization-rollout.md
@@ -1,0 +1,212 @@
+---
+status: ACTIVE
+audience: both
+last_updated: 2026-05-24
+categories: [design, analytics, rollout, visualization, truthfulness]
+keywords:
+  [fund-results, provenance, portfolio-cost-value-chart, small-multiples, sparklines, rollout, testing]
+source_of_truth: false
+agent_routing:
+  priority: 2
+  route_hint: 'Use after accepting analytics-visualization-principles.md to plan implementation PRs.'
+  use_cases:
+    [implementation_planning, chart_refactor, fund_results_provenance, scenario_comparison, visual_truthfulness_tests]
+maintenance:
+  owner: 'Product + Frontend'
+  review_cadence: 'P60D'
+---
+
+# Analytics Visualization Rollout Plan
+
+## Purpose
+
+This plan applies `docs/design/analytics-visualization-principles.md` to the `Updog_restore` product without distracting from the core priority: a truthful, authoritative fund-modeling flow from setup to published results.
+
+The rollout is presentation-layer first. It should not modify calculation semantics unless a visualization exposes a data-contract gap that must be solved at the source.
+
+## Sequencing principle
+
+Do not launch a cosmetic analytics redesign ahead of the data layer. The correct order is:
+
+1. Make the result true.
+2. Make the result traceable.
+3. Make the result comparable.
+4. Make the result beautiful.
+
+## Phase 0 — Adopt the rule, not the redesign
+
+**Goal:** Establish a shared review standard for analytical displays.
+
+**Actions:**
+
+- Add `analytics-visualization-principles.md` to design docs.
+- Route chart/dashboard reviews through its checklist.
+- Treat it as presentation-layer doctrine, not backend architecture guidance.
+- Require any production analytics surface to state whether it is live, stale, unavailable, or demo/sample-backed.
+
+**Exit criteria:**
+
+- The doc is linked from `docs/INDEX.md`.
+- New chart PRs can cite the checklist.
+- Designers and engineers agree that visual truthfulness outranks decorative polish.
+
+## Phase 1 — Fund results evidence headers
+
+**Surface:** `/fund-model-results/:fundId`
+
+**Why first:** This is the authoritative post-publish destination for the fund model. It is where users need the clearest evidence that outputs came from server-backed results rather than UI state or local placeholders.
+
+**Actions:**
+
+- Introduce an `EvidenceHeader` or equivalent component.
+- Add evidence headers to each major results section when server fields are available.
+- Include calculation status, published config version, run ID, timestamp, source section, and current/stale state.
+- Keep unavailable sections visible with clear explanations.
+- Preserve background polling and lifecycle behavior; do not hide prior results during recalculation unless the prior result is invalid.
+
+**Suggested UI copy:**
+
+```text
+READY · CONFIG v12 · RUN #148 · CALCULATED MAY 24, 2026 09:41 PT · SOURCE /api/funds/:id/results · CURRENT
+```
+
+**Engineering notes:**
+
+- Prefer existing contract fields before expanding API contracts.
+- If a needed provenance field is missing, add a small contract change rather than fabricating UI-only evidence.
+- Keep evidence compact by default; allow expanded details for audit/review workflows.
+
+**Tests:**
+
+- Each available results section renders its evidence state.
+- Stale lifecycle state renders a visible warning and recalculation action.
+- Failed or unavailable sections render an explanatory panel instead of disappearing.
+
+## Phase 2 — Pilot chart refactor: Portfolio Cost and Value
+
+**Surface:** `client/src/components/charts/portfolio-cost-value-chart.tsx`
+
+**Why this chart:** It currently combines sample data, bars, a line, gridlines, tooltip, Recharts legend, and a second custom legend. It is a good pilot for reducing chart furniture and improving data provenance.
+
+**Actions:**
+
+- Split demo/sample data from the production chart component.
+- Require live data through props or a clearly labeled demo wrapper.
+- Remove duplicate legends.
+- Prefer direct labels or a single compact legend.
+- Reduce gridline weight and avoid decorative chart furniture.
+- Add a source/state line when the chart is production-facing.
+- Ensure tooltip content supplements visible labels instead of carrying all meaning.
+
+**Target outcome:**
+
+A reference implementation for Updog chart style: fewer decorations, clearer comparison, visible data state, and no silent sample data.
+
+**Tests:**
+
+- The production chart does not import or default to sample data.
+- Demo/sample usage renders a visible demo/sample label.
+- Only one legend mechanism exists.
+- Empty, loading, stale, and partial data states render intentionally.
+
+## Phase 3 — Scenario comparison and small multiples
+
+**Surfaces:** Scenario builder, construction vs. current forecasts, MOIC/TVPI/DPI/IRR analysis.
+
+**Why:** Venture modeling is inherently comparative. Users need to see how assumptions change outcomes without mentally translating across different charts.
+
+**Actions:**
+
+- Add `SmallMultipleGrid` or an equivalent layout primitive.
+- Show base/upside/downside/current/conservative cases side by side where applicable.
+- Lock scales across compared charts by default.
+- Place assumption diffs beside outcome deltas.
+- Add short captions that explain the mechanism behind the difference.
+
+**Tests:**
+
+- Small multiples share a common domain unless explicitly overridden.
+- Assumption diffs and outcome deltas are visible in the same comparison surface.
+- Scenario labels are visible without relying on color alone.
+
+## Phase 4 — Reserve planning and ranked tables
+
+**Surfaces:** Reserve planning, optimal reserves ranking, portfolio-company watchlists, capital allocation tables.
+
+**Why:** Reserve planning is a ranked decision problem. The UI should explain why a company needs follow-on dollars, not just show a static total.
+
+**Actions:**
+
+- Add row-level sparklines for compact trend reading.
+- Include current/planned/deployed reserve columns where the underlying data supports it.
+- Add “why this company?” annotations: runway, ownership effect, round timing, valuation movement, or trigger condition.
+- Keep ranking methodology visible near the table.
+
+**Tests:**
+
+- Ranking tables expose the ranking basis.
+- Sparklines render with text values and do not encode meaning by color alone.
+- Empty or unsupported ranking inputs show an unavailable state.
+
+## Phase 5 — LP reports and shared dashboards
+
+**Surfaces:** LP reports, shared dashboards, report exports.
+
+**Why:** LP-facing surfaces need high trust and low ambiguity. They should integrate words, numbers, charts, and evidence notes.
+
+**Actions:**
+
+- Add export timestamp, report version, and data-source notes.
+- Include calculation version/run evidence for material metrics.
+- Prefer annotated visual summaries over chart-only pages.
+- Label demo or preview exports clearly.
+
+**Tests:**
+
+- Export/report surfaces include timestamp and source/version evidence.
+- Unsupported sections explain what is missing.
+- LP-facing metrics do not render without evidence or a visible fallback state.
+
+## Phase 6 — Visual truthfulness tests and guardrails
+
+**Goal:** Convert the doctrine into sustainable lightweight checks.
+
+**Actions:**
+
+- Add unit tests around evidence headers and stale/demo states.
+- Add lint or static checks for suspicious `SAMPLE_DATA` usage in production chart components.
+- Add component tests for shared-scale behavior in comparison charts.
+- Add review checklist references to PR templates or design-review notes when appropriate.
+
+**Avoid initially:**
+
+- Screenshot-perfect tests for every chart.
+- Broad chart-library migrations.
+- Overly rigid visual linting that blocks legitimate prototypes.
+
+## Candidate implementation order
+
+1. `docs/design/*` doctrine and index links.
+2. `EvidenceHeader` component prototype.
+3. Fund results section evidence headers.
+4. Portfolio Cost and Value chart pilot refactor.
+5. Scenario small-multiple primitive.
+6. Reserve ranking table improvements.
+7. LP/report provenance and export evidence.
+8. Static/sample-data guardrails.
+
+## Definition of done for a chart PR
+
+A chart PR is done when it can answer:
+
+- What decision does the visual support?
+- What is the baseline comparison?
+- What data source/run/version produced the values?
+- What states are supported: loading, empty, partial, stale, failed, demo?
+- Are labels, units, and axes honest?
+- Is any essential meaning hidden only in a tooltip?
+- Is sample data isolated from production paths?
+
+## Relationship to the current repo
+
+Use this rollout with existing libraries and components first. The repo already includes chart libraries such as Recharts/Chart.js, route-level fund results behavior, and lifecycle-aware server-backed results. The first improvements should refine evidence, comparison, and labeling rather than introduce a new visualization stack.


### PR DESCRIPTION
## Summary

Adds presentation-layer doctrine for applying Tufte-style analytical display principles to Updog without distracting from core modeling truthfulness.

### Added

- `docs/design/README.md` — design-doc routing for analytics visualization doctrine
- `docs/design/analytics-visualization-principles.md` — house rules for charts, dashboards, reports, fund results, scenarios, reserves, and LP-facing analytical displays
- `docs/design/analytics-visualization-rollout.md` — staged implementation sequence for evidence headers, chart refactors, small multiples, reserve tables, LP reports, and visual truthfulness tests

## Why

The gist is most useful for Updog's presentation layer: fund results, scenario comparison, MOIC/TVPI/DPI/IRR displays, reserves, portfolio dashboards, and LP reports. It is intentionally not treated as a backend/modeling rewrite.

## Doctrine highlights

- Truthfulness beats polish: no silent mock/sample data in production analytics
- Comparison is the default analytical act: every major number should answer “compared to what?”
- Evidence travels with the number: version, run, timestamp, source, state, and assumptions
- Words, numbers, and graphics belong together: captions, callouts, and direct labels near data
- Reduce chart furniture: remove duplicate legends, decorative gridlines, and non-informative ink
- Axis integrity: shared scales for comparisons and visible units
- Compact trend cues: sparklines for ranking/scanning tables

## Implementation focus

1. Add evidence headers to `/fund-model-results/:fundId`
2. Refactor `portfolio-cost-value-chart.tsx` as the pilot chart
3. Use small multiples for scenarios and construction-vs-current comparisons
4. Add ranked/sparkline tables for reserves and portfolio triage
5. Add LP/report provenance and export evidence
6. Add lightweight visual truthfulness tests

## Validation

Docs-only change. No tests run.