### PR TITLE
feat(results): add evidence header to fund model results

### DIFF
--- a/client/src/components/results/EvidenceHeader.tsx
+++ b/client/src/components/results/EvidenceHeader.tsx
@@ -1,0 +1,125 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { FundStateReadV1 } from '@shared/contracts/fund-state-read-v1.contract';
+
+type LifecycleStatus = FundStateReadV1['calculationState']['status'];
+
+export interface EvidenceHeaderLifecycle {
+  status: LifecycleStatus;
+  configVersion: number | null;
+  runId: number | null;
+  lastCalculatedAt: string | null;
+  publishedVersion?: number | null;
+  source?: string | null;
+}
+
+interface EvidenceHeaderProps {
+  lifecycle: EvidenceHeaderLifecycle;
+  className?: string | undefined;
+  testId?: string | undefined;
+}
+
+type EvidenceState = 'READY' | 'CALCULATING' | 'FAILED' | 'STALE' | 'UNAVAILABLE';
+
+const DEFAULT_SOURCE = '/api/funds/:id/results';
+
+function deriveEvidenceState(lifecycle: EvidenceHeaderLifecycle): EvidenceState {
+  if (lifecycle.status === 'failed') return 'FAILED';
+  if (lifecycle.status === 'submitted' || lifecycle.status === 'calculating') return 'CALCULATING';
+  if (lifecycle.status !== 'ready') return 'UNAVAILABLE';
+
+  if (
+    lifecycle.configVersion != null &&
+    lifecycle.publishedVersion != null &&
+    lifecycle.configVersion < lifecycle.publishedVersion
+  ) {
+    return 'STALE';
+  }
+
+  return 'READY';
+}
+
+function statusClasses(state: EvidenceState) {
+  switch (state) {
+    case 'READY':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+    case 'CALCULATING':
+      return 'border-amber-200 bg-amber-50 text-amber-800';
+    case 'FAILED':
+      return 'border-rose-200 bg-rose-50 text-rose-800';
+    case 'STALE':
+      return 'border-amber-200 bg-amber-50 text-amber-800';
+    default:
+      return 'border-beige-200 bg-beige-50 text-charcoal-500';
+  }
+}
+
+function formatEvidenceTimestamp(value: string | null, state: EvidenceState) {
+  if (!value) {
+    return state === 'CALCULATING' ? 'CALCULATED PENDING' : 'CALCULATED UNAVAILABLE';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'CALCULATED UNAVAILABLE';
+
+  return `CALCULATED ${new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(date)}`;
+}
+
+function formatRun(runId: number | null, state: EvidenceState) {
+  if (runId == null) return 'RUN UNAVAILABLE';
+  return state === 'CALCULATING' ? `RUN IN PROGRESS #${runId}` : `RUN #${runId}`;
+}
+
+function formatSource(source: string | null | undefined) {
+  const trimmed = source?.trim();
+  return `SOURCE ${trimmed ? trimmed : DEFAULT_SOURCE}`;
+}
+
+function evidenceSegments(lifecycle: EvidenceHeaderLifecycle, state: EvidenceState) {
+  const freshness = state === 'READY' ? 'CURRENT' : state === 'CALCULATING' ? 'IN PROGRESS' : state;
+
+  return [
+    lifecycle.configVersion != null ? `CONFIG v${lifecycle.configVersion}` : 'CONFIG UNAVAILABLE',
+    formatRun(lifecycle.runId, state),
+    formatEvidenceTimestamp(lifecycle.lastCalculatedAt, state),
+    formatSource(lifecycle.source),
+    freshness,
+  ];
+}
+
+export function EvidenceHeader({ lifecycle, className, testId }: EvidenceHeaderProps) {
+  const state = deriveEvidenceState(lifecycle);
+  const segments = evidenceSegments(lifecycle, state);
+
+  // Follows docs/design/analytics-visualization-principles.md: provenance stays
+  // beside material outputs, and missing lifecycle fields are labeled plainly.
+  return (
+    <div
+      aria-label="Evidence header"
+      className={cn(
+        'flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-poppins uppercase text-charcoal-500',
+        className
+      )}
+      data-testid={testId}
+    >
+      <Badge variant="outline" className={cn('font-poppins uppercase', statusClasses(state))}>
+        {state}
+      </Badge>
+      {segments.map((segment) => (
+        <span key={segment} className="inline-flex items-center gap-2">
+          <span aria-hidden="true" className="text-charcoal-300">
+            ·
+          </span>
+          <span>{segment}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -24,6 +24,7 @@ import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { EvidenceHeader, type EvidenceHeaderLifecycle } from '@/components/results/EvidenceHeader';
 import { QuarterlyReviewTrace } from '@/features/analytics-parity/QuarterlyReviewTrace';
 import { cn } from '@/lib/utils';
 import type {
@@ -1415,13 +1416,53 @@ interface SectionRendererProps {
     [key: string]: unknown;
   };
   renderPayload?: (payload: unknown) => React.ReactNode;
+  evidenceLifecycle?: EvidenceHeaderLifecycle;
+  evidenceTestId?: string;
 }
 
-function SectionRenderer({ title, section, renderPayload }: SectionRendererProps) {
+function getSectionSource(section: SectionRendererProps['section']) {
+  const source = section['source'];
+  return typeof source === 'string' && source.trim().length > 0 ? source : null;
+}
+
+function sectionEvidence(
+  lifecycle: EvidenceHeaderLifecycle | undefined,
+  section: SectionRendererProps['section']
+): EvidenceHeaderLifecycle | null {
+  if (!lifecycle) return null;
+  return {
+    ...lifecycle,
+    source: getSectionSource(section) ?? lifecycle.source ?? null,
+  };
+}
+
+function evidenceFromLifecycle(lifecycle: FundStateReadV1): EvidenceHeaderLifecycle {
+  return {
+    status: lifecycle.calculationState.status,
+    configVersion: lifecycle.calculationState.configVersion,
+    runId: lifecycle.calculationState.runId,
+    lastCalculatedAt: lifecycle.calculationState.lastCalculatedAt,
+    publishedVersion: lifecycle.configState.publishedVersion,
+    source: '/api/funds/:id/results',
+  };
+}
+
+function SectionRenderer({
+  title,
+  section,
+  renderPayload,
+  evidenceLifecycle,
+  evidenceTestId,
+}: SectionRendererProps) {
+  const evidence = sectionEvidence(evidenceLifecycle, section);
+
   if (section.status === 'available') {
     return (
       <div className="bg-white rounded-lg border border-beige-200 p-6">
-        <h2 className="text-lg font-medium text-charcoal mb-4">{title}</h2>
+        <div className="mb-4 space-y-2">
+          <h2 className="text-lg font-medium text-charcoal">{title}</h2>
+          {evidence && <EvidenceHeader lifecycle={evidence} testId={evidenceTestId} />}
+        </div>
         {section.legacyEvidence && (
           <p className="text-xs text-charcoal-400 mb-2">
             Based on previous calculation (legacy data)
@@ -1450,7 +1491,10 @@ function SectionRenderer({ title, section, renderPayload }: SectionRendererProps
 
   return (
     <div className="bg-beige-50 rounded-lg border border-beige-200 p-6">
-      <h2 className="text-lg font-medium text-charcoal-400 mb-2">{title}</h2>
+      <div className="mb-2 space-y-2">
+        <h2 className="text-lg font-medium text-charcoal-400">{title}</h2>
+        {evidence && <EvidenceHeader lifecycle={evidence} testId={evidenceTestId} />}
+      </div>
       <p className="text-sm text-charcoal-500 font-poppins">
         {statusLabel ? `${statusLabel}: ` : ''}
         {copy}
@@ -1570,6 +1614,7 @@ function FundModelResultsPage() {
   }
 
   const { results } = fetchState;
+  const evidenceLifecycle = evidenceFromLifecycle(results.lifecycle);
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-8 space-y-8">
@@ -1612,12 +1657,22 @@ function FundModelResultsPage() {
 
       {/* Reserve section */}
       <FadeInSection>
-        <SectionRenderer title="Reserve Allocation" section={results.sections.reserve} />
+        <SectionRenderer
+          title="Reserve Allocation"
+          section={results.sections.reserve}
+          evidenceLifecycle={evidenceLifecycle}
+          evidenceTestId="evidence-header-reserve-allocation"
+        />
       </FadeInSection>
 
       {/* Pacing section */}
       <FadeInSection>
-        <SectionRenderer title="Deployment Pacing" section={results.sections.pacing} />
+        <SectionRenderer
+          title="Deployment Pacing"
+          section={results.sections.pacing}
+          evidenceLifecycle={evidenceLifecycle}
+          evidenceTestId="evidence-header-deployment-pacing"
+        />
       </FadeInSection>
 
       {/* Overview (scorecard) section */}

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -449,6 +449,99 @@ describe('FundModelResultsPage (server-backed)', () => {
     expect(screen.getAllByText('RESERVE, PACING').length).toBeGreaterThanOrEqual(1);
   });
 
+  // -- Evidence headers --
+
+  it('renders READY evidence header segments from lifecycle and section source', async () => {
+    mockFundPageFetches();
+    await renderPage('/fund-model-results/123');
+
+    const header = await screen.findByTestId('evidence-header-reserve-allocation');
+    expect(within(header).getByText('READY')).toBeInTheDocument();
+    expect(within(header).getByText('CONFIG v1')).toBeInTheDocument();
+    expect(within(header).getByText('RUN #10')).toBeInTheDocument();
+    expect(
+      within(header).getByText(`CALCULATED ${formatEvidenceTimestamp('2026-03-20T12:30:00.000Z')}`)
+    ).toBeInTheDocument();
+    expect(within(header).getByText('SOURCE fund_snapshots')).toBeInTheDocument();
+    expect(within(header).getByText('CURRENT')).toBeInTheDocument();
+  });
+
+  it('renders CALCULATING evidence with explanatory pending timestamp copy', async () => {
+    mockFundPageFetches({ results: calculatingResponse({ runId: 10 }) });
+    await renderPage('/fund-model-results/123');
+
+    const header = await screen.findByTestId('evidence-header-reserve-allocation');
+    expect(within(header).getByText('CALCULATING')).toBeInTheDocument();
+    expect(within(header).getByText('CONFIG v1')).toBeInTheDocument();
+    expect(within(header).getByText('RUN IN PROGRESS #10')).toBeInTheDocument();
+    expect(within(header).getByText('CALCULATED PENDING')).toBeInTheDocument();
+    expect(header).not.toHaveTextContent('RUN #10');
+  });
+
+  it('renders FAILED evidence when lifecycle calculation fails', async () => {
+    mockFundPageFetches({ results: failedResponse() });
+    await renderPage('/fund-model-results/123');
+
+    const header = await screen.findByTestId('evidence-header-reserve-allocation');
+    expect(within(header).getAllByText('FAILED').length).toBeGreaterThanOrEqual(1);
+    expect(within(header).getByText('CONFIG v1')).toBeInTheDocument();
+    expect(within(header).getByText('RUN #10')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Worker timed out during reserve snapshot generation/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders STALE evidence with truthful run and config version', async () => {
+    const resp = readyResponse();
+    resp.lifecycle.configState.publishedVersion = 2;
+    resp.lifecycle.calculationState.configVersion = 1;
+
+    mockFundPageFetches({ results: resp });
+    await renderPage('/fund-model-results/123');
+
+    const header = await screen.findByTestId('evidence-header-reserve-allocation');
+    expect(within(header).getAllByText('STALE').length).toBeGreaterThanOrEqual(1);
+    expect(within(header).getByText('CONFIG v1')).toBeInTheDocument();
+    expect(within(header).getByText('RUN #10')).toBeInTheDocument();
+    expect(within(header).getByText('SOURCE fund_snapshots')).toBeInTheDocument();
+  });
+
+  it('renders UNAVAILABLE evidence without fabricated IDs when lifecycle fields are missing', async () => {
+    const resp = readyResponse();
+    resp.lifecycle.configState.hasPublished = false;
+    resp.lifecycle.configState.publishedVersion = null;
+    resp.lifecycle.configState.publishedAt = null;
+    resp.lifecycle.calculationState.status = 'not_requested';
+    resp.lifecycle.calculationState.configVersion = null;
+    resp.lifecycle.calculationState.runId = null;
+    resp.lifecycle.calculationState.lastCalculatedAt = null;
+
+    mockFundPageFetches({ results: resp, history: { fundId: 123, entries: [] } });
+    await renderPage('/fund-model-results/123');
+
+    const header = await screen.findByTestId('evidence-header-reserve-allocation');
+    expect(within(header).getAllByText('UNAVAILABLE').length).toBeGreaterThanOrEqual(1);
+    expect(within(header).getByText('CONFIG UNAVAILABLE')).toBeInTheDocument();
+    expect(within(header).getByText('RUN UNAVAILABLE')).toBeInTheDocument();
+    expect(within(header).getByText('CALCULATED UNAVAILABLE')).toBeInTheDocument();
+    expect(header).not.toHaveTextContent('RUN #');
+    expect(header).not.toHaveTextContent('CONFIG v');
+  });
+
+  it('renders null configVersion and runId as unavailable evidence segments', async () => {
+    const resp = readyResponse();
+    resp.lifecycle.calculationState.configVersion = null;
+    resp.lifecycle.calculationState.runId = null;
+
+    mockFundPageFetches({ results: resp });
+    await renderPage('/fund-model-results/123');
+
+    const header = await screen.findByTestId('evidence-header-reserve-allocation');
+    expect(within(header).getByText('CONFIG UNAVAILABLE')).toBeInTheDocument();
+    expect(within(header).getByText('RUN UNAVAILABLE')).toBeInTheDocument();
+    expect(header).not.toHaveTextContent('RUN #');
+  });
+
   // -- Legacy evidence --
 
   it('shows legacy evidence notice when section has legacyEvidence flag', async () => {
@@ -1037,6 +1130,17 @@ describe('FundModelResultsPage (server-backed)', () => {
 });
 
 // -- Helpers --
+
+function formatEvidenceTimestamp(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(new Date(value));
+}
 
 function jsonResponse(body: unknown) {
   return new Response(JSON.stringify(body), {


### PR DESCRIPTION
## Summary

Implements Phase 1 of the analytics visualization rollout: an `EvidenceHeader` on `/fund-model-results/:fundId` that surfaces lifecycle provenance for the displayed results. Consumes existing `results.lifecycle` fields only — no contract change (proven by #704).

## What changed

- **New**: `client/src/components/results/EvidenceHeader.tsx` — typed component reading `EvidenceHeaderLifecycle` (configState.publishedVersion, calculationState.{configVersion, runId, status, lastCalculatedAt}); covers READY, CALCULATING, FAILED, STALE, UNAVAILABLE states; truthful unavailable fallbacks (\`CONFIG UNAVAILABLE\`, \`RUN UNAVAILABLE\`, \`CALCULATED UNAVAILABLE\`) instead of fabricated IDs.
- **Modified**: \`client/src/pages/fund-model-results.tsx\` — mounts EvidenceHeader on **Reserve Allocation** and **Deployment Pacing** sections. Existing polling/backoff behavior preserved. Section source prefers \`fund_snapshots\` when available, else \`/api/funds/:id/results\`.
- **Modified**: \`tests/unit/pages/fund-model-results.test.tsx\` — coverage for all five states, null configVersion/runId handling, and existing-polling regression.

## Doctrine compliance

Per \`docs/design/analytics-visualization-principles.md\`:
- [x] Production analytics do not silently use sample/mock/fixture data
- [x] State indicators visible (READY/CALCULATING/FAILED/STALE/UNAVAILABLE)
- [x] Source, config version, run ID, timestamp shown when available; truthful unavailable state otherwise
- [x] Timestamp formatted via \`Intl.DateTimeFormat\` with \`timeZoneName: 'short'\` for honest tz context
- [x] No fabricated IDs

## Verification

- \`npm run check\` → 0 TypeScript errors
- \`npm run lint\` → clean (eslint + console/eslint-disable/script-alias guardrails)
- \`npm run test:phase4:client\` → **45/45 pass** (2.27s)
- \`npm run docs:check-links\` → 1481 links / 0 broken
- \`git diff --check\` → clean
- Pre-push hook: TS baseline + 122 changed-file targeted tests all green

\`npm run calc-gate\` not run — no calculation semantics touched.

## Test plan

- [ ] Visual smoke on \`/fund-model-results/:fundId\` for a fund with successful recent calculation → READY header with live config/run/timestamp
- [ ] Switch to a fund with stale snapshot → STALE rendering with reason
- [ ] Query fund with no snapshot → UNAVAILABLE rendering, no fabricated IDs
- [ ] Confirm polling/backoff behavior unchanged when calculation transitions

## Rollback

Revert this commit. No schema migration, no shared contract change, no server change.