### PR TITLE
docs: repair Phase 2 mechanical broken links

### DIFF
--- a/docs/ai-optimization/CODEX_AGENT_MIGRATION.md
+++ b/docs/ai-optimization/CODEX_AGENT_MIGRATION.md
@@ -532,10 +532,10 @@ npm run review:watch
 
 - **[AI_ORCHESTRATOR_IMPLEMENTATION.md](./AI_ORCHESTRATOR_IMPLEMENTATION.md)** -
   Complete orchestrator guide
-- **[DECISIONS.md](./DECISIONS.md)** - Architecture decision record
+- **[DECISIONS.md](../../DECISIONS.md)** - Architecture decision record
 - **[MCP_MULTI_AI_INCIDENT_REPORT.md](./MCP_MULTI_AI_INCIDENT_REPORT.md)** -
   Original security issue
-- **[Codex Review Agent README](./packages/codex-review-agent/README.md)** -
+- **[Codex Review Agent README](../../packages/codex-review-agent/README.md)** -
   Agent documentation
 
 ---

--- a/docs/internal/architecture/state-flow.md
+++ b/docs/internal/architecture/state-flow.md
@@ -74,10 +74,10 @@ sequenceDiagram
 
 **File References:**
 
-- Middleware: [server/routes.ts:15-25](../../server/routes.ts#L15-L25)
+- Middleware: [server/routes.ts:15-25](../../../server/routes.ts#L15-L25)
 - Validation:
-  [server/validators/fundSchema.ts:10-45](../../server/validators/fundSchema.ts#L10-L45)
-- Storage: [server/storage.ts:458-471](../../server/storage.ts#L458-L471)
+  [server/validators/fundSchema.ts:10-45](../../../server/validators/fundSchema.ts#L10-L45)
+- Storage: [server/storage.ts:458-471](../../../server/storage.ts#L458-L471)
 
 ---
 
@@ -120,7 +120,7 @@ flowchart TD
 **File References:**
 
 - Write path:
-  [server/routes/fund-config.ts:46-120](../../server/routes/fund-config.ts#L46-L120)
+  [server/routes/fund-config.ts:46-120](../../../server/routes/fund-config.ts#L46-L120)
 - Worker:
   [server/workers/reserve-worker.ts:15-40](../../server/workers/reserve-worker.ts#L15-L40)
 
@@ -164,9 +164,9 @@ flowchart LR
 **File References:**
 
 - Read path:
-  [server/routes/funds.ts:120-145](../../server/routes/funds.ts#L120-L145)
+  [server/routes/funds.ts:120-145](../../../server/routes/funds.ts#L120-L145)
 - TanStack Query config:
-  [client/src/hooks/use-fund-data.ts:15-30](../../client/src/hooks/use-fund-data.ts#L15-L30)
+  [client/src/hooks/use-fund-data.ts:15-30](../../../client/src/hooks/use-fund-data.ts#L15-L30)
 
 ---
 
@@ -250,9 +250,9 @@ stateDiagram-v2
 **File References:**
 
 - Zustand store:
-  [client/src/stores/useFundStore.ts:45-120](../../client/src/stores/useFundStore.ts#L45-L120)
+  [client/src/stores/useFundStore.ts:45-120](../../../client/src/stores/useFundStore.ts#L45-L120)
 - Mutation hooks:
-  [client/src/hooks/use-fund-data.ts:60-85](../../client/src/hooks/use-fund-data.ts#L60-L85)
+  [client/src/hooks/use-fund-data.ts:60-85](../../../client/src/hooks/use-fund-data.ts#L60-L85)
 
 ---
 
@@ -350,10 +350,10 @@ CREATE TABLE strategy_stages (
 **File References:**
 
 - Client validation:
-  [client/src/lib/validation.ts:15-40](../../client/src/lib/validation.ts#L15-L40)
+  [client/src/lib/validation.ts:15-40](../../../client/src/lib/validation.ts#L15-L40)
 - API validation:
-  [server/validators/fundSchema.ts:45-120](../../server/validators/fundSchema.ts#L45-L120)
-- Database schema: [shared/schema.ts:95-130](../../shared/schema.ts#L95-L130)
+  [server/validators/fundSchema.ts:45-120](../../../server/validators/fundSchema.ts#L45-L120)
+- Database schema: [shared/schema.ts:95-130](../../../shared/schema.ts#L95-L130)
 
 ---
 
@@ -505,11 +505,11 @@ queryClient.invalidateQueries(['funds', fundId, 'reserves']);
 **File References:**
 
 - Cache invalidation:
-  [client/src/hooks/use-fund-data.ts:75-110](../../client/src/hooks/use-fund-data.ts#L75-L110)
+  [client/src/hooks/use-fund-data.ts:75-110](../../../client/src/hooks/use-fund-data.ts#L75-L110)
 - Optimistic updates:
   [client/src/hooks/use-reallocation.ts:45-85](../../client/src/hooks/use-reallocation.ts#L45-L85)
 - Cache configuration:
-  [client/src/lib/queryClient.ts:10-25](../../client/src/lib/queryClient.ts#L10-L25)
+  [client/src/lib/queryClient.ts:10-25](../../../client/src/lib/queryClient.ts#L10-L25)
 
 ---
 

--- a/docs/internal/index.md
+++ b/docs/internal/index.md
@@ -131,7 +131,7 @@ reference, not marketing)
 
 ### Code References
 
-- File links: `[schema.ts](../shared/schema.ts)`
+- File links: `[schema.ts](../../shared/schema.ts)`
 - Line references: `[fund-calc.ts:142](../server/lib/fund-calc.ts#L142)`
 - Auto-generated via `node scripts/extract-code-references.mjs`
 

--- a/docs/iterations/IMPLEMENTATION-STATUS.md
+++ b/docs/iterations/IMPLEMENTATION-STATUS.md
@@ -5,68 +5,67 @@ last_updated: 2026-01-19
 
 # Implementation Status: Iteration A
 
-**Last Updated**: 2025-10-03
-**Status**: PR #1 Foundation - 90% Complete
+**Last Updated**: 2025-10-03 **Status**: PR #1 Foundation - 90% Complete
 
 ---
 
-## 📊 Overall Progress
+## Overall Progress
 
-| PR # | Title | Status | Files Changed | Tests | Docs |
-|------|-------|--------|---------------|-------|------|
-| #1 | Foundation | 🟡 90% | 2 modified | N/A | ✅ Complete |
-| #2 | CSV & Calc API | 📝 Ready | 0 / 4 new files | Pending | ✅ Complete |
-| #3 | Parity Kit | 📝 Ready | 0 / 8 new files | Pending | ✅ Complete |
-| #4 | Scenarios | 📝 Ready | 0 / 4 new files | Pending | ✅ Complete |
-| #5 | Reserves | 📝 Ready | 0 / 3 new files | Pending | ✅ Complete |
-| #6 | Observability | 📝 Ready | 0 / 7 new files | Pending | ✅ Complete |
-| #7 | UX Polish | 📝 Ready | 0 / 3 new files | Pending | ✅ Complete |
+| PR # | Title          | Status          | Files Changed   | Tests   | Docs     |
+| ---- | -------------- | --------------- | --------------- | ------- | -------- |
+| #1   | Foundation     | In progress 90% | 2 modified      | N/A     | Complete |
+| #2   | CSV & Calc API | Ready           | 0 / 4 new files | Pending | Complete |
+| #3   | Parity Kit     | Ready           | 0 / 8 new files | Pending | Complete |
+| #4   | Scenarios      | Ready           | 0 / 4 new files | Pending | Complete |
+| #5   | Reserves       | Ready           | 0 / 3 new files | Pending | Complete |
+| #6   | Observability  | Ready           | 0 / 7 new files | Pending | Complete |
+| #7   | UX Polish      | Ready           | 0 / 3 new files | Pending | Complete |
 
 ---
 
-## ✅ Completed: Documentation & Planning
+## Completed: Documentation & Planning
 
 ### Strategy Documents (100% Complete)
 
-1. ✅ **[ITERATION-A-QUICKSTART.md](../../ITERATION-A-QUICKSTART.md)**
+1. [x] **[ITERATION-A-QUICKSTART.md](../../ITERATION-A-QUICKSTART.md)**
    - Quick start guide with immediate actions
    - All 7 PR checklists
    - Success metrics and DoD
 
-2. ✅ **[docs/iterations/STRATEGY-SUMMARY.md](STRATEGY-SUMMARY.md)**
+2. [x] **[docs/iterations/STRATEGY-SUMMARY.md](STRATEGY-SUMMARY.md)**
    - Complete strategy overview
    - Multi-AI validation results
    - Risk mitigation summary
    - What's NOT in Iteration A
 
-3. ✅ **[docs/iterations/iteration-a-implementation-guide.md](iteration-a-implementation-guide.md)**
+3. [x] **[docs/iterations/iteration-a-implementation-guide.md](iteration-a-implementation-guide.md)**
    - Detailed implementation for PRs #1-2
    - Paste-ready code snippets
    - Full PR #2 schema definitions
 
-4. ✅ **[docs/iterations/iteration-a-dod.md](iteration-a-dod.md)**
+4. [x] **[docs/iterations/iteration-a-dod.md](iteration-a-dod.md)**
    - Definition of Done checklist
    - All acceptance criteria
    - Green lights checklist
 
 ### Policy Documents (100% Complete)
 
-5. ✅ **[docs/rounding-policy.md](../rounding-policy.md)**
+5. [x] **[docs/rounding-policy.md](../rounding-policy.md)**
    - Decimal.js precision configuration
    - Export/display rounding rules
    - Parity tolerances
 
-6. ✅ **[docs/policies/distribution-policy.md](../policies/distribution-policy.md)**
+6. [x] **[docs/policies/distribution-policy.md](../policies/distribution-policy.md)**
    - Policy A: Immediate distribution
    - Invariant implications
    - Test specifications
 
-7. ✅ **[docs/policies/allocation-policy.md](../policies/allocation-policy.md)**
+7. [x] **[docs/policies/allocation-policy.md](../policies/allocation-policy.md)**
    - Pattern 1: Reserves carved from allocations
    - Schema enforcement
    - Test cases
 
-8. ✅ **[docs/policies/feasibility-constraints.md](../policies/feasibility-constraints.md)** ⭐
+8. [x] **[docs/policies/feasibility-constraints.md](../policies/feasibility-constraints.md)**
    - 5 critical feasibility constraints
    - Check size validation
    - Preliminary reserve capacity
@@ -74,58 +73,72 @@ last_updated: 2026-01-19
 
 ---
 
-## 🟡 In Progress: PR #1 Foundation
+## In Progress: PR #1 Foundation
 
 ### Changes Made
 
 #### 1. TypeScript Configuration Fixed
+
 **File**: [tsconfig.shared.json](../../tsconfig.shared.json)
-- ✅ Removed `vite/client` types dependency
-- ✅ Added `types: ["node"]` override
-- ✅ Build passing: `npm run build:types`
+
+- PASS: Removed `vite/client` types dependency
+- PASS: Added `types: ["node"]` override
+- PASS: Build passing: `npm run build:types`
 
 #### 2. Health Endpoint Wired
+
 **Files Modified**:
-- ✅ [server/app.ts](../../server/app.ts:9) - Imported `healthRouter`
-- ✅ [server/app.ts](../../server/app.ts:106) - Mounted health router
-- ⚠️  Endpoint exists at [server/routes/health.ts:28-31](../../server/routes/health.ts#L28-31)
-- ⚠️  Runtime testing pending (server startup issues)
+
+- PASS: [server/app.ts](../../server/app.ts#L9) - Imported `healthRouter`
+- PASS: [server/app.ts](../../server/app.ts#L106) - Mounted health router
+- WARN: Endpoint exists at
+  [server/routes/health.ts:28-31](../../server/routes/health.ts#L28-31)
+- WARN: Runtime testing pending (server startup issues)
 
 #### 3. Node Version Lock
-- ✅ [.nvmrc](../../.nvmrc) already exists with `20`
-- ✅ [package.json](../../package.json:7-8) engines already correct
-- 📝 CI enforcement pending (no `.github/workflows/` directory found)
+
+- PASS: [.nvmrc](../../.nvmrc) already exists with `20`
+- PASS: [package.json](../../package.json#L7-L8) engines already correct
+- NOTE: CI enforcement pending (no `.github/workflows/` directory found)
 
 ### Remaining Tasks for PR #1
 
-- [ ] **Test /healthz endpoint** - Verify `curl http://localhost:5000/healthz` returns `{"status":"ok"}`
-- [ ] **Create CI workflow** - Add `.github/workflows/ci.yml` with Node version enforcement
+- [ ] **Test /healthz endpoint** - Verify `curl http://localhost:5000/healthz`
+      returns `{"status":"ok"}`
+- [ ] **Create CI workflow** - Add `.github/workflows/ci.yml` with Node version
+      enforcement
 - [ ] **Tag demo baseline** - `git tag -a release/demo-2025-10-03`
-- [ ] **Commit changes** - `git add . && git commit -m "chore: PR #1 - foundation (healthz + Node lock)"`
+- [ ] **Commit changes** -
+      `git add . && git commit -m "chore: PR #1 - foundation (healthz + Node lock)"`
 - [ ] **Push and create PR**
 
 ---
 
-## 📝 Ready to Implement: PRs #2-7
+## Ready to Implement: PRs #2-7
 
 All remaining PRs have complete implementation guides with:
-- ✅ Paste-ready code snippets
-- ✅ Zod schema definitions
-- ✅ Test specifications
-- ✅ Acceptance criteria
-- ✅ File-by-file checklists
+
+- PASS: Paste-ready code snippets
+- PASS: Zod schema definitions
+- PASS: Test specifications
+- PASS: Acceptance criteria
+- PASS: File-by-file checklists
 
 ### Key Artifacts Created for Implementation
 
 #### PR #2: CSV Exports & Frozen Calc API
 
 **New Files** (from implementation guide):
-1. `shared/schemas/fund-model.ts` - Complete Zod schemas with feasibility constraints
-2. `client/src/lib/decimal-utils.ts` - Decimal.js configuration + rounding functions
+
+1. `shared/schemas/fund-model.ts` - Complete Zod schemas with feasibility
+   constraints
+2. `client/src/lib/decimal-utils.ts` - Decimal.js configuration + rounding
+   functions
 3. `client/src/lib/fund-calc.ts` - Core calculation engine (stub)
 4. `server/routes/calculations.ts` - CSV export endpoints with lineage
 
-**Feasibility Constraints** ⭐ (NEW):
+**Feasibility Constraints** (NEW):
+
 - Total initial investments ≤ committed capital
 - Average check size ≤ stage allocation
 - Minimum 1 company per stage
@@ -135,39 +148,45 @@ All remaining PRs have complete implementation guides with:
 #### PR #3: Parity Kit & Golden Fixtures
 
 **Test Framework**:
+
 - 5 golden fixtures (simple, multi-stage, reserve-tight, high-fee, late-exit)
 - 8 accounting invariants including:
-  - ⭐ Cash balance never negative
-  - ⭐ Total called ≤ committed capital
+  - Cash balance never negative
+  - Total called ≤ committed capital
 - Parity tolerances: TVPI ≤ 1bp, IRR ≤ 5bps, DPI ≤ 1bp
 
 #### PR #4-7: Full Specifications Available
 
-See [iteration-a-implementation-guide.md](iteration-a-implementation-guide.md) for complete details.
+See [iteration-a-implementation-guide.md](iteration-a-implementation-guide.md)
+for complete details.
 
 ---
 
-## 🎯 Success Criteria Status
+## Success Criteria Status
 
 ### Documentation Quality
-- ✅ **8/8 policy documents** created
-- ✅ **Multi-AI validation** complete (GEMINI, OPENAI, DEEPSEEK consensus)
-- ✅ **Feasibility constraints** specified and documented
+
+- [x] **8/8 policy documents** created
+- [x] **Multi-AI validation** complete (GEMINI, OPENAI, DEEPSEEK consensus)
+- [x] **Feasibility constraints** specified and documented
 
 ### Code Readiness
-- ✅ **Zod schemas** fully specified (with constraints)
-- ✅ **CSV formats** defined with lineage fields
-- ✅ **Invariant tests** specified (8 critical checks)
-- ✅ **Reserve optimizer** algorithm documented
+
+- [x] **Zod schemas** fully specified (with constraints)
+- [x] **CSV formats** defined with lineage fields
+- [x] **Invariant tests** specified (8 critical checks)
+- [x] **Reserve optimizer** algorithm documented
 
 ### Risk Mitigation
-- ✅ **7 major risks** eliminated (carry/waterfall, floating-point, phantom money, etc.)
-- ✅ **5 feasibility constraints** prevent invalid inputs
-- ✅ **Cash balance invariant** catches impossible transactions
+
+- [x] **7 major risks** eliminated (carry/waterfall, floating-point, phantom
+      money, etc.)
+- [x] **5 feasibility constraints** prevent invalid inputs
+- [x] **Cash balance invariant** catches impossible transactions
 
 ---
 
-## 📈 Next Steps (Immediate)
+## Next Steps (Immediate)
 
 ### Option A: Complete PR #1 (30 min)
 
@@ -193,37 +212,41 @@ git push origin feat/iteration-a-foundation
 
 ### Option B: Start PR #2 (2 days)
 
-Begin implementation of CSV exports and frozen calc API using the complete code from [iteration-a-implementation-guide.md](iteration-a-implementation-guide.md#pr-2-csv-exports--frozen-calc-api).
+Begin implementation of CSV exports and frozen calc API using the complete code
+from
+[iteration-a-implementation-guide.md](iteration-a-implementation-guide.md#pr-2-csv-exports--frozen-calc-api).
 
 ---
 
-## 🔧 Environment Status
+## Environment Status
 
 ### Working
-- ✅ Node 20.x installed
-- ✅ TypeScript builds passing
-- ✅ Development server starts (port 5000)
-- ✅ Health router code exists
+
+- PASS: Node 20.x installed
+- PASS: TypeScript builds passing
+- PASS: Development server starts (port 5000)
+- PASS: Health router code exists
 
 ### Pending Verification
-- ⚠️  `/healthz` endpoint response (server startup issues during test)
-- ⚠️  CI workflow (no `.github/workflows/` directory)
+
+- WARN: `/healthz` endpoint response (server startup issues during test)
+- WARN: CI workflow (no `.github/workflows/` directory)
 
 ---
 
-## 📊 Metrics
+## Metrics
 
-| Metric | Target | Current | Status |
-|--------|--------|---------|--------|
-| Documentation Coverage | 100% | 100% | ✅ |
-| Code Specifications | 100% | 100% | ✅ |
-| PR #1 Implementation | 100% | 90% | 🟡 |
-| PR #2-7 Readiness | 100% | 100% | ✅ |
-| Multi-AI Validation | 3/3 consensus | 3/3 | ✅ |
+| Metric                 | Target        | Current | Status      |
+| ---------------------- | ------------- | ------- | ----------- |
+| Documentation Coverage | 100%          | 100%    | PASS        |
+| Code Specifications    | 100%          | 100%    | PASS        |
+| PR #1 Implementation   | 100%          | 90%     | IN PROGRESS |
+| PR #2-7 Readiness      | 100%          | 100%    | PASS        |
+| Multi-AI Validation    | 3/3 consensus | 3/3     | PASS        |
 
 ---
 
-## 🎉 Key Achievements
+## Key Achievements
 
 1. **Production-Ready Strategy**
    - Multi-AI validated (GEMINI, OPENAI, DEEPSEEK unanimous approval)
@@ -236,7 +259,7 @@ Begin implementation of CSV exports and frozen calc API using the complete code 
    - Complete API specifications
    - Paste-ready code for all 7 PRs
 
-3. **Feasibility Constraints** ⭐
+3. **Feasibility Constraints**
    - 5 critical constraints prevent nonsensical inputs
    - Ties forecast logic to fund setup
    - Integrated with Zod schema validation
@@ -249,6 +272,8 @@ Begin implementation of CSV exports and frozen calc API using the complete code 
 
 ---
 
-**Status**: Ready for execution. PR #1 is 90% complete, PRs #2-7 have complete implementation guides.
+**Status**: Ready for execution. PR #1 is 90% complete, PRs #2-7 have complete
+implementation guides.
 
-**Next Action**: Complete PR #1 testing and tagging, or begin PR #2 implementation directly.
+**Next Action**: Complete PR #1 testing and tagging, or begin PR #2
+implementation directly.

--- a/docs/plans/2026-04-03-phase-1a2-baseline-automation-hardening-validated.md
+++ b/docs/plans/2026-04-03-phase-1a2-baseline-automation-hardening-validated.md
@@ -61,8 +61,8 @@ Non-goals:
 
 Files:
 
-- [variance-metrics.ts](/C:/dev/Updog_restore/server/metrics/variance-metrics.ts)
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
+- [variance-metrics.ts](../../server/metrics/variance-metrics.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
 
 Work:
 
@@ -72,7 +72,7 @@ Work:
 - Emit structured telemetry for fallback events; do not route these through
   `recordSystemError()`.
 - If temporal-skew telemetry is added in
-  [fund-metrics-attribution-service.ts](/C:/dev/Updog_restore/server/services/fund-metrics-attribution-service.ts),
+  [fund-metrics-attribution-service.ts](../../server/services/fund-metrics-attribution-service.ts),
   scope it to real-time calc-run creation or downgrade it from warn-level
   logging so replay/backfill does not create false alarms.
 
@@ -80,7 +80,7 @@ Work:
 
 Files:
 
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
 
 Work:
 
@@ -98,7 +98,7 @@ Work:
 
 Files:
 
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
 
 Work:
 
@@ -113,8 +113,8 @@ Work:
 
 Files:
 
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
-- [fund.ts](/C:/dev/Updog_restore/shared/schema/fund.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
+- [fund.ts](../../shared/schema/fund.ts)
 
 Work:
 
@@ -130,7 +130,7 @@ Work:
 
 Files:
 
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
 
 Work:
 
@@ -143,13 +143,13 @@ Work:
 
 Files:
 
-- [calc-run-tracking.ts](/C:/dev/Updog_restore/server/services/calc-run-tracking.ts)
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
+- [calc-run-tracking.ts](../../server/services/calc-run-tracking.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
 
 Work:
 
 - Keep replay behavior in
-  [calc-run-tracking.ts](/C:/dev/Updog_restore/server/services/calc-run-tracking.ts)
+  [calc-run-tracking.ts](../../server/services/calc-run-tracking.ts)
   functionally unchanged.
 - Add comments documenting that immediate re-drive is intentional recovery.
 - Add explicit baseline lifecycle logs:
@@ -163,9 +163,9 @@ Work:
 
 Files:
 
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
-- [system-actor.ts](/C:/dev/Updog_restore/shared/constants/system-actor.ts)
-- [schema.ts](/C:/dev/Updog_restore/shared/schema.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
+- [system-actor.ts](../../shared/constants/system-actor.ts)
+- [schema.ts](../../shared/schema.ts)
 
 Work:
 
@@ -178,8 +178,8 @@ Work:
 
 Files:
 
-- [variance-tracking.ts](/C:/dev/Updog_restore/server/services/variance-tracking.ts)
-- [portfolio.ts](/C:/dev/Updog_restore/shared/schema/portfolio.ts)
+- [variance-tracking.ts](../../server/services/variance-tracking.ts)
+- [portfolio.ts](../../shared/schema/portfolio.ts)
 
 Work:
 
@@ -192,8 +192,8 @@ Work:
 
 Files:
 
-- [0002_phase0_variance_automation.sql](/C:/dev/Updog_restore/migrations/0002_phase0_variance_automation.sql)
-- [005_fundmetrics_attribution.sql](/C:/dev/Updog_restore/server/migrations/005_fundmetrics_attribution.sql)
+- [0002_phase0_variance_automation.sql](../../migrations/0002_phase0_variance_automation.sql)
+- [005_fundmetrics_attribution.sql](../../server/migrations/005_fundmetrics_attribution.sql)
 
 Work:
 
@@ -236,9 +236,9 @@ Work:
 
 Files:
 
-- [calc-run-completion-handlers.ts](/C:/dev/Updog_restore/server/services/calc-run-completion-handlers.ts)
-- [calc-run-tracking.ts](/C:/dev/Updog_restore/server/services/calc-run-tracking.ts)
-- [variance-alert-automation.ts](/C:/dev/Updog_restore/server/services/variance-alert-automation.ts)
+- [calc-run-completion-handlers.ts](../../server/services/calc-run-completion-handlers.ts)
+- [calc-run-tracking.ts](../../server/services/calc-run-tracking.ts)
+- [variance-alert-automation.ts](../../server/services/variance-alert-automation.ts)
 
 Work:
 
@@ -263,11 +263,11 @@ plan before finalizing it:
 
 Validation results:
 
-- [baseline-idempotency.test.ts](/C:/dev/Updog_restore/tests/unit/services/baseline-idempotency.test.ts)
+- [baseline-idempotency.test.ts](../../tests/unit/services/baseline-idempotency.test.ts)
   passed with a new backfill non-default contract check
-- [system-actor.test.ts](/C:/dev/Updog_restore/tests/unit/services/system-actor.test.ts)
-  passed with execution-time actor-guard coverage
-- [variance-tracking.test.ts](/C:/dev/Updog_restore/tests/unit/services/variance-tracking.test.ts)
+- [system-actor.test.ts](../../tests/unit/services/system-actor.test.ts) passed
+  with execution-time actor-guard coverage
+- [variance-tracking.test.ts](../../tests/unit/services/variance-tracking.test.ts)
   passed with strict automated metric/snapshot sourcing checks
 - `npm run check` passed with zero new TypeScript errors
 

--- a/docs/session-learning-reports/2026-03-17.md
+++ b/docs/session-learning-reports/2026-03-17.md
@@ -15,8 +15,7 @@ through REFL-028
 ### Candidate 1: GitHub Actions secrets in `if` expressions invalidate workflows
 
 - **Score:** 4 (repeated pattern +3, DX friction +1)
-- **Source:**
-  [zap-baseline.yml](/C:/dev/Updog_restore/.github/workflows/zap-baseline.yml),
+- **Source:** [zap-baseline.yml](../../.github/workflows/zap-baseline.yml),
   GitHub Actions runs `23224844394`, `23223711713`, `23213864085`
 - **Category:** Infrastructure / CI
 - **Anti-Pattern:** Referencing `secrets.*` directly inside workflow or job
@@ -32,8 +31,8 @@ through REFL-028
 ### Candidate 2: Import-time config evaluation leaks environment requirements into unit tests
 
 - **Score:** 5 (repeated pattern +3, CI breakage +1, DX friction +1)
-- **Source:** [jwt.ts](/C:/dev/Updog_restore/server/lib/auth/jwt.ts),
-  [requireFundAccess.test.ts](/C:/dev/Updog_restore/tests/unit/auth/requireFundAccess.test.ts),
+- **Source:** [jwt.ts](../../server/lib/auth/jwt.ts),
+  [requireFundAccess.test.ts](../../tests/unit/auth/requireFundAccess.test.ts),
   GitHub Actions run `23224844728`
 - **Category:** Infrastructure / Testing
 - **Anti-Pattern:** A module that exposes both pure request helpers and


### PR DESCRIPTION
## Summary

Repair Phase 2 only from the approved broken-link cleanup plan: Buckets A/B/C mechanical repairs.

- Bucket A: path-depth fixes
- Bucket B: line-number suffixes converted to markdown fragments
- Bucket C: absolute local `/C:/dev/Updog_restore/...` links converted to portable relative links
- No Phoenix-protected files changed
- No Bucket E/F/G/H repair attempted
- No dependencies, directory-wide ignores, or broad markdown exclusions added

## Delta Ledger

Command:
`npm run docs:check-links -- --report-only`

Before count:
`166 broken / 1570 total / 387 markdown files`

After count:
`120 broken / 1570 total / 387 markdown files`

Bucket IDs removed:
- A: `146, 160, 161, 162, 163, 165, 166, 167, 168, 169, 170, 171, 172, 174, 181, 183`
- B: `118, 119, 120`
- C: `050, 051, 052, 065, 066, 067, 068, 069, 070, 071, 072, 073, 074, 075, 076, 077, 078, 079, 080, 081, 082, 083, 084, 085, 086, 087, 088`

New/unclassified IDs introduced:
`0`

Expected remaining bucket composition:
- E: `61`
- F: `22`
- G: `15`
- H: `22`

Drift explanation:
None. Remaining `120` entries all map to deferred E/F/G/H from the triage artifact.

Touched files:
- `docs/ai-optimization/CODEX_AGENT_MIGRATION.md`
- `docs/internal/architecture/state-flow.md`
- `docs/internal/index.md`
- `docs/iterations/IMPLEMENTATION-STATUS.md`
- `docs/plans/2026-04-03-phase-1a2-baseline-automation-hardening-validated.md`
- `docs/session-learning-reports/2026-03-17.md`

Verification:
- `npm run docs:check-links -- --report-only` -> `120 broken / 1570 total / 387 files`
- Delta ledger -> remaining E/F/G/H only, `0` unclassified current entries
- `git diff --check`
- `git diff --cached --check`
- Pre-commit checks passed
- Push hook classified docs/config-only changes and skipped tests

## Remaining Risks

The repo still has the inherited deferred broken-link backlog in Buckets E/F/G/H. Those are intentionally out of scope for this PR.