### PR TITLE
ci(docs): enforce active documentation links

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -15,6 +15,8 @@
 #                   pipeline. NOTE: excludes scripts/validation/** because those
 #                   are doc-validation scripts treated as docs by ci-unified.
 # docs:             Documentation changes (mirror of code's exclusions).
+# docs_links:       Active documentation link-check inputs. Kept separate from
+#                   docs because docs intentionally excludes CHANGELOG.md.
 # code_with_validation:
 #                   Like `code` but includes scripts/validation/**.
 #                   core-validation.yml's existing semantics treat validation
@@ -69,6 +71,19 @@ docs:
   - '.github/*.md'
   - 'scripts/validation/**'
   - '!CHANGELOG.md'
+
+docs_links:
+  - '**/*.md'
+  - 'docs/**'
+  - '.github/*.md'
+  - 'CLAUDE.md'
+  - 'AGENTS.md'
+  - 'README.md'
+  - 'CHANGELOG.md'
+  - 'DECISIONS.md'
+  - 'CAPABILITIES.md'
+  - 'scripts/check-doc-links.mjs'
+  - 'scripts/lib/doc-link-checker.mjs'
 
 code_with_validation:
   - '**/*.ts'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -113,14 +113,14 @@ artifacts/phase0/latest/phase0-summary.txt
 ### UI/UX (if applicable)
 
 - [ ] Synthetics selectors updated (if UI change) -
-      [Test ID conventions](client/src/lib/testIds.ts)
+      [Test ID conventions](../client/src/lib/testIds.ts)
 - [ ] Responsive design tested
 - [ ] Accessibility checked (keyboard navigation, ARIA labels)
 
 ### Security
 
 - [ ] Security headers unaffected or
-      [updated tests](scripts/check-security-headers.mjs)
+      [updated tests](../scripts/check-security-headers.mjs)
 - [ ] No secrets or credentials in code
 - [ ] Input validation implemented
 

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -40,6 +40,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
+      docs_links: ${{ steps.filter.outputs.docs_links }}
       dependency: ${{ steps.filter.outputs.dependency }}
       pr_security: ${{ steps.filter.outputs.pr_security }}
       security_tests: ${{ steps.filter.outputs.security_tests }}
@@ -56,6 +57,24 @@ jobs:
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: .github/path-filters.yml
+
+  docs-link-check:
+    name: Documentation Links
+    needs: changes
+    if: needs.changes.outputs.docs_links == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          restore-tool-cache: 'false'
+
+      - name: Check documentation links
+        run: npm run docs:check-links
 
   check:
     name: Check ${{ matrix.job }}
@@ -607,6 +626,7 @@ jobs:
     name: CI Gate Status
     needs:
       - changes
+      - docs-link-check
       - check
       - test-affected
       - test-full
@@ -629,6 +649,7 @@ jobs:
           enable_security="${{ github.event.inputs.enable_security }}"
           enable_memory_mode="${{ github.event.inputs.enable_memory_mode }}"
           is_pr="${{ github.event_name == 'pull_request' }}"
+          docs_link_result="${{ needs.docs-link-check.result }}"
           check_result="${{ needs.check.result }}"
           build_result="${{ needs.build.result }}"
           guards_result="${{ needs.guards.result }}"
@@ -661,6 +682,7 @@ jobs:
           fi
 
           guards_expected="$is_pr"
+          docs_link_expected="${{ needs.changes.outputs.docs_links == 'true' }}"
           dependency_expected="${{ github.event.inputs.run_full_suite == 'true' || (needs.changes.outputs.auto_docs_only != 'true' && needs.changes.outputs.dependency == 'true') }}"
           pr_security_expected="${{ github.event.inputs.enable_security == 'true' || (needs.changes.outputs.auto_docs_only != 'true' && needs.changes.outputs.pr_security == 'true') }}"
           security_tests_expected="${{ github.event.inputs.enable_security == 'true' || (needs.changes.outputs.auto_docs_only != 'true' && (needs.changes.outputs.security_tests == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run:security')))) }}"
@@ -680,6 +702,7 @@ jobs:
             fi
           }
 
+          require_result "Documentation links" "$docs_link_result" "$docs_link_expected"
           require_result "Check" "$check_result" "$check_expected"
           require_result "Test" "$test_result" "$test_expected"
           require_result "Build" "$build_result" "$build_expected"
@@ -694,6 +717,7 @@ jobs:
             echo ""
             echo "| Job | Result | Expected |"
             echo "| --- | --- | --- |"
+            echo "| documentation-links | $docs_link_result | $docs_link_expected |"
             echo "| check | $check_result | $check_expected |"
             echo "| tests | $test_result | $test_expected |"
             echo "| build | $build_result | $build_expected |"
@@ -723,6 +747,7 @@ jobs:
 
             | Job | Result |
             | --- | --- |
+            | Documentation links | ${{ needs.docs-link-check.result }} |
             | Check | ${{ needs.check.result }} |
             | Affected tests | ${{ needs.test-affected.result }} |
             | Full tests | ${{ needs.test-full.result }} |

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -9,10 +9,14 @@
  * baselining before a deletion PR cleans up stale references).
  */
 
-import { glob } from 'glob';
-import { readFileSync, existsSync } from 'fs';
-import { join, dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  checkMarkdownFiles,
+  collectMarkdownFiles,
+  formatBrokenLinkError,
+} from './lib/doc-link-checker.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,125 +26,30 @@ const args = new Set(process.argv.slice(2));
 const analysisOnly = args.has('--analysis-only');
 const reportOnly = args.has('--report-only');
 
-const CODE_IDENTIFIER = '[A-Za-z_$][\\w$]*';
-const QUOTED_CODE_PROPERTY_LINK_TEXT = new RegExp(`^'${CODE_IDENTIFIER}'$`);
-const CODE_EXPRESSION_LINK_TARGET = new RegExp(
-  `^(?:'|\\{|\\d+$|${CODE_IDENTIFIER}(?:\\.${CODE_IDENTIFIER})?(?:\\(|$))`,
-);
-const TEMPLATE_PLACEHOLDER_LINK = /^\{\{[A-Za-z_][A-Za-z0-9_-]*\}\}$/;
-
-const ROOT_GOVERNANCE_DOCS = [
-  'CAPABILITIES.md',
-  'DECISIONS.md',
-  'CHANGELOG.md',
-  'CLAUDE.md',
-  'README.md',
-];
-
-const files = analysisOnly
-  ? glob.sync('docs/analysis/**/*.md', { cwd: rootDir })
-  : [
-      ...glob.sync('docs/**/*.md', {
-        cwd: rootDir,
-        ignore: ['docs/archive/**', 'docs/_generated/**', 'docs/skills/REFL-*.md'],
-      }),
-      ...ROOT_GOVERNANCE_DOCS.filter((f) => existsSync(join(rootDir, f))),
-    ];
-
-let totalLinks = 0;
-let brokenLinks = 0;
-const errors = [];
-
-function isTemplatePlaceholderLink(linkUrl) {
-  return TEMPLATE_PLACEHOLDER_LINK.test(linkUrl);
-}
-
-function isCodeLikeParserFalsePositive(linkText, linkUrl) {
-  if (
-    QUOTED_CODE_PROPERTY_LINK_TEXT.test(linkText) &&
-    CODE_EXPRESSION_LINK_TARGET.test(linkUrl)
-  ) {
-    return true;
-  }
-
-  return linkText === 'endpoint.method' && linkUrl === 'endpoint.url';
-}
+const files = collectMarkdownFiles({ rootDir, analysisOnly });
 
 console.log(
   `Checking links in ${files.length} markdown files${analysisOnly ? ' (analysis-only)' : ''}...`,
 );
 
-for (const file of files) {
-  const filePath = join(rootDir, file);
-  const content = readFileSync(filePath, 'utf-8');
-  const fileDir = dirname(filePath);
+const result = checkMarkdownFiles({ files, rootDir });
 
-  // Match markdown links: [text](url) - skip image links and reference-style links
-  const linkRegex = /(?<!!)\[([^\]]+)\]\(([^)]+)\)/g;
-  let match;
-
-  while ((match = linkRegex.exec(content)) !== null) {
-    const linkText = match[1];
-    const linkUrl = match[2].trim();
-    totalLinks++;
-
-    if (isTemplatePlaceholderLink(linkUrl) || isCodeLikeParserFalsePositive(linkText, linkUrl)) {
-      continue;
-    }
-
-    // Skip external links and protocols
-    if (
-      linkUrl.startsWith('http://') ||
-      linkUrl.startsWith('https://') ||
-      linkUrl.startsWith('mailto:') ||
-      linkUrl.startsWith('tel:')
-    ) {
-      continue;
-    }
-
-    // Skip pure anchors
-    if (linkUrl.startsWith('#')) {
-      continue;
-    }
-
-    // Parse link URL (strip anchor + query)
-    const [pathPart] = linkUrl.split(/[#?]/);
-    if (!pathPart) continue;
-
-    // Resolve relative path
-    const targetPath = pathPart.startsWith('/')
-      ? join(rootDir, pathPart)
-      : resolve(fileDir, pathPart);
-
-    if (!existsSync(targetPath)) {
-      brokenLinks++;
-      errors.push({
-        file,
-        link: linkUrl,
-        text: linkText,
-        target: targetPath,
-      });
-    }
-  }
-}
-
-// Report results
-if (brokenLinks === 0) {
-  console.log(`\n[PASS] All ${totalLinks} links are valid`);
+if (result.brokenLinks === 0) {
+  console.log(`\n[PASS] All ${result.totalLinks} links are valid`);
   process.exit(0);
 }
 
-console.error(`\n[FAIL] Found ${brokenLinks} broken links out of ${totalLinks} total:\n`);
+console.error(
+  `\n[FAIL] Found ${result.brokenLinks} broken links out of ${result.totalLinks} total:\n`,
+);
 
-for (const error of errors) {
-  console.error(`  File: ${error.file}`);
-  console.error(`  Link: [${error.text}](${error.link})`);
-  console.error(`  Target not found: ${error.target}`);
+for (const error of result.errors) {
+  console.error(formatBrokenLinkError(error));
   console.error('');
 }
 
 if (reportOnly) {
-  console.error(`[REPORT-ONLY] Exiting 0 despite ${brokenLinks} broken links.`);
+  console.error(`[REPORT-ONLY] Exiting 0 despite ${result.brokenLinks} broken links.`);
   process.exit(0);
 }
 

--- a/scripts/lib/doc-link-checker.mjs
+++ b/scripts/lib/doc-link-checker.mjs
@@ -60,37 +60,26 @@ function isSingleBacktickDelimiter(content, index) {
   );
 }
 
+function findClosingBacktick(content, startIndex) {
+  for (let i = startIndex; i < content.length; i += 1) {
+    const ch = content[i];
+    if (ch === '\n' || ch === '\r') return -1;
+    if (isSingleBacktickDelimiter(content, i)) return i;
+  }
+  return -1;
+}
+
 export function stripInlineCodeSpans(content) {
   const sanitized = content.split('');
 
-  for (let index = 0; index < content.length; index += 1) {
-    if (!isSingleBacktickDelimiter(content, index)) {
-      continue;
-    }
+  for (let i = 0; i < content.length; i += 1) {
+    if (!isSingleBacktickDelimiter(content, i)) continue;
 
-    let closingIndex = index + 1;
-    while (
-      closingIndex < content.length &&
-      content[closingIndex] !== '\n' &&
-      content[closingIndex] !== '\r' &&
-      !isSingleBacktickDelimiter(content, closingIndex)
-    ) {
-      closingIndex += 1;
-    }
+    const close = findClosingBacktick(content, i + 1);
+    if (close === -1) continue;
 
-    if (
-      closingIndex >= content.length ||
-      content[closingIndex] === '\n' ||
-      content[closingIndex] === '\r'
-    ) {
-      continue;
-    }
-
-    for (let spanIndex = index; spanIndex <= closingIndex; spanIndex += 1) {
-      sanitized[spanIndex] = ' ';
-    }
-
-    index = closingIndex;
+    for (let j = i; j <= close; j += 1) sanitized[j] = ' ';
+    i = close;
   }
 
   return sanitized.join('');
@@ -136,12 +125,17 @@ export function shouldSkipLink(linkText, linkUrl) {
   return linkUrl.startsWith('#');
 }
 
+/**
+ * Resolves a markdown link URL to an absolute filesystem path.
+ * Absolute paths (leading `/`) resolve against `rootDir`; relative paths against `fileDir`.
+ * @param {{linkUrl: string, fileDir: string, rootDir: string}} params
+ * @returns {string | null}
+ */
 export function resolveLinkTarget({ linkUrl, fileDir, rootDir }) {
   const [pathPart] = linkUrl.split(/[#?]/);
   if (!pathPart) {
     return null;
   }
-
   return pathPart.startsWith('/') ? join(rootDir, pathPart) : resolve(fileDir, pathPart);
 }
 

--- a/scripts/lib/doc-link-checker.mjs
+++ b/scripts/lib/doc-link-checker.mjs
@@ -52,18 +52,63 @@ export function getLineNumber(content, index) {
   return line;
 }
 
+function isSingleBacktickDelimiter(content, index) {
+  return (
+    content[index] === '`' &&
+    content[index - 1] !== '`' &&
+    content[index + 1] !== '`'
+  );
+}
+
+export function stripInlineCodeSpans(content) {
+  const sanitized = content.split('');
+
+  for (let index = 0; index < content.length; index += 1) {
+    if (!isSingleBacktickDelimiter(content, index)) {
+      continue;
+    }
+
+    let closingIndex = index + 1;
+    while (
+      closingIndex < content.length &&
+      content[closingIndex] !== '\n' &&
+      content[closingIndex] !== '\r' &&
+      !isSingleBacktickDelimiter(content, closingIndex)
+    ) {
+      closingIndex += 1;
+    }
+
+    if (
+      closingIndex >= content.length ||
+      content[closingIndex] === '\n' ||
+      content[closingIndex] === '\r'
+    ) {
+      continue;
+    }
+
+    for (let spanIndex = index; spanIndex <= closingIndex; spanIndex += 1) {
+      sanitized[spanIndex] = ' ';
+    }
+
+    index = closingIndex;
+  }
+
+  return sanitized.join('');
+}
+
 export function extractMarkdownLinks(content) {
   const links = [];
   let match;
+  const scanContent = stripInlineCodeSpans(content);
 
   MARKDOWN_LINK.lastIndex = 0;
 
-  while ((match = MARKDOWN_LINK.exec(content)) !== null) {
+  while ((match = MARKDOWN_LINK.exec(scanContent)) !== null) {
     links.push({
       text: match[1],
       link: match[2].trim(),
       index: match.index,
-      line: getLineNumber(content, match.index),
+      line: getLineNumber(scanContent, match.index),
     });
   }
 

--- a/scripts/lib/doc-link-checker.mjs
+++ b/scripts/lib/doc-link-checker.mjs
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { glob } from 'glob';
+
+const CODE_IDENTIFIER = '[A-Za-z_$][\\w$]*';
+const QUOTED_CODE_PROPERTY_LINK_TEXT = new RegExp(`^'${CODE_IDENTIFIER}'$`);
+const CODE_EXPRESSION_LINK_TARGET = new RegExp(
+  `^(?:'|\\{|\\d+$|${CODE_IDENTIFIER}(?:\\.${CODE_IDENTIFIER})?(?:\\(|$))`,
+);
+const TEMPLATE_PLACEHOLDER_LINK = /^\{\{[A-Za-z_][A-Za-z0-9_-]*\}\}$/;
+const MARKDOWN_LINK = /(?<!!)\[([^\]]+)\]\(([^)]+)\)/g;
+const DEFAULT_DOC_IGNORE = [
+  'docs/archive/**',
+  'docs/**/archive/**',
+  'docs/_generated/**',
+  'docs/skills/REFL-*.md',
+];
+
+export const ROOT_GOVERNANCE_DOCS = [
+  'AGENTS.md',
+  'CAPABILITIES.md',
+  'DECISIONS.md',
+  'CHANGELOG.md',
+  'CLAUDE.md',
+  'README.md',
+];
+
+export function isTemplatePlaceholderLink(linkUrl) {
+  return TEMPLATE_PLACEHOLDER_LINK.test(linkUrl);
+}
+
+export function isCodeLikeParserFalsePositive(linkText, linkUrl) {
+  if (
+    QUOTED_CODE_PROPERTY_LINK_TEXT.test(linkText) &&
+    CODE_EXPRESSION_LINK_TARGET.test(linkUrl)
+  ) {
+    return true;
+  }
+
+  return linkText === 'endpoint.method' && linkUrl === 'endpoint.url';
+}
+
+export function getLineNumber(content, index) {
+  let line = 1;
+
+  for (let offset = 0; offset < index; offset += 1) {
+    if (content[offset] === '\n') {
+      line += 1;
+    }
+  }
+
+  return line;
+}
+
+export function extractMarkdownLinks(content) {
+  const links = [];
+  let match;
+
+  MARKDOWN_LINK.lastIndex = 0;
+
+  while ((match = MARKDOWN_LINK.exec(content)) !== null) {
+    links.push({
+      text: match[1],
+      link: match[2].trim(),
+      index: match.index,
+      line: getLineNumber(content, match.index),
+    });
+  }
+
+  return links;
+}
+
+export function shouldSkipLink(linkText, linkUrl) {
+  if (isTemplatePlaceholderLink(linkUrl)) {
+    return true;
+  }
+
+  if (isCodeLikeParserFalsePositive(linkText, linkUrl)) {
+    return true;
+  }
+
+  if (
+    linkUrl.startsWith('http://') ||
+    linkUrl.startsWith('https://') ||
+    linkUrl.startsWith('mailto:') ||
+    linkUrl.startsWith('tel:')
+  ) {
+    return true;
+  }
+
+  return linkUrl.startsWith('#');
+}
+
+export function resolveLinkTarget({ linkUrl, fileDir, rootDir }) {
+  const [pathPart] = linkUrl.split(/[#?]/);
+  if (!pathPart) {
+    return null;
+  }
+
+  return pathPart.startsWith('/') ? join(rootDir, pathPart) : resolve(fileDir, pathPart);
+}
+
+export function checkMarkdownLinksInContent({
+  content,
+  file,
+  fileDir,
+  rootDir,
+  exists = existsSync,
+}) {
+  const errors = [];
+  const links = extractMarkdownLinks(content);
+
+  for (const markdownLink of links) {
+    const linkText = markdownLink.text;
+    const linkUrl = markdownLink.link;
+
+    if (shouldSkipLink(linkText, linkUrl)) {
+      continue;
+    }
+
+    const targetPath = resolveLinkTarget({ linkUrl, fileDir, rootDir });
+    if (!targetPath) {
+      continue;
+    }
+
+    if (!exists(targetPath)) {
+      errors.push({
+        file,
+        line: markdownLink.line,
+        link: linkUrl,
+        text: linkText,
+        target: targetPath,
+      });
+    }
+  }
+
+  return {
+    totalLinks: links.length,
+    brokenLinks: errors.length,
+    errors,
+  };
+}
+
+export function checkMarkdownFiles({
+  files,
+  rootDir,
+  readFile = (filePath) => readFileSync(filePath, 'utf-8'),
+  exists = existsSync,
+}) {
+  let totalLinks = 0;
+  const errors = [];
+
+  for (const file of files) {
+    const filePath = join(rootDir, file);
+    const content = readFile(filePath);
+    const result = checkMarkdownLinksInContent({
+      content,
+      file,
+      fileDir: dirname(filePath),
+      rootDir,
+      exists,
+    });
+
+    totalLinks += result.totalLinks;
+    errors.push(...result.errors);
+  }
+
+  return {
+    totalLinks,
+    brokenLinks: errors.length,
+    errors,
+  };
+}
+
+export function collectMarkdownFiles({
+  rootDir,
+  analysisOnly = false,
+  exists = existsSync,
+  globSync = glob.sync,
+}) {
+  if (analysisOnly) {
+    return globSync('docs/analysis/**/*.md', { cwd: rootDir });
+  }
+
+  return [
+    ...globSync('docs/**/*.md', {
+      cwd: rootDir,
+      ignore: DEFAULT_DOC_IGNORE,
+    }),
+    ...globSync('.github/*.md', { cwd: rootDir }),
+    ...ROOT_GOVERNANCE_DOCS.filter((file) => exists(join(rootDir, file))),
+  ];
+}
+
+export function formatBrokenLinkError(error) {
+  return [
+    `  File: ${error.file}:${error.line}`,
+    `  Link: [${error.text}](${error.link})`,
+    `  Target not found: ${error.target}`,
+  ].join('\n');
+}

--- a/tests/unit/scripts/check-doc-links.test.mjs
+++ b/tests/unit/scripts/check-doc-links.test.mjs
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+
+import {
+  checkMarkdownLinksInContent,
+  isCodeLikeParserFalsePositive,
+  isTemplatePlaceholderLink,
+} from '../../../scripts/lib/doc-link-checker.mjs';
+
+const rootDir = resolve('/repo');
+const fileDir = resolve(rootDir, 'docs');
+
+function checkContent(content, existingTargets = []) {
+  const existing = new Set(existingTargets.map((target) => resolve(rootDir, target)));
+
+  return checkMarkdownLinksInContent({
+    content,
+    file: 'docs/example.md',
+    fileDir,
+    rootDir,
+    exists: (targetPath) => existing.has(targetPath),
+  });
+}
+
+describe('doc-link-checker false-positive handling', () => {
+  it('ignores template placeholder links', () => {
+    const result = checkContent(
+      [
+        '[template]({{link}})',
+        '[URL]({{url}})',
+        '[figma]({{figma_link}})',
+        '[valid](target.md)',
+      ].join('\n'),
+      ['docs/target.md'],
+    );
+
+    expect(isTemplatePlaceholderLink('{{link}}')).toBe(true);
+    expect(result.totalLinks).toBe(4);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('ignores code-expression parser false positives', () => {
+    const result = checkContent(
+      [
+        "['method'](endpoint.method)",
+        "['handler'](endpoint.handler())",
+        '[endpoint.method](endpoint.url)',
+        '[valid](target.md)',
+      ].join('\n'),
+      ['docs/target.md'],
+    );
+
+    expect(isCodeLikeParserFalsePositive('endpoint.method', 'endpoint.url')).toBe(true);
+    expect(result.totalLinks).toBe(4);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+describe('doc-link-checker broken-link detection', () => {
+  it('reports broken local links with line numbers', () => {
+    const result = checkContent(
+      ['Intro paragraph.', '', 'See [missing](missing.md) for details.'].join('\n'),
+    );
+
+    expect(result.totalLinks).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      file: 'docs/example.md',
+      line: 3,
+      link: 'missing.md',
+      text: 'missing',
+    });
+  });
+});

--- a/tests/unit/scripts/check-doc-links.test.mjs
+++ b/tests/unit/scripts/check-doc-links.test.mjs
@@ -5,6 +5,7 @@ import {
   checkMarkdownLinksInContent,
   isCodeLikeParserFalsePositive,
   isTemplatePlaceholderLink,
+  stripInlineCodeSpans,
 } from '../../../scripts/lib/doc-link-checker.mjs';
 
 const rootDir = resolve('/repo');
@@ -52,6 +53,18 @@ describe('doc-link-checker false-positive handling', () => {
 
     expect(isCodeLikeParserFalsePositive('endpoint.method', 'endpoint.url')).toBe(true);
     expect(result.totalLinks).toBe(4);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('ignores link-shaped patterns inside single-backtick inline code spans', () => {
+    const content = [
+      "Use Grep tool: pattern `from ['\"](\\.\\./)+src/|from ['\"]src/`, output_mode",
+      'Inline code example: `[label](target.md)`',
+    ].join('\n');
+    const result = checkContent(content);
+
+    expect(stripInlineCodeSpans(content)).not.toContain('[label](target.md)');
+    expect(result.totalLinks).toBe(0);
     expect(result.errors).toEqual([]);
   });
 });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -110,6 +110,7 @@ export default defineConfig({
           // Also includes reflection system regression tests
           include: [
             'tests/unit/**/*.test.ts',
+            'tests/unit/scripts/**/*.test.mjs',
             'tests/perf/**/*.test.ts',
             'tests/regressions/**/*.test.ts',
           ],


### PR DESCRIPTION
## Summary

Converts the completed broken-link cleanup (PR #699: 1488/0/387) into a regression guard. Adds a dedicated `docs_links` path filter (the existing `docs` filter excludes `CHANGELOG.md`), a 3-minute CI job gated on `docs_links`, and expands the checker scope to include `AGENTS.md` and `.github/*.md`. Extracts pure functions from `scripts/check-doc-links.mjs` into `scripts/lib/doc-link-checker.mjs` and adds Vitest regression tests for the narrow false-positive filters and broken-link detection with line numbers.

Expanded scan exposed two broken relative links in `.github/pull_request_template.md` (now fixed).

## What changed

- **`.github/path-filters.yml`** — new `docs_links` filter covering markdown, root governance (incl. `AGENTS.md`), `.github/*.md`, and the checker source
- **`.github/workflows/ci-unified.yml`** — new `docs-link-check` job (timeout 3m) gated on `needs.changes.outputs.docs_links == true`
- **`scripts/check-doc-links.mjs`** — adds `AGENTS.md` to `ROOT_GOVERNANCE_DOCS`, includes `.github/*.md` in default scan, emits line numbers on broken links
- **`scripts/lib/doc-link-checker.mjs`** (new) — extracted pure helpers
- **`tests/unit/scripts/check-doc-links.test.mjs`** (new) — Vitest coverage: template-placeholder false positives, code-expression false positives, broken-link detection with line numbers
- **`vitest.config.mjs`** — discover `tests/unit/scripts/**/*.test.mjs` in the server project
- **`.github/pull_request_template.md`** — fix two relative links exposed by the expanded scan

## Verification

- \`npm run docs:check-links\` → 0 broken across **390 files / 1484 links**
- \`npm run check\` → 0 TypeScript errors
- \`npm run lint\` → clean
- \`git diff --check\` → clean
- Vitest 3/3 on the new test file

## Parallel audit

A read-only Kimi long-context audit ran in parallel and confirmed no hidden risks in this scope:

- 6 unfiltered link patterns sit green today (no broken cases)
- 1 latent over-match hazard in \`CODE_EXPRESSION_LINK_TARGET\` (could skip valid links like \`['README'](README.md)\`) — unexploited; deferred as follow-up
- Cross-module expansion to \`.claude/**/*.md\` would add 218 broken links; \`.omx/**/*.md\` would add 136 — correctly excluded from scope

## Test plan

- [ ] CI \`Documentation Links\` job triggers on this PR (touches docs/governance/checker)
- [ ] CI green on \`Documentation Links\`, \`check\`, \`lint\`
- [ ] Verify on a follow-up scratch PR that a deliberate broken link causes \`Documentation Links\` to fail with exit 1 + line number
- [ ] Verify the job is skipped on a code-only PR (no path-filter match)

## Rollback

Revert this commit. Cleanup baseline state unaffected; checker reverts to its pre-PR scope.