### PR TITLE
Clean Phase 3 E4 retired doc links

### DIFF
--- a/docs/api/testing/portfolio-route-test-strategy.md
+++ b/docs/api/testing/portfolio-route-test-strategy.md
@@ -678,9 +678,9 @@ export function assertValidLot(lot: unknown): asserts lot is InvestmentLotV1 {
 ### Related Documentation
 
 - [Portfolio Route API Schemas](../../../shared/schemas/portfolio-route.ts)
-- [Drizzle Schema](../../../shared/db/schema.ts)
-- [Idempotency Pattern](../../../docs/architecture/idempotency.md)
-- [Optimistic Locking](../../../docs/architecture/optimistic-locking.md)
+- [Drizzle Schema](../../../shared/schema.ts)
+- [Idempotency Pattern](../architecture/portfolio-route-api.md)
+- [Optimistic Locking](../architecture/portfolio-route-api.md)
 
 ### Test File Locations
 

--- a/docs/performance-logging-automation.md
+++ b/docs/performance-logging-automation.md
@@ -113,7 +113,7 @@ Add the following secret to your GitHub repository:
 DATABASE_URL=postgresql://username:password@host:5432/database
 ```
 
-**Path**: Repository Settings → Secrets and variables → Actions → New repository secret
+**Path**: Repository Settings -> Secrets and variables -> Actions -> New repository secret
 
 ### 2. Local Development
 
@@ -175,7 +175,7 @@ Performance results are appended to `perf-log.md` in this format:
 - **Throughput:** 38803 rows/sec
 
 ### Performance Grade
-**Grade: A** - Excellent performance! 🚀
+**Grade: A** - Excellent performance!
 
 ---
 ```
@@ -198,7 +198,7 @@ Performance results are appended to `perf-log.md` in this format:
 
 #### 1. Database Connection Failures
 ```
-❌ Error running analysis: connection timeout
+ERROR: Error running analysis: connection timeout
 ```
 **Solutions:**
 - Verify `DATABASE_URL` secret is correctly set
@@ -207,7 +207,7 @@ Performance results are appended to `perf-log.md` in this format:
 
 #### 2. Missing Table Error
 ```
-❌ Error running analysis: relation "mc_stats_1min" does not exist
+ERROR: Error running analysis: relation "mc_stats_1min" does not exist
 ```
 **Solutions:**
 - Ensure the `mc_stats_1min` table exists in your database
@@ -216,7 +216,7 @@ Performance results are appended to `perf-log.md` in this format:
 
 #### 3. Permission Errors
 ```
-❌ Error running analysis: permission denied for table mc_stats_1min
+ERROR: Error running analysis: permission denied for table mc_stats_1min
 ```
 **Solutions:**
 - Grant SELECT permissions to the database user
@@ -225,7 +225,7 @@ Performance results are appended to `perf-log.md` in this format:
 
 #### 4. Git Push Failures
 ```
-❌ fatal: could not read Username for 'https://github.com': terminal prompts disabled
+ERROR: fatal: could not read Username for 'https://github.com': terminal prompts disabled
 ```
 **Solutions:**
 - Check repository permissions for GitHub Actions
@@ -234,10 +234,10 @@ Performance results are appended to `perf-log.md` in this format:
 
 #### 5. Workflow Permission Issues
 ```
-❌ Resource not accessible by integration
+ERROR: Resource not accessible by integration
 ```
 **Solutions:**
-- Go to Repository Settings → Actions → General
+- Go to Repository Settings -> Actions -> General
 - Set "Workflow permissions" to "Read and write permissions"
 - Enable "Allow GitHub Actions to create and approve pull requests"
 
@@ -324,7 +324,7 @@ The GitHub Actions workflow can be extended to send notifications to Slack, emai
 
 ## Related Documentation
 
-- [BMAD Process Overview](./bmad-brief.md)
+- BMAD Process Overview (retired local brief)
 - [Database Schema](./schema.md)
 - [Observability Setup](./observability.md)
 - [GitHub Workflow Guide](./processes/GITHUB_SETUP.md)


### PR DESCRIPTION
## Summary

- Converts the retired BMAD brief link in `docs/performance-logging-automation.md` to prose.
- Redirects the portfolio route test strategy appendix to existing schema and API architecture docs.
- Removes existing no-emoji hook blockers from the touched performance doc without adding broad markdown exclusions.

## Delta ledger

Command: `npm run docs:check-links -- --report-only`
Before count: `64 broken / 1525 total / 387 markdown files`
After count: `59 broken / 1524 total / 387 markdown files`
Bucket IDs removed: `004, 178, 179, 180` in tracked PR files; `176` was corrected only in the local ignored scan source `docs/deployment/MEMORY_PHASE2_DEPLOYMENT.md`, which is untracked and ignored by `.gitignore`.
Fixed IDs: `178, 179, 180`
Converted-to-prose IDs: `004`
Deferred or blocked IDs: `176` for commit/PR purposes because the source file is ignored/untracked; not force-added.
New/unclassified IDs introduced: `none`
Expected remaining bucket composition: F `22`, G `15`, H `22`; E4 has no remaining tracked-source findings.
Drift explanation: total links decreased by one because ID `004` became non-link prose; the local checker count also dropped by ID `176` after correcting the ignored local deployment memory file, but this PR intentionally does not add that ignored artifact to git.
Touched files: `docs/performance-logging-automation.md`, `docs/api/testing/portfolio-route-test-strategy.md`

## Verification

- `npm run docs:check-links -- --report-only` -> `59 broken / 1524 total / 387 markdown files`
- `git diff --check`
- `git diff --name-only`
- `npm run lint`
- `npm run check`

Not run: `npm run phoenix:truth`; no Phoenix or modeling-truth docs were edited.
