### PR TITLE
Add Scenario UX workspace

### DIFF
--- a/client/src/app/app-routes.tsx
+++ b/client/src/app/app-routes.tsx
@@ -12,6 +12,7 @@ const VarianceTrackingPage = React.lazy(() => import('@/pages/variance-tracking'
 export const NotFound = React.lazy(() => import('@/pages/not-found'));
 // Fund Model Results (post-wizard output)
 const FundModelResults = React.lazy(() => import('@/pages/fund-model-results'));
+const FundScenarioWorkspace = React.lazy(() => import('@/pages/fund-scenario-workspace'));
 const FinancialModelingPage = React.lazy(() => import('@/pages/financial-modeling'));
 const ForecastingPage = React.lazy(() => import('@/pages/forecasting'));
 const ModelResultsPage = React.lazy(() => import('@/pages/model-results'));
@@ -77,6 +78,7 @@ export const APP_ROUTES: AppRouteEntry[] = [
   { path: '/forecasting', component: ForecastingPage, isProtected: true },
   { path: '/financial-modeling', component: FinancialModelingPage, isProtected: true },
   { path: '/model-results', component: ModelResultsPage, isProtected: true },
+  { path: '/fund-model-results/:fundId/scenarios', component: FundScenarioWorkspace, isProtected: true },
   { path: '/fund-model-results/:fundId', component: FundModelResults, isProtected: true },
   { path: '/sensitivity-analysis', component: SensitivityAnalysisPage, isProtected: true },
   { path: '/allocation-manager', component: AllocationManager, isProtected: true },

--- a/client/src/app/route-governance-registry.ts
+++ b/client/src/app/route-governance-registry.ts
@@ -47,6 +47,7 @@ const CORE_LIVE_ROUTE_PATHS = [
   '/forecasting',
   '/model-results',
   '/fund-model-results/:fundId',
+  '/fund-model-results/:fundId/scenarios',
   '/reports',
   '/settings',
   '/help',

--- a/client/src/lib/fund-routes.ts
+++ b/client/src/lib/fund-routes.ts
@@ -1,5 +1,5 @@
 const QUERY_OR_HASH_PREFIX = /[?#]/;
-const FUND_RESULTS_ROUTE_RE = /^\/fund-model-results\/(\d+)(?:\/)?$/;
+const FUND_RESULTS_ROUTE_RE = /^\/fund-model-results\/(\d+)(?:\/scenarios)?(?:\/)?$/;
 const FUND_RESULTS_ROUTE_PREFIX = '/fund-model-results';
 const ROUTE_SCOPED_FUND_CONTEXT_PATHS = new Set([
   '/financial-modeling',

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -793,14 +793,21 @@ function ScenarioComparisonPanel({ state }: { state: ScenarioComparisonState }) 
 }
 
 function ScenarioAnalysisCard({
+  fundId,
   payload,
   comparisonState,
 }: {
+  fundId: string;
   payload: ScenariosSectionPayloadV1;
   comparisonState: ScenarioComparisonState;
 }) {
   return (
     <div className="space-y-6">
+      <div className="flex justify-end">
+        <Button asChild variant="outline" size="sm">
+          <Link href={`/fund-model-results/${fundId}/scenarios`}>Open Scenario Workspace</Link>
+        </Button>
+      </div>
       <ScenarioSetsSummary payload={payload} />
       <ScenarioComparisonPanel state={comparisonState} />
     </div>
@@ -1920,6 +1927,7 @@ function FundModelResultsPage() {
           section={results.sections.scenarios}
           renderPayload={(p) => (
             <ScenarioAnalysisCard
+              fundId={fundId}
               payload={p as ScenariosSectionPayloadV1}
               comparisonState={scenarioComparisonState}
             />

--- a/client/src/pages/fund-scenario-workspace.tsx
+++ b/client/src/pages/fund-scenario-workspace.tsx
@@ -1,0 +1,512 @@
+/**
+ * Fund Scenario Workspace
+ *
+ * Dedicated ADR-022 scenario workspace backed by existing scenario-set
+ * endpoints and strict shared contracts.
+ *
+ * Route: /fund-model-results/:fundId/scenarios
+ *
+ * @module client/pages/fund-scenario-workspace
+ */
+
+import React, { useMemo, useState } from 'react';
+import { Link, useRoute } from 'wouter';
+import { ArrowLeft, RefreshCw } from 'lucide-react';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScenarioComparisonTable, ScenarioSetsSummary } from '@/components/fund-results';
+import { apiRequest } from '@/lib/queryClient';
+import {
+  FundResultsReadV1Schema,
+  type FundResultsReadV1,
+} from '@shared/contracts/fund-results-v1.contract';
+import {
+  FundScenarioCalculationResponseV1Schema,
+  FundScenarioCalculationStatusV1Schema,
+  FundScenarioReserveCalculationQueuedV1Schema,
+  FundScenarioSetDetailV1Schema,
+  FundScenarioSetListResponseV1Schema,
+  type FundScenarioCalculationStatusV1,
+  type FundScenarioSetDetailV1,
+  type FundScenarioSetSummaryV1,
+  type FundScenarioOverrideTypeV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import {
+  FundScenarioComparisonV1Schema,
+  type FundScenarioComparisonV1,
+} from '@shared/contracts/fund-scenario-comparison-v1.contract';
+
+const FUND_SCENARIO_WORKSPACE_ROUTE = '/fund-model-results/:fundId/scenarios';
+const FUND_ID_PATH_SEGMENT_PATTERN = /^\d+$/;
+const SCENARIO_SET_ID_PATH_SEGMENT_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function workspaceQueryKey(fundId: string) {
+  return ['fund-scenario-workspace', fundId] as const;
+}
+
+function scenarioSetListQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets'] as const;
+}
+
+function scenarioSetDetailQueryKey(fundId: string, scenarioSetId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'detail'] as const;
+}
+
+function scenarioSetStatusQueryKey(fundId: string, scenarioSetId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'status'] as const;
+}
+
+function fundResultsQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'results'] as const;
+}
+
+function scenarioComparisonQueryKey(fundId: string, scenarioSetId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'comparison'] as const;
+}
+
+function assertFundId(fundId: string): void {
+  if (!FUND_ID_PATH_SEGMENT_PATTERN.test(fundId)) {
+    throw new Error('Invalid fund ID');
+  }
+}
+
+function assertScenarioSetId(scenarioSetId: string): void {
+  if (!SCENARIO_SET_ID_PATH_SEGMENT_PATTERN.test(scenarioSetId)) {
+    throw new Error('Invalid scenario set ID');
+  }
+}
+
+function scenarioApiPath(fundId: string, suffix: string): string {
+  assertFundId(fundId);
+  return `/api/funds/${encodeURIComponent(fundId)}${suffix}`;
+}
+
+function scenarioSetApiPath(fundId: string, scenarioSetId: string, suffix = ''): string {
+  assertScenarioSetId(scenarioSetId);
+  return scenarioApiPath(
+    fundId,
+    `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`
+  );
+}
+
+async function fetchScenarioSetList(fundId: string) {
+  const raw = await apiRequest('GET', scenarioApiPath(fundId, '/scenario-sets'));
+  return FundScenarioSetListResponseV1Schema.parse(raw).scenarioSets;
+}
+
+async function fetchScenarioSetDetail(fundId: string, scenarioSetId: string) {
+  const raw = await apiRequest('GET', scenarioSetApiPath(fundId, scenarioSetId));
+  return FundScenarioSetDetailV1Schema.parse(raw);
+}
+
+async function fetchScenarioStatus(fundId: string, scenarioSetId: string) {
+  const raw = await apiRequest('GET', scenarioSetApiPath(fundId, scenarioSetId, '/calculation-status'));
+  return FundScenarioCalculationStatusV1Schema.parse(raw);
+}
+
+async function fetchFundResults(fundId: string) {
+  const raw = await apiRequest('GET', scenarioApiPath(fundId, '/results'));
+  return FundResultsReadV1Schema.parse(raw);
+}
+
+async function fetchScenarioComparison(fundId: string, scenarioSetId: string) {
+  const raw = await apiRequest('GET', scenarioSetApiPath(fundId, scenarioSetId, '/comparison'));
+  return FundScenarioComparisonV1Schema.parse(raw);
+}
+
+function scenarioSetOverrideType(detail: FundScenarioSetDetailV1): FundScenarioOverrideTypeV1 | null {
+  return detail.variants[0]?.override.overrideType ?? null;
+}
+
+async function calculateScenarioSet(fundId: string, detail: FundScenarioSetDetailV1) {
+  const overrideType = scenarioSetOverrideType(detail);
+  if (overrideType === 'reserve_allocation') {
+    const raw = await apiRequest('POST', scenarioSetApiPath(fundId, detail.id, '/calculate-reserve'), {});
+    return FundScenarioReserveCalculationQueuedV1Schema.parse(raw);
+  }
+
+  const raw = await apiRequest('POST', scenarioSetApiPath(fundId, detail.id, '/calculate'));
+  return FundScenarioCalculationResponseV1Schema.parse(raw);
+}
+
+function useWorkspaceFundId() {
+  const [, params] = useRoute(FUND_SCENARIO_WORKSPACE_ROUTE);
+  const fundId = params?.fundId ?? null;
+  return fundId && FUND_ID_PATH_SEGMENT_PATTERN.test(fundId) ? fundId : null;
+}
+
+function scenarioPayloadFromResults(results: FundResultsReadV1 | undefined) {
+  const scenarios = results?.sections.scenarios;
+  return scenarios?.status === 'available' ? scenarios.payload : null;
+}
+
+function scenarioStatusLabel(status: FundScenarioCalculationStatusV1['status'] | undefined) {
+  switch (status) {
+    case 'queued':
+      return 'Queued';
+    case 'calculating':
+      return 'Calculating';
+    case 'succeeded':
+      return 'Succeeded';
+    case 'failed':
+      return 'Failed';
+    case 'not_requested':
+      return 'Not requested';
+    default:
+      return 'Loading';
+  }
+}
+
+function scenarioStatusTone(status: FundScenarioCalculationStatusV1['status'] | undefined) {
+  if (status === 'succeeded') return 'bg-emerald-50 text-emerald-800';
+  if (status === 'failed') return 'bg-red-50 text-red-800';
+  if (status === 'queued' || status === 'calculating') return 'bg-blue-50 text-blue-800';
+  return 'bg-beige-100 text-charcoal-600';
+}
+
+function actionLabelFor(summary: FundScenarioSetSummaryV1, detail: FundScenarioSetDetailV1 | null) {
+  const overrideType = detail ? scenarioSetOverrideType(detail) : null;
+  return overrideType === 'reserve_allocation' ? `Queue ${summary.name}` : `Calculate ${summary.name}`;
+}
+
+function actionButtonText(detail: FundScenarioSetDetailV1 | null) {
+  const overrideType = detail ? scenarioSetOverrideType(detail) : null;
+  return overrideType === 'reserve_allocation' ? 'Queue' : 'Calculate';
+}
+
+function detailMapFromQueries(
+  queries: Array<{ data: FundScenarioSetDetailV1 | undefined }>
+): Map<string, FundScenarioSetDetailV1> {
+  return new Map(
+    queries.flatMap((query) => (query.data ? [[query.data.id, query.data] as const] : []))
+  );
+}
+
+function statusMapFromQueries(
+  queries: Array<{ data: FundScenarioCalculationStatusV1 | undefined }>
+): Map<string, FundScenarioCalculationStatusV1> {
+  return new Map(
+    queries.flatMap((query) =>
+      query.data ? [[query.data.scenarioSetId, query.data] as const] : []
+    )
+  );
+}
+
+function comparisonDataFromQueries(
+  queries: Array<{ data: FundScenarioComparisonV1 | undefined }>
+): FundScenarioComparisonV1[] {
+  return queries.flatMap((query) => (query.data ? [query.data] : []));
+}
+
+function WorkspaceLoadingState() {
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-16" role="status">
+      <div className="space-y-4">
+        <div className="h-8 w-64 rounded bg-beige-100" />
+        <div className="h-28 rounded bg-beige-100" />
+        <div className="h-44 rounded bg-beige-100" />
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceErrorState({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-16">
+      <Alert className="border-beige-200">
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription className="font-poppins text-charcoal-500">{message}</AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+function ScenarioSectionEmpty({ results }: { results: FundResultsReadV1 | undefined }) {
+  const scenarios = results?.sections.scenarios;
+  if (!scenarios || scenarios.status === 'available') return null;
+
+  return (
+    <Alert className="border-beige-200 bg-beige-50">
+      <AlertTitle>Scenario results unavailable</AlertTitle>
+      <AlertDescription className="font-poppins text-charcoal-500">
+        {scenarios.reason}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function ScenarioSetActionCard({
+  summary,
+  detail,
+  status,
+  pendingScenarioSetId,
+  onCalculate,
+}: {
+  summary: FundScenarioSetSummaryV1;
+  detail: FundScenarioSetDetailV1 | null;
+  status: FundScenarioCalculationStatusV1 | null;
+  pendingScenarioSetId: string | null;
+  onCalculate: (detail: FundScenarioSetDetailV1) => void;
+}) {
+  const isPending = pendingScenarioSetId === summary.id;
+  const overrideType = detail ? scenarioSetOverrideType(detail) : null;
+  const disabled = !detail || isPending;
+
+  return (
+    <article
+      className="rounded-md border border-beige-200 bg-white p-4"
+      data-testid={`scenario-workspace-set-${summary.id}`}
+    >
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div>
+            <h3 className="font-inter text-base font-semibold text-charcoal">{summary.name}</h3>
+            <p className="mt-1 font-poppins text-sm text-charcoal-500">
+              {summary.variantCount === 1 ? '1 variant' : `${summary.variantCount} variants`} |
+              Source config v{summary.sourceConfigVersion}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge className={scenarioStatusTone(status?.status)}>
+              {scenarioStatusLabel(status?.status)}
+            </Badge>
+            {overrideType && (
+              <Badge variant="outline">
+                {overrideType === 'fee_profile' ? 'Fee profile' : 'Reserve allocation'}
+              </Badge>
+            )}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          aria-label={actionLabelFor(summary, detail)}
+          disabled={disabled}
+          onClick={() => detail && onCalculate(detail)}
+        >
+          {isPending && <RefreshCw className="h-4 w-4 animate-spin" />}
+          {isPending ? 'Submitting' : actionButtonText(detail)}
+        </Button>
+      </div>
+      {status?.lastError && (
+        <p className="mt-3 text-sm text-red-700 font-poppins">{status.lastError}</p>
+      )}
+    </article>
+  );
+}
+
+function ScenarioActionList({
+  scenarioSets,
+  detailById,
+  statusById,
+  pendingScenarioSetId,
+  onCalculate,
+}: {
+  scenarioSets: FundScenarioSetSummaryV1[];
+  detailById: Map<string, FundScenarioSetDetailV1>;
+  statusById: Map<string, FundScenarioCalculationStatusV1>;
+  pendingScenarioSetId: string | null;
+  onCalculate: (detail: FundScenarioSetDetailV1) => void;
+}) {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-medium text-charcoal">Scenario Sets</h2>
+        <p className="mt-1 text-sm text-charcoal-500 font-poppins">
+          Latest scenario sets for the published fund configuration.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {scenarioSets.map((summary) => (
+          <ScenarioSetActionCard
+            key={summary.id}
+            summary={summary}
+            detail={detailById.get(summary.id) ?? null}
+            status={statusById.get(summary.id) ?? null}
+            pendingScenarioSetId={pendingScenarioSetId}
+            onCalculate={onCalculate}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ScenarioComparisonWorkspace({
+  comparisons,
+  isLoading,
+}: {
+  comparisons: FundScenarioComparisonV1[];
+  isLoading: boolean;
+}) {
+  if (isLoading && comparisons.length === 0) {
+    return (
+      <p className="text-sm text-charcoal-500 font-poppins">Loading scenario comparisons...</p>
+    );
+  }
+
+  if (comparisons.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-medium text-charcoal">Comparisons</h2>
+        <p className="mt-1 text-sm text-charcoal-500 font-poppins">
+          Variant deltas against the authoritative baseline.
+        </p>
+      </div>
+      <div className="space-y-6">
+        {comparisons.map((comparison) => (
+          <ScenarioComparisonTable
+            key={comparison.scenarioSet.scenarioSetId}
+            comparison={comparison}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function FundScenarioWorkspacePage() {
+  const fundId = useWorkspaceFundId();
+  const queryClient = useQueryClient();
+  const [pendingScenarioSetId, setPendingScenarioSetId] = useState<string | null>(null);
+
+  const scenarioSetsQuery = useQuery({
+    queryKey: fundId ? scenarioSetListQueryKey(fundId) : ['fund-scenario-workspace', 'invalid'],
+    queryFn: () => fetchScenarioSetList(fundId ?? ''),
+    enabled: fundId != null,
+  });
+
+  const resultsQuery = useQuery({
+    queryKey: fundId ? fundResultsQueryKey(fundId) : ['fund-scenario-workspace', 'invalid-results'],
+    queryFn: () => fetchFundResults(fundId ?? ''),
+    enabled: fundId != null,
+  });
+
+  const scenarioSets = scenarioSetsQuery.data ?? [];
+
+  const detailQueries = useQueries({
+    queries: scenarioSets.map((summary) => ({
+      queryKey: scenarioSetDetailQueryKey(fundId ?? '', summary.id),
+      queryFn: () => fetchScenarioSetDetail(fundId ?? '', summary.id),
+      enabled: fundId != null,
+    })),
+  });
+
+  const statusQueries = useQueries({
+    queries: scenarioSets.map((summary) => ({
+      queryKey: scenarioSetStatusQueryKey(fundId ?? '', summary.id),
+      queryFn: () => fetchScenarioStatus(fundId ?? '', summary.id),
+      enabled: fundId != null,
+    })),
+  });
+
+  const scenarioPayload = scenarioPayloadFromResults(resultsQuery.data);
+  const calculatedScenarioSetIds = scenarioPayload?.sets.map((set) => set.scenarioSetId) ?? [];
+
+  const comparisonQueries = useQueries({
+    queries: calculatedScenarioSetIds.map((scenarioSetId) => ({
+      queryKey: scenarioComparisonQueryKey(fundId ?? '', scenarioSetId),
+      queryFn: () => fetchScenarioComparison(fundId ?? '', scenarioSetId),
+      enabled: fundId != null,
+    })),
+  });
+
+  const calculateMutation = useMutation({
+    mutationFn: (detail: FundScenarioSetDetailV1) => calculateScenarioSet(fundId ?? '', detail),
+    onSuccess: async () => {
+      if (!fundId) return;
+      await queryClient.invalidateQueries({ queryKey: workspaceQueryKey(fundId) });
+    },
+    onSettled: () => setPendingScenarioSetId(null),
+  });
+
+  const detailById = useMemo(() => detailMapFromQueries(detailQueries), [detailQueries]);
+  const statusById = useMemo(() => statusMapFromQueries(statusQueries), [statusQueries]);
+  const comparisons = useMemo(
+    () => comparisonDataFromQueries(comparisonQueries),
+    [comparisonQueries]
+  );
+
+  if (!fundId) {
+    return (
+      <WorkspaceErrorState
+        title="Invalid scenario workspace route"
+        message="Use /fund-model-results/:fundId/scenarios with a numeric fund ID."
+      />
+    );
+  }
+
+  if (scenarioSetsQuery.isLoading || resultsQuery.isLoading) {
+    return <WorkspaceLoadingState />;
+  }
+
+  if (scenarioSetsQuery.isError || resultsQuery.isError) {
+    return (
+      <WorkspaceErrorState
+        title="Scenario workspace unavailable"
+        message="Scenario workspace data could not be loaded."
+      />
+    );
+  }
+
+  const fund = resultsQuery.data?.fund;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 px-6 py-8">
+      <header className="space-y-4">
+        <Button asChild variant="outline" size="sm">
+          <Link href={`/fund-model-results/${fundId}`}>
+            <ArrowLeft className="h-4 w-4" />
+            Back to Results
+          </Link>
+        </Button>
+        <div>
+          <h1 className="text-2xl font-semibold text-charcoal">Scenario Workspace</h1>
+          <p className="mt-1 text-sm text-charcoal-500 font-poppins">
+            {fund ? `${fund.name} | Vintage ${fund.vintageYear}` : `Fund ${fundId}`} |{' '}
+            {scenarioSets.length === 1 ? '1 scenario set' : `${scenarioSets.length} scenario sets`}
+          </p>
+        </div>
+      </header>
+
+      <ScenarioActionList
+        scenarioSets={scenarioSets}
+        detailById={detailById}
+        statusById={statusById}
+        pendingScenarioSetId={pendingScenarioSetId}
+        onCalculate={(detail) => {
+          setPendingScenarioSetId(detail.id);
+          calculateMutation.mutate(detail);
+        }}
+      />
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-medium text-charcoal">Calculated Results</h2>
+          <p className="mt-1 text-sm text-charcoal-500 font-poppins">
+            Scenario outputs from the latest calculated results.
+          </p>
+        </div>
+        {scenarioPayload ? (
+          <ScenarioSetsSummary payload={scenarioPayload} />
+        ) : (
+          <ScenarioSectionEmpty results={resultsQuery.data} />
+        )}
+      </section>
+
+      <ScenarioComparisonWorkspace
+        comparisons={comparisons}
+        isLoading={comparisonQueries.some((query) => query.isLoading)}
+      />
+    </div>
+  );
+}
+
+export default FundScenarioWorkspacePage;

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -11150,6 +11150,33 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "categories": [
+          "planning",
+          "scenarios"
+        ],
+        "keywords": [
+          "scenario-workspace",
+          "scenario-sets",
+          "fund-model-results"
+        ],
+        "last_updated": "2026-05-29",
+        "owner": "Platform Team",
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-05-29",
+      "owner": "Platform Team",
+      "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
+      "staleDays": 0,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {},
       "hasExecutionClaims": true,
       "isStale": true,
@@ -12754,7 +12781,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED": 1,
-      "ACTIVE": 433,
+      "ACTIVE": 434,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETED": 1,
@@ -12775,7 +12802,7 @@
     },
     "missing_frontmatter": 18,
     "stale_docs": 100,
-    "total_docs": 655
+    "total_docs": 656
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-05-29
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 655 |
+| Total Documents | 656 |
 | Stale Documents | 100 |
 | Missing Frontmatter | 18 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-05-29
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 433 |
+| ACTIVE | 434 |
 | UNKNOWN | 126 |
 | DRAFT | 31 |
 | HISTORICAL | 29 |

--- a/docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md
+++ b/docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md
@@ -1,0 +1,323 @@
+# Scenario UX Workspace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a focused Scenario UX workspace at `/fund-model-results/:fundId/scenarios` for existing ADR-022 scenario sets.
+
+**Architecture:** Keep the new route client-only and compatibility-preserving. Reuse the scenario list/detail, calculation, status, results, and comparison endpoints from PR #728, plus the existing fund-results scenario summary/comparison components; do not add scenario creation, override expansion, reserve optimization workflow, or shared contract changes.
+
+**Tech Stack:** React 18, Wouter, TanStack Query, existing shadcn/ui primitives, strict shared Zod contracts, Vitest + Testing Library.
+
+---
+
+## Inventory
+
+- Route registration lives in `client/src/app/app-routes.tsx`; protected app routes are rendered from `APP_ROUTES` by `client/src/app/app-router.tsx`.
+- Route governance lives in `client/src/app/route-governance-registry.ts`; tests assert the exact core-live route set in `tests/unit/app/route-governance-registry.test.tsx`.
+- Fund route-scoped context extraction lives in `client/src/lib/fund-routes.ts`; `/fund-model-results/:fundId` currently parses only the base results URL.
+- Current results page lives in `client/src/pages/fund-model-results.tsx`; it already fetches `/api/funds/:fundId/results`, derives calculated scenario set IDs from `sections.scenarios`, and fetches `/api/funds/:fundId/scenario-sets/:scenarioSetId/comparison`.
+- Reusable scenario result surfaces are `client/src/components/fund-results/ScenarioSetsSummary.tsx` and `client/src/components/fund-results/ScenarioComparisonTable.tsx`.
+- Scenario contracts are `shared/contracts/fund-scenario-sets-v1.contract.ts`, `shared/contracts/fund-scenario-comparison-v1.contract.ts`, and `shared/contracts/fund-results-v1.contract.ts`.
+- Scenario endpoints are registered in `server/routes/fund-scenario-sets.ts`: list, detail, calculate fee-profile, calculate reserve, calculation-status, comparison, results, and archive.
+
+## Scope
+
+In scope:
+
+- Dedicated protected route `/fund-model-results/:fundId/scenarios`.
+- Read existing scenario sets and per-set detail.
+- Show calculated summaries and comparison cards when results exist.
+- Show per-set calculation status.
+- Trigger the existing fee-profile or reserve calculation endpoint based on the scenario set detail override type.
+- Link the existing results page scenario section to the workspace.
+
+Out of scope:
+
+- Scenario set creation or editing.
+- Allocation or sector override expansion.
+- Reserve optimization UI/workflow.
+- Forecast modes, actuals, cohort readiness, methodology guardrails.
+- Canonical hash, migration 0016, route mount normalization, provider order, public URL changes, or new dependencies.
+
+## File Structure
+
+- Create `client/src/pages/fund-scenario-workspace.tsx`
+  - Route component and local query/mutation helpers for the dedicated workspace.
+  - Strictly parse server responses with existing shared schemas.
+  - Render existing `ScenarioSetsSummary` and `ScenarioComparisonTable` instead of creating new comparison math.
+- Modify `client/src/app/app-routes.tsx`
+  - Lazy-load the new page.
+  - Register `/fund-model-results/:fundId/scenarios` before `/fund-model-results/:fundId`.
+- Modify `client/src/app/route-governance-registry.ts`
+  - Classify the scenario workspace as a protected core-live route.
+- Modify `client/src/lib/fund-routes.ts`
+  - Parse route-scoped fund IDs for `/fund-model-results/:fundId/scenarios`.
+- Modify `client/src/pages/fund-model-results.tsx`
+  - Add one link from the existing scenario section to the dedicated workspace.
+- Create `tests/unit/pages/fund-scenario-workspace.test.tsx`
+  - Cover scenario list/detail/results/comparison loading and calculate endpoint selection.
+- Modify `tests/unit/pages/fund-model-results.test.tsx`
+  - Cover the link from the results scenario section to the workspace.
+- Modify `tests/unit/app/route-governance-registry.test.tsx`
+  - Add the new core-live route expectation.
+- Modify `tests/unit/contexts/fund-context-route-selection.test.tsx`
+  - Cover route fund selection on `/fund-model-results/:fundId/scenarios`.
+
+---
+
+### Task 1: Lock Route and Workspace Behavior with Failing Tests
+
+**Files:**
+
+- Create: `tests/unit/pages/fund-scenario-workspace.test.tsx`
+- Modify: `tests/unit/app/route-governance-registry.test.tsx`
+- Modify: `tests/unit/contexts/fund-context-route-selection.test.tsx`
+- Modify: `tests/unit/pages/fund-model-results.test.tsx`
+
+- [ ] **Step 1: Add route governance and fund-context assertions**
+
+Add `/fund-model-results/:fundId/scenarios` to the expected core-live route list in `tests/unit/app/route-governance-registry.test.tsx`.
+
+Add this test to `tests/unit/contexts/fund-context-route-selection.test.tsx`:
+
+```tsx
+it('prefers the route fund ID on /fund-model-results/:fundId/scenarios', async () => {
+  const { Wrapper } = createWouterWrapper('/fund-model-results/2/scenarios');
+
+  render(
+    <Wrapper>
+      <FundProvider>
+        <Consumer />
+      </FundProvider>
+    </Wrapper>
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText('2:Route Fund:false:false')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Add results-page link assertion**
+
+In `tests/unit/pages/fund-model-results.test.tsx`, extend the available scenarios coverage with:
+
+```tsx
+expect(screen.getByRole('link', { name: /open scenario workspace/i })).toHaveAttribute(
+  'href',
+  '/fund-model-results/123/scenarios'
+);
+```
+
+- [ ] **Step 3: Add workspace page tests**
+
+Create `tests/unit/pages/fund-scenario-workspace.test.tsx` with fixtures for:
+
+```tsx
+renderWorkspace('/fund-model-results/123/scenarios');
+expect(await screen.findByText('Scenario Workspace')).toBeInTheDocument();
+expect(screen.getByText('Fee sensitivity')).toBeInTheDocument();
+expect(screen.getByText('Reserve plan')).toBeInTheDocument();
+expect(screen.getByText('Authoritative baseline')).toBeInTheDocument();
+expect(screen.getByRole('button', { name: /calculate fee sensitivity/i })).toBeInTheDocument();
+expect(screen.getByRole('button', { name: /queue reserve plan/i })).toBeInTheDocument();
+```
+
+Add click assertions:
+
+```tsx
+fireEvent.click(await screen.findByRole('button', { name: /calculate fee sensitivity/i }));
+await waitFor(() => {
+  expect(fetchSpy).toHaveBeenCalledWith(
+    '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/calculate',
+    expect.objectContaining({ method: 'POST' })
+  );
+});
+
+fireEvent.click(await screen.findByRole('button', { name: /queue reserve plan/i }));
+await waitFor(() => {
+  expect(fetchSpy).toHaveBeenCalledWith(
+    '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000211/calculate-reserve',
+    expect.objectContaining({ method: 'POST' })
+  );
+});
+```
+
+- [ ] **Step 4: Run tests to verify RED**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/pages/fund-model-results.test.tsx tests/unit/app/route-governance-registry.test.tsx tests/unit/contexts/fund-context-route-selection.test.tsx --project=client
+```
+
+Expected: FAIL because the route, page, nested fund ID parsing, and link do not exist yet.
+
+---
+
+### Task 2: Add the Scenario Workspace Route and Page
+
+**Files:**
+
+- Create: `client/src/pages/fund-scenario-workspace.tsx`
+- Modify: `client/src/app/app-routes.tsx`
+- Modify: `client/src/app/route-governance-registry.ts`
+- Modify: `client/src/lib/fund-routes.ts`
+
+- [ ] **Step 1: Implement route-scoped fund parsing**
+
+Change `FUND_RESULTS_ROUTE_RE` in `client/src/lib/fund-routes.ts` to accept the workspace suffix:
+
+```ts
+const FUND_RESULTS_ROUTE_RE = /^\/fund-model-results\/(\d+)(?:\/scenarios)?(?:\/)?$/;
+```
+
+- [ ] **Step 2: Create the workspace page**
+
+Create `client/src/pages/fund-scenario-workspace.tsx` with local helpers that:
+
+- Validate `fundId` with `/^\d+$/`.
+- Fetch and parse `FundScenarioSetListResponseV1Schema`.
+- Fetch and parse `FundScenarioSetDetailV1Schema` for active scenario sets.
+- Fetch and parse `FundResultsReadV1Schema`.
+- Fetch and parse `FundScenarioCalculationStatusV1Schema`.
+- Fetch and parse `FundScenarioComparisonV1Schema` for calculated scenario set IDs only.
+- POST to `/calculate` for `fee_profile` sets and `/calculate-reserve` for `reserve_allocation` sets.
+
+Render:
+
+- Fund name, vintage, and a link back to `/fund-model-results/:fundId`.
+- Scenario count and status overview.
+- Existing `ScenarioSetsSummary` for calculated summaries.
+- A per-set action list with status and calculate/queue buttons.
+- Existing `ScenarioComparisonTable` cards for comparison results.
+- Contract-backed empty/error states without fabricated metrics.
+
+- [ ] **Step 3: Register and govern the route**
+
+In `client/src/app/app-routes.tsx`:
+
+```ts
+const FundScenarioWorkspace = React.lazy(() => import('@/pages/fund-scenario-workspace'));
+```
+
+Register before the base results route:
+
+```ts
+{
+  path: '/fund-model-results/:fundId/scenarios',
+  component: FundScenarioWorkspace,
+  isProtected: true,
+},
+```
+
+In `client/src/app/route-governance-registry.ts`, add the same path to `CORE_LIVE_ROUTE_PATHS`.
+
+- [ ] **Step 4: Verify GREEN for focused route tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/app/route-governance-registry.test.tsx tests/unit/contexts/fund-context-route-selection.test.tsx --project=client
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Link Existing Results to the Workspace
+
+**Files:**
+
+- Modify: `client/src/pages/fund-model-results.tsx`
+- Modify: `tests/unit/pages/fund-model-results.test.tsx`
+
+- [ ] **Step 1: Add a narrow link prop to the scenario card**
+
+Extend `ScenarioAnalysisCard` in `client/src/pages/fund-model-results.tsx` to accept `fundId` and render:
+
+```tsx
+<Button asChild variant="outline" size="sm">
+  <Link href={`/fund-model-results/${fundId}/scenarios`}>Open Scenario Workspace</Link>
+</Button>
+```
+
+Place it above the existing `ScenarioSetsSummary` so the current results page remains read-only and keeps its current comparison rendering.
+
+- [ ] **Step 2: Pass `fundId` from `FundModelResultsPage`**
+
+Update the `renderPayload` call for `ScenarioAnalysisCard`:
+
+```tsx
+<ScenarioAnalysisCard
+  fundId={fundId}
+  payload={p as ScenariosSectionPayloadV1}
+  comparisonState={scenarioComparisonState}
+/>
+```
+
+- [ ] **Step 3: Verify GREEN for results page tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/pages/fund-model-results.test.tsx --project=client
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Final Verification
+
+**Files:**
+
+- All files changed in Tasks 1-3.
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/pages/fund-model-results.test.tsx tests/unit/app/route-governance-registry.test.tsx tests/unit/contexts/fund-context-route-selection.test.tsx --project=client
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run required pre-PR verification**
+
+Run:
+
+```bash
+npm run check
+npm run lint
+npm run test:scenario-release-gate
+git diff --check
+git status --short --branch
+```
+
+Expected: all commands pass. If `npm run test:scenario-release-gate` skips locally because Testcontainers are unavailable, report the skip honestly and rely on CI for the container-backed gate.
+
+- [ ] **Step 3: Commit**
+
+Use the repo Lore Commit Protocol. Suggested intent line:
+
+```text
+Expose scenario hardening through a focused GP workspace
+```
+
+Suggested trailers:
+
+```text
+Constraint: Scenario UX must reuse ADR-022 contracts and endpoints without starting override expansion or reserve optimization
+Rejected: Add scenario creation/editing in this PR | that would widen into override authoring beyond the follow-on workspace slice
+Confidence: medium
+Scope-risk: moderate
+Tested: focused client tests; npm run check; npm run lint; npm run test:scenario-release-gate; git diff --check
+```
+
+## Self-Review
+
+- Spec coverage: The plan adds only the requested Scenario UX workspace and excludes override expansion, reserve optimization, forecast modes, actuals, cohort readiness, methodology guardrails, hash/migration semantics, and dependency changes.
+- Placeholder scan: No task uses deferred-fill wording; implementation touchpoints, test commands, and expected outcomes are explicit.
+- Type consistency: The plan reuses existing V1 schemas and result/comparison components; no new shared contract is introduced.

--- a/docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md
+++ b/docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md
@@ -1,3 +1,13 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-05-29
+owner: "Platform Team"
+review_cadence: P90D
+categories: [planning, scenarios]
+keywords: [scenario-workspace, scenario-sets, fund-model-results]
+---
+
 # Scenario UX Workspace Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/tests/unit/app/route-governance-registry.test.tsx
+++ b/tests/unit/app/route-governance-registry.test.tsx
@@ -47,6 +47,7 @@ describe('route governance registry', () => {
         '/forecasting',
         '/model-results',
         '/fund-model-results/:fundId',
+        '/fund-model-results/:fundId/scenarios',
         '/reports',
         '/settings',
         '/help',

--- a/tests/unit/contexts/fund-context-route-selection.test.tsx
+++ b/tests/unit/contexts/fund-context-route-selection.test.tsx
@@ -88,6 +88,22 @@ describe('FundProvider route-aware selection', () => {
     });
   });
 
+  it('prefers the route fund ID on /fund-model-results/:fundId/scenarios', async () => {
+    const { Wrapper } = createWouterWrapper('/fund-model-results/2/scenarios');
+
+    render(
+      <Wrapper>
+        <FundProvider>
+          <Consumer />
+        </FundProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('2:Route Fund:false:false')).toBeInTheDocument();
+    });
+  });
+
   it('falls back to the first fund on non-results routes', async () => {
     const { Wrapper } = createWouterWrapper('/dashboard');
 

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -253,6 +253,10 @@ describe('FundModelResultsPage (server-backed)', () => {
     expect(screen.getByTestId('scenario-sets-summary')).toBeInTheDocument();
     expect(screen.getByText('Fee sensitivity')).toBeInTheDocument();
     expect(screen.getAllByText('2.10x').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('link', { name: /open scenario workspace/i })).toHaveAttribute(
+      'href',
+      '/fund-model-results/123/scenarios'
+    );
   });
 
   it('fetches and renders scenario-set comparison for calculated scenario sets', async () => {

--- a/tests/unit/pages/fund-scenario-workspace.test.tsx
+++ b/tests/unit/pages/fund-scenario-workspace.test.tsx
@@ -1,0 +1,513 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWouterWrapper } from '../../utils/withWouter';
+import FundScenarioWorkspacePage from '../../../client/src/pages/fund-scenario-workspace';
+import type { FundScenarioComparisonV1 } from '../../../shared/contracts/fund-scenario-comparison-v1.contract';
+import type {
+  FundScenarioCalculationStatusV1,
+  FundScenarioSetDetailV1,
+  FundScenarioSetSummaryV1,
+} from '../../../shared/contracts/fund-scenario-sets-v1.contract';
+
+describe('FundScenarioWorkspacePage', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderWorkspace(path = '/fund-model-results/123/scenarios') {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const { Wrapper } = createWouterWrapper(path);
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <Wrapper>
+          <FundScenarioWorkspacePage />
+        </Wrapper>
+      </QueryClientProvider>
+    );
+  }
+
+  function mockWorkspaceFetches() {
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+
+      if (method === 'GET' && url === '/api/funds/123/scenario-sets') {
+        return Promise.resolve(jsonResponse({ scenarioSets: scenarioSetSummaries() }));
+      }
+
+      if (
+        method === 'GET' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111'
+      ) {
+        return Promise.resolve(jsonResponse(feeScenarioSetDetail()));
+      }
+
+      if (
+        method === 'GET' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000211'
+      ) {
+        return Promise.resolve(jsonResponse(reserveScenarioSetDetail()));
+      }
+
+      if (method === 'GET' && url === '/api/funds/123/results') {
+        return Promise.resolve(jsonResponse(fundResultsResponse()));
+      }
+
+      if (
+        method === 'GET' &&
+        url ===
+          '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/comparison'
+      ) {
+        return Promise.resolve(jsonResponse(scenarioComparisonResponse()));
+      }
+
+      if (
+        method === 'GET' &&
+        url.endsWith('/scenario-sets/00000000-0000-0000-0000-000000000111/calculation-status')
+      ) {
+        return Promise.resolve(jsonResponse(statusResponse('succeeded', 42)));
+      }
+
+      if (
+        method === 'GET' &&
+        url.endsWith('/scenario-sets/00000000-0000-0000-0000-000000000211/calculation-status')
+      ) {
+        return Promise.resolve(jsonResponse(statusResponse('not_requested', null)));
+      }
+
+      if (
+        method === 'POST' &&
+        url ===
+          '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/calculate'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            snapshotId: 42,
+            correlationId: '00000000-0000-0000-0000-000000000999',
+            source: 'fund_snapshots',
+            payload: feeCalculationPayload(),
+          })
+        );
+      }
+
+      if (
+        method === 'POST' &&
+        url ===
+          '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000211/calculate-reserve'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            fundId: 123,
+            scenarioSetId: '00000000-0000-0000-0000-000000000211',
+            calculationMode: 'async_reserve_allocation',
+            status: 'queued',
+            jobId: 'fund-scenario-123-reserve',
+            correlationId: '00000000-0000-0000-0000-000000000998',
+          })
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch ${method} ${url}`));
+    });
+  }
+
+  it('loads scenario sets, statuses, results, and comparison cards', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    expect(await screen.findByText('Scenario Workspace')).toBeInTheDocument();
+    expect(screen.getByText(/Test Fund \| Vintage 2024/)).toBeInTheDocument();
+    expect(screen.getAllByText('Fee sensitivity').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Reserve plan').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByTestId('scenario-sets-summary')).toBeInTheDocument();
+    expect(screen.getByTestId('scenario-comparison-table')).toBeInTheDocument();
+    expect(screen.getByText('Authoritative baseline')).toBeInTheDocument();
+
+    const feeCard = screen.getByTestId('scenario-workspace-set-00000000-0000-0000-0000-000000000111');
+    expect(within(feeCard).getByText('Succeeded')).toBeInTheDocument();
+    expect(within(feeCard).getByRole('button', { name: /calculate fee sensitivity/i })).toBeInTheDocument();
+
+    const reserveCard = screen.getByTestId(
+      'scenario-workspace-set-00000000-0000-0000-0000-000000000211'
+    );
+    expect(within(reserveCard).getByText('Not requested')).toBeInTheDocument();
+    expect(within(reserveCard).getByRole('button', { name: /queue reserve plan/i })).toBeInTheDocument();
+  });
+
+  it('uses the fee-profile calculation endpoint for fee scenario sets', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    fireEvent.click(await screen.findByRole('button', { name: /calculate fee sensitivity/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/calculate',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  it('uses the reserve queue endpoint for reserve scenario sets', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    fireEvent.click(await screen.findByRole('button', { name: /queue reserve plan/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000211/calculate-reserve',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  it('rejects invalid fund routes before issuing API requests', () => {
+    renderWorkspace('/fund-model-results/latest/scenarios');
+
+    expect(screen.getByText('Invalid scenario workspace route')).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function scenarioSetSummaries(): FundScenarioSetSummaryV1[] {
+  return [scenarioSetSummary('00000000-0000-0000-0000-000000000111', 'Fee sensitivity', 12, 4), scenarioSetSummary('00000000-0000-0000-0000-000000000211', 'Reserve plan', 13, 4)];
+}
+
+function scenarioSetSummary(
+  id: string,
+  name: string,
+  sourceConfigId: number,
+  sourceConfigVersion: number
+): FundScenarioSetSummaryV1 {
+  return {
+    id,
+    fundId: 123,
+    name,
+    description: null,
+    sourceConfigId,
+    sourceConfigVersion,
+    variantCount: 1,
+    archivedAt: null,
+    archivedByUserId: null,
+    archivedByLabel: null,
+    createdByUserId: 17,
+    createdByLabel: 'analyst@example.com',
+    updatedByUserId: 17,
+    updatedByLabel: 'analyst@example.com',
+    createdAt: '2026-05-29T12:00:00.000Z',
+    updatedAt: '2026-05-29T12:00:00.000Z',
+  };
+}
+
+function feeScenarioSetDetail(): FundScenarioSetDetailV1 {
+  return {
+    ...scenarioSetSummary('00000000-0000-0000-0000-000000000111', 'Fee sensitivity', 12, 4),
+    variants: [
+      {
+        id: '00000000-0000-0000-0000-000000000112',
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        name: 'Lower fee',
+        description: null,
+        sortOrder: 0,
+        override: feeProfileOverride(),
+        createdAt: '2026-05-29T12:00:00.000Z',
+        updatedAt: '2026-05-29T12:00:00.000Z',
+      },
+    ],
+  };
+}
+
+function reserveScenarioSetDetail(): FundScenarioSetDetailV1 {
+  return {
+    ...scenarioSetSummary('00000000-0000-0000-0000-000000000211', 'Reserve plan', 13, 4),
+    variants: [
+      {
+        id: '00000000-0000-0000-0000-000000000212',
+        scenarioSetId: '00000000-0000-0000-0000-000000000211',
+        name: 'Follow-on cap',
+        description: null,
+        sortOrder: 0,
+        override: {
+          overrideType: 'reserve_allocation',
+          payload: {
+            allocationVersion: 4,
+            items: [
+              {
+                companyId: 101,
+                plannedReservesCents: 7_500_000,
+                maxAllocationCents: 7_500_000,
+                allocationReason: 'Cap the follow-on reserve for concentration control',
+              },
+            ],
+          },
+        },
+        createdAt: '2026-05-29T12:00:00.000Z',
+        updatedAt: '2026-05-29T12:00:00.000Z',
+      },
+    ],
+  };
+}
+
+function feeProfileOverride() {
+  return {
+    overrideType: 'fee_profile' as const,
+    payload: {
+      feeProfiles: [
+        {
+          id: 'fee-profile-upside',
+          name: 'Upside fees',
+          feeTiers: [
+            {
+              id: 'tier-1',
+              name: 'Management fee',
+              percentage: 2,
+              feeBasis: 'committed_capital' as const,
+              startMonth: 0,
+              endMonth: 120,
+              recyclingPercentage: 25,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function fundResultsResponse() {
+  return {
+    status: 'ready' as const,
+    fundId: 123,
+    fund: { name: 'Test Fund', vintageYear: 2024, size: 100_000_000 },
+    lifecycle: {
+      fundId: 123,
+      configState: {
+        latestVersion: 4,
+        draftVersion: null,
+        publishedVersion: 4,
+        hasDraft: false,
+        hasPublished: true,
+        publishedAt: '2026-05-29T12:00:00.000Z',
+        draftUpdatedAt: null,
+        publishedUpdatedAt: '2026-05-29T12:00:00.000Z',
+      },
+      calculationState: {
+        status: 'ready' as const,
+        configVersion: 4,
+        runId: 10,
+        correlationId: 'test-corr-id',
+        dispatchState: 'dispatched',
+        availableSnapshotTypes: ['RESERVE', 'PACING'],
+        expectedSnapshotTypes: ['RESERVE', 'PACING'],
+        lastCalculatedAt: '2026-05-29T12:30:00.000Z',
+        lastError: null,
+        legacyEvidence: false,
+      },
+      legacy: { engineResultsPresent: false },
+    },
+    sections: {
+      reserve: { status: 'unavailable' as const, reason: 'No calculation results available' },
+      pacing: { status: 'unavailable' as const, reason: 'No calculation results available' },
+      scorecard: {
+        status: 'available' as const,
+        payload: {
+          fundName: { value: 'Test Fund', source: 'funds' as const },
+          fundSize: { value: 100_000_000, source: 'funds' as const },
+          vintageYear: { value: 2024, source: 'funds' as const },
+        },
+      },
+      scenarios: {
+        status: 'available' as const,
+        source: 'fund_snapshots' as const,
+        calculatedAt: '2026-05-29T12:30:00.000Z',
+        payload: scenariosPayload(),
+      },
+      waterfall: { status: 'unavailable' as const, reason: 'No authoritative source' },
+      economics: {
+        status: 'unavailable' as const,
+        reason: 'GP economics is disabled',
+        reasonCode: 'ECONOMICS_DISABLED' as const,
+      },
+    },
+  };
+}
+
+function scenariosPayload() {
+  return {
+    version: 'fund-scenarios-v1' as const,
+    aggregateStaleness: 'CURRENT' as const,
+    sets: [
+      {
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        name: 'Fee sensitivity',
+        sourceConfigId: 12,
+        sourceConfigVersion: 4,
+        currentPublishedConfigVersion: 4,
+        calculatedAt: '2026-05-29T12:30:00.000Z',
+        staleness: 'CURRENT' as const,
+        variantCount: 1,
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000112',
+            name: 'Lower fee',
+            overrideType: 'fee_profile' as const,
+            economicsSummary: economicsSummary(),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function economicsSummary() {
+  return {
+    grossIrr: 0.2,
+    lpNetIrr: 0.15,
+    gpNetIrr: null,
+    totalLpPaidIn: 9_800_000,
+    totalGpCommitmentCalled: 200_000,
+    totalManagementFees: 2_000_000,
+    totalExpenses: 0,
+    totalRecycled: 0,
+    totalLpDistributions: 14_000_000,
+    totalGpInvestmentDistributions: 300_000,
+    totalGpCarryDistributed: 500_000,
+    totalGpFeeIncome: 2_000_000,
+    finalDpi: 0.6,
+    finalRvpi: 0.8,
+    finalTvpi: 2.1,
+    finalClawbackDue: 0,
+    maxEscrowAvailable: 0,
+    netGpCarryAfterClawback: 500_000,
+  };
+}
+
+function scenarioComparisonResponse(): FundScenarioComparisonV1 {
+  return {
+    fundId: 123,
+    comparisonStatus: 'comparable',
+    scenarioSet: {
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      name: 'Fee sensitivity',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+    },
+    baseline: {
+      label: 'Authoritative baseline',
+      metrics: {
+        lpNetIrr: 0.15,
+        gpNetIrr: null,
+        totalManagementFees: 2_000_000,
+        totalGpCarryDistributed: 500_000,
+        totalGpFeeIncome: 2_000_000,
+        finalDpi: 0.6,
+        finalTvpi: 1.8,
+        finalClawbackDue: 0,
+      },
+    },
+    variants: [
+      {
+        variantId: '00000000-0000-0000-0000-000000000112',
+        name: 'Lower fee',
+        overrideType: 'fee_profile',
+        metrics: {
+          lpNetIrr: 0.17,
+          gpNetIrr: null,
+          totalManagementFees: 1_500_000,
+          totalGpCarryDistributed: 500_000,
+          totalGpFeeIncome: 1_500_000,
+          finalDpi: 0.7,
+          finalTvpi: 2.1,
+          finalClawbackDue: 0,
+        },
+        metricDeltas: [
+          {
+            metric: 'finalTvpi',
+            displayName: 'TVPI',
+            baselineValue: 1.8,
+            scenarioValue: 2.1,
+            absoluteDelta: 0.3,
+            percentageDelta: 16.6666667,
+            driftCapable: true,
+            driftReason: 'stable',
+          },
+        ],
+      },
+    ],
+    staleness: 'CURRENT',
+    calculatedAt: '2026-05-29T12:30:00.000Z',
+  };
+}
+
+function statusResponse(
+  status: FundScenarioCalculationStatusV1['status'],
+  snapshotId: number | null
+): FundScenarioCalculationStatusV1 {
+  return {
+    fundId: 123,
+    scenarioSetId:
+      snapshotId === null
+        ? '00000000-0000-0000-0000-000000000211'
+        : '00000000-0000-0000-0000-000000000111',
+    calculationMode: snapshotId === null ? null : 'sync_fee_profile',
+    status,
+    jobId: null,
+    correlationId: null,
+    snapshotId,
+    lastEventAt: '2026-05-29T12:30:00.000Z',
+    lastError: null,
+  };
+}
+
+function feeCalculationPayload() {
+  return {
+    version: 'fund-scenarios-v1' as const,
+    calculationMode: 'sync_fee_profile' as const,
+    fundId: 123,
+    scenarioSetId: '00000000-0000-0000-0000-000000000111',
+    sourceConfigId: 12,
+    sourceConfigVersion: 4,
+    staleness: {
+      state: 'CURRENT' as const,
+      sourceConfigVersion: 4,
+      currentPublishedConfigVersion: 4,
+    },
+    calculatedAt: '2026-05-29T12:30:00.000Z',
+    variants: [
+      {
+        variantId: '00000000-0000-0000-0000-000000000112',
+        scenarioSetId: '00000000-0000-0000-0000-000000000111',
+        name: 'Lower fee',
+        overrideType: 'fee_profile' as const,
+        economics: {
+          version: 'v1' as const,
+          annual: [],
+          summary: economicsSummary(),
+          checks: { passed: true, tolerance: 0.01, errors: [] },
+        },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the focused Scenario UX workspace plan for `/fund-model-results/:fundId/scenarios`.
- Registers a protected scenario workspace route and keeps route-scoped fund selection working for the nested path.
- Builds the workspace from existing ADR-022 scenario set, status, results, and comparison contracts, with calculate/queue actions only for existing sets.
- Links the current fund results scenario section to the dedicated workspace.

## Scope Control
- No new dependencies.
- No shared contract, canonical hash, or migration 0016 changes.
- No scenario creation/editing, override expansion, reserve optimization workflow, forecast modes, actuals, cohort readiness, or methodology guardrails.

## Verification
- `npx vitest run --config vitest.config.mjs --configLoader native tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/pages/fund-model-results.test.tsx tests/unit/app/route-governance-registry.test.tsx tests/unit/contexts/fund-context-route-selection.test.tsx --project=client`
- `npx vitest run --config vitest.config.mjs --configLoader native tests/unit/routes/fund-scenario-sets-route-contract.test.ts tests/unit/routes/fund-scenario-sets-comparison-route.test.ts --project=server`
- `npm run check`
- `npm run lint`
- `npm run test:scenario-release-gate` exited 0 locally, but the container-backed case skipped because no working container runtime strategy was available.
- `git diff --check`
- `git status --short --branch`