### PR TITLE
docs(adr): reconcile ADR-022 status and update index specification

### DIFF
--- a/docs/adr/ADR-022-fund-scenario-architecture.md
+++ b/docs/adr/ADR-022-fund-scenario-architecture.md
@@ -1,6 +1,6 @@
 ---
-status: ACTIVE
-last_updated: 2026-05-25
+status: Proposed
+last_updated: 2026-05-26
 ---
 
 # ADR-022: Fund-Results Scenario Architecture
@@ -64,10 +64,21 @@ Store scenario analytical outputs in `fund_snapshots` with:
 ALTER TABLE fund_snapshots
   ADD COLUMN scenario_set_id UUID NULL;
 
+-- Authoritative reads filter scenario_set_id IS NULL; this partial index
+-- covers the two-tier query pattern (fund_id + type + config_version,
+-- ordered by snapshot_time DESC).
+CREATE INDEX idx_fund_snapshots_authoritative
+  ON fund_snapshots(fund_id, type, config_version, snapshot_time DESC)
+  WHERE scenario_set_id IS NULL;
+
+-- Scenario reads filter on a specific scenario_set_id.
 CREATE INDEX idx_fund_snapshots_scenario_set
-  ON fund_snapshots(fund_id, scenario_set_id)
+  ON fund_snapshots(fund_id, scenario_set_id, type, config_version)
   WHERE scenario_set_id IS NOT NULL;
 ```
+
+Both indexes use standard `CREATE INDEX` inside a `BEGIN/COMMIT` migration (the
+project's migration runner does not support `CONCURRENTLY`).
 
 Use snapshot type `'SCENARIOS'` (the `type` column is `varchar(50)`, not an enum
 — no `ALTER TYPE` migration required).


### PR DESCRIPTION
## Summary

- Resolve ADR-022 status inconsistency: frontmatter said `ACTIVE` while body (line 10) and ADR index (`docs/adr/README.md:38`) both said `Proposed`. Aligned to `Proposed` until implementation proves the architecture.
- Update index specification to match actual two-tier query access patterns: added authoritative partial index on `(fund_id, type, config_version, snapshot_time DESC) WHERE scenario_set_id IS NULL`, expanded scenario index columns.
- Documented that `CONCURRENTLY` is incompatible with the project's `BEGIN/COMMIT` migration runner (verified: zero existing migrations use it).
- Closed stale PR #706 (superseded by #707).

## Context

Pre-implementation governance gate before the `scenario_set_id` migration PR (PR B in the approved plan). ADR-022's guardrails cannot be treated as merge-blocking gates while the document's own status is ambiguous.

## Verification

- `npm run docs:check-links` -- PASS (1484 links valid)
- `npm run doctor:quick` -- PASS
- `git diff --check` -- clean

## Hermes Handoff

```
Run ID: hermes-2026-05-26-pr0
Phase: research
Owner: Claude
Reviewer: kimi
Gate: npm run doctor:quick (PASS)
Next: PR B (production phase, Codex-owned) -- atomic scenario_set_id migration
```

Generated with [Claude Code](https://claude.com/claude-code)