### PR TITLE
Wire scenario comparison into fund results

### DIFF
--- a/client/src/components/fund-results/ScenarioComparisonTable.tsx
+++ b/client/src/components/fund-results/ScenarioComparisonTable.tsx
@@ -195,6 +195,66 @@ function deltaForMetric(variant: ScenarioComparisonVariantV1, metric: ScenarioCo
   return variant.metricDeltas.find((delta) => delta.metric === metric) ?? null;
 }
 
+function deltaTextColor(delta: ScenarioComparisonMetricDeltaV1) {
+  return delta.absoluteDelta != null && delta.absoluteDelta > 0
+    ? 'text-emerald-700'
+    : 'text-red-700';
+}
+
+function MetricDeltaText({
+  metric,
+  delta,
+}: {
+  metric: ScenarioComparisonMetricKey;
+  delta: ScenarioComparisonMetricDeltaV1 | null;
+}) {
+  if (!delta) return null;
+  if (!delta.driftCapable) {
+    return <p className="text-xs font-poppins text-charcoal-400">Drift unavailable</p>;
+  }
+
+  const formattedDelta = formatMetricDelta(metric, delta.absoluteDelta);
+  if (!formattedDelta) return null;
+
+  return (
+    <p className={cn('text-xs font-poppins font-medium tabular-nums', deltaTextColor(delta))}>
+      {formattedDelta}
+    </p>
+  );
+}
+
+function MetricRow({
+  metric,
+  metrics,
+  variant,
+}: {
+  metric: ScenarioComparisonMetricKey;
+  metrics: ScenarioComparisonMetricMap;
+  variant?: ScenarioComparisonVariantV1 | undefined;
+}) {
+  const definition = METRIC_DEFINITIONS[metric];
+  const delta = variant ? deltaForMetric(variant, metric) : null;
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 py-3">
+      <div>
+        <p className="text-xs uppercase text-charcoal-400 font-poppins">{definition.label}</p>
+        {delta && !delta.driftCapable && (
+          <p className="mt-1 text-xs text-charcoal-500 font-poppins">
+            {driftReasonCopy(delta.driftReason)}
+          </p>
+        )}
+      </div>
+      <div className="text-right">
+        <p className="font-inter text-base font-semibold tabular-nums text-charcoal">
+          {formatMetricValue(metric, metrics[metric])}
+        </p>
+        <MetricDeltaText metric={metric} delta={delta} />
+      </div>
+    </div>
+  );
+}
+
 function MetricRows({
   metrics,
   variant,
@@ -204,44 +264,9 @@ function MetricRows({
 }) {
   return (
     <div className="divide-y divide-beige-200">
-      {SCENARIO_COMPARISON_METRIC_KEYS.map((metric) => {
-        const definition = METRIC_DEFINITIONS[metric];
-        const delta = variant ? deltaForMetric(variant, metric) : null;
-        const formattedDelta = delta ? formatMetricDelta(metric, delta.absoluteDelta) : null;
-
-        return (
-          <div key={metric} className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 py-3">
-            <div>
-              <p className="text-xs uppercase text-charcoal-400 font-poppins">{definition.label}</p>
-              {delta && !delta.driftCapable && (
-                <p className="mt-1 text-xs text-charcoal-500 font-poppins">
-                  {driftReasonCopy(delta.driftReason)}
-                </p>
-              )}
-            </div>
-            <div className="text-right">
-              <p className="font-inter text-base font-semibold tabular-nums text-charcoal">
-                {formatMetricValue(metric, metrics[metric])}
-              </p>
-              {delta && delta.driftCapable && formattedDelta && (
-                <p
-                  className={cn(
-                    'text-xs font-poppins font-medium tabular-nums',
-                    delta.absoluteDelta != null && delta.absoluteDelta > 0
-                      ? 'text-emerald-700'
-                      : 'text-red-700'
-                  )}
-                >
-                  {formattedDelta}
-                </p>
-              )}
-              {delta && !delta.driftCapable && (
-                <p className="text-xs font-poppins text-charcoal-400">Drift unavailable</p>
-              )}
-            </div>
-          </div>
-        );
-      })}
+      {SCENARIO_COMPARISON_METRIC_KEYS.map((metric) => (
+        <MetricRow key={metric} metric={metric} metrics={metrics} variant={variant} />
+      ))}
     </div>
   );
 }

--- a/client/src/components/fund-results/ScenarioComparisonTable.tsx
+++ b/client/src/components/fund-results/ScenarioComparisonTable.tsx
@@ -1,8 +1,8 @@
 /**
- * ScenarioComparisonTable - Side-by-side scenario comparison cards
+ * ScenarioComparisonTable - ADR-022 scenario-set comparison cards.
  *
- * Displays base/optimistic/pessimistic scenarios as adjacent cards
- * with delta badges relative to the base case (first scenario).
+ * Renders one calculated fee-profile scenario set against the authoritative
+ * economics baseline for that set's source configuration version.
  *
  * @module client/components/fund-results/ScenarioComparisonTable
  */
@@ -10,154 +10,306 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import type { ScenarioEvidenceStateV1 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 
-// ============================================================================
-// TYPES
-// ============================================================================
+export const SCENARIO_COMPARISON_METRIC_KEYS = [
+  'lpNetIrr',
+  'gpNetIrr',
+  'totalManagementFees',
+  'totalGpCarryDistributed',
+  'totalGpFeeIncome',
+  'finalDpi',
+  'finalTvpi',
+  'finalClawbackDue',
+] as const;
+
+export type ScenarioComparisonMetricKey = (typeof SCENARIO_COMPARISON_METRIC_KEYS)[number];
+export type ScenarioComparisonStatus =
+  | 'no_scenario_results'
+  | 'baseline_unavailable'
+  | 'comparable';
+export type ScenarioComparisonMetricValue = number | null;
+export type ScenarioComparisonMetricMap = Record<
+  ScenarioComparisonMetricKey,
+  ScenarioComparisonMetricValue
+>;
+export interface ScenarioComparisonStalenessObjectV1 {
+  state: ScenarioEvidenceStateV1;
+  sourceConfigVersion: number;
+  currentPublishedConfigVersion: number | null;
+}
+export type ScenarioComparisonStalenessV1 =
+  | ScenarioEvidenceStateV1
+  | ScenarioComparisonStalenessObjectV1;
+export type ScenarioComparisonMetricKind = 'percent' | 'money' | 'multiple';
+export type ScenarioComparisonDriftReason =
+  | 'stable'
+  | 'missing_baseline'
+  | 'missing_scenario'
+  | 'missing_both'
+  | 'zero_baseline';
+
+export interface ScenarioComparisonScenarioSetV1 {
+  scenarioSetId: string;
+  name: string;
+  sourceConfigId: number;
+  sourceConfigVersion: number;
+}
+
+export interface ScenarioComparisonBaselineV1 {
+  label?: string | null;
+  metrics: ScenarioComparisonMetricMap;
+}
+
+export interface ScenarioComparisonMetricDeltaV1 {
+  metric: ScenarioComparisonMetricKey;
+  displayName: string;
+  baselineValue: ScenarioComparisonMetricValue;
+  scenarioValue: ScenarioComparisonMetricValue;
+  absoluteDelta: ScenarioComparisonMetricValue;
+  percentageDelta: ScenarioComparisonMetricValue;
+  driftCapable: boolean;
+  driftReason: ScenarioComparisonDriftReason;
+}
+
+export interface ScenarioComparisonVariantV1 {
+  variantId: string;
+  name: string;
+  overrideType: 'fee_profile';
+  metrics: ScenarioComparisonMetricMap;
+  metricDeltas: ScenarioComparisonMetricDeltaV1[];
+}
+
+export interface FundScenarioComparisonV1 {
+  fundId: number;
+  comparisonStatus: ScenarioComparisonStatus;
+  scenarioSet: ScenarioComparisonScenarioSetV1;
+  baseline: ScenarioComparisonBaselineV1 | null;
+  variants: ScenarioComparisonVariantV1[];
+  staleness: ScenarioComparisonStalenessV1 | null;
+  calculatedAt: string | null;
+}
 
 export interface ScenarioComparisonTableProps {
-  scenarios: Array<{
-    name: string;
-    moic: number;
-    irr: number | null;
-    reserveUtilization: number;
-    riskLevel: 'LOW' | 'MEDIUM' | 'HIGH';
-  }>;
+  comparison: FundScenarioComparisonV1;
 }
 
-// ============================================================================
-// HELPERS
-// ============================================================================
+interface MetricDefinition {
+  label: string;
+  kind: ScenarioComparisonMetricKind;
+}
 
-const RISK_COLORS: Record<string, string> = {
-  LOW: 'bg-emerald-100 text-emerald-700 border-emerald-200',
-  MEDIUM: 'bg-amber-100 text-amber-700 border-amber-200',
-  HIGH: 'bg-red-100 text-red-700 border-red-200',
+const METRIC_DEFINITIONS: Record<ScenarioComparisonMetricKey, MetricDefinition> = {
+  lpNetIrr: { label: 'Net LP IRR', kind: 'percent' },
+  gpNetIrr: { label: 'Net GP IRR', kind: 'percent' },
+  totalManagementFees: { label: 'Management Fees', kind: 'money' },
+  totalGpCarryDistributed: { label: 'GP Carry', kind: 'money' },
+  totalGpFeeIncome: { label: 'GP Fee Income', kind: 'money' },
+  finalDpi: { label: 'DPI', kind: 'multiple' },
+  finalTvpi: { label: 'TVPI', kind: 'multiple' },
+  finalClawbackDue: { label: 'Clawback Due', kind: 'money' },
 };
 
-/** Returns card border color based on scenario position */
-function getCardBorder(index: number): string {
-  if (index === 0) return 'border-charcoal-300'; // Base
-  if (index === 1) return 'border-emerald-300'; // Optimistic
-  return 'border-amber-300'; // Pessimistic
+function formatMetricValue(
+  metric: ScenarioComparisonMetricKey,
+  value: ScenarioComparisonMetricValue
+) {
+  if (value == null) return 'N/A';
+
+  const kind = METRIC_DEFINITIONS[metric].kind;
+  if (kind === 'percent') {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  if (kind === 'money') {
+    return formatMoney(value);
+  }
+  return `${value.toFixed(2)}x`;
 }
 
-function getCardAccent(index: number): string {
-  if (index === 0) return 'bg-charcoal-50';
-  if (index === 1) return 'bg-emerald-50/50';
-  return 'bg-amber-50/50';
+function formatMetricDelta(
+  metric: ScenarioComparisonMetricKey,
+  value: ScenarioComparisonMetricValue
+) {
+  if (value == null || value === 0) return null;
+
+  const kind = METRIC_DEFINITIONS[metric].kind;
+  if (kind === 'percent') {
+    const sign = value > 0 ? '+' : '';
+    return `${sign}${(value * 100).toFixed(1)} pts`;
+  }
+  if (kind === 'money') {
+    return formatMoney(value, { showPositiveSign: true });
+  }
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}x`;
 }
 
-/** Format delta value with sign and color */
-function DeltaBadge({ value, suffix }: { value: number; suffix: string }) {
-  if (value === 0) return null;
-  const isPositive = value > 0;
+function formatMoney(value: number, options: { showPositiveSign?: boolean } = {}) {
+  const sign = value < 0 ? '-' : options.showPositiveSign && value > 0 ? '+' : '';
+  const absolute = Math.abs(value);
+  if (absolute >= 1_000_000) {
+    return `${sign}$${(absolute / 1_000_000).toFixed(1)}M`;
+  }
+  if (absolute >= 1_000) {
+    return `${sign}$${(absolute / 1_000).toFixed(0)}K`;
+  }
+  return `${sign}$${absolute.toFixed(0)}`;
+}
+
+function formatStatus(value: ScenarioComparisonStalenessV1 | null) {
+  if (!value) return 'Evidence unavailable';
+  const state = typeof value === 'string' ? value : value.state;
+  return state
+    .split('_')
+    .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function statusCopy(comparison: FundScenarioComparisonV1) {
+  if (comparison.comparisonStatus === 'no_scenario_results') {
+    return 'Calculate this scenario set to compare it with the authoritative economics baseline.';
+  }
+  if (comparison.comparisonStatus === 'baseline_unavailable') {
+    return `Authoritative economics baseline is unavailable for source config v${comparison.scenarioSet.sourceConfigVersion}.`;
+  }
+  return 'Scenario comparison is unavailable.';
+}
+
+function driftReasonCopy(reason: ScenarioComparisonDriftReason) {
+  switch (reason) {
+    case 'missing_baseline':
+      return 'Baseline value is unavailable.';
+    case 'missing_scenario':
+      return 'Scenario value is unavailable.';
+    case 'missing_both':
+      return 'Baseline and scenario values are unavailable.';
+    case 'zero_baseline':
+      return 'Baseline value is zero, so percentage drift is unstable.';
+    case 'stable':
+    default:
+      return 'Stable comparison.';
+  }
+}
+
+function deltaForMetric(variant: ScenarioComparisonVariantV1, metric: ScenarioComparisonMetricKey) {
+  return variant.metricDeltas.find((delta) => delta.metric === metric) ?? null;
+}
+
+function MetricRows({
+  metrics,
+  variant,
+}: {
+  metrics: ScenarioComparisonMetricMap;
+  variant?: ScenarioComparisonVariantV1 | undefined;
+}) {
   return (
-    <span
-      className={cn(
-        'ml-2 text-xs font-poppins font-medium',
-        isPositive ? 'text-emerald-600' : 'text-red-600'
-      )}
-    >
-      {isPositive ? '+' : ''}
-      {value.toFixed(1)}
-      {suffix}
-    </span>
+    <div className="divide-y divide-beige-200">
+      {SCENARIO_COMPARISON_METRIC_KEYS.map((metric) => {
+        const definition = METRIC_DEFINITIONS[metric];
+        const delta = variant ? deltaForMetric(variant, metric) : null;
+        const formattedDelta = delta ? formatMetricDelta(metric, delta.absoluteDelta) : null;
+
+        return (
+          <div key={metric} className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 py-3">
+            <div>
+              <p className="text-xs uppercase text-charcoal-400 font-poppins">{definition.label}</p>
+              {delta && !delta.driftCapable && (
+                <p className="mt-1 text-xs text-charcoal-500 font-poppins">
+                  {driftReasonCopy(delta.driftReason)}
+                </p>
+              )}
+            </div>
+            <div className="text-right">
+              <p className="font-inter text-base font-semibold tabular-nums text-charcoal">
+                {formatMetricValue(metric, metrics[metric])}
+              </p>
+              {delta && delta.driftCapable && formattedDelta && (
+                <p
+                  className={cn(
+                    'text-xs font-poppins font-medium tabular-nums',
+                    delta.absoluteDelta != null && delta.absoluteDelta > 0
+                      ? 'text-emerald-700'
+                      : 'text-red-700'
+                  )}
+                >
+                  {formattedDelta}
+                </p>
+              )}
+              {delta && !delta.driftCapable && (
+                <p className="text-xs font-poppins text-charcoal-400">Drift unavailable</p>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
-// ============================================================================
-// COMPONENT
-// ============================================================================
+function MetricsCard({
+  title,
+  badge,
+  metrics,
+  variant,
+}: {
+  title: string;
+  badge: string;
+  metrics: ScenarioComparisonMetricMap;
+  variant?: ScenarioComparisonVariantV1 | undefined;
+}) {
+  return (
+    <article className="rounded-md border border-beige-200 bg-white p-5">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <h4 className="font-inter text-base font-semibold text-charcoal">{title}</h4>
+        <Badge className="border-0 bg-charcoal text-[10px] text-white">{badge}</Badge>
+      </div>
+      <MetricRows metrics={metrics} variant={variant} />
+    </article>
+  );
+}
 
-/** Side-by-side scenario comparison with delta badges relative to base case */
-export function ScenarioComparisonTable({ scenarios }: ScenarioComparisonTableProps) {
-  const base = scenarios[0];
+/** Side-by-side scenario comparison against the authoritative economics baseline. */
+export function ScenarioComparisonTable({ comparison }: ScenarioComparisonTableProps) {
+  const baseline = comparison.baseline;
+  const hasComparablePayload =
+    comparison.comparisonStatus === 'comparable' &&
+    baseline != null &&
+    comparison.variants.length > 0;
 
   return (
-    <section aria-label="Scenario comparison">
-      <h2 className="font-inter font-bold text-lg text-charcoal mb-6">Scenario Comparison</h2>
-
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {scenarios.map((scenario, index) => {
-          const isBase = index === 0;
-          const moicDelta = scenario.moic - (base?.moic ?? 0);
-          const irrDelta = scenario.irr != null && base?.irr != null ? scenario.irr - base.irr : 0;
-          const utilizationDelta = scenario.reserveUtilization - (base?.reserveUtilization ?? 0);
-
-          return (
-            <article
-              key={scenario.name}
-              className={cn(
-                'rounded-lg border-2 p-6 font-poppins transition-shadow hover:shadow-elevated',
-                getCardBorder(index),
-                getCardAccent(index)
-              )}
-            >
-              {/* Card header */}
-              <div className="flex items-center justify-between mb-6">
-                <h3 className="font-inter font-bold text-base text-charcoal">{scenario.name}</h3>
-                {isBase && (
-                  <Badge className="bg-charcoal text-white text-[10px] border-0">BASE</Badge>
-                )}
-              </div>
-
-              {/* Metrics rows */}
-              <div className="space-y-4">
-                {/* MOIC */}
-                <div className="flex items-baseline justify-between">
-                  <span className="text-xs uppercase tracking-wider text-charcoal-500">MOIC</span>
-                  <div>
-                    <span className="font-inter font-bold text-xl text-charcoal tabular-nums">
-                      {scenario.moic.toFixed(1)}x
-                    </span>
-                    {!isBase && <DeltaBadge value={moicDelta} suffix="x" />}
-                  </div>
-                </div>
-
-                {/* IRR */}
-                <div className="flex items-baseline justify-between">
-                  <span className="text-xs uppercase tracking-wider text-charcoal-500">IRR</span>
-                  <div>
-                    <span className="font-inter font-bold text-xl text-charcoal tabular-nums">
-                      {scenario.irr != null ? `${scenario.irr.toFixed(1)}%` : 'N/A'}
-                    </span>
-                    {!isBase && irrDelta !== 0 && <DeltaBadge value={irrDelta} suffix="%" />}
-                  </div>
-                </div>
-
-                {/* Reserve Utilization */}
-                <div className="flex items-baseline justify-between">
-                  <span className="text-xs uppercase tracking-wider text-charcoal-500">
-                    Reserve Util.
-                  </span>
-                  <div>
-                    <span className="font-inter font-bold text-xl text-charcoal tabular-nums">
-                      {scenario.reserveUtilization.toFixed(0)}%
-                    </span>
-                    {!isBase && <DeltaBadge value={utilizationDelta} suffix="%" />}
-                  </div>
-                </div>
-
-                {/* Risk Level */}
-                <div className="flex items-center justify-between pt-2">
-                  <span className="text-xs uppercase tracking-wider text-charcoal-500">
-                    Risk Level
-                  </span>
-                  <Badge
-                    className={cn(
-                      'text-xs font-inter font-bold border',
-                      RISK_COLORS[scenario.riskLevel]
-                    )}
-                  >
-                    {scenario.riskLevel}
-                  </Badge>
-                </div>
-              </div>
-            </article>
-          );
-        })}
+    <section className="space-y-4" data-testid="scenario-comparison-table">
+      <div className="space-y-1">
+        <h3 className="font-inter text-base font-semibold text-charcoal">Scenario Comparison</h3>
+        <p className="text-sm text-charcoal-500 font-poppins">
+          {comparison.scenarioSet.name} · Source config v
+          {comparison.scenarioSet.sourceConfigVersion} · {formatStatus(comparison.staleness)}
+        </p>
       </div>
+
+      {!hasComparablePayload && (
+        <div className="rounded-md border border-beige-200 bg-beige-50 p-4">
+          <p className="text-sm text-charcoal-600 font-poppins">{statusCopy(comparison)}</p>
+        </div>
+      )}
+
+      {hasComparablePayload && baseline && (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <MetricsCard
+            title={baseline.label ?? 'Authoritative baseline'}
+            badge="BASELINE"
+            metrics={baseline.metrics}
+          />
+          {comparison.variants.map((variant) => (
+            <MetricsCard
+              key={variant.variantId}
+              title={variant.name}
+              badge="FEE PROFILE"
+              metrics={variant.metrics}
+              variant={variant}
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/client/src/components/fund-results/index.ts
+++ b/client/src/components/fund-results/index.ts
@@ -6,12 +6,18 @@
 
 export { FundModelScorecard } from './FundModelScorecard';
 export { ReserveAllocationBreakdown } from './ReserveAllocationBreakdown';
-export { ScenarioComparisonTable } from './ScenarioComparisonTable';
+export {
+  ScenarioComparisonTable,
+  SCENARIO_COMPARISON_METRIC_KEYS,
+} from './ScenarioComparisonTable';
 export { ScenarioSetsSummary } from './ScenarioSetsSummary';
 export { EngineMetricsGrid } from './EngineMetricsGrid';
 
 export type { FundModelScorecardProps } from './FundModelScorecard';
 export type { ReserveAllocationBreakdownProps } from './ReserveAllocationBreakdown';
-export type { ScenarioComparisonTableProps } from './ScenarioComparisonTable';
+export type {
+  FundScenarioComparisonV1,
+  ScenarioComparisonTableProps,
+} from './ScenarioComparisonTable';
 export type { ScenarioSetsSummaryProps } from './ScenarioSetsSummary';
 export type { EngineMetricsGridProps } from './EngineMetricsGrid';

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -24,7 +24,11 @@ import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { ScenarioSetsSummary } from '@/components/fund-results';
+import {
+  ScenarioComparisonTable,
+  ScenarioSetsSummary,
+  type FundScenarioComparisonV1,
+} from '@/components/fund-results';
 import { EvidenceHeader, type EvidenceHeaderLifecycle } from '@/components/results/EvidenceHeader';
 import { QuarterlyReviewTrace } from '@/features/analytics-parity/QuarterlyReviewTrace';
 import { cn } from '@/lib/utils';
@@ -66,6 +70,12 @@ type ResultsComparisonState =
   | { kind: 'loading'; comparison: FundResultsComparisonV1 | null }
   | { kind: 'error'; message: string; comparison: FundResultsComparisonV1 | null }
   | { kind: 'data'; comparison: FundResultsComparisonV1 };
+
+type ScenarioComparisonState =
+  | { kind: 'idle'; comparisons: FundScenarioComparisonV1[] }
+  | { kind: 'loading'; comparisons: FundScenarioComparisonV1[] }
+  | { kind: 'error'; message: string; comparisons: FundScenarioComparisonV1[] }
+  | { kind: 'data'; comparisons: FundScenarioComparisonV1[] };
 
 type LifecycleStatus = FundStateReadV1['calculationState']['status'];
 
@@ -408,6 +418,81 @@ function useFundResultsComparison(fundId: string | null) {
   return { state, refresh: fetchComparison };
 }
 
+function useFundScenarioComparisons(fundId: string | null, scenarioSetIds: readonly string[]) {
+  const scenarioSetIdsKey = scenarioSetIds.join('|');
+  const [state, setState] = useState<ScenarioComparisonState>({
+    kind: 'idle',
+    comparisons: [],
+  });
+  const abortRef = useRef<AbortController | null>(null);
+
+  const cancelInFlight = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
+  const fetchComparisons = useCallback(async () => {
+    const ids = scenarioSetIdsKey.length > 0 ? scenarioSetIdsKey.split('|') : [];
+    if (!fundId || fundId === 'latest' || ids.length === 0) {
+      cancelInFlight();
+      setState({ kind: 'idle', comparisons: [] });
+      return;
+    }
+
+    cancelInFlight();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setState((previous) => ({
+      kind: 'loading',
+      comparisons: previous.comparisons,
+    }));
+
+    try {
+      const comparisons = await Promise.all(
+        ids.map(async (scenarioSetId) => {
+          const res = await fetch(
+            `/api/funds/${fundId}/scenario-sets/${encodeURIComponent(scenarioSetId)}/comparison`,
+            { signal: controller.signal }
+          );
+          if (!res.ok) {
+            throw new Error(`Scenario comparison unavailable (${res.status})`);
+          }
+          return (await res.json()) as FundScenarioComparisonV1;
+        })
+      );
+      setState({ kind: 'data', comparisons });
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      const message = error instanceof Error ? error.message : 'Scenario comparison unavailable';
+      setState((previous) => ({
+        kind: 'error',
+        message,
+        comparisons: previous.comparisons,
+      }));
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+    }
+  }, [cancelInFlight, fundId, scenarioSetIdsKey]);
+
+  useEffect(() => {
+    void fetchComparisons();
+    return () => cancelInFlight();
+  }, [cancelInFlight, fetchComparisons]);
+
+  return { state, refresh: fetchComparisons };
+}
+
+function scenarioSetIdsFromFetchState(fetchState: FetchState): string[] {
+  if (fetchState.kind !== 'data') return [];
+  const scenarios = fetchState.results.sections.scenarios;
+  if (scenarios.status !== 'available') return [];
+  return scenarios.payload.sets.map((scenarioSet) => scenarioSet.scenarioSetId);
+}
+
 function useRecalculatePublished(fundId: string | null, onSuccess: () => void) {
   const [state, setState] = useState<RecalculateState>({ kind: 'idle' });
 
@@ -584,6 +669,56 @@ function WaterfallSetupCard({ payload }: { payload: WaterfallSetupSection }) {
           </div>
         ))}
       </div>
+    </div>
+  );
+}
+
+function ScenarioComparisonPanel({ state }: { state: ScenarioComparisonState }) {
+  if (state.kind === 'idle') return null;
+
+  const hasComparisons = state.comparisons.length > 0;
+
+  return (
+    <div className="space-y-4">
+      {state.kind === 'loading' && !hasComparisons && (
+        <p className="text-sm text-charcoal-500 font-poppins">Loading scenario comparison...</p>
+      )}
+
+      {state.kind === 'loading' && hasComparisons && (
+        <p className="text-xs text-charcoal-400 font-poppins">Refreshing scenario comparison...</p>
+      )}
+
+      {state.kind === 'error' && (
+        <Alert className="border-beige-200 bg-beige-50">
+          <AlertCircle className="h-4 w-4 text-charcoal-400" />
+          <AlertTitle>Scenario comparison unavailable</AlertTitle>
+          <AlertDescription className="font-poppins text-charcoal-500">
+            {state.message}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {state.comparisons.map((comparison) => (
+        <ScenarioComparisonTable
+          key={comparison.scenarioSet.scenarioSetId}
+          comparison={comparison}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ScenarioAnalysisCard({
+  payload,
+  comparisonState,
+}: {
+  payload: ScenariosSectionPayloadV1;
+  comparisonState: ScenarioComparisonState;
+}) {
+  return (
+    <div className="space-y-6">
+      <ScenarioSetsSummary payload={payload} />
+      <ScenarioComparisonPanel state={comparisonState} />
     </div>
   );
 }
@@ -1581,10 +1716,14 @@ function FundModelResultsPage() {
   const { state: fetchState, refresh: refreshResults } = useFundResults(fundId);
   const { state: historyState, refresh: refreshHistory } = useFundLifecycleHistory(fundId);
   const { state: comparisonState, refresh: refreshComparison } = useFundResultsComparison(fundId);
+  const scenarioSetIds = scenarioSetIdsFromFetchState(fetchState);
+  const { state: scenarioComparisonState, refresh: refreshScenarioComparisons } =
+    useFundScenarioComparisons(fundId, scenarioSetIds);
   const { state: recalculateState, recalculate } = useRecalculatePublished(fundId, () => {
     void refreshResults();
     void refreshHistory();
     void refreshComparison();
+    void refreshScenarioComparisons();
   });
   const previousCalculationStatusRef = useRef<LifecycleStatus | null>(null);
 
@@ -1600,10 +1739,11 @@ function FundModelResultsPage() {
     ) {
       void refreshHistory();
       void refreshComparison();
+      void refreshScenarioComparisons();
     }
 
     previousCalculationStatusRef.current = status;
-  }, [fetchState, refreshComparison, refreshHistory]);
+  }, [fetchState, refreshComparison, refreshHistory, refreshScenarioComparisons]);
 
   // Handle /latest or missing fundId
   if (fundId === 'latest' || !fundId) {
@@ -1694,7 +1834,12 @@ function FundModelResultsPage() {
         <SectionRenderer
           title="Scenario Analysis"
           section={results.sections.scenarios}
-          renderPayload={(p) => <ScenarioSetsSummary payload={p as ScenariosSectionPayloadV1} />}
+          renderPayload={(p) => (
+            <ScenarioAnalysisCard
+              payload={p as ScenariosSectionPayloadV1}
+              comparisonState={scenarioComparisonState}
+            />
+          )}
         />
       </FadeInSection>
 

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/components/fund-results';
 import { EvidenceHeader, type EvidenceHeaderLifecycle } from '@/components/results/EvidenceHeader';
 import { QuarterlyReviewTrace } from '@/features/analytics-parity/QuarterlyReviewTrace';
+import { queryClient } from '@/lib/queryClient';
 import { cn } from '@/lib/utils';
 import type {
   FundResultsReadV1,
@@ -426,6 +427,7 @@ interface ScenarioComparisonFetchRequest {
 const FUND_ID_PATH_SEGMENT_PATTERN = /^\d+$/;
 const SCENARIO_SET_ID_PATH_SEGMENT_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SCENARIO_COMPARISON_API_ROOT = '/api/funds';
 
 function scenarioComparisonIdsFromKey(scenarioSetIdsKey: string) {
   return scenarioSetIdsKey.length > 0 ? scenarioSetIdsKey.split('|') : [];
@@ -452,30 +454,31 @@ function createScenarioComparisonFetchRequest(
   return isSafeScenarioComparisonRequest(request) ? request : null;
 }
 
-function scenarioComparisonPath(fundId: string, scenarioSetId: string) {
-  return ['/api/funds', fundId, 'scenario-sets', scenarioSetId, 'comparison'].join('/');
+function scenarioComparisonQueryKey(fundId: string, scenarioSetId: string) {
+  return [
+    SCENARIO_COMPARISON_API_ROOT,
+    fundId,
+    'scenario-sets',
+    scenarioSetId,
+    'comparison',
+  ] as const;
 }
 
-async function fetchScenarioComparisonForSet(
-  fundId: string,
-  scenarioSetId: string,
-  signal: AbortSignal
-) {
-  const comparisonUrl = scenarioComparisonPath(fundId, scenarioSetId);
-  const res = await fetch(comparisonUrl, { signal });
-  if (!res.ok) {
-    throw new Error(`Scenario comparison unavailable (${res.status})`);
-  }
-  return (await res.json()) as FundScenarioComparisonV1;
+function scenarioComparisonQueryPrefix(fundId: string) {
+  return [SCENARIO_COMPARISON_API_ROOT, fundId, 'scenario-sets'] as const;
 }
 
-function fetchScenarioComparisonBatch(
-  request: ScenarioComparisonFetchRequest,
-  signal: AbortSignal
-) {
+async function fetchScenarioComparisonForSet(fundId: string, scenarioSetId: string) {
+  return queryClient.fetchQuery<FundScenarioComparisonV1>({
+    queryKey: scenarioComparisonQueryKey(fundId, scenarioSetId),
+    staleTime: 0,
+  });
+}
+
+function fetchScenarioComparisonBatch(request: ScenarioComparisonFetchRequest) {
   return Promise.all(
     request.scenarioSetIds.map((scenarioSetId) =>
-      fetchScenarioComparisonForSet(request.fundId, scenarioSetId, signal)
+      fetchScenarioComparisonForSet(request.fundId, scenarioSetId)
     )
   );
 }
@@ -506,7 +509,11 @@ function useFundScenarioComparisons(fundId: string | null, scenarioSetIds: reado
       abortRef.current.abort();
       abortRef.current = null;
     }
-  }, []);
+    const request = createScenarioComparisonFetchRequest(fundId, scenarioSetIdsKey);
+    if (request) {
+      void queryClient.cancelQueries({ queryKey: scenarioComparisonQueryPrefix(request.fundId) });
+    }
+  }, [fundId, scenarioSetIdsKey]);
 
   const fetchComparisons = useCallback(async () => {
     const request = createScenarioComparisonFetchRequest(fundId, scenarioSetIdsKey);
@@ -525,7 +532,8 @@ function useFundScenarioComparisons(fundId: string | null, scenarioSetIds: reado
     }));
 
     try {
-      const comparisons = await fetchScenarioComparisonBatch(request, controller.signal);
+      const comparisons = await fetchScenarioComparisonBatch(request);
+      if (controller.signal.aborted) return;
       setState({ kind: 'data', comparisons });
     } catch (error) {
       if (controller.signal.aborted) return;

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -418,6 +418,81 @@ function useFundResultsComparison(fundId: string | null) {
   return { state, refresh: fetchComparison };
 }
 
+interface ScenarioComparisonFetchRequest {
+  fundId: string;
+  scenarioSetIds: string[];
+}
+
+const FUND_ID_PATH_SEGMENT_PATTERN = /^\d+$/;
+const SCENARIO_SET_ID_PATH_SEGMENT_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function scenarioComparisonIdsFromKey(scenarioSetIdsKey: string) {
+  return scenarioSetIdsKey.length > 0 ? scenarioSetIdsKey.split('|') : [];
+}
+
+function isSafeScenarioComparisonRequest(request: ScenarioComparisonFetchRequest) {
+  return (
+    FUND_ID_PATH_SEGMENT_PATTERN.test(request.fundId) &&
+    request.scenarioSetIds.length > 0 &&
+    request.scenarioSetIds.every((id) => SCENARIO_SET_ID_PATH_SEGMENT_PATTERN.test(id))
+  );
+}
+
+function createScenarioComparisonFetchRequest(
+  fundId: string | null,
+  scenarioSetIdsKey: string
+): ScenarioComparisonFetchRequest | null {
+  if (!fundId || fundId === 'latest') return null;
+
+  const request = {
+    fundId,
+    scenarioSetIds: scenarioComparisonIdsFromKey(scenarioSetIdsKey),
+  };
+  return isSafeScenarioComparisonRequest(request) ? request : null;
+}
+
+function scenarioComparisonPath(fundId: string, scenarioSetId: string) {
+  return ['/api/funds', fundId, 'scenario-sets', scenarioSetId, 'comparison'].join('/');
+}
+
+async function fetchScenarioComparisonForSet(
+  fundId: string,
+  scenarioSetId: string,
+  signal: AbortSignal
+) {
+  const comparisonUrl = scenarioComparisonPath(fundId, scenarioSetId);
+  const res = await fetch(comparisonUrl, { signal });
+  if (!res.ok) {
+    throw new Error(`Scenario comparison unavailable (${res.status})`);
+  }
+  return (await res.json()) as FundScenarioComparisonV1;
+}
+
+function fetchScenarioComparisonBatch(
+  request: ScenarioComparisonFetchRequest,
+  signal: AbortSignal
+) {
+  return Promise.all(
+    request.scenarioSetIds.map((scenarioSetId) =>
+      fetchScenarioComparisonForSet(request.fundId, scenarioSetId, signal)
+    )
+  );
+}
+
+function scenarioComparisonErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Scenario comparison unavailable';
+}
+
+function clearScenarioComparisonAbort(
+  abortRef: React.MutableRefObject<AbortController | null>,
+  controller: AbortController
+) {
+  if (abortRef.current === controller) {
+    abortRef.current = null;
+  }
+}
+
 function useFundScenarioComparisons(fundId: string | null, scenarioSetIds: readonly string[]) {
   const scenarioSetIdsKey = scenarioSetIds.join('|');
   const [state, setState] = useState<ScenarioComparisonState>({
@@ -434,8 +509,8 @@ function useFundScenarioComparisons(fundId: string | null, scenarioSetIds: reado
   }, []);
 
   const fetchComparisons = useCallback(async () => {
-    const ids = scenarioSetIdsKey.length > 0 ? scenarioSetIdsKey.split('|') : [];
-    if (!fundId || fundId === 'latest' || ids.length === 0) {
+    const request = createScenarioComparisonFetchRequest(fundId, scenarioSetIdsKey);
+    if (!request) {
       cancelInFlight();
       setState({ kind: 'idle', comparisons: [] });
       return;
@@ -450,31 +525,17 @@ function useFundScenarioComparisons(fundId: string | null, scenarioSetIds: reado
     }));
 
     try {
-      const comparisons = await Promise.all(
-        ids.map(async (scenarioSetId) => {
-          const res = await fetch(
-            `/api/funds/${fundId}/scenario-sets/${encodeURIComponent(scenarioSetId)}/comparison`,
-            { signal: controller.signal }
-          );
-          if (!res.ok) {
-            throw new Error(`Scenario comparison unavailable (${res.status})`);
-          }
-          return (await res.json()) as FundScenarioComparisonV1;
-        })
-      );
+      const comparisons = await fetchScenarioComparisonBatch(request, controller.signal);
       setState({ kind: 'data', comparisons });
     } catch (error) {
       if (controller.signal.aborted) return;
-      const message = error instanceof Error ? error.message : 'Scenario comparison unavailable';
       setState((previous) => ({
         kind: 'error',
-        message,
+        message: scenarioComparisonErrorMessage(error),
         comparisons: previous.comparisons,
       }));
     } finally {
-      if (abortRef.current === controller) {
-        abortRef.current = null;
-      }
+      clearScenarioComparisonAbort(abortRef, controller);
     }
   }, [cancelInFlight, fundId, scenarioSetIdsKey]);
 

--- a/tests/unit/components/fund-results/ScenarioComparisonTable.test.tsx
+++ b/tests/unit/components/fund-results/ScenarioComparisonTable.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  ScenarioComparisonTable,
+  SCENARIO_COMPARISON_METRIC_KEYS,
+  type FundScenarioComparisonV1,
+} from '../../../../client/src/components/fund-results/ScenarioComparisonTable';
+
+describe('ScenarioComparisonTable', () => {
+  it('renders the ADR-022 scenario comparison metric contract', () => {
+    render(<ScenarioComparisonTable comparison={comparableComparison()} />);
+
+    const table = screen.getByTestId('scenario-comparison-table');
+    expect(within(table).getByText('Authoritative baseline')).toBeInTheDocument();
+    expect(within(table).getByText('Lower fee')).toBeInTheDocument();
+    expect(within(table).getAllByText('Net LP IRR').length).toBe(2);
+    expect(within(table).getAllByText('Net GP IRR').length).toBe(2);
+    expect(within(table).getAllByText('Management Fees').length).toBe(2);
+    expect(within(table).getAllByText('GP Carry').length).toBe(2);
+    expect(within(table).getAllByText('GP Fee Income').length).toBe(2);
+    expect(within(table).getAllByText('DPI').length).toBe(2);
+    expect(within(table).getAllByText('TVPI').length).toBe(2);
+    expect(within(table).getAllByText('Clawback Due').length).toBe(2);
+    expect(within(table).getByText('15.0%')).toBeInTheDocument();
+    expect(within(table).getAllByText('$2.0M').length).toBeGreaterThanOrEqual(1);
+    expect(within(table).getByText('2.10x')).toBeInTheDocument();
+    expect(within(table).getByText('+0.30x')).toBeInTheDocument();
+    expect(within(table).getAllByText('N/A').length).toBeGreaterThanOrEqual(1);
+    expect(table).not.toHaveTextContent('MOIC');
+    expect(table).not.toHaveTextContent('Reserve Util.');
+    expect(table).not.toHaveTextContent('Risk Level');
+  });
+
+  it('keeps the frontend metric list fixed to the backend comparison contract', () => {
+    expect(SCENARIO_COMPARISON_METRIC_KEYS).toEqual([
+      'lpNetIrr',
+      'gpNetIrr',
+      'totalManagementFees',
+      'totalGpCarryDistributed',
+      'totalGpFeeIncome',
+      'finalDpi',
+      'finalTvpi',
+      'finalClawbackDue',
+    ]);
+  });
+
+  it('renders backend status fallbacks without fabricating comparison rows', () => {
+    render(<ScenarioComparisonTable comparison={baselineUnavailableComparison()} />);
+
+    const table = screen.getByTestId('scenario-comparison-table');
+    expect(
+      within(table).getByText(/Authoritative economics baseline is unavailable/i)
+    ).toBeInTheDocument();
+    expect(table).not.toHaveTextContent('Lower fee');
+    expect(table).not.toHaveTextContent('Net LP IRR');
+  });
+});
+
+function comparableComparison(): FundScenarioComparisonV1 {
+  return {
+    fundId: 123,
+    comparisonStatus: 'comparable',
+    scenarioSet: {
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      name: 'Fee sensitivity',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+    },
+    baseline: {
+      label: 'Authoritative baseline',
+      metrics: {
+        lpNetIrr: 0.15,
+        gpNetIrr: null,
+        totalManagementFees: 2_000_000,
+        totalGpCarryDistributed: 500_000,
+        totalGpFeeIncome: 2_000_000,
+        finalDpi: 0.6,
+        finalTvpi: 1.8,
+        finalClawbackDue: 0,
+      },
+    },
+    variants: [
+      {
+        variantId: '00000000-0000-0000-0000-000000000112',
+        name: 'Lower fee',
+        overrideType: 'fee_profile',
+        metrics: {
+          lpNetIrr: 0.17,
+          gpNetIrr: null,
+          totalManagementFees: 1_500_000,
+          totalGpCarryDistributed: 500_000,
+          totalGpFeeIncome: 1_500_000,
+          finalDpi: 0.7,
+          finalTvpi: 2.1,
+          finalClawbackDue: 0,
+        },
+        metricDeltas: [
+          {
+            metric: 'finalTvpi',
+            displayName: 'TVPI',
+            baselineValue: 1.8,
+            scenarioValue: 2.1,
+            absoluteDelta: 0.3,
+            percentageDelta: 16.6666667,
+            driftCapable: true,
+            driftReason: 'stable',
+          },
+        ],
+      },
+    ],
+    staleness: 'CURRENT',
+    calculatedAt: '2026-05-26T12:30:00.000Z',
+  };
+}
+
+function baselineUnavailableComparison(): FundScenarioComparisonV1 {
+  return {
+    fundId: 123,
+    comparisonStatus: 'baseline_unavailable',
+    scenarioSet: {
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      name: 'Fee sensitivity',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+    },
+    baseline: null,
+    variants: [],
+    staleness: 'CURRENT',
+    calculatedAt: '2026-05-26T12:30:00.000Z',
+  };
+}

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -264,7 +264,7 @@ describe('FundModelResultsPage (server-backed)', () => {
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
         '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/comparison',
-        expect.objectContaining({ signal: expect.any(AbortSignal) })
+        expect.objectContaining({ credentials: 'include' })
       );
     });
 

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -15,6 +15,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import React from 'react';
 import { createWouterWrapper } from '../../utils/withWouter';
 import FundModelResultsPage from '../../../client/src/pages/fund-model-results';
+import type { FundScenarioComparisonV1 } from '../../../client/src/components/fund-results/ScenarioComparisonTable';
 
 describe('FundModelResultsPage (server-backed)', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -63,6 +64,7 @@ describe('FundModelResultsPage (server-backed)', () => {
     results?: ReturnType<typeof readyResponse>;
     history?: ReturnType<typeof lifecycleHistoryResponse>;
     comparison?: ReturnType<typeof resultsComparisonResponse>;
+    scenarioComparison?: FundScenarioComparisonV1;
     recalculateResponse?: {
       success: boolean;
       correlationId: string;
@@ -74,6 +76,7 @@ describe('FundModelResultsPage (server-backed)', () => {
     const results = options?.results ?? readyResponse();
     const history = options?.history ?? lifecycleHistoryResponse();
     const comparison = options?.comparison ?? resultsComparisonResponse();
+    const scenarioComparison = options?.scenarioComparison ?? scenarioComparisonResponse();
     const recalculateStatus = options?.recalculateStatus ?? 200;
     const recalculateResponse = options?.recalculateResponse ?? {
       success: true,
@@ -95,6 +98,10 @@ describe('FundModelResultsPage (server-backed)', () => {
 
       if (url.endsWith('/results-comparison')) {
         return Promise.resolve(jsonResponse(comparison));
+      }
+
+      if (url.includes('/scenario-sets/') && url.endsWith('/comparison')) {
+        return Promise.resolve(jsonResponse(scenarioComparison));
       }
 
       if (url.endsWith('/recalculate')) {
@@ -245,7 +252,27 @@ describe('FundModelResultsPage (server-backed)', () => {
     });
     expect(screen.getByTestId('scenario-sets-summary')).toBeInTheDocument();
     expect(screen.getByText('Fee sensitivity')).toBeInTheDocument();
-    expect(screen.getByText('2.10x')).toBeInTheDocument();
+    expect(screen.getAllByText('2.10x').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('fetches and renders scenario-set comparison for calculated scenario sets', async () => {
+    const resp = readyResponse();
+    resp.sections.scenarios = validScenariosSection();
+    mockFundPageFetches({ results: resp, scenarioComparison: scenarioComparisonResponse() });
+    await renderPage('/fund-model-results/123');
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/comparison',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    const comparison = await screen.findByTestId('scenario-comparison-table');
+    expect(within(comparison).getByText('Authoritative baseline')).toBeInTheDocument();
+    expect(within(comparison).getByText('Lower fee')).toBeInTheDocument();
+    expect(within(comparison).getAllByText('Net LP IRR').length).toBe(2);
+    expect(within(comparison).getByText('+0.30x')).toBeInTheDocument();
   });
 
   // -- Unavailable sections --
@@ -1362,6 +1389,63 @@ function validScenariosSection() {
         },
       ],
     },
+  };
+}
+
+function scenarioComparisonResponse(): FundScenarioComparisonV1 {
+  return {
+    fundId: 123,
+    comparisonStatus: 'comparable',
+    scenarioSet: {
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      name: 'Fee sensitivity',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+    },
+    baseline: {
+      label: 'Authoritative baseline',
+      metrics: {
+        lpNetIrr: 0.15,
+        gpNetIrr: null,
+        totalManagementFees: 2_000_000,
+        totalGpCarryDistributed: 500_000,
+        totalGpFeeIncome: 2_000_000,
+        finalDpi: 0.6,
+        finalTvpi: 1.8,
+        finalClawbackDue: 0,
+      },
+    },
+    variants: [
+      {
+        variantId: '00000000-0000-0000-0000-000000000112',
+        name: 'Lower fee',
+        overrideType: 'fee_profile',
+        metrics: {
+          lpNetIrr: 0.17,
+          gpNetIrr: null,
+          totalManagementFees: 1_500_000,
+          totalGpCarryDistributed: 500_000,
+          totalGpFeeIncome: 1_500_000,
+          finalDpi: 0.7,
+          finalTvpi: 2.1,
+          finalClawbackDue: 0,
+        },
+        metricDeltas: [
+          {
+            metric: 'finalTvpi',
+            displayName: 'TVPI',
+            baselineValue: 1.8,
+            scenarioValue: 2.1,
+            absoluteDelta: 0.3,
+            percentageDelta: 16.6666667,
+            driftCapable: true,
+            driftReason: 'stable',
+          },
+        ],
+      },
+    ],
+    staleness: 'CURRENT',
+    calculatedAt: '2026-05-26T12:30:00.000Z',
   };
 }
 


### PR DESCRIPTION
The next scenario UI slice needs the existing fund-results comparison component to consume the ADR-022 scenario-set comparison surface without broad page redesign. This keeps the scenario summary in place, adds a narrow comparison fetch keyed by calculated scenario sets, and pins the frontend metric list to the upcoming backend contract.

Constraint: PR F backend contract is upcoming on current main, so the UI mirrors the expected response type locally until the shared contract lands.

Rejected: Extend fund-results publish comparison UI | ADR-022 keeps scenario comparison separate from publish-to-publish comparison.

Confidence: high

Scope-risk: narrow

Directive: Replace the local FundScenarioComparisonV1 mirror with the shared contract once PR F lands; do not add metrics outside the backend fixed list.

Tested: npm run test:unit -- tests/unit/components/fund-results/ScenarioComparisonTable.test.tsx tests/unit/pages/fund-model-results.test.tsx --project=client

Tested: npm run check

Tested: npm run lint

Tested: git diff --check

Not-tested: Full npm test suite