### PR TITLE
test(results): verify fund results evidence fields

### DIFF
--- a/tests/unit/contract/fund-results-route.test.ts
+++ b/tests/unit/contract/fund-results-route.test.ts
@@ -185,6 +185,28 @@ describe('GET /api/funds/:id/results', () => {
     expect(res.body.lifecycle).toHaveProperty('calculationState');
   });
 
+  it('response includes lifecycle evidence fields for results provenance', async () => {
+    const res = await request(app).get('/api/funds/1/results');
+
+    expect(res.status).toBe(200);
+    expect(res.body.lifecycle.configState).toHaveProperty('publishedVersion', 1);
+    expect(res.body.lifecycle.calculationState).toHaveProperty('configVersion', 1);
+    expect(res.body.lifecycle.calculationState).toHaveProperty('runId', 10);
+    expect(res.body.lifecycle.calculationState).toHaveProperty('status', 'ready');
+    expect(res.body.lifecycle.calculationState).toHaveProperty(
+      'lastCalculatedAt',
+      '2026-03-20T12:30:00.000Z'
+    );
+
+    const { FundResultsReadV1Schema } = await import('@shared/contracts/fund-results-v1.contract');
+    const parsed = FundResultsReadV1Schema.parse(res.body);
+    expect(parsed.lifecycle.configState.publishedVersion).toBe(1);
+    expect(parsed.lifecycle.calculationState.configVersion).toBe(1);
+    expect(parsed.lifecycle.calculationState.runId).toBe(10);
+    expect(parsed.lifecycle.calculationState.status).toBe('ready');
+    expect(parsed.lifecycle.calculationState.lastCalculatedAt).toBe('2026-03-20T12:30:00.000Z');
+  });
+
   it('available section includes legacyEvidence flag', async () => {
     const res = await request(app).get('/api/funds/1/results');
 


### PR DESCRIPTION
## Summary

Readiness audit for the planned **EvidenceHeader** on `/fund-model-results/:fundId`. Confirms the existing `FundResultsReadV1` contract is sufficient — **no contract bump required**.

`FundResultsReadV1Schema` embeds `FundStateReadV1Schema` as the `lifecycle` field, and `GET /api/funds/:id/results` returns all provenance paths `EvidenceHeader` needs.

## What was checked

Five field paths on the live response:

- \`results.lifecycle.configState.publishedVersion\`
- \`results.lifecycle.calculationState.configVersion\`
- \`results.lifecycle.calculationState.runId\`
- \`results.lifecycle.calculationState.status\`
- \`results.lifecycle.calculationState.lastCalculatedAt\`

All present; all schema-valid. The new test asserts both literal property presence and that the full response parses cleanly via \`FundResultsReadV1Schema\`.

## What changed

One new test in \`tests/unit/contract/fund-results-route.test.ts\` (+22 lines), positioned alongside the existing \`response includes lifecycle block\` test. No production code changes. No contract changes. No client code changes.

## Decision recorded

Earlier strategy draft floated a contract bump as a pre-step for EvidenceHeader. This audit retires that hypothesis: \`results.lifecycle\` already carries everything EvidenceHeader needs. **PR 4 (EvidenceHeader implementation) can proceed without touching contracts.**

## Verification

- \`npm test -- tests/unit/contract/fund-results-route.test.ts --project=server\` → 13/13 pass
- \`npm run check\` → 0 TypeScript errors
- \`npm run lint\` → clean
- \`git diff --check\` → clean

## Test plan

- [ ] CI server-test project picks up the new test
- [ ] Test passes on a cold runner (not just locally)
- [ ] Confirm test still passes after PR #700 (docs-link CI) and PR #701 (analytics checklist) merge — no overlap expected

## Rollback

Revert this commit. Test removal is no-op for production behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)