### PR TITLE
Close roadmap slices 16-18 behind contract evidence

### DIFF
--- a/client/src/debug/emergency-rollback.ts
+++ b/client/src/debug/emergency-rollback.ts
@@ -1,0 +1,40 @@
+export interface EmergencyRollbackWindow extends Window {
+  __FORCE_LEGACY_STATE?: boolean;
+}
+
+function getRollbackWindow(): EmergencyRollbackWindow {
+  return window as EmergencyRollbackWindow;
+}
+
+function showEmergencyRollbackNotification() {
+  const notification = document.createElement('div');
+  notification.innerHTML = `
+    <div style="position: fixed; top: 10px; right: 10px; z-index: 9999; background: #ff4444; color: white; padding: 12px 16px; border-radius: 4px; font-family: monospace; max-width: 300px;">
+      [CRITICAL] Emergency Mode Active<br>
+      <small>Using legacy state system. Contact support if this persists.</small>
+    </div>
+  `;
+  document.body.appendChild(notification);
+
+  setTimeout(() => notification.remove(), 10000);
+}
+
+export function checkEmergencyRollback() {
+  try {
+    const rollbackWindow = getRollbackWindow();
+    const urlParams = new URLSearchParams(rollbackWindow.location.search);
+    if (urlParams.get('emergency_rollback') === 'true') {
+      rollbackWindow.__FORCE_LEGACY_STATE = true;
+      console.warn('[CRITICAL] Emergency rollback activated via URL parameter');
+      return;
+    }
+
+    if (rollbackWindow.localStorage.getItem('emergency_rollback') === 'true') {
+      rollbackWindow.__FORCE_LEGACY_STATE = true;
+      console.warn('[CRITICAL] Emergency rollback activated via localStorage');
+      showEmergencyRollbackNotification();
+    }
+  } catch (error) {
+    console.warn('Emergency rollback check failed:', error);
+  }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,80 +4,22 @@ import App from './App';
 import './index.css';
 import './styles/brand-tokens.css'; // Phase 1: Brand consistency (Inter/Poppins, neutral palette)
 import { installFetchTap } from './debug/fetch-tap';
-// Vitals loaded dynamically in production
+import { checkEmergencyRollback } from './debug/emergency-rollback';
+import { bootstrapMonitoring } from './monitoring/bootstrap';
 
-declare global {
-  interface Window {
-    __FORCE_LEGACY_STATE?: boolean;
-  }
+if (import.meta.env.DEV) {
+  installFetchTap();
 }
 
-// Install fetch interceptor for debugging
-installFetchTap();
-
-// Emergency rollback failsafe - provides backdoor even if env vars are stuck
-function checkEmergencyRollback() {
-  try {
-    // Check URL parameter first (highest priority)
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams['get']('emergency_rollback') === 'true') {
-      window.__FORCE_LEGACY_STATE = true;
-      console.warn('[CRITICAL] Emergency rollback activated via URL parameter');
-      return;
-    }
-
-    // Check localStorage (persistent emergency rollback)
-    if (localStorage.getItem('emergency_rollback') === 'true') {
-      window.__FORCE_LEGACY_STATE = true;
-      console.warn('[CRITICAL] Emergency rollback activated via localStorage');
-
-      // Show user-friendly notification
-      const notification = document.createElement('div');
-      notification.innerHTML = `
-        <div style="position: fixed; top: 10px; right: 10px; z-index: 9999; background: #ff4444; color: white; padding: 12px 16px; border-radius: 4px; font-family: monospace; max-width: 300px;">
-          [CRITICAL] Emergency Mode Active<br>
-          <small>Using legacy state system. Contact support if this persists.</small>
-        </div>
-      `;
-      document.body.appendChild(notification);
-
-      // Auto-remove notification after 10 seconds
-      setTimeout(() => notification.remove(), 10000);
-    }
-  } catch (e) {
-    console.warn('Emergency rollback check failed:', e);
-  }
-}
-
-// Check for emergency rollback before app initialization
 checkEmergencyRollback();
-
-// Initialize monitoring in production
-if (import.meta.env.PROD) {
-  // Code-split Sentry - only load when DSN is configured
-  if (import.meta.env.VITE_SENTRY_DSN) {
-    import('@/monitoring')
-      .then(() => undefined)
-      .catch((err) => {
-        console.warn('Failed to load Sentry:', err);
-      });
-  }
-  // Start Web Vitals collection after app mounts
-  const startVitalsWhenIdle = () => {
-    import('./vitals').then(({ startVitals }) => startVitals());
-  };
-
-  if (typeof window.requestIdleCallback === 'function') {
-    window.requestIdleCallback(startVitalsWhenIdle);
-  } else {
-    window.setTimeout(startVitalsWhenIdle, 1);
-  }
-}
+bootstrapMonitoring({
+  loadVitals: () => import('./vitals'),
+});
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
   createRoot(rootElement).render(
-    process.env['NODE_ENV'] === 'development' ? (
+    import.meta.env.DEV ? (
       <StrictMode>
         <App />
       </StrictMode>

--- a/client/src/monitoring/bootstrap.ts
+++ b/client/src/monitoring/bootstrap.ts
@@ -1,0 +1,46 @@
+type MonitoringEnv = Pick<ImportMetaEnv, 'PROD' | 'VITE_SENTRY_DSN'>;
+
+interface VitalsModule {
+  startVitals: () => void;
+}
+
+export interface MonitoringBootstrapOptions {
+  env?: MonitoringEnv;
+  loadMonitoring?: () => Promise<unknown>;
+  loadVitals?: () => Promise<VitalsModule>;
+  scheduleIdle?: (callback: () => void) => void;
+  warn?: (...data: unknown[]) => void;
+}
+
+function scheduleWhenIdle(callback: () => void) {
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(callback);
+    return;
+  }
+
+  window.setTimeout(callback, 1);
+}
+
+export function bootstrapMonitoring(options: MonitoringBootstrapOptions = {}) {
+  const env = options.env ?? import.meta.env;
+  if (!env.PROD) {
+    return;
+  }
+
+  const warn = options.warn ?? console.warn;
+  const loadMonitoring = options.loadMonitoring ?? (() => import('./index'));
+  const loadVitals = options.loadVitals;
+  const scheduleIdle = options.scheduleIdle ?? scheduleWhenIdle;
+
+  if (env.VITE_SENTRY_DSN) {
+    loadMonitoring().catch((error) => {
+      warn('Failed to load Sentry:', error);
+    });
+  }
+
+  if (loadVitals) {
+    scheduleIdle(() => {
+      void loadVitals().then(({ startVitals }) => startVitals());
+    });
+  }
+}

--- a/client/src/monitoring/bootstrap.ts
+++ b/client/src/monitoring/bootstrap.ts
@@ -1,4 +1,7 @@
-type MonitoringEnv = Pick<ImportMetaEnv, 'PROD' | 'VITE_SENTRY_DSN'>;
+interface MonitoringEnv {
+  readonly PROD: boolean;
+  readonly VITE_SENTRY_DSN?: string | boolean;
+}
 
 interface VitalsModule {
   startVitals: () => void;
@@ -21,26 +24,60 @@ function scheduleWhenIdle(callback: () => void) {
   window.setTimeout(callback, 1);
 }
 
-export function bootstrapMonitoring(options: MonitoringBootstrapOptions = {}) {
-  const env = options.env ?? import.meta.env;
-  if (!env.PROD) {
-    return;
-  }
+function getMonitoringEnv(env?: MonitoringEnv): MonitoringEnv {
+  return env ?? import.meta.env;
+}
 
-  const warn = options.warn ?? console.warn;
-  const loadMonitoring = options.loadMonitoring ?? (() => import('./index'));
-  const loadVitals = options.loadVitals;
-  const scheduleIdle = options.scheduleIdle ?? scheduleWhenIdle;
+function getMonitoringLoader(loadMonitoring?: () => Promise<unknown>) {
+  return loadMonitoring ?? (() => import('./index'));
+}
 
+function getWarningLogger(warn?: (...data: unknown[]) => void) {
+  return warn ?? console.warn;
+}
+
+function getIdleScheduler(scheduleIdle?: (callback: () => void) => void) {
+  return scheduleIdle ?? scheduleWhenIdle;
+}
+
+function loadSentryWhenConfigured(
+  env: MonitoringEnv,
+  loadMonitoring: () => Promise<unknown>,
+  warn: (...data: unknown[]) => void
+) {
   if (env.VITE_SENTRY_DSN) {
     loadMonitoring().catch((error) => {
       warn('Failed to load Sentry:', error);
     });
   }
+}
 
-  if (loadVitals) {
+async function startVitals(loadVitalsModule: () => Promise<VitalsModule>) {
+  const { startVitals } = await loadVitalsModule();
+  startVitals();
+}
+
+function scheduleVitalsWhenConfigured(
+  loadVitalsModule: (() => Promise<VitalsModule>) | undefined,
+  scheduleIdle: (callback: () => void) => void
+) {
+  if (loadVitalsModule) {
     scheduleIdle(() => {
-      void loadVitals().then(({ startVitals }) => startVitals());
+      void startVitals(loadVitalsModule);
     });
   }
+}
+
+export function bootstrapMonitoring(options: MonitoringBootstrapOptions = {}) {
+  const env = getMonitoringEnv(options.env);
+  if (!env.PROD) {
+    return;
+  }
+
+  loadSentryWhenConfigured(
+    env,
+    getMonitoringLoader(options.loadMonitoring),
+    getWarningLogger(options.warn)
+  );
+  scheduleVitalsWhenConfigured(options.loadVitals, getIdleScheduler(options.scheduleIdle));
 }

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -4345,7 +4345,7 @@
           "routing",
           "documentation"
         ],
-        "last_updated": "2026-05-20",
+        "last_updated": "2026-05-28",
         "owner": "Core Team",
         "priority": 2,
         "review_cadence": "P90D",
@@ -4359,10 +4359,10 @@
       },
       "hasExecutionClaims": false,
       "isStale": false,
-      "lastUpdated": "2026-05-20",
+      "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 8,
+      "staleDays": 0,
       "status": "ACTIVE"
     },
     {
@@ -6664,7 +6664,7 @@
           "governance",
           "roadmap"
         ],
-        "last_updated": "2026-05-27",
+        "last_updated": "2026-05-28",
         "owner": "Core Team",
         "related": [
           "docs/reviews/refactor-audit-2026-05-19/README.md"
@@ -6675,10 +6675,10 @@
       },
       "hasExecutionClaims": true,
       "isStale": false,
-      "lastUpdated": "2026-05-27",
+      "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 1,
+      "staleDays": 0,
       "status": "ACTIVE"
     },
     {
@@ -6712,7 +6712,7 @@
           "deletion",
           "migration"
         ],
-        "last_updated": "2026-05-27",
+        "last_updated": "2026-05-28",
         "owner": "Core Team",
         "related": [
           "docs/governance/2026-05-19-refactor-roadmap.md"
@@ -6721,12 +6721,12 @@
         "source_of_truth": true,
         "status": "ACTIVE"
       },
-      "hasExecutionClaims": false,
+      "hasExecutionClaims": true,
       "isStale": false,
-      "lastUpdated": "2026-05-27",
+      "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 1,
+      "staleDays": 0,
       "status": "ACTIVE"
     },
     {
@@ -8536,6 +8536,18 @@
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
       "staleDays": 55,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/quarantine/2026-05-28-stabilization-triage.md",
+      "staleDays": 999,
       "status": "UNKNOWN"
     },
     {
@@ -11460,15 +11472,15 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-05-21",
+        "last_updated": "2026-05-28",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
       "isStale": false,
-      "lastUpdated": "2026-05-21",
+      "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 7,
+      "staleDays": 0,
       "status": "ACTIVE"
     },
     {
@@ -12729,14 +12741,14 @@
       "REFERENCE": 6,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 124,
+      "UNKNOWN": 125,
       "VERIFIED": 9,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 16,
-    "stale_docs": 98,
-    "total_docs": 652
+    "missing_frontmatter": 17,
+    "stale_docs": 99,
+    "total_docs": 653
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,16 +11,16 @@ last_updated: 2026-05-28
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 652 |
-| Stale Documents | 98 |
-| Missing Frontmatter | 16 |
+| Total Documents | 653 |
+| Stale Documents | 99 |
+| Missing Frontmatter | 17 |
 
 ### By Status
 
 | Status | Count |
 |--------|-------|
 | ACTIVE | 432 |
-| UNKNOWN | 124 |
+| UNKNOWN | 125 |
 | DRAFT | 31 |
 | HISTORICAL | 29 |
 | VERIFIED | 9 |
@@ -54,6 +54,7 @@ Documents that need review (older than their cadence threshold):
 | `docs/agents/triage-labels.md` | Never | 999 | No | Unassigned |
 | `docs/design/updog-design-philosophy-v3.1.1-implementation-notes.md` | Never | 999 | No | Unassigned |
 | `docs/phase2-calibration-benchmarks.md` | Never | 999 | No | Unassigned |
+| `docs/quarantine/2026-05-28-stabilization-triage.md` | Never | 999 | No | Unassigned |
 | `docs/skills/REFL-002-post-merge-jobs-not-validated-by-pr-ci.md` | Never | 999 | No | Unassigned |
 | `docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md` | Never | 999 | YES - verify! | Unassigned |
 | `docs/skills/REFL-004-schema-format-backward-compatibility.md` | Never | 999 | No | Unassigned |
@@ -94,9 +95,8 @@ Documents that need review (older than their cadence threshold):
 | `cheatsheets/codex-collaboration-protocol.md` | 2026-01-19 | 129 | No | Unassigned |
 | `cheatsheets/coding-pairs-playbook.md` | 2026-01-19 | 129 | No | Unassigned |
 | `cheatsheets/command-summary.md` | 2026-01-19 | 129 | No | Unassigned |
-| `cheatsheets/correct-workflow-example.md` | 2026-01-19 | 129 | No | Unassigned |
 
-*...and 48 more stale documents.*
+*...and 49 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
@@ -129,6 +129,7 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/agents/triage-labels.md`
 - [ ] `docs/design/updog-design-philosophy-v3.1.1-implementation-notes.md`
 - [ ] `docs/phase2-calibration-benchmarks.md`
+- [ ] `docs/quarantine/2026-05-28-stabilization-triage.md`
 - [ ] `docs/skills/SKILLS_INDEX.md`
 - [ ] `docs/skills/WIZARD_INDEX.md`
 - [ ] `docs/superpowers/plans/2026-05-15-term-conflict-tier2-fixes.md`

--- a/docs/governance/2026-05-19-refactor-roadmap.md
+++ b/docs/governance/2026-05-19-refactor-roadmap.md
@@ -117,8 +117,26 @@ As of 2026-05-28:
 19. Slice 15 is closed as conservative no-op: the tracked TypeScript config set
     has only active boundary configs, and live scans found no safe deletion
     candidate.
-20. The next separate cleanup slice is the domain golden/truth coverage gap
-    pass. Do not start it together with route logging migration, deal-pipeline
+20. Slice 16 is closed as a focused domain golden/truth gap pass. The
+    `18c3d0d9` LP metrics fixtures and golden assertions already covered the
+    core LP scenarios, so this slice only added lock metadata/hash coverage in
+    `tests/unit/golden/lp-reporting/lp-metrics-lock.test.ts`. Evidence:
+    targeted LP golden/truth run passed 10 files / 295 tests, `npm run
+    phoenix:truth` passed 7 files / 265 tests, and `npm run calc-gate` passed
+    its truth, calculation, and orphan gate segments.
+21. Slice 17 is closed as a route-contract hardening pass before any service
+    extraction. Existing `18c3d0d9` allocation and LP API contract tests were
+    kept and extended rather than duplicated. Evidence: targeted route-contract
+    run passed 5 files / 57 tests across `deal-pipeline`, `lp-api`,
+    `allocations`, `funds`, and `performance-api`.
+22. Slice 18 is closed as a `main.tsx` bootstrap cleanup. The fetch tap is now
+    development-only, emergency rollback lives in
+    `client/src/debug/emergency-rollback.ts`, environment checks use
+    `import.meta.env`, and monitoring bootstrap lives in
+    `client/src/monitoring/bootstrap.ts`. Evidence: focused bootstrap helper
+    tests passed 2 files / 5 tests.
+23. The next separate cleanup slice is `App.tsx` splitting. Do not start it
+    together with route mounting normalization, route logging migration, service
     extraction, product-code refactors, Phoenix docs, Playwright config, Docker
     config, or unrelated config cleanup.
 
@@ -1948,8 +1966,10 @@ changes and reduce future debt accumulation.
 |    13 | DONE: `chore(env): consolidate env files behind verified loader behavior`               | 2026-05-28: `.env.test` added after `.env.${NODE_ENV}` loader proof; legacy env variants kept where referenced                      |
 |    14 | DONE: `chore(test): consolidate vitest config aliases without changing unit entry`      | 2026-05-28: `vitest.config.shared.mjs` extracts aliases; `test:unit` still uses `vitest.config.mjs`                                 |
 |    15 | DONE/no-op: `chore(tsconfig): keep only active TypeScript boundaries`                   | 2026-05-28: all tracked configs are active boundaries; no deletion candidate found                                                  |
-|    16 | `test(domain): fill fund-model golden parity gaps`                                      | `phoenix:truth` + targeted truth/golden tests                                                                                       |
-|   17+ | Product refactors one area at a time                                                    | per-area gates                                                                                                                      |
+|    16 | DONE: `test(domain): fill fund-model golden parity gaps`                                | 2026-05-28: LP metrics lock metadata/hash coverage; targeted golden/truth 10 files / 295 tests; `phoenix:truth`; `calc-gate`        |
+|    17 | DONE: `test(routes): lock extraction contracts for route slices`                        | 2026-05-28: deal-pipeline, lp-api, allocations, funds, and performance-api contract run 5 files / 57 tests                          |
+|    18 | DONE: `refactor(client): clean main bootstrap boundaries`                               | 2026-05-28: fetch tap DEV gate, emergency rollback module, monitoring bootstrap module; focused bootstrap tests 2 files / 5 tests    |
+|   19+ | Product refactors one area at a time                                                    | per-area gates                                                                                                                      |
 
 ---
 
@@ -2000,11 +2020,11 @@ baseline in the roadmap.
     `vitest.config.shared.mjs`; `test:unit` still uses `vitest.config.mjs`.
 15. DONE/no-op: TypeScript config rationalization found no tracked deletion
     candidates; active boundary configs remain.
-16. NEXT: Fill gaps in existing fragmented domain golden/truth tests.
-17. Add route contract tests for `deal-pipeline`, `lp-api`, `allocations`,
-    `funds`, and `performance-api` before service extraction.
-18. Clean `main.tsx`.
-19. Split `App.tsx`.
+16. DONE: Fill gaps in existing fragmented domain golden/truth tests.
+17. DONE: Add route contract tests for `deal-pipeline`, `lp-api`,
+    `allocations`, `funds`, and `performance-api` before service extraction.
+18. DONE: Clean `main.tsx`.
+19. NEXT: Split `App.tsx`.
 20. Normalize API route mounting without changing URLs.
 21. Extract service logic from largest DB-heavy routes (`deal-pipeline.ts`
     first, then `lp-api.ts`, then `allocations.ts`); reduce direct DB/storage

--- a/docs/governance/cleanup-manifest.md
+++ b/docs/governance/cleanup-manifest.md
@@ -25,7 +25,9 @@ Batch 8 closeout; package script aliases were rechecked through Batch 9; Husky
 hooks and pre-push orchestration were rechecked through Batch 10; workflows were
 classified through Batch 11 and closed as a no-deletion Batch 12 evidence pass;
 env files, Vitest aliases, and TypeScript configs were rechecked through slices
-13-15; other rows remain from the 0e roadmap baseline refresh:
+13-15; domain golden/truth coverage, route contracts, and `main.tsx` bootstrap
+boundaries were refreshed through slices 16-18; other rows remain from the 0e
+roadmap baseline refresh:
 
 | Evidence                                   | Current result                                                                                                                                                                                                                              |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -44,6 +46,9 @@ env files, Vitest aliases, and TypeScript configs were rechecked through slices
 | `.husky/pre-push` / `scripts/pre-push.mjs` | Active after Batch 10; no equivalent command preserves changed-file classification, doc warnings, orphan checks, baseline validation, full-run handling, and related tests                                                                  |
 | `.github/workflows/*`                      | 19 tracked `.yml` workflow files; Batch 11 classified all 19 in `docs/workflows/README.md`; Batch 12 closed as no-deletion because replacement/manual/status-consumer proof remained insufficient                                           |
 | `.env*`                                    | `.env.test` added with safe deterministic values after `server/config/index.ts` loader proof; `.env.test.local` remains ignored; `.env.react`, `.env.preact`, `.env.vercel`, `.env.local.example`, and `.env.rls.example` remain referenced |
+| domain golden/truth coverage               | Slice 16 kept the `18c3d0d9` LP metrics fixtures and golden tests, then added lock metadata/hash coverage in `tests/unit/golden/lp-reporting/lp-metrics-lock.test.ts`; targeted LP golden/truth run passed 10 files / 295 tests; `phoenix:truth` passed 7 files / 265 tests; `calc-gate` passed its truth, calculation, and orphan gate segments |
+| route contracts before extraction          | Slice 17 extended existing route contracts without service extraction: deal-pipeline list pagination/filter success, allocation latest/create fund-scope denial, LP API fund-scope denial, funds detail fund-scope denial, and performance API fund-scope denial; targeted route-contract run passed 5 files / 57 tests |
+| `client/src/main.tsx` bootstrap             | Slice 18 gated the fetch tap behind `import.meta.env.DEV`, moved emergency rollback to `client/src/debug/emergency-rollback.ts`, standardized environment checks on `import.meta.env`, and moved monitoring bootstrap to `client/src/monitoring/bootstrap.ts`; focused bootstrap tests passed 2 files / 5 tests |
 | `scripts/**`                               | 381 tracked files after guardrail additions and stale `scripts/ai/` helper retirement                                                                                                                                                       |
 | `server/middleware console.*`              | 0 matches across 0 files; `rg` exits 1 because middleware logging migration 0d is complete                                                                                                                                                  |
 | `server/routes console.*`                  | 165 matches across 27 files; route-layer logging migration remains future work                                                                                                                                                              |

--- a/server/routes/allocations.ts
+++ b/server/routes/allocations.ts
@@ -588,6 +588,9 @@ router['get'](
     }
 
     const { fundId } = paramValidation.data;
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
 
     try {
       const [fund] = await db
@@ -721,6 +724,10 @@ router['post'](
     }
 
     const { fundId } = paramValidation.data;
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+
     const { expected_version, updates } = bodyValidation.data;
 
     // Get user ID from auth context (if available)

--- a/tests/unit/contract/funds-endpoint-snapshots.test.ts
+++ b/tests/unit/contract/funds-endpoint-snapshots.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 import {
   fundsEndpointKey,
@@ -43,6 +44,29 @@ beforeAll(async () => {
   const fundRoutes = await import('../../../server/routes/funds');
   app.use('/api', fundRoutes.default);
 });
+
+async function makeScopedFundsApp(fundIds: number[]) {
+  const scopedApp = express();
+  scopedApp.set('trust proxy', false);
+  scopedApp.use(express.json({ limit: '1mb' }));
+  scopedApp.use((req: Request, _res: Response, next: NextFunction) => {
+    req.user = {
+      id: 'contract-user',
+      sub: 'contract-user',
+      email: 'contract@example.com',
+      role: 'admin',
+      roles: ['admin'],
+      fundIds,
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    };
+    next();
+  });
+
+  const fundRoutes = await import('../../../server/routes/funds');
+  scopedApp.use('/api', fundRoutes.default);
+  return scopedApp;
+}
 
 describe('funds endpoint ownership manifest coverage', () => {
   it('keeps snapshot coverage aligned with the supported canonical manifest', () => {
@@ -217,6 +241,18 @@ describe('GET /api/funds/:id contract snapshot', () => {
 
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 403 for fund detail outside the provided user scope', async () => {
+    const scopedApp = await makeScopedFundsApp([2]);
+
+    const res = await request(scopedApp).get('/api/funds/1');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      error: 'Forbidden',
+      code: 'FUND_ACCESS_DENIED',
+    });
   });
 });
 

--- a/tests/unit/debug/emergency-rollback.test.ts
+++ b/tests/unit/debug/emergency-rollback.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { checkEmergencyRollback } from '@/debug/emergency-rollback';
+
+type RollbackWindow = Window & {
+  __FORCE_LEGACY_STATE?: boolean;
+};
+
+describe('emergency rollback bootstrap', () => {
+  afterEach(() => {
+    delete (window as RollbackWindow).__FORCE_LEGACY_STATE;
+    window.localStorage.clear();
+    window.history.pushState({}, '', '/');
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('activates legacy state from the emergency rollback URL parameter', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    window.history.pushState({}, '', '/?emergency_rollback=true');
+
+    checkEmergencyRollback();
+
+    expect((window as RollbackWindow).__FORCE_LEGACY_STATE).toBe(true);
+    expect(warn).toHaveBeenCalledWith('[CRITICAL] Emergency rollback activated via URL parameter');
+  });
+
+  it('activates legacy state from localStorage and shows the existing notification', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    window.localStorage.setItem('emergency_rollback', 'true');
+
+    checkEmergencyRollback();
+
+    expect((window as RollbackWindow).__FORCE_LEGACY_STATE).toBe(true);
+    expect(document.body.textContent).toContain('[CRITICAL] Emergency Mode Active');
+    expect(document.body.textContent).toContain('Using legacy state system.');
+  });
+});

--- a/tests/unit/golden/lp-reporting/lp-metrics-lock.test.ts
+++ b/tests/unit/golden/lp-reporting/lp-metrics-lock.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeMetrics } from '../../../../server/services/lp-reporting/metrics-engine';
+
+import { loadGoldenMetricFixtures } from './_loader';
+
+describe('golden LP metrics lock metadata', () => {
+  it('keeps each locked fixture input hash and diagnostics aligned with current inputs', () => {
+    for (const fx of loadGoldenMetricFixtures()) {
+      const out = computeMetrics(fx.input);
+
+      expect(fx.lock, `${fx.scenario_id} should carry lock metadata`).toBeDefined();
+      expect(fx.lock?.inputs_hash).toBe(out.inputsHash);
+      expect(fx.lock?.diagnostics).toEqual(out.diagnostics);
+    }
+  });
+
+  it('covers the current deterministic LP metric scenario classes with unique inputs', () => {
+    const fixtures = loadGoldenMetricFixtures();
+
+    expect(fixtures.map((fx) => fx.scenario_id).sort()).toEqual([
+      'fund_all_realized',
+      'fund_full_writeoff',
+      'seed_fund_no_recycling',
+      'seed_fund_with_follow_on_and_recycling',
+    ]);
+    expect(new Set(fixtures.map((fx) => fx.lock?.inputs_hash)).size).toBe(fixtures.length);
+  });
+});

--- a/tests/unit/monitoring/bootstrap.test.ts
+++ b/tests/unit/monitoring/bootstrap.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { bootstrapMonitoring } from '@/monitoring/bootstrap';
+
+describe('monitoring bootstrap', () => {
+  it('does not load monitoring or vitals outside production', () => {
+    const loadMonitoring = vi.fn();
+    const loadVitals = vi.fn();
+
+    bootstrapMonitoring({
+      env: { PROD: false, VITE_SENTRY_DSN: 'https://example.test/sentry' },
+      loadMonitoring,
+      loadVitals,
+    });
+
+    expect(loadMonitoring).not.toHaveBeenCalled();
+    expect(loadVitals).not.toHaveBeenCalled();
+  });
+
+  it('loads Sentry only when configured and schedules vitals in production', async () => {
+    const startVitals = vi.fn();
+    const loadMonitoring = vi.fn().mockResolvedValue({});
+    const loadVitals = vi.fn().mockResolvedValue({ startVitals });
+
+    bootstrapMonitoring({
+      env: { PROD: true, VITE_SENTRY_DSN: 'https://example.test/sentry' },
+      loadMonitoring,
+      loadVitals,
+      scheduleIdle: (callback) => callback(),
+    });
+
+    await vi.waitFor(() => expect(startVitals).toHaveBeenCalledTimes(1));
+    expect(loadMonitoring).toHaveBeenCalledTimes(1);
+    expect(loadVitals).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips Sentry without a DSN but still starts production vitals', async () => {
+    const startVitals = vi.fn();
+    const loadMonitoring = vi.fn().mockResolvedValue({});
+    const loadVitals = vi.fn().mockResolvedValue({ startVitals });
+
+    bootstrapMonitoring({
+      env: { PROD: true },
+      loadMonitoring,
+      loadVitals,
+      scheduleIdle: (callback) => callback(),
+    });
+
+    await vi.waitFor(() => expect(startVitals).toHaveBeenCalledTimes(1));
+    expect(loadMonitoring).not.toHaveBeenCalled();
+    expect(loadVitals).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/routes/allocations.contract.test.ts
+++ b/tests/unit/routes/allocations.contract.test.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import type { Request, Response } from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -45,6 +46,12 @@ const writeState = vi.hoisted(() => ({
   transaction: vi.fn(async (fn: (client: unknown) => unknown) => fn({ kind: 'mock-client' })),
 }));
 
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(
+    async (_req: Request, _res: Response, _fundId: number) => true
+  ),
+}));
+
 vi.mock('../../../server/db', () => ({ db: dbState.db }));
 
 vi.mock('../../../server/db/pg-circuit', () => ({
@@ -56,7 +63,7 @@ vi.mock('../../../server/services/allocation-write-service.js', () => ({
 }));
 
 vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
-  enforceProvidedFundScope: vi.fn(async () => true),
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
 }));
 
 vi.mock('../../../server/lib/stage-validation-mode', () => ({
@@ -110,6 +117,8 @@ function resetState() {
   dbState.db.select.mockClear();
   writeState.applyAllocationUpdates.mockReset();
   writeState.transaction.mockClear();
+  fundScopeState.enforceProvidedFundScope.mockReset();
+  fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
 }
 
 function companyRow(overrides: Record<string, unknown> = {}) {
@@ -142,6 +151,26 @@ describe('allocations route contracts', () => {
     expect(response.body).toMatchObject({
       error: 'invalid_fund_id',
       message: 'Fund ID must be a positive integer',
+    });
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/funds/:fundId/allocations/latest rejects denied fund scope before data reads', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({
+        error: 'Forbidden',
+        code: 'FUND_ACCESS_DENIED',
+        message: 'You do not have access to fund 2',
+      });
+      return false;
+    });
+
+    const response = await request(makeApp()).get('/api/funds/2/allocations/latest');
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      error: 'Forbidden',
+      code: 'FUND_ACCESS_DENIED',
     });
     expect(dbState.db.select).not.toHaveBeenCalled();
   });
@@ -239,6 +268,37 @@ describe('allocations route contracts', () => {
 
     expect(response.status).toBe(400);
     expect(response.body).toMatchObject({ error: 'Invalid request body' });
+    expect(writeState.applyAllocationUpdates).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/funds/:fundId/allocations rejects denied fund scope before writes', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({
+        error: 'Forbidden',
+        code: 'FUND_ACCESS_DENIED',
+        message: 'You do not have access to fund 2',
+      });
+      return false;
+    });
+
+    const response = await request(makeApp())
+      .post('/api/funds/2/allocations')
+      .send({
+        expected_version: 1,
+        updates: [
+          {
+            company_id: 11,
+            planned_reserves_cents: 800_000_00,
+          },
+        ],
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      error: 'Forbidden',
+      code: 'FUND_ACCESS_DENIED',
+    });
+    expect(writeState.transaction).not.toHaveBeenCalled();
     expect(writeState.applyAllocationUpdates).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/routes/deal-pipeline.contract.test.ts
+++ b/tests/unit/routes/deal-pipeline.contract.test.ts
@@ -289,6 +289,29 @@ describe('deal pipeline route contracts', () => {
     expect(mockState.db.select).not.toHaveBeenCalled();
   });
 
+  it('lists deals with filters and locks cursor pagination envelope', async () => {
+    mockState.state.selectResults.push([
+      dealRow({ id: 30, companyName: 'Gamma Contract', createdAt: new Date('2026-01-03Z') }),
+      dealRow({ id: 20, companyName: 'Beta Contract', createdAt: new Date('2026-01-02Z') }),
+      dealRow({ id: 10, companyName: 'Alpha Contract', createdAt: new Date('2026-01-01Z') }),
+    ]);
+
+    const response = await request(makeApp()).get(
+      '/api/deals/opportunities?limit=2&status=lead&priority=medium&fundId=1&search=Contract'
+    );
+
+    expect(response.status).toBe(200);
+    expect(Object.keys(response.body).sort()).toEqual(['data', 'pagination', 'success']);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toHaveLength(2);
+    expect(response.body.data.map((deal: { id: number }) => deal.id)).toEqual([30, 20]);
+    expect(response.body.pagination).toEqual({
+      hasMore: true,
+      nextCursor: cursorFor({ createdAt: '2026-01-02T00:00:00.000Z', id: 20 }),
+      count: 2,
+    });
+  });
+
   it('returns 404 with request id propagation for missing deal reads and mutations', async () => {
     mockState.state.selectResults.push([], [], []);
     const app = makeApp();

--- a/tests/unit/routes/lp-api.contract.test.ts
+++ b/tests/unit/routes/lp-api.contract.test.ts
@@ -324,6 +324,21 @@ describe('LP API route contracts', () => {
     });
   });
 
+  it.each([['/api/lp/funds/99/detail'], ['/api/lp/funds/99/holdings']])(
+    'rejects LP fund scope for %s before calculators run',
+    async (path) => {
+      const response = await request(makeApp()).get(path);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({
+        error: 'FORBIDDEN',
+        message: 'You do not have access to fund 99.',
+      });
+      expect(calculatorState.calculateCapitalAccount).not.toHaveBeenCalled();
+      expect(calculatorState.calculateProRataHoldings).not.toHaveBeenCalled();
+    }
+  );
+
   it('GET /api/lp/funds/:fundId/holdings locks aggregate fields', async () => {
     calculatorState.calculateProRataHoldings.mockResolvedValueOnce([
       { companyId: 1, companyName: 'Alpha', lpProRataValue: 150 },

--- a/tests/unit/routes/performance-api-observability.test.ts
+++ b/tests/unit/routes/performance-api-observability.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 
 const {
+  authState,
   getFundMock,
   calculateTimeseriesMock,
   calculateBreakdownMock,
@@ -15,24 +17,40 @@ const {
   recordDataPointsMock,
   recordErrorMock,
   loggerErrorMock,
-} = vi.hoisted(() => ({
-  getFundMock: vi.fn(),
-  calculateTimeseriesMock: vi.fn(),
-  calculateBreakdownMock: vi.fn(),
-  calculateComparisonMock: vi.fn(),
-  startTimerMock: vi.fn(),
-  recordPerformanceRequestMock: vi.fn(),
-  recordCacheHitMock: vi.fn(),
-  recordCacheMissMock: vi.fn(),
-  recordCalculationMock: vi.fn(),
-  recordDataPointsMock: vi.fn(),
-  recordErrorMock: vi.fn(),
-  loggerErrorMock: vi.fn(),
-}));
+} = vi.hoisted(() => {
+  const authState = {
+    fundAccessAllowed: true,
+    requireFundAccessMock: vi.fn((_req: Request, res: Response, next: NextFunction) => {
+      if (!authState.fundAccessAllowed) {
+        return res.status(403).json({
+          error: 'Forbidden',
+          message: 'You do not have access to this fund',
+        });
+      }
+      return next();
+    }),
+  };
+
+  return {
+    authState,
+    getFundMock: vi.fn(),
+    calculateTimeseriesMock: vi.fn(),
+    calculateBreakdownMock: vi.fn(),
+    calculateComparisonMock: vi.fn(),
+    startTimerMock: vi.fn(),
+    recordPerformanceRequestMock: vi.fn(),
+    recordCacheHitMock: vi.fn(),
+    recordCacheMissMock: vi.fn(),
+    recordCalculationMock: vi.fn(),
+    recordDataPointsMock: vi.fn(),
+    recordErrorMock: vi.fn(),
+    loggerErrorMock: vi.fn(),
+  };
+});
 
 vi.mock('../../../server/lib/auth/jwt', () => ({
   requireAuth: () => (_req: unknown, _res: unknown, next: () => void) => next(),
-  requireFundAccess: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireFundAccess: authState.requireFundAccessMock,
 }));
 
 vi.mock('../../../server/storage', () => ({
@@ -72,6 +90,7 @@ describe('performance API observability', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    authState.fundAccessAllowed = true;
 
     app = express();
     app.use(express.json());
@@ -100,6 +119,22 @@ describe('performance API observability', () => {
       comparisons: [],
       deltas: [],
     });
+  });
+
+  it('rejects denied fund scope before storage and calculators run', async () => {
+    authState.fundAccessAllowed = false;
+
+    const response = await request(app).get(
+      '/api/funds/2/performance/timeseries?startDate=2024-01-01&endDate=2024-12-31&granularity=monthly'
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      error: 'Forbidden',
+      message: 'You do not have access to this fund',
+    });
+    expect(getFundMock).not.toHaveBeenCalled();
+    expect(calculateTimeseriesMock).not.toHaveBeenCalled();
   });
 
   it.each([


### PR DESCRIPTION
Main already contained the LP metrics golden fixtures and allocation/LP contract groundwork from 18c3d0d9, so this keeps the next roadmap pass narrow: lock fixture metadata, fill remaining route contracts, add the missing allocation fund-scope checks, and move main bootstrap concerns into focused modules without extracting services or splitting App.tsx.

Constraint: Work only on slices 16-18 after PR #722; no service extraction, App split, route mounting normalization, route logging migration, Docker, Playwright, Phoenix, or CI deletion work

Rejected: Duplicate LP metrics fixtures | 18c3d0d9 already added deterministic LP golden fixtures and assertions

Rejected: Extract allocation services | route contracts needed pre-extraction coverage, not a service rewrite

Confidence: high

Scope-risk: moderate

Directive: Do not widen the next slice past App.tsx splitting without fresh roadmap evidence

Tested: focused golden/truth 10 files / 295 tests

Tested: focused route contracts 5 files / 57 tests

Tested: npm run phoenix:truth

Tested: npm run calc-gate

Tested: npm run docs:routing:check

Tested: npm run guard:scripts:check

Tested: npm run check

Tested: npm run build:prod

Tested: npm run test:unit

Tested: npm run lint

Tested: git diff --check

Not-tested: Browser manual smoke; bootstrap behavior is covered by focused jsdom tests and production build