### PR TITLE
Retire Phase 6 H broken links without guessed targets

### DIFF
--- a/docs/adr/ADR-006-fee-calculation-standards.md
+++ b/docs/adr/ADR-006-fee-calculation-standards.md
@@ -1069,8 +1069,8 @@ const validationResult = validateFeeStructure(feeProfile);
   analysis uses XIRR for net IRR calculations
 - **[ADR-004: Waterfall Names](./ADR-004-waterfall-names.md)**: European
   waterfall removed (affects `called_capital_net_of_returns` basis)
-- **[ADR-003: Waterfall Distribution System](./ADR-003-waterfall-distribution-system.md)**:
-  Carry calculations reuse waterfall module
+- **ADR-003: Waterfall Distribution System**: Carry calculations reuse waterfall
+  module
 - **[ADR-001: Evaluator Metrics](./0001-evaluator-metrics.md)**: Fee calculation
   performance tracked in evaluator framework
 
@@ -1086,8 +1086,7 @@ const validationResult = validateFeeStructure(feeProfile);
   [`shared/lib/fund-math.ts`](../../shared/lib/fund-math.ts)
 - **Code (Waterfall)**:
   [`client/src/lib/waterfall.ts`](../../client/src/lib/waterfall.ts)
-- **Tests (Schema)**:
-  [`shared/schemas/__tests__/fee-profile.test.ts`](../../shared/schemas/__tests__/fee-profile.test.ts)
+- **Tests (Schema)**: `shared/schemas/__tests__/fee-profile.test.ts`
 - **Tests (Calculations)**:
   [`tests/unit/fee-calculations.test.ts`](../../tests/unit/fee-calculations.test.ts)
 

--- a/docs/ai-optimization/CODEX_AGENT_MIGRATION.md
+++ b/docs/ai-optimization/CODEX_AGENT_MIGRATION.md
@@ -533,8 +533,7 @@ npm run review:watch
 - **[AI_ORCHESTRATOR_IMPLEMENTATION.md](./AI_ORCHESTRATOR_IMPLEMENTATION.md)** -
   Complete orchestrator guide
 - **[DECISIONS.md](../../DECISIONS.md)** - Architecture decision record
-- **[MCP_MULTI_AI_INCIDENT_REPORT.md](./MCP_MULTI_AI_INCIDENT_REPORT.md)** -
-  Original security issue
+- **MCP_MULTI_AI_INCIDENT_REPORT.md** - Original security issue
 - **[Codex Review Agent README](../../packages/codex-review-agent/README.md)** -
   Agent documentation
 

--- a/docs/api/fund-allocations-phase1b.md
+++ b/docs/api/fund-allocations-phase1b.md
@@ -5,13 +5,15 @@ last_updated: 2026-01-19
 
 # Fund Allocation Management API - Phase 1b Implementation
 
-**Date:** 2025-10-07
-**Status:** ✅ Complete
-**Endpoint:** `GET /api/funds/:fundId/companies`
+**Date:** 2025-10-07 **Status:** [x] Complete **Endpoint:**
+`GET /api/funds/:fundId/companies`
 
 ## Summary
 
-Implemented the companies list API endpoint with cursor-based pagination, filtering, and sorting capabilities for Fund Allocation Management (Phase 1b). This endpoint provides efficient access to portfolio company data with allocation metrics.
+Implemented the companies list API endpoint with cursor-based pagination,
+filtering, and sorting capabilities for Fund Allocation Management (Phase 1b).
+This endpoint provides efficient access to portfolio company data with
+allocation metrics.
 
 ## Implementation Details
 
@@ -20,14 +22,18 @@ Implemented the companies list API endpoint with cursor-based pagination, filter
 **URL:** `GET /api/funds/:fundId/companies`
 
 **Query Parameters:**
+
 - `cursor` (optional): ID of last company from previous page (string, numeric)
 - `limit` (optional): Number of results (default: 50, max: 200)
-- `q` (optional): Search query for company name (case-insensitive, max 255 chars)
+- `q` (optional): Search query for company name (case-insensitive, max 255
+  chars)
 - `status` (optional): Filter by status (`active`, `exited`, `written-off`)
 - `sector` (optional): Filter by sector (max 100 chars)
-- `sortBy` (optional): Sort order - `exit_moic_desc` (default), `planned_reserves_desc`, `name_asc`
+- `sortBy` (optional): Sort order - `exit_moic_desc` (default),
+  `planned_reserves_desc`, `name_asc`
 
 **Response Schema:**
+
 ```typescript
 interface CompanyListResponse {
   companies: Array<{
@@ -58,7 +64,9 @@ interface CompanyListResponse {
 **Location:** `server/routes/allocations.ts` (added to existing file)
 
 **Key Features:**
-1. **Cursor-based pagination** using keyset pagination (id < cursor) for O(1) performance
+
+1. **Cursor-based pagination** using keyset pagination (id < cursor) for O(1)
+   performance
 2. **Zod validation** for all query parameters with type-safe parsing
 3. **Drizzle ORM** query builder with SQL injection protection
 4. **Performance optimization:**
@@ -70,8 +78,8 @@ interface CompanyListResponse {
    - Basis points for MOIC (INTEGER, 10000 = 1.0x)
    - Decimal for ownership percentage
 
-**Database Schema:**
-Extended `portfoliocompanies` table with Phase 1a fields:
+**Database Schema:** Extended `portfoliocompanies` table with Phase 1a fields:
+
 - `deployed_reserves_cents` (BIGINT, default 0)
 - `planned_reserves_cents` (BIGINT, default 0)
 - `exit_moic_bps` (INTEGER, nullable)
@@ -83,7 +91,9 @@ Extended `portfoliocompanies` table with Phase 1a fields:
 - `allocation_version` (INTEGER, default 1)
 
 **Indexes Used:**
-- `idx_portfoliocompanies_fund_exit_moic` - MOIC sorting (partial index on active status)
+
+- `idx_portfoliocompanies_fund_exit_moic` - MOIC sorting (partial index on
+  active status)
 - `idx_portfoliocompanies_fund_status_sector` - Status/sector filtering
 - `idx_portfoliocompanies_cursor` - Cursor pagination (fund_id, id DESC)
 - `idx_portfoliocompanies_last_allocation` - Recent activity queries
@@ -91,14 +101,17 @@ Extended `portfoliocompanies` table with Phase 1a fields:
 ### Error Handling
 
 **400 Bad Request:**
+
 - Invalid fundId (non-numeric or negative)
 - Invalid query parameters (wrong type, out of range)
 - Limit exceeds 200
 
 **404 Not Found:**
+
 - Fund doesn't exist or has no companies
 
 **Example Error Response:**
+
 ```json
 {
   "error": "invalid_query_parameters",
@@ -115,25 +128,28 @@ Extended `portfoliocompanies` table with Phase 1a fields:
 
 **Test File:** `tests/api/allocations.test.ts`
 
-**Test Coverage:** 15 comprehensive test cases for GET /api/funds/:fundId/companies
+**Test Coverage:** 15 comprehensive test cases for GET
+/api/funds/:fundId/companies
 
 ### Test Cases
 
-1. ✅ **Default pagination and sorting** - Retrieves companies sorted by exit MOIC DESC
-2. ✅ **Filter by status** - Returns only companies matching status filter
-3. ✅ **Filter by sector** - Returns only companies in specified sector
-4. ✅ **Search by name** - Case-insensitive LIKE search on company name
-5. ✅ **Sort by planned reserves DESC** - Correct ordering by planned_reserves_cents
-6. ✅ **Sort by name ASC** - Alphabetical ordering
-7. ✅ **Cursor-based pagination** - No duplicates, correct has_more flag
-8. ✅ **Limit parameter** - Respects limit, validates max 200
-9. ✅ **404 for non-existent fund** - Proper error response
-10. ✅ **400 for invalid fund ID** - Input validation
-11. ✅ **400 for invalid query parameters** - Comprehensive validation
-12. ✅ **Empty result set** - Handles no matches gracefully
-13. ✅ **Multiple filters combined** - Correct AND logic
-14. ✅ **NULL values** - Proper handling of optional fields
-15. ✅ **Performance test** - < 200ms for 100 companies (p95 requirement met)
+1. [x] **Default pagination and sorting** - Retrieves companies sorted by exit
+       MOIC DESC
+2. [x] **Filter by status** - Returns only companies matching status filter
+3. [x] **Filter by sector** - Returns only companies in specified sector
+4. [x] **Search by name** - Case-insensitive LIKE search on company name
+5. [x] **Sort by planned reserves DESC** - Correct ordering by
+       planned_reserves_cents
+6. [x] **Sort by name ASC** - Alphabetical ordering
+7. [x] **Cursor-based pagination** - No duplicates, correct has_more flag
+8. [x] **Limit parameter** - Respects limit, validates max 200
+9. [x] **404 for non-existent fund** - Proper error response
+10. [x] **400 for invalid fund ID** - Input validation
+11. [x] **400 for invalid query parameters** - Comprehensive validation
+12. [x] **Empty result set** - Handles no matches gracefully
+13. [x] **Multiple filters combined** - Correct AND logic
+14. [x] **NULL values** - Proper handling of optional fields
+15. [x] **Performance test** - < 200ms for 100 companies (p95 requirement met)
 
 ### Running Tests
 
@@ -148,11 +164,13 @@ npm test -- tests/api/allocations.test.ts -t "GET /api/funds/:fundId/companies"
 ## Performance
 
 **Benchmarks:**
+
 - 100 companies query: < 200ms (p95)
 - Indexed pagination: O(1) for cursor-based navigation
 - No N+1 queries (single SELECT with joins)
 
 **Query Plan:**
+
 ```sql
 -- Optimized query using indexes
 SELECT ... FROM portfoliocompanies
@@ -170,15 +188,16 @@ LIMIT $limit + 1;
 
 ## Security
 
-- ✅ Zod validation prevents injection attacks
-- ✅ Parameterized queries (SQL injection safe)
-- ✅ Rate limiting via express-rate-limit (60 req/min)
-- ✅ Request ID logging for audit trail
-- ✅ Input sanitization (max lengths enforced)
+- [x] Zod validation prevents injection attacks
+- [x] Parameterized queries (SQL injection safe)
+- [x] Rate limiting via express-rate-limit (60 req/min)
+- [x] Request ID logging for audit trail
+- [x] Input sanitization (max lengths enforced)
 
 ## Integration
 
 **Server App Registration:** `server/app.ts`
+
 ```typescript
 import allocationsRouter from './routes/allocations.js';
 // ...
@@ -190,6 +209,7 @@ app.use('/api', allocationsRouter);
 ## Example Usage
 
 ### Request
+
 ```bash
 curl -X GET \
   'http://localhost:3001/api/funds/1/companies?limit=20&status=active&sortBy=exit_moic_desc' \
@@ -197,6 +217,7 @@ curl -X GET \
 ```
 
 ### Response
+
 ```json
 {
   "companies": [
@@ -224,6 +245,7 @@ curl -X GET \
 ```
 
 ### Pagination Example
+
 ```bash
 # Page 1
 curl 'http://localhost:3001/api/funds/1/companies?limit=50'
@@ -234,7 +256,8 @@ curl 'http://localhost:3001/api/funds/1/companies?limit=50&cursor=42'
 
 ## Files Modified
 
-1. **`server/routes/allocations.ts`** - Added GET /companies endpoint (234 lines)
+1. **`server/routes/allocations.ts`** - Added GET /companies endpoint (234
+   lines)
 2. **`shared/schema.ts`** - Added Phase 1a fields to portfolioCompanies table
 3. **`tests/api/allocations.test.ts`** - Added 15 test cases (306 lines)
 
@@ -248,6 +271,7 @@ curl 'http://localhost:3001/api/funds/1/companies?limit=50&cursor=42'
 ## Migration Reference
 
 **Migration:** `server/migrations/20251007_fund_allocation_phase1a.up.sql`
+
 - Added 9 columns to portfoliocompanies
 - Created 4 performance indexes
 - Added 7 CHECK constraints for data validation
@@ -264,25 +288,27 @@ curl 'http://localhost:3001/api/funds/1/companies?limit=50&cursor=42'
 ## Changelog
 
 **2025-10-07 16:45**
-- ✅ Implemented GET /api/funds/:fundId/companies endpoint
-- ✅ Added Zod validation schemas
-- ✅ Added cursor-based pagination with limit+1 pattern
-- ✅ Implemented filtering (status, sector, search)
-- ✅ Implemented sorting (exit MOIC, planned reserves, name)
-- ✅ Added comprehensive error handling
-- ✅ Extended Drizzle schema with Phase 1a fields
-- ✅ Added 15 unit tests with 100% coverage
-- ✅ Verified performance: < 200ms for 100 companies
+
+- [x] Implemented GET /api/funds/:fundId/companies endpoint
+- [x] Added Zod validation schemas
+- [x] Added cursor-based pagination with limit+1 pattern
+- [x] Implemented filtering (status, sector, search)
+- [x] Implemented sorting (exit MOIC, planned reserves, name)
+- [x] Added comprehensive error handling
+- [x] Extended Drizzle schema with Phase 1a fields
+- [x] Added 15 unit tests with 100% coverage
+- [x] Verified performance: < 200ms for 100 companies
 
 ## Related Documentation
 
 - [Phase 1a Migration](../../server/migrations/20251007_fund_allocation_phase1a.up.sql)
-- [Allocation POST API](../../server/routes/allocations.ts#L372) - Update allocations
-- [Allocation GET Latest API](../../server/routes/allocations.ts#L281) - Get latest state
-- [DeepSeek Architecture Review](../architecture/fund-allocation-architecture.md) (if exists)
+- [Allocation POST API](../../server/routes/allocations.ts#L372) - Update
+  allocations
+- [Allocation GET Latest API](../../server/routes/allocations.ts#L281) - Get
+  latest state
+- DeepSeek Architecture Review (if exists)
 
 ---
 
-**Implementation by:** Claude (Anthropic)
-**Reviewed by:** (Pending)
-**Production Ready:** ✅ Yes
+**Implementation by:** Claude (Anthropic) **Reviewed by:** (Pending)
+**Production Ready:** [x] Yes

--- a/docs/internal/architecture/state-flow.md
+++ b/docs/internal/architecture/state-flow.md
@@ -113,16 +113,16 @@ flowchart TD
 
 **Write Path Characteristics:**
 
-- ✅ **Synchronous:** Config save + event log (< 50ms)
-- ✅ **Transactional:** All-or-nothing commit
-- ✅ **Asynchronous:** Background calculations don't block user
+- [x] **Synchronous:** Config save + event log (< 50ms)
+- [x] **Transactional:** All-or-nothing commit
+- [x] **Asynchronous:** Background calculations don't block user
 
 **File References:**
 
 - Write path:
   [server/routes/fund-config.ts:46-120](../../../server/routes/fund-config.ts#L46-L120)
 - Worker:
-  [server/workers/reserve-worker.ts:15-40](../../server/workers/reserve-worker.ts#L15-L40)
+  [workers/reserve-worker.ts:15-40](../../../workers/reserve-worker.ts#L15-L40)
 
 ---
 
@@ -150,10 +150,10 @@ flowchart LR
 
 **Read Path Characteristics:**
 
-- ✅ **3-tier caching:** Browser (TanStack Query) → Redis → PostgreSQL
-- ✅ **Sub-second response:** 95% of requests < 200ms
-- ✅ **Eventually consistent:** Background workers update snapshots
-  asynchronously
+- [x] **3-tier caching:** Browser (TanStack Query) → Redis → PostgreSQL
+- [x] **Sub-second response:** 95% of requests < 200ms
+- [x] **Eventually consistent:** Background workers update snapshots
+      asynchronously
 
 **Cache TTLs:**
 
@@ -506,8 +506,7 @@ queryClient.invalidateQueries(['funds', fundId, 'reserves']);
 
 - Cache invalidation:
   [client/src/hooks/use-fund-data.ts:75-110](../../../client/src/hooks/use-fund-data.ts#L75-L110)
-- Optimistic updates:
-  [client/src/hooks/use-reallocation.ts:45-85](../../client/src/hooks/use-reallocation.ts#L45-L85)
+- Optimistic updates: `client/src/hooks/use-reallocation.ts:45-85`
 - Cache configuration:
   [client/src/lib/queryClient.ts:10-25](../../../client/src/lib/queryClient.ts#L10-L25)
 
@@ -538,21 +537,21 @@ queryClient.invalidateQueries(['funds', fundId, 'reserves']);
 
 **Use Optimistic Updates When:**
 
-- ✅ User expects instant feedback (form inputs, toggles)
-- ✅ Rollback is acceptable (show error, revert state)
-- ✅ Operation is likely to succeed (> 95% success rate)
+- [x] User expects instant feedback (form inputs, toggles)
+- [x] Rollback is acceptable (show error, revert state)
+- [x] Operation is likely to succeed (> 95% success rate)
 
 **Use Write-Through Invalidation When:**
 
-- ✅ Data affects multiple queries (fund update → invalidate reserves + pacing)
-- ✅ Consistency is critical (financial calculations)
-- ✅ Rollback complexity is high
+- [x] Data affects multiple queries (fund update → invalidate reserves + pacing)
+- [x] Consistency is critical (financial calculations)
+- [x] Rollback complexity is high
 
 **Use Background Processing When:**
 
-- ✅ Operation is expensive (Monte Carlo simulation)
-- ✅ User doesn't need immediate result (analytics)
-- ✅ Async is acceptable (email notifications, reports)
+- [x] Operation is expensive (Monte Carlo simulation)
+- [x] User doesn't need immediate result (analytics)
+- [x] Async is acceptable (email notifications, reports)
 
 ---
 
@@ -571,4 +570,4 @@ next review: 2026-05-06 (after Phase 3 Week 47 completion)
 **Last Updated:** 2025-11-06 **Contributors:** Phase 3 Documentation Initiative
 **Related Docs:** [database/01-overview.md](../database/01-overview.md),
 [validation/04-integration.md](../validation/04-integration.md),
-[state/01-overview.md](../state/01-overview.md)
+`state/01-overview.md`

--- a/docs/lp-observability-implementation.md
+++ b/docs/lp-observability-implementation.md
@@ -7,15 +7,20 @@ last_updated: 2026-01-19
 
 ## Overview
 
-This document describes the observability implementation for the LP Reporting Dashboard API. The implementation follows the existing patterns established in `server/observability/performance-metrics.ts` and provides comprehensive monitoring, alerting, and SLO tracking.
+This document describes the observability implementation for the LP Reporting
+Dashboard API. The implementation follows the existing patterns established in
+`server/observability/performance-metrics.ts` and provides comprehensive
+monitoring, alerting, and SLO tracking.
 
 ## Implementation Summary
 
 ### Files Created
 
-1. **`server/observability/lp-metrics.ts`** - Prometheus metrics definitions and helper functions
+1. **`server/observability/lp-metrics.ts`** - Prometheus metrics definitions and
+   helper functions
 2. **`monitoring/lp-alerts.yml`** - Prometheus alerting rules (P1, P2, P3)
-3. **`docs/lp-slo-definitions.md`** - Service Level Objectives and error budget policy
+3. **`docs/lp-slo-definitions.md`** - Service Level Objectives and error budget
+   policy
 4. **`monitoring/grafana/lp-dashboard.json`** - Grafana dashboard configuration
 
 ### Files Modified
@@ -29,42 +34,42 @@ This document describes the observability implementation for the LP Reporting Da
 
 ### Request Metrics
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| Metric                       | Type      | Labels                          | Description                      |
+| ---------------------------- | --------- | ------------------------------- | -------------------------------- |
 | `lp_api_request_duration_ms` | Histogram | endpoint, method, status, lp_id | Request duration in milliseconds |
-| `lp_api_requests_total` | Counter | endpoint, method, status | Total API requests |
+| `lp_api_requests_total`      | Counter   | endpoint, method, status        | Total API requests               |
 
 **Buckets**: 10, 25, 50, 100, 250, 500, 1000, 2000, 5000, 10000 ms
 
 ### Cache Metrics
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `lp_cache_hits_total` | Counter | endpoint | Total cache hits |
+| Metric                  | Type    | Labels   | Description        |
+| ----------------------- | ------- | -------- | ------------------ |
+| `lp_cache_hits_total`   | Counter | endpoint | Total cache hits   |
 | `lp_cache_misses_total` | Counter | endpoint | Total cache misses |
 
 ### Report Generation Metrics
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `lp_report_generation_duration_ms` | Histogram | report_type, format | Report generation duration |
-| `lp_reports_generated_total` | Counter | report_type, format | Successfully generated reports |
-| `lp_reports_failed_total` | Counter | report_type, error_type | Failed report generations |
+| Metric                             | Type      | Labels                  | Description                    |
+| ---------------------------------- | --------- | ----------------------- | ------------------------------ |
+| `lp_report_generation_duration_ms` | Histogram | report_type, format     | Report generation duration     |
+| `lp_reports_generated_total`       | Counter   | report_type, format     | Successfully generated reports |
+| `lp_reports_failed_total`          | Counter   | report_type, error_type | Failed report generations      |
 
 **Buckets**: 100, 500, 1000, 2000, 5000, 10000, 20000, 30000, 60000, 120000 ms
 
 ### Business Metrics
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `lp_active_lps_gauge` | Gauge | - | Current number of active LPs |
-| `lp_capital_activity_events_total` | Counter | activity_type, fund_id | Capital activity events processed |
-| `lp_data_points_returned` | Histogram | endpoint | Number of data points in responses |
+| Metric                             | Type      | Labels                 | Description                        |
+| ---------------------------------- | --------- | ---------------------- | ---------------------------------- |
+| `lp_active_lps_gauge`              | Gauge     | -                      | Current number of active LPs       |
+| `lp_capital_activity_events_total` | Counter   | activity_type, fund_id | Capital activity events processed  |
+| `lp_data_points_returned`          | Histogram | endpoint               | Number of data points in responses |
 
 ### Error Metrics
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| Metric                | Type    | Labels                       | Description      |
+| --------------------- | ------- | ---------------------------- | ---------------- |
 | `lp_api_errors_total` | Counter | endpoint, error_type, status | Total API errors |
 
 ---
@@ -74,16 +79,19 @@ This document describes the observability implementation for the LP Reporting Da
 ### P1 (Critical) Alerts
 
 **1. LPAPIHighErrorRate**
+
 - **Condition**: Error rate > 1% for 5 minutes
 - **Impact**: Systemic issue affecting LP experience
 - **Action**: Immediate investigation required
 
 **2. LPReportGenerationHighFailureRate**
+
 - **Condition**: Report failure rate > 10% for 5 minutes
 - **Impact**: LPs cannot access their reports
 - **Action**: Check report queue and generation service
 
 **3. LPAPINoTraffic**
+
 - **Condition**: No requests for 2 minutes
 - **Impact**: Service may be completely down
 - **Action**: Verify service health and routing
@@ -91,16 +99,19 @@ This document describes the observability implementation for the LP Reporting Da
 ### P2 (High Priority) Alerts
 
 **1. LPAPIHighLatency**
+
 - **Condition**: p99 latency > 2000ms for 10 minutes
 - **Impact**: User experience degraded
 - **Action**: Investigate slow queries and database load
 
 **2. LPAPIElevatedLatency**
+
 - **Condition**: p95 latency > 500ms for 5 minutes
 - **Impact**: Performance degradation detected
 - **Action**: Review cache hit rate and optimize queries
 
 **3. LPReportGenerationSlow**
+
 - **Condition**: p95 report generation > 30 seconds for 10 minutes
 - **Impact**: Reports taking too long to generate
 - **Action**: Optimize report generation logic
@@ -108,16 +119,19 @@ This document describes the observability implementation for the LP Reporting Da
 ### P3 (Medium Priority) Alerts
 
 **1. LPAPILowCacheHitRate**
+
 - **Condition**: Cache hit rate < 50% for 30 minutes
 - **Impact**: Increased database load and latency
 - **Action**: Review cache TTL configuration
 
 **2. LPAPIHighClientErrors**
+
 - **Condition**: 4xx error rate > 5% for 10 minutes
 - **Impact**: Integration issues or user confusion
 - **Action**: Review API documentation and client implementations
 
 **3. LPAPIEndpointErrors**
+
 - **Condition**: Per-endpoint error rate > 5% for 5 minutes
 - **Impact**: Specific endpoint may have issues
 - **Action**: Investigate endpoint-specific problems
@@ -127,31 +141,37 @@ This document describes the observability implementation for the LP Reporting Da
 ## Service Level Objectives (SLOs)
 
 ### Availability SLO
+
 - **Target**: 99.9% uptime
 - **Error Budget**: 43 minutes/month
 - **Measurement**: 30-day rolling window
 
 ### Latency SLO (p95)
+
 - **Target**: < 500ms
 - **Error Budget**: 5% of requests may exceed
 - **Measurement**: 5-minute window
 
 ### Latency SLO (p99)
+
 - **Target**: < 2000ms
 - **Error Budget**: 1% of requests may exceed
 - **Measurement**: 5-minute window
 
 ### Error Rate SLO
+
 - **Target**: < 0.1% (99.9% success rate)
 - **Error Budget**: 1 error per 1,000 requests
 - **Measurement**: 5-minute window
 
 ### Report Generation SLO
+
 - **Target**: p95 < 30 seconds
 - **Error Budget**: 5% of reports may take longer
 - **Measurement**: 10-minute window
 
 ### Cache Hit Rate SLO
+
 - **Target**: > 50% hit rate
 - **Error Budget**: Temporary dips allowed
 - **Measurement**: 30-minute window
@@ -163,34 +183,39 @@ This document describes the observability implementation for the LP Reporting Da
 The Grafana dashboard is organized into 6 sections:
 
 ### 1. SLO Overview (4 gauges)
+
 - Availability (30-day)
 - p95 Latency
 - Error Rate
 - Cache Hit Rate
 
 ### 2. Request Metrics
+
 - Request rate by endpoint (timeseries)
 - Request latency by endpoint (p50, p95, p99)
 
 ### 3. Error Tracking
+
 - Error rate by endpoint (timeseries)
 - Errors by type (timeseries)
 
 ### 4. Cache Performance
+
 - Cache hit rate by endpoint (timeseries)
 - Cache hits vs misses (stacked bars)
 
 ### 5. Report Generation
+
 - Report generation duration (p50, p95, p99)
 - Report success/failure rate (timeseries)
 
 ### 6. Business Metrics
+
 - Active LPs (stat panel)
 - Capital activity events (timeseries)
 
-**Dashboard UID**: `lp-reporting-api`
-**Refresh Rate**: 30 seconds
-**Default Time Range**: Last 6 hours
+**Dashboard UID**: `lp-reporting-api` **Refresh Rate**: 30 seconds **Default
+Time Range**: Last 6 hours
 
 ---
 
@@ -256,6 +281,7 @@ All 11 LP API endpoints have metrics instrumentation:
 ### Cache Metrics
 
 Cache hits are recorded for endpoints with `Cache-Control` headers:
+
 - `/api/lp/profile` - 5 min TTL
 - `/api/lp/summary` - 5 min TTL
 - `/api/lp/capital-account` - 5 min TTL
@@ -265,6 +291,7 @@ Cache hits are recorded for endpoints with `Cache-Control` headers:
 ### Data Points Metrics
 
 Volume tracking for data-heavy endpoints:
+
 - `/api/lp/capital-account` - Number of transactions
 - `/api/lp/performance` - Number of performance data points
 
@@ -274,27 +301,30 @@ Volume tracking for data-heavy endpoints:
 
 ### Error Budget Calculation
 
-| SLO | Monthly Budget | Weekly Budget | Daily Budget |
-|-----|----------------|---------------|--------------|
-| Availability 99.9% | 43.2 minutes | ~10 minutes | ~1.4 minutes |
-| Error rate 0.1% | ~1,000 errors | ~250 errors | ~33 errors |
-| Latency p95 < 500ms | 64,800 slow requests | 16,200 | 2,160 |
+| SLO                 | Monthly Budget       | Weekly Budget | Daily Budget |
+| ------------------- | -------------------- | ------------- | ------------ |
+| Availability 99.9%  | 43.2 minutes         | ~10 minutes   | ~1.4 minutes |
+| Error rate 0.1%     | ~1,000 errors        | ~250 errors   | ~33 errors   |
+| Latency p95 < 500ms | 64,800 slow requests | 16,200        | 2,160        |
 
 (Assuming 1M requests/month baseline)
 
 ### Error Budget Status Thresholds
 
 **Healthy (> 50% remaining)**:
+
 - Normal feature development
 - Standard deployment process
 - Experimentation allowed
 
 **Low (< 50% remaining)**:
+
 - Increased change review
 - Extra deployment monitoring
 - Caution with risky changes
 
 **Exhausted (< 10% remaining)**:
+
 - **FREEZE non-critical deployments**
 - Focus on reliability improvements
 - Incident reviews and corrective actions
@@ -346,6 +376,7 @@ Volume tracking for data-heavy endpoints:
 ### Load Testing
 
 Test scenarios with realistic LP usage patterns:
+
 - **Steady state**: 10 req/sec across all endpoints
 - **Peak load**: 50 req/sec (end of quarter reporting)
 - **Report generation**: 100 concurrent reports
@@ -354,6 +385,7 @@ Test scenarios with realistic LP usage patterns:
 ### SLO Validation
 
 Verify SLO compliance under load:
+
 - 99.9% of requests return 2xx/3xx
 - p95 latency < 500ms
 - p99 latency < 2000ms
@@ -363,6 +395,7 @@ Verify SLO compliance under load:
 ### Chaos Engineering
 
 Test resilience to failures:
+
 - Database connection failures
 - Redis unavailability
 - Network latency injection
@@ -374,7 +407,8 @@ Test resilience to failures:
 
 ### Short Term (Next Sprint)
 
-1. **Distributed Tracing**: Add OpenTelemetry spans for end-to-end request tracing
+1. **Distributed Tracing**: Add OpenTelemetry spans for end-to-end request
+   tracing
 2. **Structured Logging**: Replace console.error with Winston structured logs
 3. **Custom Dashboards**: Per-LP performance dashboards
 4. **Real User Monitoring (RUM)**: Frontend performance tracking
@@ -397,29 +431,32 @@ Test resilience to failures:
 
 ## Related Documentation
 
-- [LP API Documentation](./lp-api.md)
+- LP API documentation
 - [SLO Definitions](./lp-slo-definitions.md)
-- [Performance Optimization Guide](./performance-optimization.md)
-- [Incident Response Playbook](./incident-response.md)
-- [Monitoring Architecture](../monitoring/README.md)
+- Performance optimization guide
+- Incident response playbook
+- Monitoring architecture
 
 ---
 
 ## Maintenance
 
 ### Weekly Tasks
+
 - Review SLO compliance
 - Check error budget consumption
 - Review alert noise and adjust thresholds
 - Update dashboard annotations for incidents
 
 ### Monthly Tasks
+
 - Review SLO targets with stakeholders
 - Update alert runbooks based on incidents
 - Audit metric cardinality
 - Review Grafana dashboard usage
 
 ### Quarterly Tasks
+
 - Revise SLOs based on business needs
 - Update error budget policy
 - Review and optimize alert rules
@@ -429,6 +466,6 @@ Test resilience to failures:
 
 ## Revision History
 
-| Date | Version | Changes | Author |
-|------|---------|---------|--------|
-| 2025-12-23 | 1.0 | Initial implementation | Performance Engineering Team |
+| Date       | Version | Changes                | Author                       |
+| ---------- | ------- | ---------------------- | ---------------------------- |
+| 2025-12-23 | 1.0     | Initial implementation | Performance Engineering Team |

--- a/docs/lp-slo-definitions.md
+++ b/docs/lp-slo-definitions.md
@@ -7,31 +7,35 @@ last_updated: 2026-01-19
 
 ## Overview
 
-This document defines the Service Level Objectives (SLOs) for the LP Reporting Dashboard API. These objectives represent our commitments to Limited Partners regarding system availability, performance, and reliability.
+This document defines the Service Level Objectives (SLOs) for the LP Reporting
+Dashboard API. These objectives represent our commitments to Limited Partners
+regarding system availability, performance, and reliability.
 
 ## SLO Summary
 
-| Metric | Target | Measurement Window | Priority |
-|--------|--------|-------------------|----------|
-| Availability | 99.9% | 30 days | P1 |
-| API Latency (p95) | < 500ms | 5 minutes | P2 |
-| API Latency (p99) | < 2000ms | 5 minutes | P2 |
-| Error Rate | < 0.1% | 5 minutes | P1 |
-| Report Generation Time (p95) | < 30 seconds | 10 minutes | P2 |
-| Cache Hit Rate | > 50% | 30 minutes | P3 |
+| Metric                       | Target       | Measurement Window | Priority |
+| ---------------------------- | ------------ | ------------------ | -------- |
+| Availability                 | 99.9%        | 30 days            | P1       |
+| API Latency (p95)            | < 500ms      | 5 minutes          | P2       |
+| API Latency (p99)            | < 2000ms     | 5 minutes          | P2       |
+| Error Rate                   | < 0.1%       | 5 minutes          | P1       |
+| Report Generation Time (p95) | < 30 seconds | 10 minutes         | P2       |
+| Cache Hit Rate               | > 50%        | 30 minutes         | P3       |
 
 ## Detailed SLO Definitions
 
 ### 1. Availability SLO
 
-**Objective**: 99.9% uptime
-**Error Budget**: 43 minutes of downtime per month
+**Objective**: 99.9% uptime **Error Budget**: 43 minutes of downtime per month
 
 **Definition**:
-- Service is considered "available" when the API returns 2xx/3xx responses or valid 4xx client errors
+
+- Service is considered "available" when the API returns 2xx/3xx responses or
+  valid 4xx client errors
 - Service is considered "unavailable" when returning 5xx errors or timing out
 
 **Measurement**:
+
 ```promql
 (
   sum(rate(lp_api_requests_total{status=~"2..|3..|4.."}[30d]))
@@ -41,12 +45,14 @@ This document defines the Service Level Objectives (SLOs) for the LP Reporting D
 ```
 
 **Error Budget Calculation**:
+
 - Monthly time: 30 days × 24 hours × 60 minutes = 43,200 minutes
 - Error budget: 43,200 × 0.001 = 43.2 minutes
 - Weekly budget: 43.2 / 4.3 ≈ 10 minutes
 - Daily budget: 43.2 / 30 ≈ 1.4 minutes
 
 **Impact of Violation**:
+
 - LPs cannot access their portfolio data
 - Reports cannot be generated
 - Regulatory compliance risk
@@ -56,15 +62,17 @@ This document defines the Service Level Objectives (SLOs) for the LP Reporting D
 
 ### 2. API Latency SLO (p95 < 500ms)
 
-**Objective**: 95% of requests complete in under 500ms
-**Error Budget**: 5% of requests may exceed 500ms
+**Objective**: 95% of requests complete in under 500ms **Error Budget**: 5% of
+requests may exceed 500ms
 
 **Definition**:
+
 - Measured from request receipt to response completion
 - Includes all processing, database queries, and network time
 - Excludes client-side network latency
 
 **Measurement**:
+
 ```promql
 histogram_quantile(0.95,
   sum(rate(lp_api_request_duration_ms_bucket[5m])) by (le, endpoint)
@@ -72,6 +80,7 @@ histogram_quantile(0.95,
 ```
 
 **Endpoints Covered**:
+
 - `/api/lp/profile` - LP profile details
 - `/api/lp/summary` - Dashboard summary
 - `/api/lp/capital-account` - Capital transactions
@@ -83,6 +92,7 @@ histogram_quantile(0.95,
 - `/api/lp/reports/:reportId` - Report status
 
 **Impact of Violation**:
+
 - Degraded user experience
 - Dashboard feels slow and unresponsive
 - Increased bounce rate
@@ -92,15 +102,17 @@ histogram_quantile(0.95,
 
 ### 3. API Latency SLO (p99 < 2000ms)
 
-**Objective**: 99% of requests complete in under 2 seconds
-**Error Budget**: 1% of requests may exceed 2 seconds
+**Objective**: 99% of requests complete in under 2 seconds **Error Budget**: 1%
+of requests may exceed 2 seconds
 
 **Definition**:
+
 - Measured from request receipt to response completion
 - Ensures worst-case performance is bounded
 - Critical for long-running queries (capital account, performance)
 
 **Measurement**:
+
 ```promql
 histogram_quantile(0.99,
   sum(rate(lp_api_request_duration_ms_bucket[5m])) by (le, endpoint)
@@ -108,23 +120,27 @@ histogram_quantile(0.99,
 ```
 
 **Impact of Violation**:
+
 - Some users experience unacceptable delays
 - Risk of request timeouts
-- Potential data quality concerns (users may refresh, creating duplicate requests)
+- Potential data quality concerns (users may refresh, creating duplicate
+  requests)
 
 ---
 
 ### 4. Error Rate SLO
 
-**Objective**: < 0.1% error rate (99.9% success rate)
-**Error Budget**: 1 error per 1,000 requests
+**Objective**: < 0.1% error rate (99.9% success rate) **Error Budget**: 1 error
+per 1,000 requests
 
 **Definition**:
+
 - Errors include 5xx server errors and unhandled exceptions
 - Does not include 4xx client errors (bad requests, unauthorized, etc.)
 - Measured across all LP API endpoints
 
 **Measurement**:
+
 ```promql
 (
   sum(rate(lp_api_errors_total[5m]))
@@ -134,12 +150,14 @@ histogram_quantile(0.99,
 ```
 
 **Error Categories**:
+
 - **Database errors**: Connection failures, query timeouts
 - **Service errors**: Calculation failures, data inconsistencies
 - **Integration errors**: External service failures (if applicable)
 - **System errors**: Out of memory, file system errors
 
 **Impact of Violation**:
+
 - Data integrity concerns
 - Missing or incorrect LP reporting
 - Compliance violations
@@ -149,15 +167,17 @@ histogram_quantile(0.99,
 
 ### 5. Report Generation Time SLO
 
-**Objective**: 95% of reports generated in under 30 seconds
-**Error Budget**: 5% of reports may take longer
+**Objective**: 95% of reports generated in under 30 seconds **Error Budget**: 5%
+of reports may take longer
 
 **Definition**:
+
 - Measured from report request to completion
 - Includes all data gathering, calculation, and PDF/Excel generation
 - Does not include download time
 
 **Measurement**:
+
 ```promql
 histogram_quantile(0.95,
   sum(rate(lp_report_generation_duration_ms_bucket[10m])) by (le, report_type)
@@ -165,17 +185,20 @@ histogram_quantile(0.95,
 ```
 
 **Report Types**:
+
 - **Quarterly Statement**: Full capital account + performance
 - **Annual Summary**: Year-end holdings + tax documents
 - **Custom Report**: User-defined date ranges and metrics
 
 **Impact of Violation**:
+
 - LPs must wait excessively for reports
 - Increased support burden
 - Delayed decision-making
 - Regulatory deadline risk
 
 **Report Generation SLO Failure Budget**:
+
 - If p95 > 30s: 1 occurrence per week tolerable
 - If p95 > 60s: Immediate investigation required
 
@@ -183,15 +206,17 @@ histogram_quantile(0.95,
 
 ### 6. Cache Hit Rate SLO
 
-**Objective**: > 50% cache hit rate
-**Error Budget**: Cache hit rate may drop below 50% temporarily
+**Objective**: > 50% cache hit rate **Error Budget**: Cache hit rate may drop
+below 50% temporarily
 
 **Definition**:
+
 - Percentage of requests served from cache vs. database
 - Measured across cacheable endpoints
 - Helps reduce database load and improve response times
 
 **Measurement**:
+
 ```promql
 (
   sum(rate(lp_cache_hits_total[30m]))
@@ -201,6 +226,7 @@ histogram_quantile(0.95,
 ```
 
 **Cacheable Endpoints**:
+
 - `/api/lp/profile` - LP profile (5 min TTL)
 - `/api/lp/summary` - Dashboard summary (5 min TTL)
 - `/api/lp/capital-account` - Capital account (5 min TTL)
@@ -208,17 +234,20 @@ histogram_quantile(0.95,
 - `/api/lp/performance/benchmark` - Benchmarks (60 min TTL)
 
 **Cache Invalidation**:
+
 - On capital activity events (calls, distributions)
 - On fund valuation updates
 - On LP profile changes
 
 **Impact of Low Cache Hit Rate**:
+
 - Increased database load
 - Higher latency (especially p95/p99)
 - Increased infrastructure costs
 - Reduced system scalability
 
 **Optimization Actions**:
+
 - Increase TTL for stable data
 - Implement cache warming for common queries
 - Add cache preloading for anticipated requests
@@ -231,27 +260,30 @@ histogram_quantile(0.95,
 
 Each SLO has an error budget that represents acceptable failure or degradation:
 
-| SLO | Error Budget | Monthly Allowance |
-|-----|--------------|-------------------|
-| Availability 99.9% | 0.1% downtime | 43.2 minutes |
-| Latency p95 < 500ms | 5% slow requests | ~64,800 requests (at 1M req/month) |
-| Latency p99 < 2000ms | 1% very slow requests | ~10,000 requests (at 1M req/month) |
-| Error rate < 0.1% | 0.1% errors | ~1,000 errors (at 1M req/month) |
-| Report gen < 30s | 5% slow reports | ~150 slow reports (at 3K reports/month) |
+| SLO                  | Error Budget          | Monthly Allowance                       |
+| -------------------- | --------------------- | --------------------------------------- |
+| Availability 99.9%   | 0.1% downtime         | 43.2 minutes                            |
+| Latency p95 < 500ms  | 5% slow requests      | ~64,800 requests (at 1M req/month)      |
+| Latency p99 < 2000ms | 1% very slow requests | ~10,000 requests (at 1M req/month)      |
+| Error rate < 0.1%    | 0.1% errors           | ~1,000 errors (at 1M req/month)         |
+| Report gen < 30s     | 5% slow reports       | ~150 slow reports (at 3K reports/month) |
 
 ### Error Budget Consumption
 
 **When error budget is healthy (> 50% remaining)**:
+
 - Proceed with normal feature development
 - Deploy changes with standard testing
 - Experiment with new optimizations
 
 **When error budget is low (< 50% remaining)**:
+
 - Increase change review scrutiny
 - Add extra monitoring to deployments
 - Consider feature freeze for stability focus
 
 **When error budget is exhausted (< 10% remaining)**:
+
 - **Freeze non-critical deployments**
 - Focus entirely on reliability improvements
 - Conduct incident reviews and root cause analysis
@@ -271,16 +303,19 @@ Each SLO has an error budget that represents acceptable failure or degradation:
 ### Alert Priorities
 
 **P1 (Critical)**:
+
 - Availability violations
 - High error rate (> 1%)
 - Complete service outage
 
 **P2 (High)**:
+
 - Latency violations (p95/p99)
 - Report generation failures
 - Significant error budget burn
 
 **P3 (Medium)**:
+
 - Cache performance degradation
 - Business metric anomalies
 - Approaching error budget thresholds
@@ -288,6 +323,7 @@ Each SLO has an error budget that represents acceptable failure or degradation:
 ### Dashboards
 
 **Primary Dashboard**: LP API Health
+
 - Real-time SLO compliance status
 - Error budget burn rate
 - Request rate and latency trends
@@ -295,6 +331,7 @@ Each SLO has an error budget that represents acceptable failure or degradation:
 - Active alerts
 
 **Secondary Dashboard**: LP Business Metrics
+
 - Active LPs
 - Report generation metrics
 - Capital activity events
@@ -307,6 +344,7 @@ Each SLO has an error budget that represents acceptable failure or degradation:
 ### Planned Maintenance
 
 Planned maintenance windows are excluded from SLO calculations:
+
 - Must be scheduled during low-traffic periods (weekends preferred)
 - Must be announced 7 days in advance to LPs
 - Maximum 4 hours per quarter
@@ -314,6 +352,7 @@ Planned maintenance windows are excluded from SLO calculations:
 ### Third-Party Dependencies
 
 If SLO violations are caused by third-party service failures:
+
 - Document the external dependency failure
 - Implement circuit breaker to fail fast
 - Exclude from SLO calculation if external root cause is proven
@@ -322,15 +361,15 @@ If SLO violations are caused by third-party service failures:
 
 ## Revision History
 
-| Date | Version | Changes | Author |
-|------|---------|---------|--------|
-| 2025-12-23 | 1.0 | Initial SLO definitions | DevOps Team |
+| Date       | Version | Changes                 | Author      |
+| ---------- | ------- | ----------------------- | ----------- |
+| 2025-12-23 | 1.0     | Initial SLO definitions | DevOps Team |
 
 ---
 
 ## Related Documents
 
-- [LP API Documentation](./lp-api.md)
-- [Monitoring Runbooks](../monitoring/runbooks/)
-- [Incident Response Playbook](./incident-response.md)
-- [Performance Optimization Guide](./performance-optimization.md)
+- LP API documentation
+- Monitoring runbooks
+- Incident response playbook
+- Performance optimization guide

--- a/docs/runbooks/synthetic-monitoring.md
+++ b/docs/runbooks/synthetic-monitoring.md
@@ -7,11 +7,13 @@ last_updated: 2026-01-19
 
 ## Overview
 
-Synthetic monitoring runs automated smoke tests every 5 minutes against production to detect issues before users do.
+Synthetic monitoring runs automated smoke tests every 5 minutes against
+production to detect issues before users do.
 
 ## Components
 
 ### 1. Smoke Tests (`tests/smoke/wizard.spec.ts`)
+
 - Health endpoint validation
 - Critical user flow testing
 - Login verification
@@ -22,12 +24,14 @@ Synthetic monitoring runs automated smoke tests every 5 minutes against producti
 - Memory leak detection
 
 ### 2. GitHub Actions Workflow (`.github/workflows/synthetic.yml`)
+
 - Runs every 5 minutes via cron schedule
 - Manual trigger support
 - Automatic alerting on failures
 - Test result archiving
 
 ### 3. Alerting Channels
+
 - GitHub Issues (automatic creation)
 - Slack notifications
 - PagerDuty incidents
@@ -36,6 +40,7 @@ Synthetic monitoring runs automated smoke tests every 5 minutes against producti
 ## Configuration
 
 ### Required GitHub Secrets
+
 ```
 PROD_BASE_URL     # Production URL (e.g., https://app.example.com)
 SMOKE_USER        # Test user email
@@ -45,6 +50,7 @@ PAGERDUTY_INTEGRATION_KEY # Optional: PagerDuty integration
 ```
 
 ### Setting Up Secrets
+
 ```bash
 # Via GitHub CLI
 gh secret set PROD_BASE_URL --body "https://app.example.com"
@@ -55,6 +61,7 @@ gh secret set SMOKE_PASS --body "secure-password-123"
 ## Test Coverage
 
 ### Critical Paths Monitored
+
 1. **Health Checks**
    - `/ready` endpoint
    - `/health` endpoint
@@ -94,16 +101,17 @@ gh secret set SMOKE_PASS --body "secure-password-123"
    - Tertiary: Engineering manager (Email)
 
 3. **Investigation Commands**
+
    ```bash
    # Check health
    curl https://app.example.com/health
-   
+
    # Check ready
    curl https://app.example.com/ready
-   
+
    # Check circuit breakers
    curl https://app.example.com/api/circuit-breaker/status
-   
+
    # View recent logs
    kubectl logs -l app=api --tail=100
    ```
@@ -111,6 +119,7 @@ gh secret set SMOKE_PASS --body "secure-password-123"
 ## Running Tests Locally
 
 ### Full Smoke Suite
+
 ```bash
 # With production URL
 BASE_URL=https://app.example.com \
@@ -120,12 +129,14 @@ npm run test:smoke
 ```
 
 ### Individual Tests
+
 ```bash
 # Test specific flow
 npx playwright test tests/smoke/wizard.spec.ts -g "Health endpoints"
 ```
 
 ### Debug Mode
+
 ```bash
 # Run with headed browser
 npx playwright test tests/smoke/wizard.spec.ts --headed
@@ -137,18 +148,22 @@ npx playwright test tests/smoke/wizard.spec.ts --trace on
 ## Maintenance
 
 ### Adding New Tests
+
 1. Add test cases to `tests/smoke/wizard.spec.ts`
 2. Keep tests fast (< 30s per test)
 3. Focus on critical paths only
 4. Avoid flaky selectors
 
 ### Updating Thresholds
+
 Edit in `tests/smoke/wizard.spec.ts`:
+
 - Response time limits
 - Memory usage thresholds
 - Error tolerance
 
 ### Disabling Monitoring
+
 ```yaml
 # In .github/workflows/synthetic.yml
 on:
@@ -160,13 +175,16 @@ on:
 ## Metrics
 
 ### Success Metrics
+
 - Uptime: > 99.9%
 - False positive rate: < 1%
 - Detection time: < 5 minutes
 - Alert response time: < 10 minutes
 
 ### Monitoring Dashboard
+
 Track in Grafana/Datadog:
+
 - `smoke_test_passed` - Pass/fail status
 - `smoke_test_duration_seconds` - Test execution time
 - `smoke_test_failures_total` - Cumulative failures
@@ -196,6 +214,7 @@ Track in Grafana/Datadog:
    - Adjust timing/thresholds
 
 ### Debug Workflow
+
 ```bash
 # Run workflow manually
 gh workflow run synthetic.yml
@@ -230,7 +249,8 @@ gh run download <RUN_ID>
    - Annual architecture review
 
 ## Related Documentation
+
 - [Rollback Procedures](./rollback.md)
-- [Incident Response](./incident-response.md)
-- [Monitoring Setup](../monitoring.md)
-- [Testing Strategy](../testing.md)
+- [Incident Response](./incident.md)
+- Monitoring setup
+- Testing strategy

--- a/docs/wizard/COMPLETION_SUMMARY.md
+++ b/docs/wizard/COMPLETION_SUMMARY.md
@@ -5,93 +5,99 @@ last_updated: 2026-01-19
 
 # Wizard Integration - Completion Summary
 
-**Status:** ✅ **COMPLETE**
-**Date:** 2025-10-07
-**Sprint:** Q4 2025
+**Status:** [x] **COMPLETE** **Date:** 2025-10-07 **Sprint:** Q4 2025
 
 ---
 
-## 🎉 All Tasks Completed
+## All Tasks Completed
 
-### ✅ **Task 1: Fixed Import Paths**
+### [x] **Task 1: Fixed Import Paths**
+
 - Fixed backslash typo in all card files: `\\_types` → `./_types`
 - All imports now correctly reference the shared types file
 - **Files Fixed:** 4 card components
 
-### ✅ **Task 2: Reorganized File Structure**
+### [x] **Task 2: Reorganized File Structure**
+
 - Moved legacy implementations to `client/src/components/wizard/legacy/`
 - New enhanced cards in `client/src/components/wizard/cards/`
 - Clear separation between old and new implementations
 - **Files Moved:** 4 legacy components preserved for reference
 
-### ✅ **Task 3: Created Migration Guide**
+### [x] **Task 3: Created Migration Guide**
+
 - Complete step-by-step migration instructions
 - API change documentation
 - Before/after code examples
 - Rollback plan included
 - **Location:** [docs/wizard/MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md)
 
-### ✅ **Task 4: Built ReservesCard with Inline Errors**
+### [x] **Task 4: Built ReservesCard with Inline Errors**
+
 - Complete implementation with error handling
 - Strategy selection (Pro-Rata, Selective, Opportunistic)
 - Strategy-specific fields (target ratio, top performers %)
 - Dollar preview calculations
-- **Location:** [client/src/components/wizard/cards/ReservesCard.tsx](../../client/src/components/wizard/cards/ReservesCard.tsx)
+- **Location:**
+  [client/src/components/wizard/cards/ReservesCard.tsx](../../client/src/components/wizard/cards/ReservesCard.tsx)
 
 ---
 
-## 📂 Final File Structure
+## Final File Structure
 
 ```
 client/src/
 ├── components/wizard/
-│   ├── EnhancedField.tsx              ✅ Format-specific input
-│   ├── CollapsibleCard.tsx            ✅ Collapsible container
-│   ├── LiveTotalsAside.tsx            ✅ Sticky summary rail
-│   ├── legacy/                        📦 Old implementations (preserved)
+│   ├── EnhancedField.tsx              [x] Format-specific input
+│   ├── CollapsibleCard.tsx            [x] Collapsible container
+│   ├── LiveTotalsAside.tsx            [x] Sticky summary rail
+│   ├── legacy/                         Old implementations (preserved)
 │   │   ├── StageAllocationCard.tsx
 │   │   ├── ReservesCard.tsx
 │   │   ├── ExitTimingCard.tsx
 │   │   └── ExitValuesCard.tsx
-│   └── cards/                         ✨ New enhanced cards
-│       ├── _types.ts                  ✅ Shared types
-│       ├── StageAllocationCard.tsx    ✅ With inline errors
-│       ├── ReservesCard.tsx           ✅ With inline errors (NEW!)
-│       ├── GraduationMatrixCard.tsx   ✅ With inline errors
-│       ├── ExitTimingCard.tsx         ✅ With inline errors
-│       └── ExitValuesCard.tsx         ✅ With inline errors
+│   └── cards/                          New enhanced cards
+│       ├── _types.ts                  [x] Shared types
+│       ├── StageAllocationCard.tsx    [x] With inline errors
+│       ├── ReservesCard.tsx           [x] With inline errors (NEW!)
+│       ├── GraduationMatrixCard.tsx   [x] With inline errors
+│       ├── ExitTimingCard.tsx         [x] With inline errors
+│       └── ExitValuesCard.tsx         [x] With inline errors
 ├── lib/
-│   ├── validation.ts                  ✅ Error scoping utilities
-│   ├── wizard-schemas.ts              ✅ Zod validation schemas
-│   ├── wizard-types.ts                ✅ TypeScript types
-│   └── fees-wizard.ts                 ✅ Fee preview calculator
+│   ├── validation.ts                  [x] Error scoping utilities
+│   ├── wizard-schemas.ts              [x] Zod validation schemas
+│   ├── wizard-types.ts                [x] TypeScript types
+│   └── fees-wizard.ts                 [x] Fee preview calculator
 └── pages/wizard/
-    └── PortfolioDynamicsStep.tsx      ✅ Complete example
+    └── PortfolioDynamicsStep.tsx      [x] Complete example
 
 docs/wizard/
-├── WIZARD_INTEGRATION.md              ✅ Integration guide
-├── MIGRATION_GUIDE.md                 ✅ Migration instructions (NEW!)
-└── COMPLETION_SUMMARY.md              ✅ This file
+├── WIZARD_INTEGRATION.md              [x] Integration guide
+├── MIGRATION_GUIDE.md                 [x] Migration instructions (NEW!)
+└── COMPLETION_SUMMARY.md              [x] This file
 ```
 
 ---
 
-## 🚀 Ready to Use!
+## Ready to Use!
 
-All components are production-ready and fully tested. The wizard system now provides:
+All components are production-ready and fully tested. The wizard system now
+provides:
 
 ### **Core Features**
-- ✅ Type-safe validation with Zod
-- ✅ Inline error display on fields
-- ✅ Scoped error handling by section
-- ✅ Format-specific inputs (USD, percent, number)
-- ✅ Whole dollar enforcement
-- ✅ Live validation feedback
-- ✅ Sticky summary rail with error navigation
-- ✅ Full accessibility (ARIA)
-- ✅ Mobile-responsive design
+
+- [x] Type-safe validation with Zod
+- [x] Inline error display on fields
+- [x] Scoped error handling by section
+- [x] Format-specific inputs (USD, percent, number)
+- [x] Whole dollar enforcement
+- [x] Live validation feedback
+- [x] Sticky summary rail with error navigation
+- [x] Full accessibility (ARIA)
+- [x] Mobile-responsive design
 
 ### **Components Available**
+
 1. **StageAllocationCard** - Capital allocation with auto-balance
 2. **ReservesCard** - Strategy selection & follow-on settings (NEW!)
 3. **GraduationMatrixCard** - Stage progression rates
@@ -103,9 +109,10 @@ All components are production-ready and fully tested. The wizard system now prov
 
 ---
 
-## 📋 Quick Start
+## Quick Start
 
 ### 1. Import Components
+
 ```tsx
 import { StageAllocationCard } from '@/components/wizard/cards/StageAllocationCard';
 import { ReservesCard } from '@/components/wizard/cards/ReservesCard';
@@ -113,6 +120,7 @@ import { LiveTotalsAside } from '@/components/wizard/LiveTotalsAside';
 ```
 
 ### 2. Add Validation
+
 ```tsx
 import { zodErrorsToMap, pickErrors } from '@/lib/validation';
 import { stageAllocationSchema } from '@/lib/wizard-schemas';
@@ -128,6 +136,7 @@ const validate = () => {
 ```
 
 ### 3. Render with Errors
+
 ```tsx
 const allocErrors = pickErrors(errors, 'stageAllocation');
 
@@ -136,24 +145,24 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
   onChange={onChange}
   committedCapitalUSD={20_000_000}
   errors={allocErrors}
-/>
+/>;
 ```
 
 ---
 
-## 📚 Documentation
+## Documentation
 
-| Document | Description | Location |
-|----------|-------------|----------|
-| **Integration Guide** | Complete integration instructions | [WIZARD_INTEGRATION.md](./WIZARD_INTEGRATION.md) |
-| **Migration Guide** | Step-by-step migration from legacy | [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md) |
-| **Example Implementation** | Full working wizard step | [PortfolioDynamicsStep.tsx](../../client/src/pages/wizard/PortfolioDynamicsStep.tsx) |
-| **Type Definitions** | All wizard types & defaults | [wizard-types.ts](../../client/src/lib/wizard-types.ts) |
-| **Validation Schemas** | Zod schemas with cross-field rules | [wizard-schemas.ts](../../client/src/lib/wizard-schemas.ts) |
+| Document                   | Description                        | Location                                                    |
+| -------------------------- | ---------------------------------- | ----------------------------------------------------------- |
+| **Integration Guide**      | Complete integration instructions  | [WIZARD_INTEGRATION.md](./WIZARD_INTEGRATION.md)            |
+| **Migration Guide**        | Step-by-step migration from legacy | [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md)                  |
+| **Example Implementation** | Historical wizard step example     | `PortfolioDynamicsStep.tsx`                                 |
+| **Type Definitions**       | All wizard types & defaults        | [wizard-types.ts](../../client/src/lib/wizard-types.ts)     |
+| **Validation Schemas**     | Zod schemas with cross-field rules | [wizard-schemas.ts](../../client/src/lib/wizard-schemas.ts) |
 
 ---
 
-## 🧪 Testing Checklist
+## Testing Checklist
 
 - [x] Import path fixes verified
 - [x] File reorganization complete
@@ -166,6 +175,7 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
 - [x] Documentation complete
 
 ### Next Steps for QA:
+
 1. **Manual Testing**: Load PortfolioDynamicsStep example
 2. **Validation Testing**: Trigger all error scenarios
 3. **Error Navigation**: Test "Fix Error" button
@@ -174,15 +184,17 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
 
 ---
 
-## 🔄 Migration Status
+## Migration Status
 
 **Current State:**
-- ✅ New cards fully implemented
-- ✅ Legacy cards preserved in `/legacy/` folder
-- ✅ Import paths fixed
-- ✅ Documentation complete
+
+- [x] New cards fully implemented
+- [x] Legacy cards preserved in `/legacy/` folder
+- [x] Import paths fixed
+- [x] Documentation complete
 
 **Recommended Actions:**
+
 1. Review [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md)
 2. Update any existing imports to use `/cards/` path
 3. Add validation infrastructure to wizard steps
@@ -190,13 +202,14 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
 5. Roll out to staging
 
 **Rollback Available:**
+
 - Legacy components unchanged in `/legacy/` folder
 - Can revert by updating import paths
 - No data migration required
 
 ---
 
-## 🎯 Key Achievements
+## Key Achievements
 
 1. **Complete Validation System** - Zod schemas with cross-field rules
 2. **Inline Error Display** - Errors show directly on fields
@@ -208,14 +221,18 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
 
 ---
 
-## 📞 Support
+## Support
 
 **Questions?**
-- See [WIZARD_INTEGRATION.md](./WIZARD_INTEGRATION.md) for detailed integration steps
+
+- See [WIZARD_INTEGRATION.md](./WIZARD_INTEGRATION.md) for detailed integration
+  steps
 - See [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md) for migration assistance
-- Reference [PortfolioDynamicsStep.tsx](../../client/src/pages/wizard/PortfolioDynamicsStep.tsx) for working example
+- Reference the historical `PortfolioDynamicsStep.tsx` example when reviewing
+  the original integration flow
 
 **Issues?**
+
 - Check import paths are correct (`/cards/` not `/wizard/`)
 - Verify error scoping with `pickErrors()`
 - Ensure Zod schemas are imported
@@ -223,13 +240,10 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
 
 ---
 
-**Status:** ✅ Production Ready
-**Breaking Changes:** Yes (see migration guide)
-**Backward Compatibility:** Legacy components available
-**Recommended Action:** Begin migration to new cards
+**Status:** [x] Production Ready **Breaking Changes:** Yes (see migration guide)
+**Backward Compatibility:** Legacy components available **Recommended Action:**
+Begin migration to new cards
 
 ---
 
-*Generated: 2025-10-07*
-*Last Updated: 2025-10-07*
-*Version: 1.0.0*
+_Generated: 2025-10-07_ _Last Updated: 2025-10-07_ _Version: 1.0.0_

--- a/docs/wizard/MIGRATION_GUIDE.md
+++ b/docs/wizard/MIGRATION_GUIDE.md
@@ -5,22 +5,25 @@ last_updated: 2026-01-19
 
 # Wizard Cards Migration Guide
 
-Guide for migrating from legacy wizard cards to the new enhanced versions with inline validation.
+Guide for migrating from legacy wizard cards to the new enhanced versions with
+inline validation.
 
 ## Overview
 
 The new wizard card system provides:
-- ✅ **Inline error display** - Validation errors show directly on fields
-- ✅ **Scoped error handling** - Automatic error mapping by section
-- ✅ **Enhanced accessibility** - Full ARIA support
-- ✅ **Format-specific inputs** - USD, percent, number with built-in validation
-- ✅ **Collapsible UI** - Better mobile experience
+
+- [x] **Inline error display** - Validation errors show directly on fields
+- [x] **Scoped error handling** - Automatic error mapping by section
+- [x] **Enhanced accessibility** - Full ARIA support
+- [x] **Format-specific inputs** - USD, percent, number with built-in validation
+- [x] **Collapsible UI** - Better mobile experience
 
 ## What Changed
 
 ### File Structure
 
 **Old Structure:**
+
 ```
 client/src/components/wizard/
 ├── StageAllocationCard.tsx      # Used Card + Slider
@@ -30,6 +33,7 @@ client/src/components/wizard/
 ```
 
 **New Structure:**
+
 ```
 client/src/components/wizard/
 ├── EnhancedField.tsx             # NEW: Format-specific input
@@ -54,22 +58,24 @@ client/src/components/wizard/
 #### StageAllocationCard
 
 **Old API:**
+
 ```tsx
 <StageAllocationCard
-  allocation={allocation}          // Old prop name
+  allocation={allocation} // Old prop name
   onChange={onChange}
-  committedCapital={20_000_000}    // Old prop name
+  committedCapital={20_000_000} // Old prop name
   disabled={false}
 />
 ```
 
 **New API:**
+
 ```tsx
 <StageAllocationCard
-  value={allocation}               // ✅ Renamed to 'value'
+  value={allocation} // [x] Renamed to 'value'
   onChange={onChange}
-  committedCapitalUSD={20_000_000} // ✅ Renamed for clarity
-  errors={scopedErrors}            // ✅ NEW: Inline error display
+  committedCapitalUSD={20_000_000} // [x] Renamed for clarity
+  errors={scopedErrors} // [x] NEW: Inline error display
   disabled={false}
 />
 ```
@@ -77,62 +83,68 @@ client/src/components/wizard/
 #### ReservesCard
 
 **Old API:**
+
 ```tsx
 <ReservesCard
-  config={reserveSettings}         // Old prop name
+  config={reserveSettings} // Old prop name
   onChange={onChange}
   committedCapital={20_000_000}
 />
 ```
 
 **New API:**
+
 ```tsx
 <ReservesCard
-  value={reserveSettings}          // ✅ Renamed to 'value'
+  value={reserveSettings} // [x] Renamed to 'value'
   onChange={onChange}
-  committedCapitalUSD={20_000_000} // ✅ Renamed for clarity
-  errors={scopedErrors}            // ✅ NEW: Inline error display
+  committedCapitalUSD={20_000_000} // [x] Renamed for clarity
+  errors={scopedErrors} // [x] NEW: Inline error display
 />
 ```
 
 #### ExitTimingCard
 
 **Old API:**
+
 ```tsx
 <ExitTimingCard
-  timing={exitTiming}              // Old prop name
+  timing={exitTiming} // Old prop name
   onChange={onChange}
 />
 ```
 
 **New API:**
+
 ```tsx
 <ExitTimingCard
-  value={exitTiming}               // ✅ Renamed to 'value'
+  value={exitTiming} // [x] Renamed to 'value'
   onChange={onChange}
-  errors={scopedErrors}            // ✅ NEW: Inline error display
+  errors={scopedErrors} // [x] NEW: Inline error display
 />
 ```
 
 #### ExitValuesCard
 
 **Old API:**
+
 ```tsx
 <ExitValuesCard
-  exitValues={values}              // Old prop name
+  exitValues={values} // Old prop name
   onChange={onChange}
-  checkSizes={checkSizes}          // Old prop name
+  checkSizes={checkSizes} // Old prop name
 />
 ```
 
 **New API:**
+
 ```tsx
 <ExitValuesCard
-  value={values}                   // ✅ Renamed to 'value'
+  value={values} // [x] Renamed to 'value'
   onChange={onChange}
-  costBasisAtStageUSD={costBasis}  // ✅ Renamed for clarity
-  errors={scopedErrors}            // ✅ NEW: Inline error display
-  showWeights={false}              // ✅ NEW: Optional weight inputs
+  costBasisAtStageUSD={costBasis} // [x] Renamed for clarity
+  errors={scopedErrors} // [x] NEW: Inline error display
+  showWeights={false} // [x] NEW: Optional weight inputs
 />
 ```
 
@@ -141,6 +153,7 @@ client/src/components/wizard/
 ### Step 1: Update Imports
 
 **Before:**
+
 ```tsx
 import { StageAllocationCard } from '@/components/wizard/StageAllocationCard';
 import { ReservesCard } from '@/components/wizard/ReservesCard';
@@ -149,6 +162,7 @@ import { ExitValuesCard } from '@/components/wizard/ExitValuesCard';
 ```
 
 **After:**
+
 ```tsx
 import { StageAllocationCard } from '@/components/wizard/cards/StageAllocationCard';
 import { ReservesCard } from '@/components/wizard/cards/ReservesCard';
@@ -190,6 +204,7 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
 ### Step 3: Update Component Props
 
 **Before:**
+
 ```tsx
 <StageAllocationCard
   allocation={state.stageAllocation}
@@ -199,12 +214,13 @@ const allocErrors = pickErrors(errors, 'stageAllocation');
 ```
 
 **After:**
+
 ```tsx
 <StageAllocationCard
-  value={state.stageAllocation}                           // ✅ Renamed prop
+  value={state.stageAllocation} // [x] Renamed prop
   onChange={(next) => setState({ ...state, stageAllocation: next })}
-  committedCapitalUSD={committedCapitalUSD}               // ✅ Renamed prop
-  errors={allocErrors}                                     // ✅ Added errors
+  committedCapitalUSD={committedCapitalUSD} // [x] Renamed prop
+  errors={allocErrors} // [x] Added errors
 />
 ```
 
@@ -225,7 +241,7 @@ const firstError = getFirstError(errors);
   estimatedAnnualFeesUSD={estimatedAnnualFeesUSD}
   firstErrorLabel={firstError?.message}
   onFixFirstError={() => firstError && focusFirstError(firstError.field)}
-/>
+/>;
 ```
 
 ## Complete Example
@@ -257,7 +273,12 @@ export function WizardStep() {
 ```tsx
 import { StageAllocationCard } from '@/components/wizard/cards/StageAllocationCard';
 import { LiveTotalsAside } from '@/components/wizard/LiveTotalsAside';
-import { zodErrorsToMap, pickErrors, getFirstError, focusFirstError } from '@/lib/validation';
+import {
+  zodErrorsToMap,
+  pickErrors,
+  getFirstError,
+  focusFirstError,
+} from '@/lib/validation';
 import { stageAllocationSchema } from '@/lib/wizard-schemas';
 import type { FieldErrors } from '@/lib/validation';
 
@@ -331,16 +352,17 @@ All cards now work with Zod schemas:
 ```tsx
 // Available schemas
 import {
-  stageAllocationSchema,      // For StageAllocationCard
-  graduationRatesSchema,       // For GraduationMatrixCard
-  exitTimingSchema,            // For ExitTimingCard
-  exitValuesByStageSchema,     // For ExitValuesCard
+  stageAllocationSchema, // For StageAllocationCard
+  graduationRatesSchema, // For GraduationMatrixCard
+  exitTimingSchema, // For ExitTimingCard
+  exitValuesByStageSchema, // For ExitValuesCard
 } from '@/lib/wizard-schemas';
 ```
 
 ## Error Handling Patterns
 
 ### Basic Pattern
+
 ```tsx
 // 1. Validate
 const result = schema.safeParse(data);
@@ -352,10 +374,11 @@ const errors = result.success ? {} : zodErrorsToMap(result.error);
 const scopedErrors = pickErrors(errors, 'sectionName');
 
 // 4. Pass to card
-<Card errors={scopedErrors} />
+<Card errors={scopedErrors} />;
 ```
 
 ### Auto-Clear on Edit
+
 ```tsx
 const setField = (key: string, value: any) => {
   setState({ ...state, [key]: value });
@@ -364,8 +387,8 @@ const setField = (key: string, value: any) => {
   setErrors((prev) => {
     const next = { ...prev };
     Object.keys(next)
-      .filter(k => k.startsWith(`${key}.`))
-      .forEach(k => delete next[k]);
+      .filter((k) => k.startsWith(`${key}.`))
+      .forEach((k) => delete next[k]);
     return next;
   });
 };
@@ -384,7 +407,7 @@ import { StageAllocationCard } from '@/components/wizard/legacy/StageAllocationC
   allocation={state.stageAllocation}
   onChange={onChange}
   committedCapital={20_000_000}
-/>
+/>;
 ```
 
 Legacy components remain fully functional and unchanged.
@@ -399,13 +422,13 @@ Legacy components remain fully functional and unchanged.
 
 ## Support
 
-- **Full Example**: See [PortfolioDynamicsStep.tsx](../../client/src/pages/wizard/PortfolioDynamicsStep.tsx)
+- **Full Example**: Historical `PortfolioDynamicsStep.tsx` example
 - **Integration Guide**: See [WIZARD_INTEGRATION.md](./WIZARD_INTEGRATION.md)
-- **Legacy Code**: Reference implementations in `client/src/components/wizard/legacy/`
+- **Legacy Code**: Reference implementations in
+  `client/src/components/wizard/legacy/`
 
 ---
 
-**Migration Status:** In Progress
-**Target Completion:** Current Sprint
-**Breaking Changes:** Yes (prop renames, error handling required)
-**Backward Compatibility:** Legacy components available in `/legacy/` folder
+**Migration Status:** In Progress **Target Completion:** Current Sprint
+**Breaking Changes:** Yes (prop renames, error handling required) **Backward
+Compatibility:** Legacy components available in `/legacy/` folder

--- a/docs/wizard/WIZARD_INTEGRATION.md
+++ b/docs/wizard/WIZARD_INTEGRATION.md
@@ -5,11 +5,13 @@ last_updated: 2026-01-19
 
 # Wizard Component Integration Guide
 
-Complete guide for integrating the wizard component system with Zod validation, inline errors, and live totals.
+Complete guide for integrating the wizard component system with Zod validation,
+inline errors, and live totals.
 
 ## Overview
 
 The wizard system provides a complete form infrastructure with:
+
 - **Type-safe validation** using Zod schemas
 - **Inline error display** with scoped error messages
 - **Live validation** with real-time feedback
@@ -48,13 +50,18 @@ The wizard system provides a complete form infrastructure with:
 ### 1. Validation Layer
 
 **Files:**
+
 - `client/src/lib/wizard-schemas.ts` - Zod validation schemas
 - `client/src/lib/wizard-types.ts` - TypeScript types + defaults
 - `client/src/lib/validation.ts` - Error mapping utilities
 
 **Key Schemas:**
+
 ```typescript
-import { stageAllocationSchema, graduationRatesSchema } from '@/lib/wizard-schemas';
+import {
+  stageAllocationSchema,
+  graduationRatesSchema,
+} from '@/lib/wizard-schemas';
 
 // Validate data
 const result = stageAllocationSchema.safeParse(data);
@@ -69,6 +76,7 @@ if (!result.success) {
 **Location:** `client/src/components/wizard/cards/`
 
 All cards accept:
+
 - `value` - Current data
 - `onChange` - Update callback
 - `errors` - Scoped FieldErrors (keys without prefix)
@@ -76,6 +84,7 @@ All cards accept:
 - `className` - Additional classes
 
 **Example:**
+
 ```tsx
 <StageAllocationCard
   value={state.stageAllocation}
@@ -88,6 +97,7 @@ All cards accept:
 ### 3. Base Components
 
 **EnhancedField** - Format-specific input with inline errors
+
 ```tsx
 <EnhancedField
   id="field-id"
@@ -102,6 +112,7 @@ All cards accept:
 ```
 
 **CollapsibleCard** - Expandable card container
+
 ```tsx
 <CollapsibleCard
   title="Card Title"
@@ -113,6 +124,7 @@ All cards accept:
 ```
 
 **LiveTotalsAside** - Sticky right rail with live validation
+
 ```tsx
 <LiveTotalsAside
   committedCapitalUSD={20_000_000}
@@ -235,7 +247,7 @@ const firstError = getFirstError(errors);
   estimatedAnnualFeesUSD={estimatedFees}
   firstErrorLabel={firstError?.message}
   onFixFirstError={() => firstError && focusFirstError(firstError.field)}
-/>
+/>;
 ```
 
 ## Validation Patterns
@@ -308,11 +320,13 @@ const err = firstError(exitValErrors, 'preSeed.median');
 ```tsx
 const rootError = firstError(scopedErrors, '_root');
 
-{rootError && (
-  <div className="rounded-lg bg-red-50 border border-red-200 p-3">
-    <p className="text-sm text-red-700">{rootError}</p>
-  </div>
-)}
+{
+  rootError && (
+    <div className="rounded-lg bg-red-50 border border-red-200 p-3">
+      <p className="text-sm text-red-700">{rootError}</p>
+    </div>
+  );
+}
 ```
 
 ### Global Error Navigation
@@ -339,8 +353,8 @@ const setField = <K extends keyof State>(key: K, value: State[K]) => {
   setErrors((prev) => {
     const next = { ...prev };
     Object.keys(next)
-      .filter(k => k.startsWith(`${key}.`))
-      .forEach(k => delete next[k]);
+      .filter((k) => k.startsWith(`${key}.`))
+      .forEach((k) => delete next[k]);
     return next;
   });
 };
@@ -478,12 +492,12 @@ All components follow ARIA best practices:
 3. Ensure `firstError()` key matches field
 
 ```typescript
-// ✅ Correct
+// [x] Correct
 const errors = { 'stageAllocation.reserves': ['Error'] };
 const scoped = pickErrors(errors, 'stageAllocation');
 const err = firstError(scoped, 'reserves'); // Found!
 
-// ❌ Wrong
+// NO: Wrong
 const err = firstError(scoped, 'stageAllocation.reserves'); // Not found
 ```
 
@@ -496,11 +510,11 @@ const err = firstError(scoped, 'stageAllocation.reserves'); // Not found
 ```typescript
 // Missing validation
 const result = schema.safeParse(data);
-setErrors({}); // ❌ Errors cleared but not set
+setErrors({}); // NO: Errors cleared but not set
 
 // Correct
 if (!result.success) {
-  setErrors(zodErrorsToMap(result.error)); // ✅
+  setErrors(zodErrorsToMap(result.error)); // [x]
 }
 ```
 
@@ -515,13 +529,14 @@ if (!result.success) {
 const element = document.getElementById(fieldId);
 if (element) {
   element.scrollIntoView({ behavior: 'smooth' });
-  setTimeout(() => element.focus(), 300); // ✅ Wait for scroll
+  setTimeout(() => element.focus(), 300); // [x] Wait for scroll
 }
 ```
 
 ## Complete Example
 
-See [PortfolioDynamicsStep.tsx](../../client/src/pages/wizard/PortfolioDynamicsStep.tsx) for a complete, working example demonstrating all integration patterns.
+The historical `PortfolioDynamicsStep.tsx` example demonstrated all integration
+patterns.
 
 ## Next Steps
 
@@ -532,6 +547,6 @@ See [PortfolioDynamicsStep.tsx](../../client/src/pages/wizard/PortfolioDynamicsS
 
 ---
 
-**Last Updated:** 2025-10-07
-**Maintained By:** Engineering Team
-**Related Docs:** [Wizard Types](../../client/src/lib/wizard-types.ts), [Validation Utilities](../../client/src/lib/validation.ts)
+**Last Updated:** 2025-10-07 **Maintained By:** Engineering Team **Related
+Docs:** [Wizard Types](../../client/src/lib/wizard-types.ts),
+[Validation Utilities](../../client/src/lib/validation.ts)


### PR DESCRIPTION
## Summary

Execute Phase 6 Bucket H of the approved broken-link cleanup after PR #697 merged.

## Delta ledger

Command:
`npm run docs:check-links -- --report-only`

Before count:
32 broken / 1516 total / 387 markdown files

After count:
10 broken / 1496 total / 387 markdown files

Bucket IDs removed:
005-012, 025-028, 054-056, 164, 173, 175, 177, 182, 184, 185

Fixed IDs:
054, 164

Converted-to-prose IDs:
005-012, 025-028, 055-056, 173, 175, 177, 182, 184, 185

Deferred or blocked IDs:
None in Bucket H after prose conversion. Remaining unresolved findings are inherited Phoenix-protected Bucket G items.

New/unclassified IDs introduced:
None

Expected remaining bucket composition:
10 Phoenix-protected Bucket G IDs: 059, 061-064, 089-090, 093, 109-110

Drift explanation:
Phase 6 converted 20 stale, missing, or ambiguous H references from links to prose, reducing total links from 1516 to 1496. Two H references stayed as links after evidence-backed mechanical repair. Broken links dropped from 32 to 10, leaving only the inherited Phoenix-protected G backlog.

Touched files:
- `docs/adr/ADR-006-fee-calculation-standards.md`
- `docs/ai-optimization/CODEX_AGENT_MIGRATION.md`
- `docs/api/fund-allocations-phase1b.md`
- `docs/internal/architecture/state-flow.md`
- `docs/lp-observability-implementation.md`
- `docs/lp-slo-definitions.md`
- `docs/runbooks/synthetic-monitoring.md`
- `docs/wizard/COMPLETION_SUMMARY.md`
- `docs/wizard/MIGRATION_GUIDE.md`
- `docs/wizard/WIZARD_INTEGRATION.md`

Verification:
- `npm run docs:check-links -- --report-only` -> 10 broken / 1496 total / 387 markdown files
- `git diff --check`
- `git diff --name-only`
- `npm run lint`
- `npm run check`
- Pre-commit hook passed
- Pre-push hook passed; docs/config-only path skipped tests