### PR TITLE
[codex] Broken links phase 3 E3 XIRR roadmap cleanup

### DIFF
--- a/docs/phase1-xirr-waterfall-roadmap.md
+++ b/docs/phase1-xirr-waterfall-roadmap.md
@@ -124,6 +124,7 @@ IRRConfig threading); now we lock in the gains with:
 3. **Update `docs/xirr.truth-cases.json`**:
    - Only when justified by external calculation
    - Document change in `docs/xirr.truth-cases.changes.md`:
+
      ```md
      ## 2025-12-11: Test 13 Leap Year Correction
 
@@ -135,6 +136,7 @@ IRRConfig threading); now we lock in the gains with:
 
 4. **Document exceptions**:
    - Create `docs/xirr-known-limitations.md`:
+
      ```md
      ## Test 07: Newton failure + bisection fallback
 
@@ -654,8 +656,10 @@ debugXirr('Requires at least 2 cashflows:', cashflows.length);
 
 - [XIRR Analysis](./phase0-xirr-analysis-eda20590.md) - Detailed failure
   categorization
-- [XIRR Parity Heatmap](./xirr-parity-heatmap.md) - 51-scenario baseline (TBD)
-- [Known Limitations](./xirr-known-limitations.md) - Documented edge cases (TBD)
+- [XIRR Baseline Heatmap](./phase1-xirr-baseline-heatmap.md) - 51-scenario
+  baseline
+- [Phase 1.1.1 Analysis](./phase1-1-1-analysis.md) - documented convergence edge
+  cases
 ```
 
 **Deliverables**:
@@ -708,7 +712,8 @@ proportional shortfall-based logic.
 
 ### References
 
-- [Technical Notes](./xirr-and-waterfall-notes.md)
+- Technical Notes: XIRR and waterfall notes from this roadmap's Phase 1.5
+  outline
 - [XIRR Analysis](./phase0-xirr-analysis-eda20590.md)
 ```
 


### PR DESCRIPTION
## Summary

- Executes Phase 3 E3 only: XIRR/waterfall roadmap retired-doc references.
- Redirects the roadmap's parity heatmap and limitations references to verified current XIRR docs.
- Converts the planned standalone technical-notes reference to prose because no current or historical canonical target exists.

## Delta ledger

Command: `npm run docs:check-links -- --report-only`
Before count: 67 broken / 1526 total / 387 markdown files
After count: 64 broken / 1525 total / 387 markdown files
Bucket IDs removed: 001-003
Fixed link IDs: 001, 002
Converted-to-prose IDs: 003
Deferred IDs: none in E3; E4 IDs 004, 176, 178-180 and all Bucket F/G/H findings remain untouched
New/unclassified IDs introduced: none
Expected remaining bucket composition: remaining deferred E/F/G/H only, minus resolved E3 IDs
Drift explanation: total link count drops by 1 because ID 003 was converted to prose instead of guessing or recreating `docs/xirr-and-waterfall-notes.md`
Touched files: `docs/phase1-xirr-waterfall-roadmap.md`

## Verification

- `npm run docs:check-links -- --report-only` -> 64 broken / 1525 total / 387 markdown files
- `git diff --check`
- `git diff --name-only`
- `npm run lint`
- `npm run check`
- Pre-commit hook: archive/large-file guard, emoji scan, bigint safety, staged-file lint/format, Lore validation
- Pre-push hook: large-file and safety checks; docs/config-only branch skipped tests

Not run: `npm test` because this is a docs-only link cleanup.