### PR TITLE
feat(scenarios): enable scenario provenance and reserve calculation

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -22,6 +22,7 @@ exclude_paths:
   # SET directives that would make the migration invalid.
   - 'server/db/migrations/0012_scenario_set_id.sql'
   - 'server/db/migrations/0013_fund_scenario_sets.sql'
+  - 'server/db/migrations/0015_fund_scenario_reserve_allocation.sql'
   - '**/*.test.ts'
   - '**/*.test.tsx'
   - '**/*.spec.ts'

--- a/client/src/components/fund-results/ScenarioSetsSummary.tsx
+++ b/client/src/components/fund-results/ScenarioSetsSummary.tsx
@@ -8,11 +8,16 @@
  */
 
 import React from 'react';
-import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
+import { ScenarioEvidenceHeader } from '@/components/results/ScenarioEvidenceHeader';
+import {
+  aggregateScenarioEvidenceCopy,
+  aggregateScenarioEvidenceState,
+  scenarioEvidenceFromSet,
+  type ScenarioEvidenceSourceV1,
+} from '@/components/results/scenario-evidence';
 import type {
-  FundScenarioResultStalenessStateV1,
   ScenariosSectionPayloadV1,
+  ScenarioSetVariantResultSummaryV1,
   ScenarioSetResultSummaryV1,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 
@@ -24,20 +29,18 @@ interface ScenarioSetCardProps {
   set: ScenarioSetResultSummaryV1;
 }
 
-const STALENESS_LABELS: Record<FundScenarioResultStalenessStateV1, string> = {
-  CURRENT: 'Current',
-  STALE_PUBLISH: 'Needs recalculation',
-  STALE_CONFIG: 'Review overrides',
-};
-
-const STALENESS_BADGES: Record<FundScenarioResultStalenessStateV1, string> = {
-  CURRENT: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  STALE_PUBLISH: 'border-amber-200 bg-amber-50 text-amber-700',
-  STALE_CONFIG: 'border-red-200 bg-red-50 text-red-700',
-};
-
 function formatMultiple(value: number): string {
   return `${value.toFixed(2)}x`;
+}
+
+function formatCurrencyFromCents(value: number): string {
+  const sign = value < 0 ? '-' : '';
+  const formatted = new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(Math.abs(value) / 100);
+  return `${sign}${formatted}`;
 }
 
 function formatDate(value: string): string {
@@ -52,69 +55,174 @@ function variantCountLabel(count: number): string {
   return count === 1 ? '1 variant' : `${count} variants`;
 }
 
-function topTvpiVariant(set: ScenarioSetResultSummaryV1) {
-  return set.variants.reduce((top, variant) =>
-    variant.economicsSummary.finalTvpi > top.economicsSummary.finalTvpi ? variant : top
-  );
+function isFeeProfileVariant(
+  variant: ScenarioSetVariantResultSummaryV1
+): variant is Extract<ScenarioSetVariantResultSummaryV1, { overrideType: 'fee_profile' }> {
+  return variant.overrideType === 'fee_profile';
 }
 
-function ScenarioSetsHeader({ payload }: ScenarioSetsSummaryProps) {
+function topTvpiVariant(set: ScenarioSetResultSummaryV1) {
+  const feeVariants = set.variants.filter(isFeeProfileVariant);
+  const first = feeVariants[0];
+  if (!first) {
+    return null;
+  }
+
+  return feeVariants
+    .slice(1)
+    .reduce(
+      (top, variant) =>
+        variant.economicsSummary.finalTvpi > top.economicsSummary.finalTvpi ? variant : top,
+      first
+    );
+}
+
+function ScenarioSetsHeader({
+  payload,
+  aggregateEvidence,
+}: ScenarioSetsSummaryProps & { aggregateEvidence: ScenarioEvidenceSourceV1 | null }) {
   return (
-    <div className="flex flex-wrap items-center gap-3">
-      <Badge
-        variant="outline"
-        className={cn('border text-xs font-medium', STALENESS_BADGES[payload.aggregateStaleness])}
-      >
-        {STALENESS_LABELS[payload.aggregateStaleness]}
-      </Badge>
+    <div className="space-y-3">
       <span className="font-poppins text-sm text-charcoal-500">
         {payload.sets.length === 1 ? '1 scenario set' : `${payload.sets.length} scenario sets`}
       </span>
+      {aggregateEvidence ? (
+        <ScenarioEvidenceHeader evidence={aggregateEvidence} testId="scenario-evidence-aggregate" />
+      ) : null}
+    </div>
+  );
+}
+
+function FeeProfileScenarioMetrics({ set }: { set: ScenarioSetResultSummaryV1 }) {
+  const topVariant = topTvpiVariant(set);
+  if (!topVariant) {
+    return null;
+  }
+
+  return (
+    <div className="mt-5 grid grid-cols-2 gap-3">
+      <div>
+        <p className="font-poppins text-xs uppercase text-charcoal-400">Best TVPI</p>
+        <p className="mt-1 font-inter text-2xl font-semibold text-charcoal">
+          {formatMultiple(topVariant.economicsSummary.finalTvpi)}
+        </p>
+        <p className="mt-1 font-poppins text-xs text-charcoal-500">{topVariant.name}</p>
+      </div>
+      <div>
+        <p className="font-poppins text-xs uppercase text-charcoal-400">Calculated</p>
+        <p className="mt-1 font-poppins text-sm text-charcoal">{formatDate(set.calculatedAt)}</p>
+      </div>
+    </div>
+  );
+}
+
+function ReserveScenarioMetrics({ set }: { set: ScenarioSetResultSummaryV1 }) {
+  const reserveVariant = set.variants.find(
+    (
+      variant
+    ): variant is Extract<
+      ScenarioSetVariantResultSummaryV1,
+      { overrideType: 'reserve_allocation' }
+    > => variant.overrideType === 'reserve_allocation'
+  );
+
+  if (!reserveVariant) {
+    return null;
+  }
+
+  return (
+    <div className="mt-5 grid grid-cols-2 gap-3">
+      <div>
+        <p className="font-poppins text-xs uppercase text-charcoal-400">
+          Total scenario allocation
+        </p>
+        <p className="mt-1 font-inter text-2xl font-semibold text-charcoal">
+          {formatCurrencyFromCents(reserveVariant.reserveSummary.totalScenarioAllocationCents)}
+        </p>
+      </div>
+      <div>
+        <p className="font-poppins text-xs uppercase text-charcoal-400">Allocation delta</p>
+        <p className="mt-1 font-inter text-2xl font-semibold text-charcoal">
+          {formatCurrencyFromCents(reserveVariant.reserveSummary.totalAllocationDeltaCents)}
+        </p>
+      </div>
+      <div>
+        <p className="font-poppins text-xs uppercase text-charcoal-400">Avg confidence</p>
+        <p className="mt-1 font-poppins text-sm text-charcoal">
+          {(reserveVariant.reserveSummary.avgConfidence * 100).toFixed(0)}%
+        </p>
+      </div>
+      <div>
+        <p className="font-poppins text-xs uppercase text-charcoal-400">High-confidence count</p>
+        <p className="mt-1 font-poppins text-sm text-charcoal">
+          {reserveVariant.reserveSummary.highConfidenceCount}
+        </p>
+      </div>
+      <div>
+        <p className="font-poppins text-xs uppercase text-charcoal-400">Warnings</p>
+        <p className="mt-1 font-poppins text-sm text-charcoal">
+          {reserveVariant.reserveSummary.warningCount}
+        </p>
+      </div>
     </div>
   );
 }
 
 function ScenarioSetCard({ set }: ScenarioSetCardProps) {
-  const topVariant = topTvpiVariant(set);
+  const evidence = scenarioEvidenceFromSet(set);
+  const primaryType = set.variants[0]?.overrideType;
 
   return (
     <article className="rounded-md border border-beige-200 bg-white p-4">
-      <div className="flex items-start justify-between gap-4">
+      <div className="space-y-3">
         <div>
           <h3 className="font-inter text-base font-semibold text-charcoal">{set.name}</h3>
           <p className="mt-1 font-poppins text-sm text-charcoal-500">
             {variantCountLabel(set.variantCount)} · Source config v{set.sourceConfigVersion}
           </p>
         </div>
-        <Badge
-          variant="outline"
-          className={cn('shrink-0 border text-xs font-medium', STALENESS_BADGES[set.staleness])}
-        >
-          {STALENESS_LABELS[set.staleness]}
-        </Badge>
+        <ScenarioEvidenceHeader
+          evidence={evidence}
+          testId={`scenario-evidence-${set.scenarioSetId}`}
+        />
       </div>
 
-      <div className="mt-5 grid grid-cols-2 gap-3">
-        <div>
-          <p className="font-poppins text-xs uppercase text-charcoal-400">Best TVPI</p>
-          <p className="mt-1 font-inter text-2xl font-semibold text-charcoal">
-            {formatMultiple(topVariant.economicsSummary.finalTvpi)}
-          </p>
-          <p className="mt-1 font-poppins text-xs text-charcoal-500">{topVariant.name}</p>
-        </div>
-        <div>
-          <p className="font-poppins text-xs uppercase text-charcoal-400">Calculated</p>
-          <p className="mt-1 font-poppins text-sm text-charcoal">{formatDate(set.calculatedAt)}</p>
-        </div>
-      </div>
+      {primaryType === 'reserve_allocation' ? (
+        <ReserveScenarioMetrics set={set} />
+      ) : (
+        <FeeProfileScenarioMetrics set={set} />
+      )}
     </article>
   );
 }
 
 export function ScenarioSetsSummary({ payload }: ScenarioSetsSummaryProps) {
+  const evidenceItems = payload.sets.map(scenarioEvidenceFromSet);
+  const aggregateState = aggregateScenarioEvidenceState(evidenceItems.map((item) => item.state));
+  const latestCalculatedAt =
+    evidenceItems
+      .map((item) => item.calculatedAt)
+      .filter((value): value is string => value !== null)
+      .sort()
+      .reverse()[0] ?? null;
+  const aggregateEvidence: ScenarioEvidenceSourceV1 | null =
+    aggregateState === 'CURRENT'
+      ? null
+      : {
+          scenarioSetId: null,
+          scenarioSetName: null,
+          calculationMode: null,
+          sourceConfigVersion: null,
+          currentPublishedConfigVersion: null,
+          calculatedAt: latestCalculatedAt,
+          source: 'fund_snapshots',
+          state: aggregateState,
+          reason: aggregateScenarioEvidenceCopy(aggregateState),
+        };
+
   return (
     <div className="space-y-4" data-testid="scenario-sets-summary">
-      <ScenarioSetsHeader payload={payload} />
+      <ScenarioSetsHeader payload={payload} aggregateEvidence={aggregateEvidence} />
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {payload.sets.map((set) => (
           <ScenarioSetCard key={set.scenarioSetId} set={set} />

--- a/client/src/components/results/ScenarioEvidenceHeader.tsx
+++ b/client/src/components/results/ScenarioEvidenceHeader.tsx
@@ -1,0 +1,116 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { ScenarioEvidenceStateV1 } from '@shared/contracts/fund-scenario-sets-v1.contract';
+import type { ScenarioEvidenceSourceV1 } from './scenario-evidence';
+
+interface ScenarioEvidenceHeaderProps {
+  evidence: ScenarioEvidenceSourceV1;
+  className?: string;
+  testId?: string;
+}
+
+function scenarioStatusClasses(state: ScenarioEvidenceStateV1): string {
+  switch (state) {
+    case 'CURRENT':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+    case 'STALE_PUBLISH':
+    case 'CALCULATING':
+      return 'border-amber-200 bg-amber-50 text-amber-800';
+    case 'STALE_CONFIG':
+    case 'FAILED':
+      return 'border-rose-200 bg-rose-50 text-rose-800';
+    case 'UNAVAILABLE':
+      return 'border-beige-200 bg-beige-50 text-charcoal-500';
+  }
+}
+
+function scenarioEvidenceExplanation(state: ScenarioEvidenceStateV1): string {
+  switch (state) {
+    case 'CURRENT':
+      return 'Scenario results were calculated against the current published configuration.';
+    case 'STALE_PUBLISH':
+      return 'A newer configuration has been published since this scenario was calculated.';
+    case 'STALE_CONFIG':
+      return 'Scenario overrides reference entities that are no longer valid in the current configuration.';
+    case 'CALCULATING':
+      return 'Scenario calculation is in progress.';
+    case 'FAILED':
+      return 'Scenario calculation failed.';
+    case 'UNAVAILABLE':
+      return 'Scenario evidence is unavailable.';
+  }
+}
+
+function shortScenarioId(value: string | null): string {
+  if (!value) return 'UNAVAILABLE';
+  return value.length <= 8 ? value : value.slice(0, 8);
+}
+
+function formatVersion(label: string, value: number | null): string {
+  return value == null ? `${label} UNAVAILABLE` : `${label} v${value}`;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'CALCULATED UNAVAILABLE';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'CALCULATED UNAVAILABLE';
+
+  return `CALCULATED ${new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(date)}`;
+}
+
+function evidenceSegments(evidence: ScenarioEvidenceSourceV1): string[] {
+  return [
+    `SCENARIO ${shortScenarioId(evidence.scenarioSetId)}`,
+    formatVersion('SOURCE CONFIG', evidence.sourceConfigVersion),
+    formatVersion('PUBLISHED CONFIG', evidence.currentPublishedConfigVersion),
+    formatTimestamp(evidence.calculatedAt),
+    `SOURCE ${evidence.source ?? 'UNAVAILABLE'}`,
+  ];
+}
+
+export function ScenarioEvidenceHeader({
+  evidence,
+  className,
+  testId,
+}: ScenarioEvidenceHeaderProps) {
+  const explanation = evidence.reason ?? scenarioEvidenceExplanation(evidence.state);
+  const segments = evidenceSegments(evidence);
+
+  return (
+    <div
+      aria-label={`Scenario evidence: ${explanation}`}
+      className={cn(
+        'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs font-poppins uppercase text-charcoal-500',
+        className
+      )}
+      data-testid={testId}
+    >
+      <Badge
+        variant="outline"
+        className={cn('font-poppins uppercase', scenarioStatusClasses(evidence.state))}
+        title={explanation}
+        aria-label={explanation}
+      >
+        {evidence.state}
+      </Badge>
+      {segments.map((segment) => (
+        <span key={segment} className="inline-flex min-w-0 items-center gap-2">
+          <span aria-hidden="true" className="text-charcoal-300">
+            /
+          </span>
+          <span className="truncate">{segment}</span>
+        </span>
+      ))}
+      {evidence.reason ? (
+        <span className="basis-full normal-case text-charcoal-500">{evidence.reason}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/components/results/scenario-evidence.ts
+++ b/client/src/components/results/scenario-evidence.ts
@@ -1,0 +1,67 @@
+import type {
+  ScenarioEvidenceStateV1,
+  ScenarioSetResultSummaryV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+
+export interface ScenarioEvidenceSourceV1 {
+  scenarioSetId: string | null;
+  scenarioSetName: string | null;
+  calculationMode: string | null;
+  sourceConfigVersion: number | null;
+  currentPublishedConfigVersion: number | null;
+  calculatedAt: string | null;
+  source: 'fund_snapshots' | null;
+  state: ScenarioEvidenceStateV1;
+  reason?: string | null;
+}
+
+const SCENARIO_EVIDENCE_PRECEDENCE: Record<ScenarioEvidenceStateV1, number> = {
+  CURRENT: 0,
+  UNAVAILABLE: 1,
+  CALCULATING: 2,
+  STALE_PUBLISH: 3,
+  STALE_CONFIG: 4,
+  FAILED: 5,
+};
+
+export function scenarioEvidenceFromSet(set: ScenarioSetResultSummaryV1): ScenarioEvidenceSourceV1 {
+  return {
+    scenarioSetId: set.scenarioSetId,
+    scenarioSetName: set.name,
+    calculationMode: null,
+    sourceConfigVersion: set.sourceConfigVersion,
+    currentPublishedConfigVersion: set.currentPublishedConfigVersion,
+    calculatedAt: set.calculatedAt,
+    source: 'fund_snapshots',
+    state: set.staleness,
+  };
+}
+
+export function aggregateScenarioEvidenceState(
+  states: ScenarioEvidenceStateV1[]
+): ScenarioEvidenceStateV1 {
+  if (states.length === 0) {
+    return 'UNAVAILABLE';
+  }
+
+  return states.reduce((worst, next) =>
+    SCENARIO_EVIDENCE_PRECEDENCE[next] > SCENARIO_EVIDENCE_PRECEDENCE[worst] ? next : worst
+  );
+}
+
+export function aggregateScenarioEvidenceCopy(state: ScenarioEvidenceStateV1): string {
+  switch (state) {
+    case 'FAILED':
+      return 'One or more scenario calculations failed.';
+    case 'STALE_CONFIG':
+      return 'One or more scenarios reference configuration entities that may no longer be valid.';
+    case 'STALE_PUBLISH':
+      return 'One or more scenario results are stale relative to the latest published configuration.';
+    case 'CALCULATING':
+      return 'One or more scenario calculations are still in progress.';
+    case 'UNAVAILABLE':
+      return 'Scenario evidence is unavailable for one or more scenario sets.';
+    case 'CURRENT':
+      return 'All scenario results are current.';
+  }
+}

--- a/server/db/migrations/0015_fund_scenario_reserve_allocation.sql
+++ b/server/db/migrations/0015_fund_scenario_reserve_allocation.sql
@@ -1,0 +1,28 @@
+-- 0015_fund_scenario_reserve_allocation.sql
+-- ADR-022: add reserve-allocation scenario contract support and async lifecycle events.
+
+BEGIN;
+
+ALTER TABLE fund_scenario_variants
+  DROP CONSTRAINT IF EXISTS fund_scenario_variants_override_type_check;
+
+ALTER TABLE fund_scenario_variants
+  ADD CONSTRAINT fund_scenario_variants_override_type_check
+  CHECK (override_type IN ('fee_profile', 'reserve_allocation'));
+
+ALTER TABLE fund_scenario_set_events
+  DROP CONSTRAINT IF EXISTS fund_scenario_set_events_type_check;
+
+ALTER TABLE fund_scenario_set_events
+  ADD CONSTRAINT fund_scenario_set_events_type_check
+  CHECK (event_type IN (
+    'created',
+    'updated',
+    'archived',
+    'calculated',
+    'calculation_queued',
+    'calculation_started',
+    'calculation_failed'
+  ));
+
+COMMIT;

--- a/server/queues/registry.ts
+++ b/server/queues/registry.ts
@@ -6,6 +6,7 @@ export type QueueRegistryKey =
   | 'report'
   | 'backtesting'
   | 'reserve-calc'
+  | 'fund-scenario-calc'
   | 'pacing-calc'
   | 'cohort-calc'
   | 'economics-calc';
@@ -57,6 +58,14 @@ export const QUEUE_CATALOG: readonly QueueCatalogEntry[] = [
     healthMode: 'producer',
     owner: 'route',
     fundCalculationAuthority: 'authoritative',
+  },
+  {
+    key: 'fund-scenario-calc',
+    queueName: 'fund-scenario-calc',
+    displayName: 'Fund Scenario Calculations',
+    healthMode: 'producer',
+    owner: 'route',
+    fundCalculationAuthority: 'experimental',
   },
   {
     key: 'pacing-calc',

--- a/server/routes/fund-scenario-sets.ts
+++ b/server/routes/fund-scenario-sets.ts
@@ -1,8 +1,10 @@
 import { Router, type NextFunction, type Request, type Response } from 'express';
+import crypto from 'node:crypto';
 import { z } from 'zod';
 import {
   ArchiveFundScenarioSetV1Schema,
   CreateFundScenarioSetV1Schema,
+  FundScenarioReserveCalculationRequestV1Schema,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
 import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
@@ -18,6 +20,8 @@ import {
   calculateFundScenarioSet,
   getScenarioResults,
 } from '../services/fund-scenario-calculation-service.js';
+import { enqueueReserveScenarioCalculation } from '../services/fund-scenario-calc-queue-service.js';
+import { getFundScenarioCalculationStatus } from '../services/fund-scenario-calculation-status-service.js';
 
 interface HttpError extends Error {
   statusCode?: number;
@@ -189,6 +193,49 @@ router.post(
 
     const result = await calculateFundScenarioSet(fundId, scenarioSetId, parseActor(req));
     return res.status(200).json(result);
+  })
+);
+
+router.post(
+  '/funds/:fundId/scenario-sets/:scenarioSetId/calculate-reserve',
+  requireAuth(),
+  requireFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseFundId(req, res);
+    const scenarioSetId = parseScenarioSetId(req, res);
+    if (fundId === null || scenarioSetId === null) {
+      return;
+    }
+
+    const parsed = FundScenarioReserveCalculationRequestV1Schema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      sendBodyValidationError(res, parsed.error, 'Invalid reserve scenario calculation payload');
+      return;
+    }
+
+    const queued = await enqueueReserveScenarioCalculation({
+      fundId,
+      scenarioSetId,
+      correlationId: crypto.randomUUID(),
+      actor: parseActor(req),
+    });
+    return res.status(202).json(queued);
+  })
+);
+
+router.get(
+  '/funds/:fundId/scenario-sets/:scenarioSetId/calculation-status',
+  requireAuth(),
+  requireFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseFundId(req, res);
+    const scenarioSetId = parseScenarioSetId(req, res);
+    if (fundId === null || scenarioSetId === null) {
+      return;
+    }
+
+    const status = await getFundScenarioCalculationStatus(fundId, scenarioSetId);
+    return res.status(200).json(status);
   })
 );
 

--- a/server/services/fund-scenario-calc-queue-service.ts
+++ b/server/services/fund-scenario-calc-queue-service.ts
@@ -1,0 +1,104 @@
+import { Queue } from 'bullmq';
+import { getQueueConfig, getQueueConnectionOptions } from '../config/features';
+import { registerQueueRuntime } from '../queues/registry';
+import { transaction } from '../db/pg-circuit.js';
+import {
+  FundScenarioReserveCalculationQueuedV1Schema,
+  type FundScenarioReserveCalculationQueuedV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import { getReserveScenarioCalculationIdentity } from './fund-scenario-reserve-calculation-service.js';
+import {
+  createHttpError,
+  insertScenarioSetEvent,
+  normalizeActor,
+  type FundScenarioMutationActor,
+} from './fund-scenario-set-service.js';
+
+const QUEUE_NAME = 'fund-scenario-calc';
+const queueConfig = getQueueConfig();
+const connection = (() => {
+  try {
+    return getQueueConnectionOptions();
+  } catch {
+    return null;
+  }
+})();
+
+const fundScenarioCalcQueue =
+  queueConfig.enabled && connection ? new Queue(QUEUE_NAME, { connection }) : null;
+
+if (fundScenarioCalcQueue) {
+  registerQueueRuntime('fund-scenario-calc', {
+    getQueue: () => fundScenarioCalcQueue,
+    isInitialized: () => fundScenarioCalcQueue !== null,
+  });
+}
+
+export async function enqueueReserveScenarioCalculation(input: {
+  fundId: number;
+  scenarioSetId: string;
+  correlationId: string;
+  actor: FundScenarioMutationActor;
+}): Promise<FundScenarioReserveCalculationQueuedV1> {
+  if (!fundScenarioCalcQueue) {
+    throw createHttpError(503, 'Fund scenario calculation queue is not available', {
+      code: 'scenario_calculation_queue_unavailable',
+      details: { reason: queueConfig.reason },
+    });
+  }
+
+  const identity = await getReserveScenarioCalculationIdentity(input.fundId, input.scenarioSetId);
+  const job = await fundScenarioCalcQueue.add(
+    'async_reserve_allocation',
+    {
+      fundId: input.fundId,
+      scenarioSetId: input.scenarioSetId,
+      correlationId: input.correlationId,
+      calculationMode: 'async_reserve_allocation',
+      actor: normalizeActor(input.actor),
+      inputHash: identity.inputHash,
+    },
+    {
+      jobId: `reserve-scenario:${input.fundId}:${input.scenarioSetId}:${identity.inputHash}`,
+      attempts: 2,
+      backoff: {
+        type: 'exponential',
+        delay: 2_000,
+      },
+      removeOnComplete: {
+        age: 3600,
+        count: 100,
+      },
+      removeOnFail: {
+        age: 86400,
+      },
+    }
+  );
+
+  await transaction(async (client) => {
+    await insertScenarioSetEvent(client, {
+      scenarioSetId: input.scenarioSetId,
+      fundId: input.fundId,
+      eventType: 'calculation_queued',
+      actor: normalizeActor(input.actor),
+      changeSummary: {
+        headline: 'Queued reserve scenario calculation',
+        calculation_mode: 'async_reserve_allocation',
+        correlation_id: input.correlationId,
+        job_id: String(job.id),
+        input_hash: identity.inputHash,
+        source_config_version: identity.sourceConfigVersion,
+        variant_count: identity.variantCount,
+      },
+    });
+  });
+
+  return FundScenarioReserveCalculationQueuedV1Schema.parse({
+    fundId: input.fundId,
+    scenarioSetId: input.scenarioSetId,
+    calculationMode: 'async_reserve_allocation',
+    status: 'queued',
+    jobId: String(job.id),
+    correlationId: input.correlationId,
+  });
+}

--- a/server/services/fund-scenario-calculation-service.ts
+++ b/server/services/fund-scenario-calculation-service.ts
@@ -63,8 +63,11 @@ export type AllScenarioResultsForFund =
 
 const STALENESS_ORDER: Record<FundScenarioResultStalenessStateV1, number> = {
   CURRENT: 0,
-  STALE_PUBLISH: 1,
-  STALE_CONFIG: 2,
+  UNAVAILABLE: 1,
+  CALCULATING: 2,
+  STALE_PUBLISH: 3,
+  STALE_CONFIG: 4,
+  FAILED: 5,
 };
 
 function parseJsonPayload(value: unknown): unknown {
@@ -79,8 +82,13 @@ function applyScenarioReadStaleness(
   payload: FundScenarioCalculationPayloadV1,
   currentPublishedVersion: number | null
 ): FundScenarioResultStalenessStateV1 {
-  if (payload.staleness.state === 'STALE_CONFIG') {
-    return 'STALE_CONFIG';
+  if (
+    payload.staleness.state === 'STALE_CONFIG' ||
+    payload.staleness.state === 'CALCULATING' ||
+    payload.staleness.state === 'FAILED' ||
+    payload.staleness.state === 'UNAVAILABLE'
+  ) {
+    return payload.staleness.state;
   }
 
   if (currentPublishedVersion != null && currentPublishedVersion > payload.sourceConfigVersion) {
@@ -88,6 +96,30 @@ function applyScenarioReadStaleness(
   }
 
   return 'CURRENT';
+}
+
+function mapScenarioVariantSummary(variant: FundScenarioCalculationPayloadV1['variants'][number]) {
+  if (variant.overrideType === 'fee_profile') {
+    return {
+      variantId: variant.variantId,
+      name: variant.name,
+      overrideType: variant.overrideType,
+      economicsSummary: variant.economics.summary,
+    };
+  }
+
+  return {
+    variantId: variant.variantId,
+    name: variant.name,
+    overrideType: variant.overrideType,
+    reserveSummary: {
+      totalScenarioAllocationCents: variant.reserve.totalScenarioAllocationCents,
+      totalAllocationDeltaCents: variant.reserve.totalAllocationDeltaCents,
+      avgConfidence: variant.reserve.avgConfidence,
+      highConfidenceCount: variant.reserve.highConfidenceCount,
+      warningCount: variant.reserve.warnings.length,
+    },
+  };
 }
 
 function mapScenarioResultSummary(
@@ -104,21 +136,21 @@ function mapScenarioResultSummary(
     name: row.scenario_set_name,
     sourceConfigId: row.source_config_id,
     sourceConfigVersion: row.source_config_version,
+    currentPublishedConfigVersion: currentPublishedVersion,
     calculatedAt: payload.calculatedAt,
     staleness,
     variantCount: parseCount(row.variant_count),
-    variants: payload.variants.map((variant) => ({
-      variantId: variant.variantId,
-      name: variant.name,
-      overrideType: variant.overrideType,
-      economicsSummary: variant.economics.summary,
-    })),
+    variants: payload.variants.map(mapScenarioVariantSummary),
   });
 }
 
 export function worstScenarioStaleness(
   states: FundScenarioResultStalenessStateV1[]
 ): FundScenarioResultStalenessStateV1 {
+  if (states.length === 0) {
+    return 'UNAVAILABLE';
+  }
+
   return states.reduce<FundScenarioResultStalenessStateV1>(
     (worst, state) => (STALENESS_ORDER[state] > STALENESS_ORDER[worst] ? state : worst),
     'CURRENT'
@@ -242,7 +274,7 @@ function withReadTimeStaleness(
 
 function applyFeeProfileOverride(
   sourceConfig: FundDraftWriteV1,
-  override: FundScenarioVariantOverrideV1
+  override: Extract<FundScenarioVariantOverrideV1, { overrideType: 'fee_profile' }>
 ): FundDraftWriteV1 {
   const economicsAssumptions = sourceConfig.economicsAssumptions;
   const variantConfig: FundDraftWriteV1 = {
@@ -263,6 +295,18 @@ function applyFeeProfileOverride(
       },
     },
   };
+}
+
+function assertFeeProfileScenarioSet(
+  variants: Array<{ override: FundScenarioVariantOverrideV1 }>
+): void {
+  if (variants.every((variant) => variant.override.overrideType === 'fee_profile')) {
+    return;
+  }
+
+  throw createHttpError(409, 'Use calculate-reserve for reserve-allocation scenario sets', {
+    code: 'scenario_calculation_mode_mismatch',
+  });
 }
 
 async function findReusableScenarioSnapshot(
@@ -381,6 +425,7 @@ export async function calculateFundScenarioSet(
         code: 'scenario_set_archived',
       });
     }
+    assertFeeProfileScenarioSet(scenarioSet.variants);
 
     const sourceConfig = await loadSourceConfig(
       client,
@@ -415,6 +460,11 @@ export async function calculateFundScenarioSet(
     const startedAt = performance.now();
     const variants = scenarioSet.variants.map((variant) => {
       assertWithinSyncDeadline(startedAt);
+      if (variant.override.overrideType !== 'fee_profile') {
+        throw createHttpError(409, 'Use calculate-reserve for reserve-allocation scenario sets', {
+          code: 'scenario_calculation_mode_mismatch',
+        });
+      }
       const variantConfig = applyFeeProfileOverride(sourceConfigBody, variant.override);
       const economics = runEconomicsModel(variantConfig);
       assertWithinSyncDeadline(startedAt);

--- a/server/services/fund-scenario-calculation-status-service.ts
+++ b/server/services/fund-scenario-calculation-status-service.ts
@@ -1,0 +1,130 @@
+import { transaction } from '../db/pg-circuit.js';
+import {
+  FundScenarioCalculationStatusV1Schema,
+  type FundScenarioCalculationStatusV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import { getReserveScenarioCalculationIdentity } from './fund-scenario-reserve-calculation-service.js';
+
+interface SnapshotStatusRow {
+  id: number;
+  correlation_id: string;
+  created_at: Date | string | null;
+}
+
+interface EventStatusRow {
+  event_type: 'calculation_queued' | 'calculation_started' | 'calculation_failed' | 'calculated';
+  change_summary_json: unknown;
+  created_at: Date | string | null;
+}
+
+function parseChangeSummary(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : {};
+  }
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function nullableIso(value: Date | string | null): string | null {
+  return value == null ? null : new Date(value).toISOString();
+}
+
+function eventStatus(
+  eventType: EventStatusRow['event_type']
+): FundScenarioCalculationStatusV1['status'] {
+  switch (eventType) {
+    case 'calculation_queued':
+      return 'queued';
+    case 'calculation_started':
+      return 'calculating';
+    case 'calculation_failed':
+      return 'failed';
+    case 'calculated':
+      return 'succeeded';
+  }
+}
+
+export async function getFundScenarioCalculationStatus(
+  fundId: number,
+  scenarioSetId: string
+): Promise<FundScenarioCalculationStatusV1> {
+  const identity = await getReserveScenarioCalculationIdentity(fundId, scenarioSetId);
+
+  return transaction(async (client) => {
+    const snapshotResult = await client.query<SnapshotStatusRow>(
+      `SELECT id, correlation_id, created_at
+         FROM fund_snapshots
+        WHERE fund_id = $1
+          AND scenario_set_id = $2
+          AND type = 'SCENARIOS'
+          AND metadata ->> 'input_hash' = $3
+          AND metadata ->> 'calculation_mode' = 'async_reserve_allocation'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [fundId, scenarioSetId, identity.inputHash]
+    );
+    const eventResult = await client.query<EventStatusRow>(
+      `SELECT event_type, change_summary_json, created_at
+         FROM fund_scenario_set_events
+        WHERE fund_id = $1
+          AND scenario_set_id = $2
+          AND event_type IN (
+            'calculation_queued',
+            'calculation_started',
+            'calculation_failed',
+            'calculated'
+          )
+          AND change_summary_json ->> 'input_hash' = $3
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1`,
+      [fundId, scenarioSetId, identity.inputHash]
+    );
+    const snapshot = snapshotResult.rows[0];
+    const event = eventResult.rows[0];
+    const summary = event ? parseChangeSummary(event.change_summary_json) : {};
+
+    if (snapshot) {
+      return FundScenarioCalculationStatusV1Schema.parse({
+        fundId,
+        scenarioSetId,
+        calculationMode: 'async_reserve_allocation',
+        status: 'succeeded',
+        jobId: typeof summary['job_id'] === 'string' ? summary['job_id'] : null,
+        correlationId: snapshot.correlation_id,
+        snapshotId: snapshot.id,
+        lastEventAt: nullableIso(event?.created_at ?? snapshot.created_at),
+        lastError: null,
+      });
+    }
+
+    if (event) {
+      return FundScenarioCalculationStatusV1Schema.parse({
+        fundId,
+        scenarioSetId,
+        calculationMode: 'async_reserve_allocation',
+        status: eventStatus(event.event_type),
+        jobId: typeof summary['job_id'] === 'string' ? summary['job_id'] : null,
+        correlationId:
+          typeof summary['correlation_id'] === 'string' ? summary['correlation_id'] : null,
+        snapshotId: null,
+        lastEventAt: nullableIso(event.created_at),
+        lastError:
+          event.event_type === 'calculation_failed' && typeof summary['error_message'] === 'string'
+            ? summary['error_message']
+            : null,
+      });
+    }
+
+    return FundScenarioCalculationStatusV1Schema.parse({
+      fundId,
+      scenarioSetId,
+      calculationMode: 'async_reserve_allocation',
+      status: 'not_requested',
+      jobId: null,
+      correlationId: null,
+      snapshotId: null,
+      lastEventAt: null,
+      lastError: null,
+    });
+  });
+}

--- a/server/services/fund-scenario-calculation-status-service.ts
+++ b/server/services/fund-scenario-calculation-status-service.ts
@@ -3,6 +3,7 @@ import {
   FundScenarioCalculationStatusV1Schema,
   type FundScenarioCalculationStatusV1,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
+import type { PoolClient } from 'pg';
 import { getReserveScenarioCalculationIdentity } from './fund-scenario-reserve-calculation-service.js';
 
 interface SnapshotStatusRow {
@@ -12,10 +13,16 @@ interface SnapshotStatusRow {
 }
 
 interface EventStatusRow {
-  event_type: 'calculation_queued' | 'calculation_started' | 'calculation_failed' | 'calculated';
+  event_type: ScenarioCalculationEventType;
   change_summary_json: unknown;
   created_at: Date | string | null;
 }
+
+type ScenarioCalculationEventType =
+  | 'calculation_queued'
+  | 'calculation_started'
+  | 'calculation_failed'
+  | 'calculated';
 
 function parseChangeSummary(value: unknown): Record<string, unknown> {
   if (typeof value === 'string') {
@@ -30,7 +37,7 @@ function nullableIso(value: Date | string | null): string | null {
 }
 
 function eventStatus(
-  eventType: EventStatusRow['event_type']
+  eventType: ScenarioCalculationEventType
 ): FundScenarioCalculationStatusV1['status'] {
   switch (eventType) {
     case 'calculation_queued':
@@ -44,6 +51,141 @@ function eventStatus(
   }
 }
 
+async function findLatestScenarioSnapshot(
+  client: PoolClient,
+  fundId: number,
+  scenarioSetId: string,
+  inputHash: string
+): Promise<SnapshotStatusRow | null> {
+  const result = await client.query<SnapshotStatusRow>(
+    `SELECT id, correlation_id, created_at
+       FROM fund_snapshots
+      WHERE fund_id = $1
+        AND scenario_set_id = $2
+        AND type = 'SCENARIOS'
+        AND metadata ->> 'input_hash' = $3
+        AND metadata ->> 'calculation_mode' = 'async_reserve_allocation'
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [fundId, scenarioSetId, inputHash]
+  );
+
+  return result.rows[0] ?? null;
+}
+
+async function findLatestScenarioEvent(
+  client: PoolClient,
+  fundId: number,
+  scenarioSetId: string,
+  inputHash: string
+): Promise<EventStatusRow | null> {
+  const result = await client.query<EventStatusRow>(
+    `SELECT event_type, change_summary_json, created_at
+       FROM fund_scenario_set_events
+      WHERE fund_id = $1
+        AND scenario_set_id = $2
+        AND event_type IN (
+          'calculation_queued',
+          'calculation_started',
+          'calculation_failed',
+          'calculated'
+        )
+        AND change_summary_json ->> 'input_hash' = $3
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1`,
+    [fundId, scenarioSetId, inputHash]
+  );
+
+  return result.rows[0] ?? null;
+}
+
+function summaryString(summary: Record<string, unknown>, key: string): string | null {
+  return typeof summary[key] === 'string' ? summary[key] : null;
+}
+
+function failedEventError(event: EventStatusRow, summary: Record<string, unknown>): string | null {
+  if (event.event_type !== 'calculation_failed') {
+    return null;
+  }
+
+  return summaryString(summary, 'error_message');
+}
+
+function buildSucceededStatus(input: {
+  fundId: number;
+  scenarioSetId: string;
+  snapshot: SnapshotStatusRow;
+  event: EventStatusRow | null;
+  summary: Record<string, unknown>;
+}): FundScenarioCalculationStatusV1 {
+  return FundScenarioCalculationStatusV1Schema.parse({
+    fundId: input.fundId,
+    scenarioSetId: input.scenarioSetId,
+    calculationMode: 'async_reserve_allocation',
+    status: 'succeeded',
+    jobId: summaryString(input.summary, 'job_id'),
+    correlationId: input.snapshot.correlation_id,
+    snapshotId: input.snapshot.id,
+    lastEventAt: nullableIso(input.event?.created_at ?? input.snapshot.created_at),
+    lastError: null,
+  });
+}
+
+function buildEventStatus(input: {
+  fundId: number;
+  scenarioSetId: string;
+  event: EventStatusRow;
+  summary: Record<string, unknown>;
+}): FundScenarioCalculationStatusV1 {
+  return FundScenarioCalculationStatusV1Schema.parse({
+    fundId: input.fundId,
+    scenarioSetId: input.scenarioSetId,
+    calculationMode: 'async_reserve_allocation',
+    status: eventStatus(input.event.event_type),
+    jobId: summaryString(input.summary, 'job_id'),
+    correlationId: summaryString(input.summary, 'correlation_id'),
+    snapshotId: null,
+    lastEventAt: nullableIso(input.event.created_at),
+    lastError: failedEventError(input.event, input.summary),
+  });
+}
+
+function buildNotRequestedStatus(
+  fundId: number,
+  scenarioSetId: string
+): FundScenarioCalculationStatusV1 {
+  return FundScenarioCalculationStatusV1Schema.parse({
+    fundId,
+    scenarioSetId,
+    calculationMode: 'async_reserve_allocation',
+    status: 'not_requested',
+    jobId: null,
+    correlationId: null,
+    snapshotId: null,
+    lastEventAt: null,
+    lastError: null,
+  });
+}
+
+function buildCalculationStatus(input: {
+  fundId: number;
+  scenarioSetId: string;
+  snapshot: SnapshotStatusRow | null;
+  event: EventStatusRow | null;
+}): FundScenarioCalculationStatusV1 {
+  const summary = input.event ? parseChangeSummary(input.event.change_summary_json) : {};
+
+  if (input.snapshot) {
+    return buildSucceededStatus({ ...input, snapshot: input.snapshot, summary });
+  }
+
+  if (input.event) {
+    return buildEventStatus({ ...input, event: input.event, summary });
+  }
+
+  return buildNotRequestedStatus(input.fundId, input.scenarioSetId);
+}
+
 export async function getFundScenarioCalculationStatus(
   fundId: number,
   scenarioSetId: string
@@ -51,80 +193,19 @@ export async function getFundScenarioCalculationStatus(
   const identity = await getReserveScenarioCalculationIdentity(fundId, scenarioSetId);
 
   return transaction(async (client) => {
-    const snapshotResult = await client.query<SnapshotStatusRow>(
-      `SELECT id, correlation_id, created_at
-         FROM fund_snapshots
-        WHERE fund_id = $1
-          AND scenario_set_id = $2
-          AND type = 'SCENARIOS'
-          AND metadata ->> 'input_hash' = $3
-          AND metadata ->> 'calculation_mode' = 'async_reserve_allocation'
-        ORDER BY created_at DESC
-        LIMIT 1`,
-      [fundId, scenarioSetId, identity.inputHash]
-    );
-    const eventResult = await client.query<EventStatusRow>(
-      `SELECT event_type, change_summary_json, created_at
-         FROM fund_scenario_set_events
-        WHERE fund_id = $1
-          AND scenario_set_id = $2
-          AND event_type IN (
-            'calculation_queued',
-            'calculation_started',
-            'calculation_failed',
-            'calculated'
-          )
-          AND change_summary_json ->> 'input_hash' = $3
-        ORDER BY created_at DESC, id DESC
-        LIMIT 1`,
-      [fundId, scenarioSetId, identity.inputHash]
-    );
-    const snapshot = snapshotResult.rows[0];
-    const event = eventResult.rows[0];
-    const summary = event ? parseChangeSummary(event.change_summary_json) : {};
-
-    if (snapshot) {
-      return FundScenarioCalculationStatusV1Schema.parse({
-        fundId,
-        scenarioSetId,
-        calculationMode: 'async_reserve_allocation',
-        status: 'succeeded',
-        jobId: typeof summary['job_id'] === 'string' ? summary['job_id'] : null,
-        correlationId: snapshot.correlation_id,
-        snapshotId: snapshot.id,
-        lastEventAt: nullableIso(event?.created_at ?? snapshot.created_at),
-        lastError: null,
-      });
-    }
-
-    if (event) {
-      return FundScenarioCalculationStatusV1Schema.parse({
-        fundId,
-        scenarioSetId,
-        calculationMode: 'async_reserve_allocation',
-        status: eventStatus(event.event_type),
-        jobId: typeof summary['job_id'] === 'string' ? summary['job_id'] : null,
-        correlationId:
-          typeof summary['correlation_id'] === 'string' ? summary['correlation_id'] : null,
-        snapshotId: null,
-        lastEventAt: nullableIso(event.created_at),
-        lastError:
-          event.event_type === 'calculation_failed' && typeof summary['error_message'] === 'string'
-            ? summary['error_message']
-            : null,
-      });
-    }
-
-    return FundScenarioCalculationStatusV1Schema.parse({
+    const snapshot = await findLatestScenarioSnapshot(
+      client,
       fundId,
       scenarioSetId,
-      calculationMode: 'async_reserve_allocation',
-      status: 'not_requested',
-      jobId: null,
-      correlationId: null,
-      snapshotId: null,
-      lastEventAt: null,
-      lastError: null,
+      identity.inputHash
+    );
+    const event = await findLatestScenarioEvent(client, fundId, scenarioSetId, identity.inputHash);
+
+    return buildCalculationStatus({
+      fundId,
+      scenarioSetId,
+      snapshot,
+      event,
     });
   });
 }

--- a/server/services/fund-scenario-reserve-calculation-service.ts
+++ b/server/services/fund-scenario-reserve-calculation-service.ts
@@ -4,6 +4,7 @@ import { transaction } from '../db/pg-circuit.js';
 import {
   FundScenarioCalculationPayloadV1Schema,
   FundScenarioCalculationResponseV1Schema,
+  type FundScenarioCalculationPayloadV1,
   type FundScenarioCalculationResponseV1,
   type FundScenarioResultStalenessStateV1,
   type FundScenarioSetDetailV1,
@@ -21,6 +22,37 @@ import {
 
 const ASYNC_RESERVE_TIMEOUT_MS = 300_000;
 const FUND_SCENARIO_CALC_VERSION = process.env['ALG_FUND_SCENARIO_VERSION'] ?? 'fund-scenarios-v1';
+const RESERVE_SCENARIO_SNAPSHOT_UPSERT_SQL = `INSERT INTO fund_snapshots (
+       fund_id,
+       type,
+       payload,
+       calc_version,
+       correlation_id,
+       metadata,
+       snapshot_time,
+       config_id,
+       config_version,
+       scenario_set_id
+     )
+      VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
+      ON CONFLICT (fund_id, scenario_set_id)
+      WHERE scenario_set_id IS NOT NULL AND type = 'SCENARIOS'
+      DO UPDATE SET
+        payload = EXCLUDED.payload,
+        calc_version = EXCLUDED.calc_version,
+        correlation_id = EXCLUDED.correlation_id,
+        metadata = EXCLUDED.metadata,
+        snapshot_time = EXCLUDED.snapshot_time,
+        config_id = EXCLUDED.config_id,
+        config_version = EXCLUDED.config_version,
+        created_at = NOW()
+      RETURNING id, payload, correlation_id, created_at, snapshot_time`;
+
+type ReserveScenarioVariant = Extract<
+  FundScenarioCalculationPayloadV1['variants'][number],
+  { overrideType: 'reserve_allocation' }
+>;
+type ReserveScenarioPortfolio = Awaited<ReturnType<typeof buildReservePortfolioInputForClient>>;
 
 interface SourceConfigRow {
   id: number;
@@ -41,6 +73,41 @@ interface SnapshotRow {
   correlation_id: string;
   created_at: Date | string | null;
   snapshot_time: Date | string | null;
+}
+
+interface ReserveScenarioSnapshotInput {
+  fundId: number;
+  scenarioSetId: string;
+  sourceConfigId: number;
+  sourceConfigVersion: number;
+  correlationId: string;
+  payload: FundScenarioCalculationPayloadV1;
+  inputHash: string;
+  variantCount: number;
+  companyCount: number;
+  warningCount: number;
+}
+
+interface RunReserveScenarioCalculationInput {
+  fundId: number;
+  scenarioSetId: string;
+  correlationId: string;
+  actor: FundScenarioMutationActor;
+  jobId: string | null;
+}
+
+interface ReserveScenarioRunContext {
+  scenarioSet: FundScenarioSetDetailV1;
+  sourceConfig: SourceConfigRow;
+  currentPublishedVersion: number | null;
+  inputHash: string;
+}
+
+interface ReserveScenarioCalculationData {
+  portfolio: ReserveScenarioPortfolio;
+  variants: ReserveScenarioVariant[];
+  warningCount: number;
+  payload: FundScenarioCalculationPayloadV1;
 }
 
 export interface ReserveScenarioCalculationIdentity {
@@ -303,64 +370,18 @@ async function findReusableReserveScenarioSnapshot(
 
 async function persistReserveScenarioSnapshot(
   client: PoolClient,
-  input: {
-    fundId: number;
-    scenarioSetId: string;
-    sourceConfigId: number;
-    sourceConfigVersion: number;
-    correlationId: string;
-    payload: unknown;
-    inputHash: string;
-    variantCount: number;
-    companyCount: number;
-    warningCount: number;
-  }
+  input: ReserveScenarioSnapshotInput
 ): Promise<FundScenarioCalculationResponseV1> {
-  const result = await client.query<SnapshotRow>(
-    `INSERT INTO fund_snapshots (
-       fund_id,
-       type,
-       payload,
-       calc_version,
-       correlation_id,
-       metadata,
-       snapshot_time,
-       config_id,
-       config_version,
-       scenario_set_id
-     )
-      VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
-      ON CONFLICT (fund_id, scenario_set_id)
-      WHERE scenario_set_id IS NOT NULL AND type = 'SCENARIOS'
-      DO UPDATE SET
-        payload = EXCLUDED.payload,
-        calc_version = EXCLUDED.calc_version,
-        correlation_id = EXCLUDED.correlation_id,
-        metadata = EXCLUDED.metadata,
-        snapshot_time = EXCLUDED.snapshot_time,
-        config_id = EXCLUDED.config_id,
-        config_version = EXCLUDED.config_version,
-        created_at = NOW()
-      RETURNING id, payload, correlation_id, created_at, snapshot_time`,
-    [
-      input.fundId,
-      input.payload,
-      FUND_SCENARIO_CALC_VERSION,
-      input.correlationId,
-      {
-        input_hash: input.inputHash,
-        calculation_mode: 'async_reserve_allocation',
-        timeout_ms: ASYNC_RESERVE_TIMEOUT_MS,
-        variant_count: input.variantCount,
-        company_count: input.companyCount,
-        warning_count: input.warningCount,
-        override_type: 'reserve_allocation',
-      },
-      input.sourceConfigId,
-      input.sourceConfigVersion,
-      input.scenarioSetId,
-    ]
-  );
+  const result = await client.query<SnapshotRow>(RESERVE_SCENARIO_SNAPSHOT_UPSERT_SQL, [
+    input.fundId,
+    input.payload,
+    FUND_SCENARIO_CALC_VERSION,
+    input.correlationId,
+    reserveScenarioSnapshotMetadata(input),
+    input.sourceConfigId,
+    input.sourceConfigVersion,
+    input.scenarioSetId,
+  ]);
 
   const snapshot = result.rows[0];
   if (!snapshot) {
@@ -370,6 +391,18 @@ async function persistReserveScenarioSnapshot(
   }
 
   return responseFromSnapshot(snapshot);
+}
+
+function reserveScenarioSnapshotMetadata(input: ReserveScenarioSnapshotInput) {
+  return {
+    input_hash: input.inputHash,
+    calculation_mode: 'async_reserve_allocation',
+    timeout_ms: ASYNC_RESERVE_TIMEOUT_MS,
+    variant_count: input.variantCount,
+    company_count: input.companyCount,
+    warning_count: input.warningCount,
+    override_type: 'reserve_allocation',
+  };
 }
 
 async function recordCalculationFailedEvent(input: {
@@ -403,129 +436,232 @@ async function recordCalculationFailedEvent(input: {
   }
 }
 
-export async function runReserveScenarioCalculation(input: {
+async function loadReserveScenarioRunContext(
+  client: PoolClient,
+  input: RunReserveScenarioCalculationInput
+): Promise<ReserveScenarioRunContext> {
+  return loadReserveScenarioIdentityInTransaction(client, input.fundId, input.scenarioSetId, {
+    forUpdate: true,
+  });
+}
+
+async function recordCalculationStartedEvent(
+  client: PoolClient,
+  input: RunReserveScenarioCalculationInput,
+  inputHash: string
+): Promise<void> {
+  await insertScenarioSetEvent(client, {
+    scenarioSetId: input.scenarioSetId,
+    fundId: input.fundId,
+    eventType: 'calculation_started',
+    actor: normalizeActor(input.actor),
+    changeSummary: {
+      headline: 'Started reserve scenario calculation',
+      calculation_mode: 'async_reserve_allocation',
+      correlation_id: input.correlationId,
+      job_id: input.jobId,
+      input_hash: inputHash,
+    },
+  });
+}
+
+function reserveScenarioStaleness(
+  sourceConfigVersion: number,
+  currentPublishedVersion: number | null
+): FundScenarioResultStalenessStateV1 {
+  return currentPublishedVersion != null && currentPublishedVersion > sourceConfigVersion
+    ? 'STALE_PUBLISH'
+    : 'CURRENT';
+}
+
+function buildReserveScenarioVariants(input: {
+  fundId: number;
+  fundSizeCents: number | null;
+  portfolio: ReserveScenarioPortfolio;
+  scenarioSet: FundScenarioSetDetailV1;
+}): ReserveScenarioVariant[] {
+  return input.scenarioSet.variants.map((variant) => {
+    if (variant.override.overrideType !== 'reserve_allocation') {
+      throw createHttpError(409, 'Use calculate for fee-profile scenario sets', {
+        code: 'scenario_calculation_mode_mismatch',
+      });
+    }
+
+    return {
+      variantId: variant.id,
+      scenarioSetId: variant.scenarioSetId,
+      name: variant.name,
+      overrideType: variant.override.overrideType,
+      reserve: buildScenarioReserveSummary({
+        fundId: input.fundId,
+        fundSizeCents: input.fundSizeCents,
+        portfolio: input.portfolio,
+        override: variant.override,
+      }),
+    };
+  });
+}
+
+function buildReserveScenarioPayload(input: {
   fundId: number;
   scenarioSetId: string;
-  correlationId: string;
-  actor: FundScenarioMutationActor;
-  jobId: string | null;
-}): Promise<FundScenarioCalculationResponseV1> {
+  sourceConfig: SourceConfigRow;
+  currentPublishedVersion: number | null;
+  variants: ReserveScenarioVariant[];
+}): FundScenarioCalculationPayloadV1 {
+  const stalenessState = reserveScenarioStaleness(
+    input.sourceConfig.version,
+    input.currentPublishedVersion
+  );
+
+  return FundScenarioCalculationPayloadV1Schema.parse({
+    version: 'fund-scenarios-v1',
+    calculationMode: 'async_reserve_allocation',
+    fundId: input.fundId,
+    scenarioSetId: input.scenarioSetId,
+    sourceConfigId: input.sourceConfig.id,
+    sourceConfigVersion: input.sourceConfig.version,
+    staleness: {
+      state: stalenessState,
+      sourceConfigVersion: input.sourceConfig.version,
+      currentPublishedConfigVersion: input.currentPublishedVersion,
+    },
+    calculatedAt: new Date().toISOString(),
+    variants: input.variants,
+  });
+}
+
+async function recordCalculatedReserveScenarioEvent(
+  client: PoolClient,
+  input: RunReserveScenarioCalculationInput,
+  result: {
+    response: FundScenarioCalculationResponseV1;
+    context: ReserveScenarioRunContext;
+    variantCount: number;
+    companyCount: number;
+    warningCount: number;
+  }
+): Promise<void> {
+  await insertScenarioSetEvent(client, {
+    scenarioSetId: input.scenarioSetId,
+    fundId: input.fundId,
+    eventType: 'calculated',
+    actor: normalizeActor(input.actor),
+    changeSummary: {
+      headline: 'Calculated reserve scenario set',
+      calculation_mode: 'async_reserve_allocation',
+      correlation_id: input.correlationId,
+      job_id: input.jobId,
+      input_hash: result.context.inputHash,
+      snapshot_id: result.response.snapshotId,
+      variant_count: result.variantCount,
+      company_count: result.companyCount,
+      warning_count: result.warningCount,
+      source_config_version: result.context.sourceConfig.version,
+      staleness_state: result.response.payload.staleness.state,
+    },
+  });
+}
+
+async function calculateReserveScenarioForContext(
+  client: PoolClient,
+  input: RunReserveScenarioCalculationInput,
+  context: ReserveScenarioRunContext
+): Promise<FundScenarioCalculationResponseV1> {
+  const reusableResponse = await findReusableReserveScenarioResponse(client, input, context);
+  if (reusableResponse) {
+    return reusableResponse;
+  }
+
+  await recordCalculationStartedEvent(client, input, context.inputHash);
+
+  const data = await buildReserveScenarioCalculationData(client, input, context);
+  return persistReserveScenarioCalculation(client, input, context, data);
+}
+
+async function findReusableReserveScenarioResponse(
+  client: PoolClient,
+  input: RunReserveScenarioCalculationInput,
+  context: ReserveScenarioRunContext
+): Promise<FundScenarioCalculationResponseV1 | null> {
+  const reusableSnapshot = await findReusableReserveScenarioSnapshot(client, {
+    fundId: input.fundId,
+    scenarioSetId: input.scenarioSetId,
+    sourceConfigId: context.sourceConfig.id,
+    sourceConfigVersion: context.sourceConfig.version,
+    inputHash: context.inputHash,
+  });
+
+  return reusableSnapshot
+    ? applyScenarioReadStaleness(reusableSnapshot, context.currentPublishedVersion)
+    : null;
+}
+
+async function buildReserveScenarioCalculationData(
+  client: PoolClient,
+  input: RunReserveScenarioCalculationInput,
+  context: ReserveScenarioRunContext
+): Promise<ReserveScenarioCalculationData> {
+  const portfolio = await buildReservePortfolioInputForClient(client, input.fundId);
+  const fundSizeCents = await loadFundSizeCents(client, input.fundId);
+  const variants = buildReserveScenarioVariants({
+    fundId: input.fundId,
+    fundSizeCents,
+    portfolio,
+    scenarioSet: context.scenarioSet,
+  });
+  const warningCount = variants.reduce((sum, variant) => sum + variant.reserve.warnings.length, 0);
+  const payload = buildReserveScenarioPayload({
+    fundId: input.fundId,
+    scenarioSetId: input.scenarioSetId,
+    sourceConfig: context.sourceConfig,
+    currentPublishedVersion: context.currentPublishedVersion,
+    variants,
+  });
+
+  return { portfolio, variants, warningCount, payload };
+}
+
+async function persistReserveScenarioCalculation(
+  client: PoolClient,
+  input: RunReserveScenarioCalculationInput,
+  context: ReserveScenarioRunContext,
+  data: ReserveScenarioCalculationData
+): Promise<FundScenarioCalculationResponseV1> {
+  const response = await persistReserveScenarioSnapshot(client, {
+    fundId: input.fundId,
+    scenarioSetId: input.scenarioSetId,
+    sourceConfigId: context.sourceConfig.id,
+    sourceConfigVersion: context.sourceConfig.version,
+    correlationId: input.correlationId,
+    payload: data.payload,
+    inputHash: context.inputHash,
+    variantCount: data.variants.length,
+    companyCount: data.portfolio.length,
+    warningCount: data.warningCount,
+  });
+
+  await recordCalculatedReserveScenarioEvent(client, input, {
+    response,
+    context,
+    variantCount: data.variants.length,
+    companyCount: data.portfolio.length,
+    warningCount: data.warningCount,
+  });
+
+  return response;
+}
+
+export async function runReserveScenarioCalculation(
+  input: RunReserveScenarioCalculationInput
+): Promise<FundScenarioCalculationResponseV1> {
   let inputHashForFailure: string | null = null;
 
   try {
     return await transaction(async (client) => {
-      const { scenarioSet, sourceConfig, currentPublishedVersion, inputHash } =
-        await loadReserveScenarioIdentityInTransaction(client, input.fundId, input.scenarioSetId, {
-          forUpdate: true,
-        });
-      inputHashForFailure = inputHash;
-      const reusableSnapshot = await findReusableReserveScenarioSnapshot(client, {
-        fundId: input.fundId,
-        scenarioSetId: input.scenarioSetId,
-        sourceConfigId: sourceConfig.id,
-        sourceConfigVersion: sourceConfig.version,
-        inputHash,
-      });
-
-      if (reusableSnapshot) {
-        return applyScenarioReadStaleness(reusableSnapshot, currentPublishedVersion);
-      }
-
-      await insertScenarioSetEvent(client, {
-        scenarioSetId: input.scenarioSetId,
-        fundId: input.fundId,
-        eventType: 'calculation_started',
-        actor: normalizeActor(input.actor),
-        changeSummary: {
-          headline: 'Started reserve scenario calculation',
-          calculation_mode: 'async_reserve_allocation',
-          correlation_id: input.correlationId,
-          job_id: input.jobId,
-          input_hash: inputHash,
-        },
-      });
-
-      const portfolio = await buildReservePortfolioInputForClient(client, input.fundId);
-      const fundSizeCents = await loadFundSizeCents(client, input.fundId);
-      const variants = scenarioSet.variants.map((variant) => {
-        if (variant.override.overrideType !== 'reserve_allocation') {
-          throw createHttpError(409, 'Use calculate for fee-profile scenario sets', {
-            code: 'scenario_calculation_mode_mismatch',
-          });
-        }
-
-        return {
-          variantId: variant.id,
-          scenarioSetId: variant.scenarioSetId,
-          name: variant.name,
-          overrideType: variant.override.overrideType,
-          reserve: buildScenarioReserveSummary({
-            fundId: input.fundId,
-            fundSizeCents,
-            portfolio,
-            override: variant.override,
-          }),
-        };
-      });
-      const warningCount = variants.reduce(
-        (sum, variant) => sum + variant.reserve.warnings.length,
-        0
-      );
-      const calculatedAt = new Date().toISOString();
-      const stalenessState =
-        currentPublishedVersion != null && currentPublishedVersion > sourceConfig.version
-          ? 'STALE_PUBLISH'
-          : 'CURRENT';
-      const payload = FundScenarioCalculationPayloadV1Schema.parse({
-        version: 'fund-scenarios-v1',
-        calculationMode: 'async_reserve_allocation',
-        fundId: input.fundId,
-        scenarioSetId: input.scenarioSetId,
-        sourceConfigId: sourceConfig.id,
-        sourceConfigVersion: sourceConfig.version,
-        staleness: {
-          state: stalenessState,
-          sourceConfigVersion: sourceConfig.version,
-          currentPublishedConfigVersion: currentPublishedVersion,
-        },
-        calculatedAt,
-        variants,
-      });
-
-      const response = await persistReserveScenarioSnapshot(client, {
-        fundId: input.fundId,
-        scenarioSetId: input.scenarioSetId,
-        sourceConfigId: sourceConfig.id,
-        sourceConfigVersion: sourceConfig.version,
-        correlationId: input.correlationId,
-        payload,
-        inputHash,
-        variantCount: variants.length,
-        companyCount: portfolio.length,
-        warningCount,
-      });
-
-      await insertScenarioSetEvent(client, {
-        scenarioSetId: input.scenarioSetId,
-        fundId: input.fundId,
-        eventType: 'calculated',
-        actor: normalizeActor(input.actor),
-        changeSummary: {
-          headline: 'Calculated reserve scenario set',
-          calculation_mode: 'async_reserve_allocation',
-          correlation_id: input.correlationId,
-          job_id: input.jobId,
-          input_hash: inputHash,
-          snapshot_id: response.snapshotId,
-          variant_count: variants.length,
-          company_count: portfolio.length,
-          warning_count: warningCount,
-          source_config_version: sourceConfig.version,
-          staleness_state: stalenessState,
-        },
-      });
-
-      return response;
+      const context = await loadReserveScenarioRunContext(client, input);
+      inputHashForFailure = context.inputHash;
+      return calculateReserveScenarioForContext(client, input, context);
     });
   } catch (error) {
     await recordCalculationFailedEvent({

--- a/server/services/fund-scenario-reserve-calculation-service.ts
+++ b/server/services/fund-scenario-reserve-calculation-service.ts
@@ -1,0 +1,542 @@
+import crypto from 'node:crypto';
+import type { PoolClient } from 'pg';
+import { transaction } from '../db/pg-circuit.js';
+import {
+  FundScenarioCalculationPayloadV1Schema,
+  FundScenarioCalculationResponseV1Schema,
+  type FundScenarioCalculationResponseV1,
+  type FundScenarioResultStalenessStateV1,
+  type FundScenarioSetDetailV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import { buildReservePortfolioInputForClient } from './reserve-input-builder';
+import { buildScenarioReserveSummary } from './fund-scenario-reserve-summary';
+import {
+  createHttpError,
+  fetchScenarioSetDetail,
+  insertScenarioSetEvent,
+  normalizeActor,
+  verifyFundExists,
+  type FundScenarioMutationActor,
+} from './fund-scenario-set-service.js';
+
+const ASYNC_RESERVE_TIMEOUT_MS = 300_000;
+const FUND_SCENARIO_CALC_VERSION = process.env['ALG_FUND_SCENARIO_VERSION'] ?? 'fund-scenarios-v1';
+
+interface SourceConfigRow {
+  id: number;
+  version: number;
+}
+
+interface CurrentPublishedConfigRow {
+  version: number;
+}
+
+interface FundSizeRow {
+  size: string | number;
+}
+
+interface SnapshotRow {
+  id: number;
+  payload: unknown;
+  correlation_id: string;
+  created_at: Date | string | null;
+  snapshot_time: Date | string | null;
+}
+
+export interface ReserveScenarioCalculationIdentity {
+  fundId: number;
+  scenarioSetId: string;
+  sourceConfigId: number;
+  sourceConfigVersion: number;
+  currentPublishedConfigVersion: number | null;
+  inputHash: string;
+  variantCount: number;
+}
+
+export function createReserveScenarioInputHash(input: {
+  fundId: number;
+  scenarioSetId: string;
+  sourceConfigId: number;
+  sourceConfigVersion: number;
+  calcVersion: string;
+  calculationMode: 'async_reserve_allocation';
+  variants: Array<{
+    id: string;
+    override: unknown;
+  }>;
+}): string {
+  return crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify({
+        fundId: input.fundId,
+        scenarioSetId: input.scenarioSetId,
+        sourceConfigId: input.sourceConfigId,
+        sourceConfigVersion: input.sourceConfigVersion,
+        calcVersion: input.calcVersion,
+        calculationMode: input.calculationMode,
+        variants: input.variants
+          .map((variant) => ({
+            id: variant.id,
+            override: variant.override,
+          }))
+          .sort((a, b) => a.id.localeCompare(b.id)),
+      })
+    )
+    .digest('hex');
+}
+
+function parseJsonPayload(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return JSON.parse(value) as unknown;
+}
+
+function applyScenarioReadStaleness(
+  response: FundScenarioCalculationResponseV1,
+  currentPublishedVersion: number | null
+): FundScenarioCalculationResponseV1 {
+  const state = response.payload.staleness.state;
+  const nextState: FundScenarioResultStalenessStateV1 =
+    state === 'STALE_CONFIG' ||
+    state === 'CALCULATING' ||
+    state === 'FAILED' ||
+    state === 'UNAVAILABLE'
+      ? state
+      : currentPublishedVersion != null &&
+          currentPublishedVersion > response.payload.sourceConfigVersion
+        ? 'STALE_PUBLISH'
+        : 'CURRENT';
+
+  response.payload.staleness.state = nextState;
+  response.payload.staleness.currentPublishedConfigVersion = currentPublishedVersion;
+  return response;
+}
+
+function responseFromSnapshot(row: SnapshotRow): FundScenarioCalculationResponseV1 {
+  const payload = FundScenarioCalculationPayloadV1Schema.parse(parseJsonPayload(row.payload));
+  return FundScenarioCalculationResponseV1Schema.parse({
+    snapshotId: row.id,
+    correlationId: row.correlation_id,
+    source: 'fund_snapshots',
+    payload,
+  });
+}
+
+function assertReserveScenarioSet(scenarioSet: FundScenarioSetDetailV1): void {
+  if (
+    scenarioSet.variants.every((variant) => variant.override.overrideType === 'reserve_allocation')
+  ) {
+    return;
+  }
+
+  throw createHttpError(409, 'Use calculate for fee-profile scenario sets', {
+    code: 'scenario_calculation_mode_mismatch',
+  });
+}
+
+async function loadSourceConfig(
+  client: PoolClient,
+  fundId: number,
+  configId: number,
+  configVersion: number
+): Promise<SourceConfigRow> {
+  const result = await client.query<SourceConfigRow>(
+    `SELECT id, version
+       FROM fundconfigs
+      WHERE fund_id = $1
+        AND id = $2
+        AND version = $3
+      LIMIT 1`,
+    [fundId, configId, configVersion]
+  );
+
+  const sourceConfig = result.rows[0];
+  if (!sourceConfig) {
+    throw createHttpError(409, `Scenario source config ${configId} could not be loaded`, {
+      code: 'scenario_source_config_missing',
+      details: { sourceConfigId: configId, sourceConfigVersion: configVersion },
+    });
+  }
+
+  return sourceConfig;
+}
+
+async function loadCurrentPublishedVersion(
+  client: PoolClient,
+  fundId: number
+): Promise<number | null> {
+  const result = await client.query<CurrentPublishedConfigRow>(
+    `SELECT version
+       FROM fundconfigs
+      WHERE fund_id = $1
+        AND is_published = TRUE
+      ORDER BY version DESC
+      LIMIT 1`,
+    [fundId]
+  );
+
+  return result.rows[0]?.version ?? null;
+}
+
+async function loadFundSizeCents(client: PoolClient, fundId: number): Promise<number | null> {
+  const result = await client.query<FundSizeRow>('SELECT size FROM funds WHERE id = $1 LIMIT 1', [
+    fundId,
+  ]);
+  const size = result.rows[0]?.size;
+  if (size == null) {
+    return null;
+  }
+  const parsed = typeof size === 'number' ? size : Number.parseFloat(size);
+  return Number.isFinite(parsed) ? Math.round(parsed * 100) : null;
+}
+
+async function loadReserveScenarioIdentityInTransaction(
+  client: PoolClient,
+  fundId: number,
+  scenarioSetId: string,
+  options: { forUpdate?: boolean } = {}
+): Promise<{
+  scenarioSet: FundScenarioSetDetailV1;
+  sourceConfig: SourceConfigRow;
+  currentPublishedVersion: number | null;
+  inputHash: string;
+}> {
+  await verifyFundExists(client, fundId);
+  const scenarioSetOptions =
+    options.forUpdate === undefined ? undefined : { forUpdate: options.forUpdate };
+  const scenarioSet = await fetchScenarioSetDetail(
+    client,
+    fundId,
+    scenarioSetId,
+    scenarioSetOptions
+  );
+  assertReserveScenarioSet(scenarioSet);
+
+  if (scenarioSet.archivedAt !== null) {
+    throw createHttpError(409, `Scenario set ${scenarioSetId} is archived`, {
+      code: 'scenario_set_archived',
+    });
+  }
+
+  const sourceConfig = await loadSourceConfig(
+    client,
+    fundId,
+    scenarioSet.sourceConfigId,
+    scenarioSet.sourceConfigVersion
+  );
+  const currentPublishedVersion = await loadCurrentPublishedVersion(client, fundId);
+  const inputHash = createReserveScenarioInputHash({
+    fundId,
+    scenarioSetId,
+    sourceConfigId: sourceConfig.id,
+    sourceConfigVersion: sourceConfig.version,
+    calcVersion: FUND_SCENARIO_CALC_VERSION,
+    calculationMode: 'async_reserve_allocation',
+    variants: scenarioSet.variants.map((variant) => ({
+      id: variant.id,
+      override: variant.override,
+    })),
+  });
+
+  return { scenarioSet, sourceConfig, currentPublishedVersion, inputHash };
+}
+
+export async function getReserveScenarioCalculationIdentity(
+  fundId: number,
+  scenarioSetId: string
+): Promise<ReserveScenarioCalculationIdentity> {
+  return transaction(async (client) => {
+    const { scenarioSet, sourceConfig, currentPublishedVersion, inputHash } =
+      await loadReserveScenarioIdentityInTransaction(client, fundId, scenarioSetId);
+
+    return {
+      fundId,
+      scenarioSetId,
+      sourceConfigId: sourceConfig.id,
+      sourceConfigVersion: sourceConfig.version,
+      currentPublishedConfigVersion: currentPublishedVersion,
+      inputHash,
+      variantCount: scenarioSet.variants.length,
+    };
+  });
+}
+
+async function findReusableReserveScenarioSnapshot(
+  client: PoolClient,
+  input: {
+    fundId: number;
+    scenarioSetId: string;
+    sourceConfigId: number;
+    sourceConfigVersion: number;
+    inputHash: string;
+  }
+): Promise<FundScenarioCalculationResponseV1 | null> {
+  const result = await client.query<SnapshotRow>(
+    `SELECT id, payload, correlation_id, created_at, snapshot_time
+       FROM fund_snapshots
+      WHERE fund_id = $1
+        AND scenario_set_id = $2
+        AND type = 'SCENARIOS'
+        AND config_id = $3
+        AND config_version = $4
+        AND calc_version = $5
+        AND metadata ->> 'input_hash' = $6
+        AND metadata ->> 'calculation_mode' = 'async_reserve_allocation'
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [
+      input.fundId,
+      input.scenarioSetId,
+      input.sourceConfigId,
+      input.sourceConfigVersion,
+      FUND_SCENARIO_CALC_VERSION,
+      input.inputHash,
+    ]
+  );
+
+  const snapshot = result.rows[0];
+  return snapshot ? responseFromSnapshot(snapshot) : null;
+}
+
+async function persistReserveScenarioSnapshot(
+  client: PoolClient,
+  input: {
+    fundId: number;
+    scenarioSetId: string;
+    sourceConfigId: number;
+    sourceConfigVersion: number;
+    correlationId: string;
+    payload: unknown;
+    inputHash: string;
+    variantCount: number;
+    companyCount: number;
+    warningCount: number;
+  }
+): Promise<FundScenarioCalculationResponseV1> {
+  const result = await client.query<SnapshotRow>(
+    `INSERT INTO fund_snapshots (
+       fund_id,
+       type,
+       payload,
+       calc_version,
+       correlation_id,
+       metadata,
+       snapshot_time,
+       config_id,
+       config_version,
+       scenario_set_id
+     )
+      VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
+      ON CONFLICT (fund_id, scenario_set_id)
+      WHERE scenario_set_id IS NOT NULL AND type = 'SCENARIOS'
+      DO UPDATE SET
+        payload = EXCLUDED.payload,
+        calc_version = EXCLUDED.calc_version,
+        correlation_id = EXCLUDED.correlation_id,
+        metadata = EXCLUDED.metadata,
+        snapshot_time = EXCLUDED.snapshot_time,
+        config_id = EXCLUDED.config_id,
+        config_version = EXCLUDED.config_version,
+        created_at = NOW()
+      RETURNING id, payload, correlation_id, created_at, snapshot_time`,
+    [
+      input.fundId,
+      input.payload,
+      FUND_SCENARIO_CALC_VERSION,
+      input.correlationId,
+      {
+        input_hash: input.inputHash,
+        calculation_mode: 'async_reserve_allocation',
+        timeout_ms: ASYNC_RESERVE_TIMEOUT_MS,
+        variant_count: input.variantCount,
+        company_count: input.companyCount,
+        warning_count: input.warningCount,
+        override_type: 'reserve_allocation',
+      },
+      input.sourceConfigId,
+      input.sourceConfigVersion,
+      input.scenarioSetId,
+    ]
+  );
+
+  const snapshot = result.rows[0];
+  if (!snapshot) {
+    throw createHttpError(500, 'Reserve scenario snapshot insert did not return an id', {
+      code: 'scenario_snapshot_insert_failed',
+    });
+  }
+
+  return responseFromSnapshot(snapshot);
+}
+
+async function recordCalculationFailedEvent(input: {
+  fundId: number;
+  scenarioSetId: string;
+  actor: FundScenarioMutationActor;
+  correlationId: string;
+  jobId: string | null;
+  inputHash: string | null;
+  error: unknown;
+}): Promise<void> {
+  try {
+    await transaction(async (client) => {
+      await insertScenarioSetEvent(client, {
+        scenarioSetId: input.scenarioSetId,
+        fundId: input.fundId,
+        eventType: 'calculation_failed',
+        actor: normalizeActor(input.actor),
+        changeSummary: {
+          headline: 'Reserve scenario calculation failed',
+          calculation_mode: 'async_reserve_allocation',
+          correlation_id: input.correlationId,
+          job_id: input.jobId,
+          input_hash: input.inputHash,
+          error_message: input.error instanceof Error ? input.error.message : String(input.error),
+        },
+      });
+    });
+  } catch {
+    // Preserve the original calculation failure.
+  }
+}
+
+export async function runReserveScenarioCalculation(input: {
+  fundId: number;
+  scenarioSetId: string;
+  correlationId: string;
+  actor: FundScenarioMutationActor;
+  jobId: string | null;
+}): Promise<FundScenarioCalculationResponseV1> {
+  let inputHashForFailure: string | null = null;
+
+  try {
+    return await transaction(async (client) => {
+      const { scenarioSet, sourceConfig, currentPublishedVersion, inputHash } =
+        await loadReserveScenarioIdentityInTransaction(client, input.fundId, input.scenarioSetId, {
+          forUpdate: true,
+        });
+      inputHashForFailure = inputHash;
+      const reusableSnapshot = await findReusableReserveScenarioSnapshot(client, {
+        fundId: input.fundId,
+        scenarioSetId: input.scenarioSetId,
+        sourceConfigId: sourceConfig.id,
+        sourceConfigVersion: sourceConfig.version,
+        inputHash,
+      });
+
+      if (reusableSnapshot) {
+        return applyScenarioReadStaleness(reusableSnapshot, currentPublishedVersion);
+      }
+
+      await insertScenarioSetEvent(client, {
+        scenarioSetId: input.scenarioSetId,
+        fundId: input.fundId,
+        eventType: 'calculation_started',
+        actor: normalizeActor(input.actor),
+        changeSummary: {
+          headline: 'Started reserve scenario calculation',
+          calculation_mode: 'async_reserve_allocation',
+          correlation_id: input.correlationId,
+          job_id: input.jobId,
+          input_hash: inputHash,
+        },
+      });
+
+      const portfolio = await buildReservePortfolioInputForClient(client, input.fundId);
+      const fundSizeCents = await loadFundSizeCents(client, input.fundId);
+      const variants = scenarioSet.variants.map((variant) => {
+        if (variant.override.overrideType !== 'reserve_allocation') {
+          throw createHttpError(409, 'Use calculate for fee-profile scenario sets', {
+            code: 'scenario_calculation_mode_mismatch',
+          });
+        }
+
+        return {
+          variantId: variant.id,
+          scenarioSetId: variant.scenarioSetId,
+          name: variant.name,
+          overrideType: variant.override.overrideType,
+          reserve: buildScenarioReserveSummary({
+            fundId: input.fundId,
+            fundSizeCents,
+            portfolio,
+            override: variant.override,
+          }),
+        };
+      });
+      const warningCount = variants.reduce(
+        (sum, variant) => sum + variant.reserve.warnings.length,
+        0
+      );
+      const calculatedAt = new Date().toISOString();
+      const stalenessState =
+        currentPublishedVersion != null && currentPublishedVersion > sourceConfig.version
+          ? 'STALE_PUBLISH'
+          : 'CURRENT';
+      const payload = FundScenarioCalculationPayloadV1Schema.parse({
+        version: 'fund-scenarios-v1',
+        calculationMode: 'async_reserve_allocation',
+        fundId: input.fundId,
+        scenarioSetId: input.scenarioSetId,
+        sourceConfigId: sourceConfig.id,
+        sourceConfigVersion: sourceConfig.version,
+        staleness: {
+          state: stalenessState,
+          sourceConfigVersion: sourceConfig.version,
+          currentPublishedConfigVersion: currentPublishedVersion,
+        },
+        calculatedAt,
+        variants,
+      });
+
+      const response = await persistReserveScenarioSnapshot(client, {
+        fundId: input.fundId,
+        scenarioSetId: input.scenarioSetId,
+        sourceConfigId: sourceConfig.id,
+        sourceConfigVersion: sourceConfig.version,
+        correlationId: input.correlationId,
+        payload,
+        inputHash,
+        variantCount: variants.length,
+        companyCount: portfolio.length,
+        warningCount,
+      });
+
+      await insertScenarioSetEvent(client, {
+        scenarioSetId: input.scenarioSetId,
+        fundId: input.fundId,
+        eventType: 'calculated',
+        actor: normalizeActor(input.actor),
+        changeSummary: {
+          headline: 'Calculated reserve scenario set',
+          calculation_mode: 'async_reserve_allocation',
+          correlation_id: input.correlationId,
+          job_id: input.jobId,
+          input_hash: inputHash,
+          snapshot_id: response.snapshotId,
+          variant_count: variants.length,
+          company_count: portfolio.length,
+          warning_count: warningCount,
+          source_config_version: sourceConfig.version,
+          staleness_state: stalenessState,
+        },
+      });
+
+      return response;
+    });
+  } catch (error) {
+    await recordCalculationFailedEvent({
+      fundId: input.fundId,
+      scenarioSetId: input.scenarioSetId,
+      actor: input.actor,
+      correlationId: input.correlationId,
+      jobId: input.jobId,
+      inputHash: inputHashForFailure,
+      error,
+    });
+    throw error;
+  }
+}

--- a/server/services/fund-scenario-reserve-calculation-service.ts
+++ b/server/services/fund-scenario-reserve-calculation-service.ts
@@ -3,7 +3,6 @@ import type { PoolClient } from 'pg';
 import { transaction } from '../db/pg-circuit.js';
 import {
   FundScenarioCalculationPayloadV1Schema,
-  FundScenarioCalculationResponseV1Schema,
   type FundScenarioCalculationPayloadV1,
   type FundScenarioCalculationResponseV1,
   type FundScenarioResultStalenessStateV1,
@@ -12,6 +11,12 @@ import {
 import { buildReservePortfolioInputForClient } from './reserve-input-builder';
 import { buildScenarioReserveSummary } from './fund-scenario-reserve-summary';
 import {
+  FUND_SCENARIO_CALC_VERSION,
+  applyScenarioReadStaleness,
+  findReusableReserveScenarioSnapshot,
+  persistReserveScenarioSnapshot,
+} from './fund-scenario-reserve-snapshot-store';
+import {
   createHttpError,
   fetchScenarioSetDetail,
   insertScenarioSetEvent,
@@ -19,34 +24,6 @@ import {
   verifyFundExists,
   type FundScenarioMutationActor,
 } from './fund-scenario-set-service.js';
-
-const ASYNC_RESERVE_TIMEOUT_MS = 300_000;
-const FUND_SCENARIO_CALC_VERSION = process.env['ALG_FUND_SCENARIO_VERSION'] ?? 'fund-scenarios-v1';
-const RESERVE_SCENARIO_SNAPSHOT_UPSERT_SQL = `INSERT INTO fund_snapshots (
-       fund_id,
-       type,
-       payload,
-       calc_version,
-       correlation_id,
-       metadata,
-       snapshot_time,
-       config_id,
-       config_version,
-       scenario_set_id
-     )
-      VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
-      ON CONFLICT (fund_id, scenario_set_id)
-      WHERE scenario_set_id IS NOT NULL AND type = 'SCENARIOS'
-      DO UPDATE SET
-        payload = EXCLUDED.payload,
-        calc_version = EXCLUDED.calc_version,
-        correlation_id = EXCLUDED.correlation_id,
-        metadata = EXCLUDED.metadata,
-        snapshot_time = EXCLUDED.snapshot_time,
-        config_id = EXCLUDED.config_id,
-        config_version = EXCLUDED.config_version,
-        created_at = NOW()
-      RETURNING id, payload, correlation_id, created_at, snapshot_time`;
 
 type ReserveScenarioVariant = Extract<
   FundScenarioCalculationPayloadV1['variants'][number],
@@ -65,27 +42,6 @@ interface CurrentPublishedConfigRow {
 
 interface FundSizeRow {
   size: string | number;
-}
-
-interface SnapshotRow {
-  id: number;
-  payload: unknown;
-  correlation_id: string;
-  created_at: Date | string | null;
-  snapshot_time: Date | string | null;
-}
-
-interface ReserveScenarioSnapshotInput {
-  fundId: number;
-  scenarioSetId: string;
-  sourceConfigId: number;
-  sourceConfigVersion: number;
-  correlationId: string;
-  payload: FundScenarioCalculationPayloadV1;
-  inputHash: string;
-  variantCount: number;
-  companyCount: number;
-  warningCount: number;
 }
 
 interface RunReserveScenarioCalculationInput {
@@ -151,45 +107,6 @@ export function createReserveScenarioInputHash(input: {
       })
     )
     .digest('hex');
-}
-
-function parseJsonPayload(value: unknown): unknown {
-  if (typeof value !== 'string') {
-    return value;
-  }
-
-  return JSON.parse(value) as unknown;
-}
-
-function applyScenarioReadStaleness(
-  response: FundScenarioCalculationResponseV1,
-  currentPublishedVersion: number | null
-): FundScenarioCalculationResponseV1 {
-  const state = response.payload.staleness.state;
-  const nextState: FundScenarioResultStalenessStateV1 =
-    state === 'STALE_CONFIG' ||
-    state === 'CALCULATING' ||
-    state === 'FAILED' ||
-    state === 'UNAVAILABLE'
-      ? state
-      : currentPublishedVersion != null &&
-          currentPublishedVersion > response.payload.sourceConfigVersion
-        ? 'STALE_PUBLISH'
-        : 'CURRENT';
-
-  response.payload.staleness.state = nextState;
-  response.payload.staleness.currentPublishedConfigVersion = currentPublishedVersion;
-  return response;
-}
-
-function responseFromSnapshot(row: SnapshotRow): FundScenarioCalculationResponseV1 {
-  const payload = FundScenarioCalculationPayloadV1Schema.parse(parseJsonPayload(row.payload));
-  return FundScenarioCalculationResponseV1Schema.parse({
-    snapshotId: row.id,
-    correlationId: row.correlation_id,
-    source: 'fund_snapshots',
-    payload,
-  });
 }
 
 function assertReserveScenarioSet(scenarioSet: FundScenarioSetDetailV1): void {
@@ -329,80 +246,6 @@ export async function getReserveScenarioCalculationIdentity(
       variantCount: scenarioSet.variants.length,
     };
   });
-}
-
-async function findReusableReserveScenarioSnapshot(
-  client: PoolClient,
-  input: {
-    fundId: number;
-    scenarioSetId: string;
-    sourceConfigId: number;
-    sourceConfigVersion: number;
-    inputHash: string;
-  }
-): Promise<FundScenarioCalculationResponseV1 | null> {
-  const result = await client.query<SnapshotRow>(
-    `SELECT id, payload, correlation_id, created_at, snapshot_time
-       FROM fund_snapshots
-      WHERE fund_id = $1
-        AND scenario_set_id = $2
-        AND type = 'SCENARIOS'
-        AND config_id = $3
-        AND config_version = $4
-        AND calc_version = $5
-        AND metadata ->> 'input_hash' = $6
-        AND metadata ->> 'calculation_mode' = 'async_reserve_allocation'
-      ORDER BY created_at DESC
-      LIMIT 1`,
-    [
-      input.fundId,
-      input.scenarioSetId,
-      input.sourceConfigId,
-      input.sourceConfigVersion,
-      FUND_SCENARIO_CALC_VERSION,
-      input.inputHash,
-    ]
-  );
-
-  const snapshot = result.rows[0];
-  return snapshot ? responseFromSnapshot(snapshot) : null;
-}
-
-async function persistReserveScenarioSnapshot(
-  client: PoolClient,
-  input: ReserveScenarioSnapshotInput
-): Promise<FundScenarioCalculationResponseV1> {
-  const result = await client.query<SnapshotRow>(RESERVE_SCENARIO_SNAPSHOT_UPSERT_SQL, [
-    input.fundId,
-    input.payload,
-    FUND_SCENARIO_CALC_VERSION,
-    input.correlationId,
-    reserveScenarioSnapshotMetadata(input),
-    input.sourceConfigId,
-    input.sourceConfigVersion,
-    input.scenarioSetId,
-  ]);
-
-  const snapshot = result.rows[0];
-  if (!snapshot) {
-    throw createHttpError(500, 'Reserve scenario snapshot insert did not return an id', {
-      code: 'scenario_snapshot_insert_failed',
-    });
-  }
-
-  return responseFromSnapshot(snapshot);
-}
-
-function reserveScenarioSnapshotMetadata(input: ReserveScenarioSnapshotInput) {
-  return {
-    input_hash: input.inputHash,
-    calculation_mode: 'async_reserve_allocation',
-    timeout_ms: ASYNC_RESERVE_TIMEOUT_MS,
-    variant_count: input.variantCount,
-    company_count: input.companyCount,
-    warning_count: input.warningCount,
-    override_type: 'reserve_allocation',
-  };
 }
 
 async function recordCalculationFailedEvent(input: {

--- a/server/services/fund-scenario-reserve-snapshot-store.ts
+++ b/server/services/fund-scenario-reserve-snapshot-store.ts
@@ -1,0 +1,173 @@
+import type { PoolClient } from 'pg';
+import {
+  FundScenarioCalculationPayloadV1Schema,
+  FundScenarioCalculationResponseV1Schema,
+  type FundScenarioCalculationPayloadV1,
+  type FundScenarioCalculationResponseV1,
+  type FundScenarioResultStalenessStateV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import { createHttpError } from './fund-scenario-set-service.js';
+
+export const ASYNC_RESERVE_TIMEOUT_MS = 300_000;
+export const FUND_SCENARIO_CALC_VERSION =
+  process.env['ALG_FUND_SCENARIO_VERSION'] ?? 'fund-scenarios-v1';
+
+const RESERVE_SCENARIO_SNAPSHOT_UPSERT_SQL = `INSERT INTO fund_snapshots (
+       fund_id,
+       type,
+       payload,
+       calc_version,
+       correlation_id,
+       metadata,
+       snapshot_time,
+       config_id,
+       config_version,
+       scenario_set_id
+     )
+      VALUES ($1, 'SCENARIOS', $2, $3, $4, $5, NOW(), $6, $7, $8)
+      ON CONFLICT (fund_id, scenario_set_id)
+      WHERE scenario_set_id IS NOT NULL AND type = 'SCENARIOS'
+      DO UPDATE SET
+        payload = EXCLUDED.payload,
+        calc_version = EXCLUDED.calc_version,
+        correlation_id = EXCLUDED.correlation_id,
+        metadata = EXCLUDED.metadata,
+        snapshot_time = EXCLUDED.snapshot_time,
+        config_id = EXCLUDED.config_id,
+        config_version = EXCLUDED.config_version,
+        created_at = NOW()
+      RETURNING id, payload, correlation_id, created_at, snapshot_time`;
+
+interface SnapshotRow {
+  id: number;
+  payload: unknown;
+  correlation_id: string;
+  created_at: Date | string | null;
+  snapshot_time: Date | string | null;
+}
+
+export interface ReserveScenarioSnapshotInput {
+  fundId: number;
+  scenarioSetId: string;
+  sourceConfigId: number;
+  sourceConfigVersion: number;
+  correlationId: string;
+  payload: FundScenarioCalculationPayloadV1;
+  inputHash: string;
+  variantCount: number;
+  companyCount: number;
+  warningCount: number;
+}
+
+function parseJsonPayload(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return JSON.parse(value) as unknown;
+}
+
+function responseFromSnapshot(row: SnapshotRow): FundScenarioCalculationResponseV1 {
+  const payload = FundScenarioCalculationPayloadV1Schema.parse(parseJsonPayload(row.payload));
+  return FundScenarioCalculationResponseV1Schema.parse({
+    snapshotId: row.id,
+    correlationId: row.correlation_id,
+    source: 'fund_snapshots',
+    payload,
+  });
+}
+
+function reserveScenarioSnapshotMetadata(input: ReserveScenarioSnapshotInput) {
+  return {
+    input_hash: input.inputHash,
+    calculation_mode: 'async_reserve_allocation',
+    timeout_ms: ASYNC_RESERVE_TIMEOUT_MS,
+    variant_count: input.variantCount,
+    company_count: input.companyCount,
+    warning_count: input.warningCount,
+    override_type: 'reserve_allocation',
+  };
+}
+
+export function applyScenarioReadStaleness(
+  response: FundScenarioCalculationResponseV1,
+  currentPublishedVersion: number | null
+): FundScenarioCalculationResponseV1 {
+  const state = response.payload.staleness.state;
+  const nextState: FundScenarioResultStalenessStateV1 =
+    state === 'STALE_CONFIG' ||
+    state === 'CALCULATING' ||
+    state === 'FAILED' ||
+    state === 'UNAVAILABLE'
+      ? state
+      : currentPublishedVersion != null &&
+          currentPublishedVersion > response.payload.sourceConfigVersion
+        ? 'STALE_PUBLISH'
+        : 'CURRENT';
+
+  response.payload.staleness.state = nextState;
+  response.payload.staleness.currentPublishedConfigVersion = currentPublishedVersion;
+  return response;
+}
+
+export async function findReusableReserveScenarioSnapshot(
+  client: PoolClient,
+  input: {
+    fundId: number;
+    scenarioSetId: string;
+    sourceConfigId: number;
+    sourceConfigVersion: number;
+    inputHash: string;
+  }
+): Promise<FundScenarioCalculationResponseV1 | null> {
+  const result = await client.query<SnapshotRow>(
+    `SELECT id, payload, correlation_id, created_at, snapshot_time
+       FROM fund_snapshots
+      WHERE fund_id = $1
+        AND scenario_set_id = $2
+        AND type = 'SCENARIOS'
+        AND config_id = $3
+        AND config_version = $4
+        AND calc_version = $5
+        AND metadata ->> 'input_hash' = $6
+        AND metadata ->> 'calculation_mode' = 'async_reserve_allocation'
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [
+      input.fundId,
+      input.scenarioSetId,
+      input.sourceConfigId,
+      input.sourceConfigVersion,
+      FUND_SCENARIO_CALC_VERSION,
+      input.inputHash,
+    ]
+  );
+
+  const snapshot = result.rows[0];
+  return snapshot ? responseFromSnapshot(snapshot) : null;
+}
+
+export async function persistReserveScenarioSnapshot(
+  client: PoolClient,
+  input: ReserveScenarioSnapshotInput
+): Promise<FundScenarioCalculationResponseV1> {
+  const result = await client.query<SnapshotRow>(RESERVE_SCENARIO_SNAPSHOT_UPSERT_SQL, [
+    input.fundId,
+    input.payload,
+    FUND_SCENARIO_CALC_VERSION,
+    input.correlationId,
+    reserveScenarioSnapshotMetadata(input),
+    input.sourceConfigId,
+    input.sourceConfigVersion,
+    input.scenarioSetId,
+  ]);
+
+  const snapshot = result.rows[0];
+  if (!snapshot) {
+    throw createHttpError(500, 'Reserve scenario snapshot insert did not return an id', {
+      code: 'scenario_snapshot_insert_failed',
+    });
+  }
+
+  return responseFromSnapshot(snapshot);
+}

--- a/server/services/fund-scenario-reserve-summary.ts
+++ b/server/services/fund-scenario-reserve-summary.ts
@@ -104,29 +104,69 @@ function fundSizeWarning(input: {
   ];
 }
 
+function baseAllocationCents(row: BaseAllocationRow): number {
+  if (row.base == null) {
+    return 0;
+  }
+
+  return toCents(row.base.allocation);
+}
+
+function plannedReservesCents(
+  override: ReserveScenarioAllocationOverrideItemV1 | undefined,
+  baseAllocationCents: number
+): number {
+  return override == null ? baseAllocationCents : override.plannedReservesCents;
+}
+
+function maxAllocationCents(
+  override: ReserveScenarioAllocationOverrideItemV1 | undefined
+): number | null {
+  return override?.maxAllocationCents ?? null;
+}
+
+function allocationConfidence(row: BaseAllocationRow): number {
+  return row.base == null ? 0 : row.base.confidence;
+}
+
+function allocationRationale(
+  row: BaseAllocationRow,
+  override: ReserveScenarioAllocationOverrideItemV1 | undefined
+): string {
+  if (override?.allocationReason != null) {
+    return override.allocationReason;
+  }
+
+  if (row.base?.rationale != null) {
+    return row.base.rationale;
+  }
+
+  return 'Scenario reserve allocation';
+}
+
 function buildAllocationResult(
   row: BaseAllocationRow,
   overrides: Map<number, ReserveScenarioAllocationOverrideItemV1>
 ): ScenarioReserveAllocationResult {
   const override = overrides.get(row.company.id);
-  const baseAllocationCents = toCents(row.base?.allocation ?? 0);
-  const plannedReservesCents = override?.plannedReservesCents ?? baseAllocationCents;
-  const maxAllocationCents = override?.maxAllocationCents ?? null;
+  const baseAllocationCentsValue = baseAllocationCents(row);
+  const plannedReservesCentsValue = plannedReservesCents(override, baseAllocationCentsValue);
+  const maxAllocationCentsValue = maxAllocationCents(override);
   const { scenarioAllocationCents, capApplied } = effectiveAllocationCents({
-    plannedReservesCents,
-    maxAllocationCents,
+    plannedReservesCents: plannedReservesCentsValue,
+    maxAllocationCents: maxAllocationCentsValue,
   });
 
   return {
     companyId: row.company.id,
-    baseAllocationCents,
-    plannedReservesCents,
-    maxAllocationCents,
+    baseAllocationCents: baseAllocationCentsValue,
+    plannedReservesCents: plannedReservesCentsValue,
+    maxAllocationCents: maxAllocationCentsValue,
     scenarioAllocationCents,
-    allocationDeltaCents: scenarioAllocationCents - baseAllocationCents,
+    allocationDeltaCents: scenarioAllocationCents - baseAllocationCentsValue,
     capApplied,
-    confidence: row.base?.confidence ?? 0,
-    rationale: override?.allocationReason ?? row.base?.rationale ?? 'Scenario reserve allocation',
+    confidence: allocationConfidence(row),
+    rationale: allocationRationale(row, override),
   };
 }
 

--- a/server/services/fund-scenario-reserve-summary.ts
+++ b/server/services/fund-scenario-reserve-summary.ts
@@ -8,24 +8,27 @@ import {
   type ScenarioReserveWarningV1,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 
+type ScenarioReserveAllocationResult = ScenarioReserveSummaryV1['allocations'][number];
+
+interface BaseAllocationRow {
+  company: ReserveCompanyInput;
+  base: ReserveOutput | null;
+  inputIndex: number;
+}
+
 function toCents(value: number): number {
   return Math.round(value * 100);
 }
 
-function buildBaseOutputByCompanyId(
+function buildBaseAllocationRows(
   portfolio: ReserveCompanyInput[],
   baseOutputs: ReserveOutput[]
-): Map<number, ReserveOutput> {
-  const byCompanyId = new Map<number, ReserveOutput>();
-
-  portfolio.forEach((company, index) => {
-    const base = baseOutputs[index];
-    if (base) {
-      byCompanyId.set(company.id, base);
-    }
-  });
-
-  return byCompanyId;
+): BaseAllocationRow[] {
+  return portfolio.map((company, index) => ({
+    company,
+    base: baseOutputs[index] ?? null,
+    inputIndex: index,
+  }));
 }
 
 function buildOverrideMap(items: ReserveScenarioAllocationOverrideItemV1[]) {
@@ -42,28 +45,21 @@ function buildOverrideMap(items: ReserveScenarioAllocationOverrideItemV1[]) {
   return { byCompanyId, duplicateCompanyIds };
 }
 
-function effectiveAllocationCents(item: ReserveScenarioAllocationOverrideItemV1) {
-  const max = item.maxAllocationCents ?? null;
+function effectiveAllocationCents(input: {
+  plannedReservesCents: number;
+  maxAllocationCents: number | null;
+}): Pick<ScenarioReserveAllocationResult, 'scenarioAllocationCents' | 'capApplied'> {
+  const max = input.maxAllocationCents;
   const scenarioAllocationCents =
-    max == null ? item.plannedReservesCents : Math.min(item.plannedReservesCents, max);
+    max == null ? input.plannedReservesCents : Math.min(input.plannedReservesCents, max);
 
   return {
     scenarioAllocationCents,
-    capApplied: max != null && max < item.plannedReservesCents,
+    capApplied: max != null && max < input.plannedReservesCents,
   };
 }
 
-export function buildScenarioReserveSummary(input: {
-  fundId: number;
-  fundSizeCents: number | null;
-  portfolio: ReserveCompanyInput[];
-  override: FundScenarioReserveAllocationOverrideV1;
-}): ScenarioReserveSummaryV1 {
-  const baseOutputs = ReserveEngine(input.portfolio);
-  const baseByCompanyId = buildBaseOutputByCompanyId(input.portfolio, baseOutputs);
-  const { byCompanyId: overrides, duplicateCompanyIds } = buildOverrideMap(
-    input.override.payload.items
-  );
+function duplicateOverrideWarnings(duplicateCompanyIds: Set<number>): ScenarioReserveWarningV1[] {
   const warnings: ScenarioReserveWarningV1[] = [];
 
   for (const companyId of duplicateCompanyIds) {
@@ -74,8 +70,17 @@ export function buildScenarioReserveSummary(input: {
     });
   }
 
+  return warnings;
+}
+
+function missingCompanyWarnings(
+  overrides: Map<number, ReserveScenarioAllocationOverrideItemV1>,
+  portfolioCompanyIds: Set<number>
+): ScenarioReserveWarningV1[] {
+  const warnings: ScenarioReserveWarningV1[] = [];
+
   for (const override of overrides.values()) {
-    if (!baseByCompanyId.has(override.companyId)) {
+    if (!portfolioCompanyIds.has(override.companyId)) {
       warnings.push({
         code: 'OVERRIDE_COMPANY_NOT_FOUND',
         companyId: override.companyId,
@@ -84,61 +89,107 @@ export function buildScenarioReserveSummary(input: {
     }
   }
 
-  const allocations = input.portfolio
-    .map((company) => {
-      const base = baseByCompanyId.get(company.id);
-      const override = overrides.get(company.id);
-      const baseAllocationCents = toCents(base?.allocation ?? 0);
-      const plannedReservesCents = override?.plannedReservesCents ?? baseAllocationCents;
-      const maxAllocationCents = override?.maxAllocationCents ?? null;
-      const { scenarioAllocationCents, capApplied } = override
-        ? effectiveAllocationCents(override)
-        : {
-            scenarioAllocationCents: baseAllocationCents,
-            capApplied: false,
-          };
+  return warnings;
+}
 
-      return {
-        companyId: company.id,
-        baseAllocationCents,
-        plannedReservesCents,
-        maxAllocationCents,
-        scenarioAllocationCents,
-        allocationDeltaCents: scenarioAllocationCents - baseAllocationCents,
-        capApplied,
-        confidence: base?.confidence ?? 0,
-        rationale: override?.allocationReason ?? base?.rationale ?? 'Scenario reserve allocation',
-      };
-    })
-    .sort((a, b) => a.companyId - b.companyId);
-
-  const totalBaseAllocationCents = allocations.reduce(
-    (sum, item) => sum + item.baseAllocationCents,
-    0
-  );
-  const totalScenarioAllocationCents = allocations.reduce(
-    (sum, item) => sum + item.scenarioAllocationCents,
-    0
-  );
-
-  if (input.fundSizeCents != null && totalScenarioAllocationCents > input.fundSizeCents) {
-    warnings.push({
-      code: 'TOTAL_SCENARIO_ALLOCATION_EXCEEDS_FUND_SIZE',
-      message: 'Total scenario reserve allocation exceeds fund size.',
-    });
+function fundSizeWarning(input: {
+  fundSizeCents: number | null;
+  totalScenarioAllocationCents: number;
+}): ScenarioReserveWarningV1[] {
+  if (input.fundSizeCents == null || input.totalScenarioAllocationCents <= input.fundSizeCents) {
+    return [];
   }
 
-  const avgConfidence =
-    allocations.length === 0
-      ? 0
-      : allocations.reduce((sum, item) => sum + item.confidence, 0) / allocations.length;
+  return [
+    {
+      code: 'TOTAL_SCENARIO_ALLOCATION_EXCEEDS_FUND_SIZE',
+      message: 'Total scenario reserve allocation exceeds fund size.',
+    },
+  ];
+}
+
+function buildAllocationResult(
+  row: BaseAllocationRow,
+  overrides: Map<number, ReserveScenarioAllocationOverrideItemV1>
+): ScenarioReserveAllocationResult {
+  const override = overrides.get(row.company.id);
+  const baseAllocationCents = toCents(row.base?.allocation ?? 0);
+  const plannedReservesCents = override?.plannedReservesCents ?? baseAllocationCents;
+  const maxAllocationCents = override?.maxAllocationCents ?? null;
+  const { scenarioAllocationCents, capApplied } = effectiveAllocationCents({
+    plannedReservesCents,
+    maxAllocationCents,
+  });
+
+  return {
+    companyId: row.company.id,
+    baseAllocationCents,
+    plannedReservesCents,
+    maxAllocationCents,
+    scenarioAllocationCents,
+    allocationDeltaCents: scenarioAllocationCents - baseAllocationCents,
+    capApplied,
+    confidence: row.base?.confidence ?? 0,
+    rationale: override?.allocationReason ?? row.base?.rationale ?? 'Scenario reserve allocation',
+  };
+}
+
+function buildAllocations(
+  rows: BaseAllocationRow[],
+  overrides: Map<number, ReserveScenarioAllocationOverrideItemV1>
+): ScenarioReserveAllocationResult[] {
+  return rows
+    .map((row) => ({
+      allocation: buildAllocationResult(row, overrides),
+      inputIndex: row.inputIndex,
+    }))
+    .sort((a, b) => a.allocation.companyId - b.allocation.companyId || a.inputIndex - b.inputIndex)
+    .map((item) => item.allocation);
+}
+
+function allocationTotal(
+  allocations: ScenarioReserveAllocationResult[],
+  key: 'baseAllocationCents' | 'scenarioAllocationCents'
+): number {
+  return allocations.reduce((sum, item) => sum + item[key], 0);
+}
+
+function averageConfidence(allocations: ScenarioReserveAllocationResult[]): number {
+  if (allocations.length === 0) {
+    return 0;
+  }
+
+  const average = allocations.reduce((sum, item) => sum + item.confidence, 0) / allocations.length;
+  return Math.round(average * 100) / 100;
+}
+
+export function buildScenarioReserveSummary(input: {
+  fundId: number;
+  fundSizeCents: number | null;
+  portfolio: ReserveCompanyInput[];
+  override: FundScenarioReserveAllocationOverrideV1;
+}): ScenarioReserveSummaryV1 {
+  const baseRows = buildBaseAllocationRows(input.portfolio, ReserveEngine(input.portfolio));
+  const { byCompanyId: overrides, duplicateCompanyIds } = buildOverrideMap(
+    input.override.payload.items
+  );
+  const allocations = buildAllocations(baseRows, overrides);
+
+  const totalBaseAllocationCents = allocationTotal(allocations, 'baseAllocationCents');
+  const totalScenarioAllocationCents = allocationTotal(allocations, 'scenarioAllocationCents');
+  const portfolioCompanyIds = new Set(input.portfolio.map((company) => company.id));
+  const warnings = [
+    ...duplicateOverrideWarnings(duplicateCompanyIds),
+    ...missingCompanyWarnings(overrides, portfolioCompanyIds),
+    ...fundSizeWarning({ fundSizeCents: input.fundSizeCents, totalScenarioAllocationCents }),
+  ];
 
   return ScenarioReserveSummaryV1Schema.parse({
     fundId: input.fundId,
     totalBaseAllocationCents,
     totalScenarioAllocationCents,
     totalAllocationDeltaCents: totalScenarioAllocationCents - totalBaseAllocationCents,
-    avgConfidence: Math.round(avgConfidence * 100) / 100,
+    avgConfidence: averageConfidence(allocations),
     highConfidenceCount: allocations.filter((item) => item.confidence >= 0.6).length,
     allocations,
     warnings,

--- a/server/services/fund-scenario-reserve-summary.ts
+++ b/server/services/fund-scenario-reserve-summary.ts
@@ -16,6 +16,16 @@ interface BaseAllocationRow {
   inputIndex: number;
 }
 
+interface EffectiveAllocationInput {
+  plannedReservesCents: number;
+  maxAllocationCents: number | null;
+}
+
+interface EffectiveAllocationResult {
+  scenarioAllocationCents: number;
+  capApplied: boolean;
+}
+
 function toCents(value: number): number {
   return Math.round(value * 100);
 }
@@ -43,20 +53,6 @@ function buildOverrideMap(items: ReserveScenarioAllocationOverrideItemV1[]) {
   }
 
   return { byCompanyId, duplicateCompanyIds };
-}
-
-function effectiveAllocationCents(input: {
-  plannedReservesCents: number;
-  maxAllocationCents: number | null;
-}): Pick<ScenarioReserveAllocationResult, 'scenarioAllocationCents' | 'capApplied'> {
-  const max = input.maxAllocationCents;
-  const scenarioAllocationCents =
-    max == null ? input.plannedReservesCents : Math.min(input.plannedReservesCents, max);
-
-  return {
-    scenarioAllocationCents,
-    capApplied: max != null && max < input.plannedReservesCents,
-  };
 }
 
 function duplicateOverrideWarnings(duplicateCompanyIds: Set<number>): ScenarioReserveWarningV1[] {
@@ -195,4 +191,15 @@ export function buildScenarioReserveSummary(input: {
     warnings,
     generatedAt: new Date().toISOString(),
   });
+}
+
+function effectiveAllocationCents(input: EffectiveAllocationInput): EffectiveAllocationResult {
+  const max = input.maxAllocationCents;
+  const scenarioAllocationCents =
+    max == null ? input.plannedReservesCents : Math.min(input.plannedReservesCents, max);
+
+  return {
+    scenarioAllocationCents,
+    capApplied: max != null && max < input.plannedReservesCents,
+  };
 }

--- a/server/services/fund-scenario-reserve-summary.ts
+++ b/server/services/fund-scenario-reserve-summary.ts
@@ -1,0 +1,147 @@
+import { ReserveEngine } from '@shared/core/reserves/ReserveEngine';
+import type { ReserveCompanyInput, ReserveOutput } from '@shared/types';
+import {
+  ScenarioReserveSummaryV1Schema,
+  type FundScenarioReserveAllocationOverrideV1,
+  type ReserveScenarioAllocationOverrideItemV1,
+  type ScenarioReserveSummaryV1,
+  type ScenarioReserveWarningV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+
+function toCents(value: number): number {
+  return Math.round(value * 100);
+}
+
+function buildBaseOutputByCompanyId(
+  portfolio: ReserveCompanyInput[],
+  baseOutputs: ReserveOutput[]
+): Map<number, ReserveOutput> {
+  const byCompanyId = new Map<number, ReserveOutput>();
+
+  portfolio.forEach((company, index) => {
+    const base = baseOutputs[index];
+    if (base) {
+      byCompanyId.set(company.id, base);
+    }
+  });
+
+  return byCompanyId;
+}
+
+function buildOverrideMap(items: ReserveScenarioAllocationOverrideItemV1[]) {
+  const byCompanyId = new Map<number, ReserveScenarioAllocationOverrideItemV1>();
+  const duplicateCompanyIds = new Set<number>();
+
+  for (const item of items) {
+    if (byCompanyId.has(item.companyId)) {
+      duplicateCompanyIds.add(item.companyId);
+    }
+    byCompanyId.set(item.companyId, item);
+  }
+
+  return { byCompanyId, duplicateCompanyIds };
+}
+
+function effectiveAllocationCents(item: ReserveScenarioAllocationOverrideItemV1) {
+  const max = item.maxAllocationCents ?? null;
+  const scenarioAllocationCents =
+    max == null ? item.plannedReservesCents : Math.min(item.plannedReservesCents, max);
+
+  return {
+    scenarioAllocationCents,
+    capApplied: max != null && max < item.plannedReservesCents,
+  };
+}
+
+export function buildScenarioReserveSummary(input: {
+  fundId: number;
+  fundSizeCents: number | null;
+  portfolio: ReserveCompanyInput[];
+  override: FundScenarioReserveAllocationOverrideV1;
+}): ScenarioReserveSummaryV1 {
+  const baseOutputs = ReserveEngine(input.portfolio);
+  const baseByCompanyId = buildBaseOutputByCompanyId(input.portfolio, baseOutputs);
+  const { byCompanyId: overrides, duplicateCompanyIds } = buildOverrideMap(
+    input.override.payload.items
+  );
+  const warnings: ScenarioReserveWarningV1[] = [];
+
+  for (const companyId of duplicateCompanyIds) {
+    warnings.push({
+      code: 'DUPLICATE_COMPANY_OVERRIDE',
+      companyId,
+      message: `Duplicate reserve override for company ${companyId}; last value was used.`,
+    });
+  }
+
+  for (const override of overrides.values()) {
+    if (!baseByCompanyId.has(override.companyId)) {
+      warnings.push({
+        code: 'OVERRIDE_COMPANY_NOT_FOUND',
+        companyId: override.companyId,
+        message: `Reserve override references company ${override.companyId}, which was not found in the scenario portfolio.`,
+      });
+    }
+  }
+
+  const allocations = input.portfolio
+    .map((company) => {
+      const base = baseByCompanyId.get(company.id);
+      const override = overrides.get(company.id);
+      const baseAllocationCents = toCents(base?.allocation ?? 0);
+      const plannedReservesCents = override?.plannedReservesCents ?? baseAllocationCents;
+      const maxAllocationCents = override?.maxAllocationCents ?? null;
+      const { scenarioAllocationCents, capApplied } = override
+        ? effectiveAllocationCents(override)
+        : {
+            scenarioAllocationCents: baseAllocationCents,
+            capApplied: false,
+          };
+
+      return {
+        companyId: company.id,
+        baseAllocationCents,
+        plannedReservesCents,
+        maxAllocationCents,
+        scenarioAllocationCents,
+        allocationDeltaCents: scenarioAllocationCents - baseAllocationCents,
+        capApplied,
+        confidence: base?.confidence ?? 0,
+        rationale: override?.allocationReason ?? base?.rationale ?? 'Scenario reserve allocation',
+      };
+    })
+    .sort((a, b) => a.companyId - b.companyId);
+
+  const totalBaseAllocationCents = allocations.reduce(
+    (sum, item) => sum + item.baseAllocationCents,
+    0
+  );
+  const totalScenarioAllocationCents = allocations.reduce(
+    (sum, item) => sum + item.scenarioAllocationCents,
+    0
+  );
+
+  if (input.fundSizeCents != null && totalScenarioAllocationCents > input.fundSizeCents) {
+    warnings.push({
+      code: 'TOTAL_SCENARIO_ALLOCATION_EXCEEDS_FUND_SIZE',
+      message: 'Total scenario reserve allocation exceeds fund size.',
+    });
+  }
+
+  const avgConfidence =
+    allocations.length === 0
+      ? 0
+      : allocations.reduce((sum, item) => sum + item.confidence, 0) / allocations.length;
+
+  return ScenarioReserveSummaryV1Schema.parse({
+    fundId: input.fundId,
+    totalBaseAllocationCents,
+    totalScenarioAllocationCents,
+    totalAllocationDeltaCents: totalScenarioAllocationCents - totalBaseAllocationCents,
+    avgConfidence: Math.round(avgConfidence * 100) / 100,
+    highConfidenceCount: allocations.filter((item) => item.confidence >= 0.6).length,
+    allocations,
+    warnings,
+    generatedAt: new Date().toISOString(),
+  });
+}

--- a/server/services/fund-scenario-set-service.ts
+++ b/server/services/fund-scenario-set-service.ts
@@ -246,7 +246,14 @@ export async function insertScenarioSetEvent(
   input: {
     scenarioSetId: string;
     fundId: number;
-    eventType: 'created' | 'updated' | 'archived' | 'calculated';
+    eventType:
+      | 'created'
+      | 'updated'
+      | 'archived'
+      | 'calculated'
+      | 'calculation_queued'
+      | 'calculation_started'
+      | 'calculation_failed';
     actor: ReturnType<typeof normalizeActor>;
     changeSummary: Record<string, unknown>;
   }

--- a/server/services/reserve-calculation-service.ts
+++ b/server/services/reserve-calculation-service.ts
@@ -1,8 +1,8 @@
 import { db } from '../db';
 import { fundSnapshots } from '@shared/schema';
 import { generateReserveSummary } from '@shared/core/reserves/ReserveEngine';
-import type { ReserveCompanyInput } from '@shared/types';
 import { markCalcRunCompletedIfReady } from './calc-run-tracking';
+import { buildReservePortfolioInput } from './reserve-input-builder';
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
@@ -19,11 +19,6 @@ async function retryWithBackoff<T>(
     await new Promise((resolve) => setTimeout(resolve, delay));
     return retryWithBackoff(fn, retries - 1, delay * 2);
   }
-}
-
-function getInvestmentSector(investment: unknown): string {
-  const company = (investment as { company?: { sector?: string | null } | null }).company;
-  return company?.sector ?? 'unknown';
 }
 
 export interface ReserveCalculationInput {
@@ -61,38 +56,7 @@ export async function runReserveCalculation({
     throw new Error(`Fund ${fundId} not found`);
   }
 
-  const investments = await retryWithBackoff(() =>
-    db.query.investments.findMany({
-      where: (inv, { eq }) => eq(inv.fundId, fundId),
-      with: {
-        company: true,
-      },
-    })
-  );
-
-  let portfolio: ReserveCompanyInput[];
-
-  if (investments.length > 0) {
-    portfolio = investments.map((inv) => ({
-      id: inv.companyId || inv.id,
-      invested: parseFloat(inv.amount),
-      ownership: inv.ownershipPercentage ? parseFloat(inv.ownershipPercentage) : 0.15,
-      stage: inv.round || 'seed',
-      sector: getInvestmentSector(inv),
-    }));
-  } else {
-    const portfolioCompanies = await db.query.portfolioCompanies.findMany({
-      where: (companies, { eq }) => eq(companies.fundId, fundId),
-    });
-
-    portfolio = portfolioCompanies.map((company) => ({
-      id: company.id,
-      invested: parseFloat(company.investmentAmount || '0'),
-      ownership: 0.15,
-      stage: company.stage,
-      sector: company.sector,
-    }));
-  }
+  const portfolio = await retryWithBackoff(() => buildReservePortfolioInput(fundId));
 
   const reserves = generateReserveSummary(fundId, portfolio);
 

--- a/server/services/reserve-input-builder.ts
+++ b/server/services/reserve-input-builder.ts
@@ -1,0 +1,117 @@
+import type { PoolClient } from 'pg';
+import { db } from '../db';
+import type { ReserveCompanyInput } from '@shared/types';
+
+interface InvestmentPortfolioRow {
+  id: number;
+  company_id: number | null;
+  amount: string | number;
+  ownership_percentage: string | number | null;
+  round: string | null;
+  sector: string | null;
+}
+
+interface PortfolioCompanyRow {
+  id: number;
+  investment_amount: string | number | null;
+  stage: string | null;
+  sector: string | null;
+}
+
+function getInvestmentSector(investment: { company?: { sector?: string | null } | null }): string {
+  return investment.company?.sector ?? 'unknown';
+}
+
+function toNumber(value: string | number | null | undefined, fallback = 0): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+function investmentRowToPortfolio(row: InvestmentPortfolioRow): ReserveCompanyInput {
+  return {
+    id: row.company_id ?? row.id,
+    invested: toNumber(row.amount),
+    ownership: toNumber(row.ownership_percentage, 0.15),
+    stage: row.round ?? 'seed',
+    sector: row.sector ?? 'unknown',
+  };
+}
+
+function companyRowToPortfolio(row: PortfolioCompanyRow): ReserveCompanyInput {
+  return {
+    id: row.id,
+    invested: toNumber(row.investment_amount),
+    ownership: 0.15,
+    stage: row.stage ?? 'seed',
+    sector: row.sector ?? 'unknown',
+  };
+}
+
+export async function buildReservePortfolioInput(fundId: number): Promise<ReserveCompanyInput[]> {
+  const investments = await db.query.investments.findMany({
+    where: (inv, { eq }) => eq(inv.fundId, fundId),
+    with: {
+      company: true,
+    },
+  });
+
+  if (investments.length > 0) {
+    return investments.map((inv) => ({
+      id: inv.companyId || inv.id,
+      invested: toNumber(inv.amount),
+      ownership: inv.ownershipPercentage ? toNumber(inv.ownershipPercentage) : 0.15,
+      stage: inv.round || 'seed',
+      sector: getInvestmentSector(inv),
+    }));
+  }
+
+  const portfolioCompanies = await db.query.portfolioCompanies.findMany({
+    where: (companies, { eq }) => eq(companies.fundId, fundId),
+  });
+
+  return portfolioCompanies.map((company) => ({
+    id: company.id,
+    invested: toNumber(company.investmentAmount),
+    ownership: 0.15,
+    stage: company.stage,
+    sector: company.sector,
+  }));
+}
+
+export async function buildReservePortfolioInputForClient(
+  client: PoolClient,
+  fundId: number
+): Promise<ReserveCompanyInput[]> {
+  const investments = await client.query<InvestmentPortfolioRow>(
+    `SELECT
+       i.id,
+       i.company_id,
+       i.amount,
+       i.ownership_percentage,
+       i.round,
+       pc.sector
+     FROM investments i
+     LEFT JOIN portfoliocompanies pc ON pc.id = i.company_id
+     WHERE i.fund_id = $1
+     ORDER BY COALESCE(i.company_id, i.id), i.id`,
+    [fundId]
+  );
+
+  if (investments.rows.length > 0) {
+    return investments.rows.map(investmentRowToPortfolio);
+  }
+
+  const companies = await client.query<PortfolioCompanyRow>(
+    `SELECT id, investment_amount, stage, sector
+       FROM portfoliocompanies
+      WHERE fund_id = $1
+      ORDER BY id ASC`,
+    [fundId]
+  );
+
+  return companies.rows.map(companyRowToPortfolio);
+}

--- a/shared/contracts/fund-scenario-sets-v1.contract.ts
+++ b/shared/contracts/fund-scenario-sets-v1.contract.ts
@@ -1,10 +1,6 @@
 /**
  * FundScenarioSetsV1 -- Canonical contract for ADR-022 fund-results scenarios.
  *
- * This slice persists fund-scoped scenario sets and variants, then supports
- * sync fee-profile calculation. It intentionally does not extend the
- * publish-comparison contract.
- *
  * Strict schema: unknown keys are rejected (.strict()).
  *
  * @module shared/contracts/fund-scenario-sets-v1.contract
@@ -16,7 +12,7 @@ import { FundDraftWriteV1Schema } from './fund-draft-write-v1.contract';
 
 const DateTimeStringSchema = z.string().datetime();
 
-export const FundScenarioOverrideTypeV1Schema = z.literal('fee_profile');
+export const FundScenarioOverrideTypeV1Schema = z.enum(['fee_profile', 'reserve_allocation']);
 
 const FeeProfileOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
   feeProfiles: true,
@@ -30,12 +26,36 @@ const FeeProfileOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
 
 export const FundScenarioFeeProfileOverrideV1Schema = z
   .object({
-    overrideType: FundScenarioOverrideTypeV1Schema,
+    overrideType: z.literal('fee_profile'),
     payload: FeeProfileOverridePayloadV1Schema,
   })
   .strict();
 
-export const FundScenarioVariantOverrideV1Schema = FundScenarioFeeProfileOverrideV1Schema;
+export const ReserveScenarioAllocationOverrideItemV1Schema = z
+  .object({
+    companyId: z.number().int().positive(),
+    plannedReservesCents: z.number().int().min(0),
+    maxAllocationCents: z.number().int().min(0).nullable().optional(),
+    allocationReason: z.string().trim().max(1000).nullable().optional(),
+  })
+  .strict();
+
+export const FundScenarioReserveAllocationOverrideV1Schema = z
+  .object({
+    overrideType: z.literal('reserve_allocation'),
+    payload: z
+      .object({
+        allocationVersion: z.number().int().positive().nullable().optional(),
+        items: z.array(ReserveScenarioAllocationOverrideItemV1Schema).min(1).max(500),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const FundScenarioVariantOverrideV1Schema = z.discriminatedUnion('overrideType', [
+  FundScenarioFeeProfileOverrideV1Schema,
+  FundScenarioReserveAllocationOverrideV1Schema,
+]);
 
 export const CreateFundScenarioVariantV1Schema = z
   .object({
@@ -45,13 +65,24 @@ export const CreateFundScenarioVariantV1Schema = z
   })
   .strict();
 
+function allVariantsShareOverrideType(
+  variants: Array<{ override: { overrideType: FundScenarioOverrideTypeV1 } }>
+): boolean {
+  const first = variants[0]?.override.overrideType;
+  return first != null && variants.every((variant) => variant.override.overrideType === first);
+}
+
 export const CreateFundScenarioSetV1Schema = z
   .object({
     name: z.string().trim().min(1).max(120),
     description: z.string().trim().max(4000).nullable().optional(),
     variants: z.array(CreateFundScenarioVariantV1Schema).min(1).max(5),
   })
-  .strict();
+  .strict()
+  .refine((value) => allVariantsShareOverrideType(value.variants), {
+    message: 'All variants in a scenario set must use the same overrideType',
+    path: ['variants'],
+  });
 
 export const ArchiveFundScenarioSetV1Schema = z
   .object({
@@ -103,19 +134,24 @@ export const FundScenarioSetListResponseV1Schema = z
   })
   .strict();
 
+export const ScenarioEvidenceStateV1Schema = z.enum([
+  'CURRENT',
+  'STALE_PUBLISH',
+  'STALE_CONFIG',
+  'CALCULATING',
+  'FAILED',
+  'UNAVAILABLE',
+]);
+
 export const FundScenarioCalculationStalenessV1Schema = z
   .object({
-    state: z.enum(['CURRENT', 'STALE_PUBLISH', 'STALE_CONFIG']),
+    state: ScenarioEvidenceStateV1Schema,
     sourceConfigVersion: z.number().int().positive(),
     currentPublishedConfigVersion: z.number().int().positive().nullable(),
   })
   .strict();
 
-export const FundScenarioResultStalenessStateV1Schema = z.enum([
-  'CURRENT',
-  'STALE_PUBLISH',
-  'STALE_CONFIG',
-]);
+export const FundScenarioResultStalenessStateV1Schema = ScenarioEvidenceStateV1Schema;
 
 export const FundScenariosSectionReasonCodeV1Schema = z.enum([
   'SCENARIOS_NONE_EXIST',
@@ -123,14 +159,80 @@ export const FundScenariosSectionReasonCodeV1Schema = z.enum([
   'SCENARIOS_LOAD_FAILED',
 ]);
 
-export const ScenarioSetVariantResultSummaryV1Schema = z
+export const ScenarioReserveAllocationResultV1Schema = z
+  .object({
+    companyId: z.number().int().positive(),
+    baseAllocationCents: z.number().int().min(0),
+    plannedReservesCents: z.number().int().min(0),
+    maxAllocationCents: z.number().int().min(0).nullable(),
+    scenarioAllocationCents: z.number().int().min(0),
+    allocationDeltaCents: z.number().int(),
+    capApplied: z.boolean(),
+    confidence: z.number().min(0).max(1),
+    rationale: z.string(),
+  })
+  .strict();
+
+export const ScenarioReserveWarningCodeV1Schema = z.enum([
+  'TOTAL_SCENARIO_ALLOCATION_EXCEEDS_FUND_SIZE',
+  'OVERRIDE_COMPANY_NOT_FOUND',
+  'DUPLICATE_COMPANY_OVERRIDE',
+]);
+
+export const ScenarioReserveWarningV1Schema = z
+  .object({
+    code: ScenarioReserveWarningCodeV1Schema,
+    message: z.string(),
+    companyId: z.number().int().positive().nullable().optional(),
+  })
+  .strict();
+
+export const ScenarioReserveSummaryV1Schema = z
+  .object({
+    fundId: z.number().int().positive(),
+    totalBaseAllocationCents: z.number().int().min(0),
+    totalScenarioAllocationCents: z.number().int().min(0),
+    totalAllocationDeltaCents: z.number().int(),
+    avgConfidence: z.number().min(0).max(1),
+    highConfidenceCount: z.number().int().min(0),
+    allocations: z.array(ScenarioReserveAllocationResultV1Schema),
+    warnings: z.array(ScenarioReserveWarningV1Schema),
+    generatedAt: DateTimeStringSchema,
+  })
+  .strict();
+
+export const ScenarioReserveResultSummaryV1Schema = z
+  .object({
+    totalScenarioAllocationCents: z.number().int().min(0),
+    totalAllocationDeltaCents: z.number().int(),
+    avgConfidence: z.number().min(0).max(1),
+    highConfidenceCount: z.number().int().min(0),
+    warningCount: z.number().int().min(0),
+  })
+  .strict();
+
+export const ScenarioSetFeeProfileVariantResultSummaryV1Schema = z
   .object({
     variantId: z.string().uuid(),
     name: z.string(),
-    overrideType: FundScenarioOverrideTypeV1Schema,
+    overrideType: z.literal('fee_profile'),
     economicsSummary: EconomicsSummaryV1Schema,
   })
   .strict();
+
+export const ScenarioSetReserveVariantResultSummaryV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('reserve_allocation'),
+    reserveSummary: ScenarioReserveResultSummaryV1Schema,
+  })
+  .strict();
+
+export const ScenarioSetVariantResultSummaryV1Schema = z.discriminatedUnion('overrideType', [
+  ScenarioSetFeeProfileVariantResultSummaryV1Schema,
+  ScenarioSetReserveVariantResultSummaryV1Schema,
+]);
 
 export const ScenarioSetResultSummaryV1Schema = z
   .object({
@@ -138,6 +240,7 @@ export const ScenarioSetResultSummaryV1Schema = z
     name: z.string(),
     sourceConfigId: z.number().int().positive(),
     sourceConfigVersion: z.number().int().positive(),
+    currentPublishedConfigVersion: z.number().int().positive().nullable(),
     calculatedAt: DateTimeStringSchema,
     staleness: FundScenarioResultStalenessStateV1Schema,
     variantCount: z.number().int().min(0).max(5),
@@ -162,20 +265,40 @@ export const ScenariosSectionPayloadV1Schema = z
   })
   .strict();
 
-export const FundScenarioCalculationVariantV1Schema = z
+export const FundScenarioCalculationModeV1Schema = z.enum([
+  'sync_fee_profile',
+  'async_reserve_allocation',
+]);
+
+export const FundScenarioFeeProfileCalculationVariantV1Schema = z
   .object({
     variantId: z.string().uuid(),
     scenarioSetId: z.string().uuid(),
     name: z.string(),
-    overrideType: FundScenarioOverrideTypeV1Schema,
+    overrideType: z.literal('fee_profile'),
     economics: EconomicsResultV1Schema,
   })
   .strict();
 
+export const FundScenarioReserveCalculationVariantV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    scenarioSetId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('reserve_allocation'),
+    reserve: ScenarioReserveSummaryV1Schema,
+  })
+  .strict();
+
+export const FundScenarioCalculationVariantV1Schema = z.discriminatedUnion('overrideType', [
+  FundScenarioFeeProfileCalculationVariantV1Schema,
+  FundScenarioReserveCalculationVariantV1Schema,
+]);
+
 export const FundScenarioCalculationPayloadV1Schema = z
   .object({
     version: z.literal('fund-scenarios-v1'),
-    calculationMode: z.literal('sync_fee_profile'),
+    calculationMode: FundScenarioCalculationModeV1Schema,
     fundId: z.number().int().positive(),
     scenarioSetId: z.string().uuid(),
     sourceConfigId: z.number().int().positive(),
@@ -184,7 +307,20 @@ export const FundScenarioCalculationPayloadV1Schema = z
     calculatedAt: DateTimeStringSchema,
     variants: z.array(FundScenarioCalculationVariantV1Schema).min(1).max(5),
   })
-  .strict();
+  .strict()
+  .superRefine((value, ctx) => {
+    const expectedOverrideType =
+      value.calculationMode === 'sync_fee_profile' ? 'fee_profile' : 'reserve_allocation';
+    for (const [index, variant] of value.variants.entries()) {
+      if (variant.overrideType !== expectedOverrideType) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['variants', index, 'overrideType'],
+          message: `${value.calculationMode} requires ${expectedOverrideType} variants`,
+        });
+      }
+    }
+  });
 
 export const FundScenarioCalculationResponseV1Schema = z
   .object({
@@ -195,28 +331,73 @@ export const FundScenarioCalculationResponseV1Schema = z
   })
   .strict();
 
+export const FundScenarioReserveCalculationRequestV1Schema = z
+  .object({
+    calculationMode: z.literal('async_reserve_allocation').optional(),
+  })
+  .strict();
+
+export const FundScenarioReserveCalculationQueuedV1Schema = z
+  .object({
+    fundId: z.number().int().positive(),
+    scenarioSetId: z.string().uuid(),
+    calculationMode: z.literal('async_reserve_allocation'),
+    status: z.literal('queued'),
+    jobId: z.string(),
+    correlationId: z.string().uuid(),
+  })
+  .strict();
+
+export const FundScenarioCalculationStatusV1Schema = z
+  .object({
+    fundId: z.number().int().positive(),
+    scenarioSetId: z.string().uuid(),
+    calculationMode: FundScenarioCalculationModeV1Schema.nullable(),
+    status: z.enum(['not_requested', 'queued', 'calculating', 'succeeded', 'failed']),
+    jobId: z.string().nullable(),
+    correlationId: z.string().uuid().nullable(),
+    snapshotId: z.number().int().positive().nullable(),
+    lastEventAt: DateTimeStringSchema.nullable(),
+    lastError: z.string().nullable(),
+  })
+  .strict();
+
 export type FundScenarioOverrideTypeV1 = z.infer<typeof FundScenarioOverrideTypeV1Schema>;
 export type FundScenarioVariantOverrideV1 = z.infer<typeof FundScenarioVariantOverrideV1Schema>;
+export type FundScenarioReserveAllocationOverrideV1 = z.infer<
+  typeof FundScenarioReserveAllocationOverrideV1Schema
+>;
+export type ReserveScenarioAllocationOverrideItemV1 = z.infer<
+  typeof ReserveScenarioAllocationOverrideItemV1Schema
+>;
 export type CreateFundScenarioVariantV1 = z.infer<typeof CreateFundScenarioVariantV1Schema>;
 export type CreateFundScenarioSetV1 = z.infer<typeof CreateFundScenarioSetV1Schema>;
 export type ArchiveFundScenarioSetV1 = z.infer<typeof ArchiveFundScenarioSetV1Schema>;
 export type FundScenarioVariantV1 = z.infer<typeof FundScenarioVariantV1Schema>;
 export type FundScenarioSetSummaryV1 = z.infer<typeof FundScenarioSetSummaryV1Schema>;
 export type FundScenarioSetDetailV1 = z.infer<typeof FundScenarioSetDetailV1Schema>;
+export type ScenarioEvidenceStateV1 = z.infer<typeof ScenarioEvidenceStateV1Schema>;
 export type FundScenarioResultStalenessStateV1 = z.infer<
   typeof FundScenarioResultStalenessStateV1Schema
 >;
 export type FundScenariosSectionReasonCodeV1 = z.infer<
   typeof FundScenariosSectionReasonCodeV1Schema
 >;
+export type ScenarioReserveSummaryV1 = z.infer<typeof ScenarioReserveSummaryV1Schema>;
+export type ScenarioReserveWarningV1 = z.infer<typeof ScenarioReserveWarningV1Schema>;
 export type ScenarioSetVariantResultSummaryV1 = z.infer<
   typeof ScenarioSetVariantResultSummaryV1Schema
 >;
 export type ScenarioSetResultSummaryV1 = z.infer<typeof ScenarioSetResultSummaryV1Schema>;
 export type ScenariosSectionPayloadV1 = z.infer<typeof ScenariosSectionPayloadV1Schema>;
+export type FundScenarioCalculationModeV1 = z.infer<typeof FundScenarioCalculationModeV1Schema>;
 export type FundScenarioCalculationPayloadV1 = z.infer<
   typeof FundScenarioCalculationPayloadV1Schema
 >;
 export type FundScenarioCalculationResponseV1 = z.infer<
   typeof FundScenarioCalculationResponseV1Schema
 >;
+export type FundScenarioReserveCalculationQueuedV1 = z.infer<
+  typeof FundScenarioReserveCalculationQueuedV1Schema
+>;
+export type FundScenarioCalculationStatusV1 = z.infer<typeof FundScenarioCalculationStatusV1Schema>;

--- a/shared/schema/fund.ts
+++ b/shared/schema/fund.ts
@@ -204,7 +204,9 @@ export const fundScenarioVariants = pgTable(
     name: varchar('name', { length: 120 }).notNull(),
     description: text('description'),
     sortOrder: integer('sort_order').notNull().default(0),
-    overrideType: varchar('override_type', { length: 32 }).notNull().$type<'fee_profile'>(),
+    overrideType: varchar('override_type', { length: 32 })
+      .notNull()
+      .$type<'fee_profile' | 'reserve_allocation'>(),
     overridePayload: jsonb('override_payload').notNull().$type<Record<string, unknown>>(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),

--- a/tests/unit/components/ScenarioEvidenceHeader.test.tsx
+++ b/tests/unit/components/ScenarioEvidenceHeader.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ScenarioEvidenceHeader } from '../../../client/src/components/results/ScenarioEvidenceHeader';
+import type { ScenarioEvidenceSourceV1 } from '../../../client/src/components/results/scenario-evidence';
+
+describe('ScenarioEvidenceHeader', () => {
+  it('renders current scenario provenance with config versions and source', () => {
+    render(<ScenarioEvidenceHeader evidence={evidence()} testId="scenario-evidence" />);
+
+    const header = screen.getByTestId('scenario-evidence');
+    expect(within(header).getByText('CURRENT')).toBeInTheDocument();
+    expect(within(header).getByText('SCENARIO 00000000')).toBeInTheDocument();
+    expect(within(header).getByText('SOURCE CONFIG v4')).toBeInTheDocument();
+    expect(within(header).getByText('PUBLISHED CONFIG v4')).toBeInTheDocument();
+    expect(within(header).getByText('SOURCE fund_snapshots')).toBeInTheDocument();
+  });
+
+  it('renders explicit accessible explanations for stale, failed, and unavailable states', () => {
+    const states: ScenarioEvidenceSourceV1['state'][] = [
+      'STALE_PUBLISH',
+      'STALE_CONFIG',
+      'FAILED',
+      'UNAVAILABLE',
+    ];
+
+    for (const state of states) {
+      const { unmount } = render(<ScenarioEvidenceHeader evidence={evidence({ state })} />);
+      const badge = screen.getByText(state);
+
+      expect(badge).toHaveAttribute('title');
+      expect(badge).toHaveAttribute('aria-label');
+      expect(badge.getAttribute('aria-label')).not.toBe('');
+
+      unmount();
+    }
+  });
+
+  it('renders unavailable segments for null or invalid evidence fields', () => {
+    render(
+      <ScenarioEvidenceHeader
+        evidence={evidence({
+          scenarioSetId: null,
+          sourceConfigVersion: null,
+          currentPublishedConfigVersion: null,
+          calculatedAt: 'not-a-date',
+          state: 'UNAVAILABLE',
+        })}
+        testId="scenario-evidence"
+      />
+    );
+
+    const header = screen.getByTestId('scenario-evidence');
+    expect(within(header).getByText('SCENARIO UNAVAILABLE')).toBeInTheDocument();
+    expect(within(header).getByText('SOURCE CONFIG UNAVAILABLE')).toBeInTheDocument();
+    expect(within(header).getByText('PUBLISHED CONFIG UNAVAILABLE')).toBeInTheDocument();
+    expect(within(header).getByText('CALCULATED UNAVAILABLE')).toBeInTheDocument();
+  });
+});
+
+function evidence(overrides: Partial<ScenarioEvidenceSourceV1> = {}): ScenarioEvidenceSourceV1 {
+  return {
+    scenarioSetId: '00000000-0000-0000-0000-000000000111',
+    scenarioSetName: 'Fee sensitivity',
+    calculationMode: null,
+    sourceConfigVersion: 4,
+    currentPublishedConfigVersion: 4,
+    calculatedAt: '2026-05-26T12:00:00.000Z',
+    source: 'fund_snapshots',
+    state: 'CURRENT',
+    reason: null,
+    ...overrides,
+  };
+}

--- a/tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx
+++ b/tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx
@@ -9,7 +9,8 @@ describe('ScenarioSetsSummary', () => {
 
     expect(screen.getByTestId('scenario-sets-summary')).toBeInTheDocument();
     expect(screen.getByText('2 scenario sets')).toBeInTheDocument();
-    expect(screen.getAllByText('Needs recalculation').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByTestId('scenario-evidence-aggregate')).toHaveTextContent('STALE_PUBLISH');
+    expect(screen.getAllByLabelText(/Scenario evidence:/)).toHaveLength(3);
 
     const feeCard = screen.getByText('Fee sensitivity').closest('article');
     if (!(feeCard instanceof HTMLElement)) {
@@ -23,6 +24,42 @@ describe('ScenarioSetsSummary', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
+
+  it('renders aggregate evidence for failed scenario sets and omits it when all sets are current', () => {
+    const failedPayload = scenarioPayload();
+    failedPayload.aggregateStaleness = 'FAILED';
+    failedPayload.sets[0]!.staleness = 'FAILED';
+
+    const { rerender } = render(<ScenarioSetsSummary payload={failedPayload} />);
+    expect(screen.getByTestId('scenario-evidence-aggregate')).toHaveTextContent('FAILED');
+    expect(screen.getByText('One or more scenario calculations failed.')).toBeInTheDocument();
+
+    const currentPayload = scenarioPayload();
+    currentPayload.aggregateStaleness = 'CURRENT';
+    currentPayload.sets.forEach((set) => {
+      set.staleness = 'CURRENT';
+      set.currentPublishedConfigVersion = set.sourceConfigVersion;
+    });
+
+    rerender(<ScenarioSetsSummary payload={currentPayload} />);
+    expect(screen.queryByTestId('scenario-evidence-aggregate')).not.toBeInTheDocument();
+  });
+
+  it('renders reserve scenario summary cards without assuming economics payloads', () => {
+    render(<ScenarioSetsSummary payload={reservePayload()} />);
+
+    const reserveCard = screen.getByText('Reserve plan').closest('article');
+    if (!(reserveCard instanceof HTMLElement)) {
+      throw new Error('Reserve plan card was not rendered');
+    }
+
+    expect(within(reserveCard).getByText('Total scenario allocation')).toBeInTheDocument();
+    expect(within(reserveCard).getByText('$75,000')).toBeInTheDocument();
+    expect(within(reserveCard).getByText('Allocation delta')).toBeInTheDocument();
+    expect(within(reserveCard).getByText('-$25,000')).toBeInTheDocument();
+    expect(within(reserveCard).getByText('Warnings')).toBeInTheDocument();
+    expect(within(reserveCard).getAllByText('1')).toHaveLength(2);
+  });
 });
 
 function scenarioPayload(): ScenariosSectionPayloadV1 {
@@ -35,6 +72,7 @@ function scenarioPayload(): ScenariosSectionPayloadV1 {
         name: 'Fee sensitivity',
         sourceConfigId: 12,
         sourceConfigVersion: 4,
+        currentPublishedConfigVersion: 4,
         calculatedAt: '2026-05-26T12:30:00.000Z',
         staleness: 'CURRENT',
         variantCount: 2,
@@ -58,6 +96,7 @@ function scenarioPayload(): ScenariosSectionPayloadV1 {
         name: 'Upside fees',
         sourceConfigId: 13,
         sourceConfigVersion: 3,
+        currentPublishedConfigVersion: 4,
         calculatedAt: '2026-05-26T12:00:00.000Z',
         staleness: 'STALE_PUBLISH',
         variantCount: 1,
@@ -67,6 +106,39 @@ function scenarioPayload(): ScenariosSectionPayloadV1 {
             name: 'Upside',
             overrideType: 'fee_profile',
             economicsSummary: economicsSummary({ finalTvpi: 1.9 }),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function reservePayload(): ScenariosSectionPayloadV1 {
+  return {
+    version: 'fund-scenarios-v1',
+    aggregateStaleness: 'CURRENT',
+    sets: [
+      {
+        scenarioSetId: '00000000-0000-0000-0000-000000000311',
+        name: 'Reserve plan',
+        sourceConfigId: 14,
+        sourceConfigVersion: 6,
+        currentPublishedConfigVersion: 6,
+        calculatedAt: '2026-05-26T12:30:00.000Z',
+        staleness: 'CURRENT',
+        variantCount: 1,
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000312',
+            name: 'Follow-on cap',
+            overrideType: 'reserve_allocation',
+            reserveSummary: {
+              totalScenarioAllocationCents: 7_500_000,
+              totalAllocationDeltaCents: -2_500_000,
+              avgConfidence: 0.62,
+              highConfidenceCount: 1,
+              warningCount: 1,
+            },
           },
         ],
       },

--- a/tests/unit/contract/fund-scenario-sets.test.ts
+++ b/tests/unit/contract/fund-scenario-sets.test.ts
@@ -4,8 +4,11 @@ import {
   CreateFundScenarioSetV1Schema,
   FundScenariosSectionReasonCodeV1Schema,
   FundScenarioCalculationResponseV1Schema,
+  FundScenarioCalculationStatusV1Schema,
+  FundScenarioReserveCalculationQueuedV1Schema,
   FundScenarioSetDetailV1Schema,
   FundScenarioVariantOverrideV1Schema,
+  ScenarioReserveSummaryV1Schema,
   ScenarioSetResultSummaryV1Schema,
   ScenariosSectionPayloadV1Schema,
 } from '../../../shared/contracts/fund-scenario-sets-v1.contract';
@@ -60,6 +63,61 @@ describe('FundScenarioSetsV1 contract', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('accepts reserve-allocation overrides with hard caps lower than planned reserves', () => {
+    const result = FundScenarioVariantOverrideV1Schema.safeParse({
+      overrideType: 'reserve_allocation',
+      payload: {
+        allocationVersion: 4,
+        items: [
+          {
+            companyId: 101,
+            plannedReservesCents: 10_000_000,
+            maxAllocationCents: 7_500_000,
+            allocationReason: 'Cap the follow-on reserve for concentration control',
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.overrideType).toBe('reserve_allocation');
+  });
+
+  it('continues to reject unknown override types', () => {
+    const result = FundScenarioVariantOverrideV1Schema.safeParse({
+      overrideType: 'allocation',
+      payload: {
+        items: [],
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects mixed override types in one scenario set', () => {
+    const result = CreateFundScenarioSetV1Schema.safeParse({
+      name: 'Mixed scenarios',
+      variants: [
+        {
+          name: 'Fee variant',
+          override: feeProfileOverride,
+        },
+        {
+          name: 'Reserve variant',
+          override: {
+            overrideType: 'reserve_allocation',
+            payload: {
+              items: [{ companyId: 101, plannedReservesCents: 5_000_000 }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain('same overrideType');
   });
 
   it('caps first-slice scenario sets at five variants', () => {
@@ -197,6 +255,129 @@ describe('FundScenarioSetsV1 contract', () => {
     expect(result.success).toBe(true);
   });
 
+  it('describes async reserve calculation queued and status responses', () => {
+    expect(
+      FundScenarioReserveCalculationQueuedV1Schema.safeParse({
+        fundId: 1,
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        calculationMode: 'async_reserve_allocation',
+        status: 'queued',
+        jobId: 'reserve-job-1',
+        correlationId: '00000000-0000-0000-0000-000000000123',
+      }).success
+    ).toBe(true);
+
+    expect(
+      FundScenarioCalculationStatusV1Schema.safeParse({
+        fundId: 1,
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        calculationMode: 'async_reserve_allocation',
+        status: 'failed',
+        jobId: 'reserve-job-1',
+        correlationId: '00000000-0000-0000-0000-000000000123',
+        snapshotId: null,
+        lastEventAt: '2026-05-26T12:00:00.000Z',
+        lastError: 'Reserve scenario calculation failed',
+      }).success
+    ).toBe(true);
+  });
+
+  it('describes reserve scenario summaries in cents with cap evidence', () => {
+    const result = ScenarioReserveSummaryV1Schema.safeParse({
+      fundId: 1,
+      totalBaseAllocationCents: 11_000_000,
+      totalScenarioAllocationCents: 9_500_000,
+      totalAllocationDeltaCents: -1_500_000,
+      avgConfidence: 0.6,
+      highConfidenceCount: 1,
+      allocations: [
+        {
+          companyId: 101,
+          baseAllocationCents: 6_000_000,
+          plannedReservesCents: 10_000_000,
+          maxAllocationCents: 7_500_000,
+          scenarioAllocationCents: 7_500_000,
+          allocationDeltaCents: 1_500_000,
+          capApplied: true,
+          confidence: 0.7,
+          rationale: 'Hard cap applied',
+        },
+      ],
+      warnings: [
+        {
+          code: 'TOTAL_SCENARIO_ALLOCATION_EXCEEDS_FUND_SIZE',
+          message: 'Total scenario reserve allocation exceeds fund size.',
+        },
+      ],
+      generatedAt: '2026-05-26T12:00:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects reserve variants without reserve payloads and fee-profile variants without economics', () => {
+    const reserveResult = FundScenarioCalculationResponseV1Schema.safeParse({
+      snapshotId: 42,
+      correlationId: '00000000-0000-0000-0000-000000000123',
+      source: 'fund_snapshots',
+      payload: {
+        version: 'fund-scenarios-v1',
+        calculationMode: 'async_reserve_allocation',
+        fundId: 1,
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+        staleness: {
+          state: 'CURRENT',
+          sourceConfigVersion: 4,
+          currentPublishedConfigVersion: 4,
+        },
+        calculatedAt: '2026-05-26T12:00:00.000Z',
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000112',
+            scenarioSetId: '00000000-0000-0000-0000-000000000111',
+            name: 'Reserve variant',
+            overrideType: 'reserve_allocation',
+            economics: economicsResult(),
+          },
+        ],
+      },
+    });
+
+    const feeResult = FundScenarioCalculationResponseV1Schema.safeParse({
+      snapshotId: 42,
+      correlationId: '00000000-0000-0000-0000-000000000123',
+      source: 'fund_snapshots',
+      payload: {
+        version: 'fund-scenarios-v1',
+        calculationMode: 'sync_fee_profile',
+        fundId: 1,
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+        staleness: {
+          state: 'CURRENT',
+          sourceConfigVersion: 4,
+          currentPublishedConfigVersion: 4,
+        },
+        calculatedAt: '2026-05-26T12:00:00.000Z',
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000112',
+            scenarioSetId: '00000000-0000-0000-0000-000000000111',
+            name: 'Fee variant',
+            overrideType: 'fee_profile',
+            reserve: reserveSummary(),
+          },
+        ],
+      },
+    });
+
+    expect(reserveResult.success).toBe(false);
+    expect(feeResult.success).toBe(false);
+  });
+
   it('describes fund-results scenario summaries without full economics results', () => {
     const result = ScenariosSectionPayloadV1Schema.safeParse({
       version: 'fund-scenarios-v1',
@@ -207,6 +388,7 @@ describe('FundScenarioSetsV1 contract', () => {
           name: 'Fee sensitivity',
           sourceConfigId: 12,
           sourceConfigVersion: 4,
+          currentPublishedConfigVersion: 4,
           calculatedAt: '2026-05-26T12:00:00.000Z',
           staleness: 'CURRENT',
           variantCount: 1,
@@ -231,6 +413,7 @@ describe('FundScenarioSetsV1 contract', () => {
       name: 'Fee sensitivity',
       sourceConfigId: 12,
       sourceConfigVersion: 4,
+      currentPublishedConfigVersion: 4,
       calculatedAt: '2026-05-26T12:00:00.000Z',
       staleness: 'CURRENT',
       variantCount: 2,
@@ -253,6 +436,7 @@ describe('FundScenarioSetsV1 contract', () => {
       name: 'Fee sensitivity',
       sourceConfigId: 12,
       sourceConfigVersion: 4,
+      currentPublishedConfigVersion: 4,
       calculatedAt: '2026-05-26T12:00:00.000Z',
       staleness: 'CURRENT',
       variantCount: 1,
@@ -281,6 +465,70 @@ describe('FundScenarioSetsV1 contract', () => {
     ]);
   });
 });
+
+function economicsResult() {
+  return {
+    version: 'v1',
+    annual: [
+      {
+        year: 1,
+        lpCapitalCalls: 1,
+        gpCommitmentCalls: 0,
+        grossExitProceeds: 0,
+        beginningCash: 0,
+        investments: 0,
+        feesPaidToManager: 1,
+        expensesPaid: 0,
+        recycledProceeds: 0,
+        endingCash: 0,
+        lpDistributions: 0,
+        gpInvestmentDistributions: 0,
+        gpCarryDistributed: 0,
+        gpCarryEscrowed: 0,
+        gpCarryReleasedFromEscrow: 0,
+        clawbackPaid: 0,
+        grossNav: 0,
+        lpNetNav: 0,
+        dpi: 0,
+        rvpi: 0,
+        tvpi: 0,
+        conservationDelta: 0,
+      },
+    ],
+    summary: economicsSummary(),
+    checks: {
+      passed: true,
+      tolerance: 0.01,
+      errors: [],
+    },
+  };
+}
+
+function reserveSummary() {
+  return {
+    fundId: 1,
+    totalBaseAllocationCents: 1_000_000,
+    totalScenarioAllocationCents: 2_000_000,
+    totalAllocationDeltaCents: 1_000_000,
+    avgConfidence: 0.7,
+    highConfidenceCount: 1,
+    allocations: [
+      {
+        companyId: 101,
+        baseAllocationCents: 1_000_000,
+        plannedReservesCents: 2_000_000,
+        maxAllocationCents: null,
+        scenarioAllocationCents: 2_000_000,
+        allocationDeltaCents: 1_000_000,
+        capApplied: false,
+        confidence: 0.7,
+        rationale: 'Scenario reserve allocation',
+      },
+    ],
+    warnings: [],
+    generatedAt: '2026-05-26T12:00:00.000Z',
+  };
+}
 
 function economicsSummary() {
   return {

--- a/tests/unit/phase2a/config-invariants.test.ts
+++ b/tests/unit/phase2a/config-invariants.test.ts
@@ -68,9 +68,9 @@ describe('Queue name consistency', () => {
 
   it('all calc queue names use hyphen separator consistently', () => {
     const calcQueues = QUEUE_CATALOG.filter((e) => e.key.endsWith('-calc'));
-    expect(calcQueues.length).toBe(4);
+    expect(calcQueues.length).toBe(5);
     for (const entry of calcQueues) {
-      expect(entry.queueName).toMatch(/^[a-z]+-calc$/);
+      expect(entry.queueName).toMatch(/^[a-z]+(?:-[a-z]+)*-calc$/);
     }
   });
 });
@@ -103,6 +103,13 @@ describe('Worker queue names match registry', () => {
       fs.readFile('workers/reserve-worker.ts', 'utf-8')
     );
     expect(workerSource).toContain("'reserve-calc'");
+  });
+
+  it('fund scenario calc worker uses fund-scenario-calc', async () => {
+    const workerSource = await import('fs/promises').then((fs) =>
+      fs.readFile('workers/fund-scenario-calc-worker.ts', 'utf-8')
+    );
+    expect(workerSource).toContain("'fund-scenario-calc'");
   });
 });
 

--- a/tests/unit/phase3/fund-results-contract.test.ts
+++ b/tests/unit/phase3/fund-results-contract.test.ts
@@ -551,6 +551,7 @@ function validScenariosSection() {
           name: 'Fee sensitivity',
           sourceConfigId: 12,
           sourceConfigVersion: 4,
+          currentPublishedConfigVersion: 4,
           calculatedAt: '2026-05-26T12:30:00.000Z',
           staleness: 'CURRENT' as const,
           variantCount: 1,

--- a/tests/unit/phase3/fund-results-read-service.test.ts
+++ b/tests/unit/phase3/fund-results-read-service.test.ts
@@ -918,6 +918,7 @@ function scenarioSetSummary(overrides: Record<string, unknown> = {}) {
     name: 'Fee sensitivity',
     sourceConfigId: 12,
     sourceConfigVersion: 4,
+    currentPublishedConfigVersion: 4,
     calculatedAt: '2026-05-26T12:00:00.000Z',
     staleness: 'CURRENT',
     variantCount: 1,

--- a/tests/unit/phase3/fund-scenario-sets-schema.test.ts
+++ b/tests/unit/phase3/fund-scenario-sets-schema.test.ts
@@ -71,7 +71,7 @@ describe('ADR-022 fund scenario set schema shell', () => {
     expect(schema.fundScenarioSetEvents.changeSummary.name).toBe('change_summary_json');
   });
 
-  it('migration creates dedicated tables and keeps first-slice overrides fee-profile only', async () => {
+  it('migration creates dedicated tables and starts with fee-profile-only overrides', async () => {
     const migration = await readRepoFile('server/db/migrations/0013_fund_scenario_sets.sql');
 
     expect(migration).toContain('CREATE TABLE IF NOT EXISTS fund_scenario_sets');
@@ -84,6 +84,17 @@ describe('ADR-022 fund scenario set schema shell', () => {
     expect(migration).toContain('idempotency_request_hash TEXT');
     expect(migration).toContain('fund_scenario_sets_fund_idempotency_unique');
     expect(migration).toContain('fund_scenario_variants_set_order_unique');
+  });
+
+  it('reserve scenario migration expands override and event constraints', async () => {
+    const migration = await readRepoFile(
+      'server/db/migrations/0015_fund_scenario_reserve_allocation.sql'
+    );
+
+    expect(migration).toContain("override_type IN ('fee_profile', 'reserve_allocation')");
+    expect(migration).toContain("'calculation_queued'");
+    expect(migration).toContain("'calculation_started'");
+    expect(migration).toContain("'calculation_failed'");
   });
 
   it('calculation migration adds an audit-visible calculated event type', async () => {

--- a/tests/unit/routes/fund-scenario-sets-route-contract.test.ts
+++ b/tests/unit/routes/fund-scenario-sets-route-contract.test.ts
@@ -13,12 +13,17 @@ describe('fund scenario set route contract', () => {
   it('keeps every fund-scoped scenario-set route protected by auth and fund access', async () => {
     const source = await readRepoFile('server/routes/fund-scenario-sets.ts');
 
-    expect((source.match(/requireAuth\(\)/g) ?? []).length).toBe(6);
-    expect((source.match(/requireFundAccess/g) ?? []).length).toBe(7);
+    expect((source.match(/requireAuth\(\)/g) ?? []).length).toBe(8);
+    expect((source.match(/requireFundAccess/g) ?? []).length).toBe(9);
     expect(source).toContain('getIdempotencyKey(req)');
     expect(source).toContain('/funds/:fundId/scenario-sets');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/calculate');
+    expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/calculate-reserve');
+    expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/calculation-status');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/results');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/archive');
+    expect(source).toContain('FundScenarioReserveCalculationRequestV1Schema.safeParse');
+    expect(source).toContain('enqueueReserveScenarioCalculation');
+    expect(source).toContain('getFundScenarioCalculationStatus');
   });
 });

--- a/tests/unit/services/fund-scenario-reserve-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-reserve-calculation-service.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { createReserveScenarioInputHash } from '../../../server/services/fund-scenario-reserve-calculation-service';
+
+describe('fund scenario reserve calculation service', () => {
+  it('creates a stable input hash regardless of equivalent variant ordering', () => {
+    const first = createReserveScenarioInputHash({
+      fundId: 1,
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+      calcVersion: 'fund-scenarios-v1',
+      calculationMode: 'async_reserve_allocation',
+      variants: [
+        { id: 'variant-b', override: { payload: { items: [{ companyId: 2 }] } } },
+        { id: 'variant-a', override: { payload: { items: [{ companyId: 1 }] } } },
+      ],
+    });
+
+    const second = createReserveScenarioInputHash({
+      fundId: 1,
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+      calcVersion: 'fund-scenarios-v1',
+      calculationMode: 'async_reserve_allocation',
+      variants: [
+        { id: 'variant-a', override: { payload: { items: [{ companyId: 1 }] } } },
+        { id: 'variant-b', override: { payload: { items: [{ companyId: 2 }] } } },
+      ],
+    });
+
+    expect(first).toBe(second);
+  });
+});

--- a/tests/unit/services/fund-scenario-reserve-summary.test.ts
+++ b/tests/unit/services/fund-scenario-reserve-summary.test.ts
@@ -75,6 +75,32 @@ describe('fund scenario reserve summary builder', () => {
     ]);
   });
 
+  it('preserves per-row base allocations when portfolio rows share a companyId', () => {
+    reserveEngineMock.mockReturnValue([
+      { allocation: 1_000, confidence: 0.7, rationale: 'Seed SaaS first check' },
+      { allocation: 500, confidence: 0.4, rationale: 'Seed SaaS follow-on' },
+    ]);
+
+    const summary = buildScenarioReserveSummary({
+      fundId: 1,
+      fundSizeCents: null,
+      portfolio: [
+        { id: 200, invested: 100, ownership: 0.1, stage: 'Seed', sector: 'SaaS' },
+        { id: 200, invested: 50, ownership: 0.05, stage: 'Seed', sector: 'SaaS' },
+      ],
+      override: {
+        overrideType: 'reserve_allocation',
+        payload: {
+          items: [{ companyId: 999, plannedReservesCents: 10_000 }],
+        },
+      },
+    });
+
+    expect(summary.allocations.map((item) => item.companyId)).toEqual([200, 200]);
+    expect(summary.allocations.map((item) => item.baseAllocationCents)).toEqual([100_000, 50_000]);
+    expect(summary.totalBaseAllocationCents).toBe(150_000);
+  });
+
   it('applies maxAllocationCents as a hard cap when the final override has a lower cap', () => {
     reserveEngineMock.mockReturnValue([
       { allocation: 1_000, confidence: 0.7, rationale: 'Seed SaaS' },

--- a/tests/unit/services/fund-scenario-reserve-summary.test.ts
+++ b/tests/unit/services/fund-scenario-reserve-summary.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { reserveEngineMock } = vi.hoisted(() => ({
+  reserveEngineMock: vi.fn(),
+}));
+
+vi.mock('../../../shared/core/reserves/ReserveEngine', () => ({
+  ReserveEngine: reserveEngineMock,
+}));
+
+import { buildScenarioReserveSummary } from '../../../server/services/fund-scenario-reserve-summary';
+
+describe('fund scenario reserve summary builder', () => {
+  it('converts base allocations to cents, applies hard caps, warns, and sorts by companyId', () => {
+    reserveEngineMock.mockReturnValue([
+      { allocation: 1_000, confidence: 0.7, rationale: 'Seed SaaS' },
+      { allocation: 500, confidence: 0.4, rationale: 'Series A Fintech' },
+    ]);
+
+    const summary = buildScenarioReserveSummary({
+      fundId: 1,
+      fundSizeCents: 100_000,
+      portfolio: [
+        { id: 200, invested: 100, ownership: 0.1, stage: 'Seed', sector: 'SaaS' },
+        { id: 100, invested: 50, ownership: 0.05, stage: 'Series A', sector: 'Fintech' },
+      ],
+      override: {
+        overrideType: 'reserve_allocation',
+        payload: {
+          items: [
+            {
+              companyId: 200,
+              plannedReservesCents: 120_000,
+              maxAllocationCents: 80_000,
+              allocationReason: 'Concentration cap',
+            },
+            {
+              companyId: 999,
+              plannedReservesCents: 10_000,
+            },
+            {
+              companyId: 200,
+              plannedReservesCents: 90_000,
+              maxAllocationCents: null,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(summary.allocations.map((item) => item.companyId)).toEqual([100, 200]);
+    expect(summary.allocations[0]).toMatchObject({
+      companyId: 100,
+      baseAllocationCents: 50_000,
+      plannedReservesCents: 50_000,
+      scenarioAllocationCents: 50_000,
+      capApplied: false,
+    });
+    expect(summary.allocations[1]).toMatchObject({
+      companyId: 200,
+      baseAllocationCents: 100_000,
+      plannedReservesCents: 90_000,
+      maxAllocationCents: null,
+      scenarioAllocationCents: 90_000,
+      allocationDeltaCents: -10_000,
+      capApplied: false,
+    });
+    expect(summary.totalBaseAllocationCents).toBe(150_000);
+    expect(summary.totalScenarioAllocationCents).toBe(140_000);
+    expect(summary.totalAllocationDeltaCents).toBe(-10_000);
+    expect(summary.warnings.map((warning) => warning.code)).toEqual([
+      'DUPLICATE_COMPANY_OVERRIDE',
+      'OVERRIDE_COMPANY_NOT_FOUND',
+      'TOTAL_SCENARIO_ALLOCATION_EXCEEDS_FUND_SIZE',
+    ]);
+  });
+
+  it('applies maxAllocationCents as a hard cap when the final override has a lower cap', () => {
+    reserveEngineMock.mockReturnValue([
+      { allocation: 1_000, confidence: 0.7, rationale: 'Seed SaaS' },
+    ]);
+
+    const summary = buildScenarioReserveSummary({
+      fundId: 1,
+      fundSizeCents: null,
+      portfolio: [{ id: 200, invested: 100, ownership: 0.1, stage: 'Seed', sector: 'SaaS' }],
+      override: {
+        overrideType: 'reserve_allocation',
+        payload: {
+          items: [
+            {
+              companyId: 200,
+              plannedReservesCents: 120_000,
+              maxAllocationCents: 80_000,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(summary.allocations[0]).toMatchObject({
+      plannedReservesCents: 120_000,
+      maxAllocationCents: 80_000,
+      scenarioAllocationCents: 80_000,
+      capApplied: true,
+    });
+  });
+});

--- a/tests/unit/workers/fund-scenario-calc-worker.test.ts
+++ b/tests/unit/workers/fund-scenario-calc-worker.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { runReserveScenarioCalculationMock, loggerInfoMock, loggerErrorMock } = vi.hoisted(() => ({
+  runReserveScenarioCalculationMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock('../../../server/services/fund-scenario-reserve-calculation-service', () => ({
+  runReserveScenarioCalculation: runReserveScenarioCalculationMock,
+}));
+
+vi.mock('../../../lib/logger', () => ({
+  logger: {
+    info: loggerInfoMock,
+    error: loggerErrorMock,
+  },
+}));
+
+vi.mock('../../../lib/metrics', () => ({
+  withMetrics: (_name: string, callback: () => unknown) => callback(),
+  metrics: {
+    counter: vi.fn(),
+  },
+}));
+
+vi.mock('../../../workers/health-server', () => ({
+  registerWorker: vi.fn(),
+  createHealthServer: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Worker: class MockWorker {
+    close = vi.fn();
+  },
+}));
+
+import { handleFundScenarioCalcJob } from '../../../workers/fund-scenario-calc-worker';
+
+describe('fund scenario calc worker handler', () => {
+  it('dispatches async reserve allocation jobs to the reserve scenario service', async () => {
+    runReserveScenarioCalculationMock.mockResolvedValue({ snapshotId: 42 });
+
+    const result = await handleFundScenarioCalcJob({
+      id: 'job-1',
+      data: {
+        fundId: 1,
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        correlationId: '00000000-0000-0000-0000-000000000123',
+        calculationMode: 'async_reserve_allocation',
+        actor: { userId: 17, label: 'analyst@example.com' },
+      },
+    });
+
+    expect(result).toEqual({ snapshotId: 42 });
+    expect(runReserveScenarioCalculationMock).toHaveBeenCalledWith({
+      fundId: 1,
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      correlationId: '00000000-0000-0000-0000-000000000123',
+      actor: { userId: 17, label: 'analyst@example.com' },
+      jobId: 'job-1',
+    });
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'Processing reserve scenario calculation',
+      expect.objectContaining({ jobId: 'job-1' })
+    );
+  });
+
+  it('rejects unsupported calculation modes and logs failures', async () => {
+    await expect(
+      handleFundScenarioCalcJob({
+        id: 'job-2',
+        data: {
+          fundId: 1,
+          scenarioSetId: '00000000-0000-0000-0000-000000000111',
+          correlationId: '00000000-0000-0000-0000-000000000123',
+          calculationMode: 'sync_fee_profile',
+          actor: null,
+        },
+      })
+    ).rejects.toThrow(/Unsupported fund scenario calculation mode/);
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'Reserve scenario calculation failed',
+      expect.any(Error),
+      expect.objectContaining({ jobId: 'job-2' })
+    );
+  });
+});

--- a/workers/fund-scenario-calc-worker.ts
+++ b/workers/fund-scenario-calc-worker.ts
@@ -1,0 +1,106 @@
+import { Worker, type Job } from 'bullmq';
+import { logger } from '../lib/logger';
+import { withMetrics, metrics } from '../lib/metrics';
+import { registerWorker, createHealthServer } from './health-server';
+import { runReserveScenarioCalculation } from '../server/services/fund-scenario-reserve-calculation-service';
+
+const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: parseInt(process.env.REDIS_PORT || '6379'),
+};
+
+interface FundScenarioCalcJobData {
+  fundId: number;
+  scenarioSetId: string;
+  correlationId: string;
+  calculationMode: string;
+  actor: {
+    userId: number | null;
+    label: string | null;
+  } | null;
+}
+
+export async function handleFundScenarioCalcJob(
+  job: Pick<Job<FundScenarioCalcJobData>, 'id' | 'data'>
+) {
+  const { fundId, scenarioSetId, correlationId, calculationMode, actor } = job.data;
+
+  logger.info('Processing reserve scenario calculation', {
+    fundId,
+    scenarioSetId,
+    correlationId,
+    jobId: job.id,
+    calculationMode,
+  });
+
+  try {
+    if (calculationMode !== 'async_reserve_allocation') {
+      throw new Error(`Unsupported fund scenario calculation mode: ${calculationMode}`);
+    }
+
+    return await withMetrics('fund-scenario-reserve', async () =>
+      runReserveScenarioCalculation({
+        fundId,
+        scenarioSetId,
+        correlationId,
+        actor: actor ?? {},
+        jobId: String(job.id),
+      })
+    );
+  } catch (error) {
+    const err = error as Error;
+    logger.error('Reserve scenario calculation failed', err, {
+      fundId,
+      scenarioSetId,
+      correlationId,
+      jobId: job.id,
+      errorName: err.name,
+      errorMessage: err.message,
+      errorStack: err.stack,
+    });
+    metrics.counter('fund_scenario_reserve_calculation_failed_total', 1, {
+      fundId: String(fundId),
+      errorType: err.name,
+    });
+    throw error;
+  }
+}
+
+export const fundScenarioCalcWorker = new Worker<FundScenarioCalcJobData>(
+  'fund-scenario-calc',
+  handleFundScenarioCalcJob,
+  {
+    connection,
+    concurrency: 2,
+    lockDuration: 300_000,
+    attempts: 2,
+    backoff: {
+      type: 'exponential',
+      delay: 2_000,
+    },
+    removeOnComplete: {
+      age: 3600,
+      count: 100,
+    },
+    removeOnFail: {
+      age: 86400,
+    },
+  }
+);
+
+registerWorker('fund-scenario-calc', fundScenarioCalcWorker);
+
+const HEALTH_PORT = parseInt(process.env.FUND_SCENARIO_WORKER_HEALTH_PORT || '9004');
+createHealthServer(HEALTH_PORT);
+
+process.on('SIGTERM', async () => {
+  logger.info('Fund scenario calculation worker shutting down gracefully...');
+  await fundScenarioCalcWorker.close();
+  logger.info('Fund scenario calculation worker shut down complete');
+});
+
+process.on('SIGINT', async () => {
+  logger.info('Fund scenario calculation worker received SIGINT, shutting down...');
+  await fundScenarioCalcWorker.close();
+  process.exit(0);
+});


### PR DESCRIPTION
Scenario analysis now carries its own evidence language instead of borrowing authoritative lifecycle evidence, and reserve scenario sets can calculate asynchronously without contaminating authoritative RESERVE snapshots.

This extends the strict fund scenario contract with reserve_allocation variants, cents-based reserve outputs, queued/status DTOs, and scenario evidence states. The backend adds a dedicated reserve scenario summary builder, queue producer, status derivation, worker entrypoint, and SCENARIOS snapshot writer keyed by deterministic reserve input hashes. The results UI now renders card-level and aggregate scenario evidence, and it branches fee-profile versus reserve metrics.

Constraint: ADR-022 requires scenario analytical outputs to live in fund_snapshots as type SCENARIOS with non-null scenario_set_id.

Constraint: Scenario override contracts stay strict; unknown override types must fail validation.

Rejected: Use open-ended overrideType strings | this would weaken the current scenario contract boundary.

Rejected: Reuse authoritative EvidenceHeader | scenario provenance has different semantics and stale states.

Confidence: high

Scope-risk: broad

Reversibility: clean

Directive: Keep authoritative RESERVE readers filtered with scenario_set_id IS NULL and keep reserve scenario snapshots out of RESERVE writes.

Tested: npx vitest run focused scenario evidence/reserve bundle; npx vitest run fund-model-results page; npx vitest run scenario isolation/schema checks; npm run check; npm run lint; npm run test:unit; git diff --check; git grep -n fund_snapshots\\|fundSnapshots -- server/ shared/

Not-tested: Live BullMQ/Redis worker execution against a real queue.
