### PR TITLE
chore(governance): add analytics truthfulness review checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -117,6 +117,20 @@ artifacts/phase0/latest/phase0-summary.txt
 - [ ] Responsive design tested
 - [ ] Accessibility checked (keyboard navigation, ARIA labels)
 
+### Analytics / Results Truthfulness (if applicable)
+
+See
+[analytics visualization principles](../docs/design/analytics-visualization-principles.md)
+for rationale.
+
+- [ ] Production analytics do not silently use sample, mock, or fixture data
+- [ ] Demo/sample states are visibly labeled in the UI
+- [ ] Major metrics show source, run/version, timestamp, or a truthful
+      unavailable state
+- [ ] Stale/calculating/failed states remain visible and explained
+- [ ] Comparisons use clear baselines and honest shared units/scales
+- [ ] Essential meaning is not hidden only in a tooltip
+
 ### Security
 
 - [ ] Security headers unaffected or


### PR DESCRIPTION
## Summary

Operationalizes the analytics visualization doctrine landed in PR #690. Adds a self-contained checklist section as a sibling to the existing UI/UX block in `.github/pull_request_template.md`, linking to `docs/design/analytics-visualization-principles.md` for rationale but keeping the checks inline so reviewers do not skip them.

No CODEOWNERS gating yet — design-review enforcement is deferred until at least one chart has shipped under the doctrine.

## What changed

Added a new `### Analytics / Results Truthfulness (if applicable)` section to `.github/pull_request_template.md` with six checklist items derived from `docs/design/analytics-visualization-principles.md`:

- Production analytics do not silently use sample/mock/fixture data
- Demo/sample states are visibly labeled
- Major metrics show source, run/version, timestamp, or a truthful unavailable state
- Stale/calculating/failed states remain visible and explained
- Comparisons use clear baselines and honest shared units/scales
- Essential meaning is not hidden only in a tooltip

## Relationship to PR #700

Stacks logically on PR #700 (\`ci(docs): enforce active documentation links\`), which expands the docs-link checker scope to include \`.github/*.md\`. After #700 lands, this template will be link-checked on every PR — the one new link added here (\`../docs/design/analytics-visualization-principles.md\`) resolves correctly.

If #700 merges first, this branch needs a trivial rebase to pick up the two unrelated relative-link fixes there. Both PRs touch the same file but different lines and should auto-merge.

## Verification

- \`npm run docs:check-links\` → 0 broken across 390 files / 1490 links
- Pre-commit hook formatted the link line cleanly
- No CODEOWNERS or workflow changes — no CI gate change required

## Test plan

- [ ] Open a draft test PR after merge to confirm the new section renders correctly in the PR body
- [ ] Confirm the new section is collapsible/skippable for non-analytics PRs (it is — labeled \`(if applicable)\`)

## Rollback

Revert this commit. Template returns to the prior shape; doctrine doc itself is unaffected.