### PR TITLE
feat(scenarios): add fee-profile scenario calculation

### DIFF
--- a/server/db/migrations/0014_fund_scenario_calculated_event.sql
+++ b/server/db/migrations/0014_fund_scenario_calculated_event.sql
@@ -10,4 +10,9 @@ ALTER TABLE fund_scenario_set_events
   ADD CONSTRAINT fund_scenario_set_events_type_check
   CHECK (event_type IN ('created', 'updated', 'archived', 'calculated'));
 
+CREATE UNIQUE INDEX IF NOT EXISTS fund_snapshots_scenario_set_calculation_unique
+  ON fund_snapshots(fund_id, scenario_set_id)
+  WHERE scenario_set_id IS NOT NULL
+    AND type = 'SCENARIOS';
+
 COMMIT;

--- a/server/db/migrations/0014_fund_scenario_calculated_event.sql
+++ b/server/db/migrations/0014_fund_scenario_calculated_event.sql
@@ -1,0 +1,13 @@
+-- 0014_fund_scenario_calculated_event.sql
+-- ADR-022: scenario calculations write fund_snapshots rows and must be audit-visible.
+
+BEGIN;
+
+ALTER TABLE fund_scenario_set_events
+  DROP CONSTRAINT IF EXISTS fund_scenario_set_events_type_check;
+
+ALTER TABLE fund_scenario_set_events
+  ADD CONSTRAINT fund_scenario_set_events_type_check
+  CHECK (event_type IN ('created', 'updated', 'archived', 'calculated'));
+
+COMMIT;

--- a/server/routes/fund-scenario-sets.ts
+++ b/server/routes/fund-scenario-sets.ts
@@ -14,6 +14,10 @@ import {
   listFundScenarioSets,
 } from '../services/fund-scenario-set-service.js';
 import { createFundScenarioSet } from '../services/fund-scenario-set-create-service.js';
+import {
+  calculateFundScenarioSet,
+  getScenarioResults,
+} from '../services/fund-scenario-calculation-service.js';
 
 interface HttpError extends Error {
   statusCode?: number;
@@ -169,6 +173,44 @@ router.post(
       idempotencyKey: getIdempotencyKey(req),
     });
     return res.status(201).json(scenarioSet);
+  })
+);
+
+router.post(
+  '/funds/:fundId/scenario-sets/:scenarioSetId/calculate',
+  requireAuth(),
+  requireFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseFundId(req, res);
+    const scenarioSetId = parseScenarioSetId(req, res);
+    if (fundId === null || scenarioSetId === null) {
+      return;
+    }
+
+    const result = await calculateFundScenarioSet(fundId, scenarioSetId, parseActor(req));
+    return res.status(200).json(result);
+  })
+);
+
+router.get(
+  '/funds/:fundId/scenario-sets/:scenarioSetId/results',
+  requireAuth(),
+  requireFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseFundId(req, res);
+    const scenarioSetId = parseScenarioSetId(req, res);
+    if (fundId === null || scenarioSetId === null) {
+      return;
+    }
+
+    const result = await getScenarioResults(fundId, scenarioSetId);
+    if (result === null) {
+      return res.status(404).json({
+        error: 'not_found',
+        message: 'No scenario calculation results found for this set',
+      });
+    }
+    return res.status(200).json(result);
   })
 );
 

--- a/server/services/fund-scenario-calculation-service.ts
+++ b/server/services/fund-scenario-calculation-service.ts
@@ -1,0 +1,396 @@
+import crypto from 'node:crypto';
+import type { PoolClient } from 'pg';
+import { transaction } from '../db/pg-circuit.js';
+import {
+  FundScenarioCalculationPayloadV1Schema,
+  FundScenarioCalculationResponseV1Schema,
+  type FundScenarioCalculationPayloadV1,
+  type FundScenarioCalculationResponseV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import {
+  FundDraftWriteV1Schema,
+  type FundDraftWriteV1,
+} from '@shared/contracts/fund-draft-write-v1.contract';
+import { hasEconomicsAssumptions, runEconomicsModel } from '@shared/lib/economics/economics-engine';
+import {
+  createHttpError,
+  fetchScenarioSetDetail,
+  insertScenarioSetEvent,
+  normalizeActor,
+  verifyFundExists,
+  type FundScenarioMutationActor,
+} from './fund-scenario-set-service.js';
+
+const SYNC_CALCULATION_TIMEOUT_MS = 10_000;
+const FUND_SCENARIO_CALC_VERSION = process.env['ALG_FUND_SCENARIO_VERSION'] ?? 'fund-scenarios-v1';
+
+interface SourceConfigRow {
+  id: number;
+  version: number;
+  config: unknown;
+}
+
+interface CurrentPublishedConfigRow {
+  version: number;
+}
+
+interface SnapshotRow {
+  id: number;
+  payload: unknown;
+  correlation_id: string;
+  created_at: Date | string | null;
+  snapshot_time: Date | string | null;
+}
+
+function parseJsonPayload(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return JSON.parse(value) as unknown;
+}
+
+function createInputHash(input: unknown): string {
+  return crypto.createHash('sha256').update(JSON.stringify(input)).digest('hex');
+}
+
+function assertWithinSyncDeadline(startedAt: number): void {
+  const elapsedMs = performance.now() - startedAt;
+  if (elapsedMs <= SYNC_CALCULATION_TIMEOUT_MS) {
+    return;
+  }
+
+  throw createHttpError(504, 'Fee-profile scenario calculation exceeded the 10s sync limit', {
+    code: 'scenario_calculation_timeout',
+    details: { timeoutMs: SYNC_CALCULATION_TIMEOUT_MS },
+  });
+}
+
+async function loadSourceConfig(
+  client: PoolClient,
+  fundId: number,
+  configId: number,
+  configVersion: number
+): Promise<SourceConfigRow> {
+  const result = await client.query<SourceConfigRow>(
+    `SELECT id, version, config
+       FROM fundconfigs
+      WHERE fund_id = $1
+        AND id = $2
+        AND version = $3
+      LIMIT 1`,
+    [fundId, configId, configVersion]
+  );
+
+  const sourceConfig = result.rows[0];
+  if (!sourceConfig) {
+    throw createHttpError(409, `Scenario source config ${configId} could not be loaded`, {
+      code: 'scenario_source_config_missing',
+      details: { sourceConfigId: configId, sourceConfigVersion: configVersion },
+    });
+  }
+
+  return sourceConfig;
+}
+
+async function loadCurrentPublishedVersion(
+  client: PoolClient,
+  fundId: number
+): Promise<number | null> {
+  const result = await client.query<CurrentPublishedConfigRow>(
+    `SELECT version
+       FROM fundconfigs
+      WHERE fund_id = $1
+        AND is_published = TRUE
+      ORDER BY version DESC
+      LIMIT 1`,
+    [fundId]
+  );
+
+  return result.rows[0]?.version ?? null;
+}
+
+function parseSourceConfig(fundId: number, sourceConfig: SourceConfigRow): FundDraftWriteV1 {
+  const parsed = FundDraftWriteV1Schema.safeParse(sourceConfig.config);
+  if (!parsed.success) {
+    throw createHttpError(409, `Scenario source config for fund ${fundId} is invalid`, {
+      code: 'scenario_source_config_invalid',
+      details: {
+        sourceConfigId: sourceConfig.id,
+        sourceConfigVersion: sourceConfig.version,
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.map(String),
+          message: issue.message,
+        })),
+      },
+    });
+  }
+
+  if (!hasEconomicsAssumptions(parsed.data)) {
+    throw createHttpError(
+      409,
+      `Scenario source config for fund ${fundId} has no economics assumptions`,
+      {
+        code: 'scenario_economics_not_configured',
+        details: {
+          sourceConfigId: sourceConfig.id,
+          sourceConfigVersion: sourceConfig.version,
+        },
+      }
+    );
+  }
+
+  return parsed.data;
+}
+
+function responseFromSnapshot(row: SnapshotRow): FundScenarioCalculationResponseV1 {
+  const payload = FundScenarioCalculationPayloadV1Schema.parse(parseJsonPayload(row.payload));
+  return FundScenarioCalculationResponseV1Schema.parse({
+    snapshotId: row.id,
+    correlationId: row.correlation_id,
+    source: 'fund_snapshots',
+    payload,
+  });
+}
+
+async function findReusableScenarioSnapshot(
+  client: PoolClient,
+  input: {
+    fundId: number;
+    scenarioSetId: string;
+    sourceConfigId: number;
+    sourceConfigVersion: number;
+    inputHash: string;
+  }
+): Promise<FundScenarioCalculationResponseV1 | null> {
+  const result = await client.query<SnapshotRow>(
+    `SELECT id, payload, correlation_id, created_at, snapshot_time
+       FROM fund_snapshots
+      WHERE fund_id = $1
+        AND scenario_set_id = $2
+        AND type = 'SCENARIOS'
+        AND config_id = $3
+        AND config_version = $4
+        AND calc_version = $5
+        AND metadata ->> 'input_hash' = $6
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [
+      input.fundId,
+      input.scenarioSetId,
+      input.sourceConfigId,
+      input.sourceConfigVersion,
+      FUND_SCENARIO_CALC_VERSION,
+      input.inputHash,
+    ]
+  );
+
+  const snapshot = result.rows[0];
+  return snapshot ? responseFromSnapshot(snapshot) : null;
+}
+
+async function persistScenarioSnapshot(
+  client: PoolClient,
+  input: {
+    fundId: number;
+    scenarioSetId: string;
+    sourceConfigId: number;
+    sourceConfigVersion: number;
+    correlationId: string;
+    payload: FundScenarioCalculationPayloadV1;
+    inputHash: string;
+  }
+): Promise<FundScenarioCalculationResponseV1> {
+  const result = await client.query<SnapshotRow>(
+    `INSERT INTO fund_snapshots (
+       fund_id,
+       type,
+       payload,
+       calc_version,
+       correlation_id,
+       metadata,
+       snapshot_time,
+       config_id,
+       config_version,
+       scenario_set_id
+     )
+     VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
+     RETURNING id, payload, correlation_id, created_at, snapshot_time`,
+    [
+      input.fundId,
+      input.payload,
+      FUND_SCENARIO_CALC_VERSION,
+      input.correlationId,
+      {
+        input_hash: input.inputHash,
+        calculation_mode: 'sync_fee_profile',
+        timeout_ms: SYNC_CALCULATION_TIMEOUT_MS,
+      },
+      input.sourceConfigId,
+      input.sourceConfigVersion,
+      input.scenarioSetId,
+    ]
+  );
+
+  const snapshot = result.rows[0];
+  if (!snapshot) {
+    throw createHttpError(500, 'Scenario snapshot insert did not return an id', {
+      code: 'scenario_snapshot_insert_failed',
+    });
+  }
+
+  return responseFromSnapshot(snapshot);
+}
+
+export async function calculateFundScenarioSet(
+  fundId: number,
+  scenarioSetId: string,
+  actorInput: FundScenarioMutationActor = {}
+): Promise<FundScenarioCalculationResponseV1> {
+  return transaction(async (client) => {
+    await verifyFundExists(client, fundId);
+    const scenarioSet = await fetchScenarioSetDetail(client, fundId, scenarioSetId);
+
+    if (scenarioSet.archivedAt !== null) {
+      throw createHttpError(409, `Scenario set ${scenarioSetId} is archived`, {
+        code: 'scenario_set_archived',
+      });
+    }
+
+    const sourceConfig = await loadSourceConfig(
+      client,
+      fundId,
+      scenarioSet.sourceConfigId,
+      scenarioSet.sourceConfigVersion
+    );
+    const currentPublishedVersion = await loadCurrentPublishedVersion(client, fundId);
+    const sourceConfigBody = parseSourceConfig(fundId, sourceConfig);
+    const inputHash = createInputHash({
+      scenarioSetId,
+      sourceConfigId: sourceConfig.id,
+      sourceConfigVersion: sourceConfig.version,
+      currentPublishedVersion,
+      calcVersion: FUND_SCENARIO_CALC_VERSION,
+      variants: scenarioSet.variants.map((variant) => ({
+        id: variant.id,
+        override: variant.override,
+      })),
+    });
+
+    const reusableSnapshot = await findReusableScenarioSnapshot(client, {
+      fundId,
+      scenarioSetId,
+      sourceConfigId: sourceConfig.id,
+      sourceConfigVersion: sourceConfig.version,
+      inputHash,
+    });
+    if (reusableSnapshot) {
+      return reusableSnapshot;
+    }
+
+    const startedAt = performance.now();
+    const variants = scenarioSet.variants.map((variant) => {
+      assertWithinSyncDeadline(startedAt);
+      const variantConfig: FundDraftWriteV1 = {
+        ...sourceConfigBody,
+        feeProfiles: variant.override.payload.feeProfiles,
+      };
+      const economics = runEconomicsModel(variantConfig);
+      assertWithinSyncDeadline(startedAt);
+
+      return {
+        variantId: variant.id,
+        scenarioSetId: variant.scenarioSetId,
+        name: variant.name,
+        overrideType: variant.override.overrideType,
+        economics,
+      };
+    });
+
+    const calculatedAt = new Date().toISOString();
+    const stalenessState =
+      currentPublishedVersion != null && currentPublishedVersion > sourceConfig.version
+        ? 'STALE_PUBLISH'
+        : 'CURRENT';
+    const payload = FundScenarioCalculationPayloadV1Schema.parse({
+      version: 'fund-scenarios-v1',
+      calculationMode: 'sync_fee_profile',
+      fundId,
+      scenarioSetId,
+      sourceConfigId: sourceConfig.id,
+      sourceConfigVersion: sourceConfig.version,
+      staleness: {
+        state: stalenessState,
+        sourceConfigVersion: sourceConfig.version,
+        currentPublishedConfigVersion: currentPublishedVersion,
+      },
+      calculatedAt,
+      variants,
+    });
+
+    const response = await persistScenarioSnapshot(client, {
+      fundId,
+      scenarioSetId,
+      sourceConfigId: sourceConfig.id,
+      sourceConfigVersion: sourceConfig.version,
+      correlationId: crypto.randomUUID(),
+      payload,
+      inputHash,
+    });
+
+    await insertScenarioSetEvent(client, {
+      scenarioSetId,
+      fundId,
+      eventType: 'calculated',
+      actor: normalizeActor(actorInput),
+      changeSummary: {
+        headline: 'Calculated fee-profile scenario set',
+        snapshot_id: response.snapshotId,
+        variant_count: variants.length,
+        source_config_version: sourceConfig.version,
+        staleness_state: stalenessState,
+      },
+    });
+
+    return response;
+  });
+}
+
+export async function getScenarioResults(
+  fundId: number,
+  scenarioSetId: string
+): Promise<FundScenarioCalculationResponseV1 | null> {
+  return transaction(async (client) => {
+    await verifyFundExists(client, fundId);
+    await fetchScenarioSetDetail(client, fundId, scenarioSetId);
+
+    const result = await client.query<SnapshotRow>(
+      `SELECT id, payload, correlation_id, created_at, snapshot_time
+         FROM fund_snapshots
+        WHERE fund_id = $1
+          AND scenario_set_id = $2
+          AND type = 'SCENARIOS'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [fundId, scenarioSetId]
+    );
+
+    const snapshot = result.rows[0];
+    if (!snapshot) {
+      return null;
+    }
+
+    const response = responseFromSnapshot(snapshot);
+
+    const currentPublishedVersion = await loadCurrentPublishedVersion(client, fundId);
+    if (
+      currentPublishedVersion != null &&
+      currentPublishedVersion > response.payload.sourceConfigVersion
+    ) {
+      response.payload.staleness.state = 'STALE_PUBLISH';
+      response.payload.staleness.currentPublishedConfigVersion = currentPublishedVersion;
+    }
+
+    return response;
+  });
+}

--- a/server/services/fund-scenario-calculation-service.ts
+++ b/server/services/fund-scenario-calculation-service.ts
@@ -6,6 +6,7 @@ import {
   FundScenarioCalculationResponseV1Schema,
   type FundScenarioCalculationPayloadV1,
   type FundScenarioCalculationResponseV1,
+  type FundScenarioVariantOverrideV1,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 import {
   FundDraftWriteV1Schema,
@@ -153,6 +154,44 @@ function responseFromSnapshot(row: SnapshotRow): FundScenarioCalculationResponse
   });
 }
 
+function withReadTimeStaleness(
+  response: FundScenarioCalculationResponseV1,
+  currentPublishedVersion: number | null
+): FundScenarioCalculationResponseV1 {
+  response.payload.staleness.state =
+    currentPublishedVersion != null &&
+    currentPublishedVersion > response.payload.sourceConfigVersion
+      ? 'STALE_PUBLISH'
+      : 'CURRENT';
+  response.payload.staleness.currentPublishedConfigVersion = currentPublishedVersion;
+  return response;
+}
+
+function applyFeeProfileOverride(
+  sourceConfig: FundDraftWriteV1,
+  override: FundScenarioVariantOverrideV1
+): FundDraftWriteV1 {
+  const economicsAssumptions = sourceConfig.economicsAssumptions;
+  const variantConfig: FundDraftWriteV1 = {
+    ...sourceConfig,
+    feeProfiles: override.payload.feeProfiles,
+  };
+
+  if (economicsAssumptions == null) {
+    return variantConfig;
+  }
+
+  return {
+    ...variantConfig,
+    economicsAssumptions: {
+      ...economicsAssumptions,
+      feeModel: {
+        source: 'legacy_fee_profiles',
+      },
+    },
+  };
+}
+
 async function findReusableScenarioSnapshot(
   client: PoolClient,
   input: {
@@ -214,8 +253,19 @@ async function persistScenarioSnapshot(
        config_version,
        scenario_set_id
      )
-     VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
-     RETURNING id, payload, correlation_id, created_at, snapshot_time`,
+      VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
+      ON CONFLICT (fund_id, scenario_set_id)
+      WHERE scenario_set_id IS NOT NULL AND type = 'SCENARIOS'
+      DO UPDATE SET
+        payload = EXCLUDED.payload,
+        calc_version = EXCLUDED.calc_version,
+        correlation_id = EXCLUDED.correlation_id,
+        metadata = EXCLUDED.metadata,
+        snapshot_time = EXCLUDED.snapshot_time,
+        config_id = EXCLUDED.config_id,
+        config_version = EXCLUDED.config_version,
+        created_at = NOW()
+      RETURNING id, payload, correlation_id, created_at, snapshot_time`,
     [
       input.fundId,
       input.payload,
@@ -249,7 +299,9 @@ export async function calculateFundScenarioSet(
 ): Promise<FundScenarioCalculationResponseV1> {
   return transaction(async (client) => {
     await verifyFundExists(client, fundId);
-    const scenarioSet = await fetchScenarioSetDetail(client, fundId, scenarioSetId);
+    const scenarioSet = await fetchScenarioSetDetail(client, fundId, scenarioSetId, {
+      forUpdate: true,
+    });
 
     if (scenarioSet.archivedAt !== null) {
       throw createHttpError(409, `Scenario set ${scenarioSetId} is archived`, {
@@ -269,7 +321,6 @@ export async function calculateFundScenarioSet(
       scenarioSetId,
       sourceConfigId: sourceConfig.id,
       sourceConfigVersion: sourceConfig.version,
-      currentPublishedVersion,
       calcVersion: FUND_SCENARIO_CALC_VERSION,
       variants: scenarioSet.variants.map((variant) => ({
         id: variant.id,
@@ -285,16 +336,13 @@ export async function calculateFundScenarioSet(
       inputHash,
     });
     if (reusableSnapshot) {
-      return reusableSnapshot;
+      return withReadTimeStaleness(reusableSnapshot, currentPublishedVersion);
     }
 
     const startedAt = performance.now();
     const variants = scenarioSet.variants.map((variant) => {
       assertWithinSyncDeadline(startedAt);
-      const variantConfig: FundDraftWriteV1 = {
-        ...sourceConfigBody,
-        feeProfiles: variant.override.payload.feeProfiles,
-      };
+      const variantConfig = applyFeeProfileOverride(sourceConfigBody, variant.override);
       const economics = runEconomicsModel(variantConfig);
       assertWithinSyncDeadline(startedAt);
 
@@ -383,14 +431,6 @@ export async function getScenarioResults(
     const response = responseFromSnapshot(snapshot);
 
     const currentPublishedVersion = await loadCurrentPublishedVersion(client, fundId);
-    if (
-      currentPublishedVersion != null &&
-      currentPublishedVersion > response.payload.sourceConfigVersion
-    ) {
-      response.payload.staleness.state = 'STALE_PUBLISH';
-      response.payload.staleness.currentPublishedConfigVersion = currentPublishedVersion;
-    }
-
-    return response;
+    return withReadTimeStaleness(response, currentPublishedVersion);
   });
 }

--- a/server/services/fund-scenario-set-service.ts
+++ b/server/services/fund-scenario-set-service.ts
@@ -246,7 +246,7 @@ export async function insertScenarioSetEvent(
   input: {
     scenarioSetId: string;
     fundId: number;
-    eventType: 'created' | 'updated' | 'archived';
+    eventType: 'created' | 'updated' | 'archived' | 'calculated';
     actor: ReturnType<typeof normalizeActor>;
     changeSummary: Record<string, unknown>;
   }

--- a/server/services/fund-scenario-set-service.ts
+++ b/server/services/fund-scenario-set-service.ts
@@ -276,9 +276,10 @@ export async function insertScenarioSetEvent(
 export async function fetchScenarioSetDetail(
   client: PoolClient,
   fundId: number,
-  scenarioSetId: string
+  scenarioSetId: string,
+  options: { forUpdate?: boolean } = {}
 ): Promise<FundScenarioSetDetailV1> {
-  const summary = await getScenarioSetSummaryOrThrow(client, fundId, scenarioSetId);
+  const summary = await getScenarioSetSummaryOrThrow(client, fundId, scenarioSetId, options);
   const variants = await getScenarioSetVariants(client, scenarioSetId);
   return mapScenarioSetDetail(summary, variants);
 }

--- a/shared/contracts/fund-scenario-sets-v1.contract.ts
+++ b/shared/contracts/fund-scenario-sets-v1.contract.ts
@@ -1,9 +1,9 @@
 /**
  * FundScenarioSetsV1 -- Canonical contract for ADR-022 fund-results scenarios.
  *
- * This first slice persists fund-scoped scenario sets and variants only. It
- * supports fee-profile overrides and intentionally does not calculate scenario
- * results or extend the publish-comparison contract.
+ * This slice persists fund-scoped scenario sets and variants, then supports
+ * sync fee-profile calculation. It intentionally does not extend the
+ * publish-comparison contract.
  *
  * Strict schema: unknown keys are rejected (.strict()).
  *
@@ -11,6 +11,7 @@
  */
 
 import { z } from 'zod';
+import { EconomicsResultV1Schema } from './economics-v1.contract';
 import { FundDraftWriteV1Schema } from './fund-draft-write-v1.contract';
 
 const DateTimeStringSchema = z.string().datetime();
@@ -102,6 +103,47 @@ export const FundScenarioSetListResponseV1Schema = z
   })
   .strict();
 
+export const FundScenarioCalculationStalenessV1Schema = z
+  .object({
+    state: z.enum(['CURRENT', 'STALE_PUBLISH']),
+    sourceConfigVersion: z.number().int().positive(),
+    currentPublishedConfigVersion: z.number().int().positive().nullable(),
+  })
+  .strict();
+
+export const FundScenarioCalculationVariantV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    scenarioSetId: z.string().uuid(),
+    name: z.string(),
+    overrideType: FundScenarioOverrideTypeV1Schema,
+    economics: EconomicsResultV1Schema,
+  })
+  .strict();
+
+export const FundScenarioCalculationPayloadV1Schema = z
+  .object({
+    version: z.literal('fund-scenarios-v1'),
+    calculationMode: z.literal('sync_fee_profile'),
+    fundId: z.number().int().positive(),
+    scenarioSetId: z.string().uuid(),
+    sourceConfigId: z.number().int().positive(),
+    sourceConfigVersion: z.number().int().positive(),
+    staleness: FundScenarioCalculationStalenessV1Schema,
+    calculatedAt: DateTimeStringSchema,
+    variants: z.array(FundScenarioCalculationVariantV1Schema).min(1).max(5),
+  })
+  .strict();
+
+export const FundScenarioCalculationResponseV1Schema = z
+  .object({
+    snapshotId: z.number().int().positive(),
+    correlationId: z.string().uuid(),
+    source: z.literal('fund_snapshots'),
+    payload: FundScenarioCalculationPayloadV1Schema,
+  })
+  .strict();
+
 export type FundScenarioOverrideTypeV1 = z.infer<typeof FundScenarioOverrideTypeV1Schema>;
 export type FundScenarioVariantOverrideV1 = z.infer<typeof FundScenarioVariantOverrideV1Schema>;
 export type CreateFundScenarioVariantV1 = z.infer<typeof CreateFundScenarioVariantV1Schema>;
@@ -110,3 +152,9 @@ export type ArchiveFundScenarioSetV1 = z.infer<typeof ArchiveFundScenarioSetV1Sc
 export type FundScenarioVariantV1 = z.infer<typeof FundScenarioVariantV1Schema>;
 export type FundScenarioSetSummaryV1 = z.infer<typeof FundScenarioSetSummaryV1Schema>;
 export type FundScenarioSetDetailV1 = z.infer<typeof FundScenarioSetDetailV1Schema>;
+export type FundScenarioCalculationPayloadV1 = z.infer<
+  typeof FundScenarioCalculationPayloadV1Schema
+>;
+export type FundScenarioCalculationResponseV1 = z.infer<
+  typeof FundScenarioCalculationResponseV1Schema
+>;

--- a/tests/unit/contract/fund-scenario-sets.test.ts
+++ b/tests/unit/contract/fund-scenario-sets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CreateFundScenarioSetV1Schema,
+  FundScenarioCalculationResponseV1Schema,
   FundScenarioSetDetailV1Schema,
   FundScenarioVariantOverrideV1Schema,
 } from '../../../shared/contracts/fund-scenario-sets-v1.contract';
@@ -102,6 +103,92 @@ describe('FundScenarioSetsV1 contract', () => {
           updatedAt: '2026-05-26T12:00:00.000Z',
         },
       ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('describes persisted sync fee-profile calculation results', () => {
+    const result = FundScenarioCalculationResponseV1Schema.safeParse({
+      snapshotId: 42,
+      correlationId: '00000000-0000-0000-0000-000000000123',
+      source: 'fund_snapshots',
+      payload: {
+        version: 'fund-scenarios-v1',
+        calculationMode: 'sync_fee_profile',
+        fundId: 1,
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+        staleness: {
+          state: 'CURRENT',
+          sourceConfigVersion: 4,
+          currentPublishedConfigVersion: 4,
+        },
+        calculatedAt: '2026-05-26T12:00:00.000Z',
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000112',
+            scenarioSetId: '00000000-0000-0000-0000-000000000111',
+            name: 'Lower fee',
+            overrideType: 'fee_profile',
+            economics: {
+              version: 'v1',
+              annual: [
+                {
+                  year: 1,
+                  lpCapitalCalls: 1,
+                  gpCommitmentCalls: 0,
+                  grossExitProceeds: 0,
+                  beginningCash: 0,
+                  investments: 0,
+                  feesPaidToManager: 1,
+                  expensesPaid: 0,
+                  recycledProceeds: 0,
+                  endingCash: 0,
+                  lpDistributions: 0,
+                  gpInvestmentDistributions: 0,
+                  gpCarryDistributed: 0,
+                  gpCarryEscrowed: 0,
+                  gpCarryReleasedFromEscrow: 0,
+                  clawbackPaid: 0,
+                  grossNav: 0,
+                  lpNetNav: 0,
+                  dpi: 0,
+                  rvpi: 0,
+                  tvpi: 0,
+                  conservationDelta: 0,
+                },
+              ],
+              summary: {
+                grossIrr: null,
+                lpNetIrr: null,
+                gpNetIrr: null,
+                totalLpPaidIn: 1,
+                totalGpCommitmentCalled: 0,
+                totalManagementFees: 1,
+                totalExpenses: 0,
+                totalRecycled: 0,
+                totalLpDistributions: 0,
+                totalGpInvestmentDistributions: 0,
+                totalGpCarryDistributed: 0,
+                totalGpFeeIncome: 1,
+                finalDpi: 0,
+                finalRvpi: 0,
+                finalTvpi: 0,
+                finalClawbackDue: 0,
+                maxEscrowAvailable: 0,
+                netGpCarryAfterClawback: 0,
+              },
+              checks: {
+                passed: true,
+                tolerance: 0.01,
+                errors: [],
+              },
+            },
+          },
+        ],
+      },
     });
 
     expect(result.success).toBe(true);

--- a/tests/unit/phase3/fund-scenario-sets-schema.test.ts
+++ b/tests/unit/phase3/fund-scenario-sets-schema.test.ts
@@ -86,6 +86,15 @@ describe('ADR-022 fund scenario set schema shell', () => {
     expect(migration).toContain('fund_scenario_variants_set_order_unique');
   });
 
+  it('calculation migration adds an audit-visible calculated event type', async () => {
+    const migration = await readRepoFile(
+      'server/db/migrations/0014_fund_scenario_calculated_event.sql'
+    );
+
+    expect(migration).toContain('fund_scenario_set_events_type_check');
+    expect(migration).toContain("'calculated'");
+  });
+
   it('Drizzle fund scenario set indexes mirror the active-row SQL migration indexes', async () => {
     const schema = await import('@shared/schema');
     const config = getTableConfig(schema.fundScenarioSets);

--- a/tests/unit/phase3/fund-scenario-sets-schema.test.ts
+++ b/tests/unit/phase3/fund-scenario-sets-schema.test.ts
@@ -93,6 +93,8 @@ describe('ADR-022 fund scenario set schema shell', () => {
 
     expect(migration).toContain('fund_scenario_set_events_type_check');
     expect(migration).toContain("'calculated'");
+    expect(migration).toContain('fund_snapshots_scenario_set_calculation_unique');
+    expect(migration).toContain("type = 'SCENARIOS'");
   });
 
   it('Drizzle fund scenario set indexes mirror the active-row SQL migration indexes', async () => {

--- a/tests/unit/routes/fund-scenario-sets-route-contract.test.ts
+++ b/tests/unit/routes/fund-scenario-sets-route-contract.test.ts
@@ -13,10 +13,12 @@ describe('fund scenario set route contract', () => {
   it('keeps every fund-scoped scenario-set route protected by auth and fund access', async () => {
     const source = await readRepoFile('server/routes/fund-scenario-sets.ts');
 
-    expect((source.match(/requireAuth\(\)/g) ?? []).length).toBe(4);
-    expect((source.match(/requireFundAccess/g) ?? []).length).toBe(5);
+    expect((source.match(/requireAuth\(\)/g) ?? []).length).toBe(6);
+    expect((source.match(/requireFundAccess/g) ?? []).length).toBe(7);
     expect(source).toContain('getIdempotencyKey(req)');
     expect(source).toContain('/funds/:fundId/scenario-sets');
+    expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/calculate');
+    expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/results');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/archive');
   });
 });

--- a/tests/unit/services/fund-scenario-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-calculation-service.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { transactionMock, queryMock, runEconomicsModelMock } = vi.hoisted(() => ({
+  transactionMock: vi.fn(),
+  queryMock: vi.fn(),
+  runEconomicsModelMock: vi.fn(),
+}));
+
+vi.mock('../../../server/db/pg-circuit.js', () => ({
+  transaction: transactionMock,
+}));
+
+vi.mock('@shared/lib/economics/economics-engine', async () => {
+  const actual = await vi.importActual<typeof import('@shared/lib/economics/economics-engine')>(
+    '@shared/lib/economics/economics-engine'
+  );
+  return {
+    ...actual,
+    runEconomicsModel: runEconomicsModelMock,
+  };
+});
+
+import {
+  calculateFundScenarioSet,
+  getScenarioResults,
+} from '../../../server/services/fund-scenario-calculation-service';
+import type { FundScenarioCalculationPayloadV1 } from '../../../shared/contracts/fund-scenario-sets-v1.contract';
+
+const scenarioSetId = '00000000-0000-0000-0000-000000000111';
+const variantId = '00000000-0000-0000-0000-000000000112';
+const correlationId = '00000000-0000-0000-0000-000000000123';
+
+const feeProfileOverride = {
+  overrideType: 'fee_profile',
+  payload: {
+    feeProfiles: [
+      {
+        id: 'fee-profile-downside',
+        name: 'Lower fees',
+        feeTiers: [
+          {
+            id: 'tier-1',
+            name: 'Management fee',
+            percentage: 1.5,
+            feeBasis: 'committed_capital',
+            startMonth: 0,
+          },
+        ],
+      },
+    ],
+  },
+} as const;
+
+const baseConfig = {
+  fundName: 'Test Fund',
+  fundSize: 100_000_000,
+  vintageYear: 2026,
+  managementFeeRate: 2,
+  carriedInterest: 20,
+  feeProfiles: [
+    {
+      id: 'fee-profile-base',
+      name: 'Base fees',
+      feeTiers: [
+        {
+          id: 'base-tier',
+          name: 'Base management fee',
+          percentage: 2,
+          feeBasis: 'committed_capital',
+          startMonth: 0,
+        },
+      ],
+    },
+  ],
+  economicsAssumptions: {
+    version: 'v1',
+  },
+} as const;
+
+const economicsResult = {
+  version: 'v1',
+  annual: [
+    {
+      year: 1,
+      lpCapitalCalls: 1,
+      gpCommitmentCalls: 0,
+      grossExitProceeds: 0,
+      beginningCash: 0,
+      investments: 0,
+      feesPaidToManager: 1,
+      expensesPaid: 0,
+      recycledProceeds: 0,
+      endingCash: 0,
+      lpDistributions: 0,
+      gpInvestmentDistributions: 0,
+      gpCarryDistributed: 0,
+      gpCarryEscrowed: 0,
+      gpCarryReleasedFromEscrow: 0,
+      clawbackPaid: 0,
+      grossNav: 0,
+      lpNetNav: 0,
+      dpi: 0,
+      rvpi: 0,
+      tvpi: 0,
+      conservationDelta: 0,
+    },
+  ],
+  summary: {
+    grossIrr: null,
+    lpNetIrr: null,
+    gpNetIrr: null,
+    totalLpPaidIn: 1,
+    totalGpCommitmentCalled: 0,
+    totalManagementFees: 1,
+    totalExpenses: 0,
+    totalRecycled: 0,
+    totalLpDistributions: 0,
+    totalGpInvestmentDistributions: 0,
+    totalGpCarryDistributed: 0,
+    totalGpFeeIncome: 1,
+    finalDpi: 0,
+    finalRvpi: 0,
+    finalTvpi: 0,
+    finalClawbackDue: 0,
+    maxEscrowAvailable: 0,
+    netGpCarryAfterClawback: 0,
+  },
+  checks: {
+    passed: true,
+    tolerance: 0.01,
+    errors: [],
+  },
+} as const;
+
+function scenarioSetRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: scenarioSetId,
+    fund_id: 1,
+    name: 'Fee sensitivity',
+    description: null,
+    source_config_id: 12,
+    source_config_version: 4,
+    created_by_user_id: 17,
+    created_by_label: 'analyst@example.com',
+    updated_by_user_id: 17,
+    updated_by_label: 'analyst@example.com',
+    archived_at: null,
+    archived_by_user_id: null,
+    archived_by_label: null,
+    created_at: new Date('2026-05-26T12:00:00.000Z'),
+    updated_at: new Date('2026-05-26T12:00:00.000Z'),
+    variant_count: '1',
+    ...overrides,
+  };
+}
+
+function variantRow() {
+  return {
+    id: variantId,
+    scenario_set_id: scenarioSetId,
+    name: 'Lower fee',
+    description: null,
+    sort_order: 0,
+    override_type: 'fee_profile',
+    override_payload: feeProfileOverride.payload,
+    created_at: new Date('2026-05-26T12:00:00.000Z'),
+    updated_at: new Date('2026-05-26T12:00:00.000Z'),
+  };
+}
+
+function snapshotPayload(): FundScenarioCalculationPayloadV1 {
+  return {
+    version: 'fund-scenarios-v1',
+    calculationMode: 'sync_fee_profile',
+    fundId: 1,
+    scenarioSetId,
+    sourceConfigId: 12,
+    sourceConfigVersion: 4,
+    staleness: {
+      state: 'CURRENT',
+      sourceConfigVersion: 4,
+      currentPublishedConfigVersion: 4,
+    },
+    calculatedAt: '2026-05-26T12:05:00.000Z',
+    variants: [
+      {
+        variantId,
+        scenarioSetId,
+        name: 'Lower fee',
+        overrideType: 'fee_profile',
+        economics: economicsResult,
+      },
+    ],
+  };
+}
+
+describe('fund scenario calculation service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transactionMock.mockImplementation(
+      async (callback: (client: { query: typeof queryMock }) => unknown) =>
+        callback({ query: queryMock })
+    );
+    runEconomicsModelMock.mockReturnValue(economicsResult);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('applies fee-profile overrides, persists a scenario snapshot, and records an audit event', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config: baseConfig }] })
+      .mockResolvedValueOnce({ rows: [{ version: 4 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockImplementationOnce((_sql: string, params: unknown[]) => ({
+        rows: [
+          {
+            id: 42,
+            payload: params[1],
+            correlation_id: params[3],
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      }))
+      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000124' }] });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId, {
+      userId: 17,
+      label: 'analyst@example.com',
+    });
+
+    expect(result.snapshotId).toBe(42);
+    expect(result.source).toBe('fund_snapshots');
+    expect(result.payload.variants[0]?.economics.summary.totalManagementFees).toBe(1);
+    expect(runEconomicsModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fundName: 'Test Fund',
+        feeProfiles: feeProfileOverride.payload.feeProfiles,
+      })
+    );
+    expect(queryMock.mock.calls[6]?.[0]).toContain("VALUES ($1, 'SCENARIOS'");
+    expect(queryMock.mock.calls[6]?.[0]).toContain('scenario_set_id');
+    expect(queryMock.mock.calls[6]?.[1]?.[7]).toBe(scenarioSetId);
+    expect(queryMock.mock.calls[7]?.[0]).toContain('INSERT INTO fund_scenario_set_events');
+    expect(queryMock.mock.calls[7]?.[1]).toEqual([
+      scenarioSetId,
+      1,
+      'calculated',
+      17,
+      'analyst@example.com',
+      expect.objectContaining({
+        headline: 'Calculated fee-profile scenario set',
+        snapshot_id: 42,
+        variant_count: 1,
+      }),
+    ]);
+  });
+
+  it('returns an existing matching scenario snapshot without recalculating', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config: baseConfig }] })
+      .mockResolvedValueOnce({ rows: [{ version: 4 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 42,
+            payload: snapshotPayload(),
+            correlation_id: correlationId,
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId);
+
+    expect(result.snapshotId).toBe(42);
+    expect(result.correlationId).toBe(correlationId);
+    expect(runEconomicsModelMock).not.toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledTimes(6);
+  });
+
+  it('rejects calculation when the scenario set is archived', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow({ archived_at: '2026-05-26T13:00:00Z' })] })
+      .mockResolvedValueOnce({ rows: [variantRow()] });
+
+    await expect(calculateFundScenarioSet(1, scenarioSetId)).rejects.toThrow(/archived/i);
+  });
+
+  it('rejects calculation when the source config is missing', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(calculateFundScenarioSet(1, scenarioSetId)).rejects.toThrow(
+      /source config.*could not be loaded/i
+    );
+  });
+
+  it('computes STALE_PUBLISH staleness when published version exceeds source', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config: baseConfig }] })
+      .mockResolvedValueOnce({ rows: [{ version: 7 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockImplementationOnce((_sql: string, params: unknown[]) => ({
+        rows: [
+          {
+            id: 55,
+            payload: params[1],
+            correlation_id: params[3],
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      }))
+      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000125' }] });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId);
+
+    expect(result.payload.staleness.state).toBe('STALE_PUBLISH');
+    expect(result.payload.staleness.currentPublishedConfigVersion).toBe(7);
+    expect(result.payload.staleness.sourceConfigVersion).toBe(4);
+  });
+
+  it('getScenarioResults returns the latest snapshot for a set', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 42,
+            payload: snapshotPayload(),
+            correlation_id: correlationId,
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ version: 4 }] });
+
+    const result = await getScenarioResults(1, scenarioSetId);
+
+    expect(result).not.toBeNull();
+    expect(result!.snapshotId).toBe(42);
+    expect(result!.payload.staleness.state).toBe('CURRENT');
+  });
+
+  it('getScenarioResults returns null when no snapshot exists', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getScenarioResults(1, scenarioSetId);
+
+    expect(result).toBeNull();
+  });
+
+  it('getScenarioResults patches staleness to STALE_PUBLISH at read time', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 42,
+            payload: snapshotPayload(),
+            correlation_id: correlationId,
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ version: 9 }] });
+
+    const result = await getScenarioResults(1, scenarioSetId);
+
+    expect(result).not.toBeNull();
+    expect(result!.payload.staleness.state).toBe('STALE_PUBLISH');
+    expect(result!.payload.staleness.currentPublishedConfigVersion).toBe(9);
+  });
+});

--- a/tests/unit/services/fund-scenario-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-calculation-service.test.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { transactionMock, queryMock, runEconomicsModelMock } = vi.hoisted(() => ({
@@ -74,6 +75,59 @@ const baseConfig = {
   ],
   economicsAssumptions: {
     version: 'v1',
+  },
+} as const;
+
+const explicitFeeTierEconomicsAssumptions = {
+  version: 'v1',
+  timeline: {
+    fundLifeYears: 10,
+    period: 'annual',
+    vintageYear: 2026,
+  },
+  feeModel: {
+    source: 'economics_override',
+    tiers: [
+      {
+        id: 'base-fee-tier',
+        name: 'Base explicit fee',
+        rate: 0.02,
+        basis: 'committed_capital',
+        startYear: 1,
+      },
+    ],
+  },
+  exitModel: {
+    mode: 'cohort',
+    cohort: {
+      exitDistributionByYear: [0, 0, 0, 0, 0.2, 0.2, 0.2, 0.2, 0.1, 0.1],
+      grossMultiple: 2.5,
+      lossRatio: 0,
+    },
+  },
+  recyclingModel: {
+    enabled: false,
+    sources: ['exit_proceeds'],
+    capPctOfCommitments: 0,
+    timing: 'before_waterfall',
+  },
+  waterfallModel: {
+    type: 'american',
+    carryPct: 0.2,
+    hurdleRate: 0.08,
+    prefType: 'compounded',
+    prefCompounding: 'annual',
+    prefCatchUp: true,
+    catchUpRate: 1,
+    catchUpTargetCarryPct: 0.2,
+    clawbackEnabled: true,
+    clawbackTrigger: 'final_liquidation',
+    escrowPct: 0,
+    feeOffsetTreatment: 'none',
+  },
+  gpCommitmentModel: {
+    commitmentAmount: 10_000_000,
+    participatesInInvestmentReturns: true,
   },
 } as const;
 
@@ -194,6 +248,26 @@ function snapshotPayload(): FundScenarioCalculationPayloadV1 {
   };
 }
 
+function expectedInputHash(): string {
+  return crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify({
+        scenarioSetId,
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+        calcVersion: 'fund-scenarios-v1',
+        variants: [
+          {
+            id: variantId,
+            override: feeProfileOverride,
+          },
+        ],
+      })
+    )
+    .digest('hex');
+}
+
 describe('fund scenario calculation service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -241,10 +315,15 @@ describe('fund scenario calculation service', () => {
       expect.objectContaining({
         fundName: 'Test Fund',
         feeProfiles: feeProfileOverride.payload.feeProfiles,
+        economicsAssumptions: expect.objectContaining({
+          feeModel: { source: 'legacy_fee_profiles' },
+        }),
       })
     );
+    expect(queryMock.mock.calls[1]?.[0]).toContain('FOR UPDATE OF s');
     expect(queryMock.mock.calls[6]?.[0]).toContain("VALUES ($1, 'SCENARIOS'");
     expect(queryMock.mock.calls[6]?.[0]).toContain('scenario_set_id');
+    expect(queryMock.mock.calls[6]?.[0]).toContain('ON CONFLICT (fund_id, scenario_set_id)');
     expect(queryMock.mock.calls[6]?.[1]?.[7]).toBe(scenarioSetId);
     expect(queryMock.mock.calls[7]?.[0]).toContain('INSERT INTO fund_scenario_set_events');
     expect(queryMock.mock.calls[7]?.[1]).toEqual([
@@ -286,6 +365,79 @@ describe('fund scenario calculation service', () => {
     expect(result.correlationId).toBe(correlationId);
     expect(runEconomicsModelMock).not.toHaveBeenCalled();
     expect(queryMock).toHaveBeenCalledTimes(6);
+  });
+
+  it('reuses the calculation hash across publish staleness changes', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config: baseConfig }] })
+      .mockResolvedValueOnce({ rows: [{ version: 9 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 42,
+            payload: snapshotPayload(),
+            correlation_id: correlationId,
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId);
+    const reusableLookupParams = queryMock.mock.calls[5]?.[1] as unknown[];
+
+    expect(reusableLookupParams[5]).toBe(expectedInputHash());
+    expect(result.payload.staleness.state).toBe('STALE_PUBLISH');
+    expect(result.payload.staleness.currentPublishedConfigVersion).toBe(9);
+    expect(runEconomicsModelMock).not.toHaveBeenCalled();
+  });
+
+  it('uses fee-profile overrides with the real economics engine when source configs have explicit fee tiers', async () => {
+    const actualEconomics = await vi.importActual<
+      typeof import('@shared/lib/economics/economics-engine')
+    >('@shared/lib/economics/economics-engine');
+    runEconomicsModelMock.mockImplementation(actualEconomics.runEconomicsModel);
+
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [variantRow()] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 12,
+            version: 4,
+            config: {
+              ...baseConfig,
+              fundLife: 10,
+              investmentPeriod: 5,
+              gpCommitment: 10_000_000,
+              economicsAssumptions: explicitFeeTierEconomicsAssumptions,
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ version: 4 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockImplementationOnce((_sql: string, params: unknown[]) => ({
+        rows: [
+          {
+            id: 57,
+            payload: params[1],
+            correlation_id: params[3],
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      }))
+      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000126' }] });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId);
+
+    expect(result.payload.variants[0]?.economics.summary.totalManagementFees).toBe(15_000_000);
   });
 
   it('rejects calculation when the scenario set is archived', async () => {


### PR DESCRIPTION
## Summary

PR D of the ADR-022 scenario architecture (follows #711, #710, #708).

- Add `POST /funds/:fundId/scenario-sets/:setId/calculate` -- sync fee-profile calculation that runs the economics engine per variant with overridden fee profiles, writes a single `SCENARIOS` snapshot row with `scenarioSetId`, and records a `calculated` audit event
- Add `GET /funds/:fundId/scenario-sets/:setId/results` -- read-only endpoint that returns the latest scenario results with read-time staleness detection (`CURRENT` vs `STALE_PUBLISH`)
- Add strict Zod contracts: `FundScenarioCalculationPayloadV1Schema`, `FundScenarioCalculationResponseV1Schema`, `FundScenarioCalculationStalenessV1Schema`
- Migration 0014: extend event type check constraint to include `calculated`
- Idempotent snapshot reuse via input hash (no recalculation on repeat POST)

## ADR-022 Compliance

- [x] Sync path for fee-only overrides with 10s deadline guard (section 5)
- [x] First override type: fee_profile only (section 9)
- [x] Same economics engine with overrides on inputs, not code paths (section 5)
- [x] Snapshot type `SCENARIOS` with `scenarioSetId` populated (section 2)
- [x] Route-local `requireAuth()` + `requireFundAccess` on both endpoints (section 4)
- [x] Audit event with actor attribution (section 4)
- [x] Does NOT modify `fund-results-v1.contract.ts` -- scenarios section stays unavailable (section 7)
- [x] Authoritative-read isolation preserved -- merge gate grep confirms all existing readers filter `scenarioSetId IS NULL`
- [x] No Phoenix protected docs modified

## Verification

- `npm run check` -- PASS (0 TS errors)
- `npm run lint` -- PASS
- 18 focused tests -- PASS (contract: 5, schema: 5, route: 1, service: 8)
- `git diff --check` -- clean
- Merge gate: `git grep "fund_snapshots\|fundSnapshots" -- server/ shared/` -- all readers either filter `scenarioSetId IS NULL` or are the new scoped scenario reader

## Test plan

- [x] Calculate endpoint applies fee overrides per variant and persists snapshot
- [x] Idempotent reuse returns cached snapshot without recalculating
- [x] Archived scenario set rejected with 409
- [x] Missing source config rejected with 409
- [x] STALE_PUBLISH computed when published version > source version
- [x] GET results returns latest snapshot with CURRENT staleness
- [x] GET results returns null/404 when no snapshot exists
- [x] GET results patches staleness to STALE_PUBLISH at read time

## Hermes Handoff

```
Phase: production
Owner: Codex (initial) + Claude (review + gap fill)
Gate: npm run check (PASS), npm run lint (PASS)
Next: PR E (scenario comparison UI or fund-results section wiring)
```

Refs: ADR-022, ADR-014