### PR TITLE
[codex] Broken links phase 3 E2 ADR/debt cleanup

### DIFF
--- a/docs/ARCHITECTURAL-DEBT.md
+++ b/docs/ARCHITECTURAL-DEBT.md
@@ -97,7 +97,7 @@ blocks test repair)
 
 **Evidence:**
 
-- [COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md](plans/COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md#section-1-xirr-divergence)
+- COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md (retired divergence assessment)
 - **Phoenix Truth Cases**: N XIRR scenarios
   ([/docs/xirr.truth-cases.json](/docs/xirr.truth-cases.json)) - Excel parity
   validation
@@ -149,7 +149,7 @@ Mixing values without explicit conversion causes silent bugs.
 
 **Evidence:**
 
-- [COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md](plans/COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md#section-2-capital-allocation-divergence)
+- COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md (retired divergence assessment)
 - **Phoenix Truth Cases**: N CA scenarios
   ([/docs/capital-allocation.truth-cases.json](/docs/capital-allocation.truth-cases.json))
 - **Phoenix Domain Knowledge**:
@@ -199,11 +199,11 @@ clawback support. Different GP distributions for same fund parameters.
 
 **Evidence:**
 
-- [COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md](plans/COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md#section-3-waterfall-divergence)
+- COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md (retired divergence assessment)
 - **Phoenix Truth Cases**: N ledger scenarios
   ([/docs/waterfall-ledger.truth-cases.json](/docs/waterfall-ledger.truth-cases.json)),
   N tier scenarios
-  ([/docs/waterfall-tier.truth-cases.json](/docs/waterfall-tier.truth-cases.json))
+  ([/docs/waterfall.truth-cases.json](/docs/waterfall.truth-cases.json))
 - **Phoenix Domain Knowledge**:
   [/docs/notebooklm-sources/waterfall.md](/docs/notebooklm-sources/waterfall.md)
   (Doc Score: 94.3% Promptfoo)
@@ -250,7 +250,7 @@ using `called_capital_period` (from fees.ts) has no equivalent in other systems.
 
 **Evidence:**
 
-- [FOUNDATION-HARDENING-FEE-ALIGNMENT-REVIEW.md](plans/FOUNDATION-HARDENING-FEE-ALIGNMENT-REVIEW.md)
+- FOUNDATION-HARDENING-FEE-ALIGNMENT-REVIEW.md (retired fee alignment review)
 - **Phoenix Truth Cases**: N fee scenarios
   ([/docs/fees.truth-cases.json](/docs/fees.truth-cases.json))
 - **Phoenix Domain Knowledge**:
@@ -294,7 +294,7 @@ Phase 2.3 hits them)
 
 **Evidence:**
 
-- [COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md](plans/COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md#section-3-waterfall-divergence)
+- COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md (retired divergence assessment)
 
 **Recommended Fix:**
 
@@ -328,7 +328,7 @@ unpredictably.
 
 **Evidence:**
 
-- [COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md](plans/COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md#section-5-cross-cutting-issues)
+- COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md (retired divergence assessment)
 
 **Recommended Fix:**
 
@@ -361,7 +361,7 @@ expectations.
 
 **Evidence:**
 
-- [COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md](plans/COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md#52-error-handling-taxonomy)
+- COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md (retired divergence assessment)
 
 **Recommended Fix:**
 
@@ -409,19 +409,20 @@ explaining the issue]
 
 **Admission Criteria - ALL must be true:**
 
-1. ✅ Has reproducible symptom (failing test or production issue)
-2. ✅ Root cause is divergence (not isolated bug)
-3. ✅ Fix is complex (meets ≥1 complexity threshold from integration strategy)
-4. ✅ Blast radius is documented with specific file counts
-5. ✅ ETA is realistic estimate (not placeholder)
+1. Required: Has reproducible symptom (failing test or production issue)
+2. Required: Root cause is divergence (not isolated bug)
+3. Required: Fix is complex (meets >=1 complexity threshold from integration
+   strategy)
+4. Required: Blast radius is documented with specific file counts
+5. Required: ETA is realistic estimate (not placeholder)
 
 **Rejection Criteria - If ANY apply, DO NOT add entry:**
 
-- ❌ No failing test (speculative refactoring)
-- ❌ Root cause is not divergence (e.g., missing await)
-- ❌ Fix is simple (<30 min, 1-2 files, no shared seams)
-- ❌ Issue is vague ("XIRR has problems" - which test? which error?)
-- ❌ No proposed fix shape (must have at least rough approach)
+- Reject: No failing test (speculative refactoring)
+- Reject: Root cause is not divergence (e.g., missing await)
+- Reject: Fix is simple (<30 min, 1-2 files, no shared seams)
+- Reject: Issue is vague ("XIRR has problems" - which test? which error?)
+- Reject: No proposed fix shape (must have at least rough approach)
 
 ---
 
@@ -435,14 +436,14 @@ explaining the issue]
 
 ## Related Documents
 
-- [IMPLEMENTATION-PARITY-INTEGRATION-STRATEGY.md](plans/IMPLEMENTATION-PARITY-INTEGRATION-STRATEGY.md) -
-  How this debt registry integrates with Foundation Hardening Sprint
-- [COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md](plans/COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md) -
+- IMPLEMENTATION-PARITY-INTEGRATION-STRATEGY.md (retired strategy) - How this
+  debt registry integrates with Foundation Hardening Sprint
+- COMPREHENSIVE-DIVERGENCE-ASSESSMENT.md (retired divergence assessment) -
   Detailed analysis of 22 recent PRs
-- [FOUNDATION-HARDENING-FEE-ALIGNMENT-REVIEW.md](plans/FOUNDATION-HARDENING-FEE-ALIGNMENT-REVIEW.md) -
+- FOUNDATION-HARDENING-FEE-ALIGNMENT-REVIEW.md (retired fee alignment review) -
   Fee-specific divergence analysis
-- [FOUNDATION-HARDENING-EXECUTION-PLAN.md](../FOUNDATION-HARDENING-EXECUTION-PLAN.md) -
-  Active sprint plan
+- FOUNDATION-HARDENING-EXECUTION-PLAN.md (retired execution plan) - Former
+  active sprint plan
 
 ---
 

--- a/docs/adr/ADR-004-waterfall-names.md
+++ b/docs/adr/ADR-004-waterfall-names.md
@@ -45,10 +45,10 @@ for financial modeling.
 
 We adopt the following **canonical naming convention** for waterfall types:
 
-| Term         | Industry Alias | Status                | Description                                                                                |
-| ------------ | -------------- | --------------------- | ------------------------------------------------------------------------------------------ |
-| **AMERICAN** | Deal-by-deal   | ✅ Implemented        | Carry calculated per individual investment exit. Standard for US VC funds.                 |
-| **EUROPEAN** | Whole-fund     | ❌ Removed (Jan 2026) | Carry calculated on aggregate fund performance. Removed in PR #339 (zero usage confirmed). |
+| Term         | Industry Alias | Status             | Description                                                                                |
+| ------------ | -------------- | ------------------ | ------------------------------------------------------------------------------------------ |
+| **AMERICAN** | Deal-by-deal   | Implemented        | Carry calculated per individual investment exit. Standard for US VC funds.                 |
+| **EUROPEAN** | Whole-fund     | Removed (Jan 2026) | Carry calculated on aggregate fund performance. Removed in PR #339 (zero usage confirmed). |
 
 **Rationale:**
 
@@ -142,18 +142,20 @@ Canonical test scenarios documented in `docs/waterfall.truth-cases.json`:
 
 ### Positive
 
-✅ **Clear Terminology**: Eliminates AMERICAN/EUROPEAN confusion ✅ **Excel
-Parity**: Users can validate calculations against Excel models ✅ **Mechanical
-Validation**: Documentation drift prevented by test-linked ADRs ✅ **Type
-Safety**: TypeScript types accurately reflect implementation status ✅
-**Regression Protection**: 15-scenario truth table catches calculation bugs
+- **Clear Terminology**: Eliminates AMERICAN/EUROPEAN confusion
+- **Excel Parity**: Users can validate calculations against Excel models
+- **Mechanical Validation**: Documentation drift prevented by test-linked ADRs
+- **Type Safety**: TypeScript types accurately reflect implementation status
+- **Regression Protection**: 15-scenario truth table catches calculation bugs
 
 ### Negative
 
-⚠️ **European Waterfall Removed**: No whole-fund carry calculation (zero usage
-confirmed) ⚠️ **Rounding Overhead**: Small performance cost (~2% for
-`excelRound()` vs native) ⚠️ **Floating-Point Edge Cases**: Rare micro-drift
-possible despite 2dp rounding
+- **WARNING: European Waterfall Removed**: No whole-fund carry calculation (zero
+  usage confirmed)
+- **WARNING: Rounding Overhead**: Small performance cost (~2% for `excelRound()`
+  vs native)
+- **WARNING: Floating-Point Edge Cases**: Rare micro-drift possible despite 2dp
+  rounding
 
 ### Mitigation
 
@@ -168,16 +170,19 @@ possible despite 2dp rounding
 
 ### In Scope
 
-✅ AMERICAN waterfall (deal-by-deal carry calculation) ✅ Excel ROUND utility
-implementation ✅ Truth table with 15 canonical scenarios ✅ Invariant test
-suite (5 property-based checks) ✅ JSON Schema validation for truth cases
+- AMERICAN waterfall (deal-by-deal carry calculation)
+- Excel ROUND utility implementation
+- Truth table with 15 canonical scenarios
+- Invariant test suite (5 property-based checks)
+- JSON Schema validation for truth cases
 
 ### Out of Scope (Non-goals)
 
-❌ **Hybrid Models**: No AMERICAN-with-EUROPEAN-tiers support ❌ **Clawback
-Provisions**: Beyond standard GP catch-up ❌ **Multi-Currency**: No currency
-conversion in waterfall ❌ **Tax Withholding**: No integrated tax calculation ❌
-**Time Value of Money**: No present value discounting in waterfall tiers
+- **Hybrid Models**: No AMERICAN-with-EUROPEAN-tiers support
+- **Clawback Provisions**: Beyond standard GP catch-up
+- **Multi-Currency**: No currency conversion in waterfall
+- **Tax Withholding**: No integrated tax calculation
+- **Time Value of Money**: No present value discounting in waterfall tiers
 
 ---
 
@@ -329,8 +334,8 @@ precision and readability
   [`docs/waterfall.truth-cases.json`](../waterfall.truth-cases.json)
 - **JSON Schema**:
   [`docs/schemas/waterfall-truth-case.schema.json`](../schemas/waterfall-truth-case.schema.json)
-- **Related**: [ADR-001: Evaluator Metrics](./ADR-0001-evaluator-metrics.md),
-  [ADR-002: Token Budgeting](./ADR-0002-token-budgeting.md)
+- **Related**: [ADR-001: Evaluator Metrics](./0001-evaluator-metrics.md),
+  [ADR-002: Token Budgeting](./0002-token-budgeting.md)
 
 ---
 

--- a/docs/adr/ADR-006-fee-calculation-standards.md
+++ b/docs/adr/ADR-006-fee-calculation-standards.md
@@ -602,12 +602,12 @@ reporting).
 
 | Calculation Type                 | Use Decimal.js? | Rationale                                        |
 | -------------------------------- | --------------- | ------------------------------------------------ |
-| **Monetary amounts** ($M values) | ✅ YES          | Precision required for LP reporting              |
-| **Basis calculations**           | ✅ YES          | Affects fee amounts (e.g., FMV, unrealized cost) |
-| **Cumulative fees**              | ✅ YES          | Errors compound over time                        |
-| **Percentage rates** (2%, 1.5%)  | ❌ NO           | Native Math sufficient (not cumulative)          |
-| **IRR calculations**             | ❌ NO           | Excel uses native float (see ADR-005)            |
-| **UI display**                   | ❌ NO           | Convert to number for formatting                 |
+| **Monetary amounts** ($M values) | YES             | Precision required for LP reporting              |
+| **Basis calculations**           | YES             | Affects fee amounts (e.g., FMV, unrealized cost) |
+| **Cumulative fees**              | YES             | Errors compound over time                        |
+| **Percentage rates** (2%, 1.5%)  | NO              | Native Math sufficient (not cumulative)          |
+| **IRR calculations**             | NO              | Excel uses native float (see ADR-005)            |
+| **UI display**                   | NO              | Convert to number for formatting                 |
 
 **Implementation:**
 
@@ -998,69 +998,68 @@ const validationResult = validateFeeStructure(feeProfile);
 
 ### Positive
 
-✅ **Schema-Driven Flexibility**: Six fee basis types support diverse fund
-structures without code changes
+- **Schema-Driven Flexibility**: Six fee basis types support diverse fund
+  structures without code changes
 
-✅ **Type Safety**: Discriminated unions prevent runtime errors for
-basis-specific calculations
+- **Type Safety**: Discriminated unions prevent runtime errors for
+  basis-specific calculations
 
-✅ **Multi-Tier Step-Downs**: Accurately model modern fund economics (2-4 tiers
-common)
+- **Multi-Tier Step-Downs**: Accurately model modern fund economics (2-4 tiers
+  common)
 
-✅ **Fee Recycling Support**: Cap-based approach enables pro-forma forecasting
-with `anticipatedRecycling` flag
+- **Fee Recycling Support**: Cap-based approach enables pro-forma forecasting
+  with `anticipatedRecycling` flag
 
-✅ **Precision Guarantee**: Decimal.js for monetary calculations eliminates
-floating-point errors
+- **Precision Guarantee**: Decimal.js for monetary calculations eliminates
+  floating-point errors
 
-✅ **DRY Integration**: Reuses waterfall module for carry calculations (single
-source of truth)
+- **DRY Integration**: Reuses waterfall module for carry calculations (single
+  source of truth)
 
-✅ **Comprehensive Metrics**: Fee drag (bps), MOIC impact, and fee load provide
-LP/GP transparency
+- **Comprehensive Metrics**: Fee drag (bps), MOIC impact, and fee load provide
+  LP/GP transparency
 
-✅ **Validation Guardrails**: Market-standard warnings guide users without
-blocking exotic structures
+- **Validation Guardrails**: Market-standard warnings guide users without
+  blocking exotic structures
 
-✅ **Performance**: <5ms per quarter calculation (<200ms for 40-quarter
-timeline)
+- **Performance**: <5ms per quarter calculation (<200ms for 40-quarter timeline)
 
-✅ **Excel Explainability**: Not strict parity (unlike XIRR), but calculations
-are auditable and match GP expectations
+- **Excel Explainability**: Not strict parity (unlike XIRR), but calculations
+  are auditable and match GP expectations
 
 ### Negative
 
-⚠️ **Schema Complexity**: Six basis types + multi-tier + recycling = steep
-learning curve for new developers
+- **WARNING: Schema Complexity**: Six basis types + multi-tier + recycling =
+  steep learning curve for new developers
 
-⚠️ **Decimal.js Overhead**: 8x slower than native Math (but acceptable for
-<200ms budgets)
+- **WARNING: Decimal.js Overhead**: 8x slower than native Math (but acceptable
+  for <200ms budgets)
 
-⚠️ **European Waterfall Removed**: `called_capital_net_of_returns` basis
-supported, but European carry calculation not fully implemented (see ADR-004)
+- **WARNING: European Waterfall Removed**: `called_capital_net_of_returns` basis
+  supported, but European carry calculation not fully implemented (see ADR-004)
 
-⚠️ **Validation Maintenance**: Market standards evolve (must update validation
-thresholds periodically)
+- **WARNING: Validation Maintenance**: Market standards evolve (must update
+  validation thresholds periodically)
 
-⚠️ **Timeline Complexity**: `FeeBasisTimeline` generation requires quarterly
-context updates (CPU-intensive for Monte Carlo)
+- **WARNING: Timeline Complexity**: `FeeBasisTimeline` generation requires
+  quarterly context updates (CPU-intensive for Monte Carlo)
 
-⚠️ **No Tax Integration**: Fee calculations ignore tax withholding (LPs must
-model separately)
+- **WARNING: No Tax Integration**: Fee calculations ignore tax withholding (LPs
+  must model separately)
 
 ### Neutral
 
-🔵 **Migration Path Required**: Existing funds using legacy `fees.ts` must
-migrate to `FeeProfile` schema
+- **NOTE: Migration Path Required**: Existing funds using legacy `fees.ts` must
+  migrate to `FeeProfile` schema
 
-🔵 **UI Changes Needed**: Multi-tier configuration requires redesigned fee setup
-wizard
+- **NOTE: UI Changes Needed**: Multi-tier configuration requires redesigned fee
+  setup wizard
 
-🔵 **Testing Surface Area**: 50+ test cases required for comprehensive coverage
-(basis types × tier scenarios × edge cases)
+- **NOTE: Testing Surface Area**: 50+ test cases required for comprehensive
+  coverage (basis types × tier scenarios × edge cases)
 
-🔵 **Documentation Burden**: ADR-006 spans 550 lines (but necessary for complex
-domain)
+- **NOTE: Documentation Burden**: ADR-006 spans 550 lines (but necessary for
+  complex domain)
 
 ---
 
@@ -1090,7 +1089,7 @@ domain)
 - **Tests (Schema)**:
   [`shared/schemas/__tests__/fee-profile.test.ts`](../../shared/schemas/__tests__/fee-profile.test.ts)
 - **Tests (Calculations)**:
-  [`client/src/lib/__tests__/fee-calculations.test.ts`](../../client/src/lib/__tests__/fee-calculations.test.ts)
+  [`tests/unit/fee-calculations.test.ts`](../../tests/unit/fee-calculations.test.ts)
 
 **External References**:
 


### PR DESCRIPTION
## Summary

- Executes Phase 3 E2 only: ADR and architectural-debt retired-doc redirects.
- Converts retired Foundation Hardening and divergence plan references to non-link prose when no current canonical target exists.
- Redirects verified current targets for waterfall truth cases, fee calculation tests, and ADR cross-references.
- Normalizes status glyphs in the three touched docs to satisfy the repo no-emoji pre-commit policy.

## Delta ledger

Command: `npm run docs:check-links -- --report-only`
Before count: 82 broken / 1537 total / 387 markdown files
After count: 67 broken / 1526 total / 387 markdown files
Bucket IDs removed: 013-024, 186, 187-188
Fixed link IDs: 016, 186, 187, 188
Converted-to-prose IDs: 013, 014, 015, 017, 018, 019, 020, 021, 022, 023, 024
Deferred IDs: none in E2; adjacent ADR-006 H IDs 184 and 185 remain untouched as out of scope
New/unclassified IDs introduced: none
Expected remaining bucket composition: remaining deferred E/F/G/H only, minus resolved E2 IDs
Drift explanation: total link count drops by 11 because deleted-doc targets were converted to prose instead of guessed or recreated
Touched files: `docs/ARCHITECTURAL-DEBT.md`, `docs/adr/ADR-004-waterfall-names.md`, `docs/adr/ADR-006-fee-calculation-standards.md`

## Verification

- `npm run docs:check-links -- --report-only` -> 67 broken / 1526 total / 387 markdown files
- `git diff --check`
- `git diff --name-only`
- `npm run lint`
- `npm run check`

Not run: `npm test` because this is a docs-only link cleanup.