### PR TITLE
Prove reserve scenario worker queue path

### DIFF
--- a/tests/integration/fund-scenario-reserve-worker.test.ts
+++ b/tests/integration/fund-scenario-reserve-worker.test.ts
@@ -1,0 +1,376 @@
+import express from 'express';
+import type { Queue, QueueEvents } from 'bullmq';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { GenericContainer, Wait, type StartedTestContainer } from 'testcontainers';
+import { Pool } from 'pg';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
+
+const STARTUP_TIMEOUT_MS = 90_000;
+const JOB_TIMEOUT_MS = 30_000;
+const AUTH_SECRET = 'scenario-worker-integration-secret-minimum-32-chars';
+const AUTH_ISSUER = 'updog-api';
+const AUTH_AUDIENCE = 'updog-client';
+const scenarioSetId = '00000000-0000-0000-0000-00000000a001';
+const failingScenarioSetId = '00000000-0000-0000-0000-00000000a002';
+
+type TestContextWithSkip = { skip?: () => void };
+
+interface Runtime {
+  app: express.Express;
+  pool: Pool;
+  queue: Queue | null;
+  workerHarness: { queueEvents: QueueEvents; close: () => Promise<void> };
+  postgres: StartedPostgreSqlContainer;
+  redis: StartedTestContainer;
+  authHeader: string;
+  fundId: number;
+}
+
+let runtime: Runtime | null = null;
+let skipReason: string | null = null;
+
+function visibleLocalSkip(ctx: TestContextWithSkip): boolean {
+  if (!skipReason) {
+    return false;
+  }
+
+  console.warn(`[fund-scenario-reserve-worker] SKIP: ${skipReason}`);
+  ctx.skip?.();
+  return true;
+}
+
+function isContainerRuntimeUnavailable(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /container runtime|docker|testcontainers/i.test(message);
+}
+
+function restoreEnv(snapshot: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function applyScenarioMigrations(pool: Pool): Promise<void> {
+  await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  for (const file of [
+    '0012_scenario_set_id.sql',
+    '0013_fund_scenario_sets.sql',
+    '0014_fund_scenario_calculated_event.sql',
+    '0015_fund_scenario_reserve_allocation.sql',
+  ]) {
+    const sql = await fs.readFile(path.join(process.cwd(), 'server/db/migrations', file), 'utf8');
+    await pool.query(sql);
+  }
+}
+
+async function seedScenarioFixtures(pool: Pool): Promise<{ fundId: number }> {
+  const fund = await pool.query<{ id: number }>(
+    `INSERT INTO funds (name, size, management_fee, carry_percentage, vintage_year)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id`,
+    ['Scenario Worker Fund', '100000000.00', '0.0200', '0.2000', 2026]
+  );
+  const fundId = fund.rows[0]!.id;
+
+  const config = await pool.query<{ id: number }>(
+    `INSERT INTO fundconfigs (fund_id, version, config, is_draft, is_published)
+     VALUES ($1, $2, $3, false, true)
+     RETURNING id`,
+    [fundId, 1, { name: 'Scenario Worker Config' }]
+  );
+  const configId = config.rows[0]!.id;
+
+  const company = await pool.query<{ id: number }>(
+    `INSERT INTO portfoliocompanies (
+       fund_id, name, sector, stage, investment_amount, current_valuation, status
+     )
+     VALUES ($1, $2, $3, $4, $5, $6, 'active')
+     RETURNING id`,
+    [fundId, 'ScenarioCo', 'Software', 'seed', '1000000.00', '2500000.00']
+  );
+  const companyId = company.rows[0]!.id;
+
+  await pool.query(
+    `INSERT INTO investments (
+       fund_id, company_id, investment_date, amount, round, ownership_percentage
+     )
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [fundId, companyId, new Date('2026-01-01T00:00:00Z'), '1000000.00', 'seed', '0.1500']
+  );
+
+  await insertScenarioSet(pool, {
+    fundId,
+    configId,
+    id: scenarioSetId,
+    name: 'Reserve increase',
+    companyId,
+    plannedReservesCents: 1_500_000_00,
+  });
+  await insertScenarioSet(pool, {
+    fundId,
+    configId,
+    id: failingScenarioSetId,
+    name: 'Reserve failure',
+    companyId,
+    plannedReservesCents: 2_000_000_00,
+  });
+
+  return { fundId };
+}
+
+async function insertScenarioSet(
+  pool: Pool,
+  input: {
+    fundId: number;
+    configId: number;
+    id: string;
+    name: string;
+    companyId: number;
+    plannedReservesCents: number;
+  }
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO fund_scenario_sets (
+       id, fund_id, name, source_config_id, source_config_version, created_by_label, updated_by_label
+     )
+     VALUES ($1, $2, $3, $4, 1, 'integration@example.com', 'integration@example.com')`,
+    [input.id, input.fundId, input.name, input.configId]
+  );
+
+  await pool.query(
+    `INSERT INTO fund_scenario_variants (
+       scenario_set_id, name, sort_order, override_type, override_payload
+     )
+     VALUES ($1, $2, 0, 'reserve_allocation', $3)`,
+    [
+      input.id,
+      input.name,
+      {
+        items: [
+          {
+            companyId: input.companyId,
+            plannedReservesCents: input.plannedReservesCents,
+            allocationReason: input.name,
+          },
+        ],
+      },
+    ]
+  );
+}
+
+async function startRuntime(): Promise<Runtime> {
+  const postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+    .withDatabase('test_db')
+    .withUsername('test_user')
+    .withPassword('test_password')
+    .withStartupTimeout(STARTUP_TIMEOUT_MS)
+    .start();
+  const redis = await new GenericContainer('redis:7-alpine')
+    .withExposedPorts(6379)
+    .withWaitStrategy(Wait.forLogMessage(/.*Ready to accept connections.*/))
+    .withStartupTimeout(STARTUP_TIMEOUT_MS)
+    .start();
+
+  const connectionString = postgres.getConnectionUri();
+  const redisUrl = `redis://${redis.getHost()}:${redis.getMappedPort(6379)}`;
+  const pool = new Pool({ connectionString, max: 2 });
+
+  await runMigrationsWithConnectionString(connectionString);
+  await applyScenarioMigrations(pool);
+  const { fundId } = await seedScenarioFixtures(pool);
+
+  vi.resetModules();
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.DATABASE_URL = connectionString;
+  process.env.USE_REAL_DB_IN_VITEST = '1';
+  process.env.ENABLE_QUEUES = '1';
+  process.env.REDIS_URL = 'memory://';
+  process.env.QUEUE_REDIS_URL = redisUrl;
+  process.env.JWT_SECRET = AUTH_SECRET;
+  process.env._EXPLICIT_JWT_SECRET = AUTH_SECRET;
+  process.env.JWT_ISSUER = AUTH_ISSUER;
+  process.env._EXPLICIT_JWT_ISSUER = AUTH_ISSUER;
+  process.env.JWT_AUDIENCE = AUTH_AUDIENCE;
+  process.env._EXPLICIT_JWT_AUDIENCE = AUTH_AUDIENCE;
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+
+  const { default: scenarioRoutes } = await import('../../server/routes/fund-scenario-sets');
+  const { signToken } = await import('../../server/lib/auth/jwt');
+  const { getRegisteredQueueRuntime } = await import('../../server/queues/registry');
+  const { startInProcessFundScenarioCalcWorkerHarness } =
+    await import('../../workers/fund-scenario-calc-worker-harness');
+
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+  app.use('/api', scenarioRoutes);
+
+  const workerHarness = await startInProcessFundScenarioCalcWorkerHarness();
+  const queue = getRegisteredQueueRuntime('fund-scenario-calc')?.getQueue() ?? null;
+
+  const authHeader = `Bearer ${signToken({
+    sub: '17',
+    email: 'integration@example.com',
+    role: 'admin',
+    fundIds: [fundId],
+  })}`;
+
+  return { app, pool, queue, workerHarness, postgres, redis, authHeader, fundId };
+}
+
+async function waitForJob(runtime: Runtime, jobId: string): Promise<void> {
+  const job = await runtime.queue?.getJob(jobId);
+  expect(job).toBeTruthy();
+  await job!.waitUntilFinished(runtime.workerHarness.queueEvents, JOB_TIMEOUT_MS);
+}
+
+async function waitForFailedJob(runtime: Runtime, jobId: string): Promise<void> {
+  const job = await runtime.queue?.getJob(jobId);
+  expect(job).toBeTruthy();
+  await expect(
+    job!.waitUntilFinished(runtime.workerHarness.queueEvents, JOB_TIMEOUT_MS)
+  ).rejects.toThrow();
+}
+
+describe('fund scenario reserve worker integration', () => {
+  const originalEnv = { ...process.env };
+
+  beforeAll(async () => {
+    try {
+      runtime = await startRuntime();
+    } catch (error) {
+      if (process.env.CI || !isContainerRuntimeUnavailable(error)) {
+        throw new Error(
+          `Redis/Postgres worker proof startup failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+      skipReason = `Redis/Postgres worker proof infrastructure unavailable locally: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    }
+  }, STARTUP_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await runtime?.workerHarness.close();
+    await runtime?.queue?.close();
+    await runtime?.pool.end();
+    await runtime?.redis.stop();
+    await runtime?.postgres.stop();
+    restoreEnv(originalEnv);
+    vi.resetModules();
+  });
+
+  it(
+    'runs calculate-reserve through HTTP, BullMQ, worker, reserve service, status, and results',
+    async (ctx) => {
+      if (visibleLocalSkip(ctx)) return;
+      expect(runtime).not.toBeNull();
+      const active = runtime!;
+
+      const queued = await request(active.app)
+        .post(`/api/funds/${active.fundId}/scenario-sets/${scenarioSetId}/calculate-reserve`)
+        .set('Authorization', active.authHeader)
+        .send({ calculationMode: 'async_reserve_allocation' })
+        .expect(202);
+
+      expect(queued.body.status).toBe('queued');
+      await waitForJob(active, queued.body.jobId);
+
+      const status = await request(active.app)
+        .get(`/api/funds/${active.fundId}/scenario-sets/${scenarioSetId}/calculation-status`)
+        .set('Authorization', active.authHeader)
+        .expect(200);
+
+      expect(status.body).toMatchObject({
+        status: 'succeeded',
+        jobId: queued.body.jobId,
+        correlationId: queued.body.correlationId,
+      });
+      expect(status.body.snapshotId).toEqual(expect.any(Number));
+
+      const results = await request(active.app)
+        .get(`/api/funds/${active.fundId}/scenario-sets/${scenarioSetId}/results`)
+        .set('Authorization', active.authHeader)
+        .expect(200);
+
+      expect(results.body.payload.calculationMode).toBe('async_reserve_allocation');
+      expect(results.body.payload.variants[0].reserve.allocations[0]).toMatchObject({
+        companyId: expect.any(Number),
+        plannedReservesCents: 1_500_000_00,
+      });
+    },
+    JOB_TIMEOUT_MS + 15_000
+  );
+
+  it(
+    'records a controlled worker failure without creating scenario results',
+    async (ctx) => {
+      if (visibleLocalSkip(ctx)) return;
+      expect(runtime).not.toBeNull();
+      const active = runtime!;
+
+      expect(active.queue).not.toBeNull();
+      await active.queue!.pause();
+      let jobId = '';
+      let correlationId = '';
+
+      try {
+        const queued = await request(active.app)
+          .post(
+            `/api/funds/${active.fundId}/scenario-sets/${failingScenarioSetId}/calculate-reserve`
+          )
+          .set('Authorization', active.authHeader)
+          .send({ calculationMode: 'async_reserve_allocation' })
+          .expect(202);
+        jobId = queued.body.jobId;
+        correlationId = queued.body.correlationId;
+
+        await active.pool.query('ALTER TABLE investments RENAME TO investments_unavailable');
+      } finally {
+        await active.queue!.resume();
+      }
+
+      await waitForFailedJob(active, jobId);
+
+      const status = await request(active.app)
+        .get(`/api/funds/${active.fundId}/scenario-sets/${failingScenarioSetId}/calculation-status`)
+        .set('Authorization', active.authHeader)
+        .expect(200);
+
+      expect(status.body).toMatchObject({
+        status: 'failed',
+        jobId,
+        correlationId,
+        snapshotId: null,
+      });
+      expect(status.body.lastError).toContain('investments');
+
+      await request(active.app)
+        .get(`/api/funds/${active.fundId}/scenario-sets/${failingScenarioSetId}/results`)
+        .set('Authorization', active.authHeader)
+        .expect(404);
+
+      const snapshots = await active.pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+       FROM fund_snapshots
+       WHERE fund_id = $1
+         AND scenario_set_id = $2
+         AND type = 'SCENARIOS'`,
+        [active.fundId, failingScenarioSetId]
+      );
+      expect(snapshots.rows[0]?.count).toBe('0');
+    },
+    JOB_TIMEOUT_MS + 15_000
+  );
+});

--- a/tests/unit/workers/fund-scenario-calc-worker.test.ts
+++ b/tests/unit/workers/fund-scenario-calc-worker.test.ts
@@ -1,13 +1,29 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { runReserveScenarioCalculationMock, loggerInfoMock, loggerErrorMock } = vi.hoisted(() => ({
+const {
+  runReserveScenarioCalculationMock,
+  loggerInfoMock,
+  loggerErrorMock,
+  workerConstructorMock,
+  registerWorkerMock,
+  createHealthServerMock,
+  getQueueConnectionOptionsMock,
+} = vi.hoisted(() => ({
   runReserveScenarioCalculationMock: vi.fn(),
   loggerInfoMock: vi.fn(),
   loggerErrorMock: vi.fn(),
+  workerConstructorMock: vi.fn(),
+  registerWorkerMock: vi.fn(),
+  createHealthServerMock: vi.fn(),
+  getQueueConnectionOptionsMock: vi.fn(),
 }));
 
 vi.mock('../../../server/services/fund-scenario-reserve-calculation-service', () => ({
   runReserveScenarioCalculation: runReserveScenarioCalculationMock,
+}));
+
+vi.mock('../../../server/config/features', () => ({
+  getQueueConnectionOptions: getQueueConnectionOptionsMock,
 }));
 
 vi.mock('../../../lib/logger', () => ({
@@ -25,20 +41,28 @@ vi.mock('../../../lib/metrics', () => ({
 }));
 
 vi.mock('../../../workers/health-server', () => ({
-  registerWorker: vi.fn(),
-  createHealthServer: vi.fn(),
+  registerWorker: registerWorkerMock,
+  createHealthServer: createHealthServerMock,
 }));
 
 vi.mock('bullmq', () => ({
   Worker: class MockWorker {
+    constructor(...args: unknown[]) {
+      workerConstructorMock(...args);
+    }
+
     close = vi.fn();
   },
 }));
 
-import { handleFundScenarioCalcJob } from '../../../workers/fund-scenario-calc-worker';
-
 describe('fund scenario calc worker handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('dispatches async reserve allocation jobs to the reserve scenario service', async () => {
+    const { handleFundScenarioCalcJob } =
+      await import('../../../workers/fund-scenario-calc-handler');
     runReserveScenarioCalculationMock.mockResolvedValue({ snapshotId: 42 });
 
     const result = await handleFundScenarioCalcJob({
@@ -67,6 +91,9 @@ describe('fund scenario calc worker handler', () => {
   });
 
   it('rejects unsupported calculation modes and logs failures', async () => {
+    const { handleFundScenarioCalcJob } =
+      await import('../../../workers/fund-scenario-calc-handler');
+
     await expect(
       handleFundScenarioCalcJob({
         id: 'job-2',
@@ -85,5 +112,64 @@ describe('fund scenario calc worker handler', () => {
       expect.any(Error),
       expect.objectContaining({ jobId: 'job-2' })
     );
+  });
+
+  it('importing the handler does not start a BullMQ worker or health server', async () => {
+    await import('../../../workers/fund-scenario-calc-handler');
+
+    expect(workerConstructorMock).not.toHaveBeenCalled();
+    expect(registerWorkerMock).not.toHaveBeenCalled();
+    expect(createHealthServerMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('fund scenario calc worker startup', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    getQueueConnectionOptionsMock.mockReturnValue({
+      host: 'queue-host',
+      port: 6380,
+      username: 'queue-user',
+      password: 'queue-pass',
+      db: 4,
+    });
+  });
+
+  it('uses the shared queue connection resolver for production worker startup', async () => {
+    const { startFundScenarioCalcWorker } =
+      await import('../../../workers/fund-scenario-calc-worker');
+
+    startFundScenarioCalcWorker({ healthPort: 0 });
+
+    expect(getQueueConnectionOptionsMock).toHaveBeenCalledTimes(1);
+    expect(workerConstructorMock).toHaveBeenCalledWith(
+      'fund-scenario-calc',
+      expect.any(Function),
+      expect.objectContaining({
+        connection: {
+          host: 'queue-host',
+          port: 6380,
+          username: 'queue-user',
+          password: 'queue-pass',
+          db: 4,
+        },
+      })
+    );
+    expect(registerWorkerMock).toHaveBeenCalledWith('fund-scenario-calc', expect.any(Object));
+    expect(createHealthServerMock).toHaveBeenCalledWith(0);
+  });
+
+  it('fails fast when queue Redis is not configured', async () => {
+    getQueueConnectionOptionsMock.mockReturnValue(null);
+    const { startFundScenarioCalcWorker } =
+      await import('../../../workers/fund-scenario-calc-worker');
+
+    expect(() => startFundScenarioCalcWorker({ healthPort: 0 })).toThrow(
+      /queue Redis connection is not configured/i
+    );
+    expect(workerConstructorMock).not.toHaveBeenCalled();
+    expect(registerWorkerMock).not.toHaveBeenCalled();
+    expect(createHealthServerMock).not.toHaveBeenCalled();
   });
 });

--- a/vitest.config.int.ts
+++ b/vitest.config.int.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
   },
   test: {
-    name: 'integration',
+    name: 'server',
     globalSetup: ['tests/integration/global-setup.ts'],
     include: [
       'tests/integration/**/*.int.spec.ts',

--- a/workers/fund-scenario-calc-handler.ts
+++ b/workers/fund-scenario-calc-handler.ts
@@ -1,0 +1,61 @@
+import type { Job } from 'bullmq';
+import { logger } from '../lib/logger';
+import { metrics, withMetrics } from '../lib/metrics';
+import { runReserveScenarioCalculation } from '../server/services/fund-scenario-reserve-calculation-service';
+
+export interface FundScenarioCalcJobData {
+  fundId: number;
+  scenarioSetId: string;
+  correlationId: string;
+  calculationMode: string;
+  actor: {
+    userId: number | null;
+    label: string | null;
+  } | null;
+}
+
+export async function handleFundScenarioCalcJob(
+  job: Pick<Job<FundScenarioCalcJobData>, 'id' | 'data'>
+) {
+  const { fundId, scenarioSetId, correlationId, calculationMode, actor } = job.data;
+
+  logger.info('Processing reserve scenario calculation', {
+    fundId,
+    scenarioSetId,
+    correlationId,
+    jobId: job.id,
+    calculationMode,
+  });
+
+  try {
+    if (calculationMode !== 'async_reserve_allocation') {
+      throw new Error(`Unsupported fund scenario calculation mode: ${calculationMode}`);
+    }
+
+    return await withMetrics('fund-scenario-reserve', async () =>
+      runReserveScenarioCalculation({
+        fundId,
+        scenarioSetId,
+        correlationId,
+        actor: actor ?? {},
+        jobId: String(job.id),
+      })
+    );
+  } catch (error) {
+    const err = error as Error;
+    logger.error('Reserve scenario calculation failed', err, {
+      fundId,
+      scenarioSetId,
+      correlationId,
+      jobId: job.id,
+      errorName: err.name,
+      errorMessage: err.message,
+      errorStack: err.stack,
+    });
+    metrics.counter('fund_scenario_reserve_calculation_failed_total', 1, {
+      fundId: String(fundId),
+      errorType: err.name,
+    });
+    throw error;
+  }
+}

--- a/workers/fund-scenario-calc-worker-harness.ts
+++ b/workers/fund-scenario-calc-worker-harness.ts
@@ -1,0 +1,43 @@
+import { QueueEvents } from 'bullmq';
+import { getQueueConnectionOptions, type QueueConnectionOptions } from '../server/config/features';
+import {
+  FUND_SCENARIO_CALC_QUEUE_CONNECTION_ERROR,
+  FUND_SCENARIO_CALC_QUEUE_NAME,
+  startFundScenarioCalcWorker,
+} from './fund-scenario-calc-worker';
+
+interface InProcessFundScenarioCalcWorkerHarnessOptions {
+  connection?: QueueConnectionOptions;
+  concurrency?: number;
+}
+
+export interface InProcessFundScenarioCalcWorkerHarness {
+  queueEvents: QueueEvents;
+  close: () => Promise<void>;
+}
+
+export async function startInProcessFundScenarioCalcWorkerHarness(
+  options: InProcessFundScenarioCalcWorkerHarnessOptions = {}
+): Promise<InProcessFundScenarioCalcWorkerHarness> {
+  const connection = options.connection ?? getQueueConnectionOptions();
+
+  if (!connection) {
+    throw new Error(FUND_SCENARIO_CALC_QUEUE_CONNECTION_ERROR);
+  }
+
+  const workerRuntime = startFundScenarioCalcWorker({
+    connection,
+    ...(options.concurrency !== undefined ? { concurrency: options.concurrency } : {}),
+    healthPort: null,
+  });
+  const queueEvents = new QueueEvents(FUND_SCENARIO_CALC_QUEUE_NAME, { connection });
+  await queueEvents.waitUntilReady();
+
+  return {
+    queueEvents,
+    close: async () => {
+      await workerRuntime.close();
+      await queueEvents.close();
+    },
+  };
+}

--- a/workers/fund-scenario-calc-worker.ts
+++ b/workers/fund-scenario-calc-worker.ts
@@ -1,106 +1,113 @@
-import { Worker, type Job } from 'bullmq';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { Worker } from 'bullmq';
 import { logger } from '../lib/logger';
-import { withMetrics, metrics } from '../lib/metrics';
-import { registerWorker, createHealthServer } from './health-server';
-import { runReserveScenarioCalculation } from '../server/services/fund-scenario-reserve-calculation-service';
+import { getQueueConnectionOptions, type QueueConnectionOptions } from '../server/config/features';
+import { createHealthServer, registerWorker } from './health-server';
+import {
+  handleFundScenarioCalcJob,
+  type FundScenarioCalcJobData,
+} from './fund-scenario-calc-handler';
 
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: parseInt(process.env.REDIS_PORT || '6379'),
-};
+export const FUND_SCENARIO_CALC_QUEUE_NAME = 'fund-scenario-calc';
+export const FUND_SCENARIO_CALC_QUEUE_CONNECTION_ERROR =
+  'Fund scenario calculation queue Redis connection is not configured; set QUEUE_REDIS_URL or REDIS_URL with ENABLE_QUEUES=1';
 
-interface FundScenarioCalcJobData {
-  fundId: number;
-  scenarioSetId: string;
-  correlationId: string;
-  calculationMode: string;
-  actor: {
-    userId: number | null;
-    label: string | null;
-  } | null;
+interface StartFundScenarioCalcWorkerOptions {
+  connection?: QueueConnectionOptions;
+  concurrency?: number;
+  healthPort?: number | null;
+  installSignalHandlers?: boolean;
 }
 
-export async function handleFundScenarioCalcJob(
-  job: Pick<Job<FundScenarioCalcJobData>, 'id' | 'data'>
-) {
-  const { fundId, scenarioSetId, correlationId, calculationMode, actor } = job.data;
+interface FundScenarioCalcWorkerRuntime {
+  worker: Worker<FundScenarioCalcJobData>;
+  close: () => Promise<void>;
+}
 
-  logger.info('Processing reserve scenario calculation', {
-    fundId,
-    scenarioSetId,
-    correlationId,
-    jobId: job.id,
-    calculationMode,
+function getHealthPort(): number {
+  return Number.parseInt(process.env.FUND_SCENARIO_WORKER_HEALTH_PORT || '9004', 10);
+}
+
+export function createFundScenarioCalcWorker(input: {
+  connection: QueueConnectionOptions;
+  concurrency?: number;
+}): Worker<FundScenarioCalcJobData> {
+  return new Worker<FundScenarioCalcJobData>(
+    FUND_SCENARIO_CALC_QUEUE_NAME,
+    handleFundScenarioCalcJob,
+    {
+      connection: input.connection,
+      concurrency: input.concurrency ?? 2,
+      lockDuration: 300_000,
+      attempts: 2,
+      backoff: {
+        type: 'exponential',
+        delay: 2_000,
+      },
+      removeOnComplete: {
+        age: 3600,
+        count: 100,
+      },
+      removeOnFail: {
+        age: 86400,
+      },
+    }
+  );
+}
+
+function installGracefulShutdown(worker: Worker<FundScenarioCalcJobData>): void {
+  process.on('SIGTERM', async () => {
+    logger.info('Fund scenario calculation worker shutting down gracefully...');
+    await worker.close();
+    logger.info('Fund scenario calculation worker shut down complete');
   });
 
-  try {
-    if (calculationMode !== 'async_reserve_allocation') {
-      throw new Error(`Unsupported fund scenario calculation mode: ${calculationMode}`);
-    }
-
-    return await withMetrics('fund-scenario-reserve', async () =>
-      runReserveScenarioCalculation({
-        fundId,
-        scenarioSetId,
-        correlationId,
-        actor: actor ?? {},
-        jobId: String(job.id),
-      })
-    );
-  } catch (error) {
-    const err = error as Error;
-    logger.error('Reserve scenario calculation failed', err, {
-      fundId,
-      scenarioSetId,
-      correlationId,
-      jobId: job.id,
-      errorName: err.name,
-      errorMessage: err.message,
-      errorStack: err.stack,
-    });
-    metrics.counter('fund_scenario_reserve_calculation_failed_total', 1, {
-      fundId: String(fundId),
-      errorType: err.name,
-    });
-    throw error;
-  }
+  process.on('SIGINT', async () => {
+    logger.info('Fund scenario calculation worker received SIGINT, shutting down...');
+    await worker.close();
+    process.exit(0);
+  });
 }
 
-export const fundScenarioCalcWorker = new Worker<FundScenarioCalcJobData>(
-  'fund-scenario-calc',
-  handleFundScenarioCalcJob,
-  {
-    connection,
-    concurrency: 2,
-    lockDuration: 300_000,
-    attempts: 2,
-    backoff: {
-      type: 'exponential',
-      delay: 2_000,
-    },
-    removeOnComplete: {
-      age: 3600,
-      count: 100,
-    },
-    removeOnFail: {
-      age: 86400,
-    },
+export function startFundScenarioCalcWorker(
+  options: StartFundScenarioCalcWorkerOptions = {}
+): FundScenarioCalcWorkerRuntime {
+  const connection = options.connection ?? getQueueConnectionOptions();
+
+  if (!connection) {
+    throw new Error(FUND_SCENARIO_CALC_QUEUE_CONNECTION_ERROR);
   }
-);
 
-registerWorker('fund-scenario-calc', fundScenarioCalcWorker);
+  const worker = createFundScenarioCalcWorker({
+    connection,
+    ...(options.concurrency !== undefined ? { concurrency: options.concurrency } : {}),
+  });
 
-const HEALTH_PORT = parseInt(process.env.FUND_SCENARIO_WORKER_HEALTH_PORT || '9004');
-createHealthServer(HEALTH_PORT);
+  registerWorker(FUND_SCENARIO_CALC_QUEUE_NAME, worker);
 
-process.on('SIGTERM', async () => {
-  logger.info('Fund scenario calculation worker shutting down gracefully...');
-  await fundScenarioCalcWorker.close();
-  logger.info('Fund scenario calculation worker shut down complete');
-});
+  if (options.healthPort !== null) {
+    createHealthServer(options.healthPort ?? getHealthPort());
+  }
 
-process.on('SIGINT', async () => {
-  logger.info('Fund scenario calculation worker received SIGINT, shutting down...');
-  await fundScenarioCalcWorker.close();
-  process.exit(0);
-});
+  if (options.installSignalHandlers) {
+    installGracefulShutdown(worker);
+  }
+
+  return {
+    worker,
+    close: () => worker.close(),
+  };
+}
+
+function isDirectEntrypoint(metaUrl: string): boolean {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  return pathToFileURL(resolve(process.argv[1])).href === metaUrl;
+}
+
+if (isDirectEntrypoint(import.meta.url)) {
+  startFundScenarioCalcWorker({ installSignalHandlers: true });
+}


### PR DESCRIPTION
## Summary
- Split the reserve scenario calculation handler into a side-effect-free module and made worker startup explicit.
- Switched production worker startup to the shared queue Redis resolver used by enqueueing (`getQueueConnectionOptions`, `QUEUE_REDIS_URL` over `REDIS_URL`).
- Added an in-process worker harness plus Redis/Postgres integration coverage for HTTP `calculate-reserve` through BullMQ, worker processing, status/results, and controlled failure handling.

## Verification
- `npx vitest run tests/unit/workers/fund-scenario-calc-worker.test.ts`
- `npx vitest run -c vitest.config.int.ts --project=server tests/integration/fund-scenario-reserve-worker.test.ts` (passes locally with 2 visible skips because this machine has no working container runtime; the test hard-fails in CI if infrastructure startup fails)
- `npm run check`
- `npm run lint`
- `git diff --check`
- `npm run build`