### PR TITLE
Repair scenario comparison contract mismatch

### DIFF
--- a/client/src/components/fund-results/ScenarioComparisonTable.tsx
+++ b/client/src/components/fund-results/ScenarioComparisonTable.tsx
@@ -10,85 +10,22 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
-import type { ScenarioEvidenceStateV1 } from '@shared/contracts/fund-scenario-sets-v1.contract';
+import {
+  SCENARIO_COMPARISON_METRIC_KEYS,
+  type FundScenarioComparisonV1,
+  type ScenarioComparisonDriftReason,
+  type ScenarioComparisonMetricDeltaV1,
+  type ScenarioComparisonMetricKey,
+  type ScenarioComparisonMetricMap,
+  type ScenarioComparisonMetricValue,
+  type ScenarioComparisonStalenessV1,
+  type ScenarioComparisonVariantV1,
+} from '@shared/contracts/fund-scenario-comparison-v1.contract';
 
-export const SCENARIO_COMPARISON_METRIC_KEYS = [
-  'lpNetIrr',
-  'gpNetIrr',
-  'totalManagementFees',
-  'totalGpCarryDistributed',
-  'totalGpFeeIncome',
-  'finalDpi',
-  'finalTvpi',
-  'finalClawbackDue',
-] as const;
+export { SCENARIO_COMPARISON_METRIC_KEYS };
+export type { FundScenarioComparisonV1 };
 
-export type ScenarioComparisonMetricKey = (typeof SCENARIO_COMPARISON_METRIC_KEYS)[number];
-export type ScenarioComparisonStatus =
-  | 'no_scenario_results'
-  | 'baseline_unavailable'
-  | 'comparable';
-export type ScenarioComparisonMetricValue = number | null;
-export type ScenarioComparisonMetricMap = Record<
-  ScenarioComparisonMetricKey,
-  ScenarioComparisonMetricValue
->;
-export interface ScenarioComparisonStalenessObjectV1 {
-  state: ScenarioEvidenceStateV1;
-  sourceConfigVersion: number;
-  currentPublishedConfigVersion: number | null;
-}
-export type ScenarioComparisonStalenessV1 =
-  | ScenarioEvidenceStateV1
-  | ScenarioComparisonStalenessObjectV1;
 export type ScenarioComparisonMetricKind = 'percent' | 'money' | 'multiple';
-export type ScenarioComparisonDriftReason =
-  | 'stable'
-  | 'missing_baseline'
-  | 'missing_scenario'
-  | 'missing_both'
-  | 'zero_baseline';
-
-export interface ScenarioComparisonScenarioSetV1 {
-  scenarioSetId: string;
-  name: string;
-  sourceConfigId: number;
-  sourceConfigVersion: number;
-}
-
-export interface ScenarioComparisonBaselineV1 {
-  label?: string | null;
-  metrics: ScenarioComparisonMetricMap;
-}
-
-export interface ScenarioComparisonMetricDeltaV1 {
-  metric: ScenarioComparisonMetricKey;
-  displayName: string;
-  baselineValue: ScenarioComparisonMetricValue;
-  scenarioValue: ScenarioComparisonMetricValue;
-  absoluteDelta: ScenarioComparisonMetricValue;
-  percentageDelta: ScenarioComparisonMetricValue;
-  driftCapable: boolean;
-  driftReason: ScenarioComparisonDriftReason;
-}
-
-export interface ScenarioComparisonVariantV1 {
-  variantId: string;
-  name: string;
-  overrideType: 'fee_profile';
-  metrics: ScenarioComparisonMetricMap;
-  metricDeltas: ScenarioComparisonMetricDeltaV1[];
-}
-
-export interface FundScenarioComparisonV1 {
-  fundId: number;
-  comparisonStatus: ScenarioComparisonStatus;
-  scenarioSet: ScenarioComparisonScenarioSetV1;
-  baseline: ScenarioComparisonBaselineV1 | null;
-  variants: ScenarioComparisonVariantV1[];
-  staleness: ScenarioComparisonStalenessV1 | null;
-  calculatedAt: string | null;
-}
 
 export interface ScenarioComparisonTableProps {
   comparison: FundScenarioComparisonV1;
@@ -171,6 +108,9 @@ function statusCopy(comparison: FundScenarioComparisonV1) {
   }
   if (comparison.comparisonStatus === 'baseline_unavailable') {
     return `Authoritative economics baseline is unavailable for source config v${comparison.scenarioSet.sourceConfigVersion}.`;
+  }
+  if (comparison.comparisonStatus === 'unsupported_override_type') {
+    return 'Scenario comparison is not supported for reserve-allocation scenario sets yet.';
   }
   return 'Scenario comparison is unavailable.';
 }

--- a/client/src/components/fund-results/index.ts
+++ b/client/src/components/fund-results/index.ts
@@ -15,9 +15,7 @@ export { EngineMetricsGrid } from './EngineMetricsGrid';
 
 export type { FundModelScorecardProps } from './FundModelScorecard';
 export type { ReserveAllocationBreakdownProps } from './ReserveAllocationBreakdown';
-export type {
-  FundScenarioComparisonV1,
-  ScenarioComparisonTableProps,
-} from './ScenarioComparisonTable';
+export type { ScenarioComparisonTableProps } from './ScenarioComparisonTable';
+export type { FundScenarioComparisonV1 } from '@shared/contracts/fund-scenario-comparison-v1.contract';
 export type { ScenarioSetsSummaryProps } from './ScenarioSetsSummary';
 export type { EngineMetricsGridProps } from './EngineMetricsGrid';

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -24,11 +24,7 @@ import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import {
-  ScenarioComparisonTable,
-  ScenarioSetsSummary,
-  type FundScenarioComparisonV1,
-} from '@/components/fund-results';
+import { ScenarioComparisonTable, ScenarioSetsSummary } from '@/components/fund-results';
 import { EvidenceHeader, type EvidenceHeaderLifecycle } from '@/components/results/EvidenceHeader';
 import { QuarterlyReviewTrace } from '@/features/analytics-parity/QuarterlyReviewTrace';
 import { queryClient } from '@/lib/queryClient';
@@ -40,6 +36,10 @@ import type {
 } from '@shared/contracts/fund-results-v1.contract';
 import type { EconomicsResultV1 } from '@shared/contracts/economics-v1.contract';
 import type { ScenariosSectionPayloadV1 } from '@shared/contracts/fund-scenario-sets-v1.contract';
+import {
+  FundScenarioComparisonV1Schema,
+  type FundScenarioComparisonV1,
+} from '@shared/contracts/fund-scenario-comparison-v1.contract';
 import type { FundStateReadV1 } from '@shared/contracts/fund-state-read-v1.contract';
 import type { FundLifecycleHistoryV1 } from '@shared/contracts/fund-lifecycle-history-v1.contract';
 import type {
@@ -471,6 +471,19 @@ function scenarioComparisonQueryPrefix(fundId: string) {
 async function fetchScenarioComparisonForSet(fundId: string, scenarioSetId: string) {
   return queryClient.fetchQuery<FundScenarioComparisonV1>({
     queryKey: scenarioComparisonQueryKey(fundId, scenarioSetId),
+    queryFn: async ({ signal }) => {
+      const response = await fetch(
+        `/api/funds/${fundId}/scenario-sets/${scenarioSetId}/comparison`,
+        {
+          signal,
+          credentials: 'include',
+        }
+      );
+      if (!response.ok) {
+        throw new Error(`Server error (${response.status})`);
+      }
+      return FundScenarioComparisonV1Schema.parse(await response.json());
+    },
     staleTime: 0,
   });
 }

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -27,7 +27,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { ScenarioComparisonTable, ScenarioSetsSummary } from '@/components/fund-results';
 import { EvidenceHeader, type EvidenceHeaderLifecycle } from '@/components/results/EvidenceHeader';
 import { QuarterlyReviewTrace } from '@/features/analytics-parity/QuarterlyReviewTrace';
-import { queryClient } from '@/lib/queryClient';
+import { apiRequest, queryClient } from '@/lib/queryClient';
 import { cn } from '@/lib/utils';
 import type {
   FundResultsReadV1,
@@ -468,21 +468,23 @@ function scenarioComparisonQueryPrefix(fundId: string) {
   return [SCENARIO_COMPARISON_API_ROOT, fundId, 'scenario-sets'] as const;
 }
 
+function scenarioComparisonApiPath(fundId: string, scenarioSetId: string) {
+  if (
+    !FUND_ID_PATH_SEGMENT_PATTERN.test(fundId) ||
+    !SCENARIO_SET_ID_PATH_SEGMENT_PATTERN.test(scenarioSetId)
+  ) {
+    throw new Error('Invalid scenario comparison request path');
+  }
+
+  return `${SCENARIO_COMPARISON_API_ROOT}/${encodeURIComponent(fundId)}/scenario-sets/${encodeURIComponent(scenarioSetId)}/comparison`;
+}
+
 async function fetchScenarioComparisonForSet(fundId: string, scenarioSetId: string) {
   return queryClient.fetchQuery<FundScenarioComparisonV1>({
     queryKey: scenarioComparisonQueryKey(fundId, scenarioSetId),
-    queryFn: async ({ signal }) => {
-      const response = await fetch(
-        `/api/funds/${fundId}/scenario-sets/${scenarioSetId}/comparison`,
-        {
-          signal,
-          credentials: 'include',
-        }
-      );
-      if (!response.ok) {
-        throw new Error(`Server error (${response.status})`);
-      }
-      return FundScenarioComparisonV1Schema.parse(await response.json());
+    queryFn: async () => {
+      const response = await apiRequest('GET', scenarioComparisonApiPath(fundId, scenarioSetId));
+      return FundScenarioComparisonV1Schema.parse(response);
     },
     staleTime: 0,
   });

--- a/server/routes/fund-scenario-sets.ts
+++ b/server/routes/fund-scenario-sets.ts
@@ -22,6 +22,7 @@ import {
 } from '../services/fund-scenario-calculation-service.js';
 import { enqueueReserveScenarioCalculation } from '../services/fund-scenario-calc-queue-service.js';
 import { getFundScenarioCalculationStatus } from '../services/fund-scenario-calculation-status-service.js';
+import { getFundScenarioComparison } from '../services/fund-scenario-comparison-service.js';
 
 interface HttpError extends Error {
   statusCode?: number;
@@ -236,6 +237,22 @@ router.get(
 
     const status = await getFundScenarioCalculationStatus(fundId, scenarioSetId);
     return res.status(200).json(status);
+  })
+);
+
+router.get(
+  '/funds/:fundId/scenario-sets/:scenarioSetId/comparison',
+  requireAuth(),
+  requireFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseFundId(req, res);
+    const scenarioSetId = parseScenarioSetId(req, res);
+    if (fundId === null || scenarioSetId === null) {
+      return;
+    }
+
+    const comparison = await getFundScenarioComparison(fundId, scenarioSetId);
+    return res.status(200).json(comparison);
   })
 );
 

--- a/server/services/fund-scenario-comparison-service.ts
+++ b/server/services/fund-scenario-comparison-service.ts
@@ -1,0 +1,265 @@
+import type { PoolClient } from 'pg';
+import { transaction } from '../db/pg-circuit.js';
+import {
+  EconomicsResultV1Schema,
+  type EconomicsResultV1,
+} from '@shared/contracts/economics-v1.contract';
+import {
+  FundScenarioCalculationPayloadV1Schema,
+  type FundScenarioCalculationPayloadV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import {
+  FundScenarioComparisonV1Schema,
+  SCENARIO_COMPARISON_METRIC_KEYS,
+  type FundScenarioComparisonV1,
+  type ScenarioComparisonMetricDeltaV1,
+  type ScenarioComparisonMetricKey,
+  type ScenarioComparisonMetricMap,
+} from '@shared/contracts/fund-scenario-comparison-v1.contract';
+import { fetchScenarioSetDetail, verifyFundExists } from './fund-scenario-set-service.js';
+
+interface SnapshotRow {
+  id: number;
+  payload: unknown;
+  created_at: Date | string | null;
+  snapshot_time: Date | string | null;
+}
+
+const METRIC_LABELS: Record<ScenarioComparisonMetricKey, string> = {
+  lpNetIrr: 'Net LP IRR',
+  gpNetIrr: 'Net GP IRR',
+  totalManagementFees: 'Management Fees',
+  totalGpCarryDistributed: 'GP Carry',
+  totalGpFeeIncome: 'GP Fee Income',
+  finalDpi: 'DPI',
+  finalTvpi: 'TVPI',
+  finalClawbackDue: 'Clawback Due',
+};
+
+function parseJsonPayload(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return JSON.parse(value) as unknown;
+}
+
+function metricMapFromEconomics(economics: EconomicsResultV1): ScenarioComparisonMetricMap {
+  return {
+    lpNetIrr: economics.summary.lpNetIrr,
+    gpNetIrr: economics.summary.gpNetIrr,
+    totalManagementFees: economics.summary.totalManagementFees,
+    totalGpCarryDistributed: economics.summary.totalGpCarryDistributed,
+    totalGpFeeIncome: economics.summary.totalGpFeeIncome,
+    finalDpi: economics.summary.finalDpi,
+    finalTvpi: economics.summary.finalTvpi,
+    finalClawbackDue: economics.summary.finalClawbackDue,
+  };
+}
+
+function metricDelta(
+  metric: ScenarioComparisonMetricKey,
+  baselineValue: number | null,
+  scenarioValue: number | null
+): ScenarioComparisonMetricDeltaV1 {
+  if (baselineValue == null && scenarioValue == null) {
+    return {
+      metric,
+      displayName: METRIC_LABELS[metric],
+      baselineValue,
+      scenarioValue,
+      absoluteDelta: null,
+      percentageDelta: null,
+      driftCapable: false,
+      driftReason: 'missing_both',
+    };
+  }
+
+  if (baselineValue == null) {
+    return {
+      metric,
+      displayName: METRIC_LABELS[metric],
+      baselineValue,
+      scenarioValue,
+      absoluteDelta: null,
+      percentageDelta: null,
+      driftCapable: false,
+      driftReason: 'missing_baseline',
+    };
+  }
+
+  if (scenarioValue == null) {
+    return {
+      metric,
+      displayName: METRIC_LABELS[metric],
+      baselineValue,
+      scenarioValue,
+      absoluteDelta: null,
+      percentageDelta: null,
+      driftCapable: false,
+      driftReason: 'missing_scenario',
+    };
+  }
+
+  const absoluteDelta = scenarioValue - baselineValue;
+
+  if (baselineValue === 0) {
+    return {
+      metric,
+      displayName: METRIC_LABELS[metric],
+      baselineValue,
+      scenarioValue,
+      absoluteDelta,
+      percentageDelta: null,
+      driftCapable: false,
+      driftReason: 'zero_baseline',
+    };
+  }
+
+  return {
+    metric,
+    displayName: METRIC_LABELS[metric],
+    baselineValue,
+    scenarioValue,
+    absoluteDelta,
+    percentageDelta: (absoluteDelta / Math.abs(baselineValue)) * 100,
+    driftCapable: true,
+    driftReason: 'stable',
+  };
+}
+
+function metricDeltas(
+  baselineMetrics: ScenarioComparisonMetricMap,
+  scenarioMetrics: ScenarioComparisonMetricMap
+): ScenarioComparisonMetricDeltaV1[] {
+  return SCENARIO_COMPARISON_METRIC_KEYS.map((metric) =>
+    metricDelta(metric, baselineMetrics[metric], scenarioMetrics[metric])
+  );
+}
+
+async function loadLatestScenarioSnapshot(
+  client: PoolClient,
+  fundId: number,
+  scenarioSetId: string
+): Promise<FundScenarioCalculationPayloadV1 | null> {
+  const result = await client.query<SnapshotRow>(
+    `SELECT id, payload, created_at, snapshot_time
+       FROM fund_snapshots
+      WHERE fund_id = $1
+        AND scenario_set_id = $2
+        AND type = 'SCENARIOS'
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1`,
+    [fundId, scenarioSetId]
+  );
+
+  const snapshot = result.rows[0];
+  return snapshot
+    ? FundScenarioCalculationPayloadV1Schema.parse(parseJsonPayload(snapshot.payload))
+    : null;
+}
+
+async function loadAuthoritativeEconomicsSnapshot(
+  client: PoolClient,
+  input: {
+    fundId: number;
+    sourceConfigId: number;
+    sourceConfigVersion: number;
+  }
+): Promise<EconomicsResultV1 | null> {
+  const result = await client.query<SnapshotRow>(
+    `SELECT id, payload, created_at, snapshot_time
+       FROM fund_snapshots
+      WHERE fund_id = $1
+        AND type = 'ECONOMICS'
+        AND config_id = $2
+        AND config_version = $3
+        AND scenario_set_id IS NULL
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1`,
+    [input.fundId, input.sourceConfigId, input.sourceConfigVersion]
+  );
+
+  const snapshot = result.rows[0];
+  return snapshot ? EconomicsResultV1Schema.parse(parseJsonPayload(snapshot.payload)) : null;
+}
+
+export async function getFundScenarioComparison(
+  fundId: number,
+  scenarioSetId: string
+): Promise<FundScenarioComparisonV1> {
+  return transaction(async (client) => {
+    await verifyFundExists(client, fundId);
+    const scenarioSet = await fetchScenarioSetDetail(client, fundId, scenarioSetId);
+    const baseComparison = {
+      fundId,
+      scenarioSet: {
+        scenarioSetId: scenarioSet.id,
+        name: scenarioSet.name,
+        sourceConfigId: scenarioSet.sourceConfigId,
+        sourceConfigVersion: scenarioSet.sourceConfigVersion,
+      },
+      baseline: null,
+      variants: [],
+      staleness: null,
+      calculatedAt: null,
+    };
+
+    if (scenarioSet.variants.some((variant) => variant.override.overrideType !== 'fee_profile')) {
+      return FundScenarioComparisonV1Schema.parse({
+        ...baseComparison,
+        comparisonStatus: 'unsupported_override_type',
+      });
+    }
+
+    const scenarioPayload = await loadLatestScenarioSnapshot(client, fundId, scenarioSetId);
+    if (!scenarioPayload) {
+      return FundScenarioComparisonV1Schema.parse({
+        ...baseComparison,
+        comparisonStatus: 'no_scenario_results',
+      });
+    }
+
+    const comparisonWithScenarioEvidence = {
+      ...baseComparison,
+      staleness: scenarioPayload.staleness,
+      calculatedAt: scenarioPayload.calculatedAt,
+    };
+    const baselineSnapshot = await loadAuthoritativeEconomicsSnapshot(client, {
+      fundId,
+      sourceConfigId: scenarioSet.sourceConfigId,
+      sourceConfigVersion: scenarioSet.sourceConfigVersion,
+    });
+
+    if (!baselineSnapshot) {
+      return FundScenarioComparisonV1Schema.parse({
+        ...comparisonWithScenarioEvidence,
+        comparisonStatus: 'baseline_unavailable',
+      });
+    }
+
+    const baselineMetrics = metricMapFromEconomics(baselineSnapshot);
+    const variants = scenarioPayload.variants
+      .filter((variant) => variant.overrideType === 'fee_profile')
+      .map((variant) => {
+        const metrics = metricMapFromEconomics(variant.economics);
+        return {
+          variantId: variant.variantId,
+          name: variant.name,
+          overrideType: variant.overrideType,
+          metrics,
+          metricDeltas: metricDeltas(baselineMetrics, metrics),
+        };
+      });
+
+    return FundScenarioComparisonV1Schema.parse({
+      ...comparisonWithScenarioEvidence,
+      comparisonStatus: 'comparable',
+      baseline: {
+        label: 'Authoritative baseline',
+        metrics: baselineMetrics,
+      },
+      variants,
+    });
+  });
+}

--- a/server/services/fund-scenario-comparison-service.ts
+++ b/server/services/fund-scenario-comparison-service.ts
@@ -7,6 +7,7 @@ import {
 import {
   FundScenarioCalculationPayloadV1Schema,
   type FundScenarioCalculationPayloadV1,
+  type FundScenarioSetDetailV1,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 import {
   FundScenarioComparisonV1Schema,
@@ -15,8 +16,12 @@ import {
   type ScenarioComparisonMetricDeltaV1,
   type ScenarioComparisonMetricKey,
   type ScenarioComparisonMetricMap,
+  type ScenarioComparisonStatus,
+  type ScenarioComparisonVariantV1,
 } from '@shared/contracts/fund-scenario-comparison-v1.contract';
 import { fetchScenarioSetDetail, verifyFundExists } from './fund-scenario-set-service.js';
+
+type ScenarioComparisonBase = Omit<FundScenarioComparisonV1, 'comparisonStatus'>;
 
 interface SnapshotRow {
   id: number;
@@ -62,58 +67,16 @@ function metricDelta(
   baselineValue: number | null,
   scenarioValue: number | null
 ): ScenarioComparisonMetricDeltaV1 {
-  if (baselineValue == null && scenarioValue == null) {
-    return {
-      metric,
-      displayName: METRIC_LABELS[metric],
-      baselineValue,
-      scenarioValue,
-      absoluteDelta: null,
-      percentageDelta: null,
-      driftCapable: false,
-      driftReason: 'missing_both',
-    };
-  }
-
-  if (baselineValue == null) {
-    return {
-      metric,
-      displayName: METRIC_LABELS[metric],
-      baselineValue,
-      scenarioValue,
-      absoluteDelta: null,
-      percentageDelta: null,
-      driftCapable: false,
-      driftReason: 'missing_baseline',
-    };
-  }
-
-  if (scenarioValue == null) {
-    return {
-      metric,
-      displayName: METRIC_LABELS[metric],
-      baselineValue,
-      scenarioValue,
-      absoluteDelta: null,
-      percentageDelta: null,
-      driftCapable: false,
-      driftReason: 'missing_scenario',
-    };
+  const unavailableDelta = unavailableMetricDelta(metric, baselineValue, scenarioValue);
+  if (unavailableDelta) return unavailableDelta;
+  if (baselineValue == null || scenarioValue == null) {
+    throw new Error(`Metric ${metric} was unexpectedly incomplete after null handling`);
   }
 
   const absoluteDelta = scenarioValue - baselineValue;
 
   if (baselineValue === 0) {
-    return {
-      metric,
-      displayName: METRIC_LABELS[metric],
-      baselineValue,
-      scenarioValue,
-      absoluteDelta,
-      percentageDelta: null,
-      driftCapable: false,
-      driftReason: 'zero_baseline',
-    };
+    return zeroBaselineMetricDelta(metric, baselineValue, scenarioValue, absoluteDelta);
   }
 
   return {
@@ -125,6 +88,59 @@ function metricDelta(
     percentageDelta: (absoluteDelta / Math.abs(baselineValue)) * 100,
     driftCapable: true,
     driftReason: 'stable',
+  };
+}
+
+function unavailableMetricDelta(
+  metric: ScenarioComparisonMetricKey,
+  baselineValue: number | null,
+  scenarioValue: number | null
+): ScenarioComparisonMetricDeltaV1 | null {
+  if (baselineValue == null && scenarioValue == null) {
+    return nonDriftableMetricDelta(metric, baselineValue, scenarioValue, 'missing_both');
+  }
+  if (baselineValue == null) {
+    return nonDriftableMetricDelta(metric, baselineValue, scenarioValue, 'missing_baseline');
+  }
+  if (scenarioValue == null) {
+    return nonDriftableMetricDelta(metric, baselineValue, scenarioValue, 'missing_scenario');
+  }
+  return null;
+}
+
+function nonDriftableMetricDelta(
+  metric: ScenarioComparisonMetricKey,
+  baselineValue: number | null,
+  scenarioValue: number | null,
+  driftReason: ScenarioComparisonMetricDeltaV1['driftReason']
+): ScenarioComparisonMetricDeltaV1 {
+  return {
+    metric,
+    displayName: METRIC_LABELS[metric],
+    baselineValue,
+    scenarioValue,
+    absoluteDelta: null,
+    percentageDelta: null,
+    driftCapable: false,
+    driftReason,
+  };
+}
+
+function zeroBaselineMetricDelta(
+  metric: ScenarioComparisonMetricKey,
+  baselineValue: number,
+  scenarioValue: number,
+  absoluteDelta: number
+): ScenarioComparisonMetricDeltaV1 {
+  return {
+    metric,
+    displayName: METRIC_LABELS[metric],
+    baselineValue,
+    scenarioValue,
+    absoluteDelta,
+    percentageDelta: null,
+    driftCapable: false,
+    driftReason: 'zero_baseline',
   };
 }
 
@@ -184,82 +200,128 @@ async function loadAuthoritativeEconomicsSnapshot(
   return snapshot ? EconomicsResultV1Schema.parse(parseJsonPayload(snapshot.payload)) : null;
 }
 
+function createBaseComparison(
+  fundId: number,
+  scenarioSet: FundScenarioSetDetailV1
+): ScenarioComparisonBase {
+  return {
+    fundId,
+    scenarioSet: {
+      scenarioSetId: scenarioSet.id,
+      name: scenarioSet.name,
+      sourceConfigId: scenarioSet.sourceConfigId,
+      sourceConfigVersion: scenarioSet.sourceConfigVersion,
+    },
+    baseline: null,
+    variants: [],
+    staleness: null,
+    calculatedAt: null,
+  };
+}
+
+function comparisonWithStatus(
+  baseComparison: ScenarioComparisonBase,
+  comparisonStatus: ScenarioComparisonStatus
+): FundScenarioComparisonV1 {
+  return FundScenarioComparisonV1Schema.parse({
+    ...baseComparison,
+    comparisonStatus,
+  });
+}
+
+function comparisonWithScenarioEvidence(
+  baseComparison: ScenarioComparisonBase,
+  scenarioPayload: FundScenarioCalculationPayloadV1
+): ScenarioComparisonBase {
+  return {
+    ...baseComparison,
+    staleness: scenarioPayload.staleness,
+    calculatedAt: scenarioPayload.calculatedAt,
+  };
+}
+
+function feeProfileVariants(
+  scenarioPayload: FundScenarioCalculationPayloadV1,
+  baselineMetrics: ScenarioComparisonMetricMap
+): ScenarioComparisonVariantV1[] {
+  return scenarioPayload.variants
+    .filter((variant) => variant.overrideType === 'fee_profile')
+    .map((variant) => {
+      const metrics = metricMapFromEconomics(variant.economics);
+      return {
+        variantId: variant.variantId,
+        name: variant.name,
+        overrideType: variant.overrideType,
+        metrics,
+        metricDeltas: metricDeltas(baselineMetrics, metrics),
+      };
+    });
+}
+
+async function buildComparableComparison(
+  client: PoolClient,
+  input: {
+    fundId: number;
+    scenarioSet: FundScenarioSetDetailV1;
+    baseComparison: ScenarioComparisonBase;
+    scenarioPayload: FundScenarioCalculationPayloadV1;
+  }
+): Promise<FundScenarioComparisonV1> {
+  const comparisonBase = comparisonWithScenarioEvidence(
+    input.baseComparison,
+    input.scenarioPayload
+  );
+  const baselineSnapshot = await loadAuthoritativeEconomicsSnapshot(client, {
+    fundId: input.fundId,
+    sourceConfigId: input.scenarioSet.sourceConfigId,
+    sourceConfigVersion: input.scenarioSet.sourceConfigVersion,
+  });
+
+  if (!baselineSnapshot) {
+    return comparisonWithStatus(comparisonBase, 'baseline_unavailable');
+  }
+
+  const baselineMetrics = metricMapFromEconomics(baselineSnapshot);
+  return FundScenarioComparisonV1Schema.parse({
+    ...comparisonBase,
+    comparisonStatus: 'comparable',
+    baseline: {
+      label: 'Authoritative baseline',
+      metrics: baselineMetrics,
+    },
+    variants: feeProfileVariants(input.scenarioPayload, baselineMetrics),
+  });
+}
+
+async function buildFundScenarioComparison(
+  client: PoolClient,
+  fundId: number,
+  scenarioSetId: string
+): Promise<FundScenarioComparisonV1> {
+  await verifyFundExists(client, fundId);
+  const scenarioSet = await fetchScenarioSetDetail(client, fundId, scenarioSetId);
+  const baseComparison = createBaseComparison(fundId, scenarioSet);
+
+  if (scenarioSet.variants.some((variant) => variant.override.overrideType !== 'fee_profile')) {
+    return comparisonWithStatus(baseComparison, 'unsupported_override_type');
+  }
+
+  const scenarioPayload = await loadLatestScenarioSnapshot(client, fundId, scenarioSetId);
+  if (!scenarioPayload) {
+    return comparisonWithStatus(baseComparison, 'no_scenario_results');
+  }
+
+  return buildComparableComparison(client, {
+    fundId,
+    scenarioSet,
+    baseComparison,
+    scenarioPayload,
+  });
+}
+
 export async function getFundScenarioComparison(
   fundId: number,
   scenarioSetId: string
 ): Promise<FundScenarioComparisonV1> {
-  return transaction(async (client) => {
-    await verifyFundExists(client, fundId);
-    const scenarioSet = await fetchScenarioSetDetail(client, fundId, scenarioSetId);
-    const baseComparison = {
-      fundId,
-      scenarioSet: {
-        scenarioSetId: scenarioSet.id,
-        name: scenarioSet.name,
-        sourceConfigId: scenarioSet.sourceConfigId,
-        sourceConfigVersion: scenarioSet.sourceConfigVersion,
-      },
-      baseline: null,
-      variants: [],
-      staleness: null,
-      calculatedAt: null,
-    };
-
-    if (scenarioSet.variants.some((variant) => variant.override.overrideType !== 'fee_profile')) {
-      return FundScenarioComparisonV1Schema.parse({
-        ...baseComparison,
-        comparisonStatus: 'unsupported_override_type',
-      });
-    }
-
-    const scenarioPayload = await loadLatestScenarioSnapshot(client, fundId, scenarioSetId);
-    if (!scenarioPayload) {
-      return FundScenarioComparisonV1Schema.parse({
-        ...baseComparison,
-        comparisonStatus: 'no_scenario_results',
-      });
-    }
-
-    const comparisonWithScenarioEvidence = {
-      ...baseComparison,
-      staleness: scenarioPayload.staleness,
-      calculatedAt: scenarioPayload.calculatedAt,
-    };
-    const baselineSnapshot = await loadAuthoritativeEconomicsSnapshot(client, {
-      fundId,
-      sourceConfigId: scenarioSet.sourceConfigId,
-      sourceConfigVersion: scenarioSet.sourceConfigVersion,
-    });
-
-    if (!baselineSnapshot) {
-      return FundScenarioComparisonV1Schema.parse({
-        ...comparisonWithScenarioEvidence,
-        comparisonStatus: 'baseline_unavailable',
-      });
-    }
-
-    const baselineMetrics = metricMapFromEconomics(baselineSnapshot);
-    const variants = scenarioPayload.variants
-      .filter((variant) => variant.overrideType === 'fee_profile')
-      .map((variant) => {
-        const metrics = metricMapFromEconomics(variant.economics);
-        return {
-          variantId: variant.variantId,
-          name: variant.name,
-          overrideType: variant.overrideType,
-          metrics,
-          metricDeltas: metricDeltas(baselineMetrics, metrics),
-        };
-      });
-
-    return FundScenarioComparisonV1Schema.parse({
-      ...comparisonWithScenarioEvidence,
-      comparisonStatus: 'comparable',
-      baseline: {
-        label: 'Authoritative baseline',
-        metrics: baselineMetrics,
-      },
-      variants,
-    });
-  });
+  return transaction((client) => buildFundScenarioComparison(client, fundId, scenarioSetId));
 }

--- a/shared/contracts/fund-scenario-comparison-v1.contract.ts
+++ b/shared/contracts/fund-scenario-comparison-v1.contract.ts
@@ -1,0 +1,139 @@
+/**
+ * FundScenarioComparisonV1 -- shared contract for ADR-022 scenario comparisons.
+ *
+ * Strict schema: unknown keys are rejected (.strict()).
+ *
+ * @module shared/contracts/fund-scenario-comparison-v1.contract
+ */
+
+import { z } from 'zod';
+import { ScenarioEvidenceStateV1Schema } from './fund-scenario-sets-v1.contract';
+
+const DateTimeStringSchema = z.string().datetime();
+
+export const SCENARIO_COMPARISON_METRIC_KEYS = [
+  'lpNetIrr',
+  'gpNetIrr',
+  'totalManagementFees',
+  'totalGpCarryDistributed',
+  'totalGpFeeIncome',
+  'finalDpi',
+  'finalTvpi',
+  'finalClawbackDue',
+] as const;
+
+const MetricValueSchema = z.number().nullable();
+
+export const ScenarioComparisonMetricKeyV1Schema = z.enum(SCENARIO_COMPARISON_METRIC_KEYS);
+
+export const ScenarioComparisonStatusV1Schema = z.enum([
+  'no_scenario_results',
+  'baseline_unavailable',
+  'unsupported_override_type',
+  'comparable',
+]);
+
+export const ScenarioComparisonMetricMapV1Schema = z
+  .object({
+    lpNetIrr: MetricValueSchema,
+    gpNetIrr: MetricValueSchema,
+    totalManagementFees: MetricValueSchema,
+    totalGpCarryDistributed: MetricValueSchema,
+    totalGpFeeIncome: MetricValueSchema,
+    finalDpi: MetricValueSchema,
+    finalTvpi: MetricValueSchema,
+    finalClawbackDue: MetricValueSchema,
+  })
+  .strict();
+
+export const ScenarioComparisonStalenessObjectV1Schema = z
+  .object({
+    state: ScenarioEvidenceStateV1Schema,
+    sourceConfigVersion: z.number().int().positive(),
+    currentPublishedConfigVersion: z.number().int().positive().nullable(),
+  })
+  .strict();
+
+export const ScenarioComparisonStalenessV1Schema = z.union([
+  ScenarioEvidenceStateV1Schema,
+  ScenarioComparisonStalenessObjectV1Schema,
+]);
+
+export const ScenarioComparisonDriftReasonV1Schema = z.enum([
+  'stable',
+  'missing_baseline',
+  'missing_scenario',
+  'missing_both',
+  'zero_baseline',
+]);
+
+export const ScenarioComparisonScenarioSetV1Schema = z
+  .object({
+    scenarioSetId: z.string().uuid(),
+    name: z.string(),
+    sourceConfigId: z.number().int().positive(),
+    sourceConfigVersion: z.number().int().positive(),
+  })
+  .strict();
+
+export const ScenarioComparisonBaselineV1Schema = z
+  .object({
+    label: z.string().nullable().optional(),
+    metrics: ScenarioComparisonMetricMapV1Schema,
+  })
+  .strict();
+
+export const ScenarioComparisonMetricDeltaV1Schema = z
+  .object({
+    metric: ScenarioComparisonMetricKeyV1Schema,
+    displayName: z.string(),
+    baselineValue: MetricValueSchema,
+    scenarioValue: MetricValueSchema,
+    absoluteDelta: MetricValueSchema,
+    percentageDelta: MetricValueSchema,
+    driftCapable: z.boolean(),
+    driftReason: ScenarioComparisonDriftReasonV1Schema,
+  })
+  .strict();
+
+export const ScenarioComparisonVariantV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('fee_profile'),
+    metrics: ScenarioComparisonMetricMapV1Schema,
+    metricDeltas: z.array(ScenarioComparisonMetricDeltaV1Schema),
+  })
+  .strict();
+
+export const FundScenarioComparisonV1Schema = z
+  .object({
+    fundId: z.number().int().positive(),
+    comparisonStatus: ScenarioComparisonStatusV1Schema,
+    scenarioSet: ScenarioComparisonScenarioSetV1Schema,
+    baseline: ScenarioComparisonBaselineV1Schema.nullable(),
+    variants: z.array(ScenarioComparisonVariantV1Schema),
+    staleness: ScenarioComparisonStalenessV1Schema.nullable(),
+    calculatedAt: DateTimeStringSchema.nullable(),
+  })
+  .strict();
+
+export type ScenarioComparisonMetricKey = z.infer<typeof ScenarioComparisonMetricKeyV1Schema>;
+export type ScenarioComparisonMetricKeyV1 = ScenarioComparisonMetricKey;
+export type ScenarioComparisonStatus = z.infer<typeof ScenarioComparisonStatusV1Schema>;
+export type ScenarioComparisonStatusV1 = ScenarioComparisonStatus;
+export type ScenarioComparisonMetricValue = z.infer<typeof MetricValueSchema>;
+export type ScenarioComparisonMetricValueV1 = ScenarioComparisonMetricValue;
+export type ScenarioComparisonMetricMap = z.infer<typeof ScenarioComparisonMetricMapV1Schema>;
+export type ScenarioComparisonMetricMapV1 = ScenarioComparisonMetricMap;
+export type ScenarioComparisonStalenessObjectV1 = z.infer<
+  typeof ScenarioComparisonStalenessObjectV1Schema
+>;
+export type ScenarioComparisonStalenessV1 = z.infer<typeof ScenarioComparisonStalenessV1Schema>;
+export type ScenarioComparisonDriftReason = z.infer<typeof ScenarioComparisonDriftReasonV1Schema>;
+export type ScenarioComparisonDriftReasonV1 = ScenarioComparisonDriftReason;
+export type ScenarioComparisonScenarioSetV1 = z.infer<typeof ScenarioComparisonScenarioSetV1Schema>;
+export type ScenarioComparisonBaselineV1 = z.infer<typeof ScenarioComparisonBaselineV1Schema>;
+export type ScenarioComparisonMetricDeltaV1 = z.infer<typeof ScenarioComparisonMetricDeltaV1Schema>;
+export type ScenarioComparisonVariantV1 = z.infer<typeof ScenarioComparisonVariantV1Schema>;
+export type FundScenarioComparisonV1 = z.infer<typeof FundScenarioComparisonV1Schema>;

--- a/tests/unit/components/fund-results/ScenarioComparisonTable.test.tsx
+++ b/tests/unit/components/fund-results/ScenarioComparisonTable.test.tsx
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest';
 import {
   ScenarioComparisonTable,
   SCENARIO_COMPARISON_METRIC_KEYS,
-  type FundScenarioComparisonV1,
 } from '../../../../client/src/components/fund-results/ScenarioComparisonTable';
+import type { FundScenarioComparisonV1 } from '../../../../shared/contracts/fund-scenario-comparison-v1.contract';
 
 describe('ScenarioComparisonTable', () => {
   it('renders the ADR-022 scenario comparison metric contract', () => {
@@ -54,6 +54,16 @@ describe('ScenarioComparisonTable', () => {
     ).toBeInTheDocument();
     expect(table).not.toHaveTextContent('Lower fee');
     expect(table).not.toHaveTextContent('Net LP IRR');
+  });
+
+  it('renders unsupported override fallbacks without pretending reserve scenarios are comparable', () => {
+    render(<ScenarioComparisonTable comparison={unsupportedReserveComparison()} />);
+
+    const table = screen.getByTestId('scenario-comparison-table');
+    expect(
+      within(table).getByText(/not supported for reserve-allocation scenario sets/i)
+    ).toBeInTheDocument();
+    expect(table).not.toHaveTextContent('FEE PROFILE');
   });
 });
 
@@ -128,5 +138,22 @@ function baselineUnavailableComparison(): FundScenarioComparisonV1 {
     variants: [],
     staleness: 'CURRENT',
     calculatedAt: '2026-05-26T12:30:00.000Z',
+  };
+}
+
+function unsupportedReserveComparison(): FundScenarioComparisonV1 {
+  return {
+    fundId: 123,
+    comparisonStatus: 'unsupported_override_type',
+    scenarioSet: {
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      name: 'Reserve sensitivity',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+    },
+    baseline: null,
+    variants: [],
+    staleness: null,
+    calculatedAt: null,
   };
 }

--- a/tests/unit/contract/fund-scenario-comparison-v1.contract.test.ts
+++ b/tests/unit/contract/fund-scenario-comparison-v1.contract.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FundScenarioComparisonV1Schema,
+  SCENARIO_COMPARISON_METRIC_KEYS,
+} from '../../../shared/contracts/fund-scenario-comparison-v1.contract';
+
+const metricMap = {
+  lpNetIrr: 0.15,
+  gpNetIrr: null,
+  totalManagementFees: 2_000_000,
+  totalGpCarryDistributed: 500_000,
+  totalGpFeeIncome: 2_000_000,
+  finalDpi: 0.6,
+  finalTvpi: 1.8,
+  finalClawbackDue: 0,
+};
+
+describe('FundScenarioComparisonV1 contract', () => {
+  it('accepts the strict scenario comparison payload used by the UI', () => {
+    const result = FundScenarioComparisonV1Schema.safeParse({
+      fundId: 123,
+      comparisonStatus: 'comparable',
+      scenarioSet: {
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        name: 'Fee sensitivity',
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+      },
+      baseline: {
+        label: 'Authoritative baseline',
+        metrics: metricMap,
+      },
+      variants: [
+        {
+          variantId: '00000000-0000-0000-0000-000000000112',
+          name: 'Lower fee',
+          overrideType: 'fee_profile',
+          metrics: metricMap,
+          metricDeltas: [
+            {
+              metric: 'finalTvpi',
+              displayName: 'TVPI',
+              baselineValue: 1.8,
+              scenarioValue: 2.1,
+              absoluteDelta: 0.3,
+              percentageDelta: 16.6666667,
+              driftCapable: true,
+              driftReason: 'stable',
+            },
+          ],
+        },
+      ],
+      staleness: {
+        state: 'CURRENT',
+        sourceConfigVersion: 4,
+        currentPublishedConfigVersion: 4,
+      },
+      calculatedAt: '2026-05-26T12:30:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects extra fields so the local UI mirror cannot drift silently', () => {
+    const result = FundScenarioComparisonV1Schema.safeParse({
+      fundId: 123,
+      comparisonStatus: 'no_scenario_results',
+      scenarioSet: {
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        name: 'Fee sensitivity',
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+      },
+      baseline: null,
+      variants: [],
+      staleness: null,
+      calculatedAt: null,
+      unexpected: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('keeps the comparison metric list fixed', () => {
+    expect(SCENARIO_COMPARISON_METRIC_KEYS).toEqual([
+      'lpNetIrr',
+      'gpNetIrr',
+      'totalManagementFees',
+      'totalGpCarryDistributed',
+      'totalGpFeeIncome',
+      'finalDpi',
+      'finalTvpi',
+      'finalClawbackDue',
+    ]);
+  });
+
+  it('supports an explicit unsupported override status for reserve scenarios', () => {
+    const result = FundScenarioComparisonV1Schema.safeParse({
+      fundId: 123,
+      comparisonStatus: 'unsupported_override_type',
+      scenarioSet: {
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        name: 'Reserve sensitivity',
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+      },
+      baseline: null,
+      variants: [],
+      staleness: null,
+      calculatedAt: null,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -15,7 +15,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import React from 'react';
 import { createWouterWrapper } from '../../utils/withWouter';
 import FundModelResultsPage from '../../../client/src/pages/fund-model-results';
-import type { FundScenarioComparisonV1 } from '../../../client/src/components/fund-results/ScenarioComparisonTable';
+import type { FundScenarioComparisonV1 } from '../../../shared/contracts/fund-scenario-comparison-v1.contract';
 
 describe('FundModelResultsPage (server-backed)', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -273,6 +273,20 @@ describe('FundModelResultsPage (server-backed)', () => {
     expect(within(comparison).getByText('Lower fee')).toBeInTheDocument();
     expect(within(comparison).getAllByText('Net LP IRR').length).toBe(2);
     expect(within(comparison).getByText('+0.30x')).toBeInTheDocument();
+  });
+
+  it('rejects scenario-set comparison payloads that drift from the shared contract', async () => {
+    const resp = readyResponse();
+    resp.sections.scenarios = validScenariosSection();
+    const malformedScenarioComparison = {
+      ...scenarioComparisonResponse(),
+      unexpected: true,
+    } as unknown as FundScenarioComparisonV1;
+    mockFundPageFetches({ results: resp, scenarioComparison: malformedScenarioComparison });
+    await renderPage('/fund-model-results/123');
+
+    expect(await screen.findByText('Scenario comparison unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Authoritative baseline')).not.toBeInTheDocument();
   });
 
   // -- Unavailable sections --

--- a/tests/unit/routes/fund-scenario-sets-comparison-route.test.ts
+++ b/tests/unit/routes/fund-scenario-sets-comparison-route.test.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  const { readFile } = await import('node:fs/promises');
+  return readFile(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('fund scenario comparison route contract', () => {
+  it('registers the comparison route with route-local auth and fund access', async () => {
+    const source = await readRepoFile('server/routes/fund-scenario-sets.ts');
+
+    expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/comparison');
+    expect(source).toContain('getFundScenarioComparison');
+    expect((source.match(/requireAuth\(\)/g) ?? []).length).toBeGreaterThanOrEqual(9);
+    expect((source.match(/requireFundAccess/g) ?? []).length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/tests/unit/routes/fund-scenario-sets-route-contract.test.ts
+++ b/tests/unit/routes/fund-scenario-sets-route-contract.test.ts
@@ -13,13 +13,14 @@ describe('fund scenario set route contract', () => {
   it('keeps every fund-scoped scenario-set route protected by auth and fund access', async () => {
     const source = await readRepoFile('server/routes/fund-scenario-sets.ts');
 
-    expect((source.match(/requireAuth\(\)/g) ?? []).length).toBe(8);
-    expect((source.match(/requireFundAccess/g) ?? []).length).toBe(9);
+    expect((source.match(/requireAuth\(\)/g) ?? []).length).toBe(9);
+    expect((source.match(/requireFundAccess/g) ?? []).length).toBe(10);
     expect(source).toContain('getIdempotencyKey(req)');
     expect(source).toContain('/funds/:fundId/scenario-sets');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/calculate');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/calculate-reserve');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/calculation-status');
+    expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/comparison');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/results');
     expect(source).toContain('/funds/:fundId/scenario-sets/:scenarioSetId/archive');
     expect(source).toContain('FundScenarioReserveCalculationRequestV1Schema.safeParse');

--- a/tests/unit/services/fund-scenario-comparison-service.test.ts
+++ b/tests/unit/services/fund-scenario-comparison-service.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { transactionMock, queryMock } = vi.hoisted(() => ({
+  transactionMock: vi.fn(),
+  queryMock: vi.fn(),
+}));
+
+vi.mock('../../../server/db/pg-circuit.js', () => ({
+  transaction: transactionMock,
+}));
+
+import { getFundScenarioComparison } from '../../../server/services/fund-scenario-comparison-service';
+import type { EconomicsResultV1 } from '../../../shared/contracts/economics-v1.contract';
+import type { FundScenarioCalculationPayloadV1 } from '../../../shared/contracts/fund-scenario-sets-v1.contract';
+
+const scenarioSetId = '00000000-0000-0000-0000-000000000111';
+const variantId = '00000000-0000-0000-0000-000000000112';
+
+describe('fund scenario comparison service', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    transactionMock.mockImplementation(
+      async (callback: (client: { query: typeof queryMock }) => unknown) =>
+        callback({ query: queryMock })
+    );
+  });
+
+  it('returns no_scenario_results when no SCENARIOS snapshot exists', async () => {
+    mockScenarioSet('fee_profile');
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getFundScenarioComparison(123, scenarioSetId);
+
+    expect(result.comparisonStatus).toBe('no_scenario_results');
+    expect(result.variants).toEqual([]);
+  });
+
+  it('returns baseline_unavailable when authoritative ECONOMICS is missing', async () => {
+    mockScenarioSet('fee_profile');
+    queryMock.mockResolvedValueOnce({ rows: [scenarioSnapshotRow()] });
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getFundScenarioComparison(123, scenarioSetId);
+
+    expect(result.comparisonStatus).toBe('baseline_unavailable');
+    expect(result.baseline).toBeNull();
+  });
+
+  it('returns unsupported_override_type for reserve-allocation scenario sets', async () => {
+    mockScenarioSet('reserve_allocation');
+
+    const result = await getFundScenarioComparison(123, scenarioSetId);
+
+    expect(result.comparisonStatus).toBe('unsupported_override_type');
+    expect(result.baseline).toBeNull();
+    expect(result.variants).toEqual([]);
+  });
+
+  it('builds comparable fee-profile variants against the authoritative economics baseline', async () => {
+    mockScenarioSet('fee_profile');
+    queryMock.mockResolvedValueOnce({ rows: [scenarioSnapshotRow()] });
+    queryMock.mockResolvedValueOnce({ rows: [economicsSnapshotRow(baselineEconomics())] });
+
+    const result = await getFundScenarioComparison(123, scenarioSetId);
+
+    expect(result.comparisonStatus).toBe('comparable');
+    expect(sqlForQueryContaining("type = 'SCENARIOS'")).toContain(
+      'ORDER BY created_at DESC, id DESC'
+    );
+    const baselineSql = sqlForQueryContaining("type = 'ECONOMICS'");
+    expect(baselineSql).toContain('scenario_set_id IS NULL');
+    expect(baselineSql).toContain('ORDER BY created_at DESC, id DESC');
+    expect(result.baseline?.metrics.finalTvpi).toBe(1.8);
+    expect(result.variants[0]?.metrics.finalTvpi).toBe(2.1);
+    expect(result.variants[0]?.metricDeltas.find((delta) => delta.metric === 'finalTvpi')).toEqual(
+      expect.objectContaining({
+        baselineValue: 1.8,
+        scenarioValue: 2.1,
+        absoluteDelta: 0.30000000000000004,
+        driftCapable: true,
+        driftReason: 'stable',
+      })
+    );
+    expect(result.variants[0]?.metricDeltas.find((delta) => delta.metric === 'lpNetIrr')).toEqual(
+      expect.objectContaining({
+        baselineValue: 0,
+        scenarioValue: 0.17,
+        percentageDelta: null,
+        driftCapable: false,
+        driftReason: 'zero_baseline',
+      })
+    );
+  });
+});
+
+function sqlForQueryContaining(fragment: string) {
+  const call = queryMock.mock.calls.find(([sql]) => String(sql).includes(fragment));
+  expect(call, `expected query containing ${fragment}`).toBeDefined();
+  return String(call?.[0]);
+}
+
+function mockScenarioSet(overrideType: 'fee_profile' | 'reserve_allocation') {
+  queryMock.mockResolvedValueOnce({ rows: [{ id: 123 }] });
+  queryMock.mockResolvedValueOnce({
+    rows: [
+      {
+        id: scenarioSetId,
+        fund_id: 123,
+        name: overrideType === 'fee_profile' ? 'Fee sensitivity' : 'Reserve sensitivity',
+        description: null,
+        source_config_id: 12,
+        source_config_version: 4,
+        created_by_user_id: 17,
+        created_by_label: 'analyst@example.com',
+        updated_by_user_id: 17,
+        updated_by_label: 'analyst@example.com',
+        archived_at: null,
+        archived_by_user_id: null,
+        archived_by_label: null,
+        created_at: new Date('2026-05-26T12:00:00.000Z'),
+        updated_at: new Date('2026-05-26T12:00:00.000Z'),
+        variant_count: '1',
+      },
+    ],
+  });
+  queryMock.mockResolvedValueOnce({
+    rows: [
+      {
+        id: variantId,
+        scenario_set_id: scenarioSetId,
+        name: overrideType === 'fee_profile' ? 'Lower fee' : 'Constrained reserves',
+        description: null,
+        sort_order: 0,
+        override_type: overrideType,
+        override_payload:
+          overrideType === 'fee_profile'
+            ? {
+                feeProfiles: [
+                  {
+                    id: 'fee-profile-lower',
+                    name: 'Lower fee',
+                    feeTiers: [
+                      {
+                        id: 'tier-1',
+                        name: 'Management fee',
+                        percentage: 2,
+                        feeBasis: 'committed_capital',
+                        startMonth: 0,
+                      },
+                    ],
+                  },
+                ],
+              }
+            : { items: [{ companyId: 101, plannedReservesCents: 1_000_000 }] },
+        created_at: new Date('2026-05-26T12:00:00.000Z'),
+        updated_at: new Date('2026-05-26T12:00:00.000Z'),
+      },
+    ],
+  });
+}
+
+function scenarioSnapshotRow() {
+  return {
+    id: 42,
+    payload: scenarioPayload(),
+    created_at: new Date('2026-05-26T12:30:00.000Z'),
+    snapshot_time: new Date('2026-05-26T12:30:00.000Z'),
+  };
+}
+
+function economicsSnapshotRow(payload: EconomicsResultV1) {
+  return {
+    id: 24,
+    payload,
+    created_at: new Date('2026-05-26T12:10:00.000Z'),
+    snapshot_time: new Date('2026-05-26T12:10:00.000Z'),
+  };
+}
+
+function scenarioPayload(): FundScenarioCalculationPayloadV1 {
+  return {
+    version: 'fund-scenarios-v1',
+    calculationMode: 'sync_fee_profile',
+    fundId: 123,
+    scenarioSetId,
+    sourceConfigId: 12,
+    sourceConfigVersion: 4,
+    staleness: {
+      state: 'CURRENT',
+      sourceConfigVersion: 4,
+      currentPublishedConfigVersion: 4,
+    },
+    calculatedAt: '2026-05-26T12:30:00.000Z',
+    variants: [
+      {
+        variantId,
+        scenarioSetId,
+        name: 'Lower fee',
+        overrideType: 'fee_profile',
+        economics: scenarioEconomics(),
+      },
+    ],
+  };
+}
+
+function baselineEconomics(): EconomicsResultV1 {
+  return economicsResult({
+    lpNetIrr: 0,
+    gpNetIrr: null,
+    totalManagementFees: 2_000_000,
+    totalGpCarryDistributed: 500_000,
+    totalGpFeeIncome: 2_000_000,
+    finalDpi: 0.6,
+    finalTvpi: 1.8,
+    finalClawbackDue: 0,
+  });
+}
+
+function scenarioEconomics(): EconomicsResultV1 {
+  return economicsResult({
+    lpNetIrr: 0.17,
+    gpNetIrr: null,
+    totalManagementFees: 1_500_000,
+    totalGpCarryDistributed: 500_000,
+    totalGpFeeIncome: 1_500_000,
+    finalDpi: 0.7,
+    finalTvpi: 2.1,
+    finalClawbackDue: 0,
+  });
+}
+
+function economicsResult(summary: {
+  lpNetIrr: number | null;
+  gpNetIrr: number | null;
+  totalManagementFees: number;
+  totalGpCarryDistributed: number;
+  totalGpFeeIncome: number;
+  finalDpi: number;
+  finalTvpi: number;
+  finalClawbackDue: number;
+}): EconomicsResultV1 {
+  return {
+    version: 'v1',
+    annual: [
+      {
+        year: 1,
+        lpCapitalCalls: 1,
+        gpCommitmentCalls: 0,
+        grossExitProceeds: 0,
+        beginningCash: 0,
+        investments: 0,
+        feesPaidToManager: 1,
+        expensesPaid: 0,
+        recycledProceeds: 0,
+        endingCash: 0,
+        lpDistributions: 0,
+        gpInvestmentDistributions: 0,
+        gpCarryDistributed: 0,
+        gpCarryEscrowed: 0,
+        gpCarryReleasedFromEscrow: 0,
+        clawbackPaid: 0,
+        grossNav: 0,
+        lpNetNav: 0,
+        dpi: 0,
+        rvpi: 0,
+        tvpi: 0,
+        conservationDelta: 0,
+      },
+    ],
+    summary: {
+      grossIrr: null,
+      lpNetIrr: summary.lpNetIrr,
+      gpNetIrr: summary.gpNetIrr,
+      totalLpPaidIn: 1,
+      totalGpCommitmentCalled: 0,
+      totalManagementFees: summary.totalManagementFees,
+      totalExpenses: 0,
+      totalRecycled: 0,
+      totalLpDistributions: 0,
+      totalGpInvestmentDistributions: 0,
+      totalGpCarryDistributed: summary.totalGpCarryDistributed,
+      totalGpFeeIncome: summary.totalGpFeeIncome,
+      finalDpi: summary.finalDpi,
+      finalRvpi: 0,
+      finalTvpi: summary.finalTvpi,
+      finalClawbackDue: summary.finalClawbackDue,
+      maxEscrowAvailable: 0,
+      netGpCarryAfterClawback: 0,
+    },
+    checks: {
+      passed: true,
+      tolerance: 0.01,
+      errors: [],
+    },
+  };
+}


### PR DESCRIPTION
Scope:
- Adds `shared/contracts/fund-scenario-comparison-v1.contract.ts` as the strict shared comparison contract, including `unsupported_override_type`.
- Adds `server/services/fund-scenario-comparison-service.ts` plus `GET /api/funds/:fundId/scenario-sets/:scenarioSetId/comparison` behind route-local `requireAuth()` and `requireFundAccess`.
- Removes the client-local comparison type mirror and parses comparison responses through the shared Zod schema.
- Does not change scenario snapshot retention, worker wiring, migrations, ADR status, or reserve comparison semantics.

Evidence:
- Current main had scenario calculate/status/results/archive routes but no `/comparison` route while the results page already fetched that path.
- Comparison reads are pinned to latest `fund_snapshots.type = 'SCENARIOS'` for the requested scenario set ordered by `created_at DESC, id DESC`.
- Baseline reads are authoritative `ECONOMICS` snapshots for `source_config_id/source_config_version` with `scenario_set_id IS NULL`, ordered by `created_at DESC, id DESC`.
- Reserve-allocation scenario sets fail closed with `unsupported_override_type` instead of fabricating a baseline comparison.

Validation:
- `git diff --check`
- `npm run check`
- `npm run lint`
- `npx vitest run tests/unit/contract/fund-scenario-comparison-v1.contract.test.ts tests/unit/services/fund-scenario-comparison-service.test.ts tests/unit/routes/fund-scenario-sets-comparison-route.test.ts tests/unit/routes/fund-scenario-sets-route-contract.test.ts --project=server`
- `npx vitest run --project=client tests/unit/components/fund-results/ScenarioComparisonTable.test.tsx tests/unit/pages/fund-model-results.test.tsx`
- `npm run build`
- Pre-push hook also ran TypeScript baseline plus targeted tests: 20 files, 179 tests passed. The first push timed out and the second hit a ref-lock race, but `origin/fix/scenario-comparison-main-repair` now matches local commit `91edcbc079aaacb861dc1f104217cfc17442ea9a`.

Rollback:
- Revert commit `91edcbc079aaacb861dc1f104217cfc17442ea9a`.
- No data migration, queue wiring, or snapshot retention change is included.

Deferred:
- PR A: live Redis/BullMQ reserve worker proof.
- PR B: append-only SCENARIOS retention with concurrency-safe identical-input reuse.
- PR C: ADR-022 implementation/governance updates after PRs 0/A/B land.