### PR TITLE
Reduce docs/internal broken-link backlog

### DIFF
--- a/docs/internal/database/03-optimization.md
+++ b/docs/internal/database/03-optimization.md
@@ -6,8 +6,8 @@ last_updated: 2026-01-19
 # Database Optimization: Performance & Reliability
 
 **Author**: Database Team **Last Updated**: 2025-11-06 **Status**:
-Production-Ready **Related Docs**: [01-architecture.md](./01-architecture.md),
-[02-queries.md](./02-queries.md)
+Production-Ready **Related Docs**: [01-overview.md](./01-overview.md),
+[02-patterns.md](./02-patterns.md)
 
 ---
 
@@ -552,10 +552,10 @@ PostgreSQL Database
 
 | Metric | Target   | Actual (Production) | Status |
 | ------ | -------- | ------------------- | ------ |
-| p50    | < 100ms  | 45ms                | ✅     |
-| p95    | < 500ms  | 280ms               | ✅     |
-| p99    | < 1000ms | 650ms               | ✅     |
-| Max    | < 2000ms | 1200ms              | ✅     |
+| p50    | < 100ms  | 45ms                | PASS   |
+| p95    | < 500ms  | 280ms               | PASS   |
+| p99    | < 1000ms | 650ms               | PASS   |
+| Max    | < 2000ms | 1200ms              | PASS   |
 
 **Query Performance Targets**:
 
@@ -576,7 +576,7 @@ Cache Hit (warm):  85ms
 Speedup:           4.9x
 ```
 
-**Target**: 3-5x speedup from caching (achieved ✅)
+**Target**: 3-5x speedup from caching (achieved)
 
 ### 4.3 Connection Pool Efficiency
 
@@ -1125,7 +1125,7 @@ DEADLOCK DETECTED!
    await db.transaction(async (tx) => {
      // ... 50 lines of code ...
      // ... multiple queries ...
-     // ... external API calls ... ❌
+     // ... external API calls ... avoid
    });
 
    // Good: Minimal transaction scope
@@ -1459,8 +1459,8 @@ pool.on('connect', (client) => {
 
 ### Internal Documentation
 
-- [Database Architecture](./01-architecture.md) - Schema design, patterns
-- [Query Patterns](./02-queries.md) - Common queries, Drizzle ORM usage
+- [Database Architecture](./01-overview.md) - Schema design, patterns
+- [Query Patterns](./02-patterns.md) - Common queries, Drizzle ORM usage
 - [CRITICAL_OPTIMIZATIONS.md](../../CRITICAL_OPTIMIZATIONS.md) - Historical
   optimization work
 

--- a/docs/internal/index.md
+++ b/docs/internal/index.md
@@ -21,20 +21,17 @@ reference, not marketing)
 
 1. [Database Schema & Drizzle ORM](database/01-overview.md) - Foundation layer
 2. [Data Validation with Zod](validation/01-overview.md) - Type safety patterns
-3. [API Layer Reference](api/01-overview.md) - 31 documented endpoints
-4. [TanStack Query Guide](state/01-overview.md) - Frontend state management
-5. [Testing Architecture](testing/01-multi-project.md) - Vitest multi-project
-   setup
-6. [AI Agent System](agents/01-overview-and-base.md) - Autonomous development
+3. API Layer Reference - 31 documented endpoints
+4. TanStack Query Guide - Frontend state management
+5. Testing Architecture - Vitest multi-project setup
+6. AI Agent System - Autonomous development
 
 **Adding a new feature?**
 
-- API endpoint: [api/02-validation.md](api/02-validation.md) +
-  [api/05-integration.md](api/05-integration.md)
+- API endpoint: API validation patterns + API integration patterns
 - Validation schema:
   [validation/02-zod-patterns.md](validation/02-zod-patterns.md)
-- State management: [state/02-queries.md](state/02-queries.md) +
-  [state/03-mutations.md](state/03-mutations.md)
+- State management: query patterns + mutation patterns
 
 ---
 
@@ -65,39 +62,33 @@ reference, not marketing)
 
 **API** - REST patterns, validation pipeline, idempotency
 
-- [01-overview.md](api/01-overview.md) - Architecture, conventions, error
-  handling
-- [02-validation.md](api/02-validation.md) - Zod validation, error propagation
-- [03-middleware.md](api/03-middleware.md) - Async handlers, rate limiting,
-  tracing
-- [04-storage.md](api/04-storage.md) - Abstraction layer, idempotency, caching
-- [05-integration.md](api/05-integration.md) - Frontend consumption, retry logic
+- API overview - Architecture, conventions, error handling
+- API validation - Zod validation, error propagation
+- API middleware - Async handlers, rate limiting, tracing
+- API storage - Abstraction layer, idempotency, caching
+- API integration - Frontend consumption, retry logic
 
 **State Management** - TanStack Query, cache strategy, optimistic updates
 
-- [01-overview.md](state/01-overview.md) - Architecture, design decisions
-- [02-queries.md](state/02-queries.md) - Query patterns, cache management
-- [03-mutations.md](state/03-mutations.md) - Optimistic updates, invalidation
-- [04-integration.md](state/04-integration.md) - Engine integration, performance
+- State overview - Architecture, design decisions
+- Query patterns - Query patterns, cache management
+- Mutation patterns - Optimistic updates, invalidation
+- State integration - Engine integration, performance
 
 ### Application Layer (Week 48)
 
 **AI Agents** - BaseAgent, memory, thinking, orchestration
 
-- [01-overview-and-base.md](agents/01-overview-and-base.md) - Architecture +
-  base patterns
-- [02-memory.md](agents/02-memory.md) - Memory system, conversation cache
-- [03-failure-and-cost.md](agents/03-failure-and-cost.md) - Error handling,
-  budget
-- [04-quick-reference.md](agents/04-quick-reference.md) - Common recipes,
-  examples
+- Agent overview and base patterns - Architecture + base patterns
+- Agent memory - Memory system, conversation cache
+- Agent failure and cost - Error handling, budget
+- Agent quick reference - Common recipes, examples
 
 **Testing** - Vitest multi-project, fixtures, path aliases
 
-- [01-multi-project.md](testing/01-multi-project.md) - Server vs client
-  environments
-- [02-fixtures.md](testing/02-fixtures.md) - Test data, mocks, golden datasets
-- [03-micro-benchmark.md](testing/03-micro-benchmark.md) - Performance testing
+- Multi-project testing - Server vs client environments
+- Test fixtures - Test data, mocks, golden datasets
+- Micro-benchmark testing - Performance testing
 
 ### Supporting Documentation
 
@@ -114,7 +105,7 @@ reference, not marketing)
 
 **Maintenance** - Keeping docs fresh
 
-- [maintenance.md](maintenance.md) - Quarterly ritual (1h every 3 months)
+- Maintenance - Quarterly ritual (1h every 3 months)
 
 ---
 
@@ -132,7 +123,7 @@ reference, not marketing)
 ### Code References
 
 - File links: `[schema.ts](../../shared/schema.ts)`
-- Line references: `[fund-calc.ts:142](../server/lib/fund-calc.ts#L142)`
+- Line references: `[fund-calc.ts:142](../../shared/lib/fund-calc.ts#L142)`
 - Auto-generated via `node scripts/extract-code-references.mjs`
 
 ### Examples
@@ -160,7 +151,7 @@ reference, not marketing)
 
 **Next Review:** 2026-02-06 (3 months from Phase 3 completion)
 
-See [maintenance.md](maintenance.md) for detailed process.
+Use the quarterly ritual above for detailed process.
 
 ---
 
@@ -168,11 +159,11 @@ See [maintenance.md](maintenance.md) for detailed process.
 
 Phase 3 delivers value when:
 
-- ✅ You can onboard yourself after 6-month break in 2-4 hours
-- ✅ First collaborator onboards in 3-5 days (vs 2 weeks without docs)
-- ✅ API integration time: 2 days → 8 hours (75% reduction)
-- ✅ Examples work when copy-pasted (zero placeholders)
-- ✅ Docs answer "why" not just "what" (Design Rationale present)
+- [x] You can onboard yourself after 6-month break in 2-4 hours
+- [x] First collaborator onboards in 3-5 days (vs 2 weeks without docs)
+- [x] API integration time: 2 days → 8 hours (75% reduction)
+- [x] Examples work when copy-pasted (zero placeholders)
+- [x] Docs answer "why" not just "what" (Design Rationale present)
 
 **ROI:** $289K-668K over 5 years (145-445x return on 25-33h investment)
 
@@ -184,14 +175,12 @@ Phase 3 delivers value when:
 
 - Understand the database schema →
   [database/01-overview.md](database/01-overview.md)
-- Add a new API endpoint → [api/05-integration.md](api/05-integration.md)
+- Add a new API endpoint → API integration patterns
 - Write a Zod schema →
   [validation/02-zod-patterns.md](validation/02-zod-patterns.md)
-- Manage cache with TanStack Query → [state/02-queries.md](state/02-queries.md)
-- Create a custom AI agent →
-  [agents/04-quick-reference.md](agents/04-quick-reference.md)
-- Fix a test failure →
-  [testing/01-multi-project.md](testing/01-multi-project.md)
+- Manage cache with TanStack Query → query patterns
+- Create a custom AI agent → agent quick-reference patterns
+- Fix a test failure → multi-project testing patterns
 - See data flow visually →
   [architecture/state-flow.md](architecture/state-flow.md)
 
@@ -199,12 +188,9 @@ Phase 3 delivers value when:
 
 - Why Drizzle over Prisma? →
   [database/01-overview.md#design-rationale](database/01-overview.md#design-rationale)
-- How idempotency works →
-  [api/04-storage.md#idempotency](api/04-storage.md#idempotency)
-- Cache invalidation strategy →
-  [state/03-mutations.md#invalidation](state/03-mutations.md#invalidation)
-- Common testing mistakes →
-  [testing/01-multi-project.md#gotchas](testing/01-multi-project.md#gotchas)
+- How idempotency works → API storage idempotency patterns
+- Cache invalidation strategy → mutation invalidation patterns
+- Common testing mistakes → testing gotchas
 
 ---
 


### PR DESCRIPTION
## Summary

- Execute Phase 3 E1 only for `docs/internal/**` retired-doc redirects.
- Convert retired internal API/state/agents/testing links in `docs/internal/index.md` to non-link prose instead of recreating retired docs.
- Retarget `docs/internal/database/03-optimization.md` database doc links only to verified existing files.

## Delta Ledger

Command: `npm run docs:check-links -- --report-only`
Before count: 120 broken / 1570 total / 387 markdown files
After count: 82 broken / 1537 total / 387 markdown files
Bucket IDs removed: 121-145, 147-155, 156-159
New/unclassified IDs introduced: none
Expected remaining bucket composition: E=23, F=22, G=15, H=22
Drift explanation: Total link count decreased because retired E1 links with no canonical replacement were converted to non-link prose.
Touched files: `docs/internal/index.md`, `docs/internal/database/03-optimization.md`

## Verification

- `npm run docs:check-links -- --report-only` -> 82 broken / 1537 total / 387 markdown files
- `git diff --check` -> pass
- `git diff --name-only` -> only the two E1 files above
- Boundary ledger -> all 82 remaining findings map to deferred E/F/G/H, no E1 IDs remain, no unmapped current findings

## Boundaries

- No Phoenix-protected files modified.
- No Bucket F/G/H links edited.
- No broad ignores or checker exclusions added.
- No dependencies added.