### PR TITLE
[codex] Expand scenario allocation and sector overrides

### DIFF
--- a/client/src/components/fund-results/ScenarioSetsSummary.tsx
+++ b/client/src/components/fund-results/ScenarioSetsSummary.tsx
@@ -29,6 +29,11 @@ interface ScenarioSetCardProps {
   set: ScenarioSetResultSummaryV1;
 }
 
+type EconomicsScenarioVariant = Extract<
+  ScenarioSetVariantResultSummaryV1,
+  { overrideType: 'fee_profile' | 'allocation' | 'sector_profile' }
+>;
+
 function formatMultiple(value: number): string {
   return `${value.toFixed(2)}x`;
 }
@@ -55,20 +60,24 @@ function variantCountLabel(count: number): string {
   return count === 1 ? '1 variant' : `${count} variants`;
 }
 
-function isFeeProfileVariant(
+function hasEconomicsSummary(
   variant: ScenarioSetVariantResultSummaryV1
-): variant is Extract<ScenarioSetVariantResultSummaryV1, { overrideType: 'fee_profile' }> {
-  return variant.overrideType === 'fee_profile';
+): variant is EconomicsScenarioVariant {
+  return (
+    variant.overrideType === 'fee_profile' ||
+    variant.overrideType === 'allocation' ||
+    variant.overrideType === 'sector_profile'
+  );
 }
 
 function topTvpiVariant(set: ScenarioSetResultSummaryV1) {
-  const feeVariants = set.variants.filter(isFeeProfileVariant);
-  const first = feeVariants[0];
+  const economicsVariants = set.variants.filter(hasEconomicsSummary);
+  const first = economicsVariants[0];
   if (!first) {
     return null;
   }
 
-  return feeVariants
+  return economicsVariants
     .slice(1)
     .reduce(
       (top, variant) =>
@@ -93,7 +102,7 @@ function ScenarioSetsHeader({
   );
 }
 
-function FeeProfileScenarioMetrics({ set }: { set: ScenarioSetResultSummaryV1 }) {
+function EconomicsScenarioMetrics({ set }: { set: ScenarioSetResultSummaryV1 }) {
   const topVariant = topTvpiVariant(set);
   if (!topVariant) {
     return null;
@@ -190,7 +199,7 @@ function ScenarioSetCard({ set }: ScenarioSetCardProps) {
       {primaryType === 'reserve_allocation' ? (
         <ReserveScenarioMetrics set={set} />
       ) : (
-        <FeeProfileScenarioMetrics set={set} />
+        <EconomicsScenarioMetrics set={set} />
       )}
     </article>
   );

--- a/client/src/pages/fund-scenario-workspace.tsx
+++ b/client/src/pages/fund-scenario-workspace.tsx
@@ -42,6 +42,12 @@ const FUND_SCENARIO_WORKSPACE_ROUTE = '/fund-model-results/:fundId/scenarios';
 const FUND_ID_PATH_SEGMENT_PATTERN = /^\d+$/;
 const SCENARIO_SET_ID_PATH_SEGMENT_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const OVERRIDE_TYPE_LABELS: Record<FundScenarioOverrideTypeV1, string> = {
+  fee_profile: 'Fee profile',
+  reserve_allocation: 'Reserve allocation',
+  allocation: 'Allocation',
+  sector_profile: 'Sector profile',
+};
 
 function workspaceQueryKey(fundId: string) {
   return ['fund-scenario-workspace', fundId] as const;
@@ -86,10 +92,7 @@ function scenarioApiPath(fundId: string, suffix: string): string {
 
 function scenarioSetApiPath(fundId: string, scenarioSetId: string, suffix = ''): string {
   assertScenarioSetId(scenarioSetId);
-  return scenarioApiPath(
-    fundId,
-    `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`
-  );
+  return scenarioApiPath(fundId, `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`);
 }
 
 async function fetchScenarioSetList(fundId: string) {
@@ -103,7 +106,10 @@ async function fetchScenarioSetDetail(fundId: string, scenarioSetId: string) {
 }
 
 async function fetchScenarioStatus(fundId: string, scenarioSetId: string) {
-  const raw = await apiRequest('GET', scenarioSetApiPath(fundId, scenarioSetId, '/calculation-status'));
+  const raw = await apiRequest(
+    'GET',
+    scenarioSetApiPath(fundId, scenarioSetId, '/calculation-status')
+  );
   return FundScenarioCalculationStatusV1Schema.parse(raw);
 }
 
@@ -117,14 +123,20 @@ async function fetchScenarioComparison(fundId: string, scenarioSetId: string) {
   return FundScenarioComparisonV1Schema.parse(raw);
 }
 
-function scenarioSetOverrideType(detail: FundScenarioSetDetailV1): FundScenarioOverrideTypeV1 | null {
+function scenarioSetOverrideType(
+  detail: FundScenarioSetDetailV1
+): FundScenarioOverrideTypeV1 | null {
   return detail.variants[0]?.override.overrideType ?? null;
 }
 
 async function calculateScenarioSet(fundId: string, detail: FundScenarioSetDetailV1) {
   const overrideType = scenarioSetOverrideType(detail);
   if (overrideType === 'reserve_allocation') {
-    const raw = await apiRequest('POST', scenarioSetApiPath(fundId, detail.id, '/calculate-reserve'), {});
+    const raw = await apiRequest(
+      'POST',
+      scenarioSetApiPath(fundId, detail.id, '/calculate-reserve'),
+      {}
+    );
     return FundScenarioReserveCalculationQueuedV1Schema.parse(raw);
   }
 
@@ -169,7 +181,9 @@ function scenarioStatusTone(status: FundScenarioCalculationStatusV1['status'] | 
 
 function actionLabelFor(summary: FundScenarioSetSummaryV1, detail: FundScenarioSetDetailV1 | null) {
   const overrideType = detail ? scenarioSetOverrideType(detail) : null;
-  return overrideType === 'reserve_allocation' ? `Queue ${summary.name}` : `Calculate ${summary.name}`;
+  return overrideType === 'reserve_allocation'
+    ? `Queue ${summary.name}`
+    : `Calculate ${summary.name}`;
 }
 
 function actionButtonText(detail: FundScenarioSetDetailV1 | null) {
@@ -273,11 +287,7 @@ function ScenarioSetActionCard({
             <Badge className={scenarioStatusTone(status?.status)}>
               {scenarioStatusLabel(status?.status)}
             </Badge>
-            {overrideType && (
-              <Badge variant="outline">
-                {overrideType === 'fee_profile' ? 'Fee profile' : 'Reserve allocation'}
-              </Badge>
-            )}
+            {overrideType && <Badge variant="outline">{OVERRIDE_TYPE_LABELS[overrideType]}</Badge>}
           </div>
         </div>
         <Button

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -11138,6 +11138,21 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {
+        "last_updated": "2026-05-29",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-05-29",
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
+      "staleDays": 0,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {},
       "hasExecutionClaims": false,
       "isStale": true,
@@ -12781,7 +12796,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED": 1,
-      "ACTIVE": 434,
+      "ACTIVE": 435,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETED": 1,
@@ -12802,7 +12817,7 @@
     },
     "missing_frontmatter": 18,
     "stale_docs": 100,
-    "total_docs": 656
+    "total_docs": 657
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-05-29
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 656 |
+| Total Documents | 657 |
 | Stale Documents | 100 |
 | Missing Frontmatter | 18 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-05-29
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 434 |
+| ACTIVE | 435 |
 | UNKNOWN | 126 |
 | DRAFT | 31 |
 | HISTORICAL | 29 |

--- a/docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md
+++ b/docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md
@@ -1,0 +1,474 @@
+---
+status: ACTIVE
+last_updated: 2026-05-29
+---
+
+# Allocation And Sector Override Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand ADR-022 scenario sets to support allocation and sector-profile
+overrides without changing existing hash semantics, reserve workflow behavior,
+public URLs, or comparison contracts.
+
+**Architecture:** Keep the expansion additive to the existing V1 scenario
+contract. `allocation` and `sector_profile` variants use the existing
+synchronous `/calculate` route and economics snapshot path; `reserve_allocation`
+remains the only async worker-backed override type. Comparisons stay
+fee-profile-only and return the existing unsupported status for allocation,
+sector-profile, and reserve scenario sets.
+
+**Tech Stack:** TypeScript, Zod contracts, Express route services, Drizzle
+schema metadata, raw SQL migrations, Vitest unit tests, React workspace
+compatibility.
+
+---
+
+## Inventory Summary
+
+- `shared/contracts/fund-scenario-sets-v1.contract.ts` currently accepts only
+  `fee_profile` and `reserve_allocation`.
+- `fund_scenario_variants.override_type` is constrained by migration `0015` to
+  `('fee_profile', 'reserve_allocation')`.
+- `server/services/fund-scenario-calculation-service.ts` already applies a
+  scenario override to `FundDraftWriteV1` before calling `runEconomicsModel()`;
+  extend that path rather than creating a new endpoint.
+- `server/services/fund-scenario-reserve-calculation-service.ts` and the worker
+  queue stay unchanged except for shared type compatibility.
+- `shared/lib/scenarios/scenario-input-envelope.ts` and
+  `shared/lib/scenarios/canonicalize.ts` already provide canonical input
+  hashing; only add enum values, not canonicalization behavior changes.
+- `server/services/fund-scenario-comparison-service.ts` supports fee-profile
+  comparison only. Keep allocation and sector-profile comparison fail-closed
+  through `unsupported_override_type`.
+
+## File Structure
+
+- Modify: `shared/contracts/fund-scenario-sets-v1.contract.ts`
+  - Add `allocation` and `sector_profile` override payload schemas.
+  - Add sync calculation modes `sync_allocation` and `sync_sector_profile`.
+  - Add economics result/summary variants for the new sync override types.
+- Modify: `shared/lib/scenarios/scenario-input-envelope.ts`
+  - Add the new override and sync calculation mode literals to hash envelope
+    types only.
+- Modify: `server/services/fund-scenario-calculation-run-service.ts`
+  - Expand run identity type unions.
+- Modify: `server/services/fund-scenario-calculation-service.ts`
+  - Generalize fee-profile-only sync calculation into sync override calculation.
+  - Apply allocation and sector-profile payloads to the parsed source config.
+  - Preserve existing fee-profile behavior and snapshot dedupe.
+- Modify: `shared/schema/fund.ts`
+  - Expand the Drizzle override-type TypeScript union.
+- Create:
+  `server/db/migrations/0017_fund_scenario_allocation_sector_overrides.sql`
+  - Replace the check constraint with the additive override-type set.
+- Modify: `tests/helpers/scenario-migrations.ts`
+  - Include `0017` for scenario integration helpers.
+- Modify: `tests/unit/phase3/fund-scenario-sets-schema.test.ts`
+  - Assert the new migration preserves prior values and adds only allocation and
+    sector-profile values.
+- Modify: `tests/unit/contract/fund-scenario-sets.test.ts`
+  - Add contract red/green coverage for allocation and sector-profile payloads.
+- Modify: `tests/unit/services/fund-scenario-calculation-service.test.ts`
+  - Add red/green coverage that the sync calculation path applies each new
+    payload and records distinct hash metadata.
+- Modify: `tests/unit/services/fund-scenario-comparison-service.test.ts`
+  - Add comparison fail-closed coverage for the new override types.
+- Modify: `client/src/pages/fund-scenario-workspace.tsx`
+  - Render labels for the new override types and continue routing them to
+    `/calculate`.
+- Modify: `client/src/components/fund-results/ScenarioSetsSummary.tsx`
+  - Treat all sync economics result variants as TVPI-capable summaries.
+
+---
+
+### Task 1: Contract And Migration Guardrails
+
+**Files:**
+
+- Modify: `shared/contracts/fund-scenario-sets-v1.contract.ts`
+- Modify: `shared/lib/scenarios/scenario-input-envelope.ts`
+- Modify: `shared/schema/fund.ts`
+- Create:
+  `server/db/migrations/0017_fund_scenario_allocation_sector_overrides.sql`
+- Modify: `tests/helpers/scenario-migrations.ts`
+- Modify: `tests/unit/phase3/fund-scenario-sets-schema.test.ts`
+- Modify: `tests/unit/contract/fund-scenario-sets.test.ts`
+
+- [ ] **Step 1: Write failing contract tests**
+
+Add tests proving:
+
+```ts
+expect(
+  FundScenarioVariantOverrideV1Schema.safeParse({
+    overrideType: 'allocation',
+    payload: {
+      allocations: [{ id: 'seed', category: 'Seed', percentage: 60 }],
+      capitalPlanAllocations: [
+        {
+          id: 'seed-plan',
+          name: 'Seed plan',
+          entryRound: 'Seed',
+          capitalAllocationPct: 60,
+          initialCheckStrategy: 'amount',
+          initialCheckAmount: 1_000_000,
+          followOnStrategy: 'amount',
+          followOnAmount: 500_000,
+          followOnParticipationPct: 25,
+          investmentHorizonMonths: 48,
+        },
+      ],
+    },
+  }).success
+).toBe(true);
+
+expect(
+  FundScenarioVariantOverrideV1Schema.safeParse({
+    overrideType: 'sector_profile',
+    payload: {
+      sectorProfiles: [
+        { id: 'ai', name: 'AI Infrastructure', targetPercentage: 35 },
+      ],
+    },
+  }).success
+).toBe(true);
+```
+
+Also assert mixed override types in one scenario set still fail.
+
+- [ ] **Step 2: Run failing contract tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/contract/fund-scenario-sets.test.ts --project=server
+```
+
+Expected: FAIL because the new override types are not accepted.
+
+- [ ] **Step 3: Extend the contract additively**
+
+Add:
+
+```ts
+export const FundScenarioOverrideTypeV1Schema = z.enum([
+  'fee_profile',
+  'reserve_allocation',
+  'allocation',
+  'sector_profile',
+]);
+```
+
+Create strict payload schemas from `FundDraftWriteV1Schema`:
+
+```ts
+const AllocationOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
+  allocations: true,
+  capitalPlanAllocations: true,
+})
+  .partial()
+  .strict()
+  .refine(
+    (value) =>
+      value.allocations != null || value.capitalPlanAllocations != null,
+    {
+      message:
+        'allocation override requires allocations or capitalPlanAllocations',
+    }
+  );
+
+const SectorProfileOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
+  sectorProfiles: true,
+})
+  .required()
+  .strict()
+  .refine((value) => value.sectorProfiles.length > 0, {
+    message: 'sectorProfiles must include at least one profile',
+    path: ['sectorProfiles'],
+  });
+```
+
+Add literal override objects for `allocation` and `sector_profile`, include them
+in `FundScenarioVariantOverrideV1Schema`, and add sync economics calculation
+variant/result-summary schemas for those override types.
+
+- [ ] **Step 4: Add migration guardrail**
+
+Create
+`server/db/migrations/0017_fund_scenario_allocation_sector_overrides.sql`:
+
+```sql
+-- 0017_fund_scenario_allocation_sector_overrides.sql
+-- ADR-022: add allocation and sector-profile scenario override types.
+
+BEGIN;
+
+ALTER TABLE fund_scenario_variants
+  DROP CONSTRAINT IF EXISTS fund_scenario_variants_override_type_check;
+
+ALTER TABLE fund_scenario_variants
+  ADD CONSTRAINT fund_scenario_variants_override_type_check
+  CHECK (override_type IN (
+    'fee_profile',
+    'reserve_allocation',
+    'allocation',
+    'sector_profile'
+  ));
+
+COMMIT;
+```
+
+Add `0017_fund_scenario_allocation_sector_overrides.sql` to
+`tests/helpers/scenario-migrations.ts`.
+
+- [ ] **Step 5: Run contract and schema tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/contract/fund-scenario-sets.test.ts tests/unit/phase3/fund-scenario-sets-schema.test.ts --project=server
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: Sync Calculation Expansion
+
+**Files:**
+
+- Modify: `server/services/fund-scenario-calculation-service.ts`
+- Modify: `server/services/fund-scenario-calculation-run-service.ts`
+- Modify: `shared/lib/scenarios/scenario-input-envelope.ts`
+- Modify: `tests/unit/services/fund-scenario-calculation-service.test.ts`
+
+- [ ] **Step 1: Write failing service tests**
+
+Add tests proving `/calculate` applies allocation and sector-profile overrides
+before `runEconomicsModel()`:
+
+```ts
+expect(runEconomicsModelMock).toHaveBeenCalledWith(
+  expect.objectContaining({
+    allocations: allocationOverride.payload.allocations,
+    capitalPlanAllocations: allocationOverride.payload.capitalPlanAllocations,
+  })
+);
+```
+
+```ts
+expect(runEconomicsModelMock).toHaveBeenCalledWith(
+  expect.objectContaining({
+    sectorProfiles: sectorProfileOverride.payload.sectorProfiles,
+  })
+);
+```
+
+Each test should assert snapshot metadata contains the matching `override_type`
+and `calculation_mode`.
+
+- [ ] **Step 2: Run failing service tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/services/fund-scenario-calculation-service.test.ts --project=server
+```
+
+Expected: FAIL because only fee-profile variants are allowed in the sync path.
+
+- [ ] **Step 3: Generalize the sync path**
+
+Add helpers:
+
+```ts
+type SyncScenarioOverrideType = Exclude<
+  FundScenarioOverrideTypeV1,
+  'reserve_allocation'
+>;
+
+function syncCalculationModeForOverrideType(
+  overrideType: SyncScenarioOverrideType
+): FundScenarioCalculationModeV1 {
+  if (overrideType === 'fee_profile') return 'sync_fee_profile';
+  if (overrideType === 'allocation') return 'sync_allocation';
+  return 'sync_sector_profile';
+}
+```
+
+Replace the fee-only assert with an assert that rejects only
+`reserve_allocation` from `/calculate`.
+
+Apply new payloads with:
+
+```ts
+function applySyncScenarioOverride(
+  sourceConfig: FundDraftWriteV1,
+  override: Extract<
+    FundScenarioVariantOverrideV1,
+    { overrideType: SyncScenarioOverrideType }
+  >
+): FundDraftWriteV1 {
+  if (override.overrideType === 'fee_profile') {
+    return applyFeeProfileOverride(sourceConfig, override);
+  }
+  if (override.overrideType === 'allocation') {
+    return {
+      ...sourceConfig,
+      ...(override.payload.allocations
+        ? { allocations: override.payload.allocations }
+        : {}),
+      ...(override.payload.capitalPlanAllocations
+        ? { capitalPlanAllocations: override.payload.capitalPlanAllocations }
+        : {}),
+    };
+  }
+  return {
+    ...sourceConfig,
+    sectorProfiles: override.payload.sectorProfiles,
+  };
+}
+```
+
+Use the derived `calculationMode` and `overrideType` in hash envelopes,
+calculation-run acquisition, metadata, payload parsing, and audit events.
+
+- [ ] **Step 4: Run focused service tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/services/fund-scenario-calculation-service.test.ts tests/unit/scenarios/scenario-input-hash.test.ts --project=server
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Compatibility Surfaces
+
+**Files:**
+
+- Modify: `server/services/fund-scenario-comparison-service.ts`
+- Modify: `tests/unit/services/fund-scenario-comparison-service.test.ts`
+- Modify: `client/src/pages/fund-scenario-workspace.tsx`
+- Modify: `client/src/components/fund-results/ScenarioSetsSummary.tsx`
+- Modify: `tests/unit/pages/fund-scenario-workspace.test.tsx`
+- Modify: `tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx`
+
+- [ ] **Step 1: Write failing compatibility tests**
+
+Add comparison tests that `allocation` and `sector_profile` scenario sets
+return:
+
+```ts
+expect(result.comparisonStatus).toBe('unsupported_override_type');
+expect(result.unavailableReason).toBe('UNSUPPORTED_OVERRIDE_TYPE');
+```
+
+Add workspace tests that the new override types render readable badges and use
+the existing `/calculate` endpoint.
+
+- [ ] **Step 2: Run failing compatibility tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/services/fund-scenario-comparison-service.test.ts tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx --project=client --project=server
+```
+
+Expected: FAIL until labels and type unions are updated.
+
+- [ ] **Step 3: Update compatibility code**
+
+Add label helpers in the workspace:
+
+```ts
+const OVERRIDE_TYPE_LABELS: Record<FundScenarioOverrideTypeV1, string> = {
+  fee_profile: 'Fee profile',
+  reserve_allocation: 'Reserve allocation',
+  allocation: 'Allocation',
+  sector_profile: 'Sector profile',
+};
+```
+
+Keep route selection unchanged except that only `reserve_allocation` queues
+through `/calculate-reserve`; all other override types use `/calculate`.
+
+In `ScenarioSetsSummary`, treat any variant with `economicsSummary` as eligible
+for the existing TVPI summary and keep reserve metrics on `reserve_allocation`
+only.
+
+- [ ] **Step 4: Run compatibility tests**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/services/fund-scenario-comparison-service.test.ts tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx --project=client --project=server
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Required Verification And Publication
+
+**Files:**
+
+- Modify only the files touched in Tasks 1-3.
+
+- [ ] **Step 1: Run docs routing if this plan changed inventory**
+
+Run:
+
+```bash
+npm run docs:routing:generate
+```
+
+Expected: generator exits 0. Commit generated routing artifacts if they changed.
+
+- [ ] **Step 2: Run required gates**
+
+Run:
+
+```bash
+npx vitest run --config vitest.config.mjs --configLoader native tests/unit/contract/fund-scenario-sets.test.ts tests/unit/phase3/fund-scenario-sets-schema.test.ts tests/unit/services/fund-scenario-calculation-service.test.ts tests/unit/services/fund-scenario-comparison-service.test.ts tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx tests/unit/scenarios/scenario-input-hash.test.ts --project=server --project=client
+npm run check
+npm run lint
+npm run test:scenario-release-gate
+git diff --check
+git status --short --branch
+```
+
+Expected: all pass, except local `test:scenario-release-gate` may explicitly
+skip container-backed cases when Testcontainers are unavailable.
+
+- [ ] **Step 3: Commit, push, and open PR**
+
+Use the Lore Commit Protocol with:
+
+```text
+Expand scenario overrides after release hardening proved the lifecycle
+
+Constraint: Allocation and sector-profile overrides must reuse ADR-022 scenario routes and snapshots without changing canonicalization or reserve workflow behavior
+Rejected: Add new scenario endpoints | existing scenario-set create and calculate routes already provide the bounded V1 extension point
+Confidence: medium
+Scope-risk: moderate
+Tested: focused scenario contract/service/UI tests; npm run check; npm run lint; npm run test:scenario-release-gate; git diff --check
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+```
+
+## Self-Review
+
+- Spec coverage: The plan implements only allocation and sector-profile override
+  expansion and leaves reserve optimization, forecast modes, cohort readiness,
+  money refactors, config cleanup, route normalization, and Phoenix docs out of
+  scope.
+- Placeholder scan: No TBD or deferred implementation steps remain.
+- Type consistency: Override types are `allocation` and `sector_profile`;
+  calculation modes are `sync_allocation` and `sync_sector_profile`; reserve
+  remains `async_reserve_allocation`.

--- a/server/db/migrations/0017_fund_scenario_allocation_sector_overrides.sql
+++ b/server/db/migrations/0017_fund_scenario_allocation_sector_overrides.sql
@@ -1,0 +1,18 @@
+-- 0017_fund_scenario_allocation_sector_overrides.sql
+-- ADR-022: add allocation and sector-profile scenario override types.
+
+BEGIN;
+
+ALTER TABLE fund_scenario_variants
+  DROP CONSTRAINT IF EXISTS fund_scenario_variants_override_type_check;
+
+ALTER TABLE fund_scenario_variants
+  ADD CONSTRAINT fund_scenario_variants_override_type_check
+  CHECK (override_type IN (
+    'fee_profile',
+    'reserve_allocation',
+    'allocation',
+    'sector_profile'
+  ));
+
+COMMIT;

--- a/server/services/fund-scenario-calculation-run-service.ts
+++ b/server/services/fund-scenario-calculation-run-service.ts
@@ -7,8 +7,12 @@ export interface ScenarioCalculationRunIdentity {
   scenarioSetId: string;
   sourceConfigId: number;
   sourceConfigVersion: number;
-  calculationMode: 'sync_fee_profile' | 'async_reserve_allocation';
-  overrideType: 'fee_profile' | 'reserve_allocation';
+  calculationMode:
+    | 'sync_fee_profile'
+    | 'sync_allocation'
+    | 'sync_sector_profile'
+    | 'async_reserve_allocation';
+  overrideType: 'fee_profile' | 'allocation' | 'sector_profile' | 'reserve_allocation';
   inputHash: string;
   correlationId: string;
   jobId?: string | null;

--- a/server/services/fund-scenario-calculation-service.ts
+++ b/server/services/fund-scenario-calculation-service.ts
@@ -5,8 +5,10 @@ import {
   FundScenarioCalculationPayloadV1Schema,
   FundScenarioCalculationResponseV1Schema,
   ScenarioSetResultSummaryV1Schema,
+  type FundScenarioCalculationModeV1,
   type FundScenarioCalculationPayloadV1,
   type FundScenarioCalculationResponseV1,
+  type FundScenarioOverrideTypeV1,
   type FundScenarioResultStalenessStateV1,
   type FundScenarioVariantOverrideV1,
   type ScenarioSetResultSummaryV1,
@@ -71,6 +73,8 @@ interface FeeProfileScenarioSnapshotInput {
   scenarioSetId: string;
   sourceConfigId: number;
   sourceConfigVersion: number;
+  calculationMode: FundScenarioCalculationModeV1;
+  overrideType: FundScenarioOverrideTypeV1;
   correlationId: string;
   payload: FundScenarioCalculationPayloadV1;
   inputHash: string;
@@ -89,6 +93,12 @@ const STALENESS_ORDER: Record<FundScenarioResultStalenessStateV1, number> = {
   STALE_CONFIG: 4,
   FAILED: 5,
 };
+
+type SyncScenarioOverrideType = Exclude<FundScenarioOverrideTypeV1, 'reserve_allocation'>;
+type SyncScenarioVariantOverride = Extract<
+  FundScenarioVariantOverrideV1,
+  { overrideType: SyncScenarioOverrideType }
+>;
 
 function parseJsonPayload(value: unknown): unknown {
   if (typeof value !== 'string') {
@@ -144,8 +154,8 @@ function feeProfileScenarioSnapshotParams(input: FeeProfileScenarioSnapshotInput
     input.correlationId,
     {
       input_hash: input.inputHash,
-      calculation_mode: 'sync_fee_profile',
-      override_type: 'fee_profile',
+      calculation_mode: input.calculationMode,
+      override_type: input.overrideType,
       timeout_ms: SYNC_CALCULATION_TIMEOUT_MS,
     },
     input.sourceConfigId,
@@ -176,7 +186,7 @@ function applyScenarioReadStaleness(
 }
 
 function mapScenarioVariantSummary(variant: FundScenarioCalculationPayloadV1['variants'][number]) {
-  if (variant.overrideType === 'fee_profile') {
+  if (variant.overrideType !== 'reserve_allocation') {
     return {
       variantId: variant.variantId,
       name: variant.name,
@@ -370,11 +380,61 @@ function applyFeeProfileOverride(
   };
 }
 
-function assertFeeProfileScenarioSet(
+function isSyncScenarioOverride(
+  override: FundScenarioVariantOverrideV1
+): override is SyncScenarioVariantOverride {
+  return override.overrideType !== 'reserve_allocation';
+}
+
+function syncCalculationModeForOverrideType(
+  overrideType: SyncScenarioOverrideType
+): FundScenarioCalculationModeV1 {
+  if (overrideType === 'fee_profile') return 'sync_fee_profile';
+  if (overrideType === 'allocation') return 'sync_allocation';
+  return 'sync_sector_profile';
+}
+
+function applySyncScenarioOverride(
+  sourceConfig: FundDraftWriteV1,
+  override: SyncScenarioVariantOverride
+): FundDraftWriteV1 {
+  if (override.overrideType === 'fee_profile') {
+    return applyFeeProfileOverride(sourceConfig, override);
+  }
+
+  if (override.overrideType === 'allocation') {
+    return {
+      ...sourceConfig,
+      ...(override.payload.allocations != null
+        ? { allocations: override.payload.allocations }
+        : {}),
+      ...(override.payload.capitalPlanAllocations != null
+        ? { capitalPlanAllocations: override.payload.capitalPlanAllocations }
+        : {}),
+    };
+  }
+
+  return {
+    ...sourceConfig,
+    sectorProfiles: override.payload.sectorProfiles,
+  };
+}
+
+function assertSyncScenarioSet(
   variants: Array<{ override: FundScenarioVariantOverrideV1 }>
-): void {
-  if (variants.every((variant) => variant.override.overrideType === 'fee_profile')) {
-    return;
+): SyncScenarioOverrideType {
+  const firstOverride = variants[0]?.override;
+  if (firstOverride && isSyncScenarioOverride(firstOverride)) {
+    const firstOverrideType = firstOverride.overrideType;
+    if (
+      variants.every(
+        (variant) =>
+          isSyncScenarioOverride(variant.override) &&
+          variant.override.overrideType === firstOverrideType
+      )
+    ) {
+      return firstOverrideType;
+    }
   }
 
   throw createHttpError(409, 'Use calculate-reserve for reserve-allocation scenario sets', {
@@ -453,7 +513,8 @@ export async function calculateFundScenarioSet(
         code: 'scenario_set_archived',
       });
     }
-    assertFeeProfileScenarioSet(scenarioSet.variants);
+    const overrideType = assertSyncScenarioSet(scenarioSet.variants);
+    const calculationMode = syncCalculationModeForOverrideType(overrideType);
 
     const sourceConfig = await loadSourceConfig(
       client,
@@ -469,8 +530,8 @@ export async function calculateFundScenarioSet(
       scenarioSetId,
       sourceConfigId: sourceConfig.id,
       sourceConfigVersion: sourceConfig.version,
-      calculationMode: 'sync_fee_profile',
-      overrideType: 'fee_profile',
+      calculationMode,
+      overrideType,
       engineVersion: FUND_SCENARIO_CALC_VERSION,
       variants: scenarioSet.variants.map((variant) => ({
         variantId: variant.id,
@@ -496,8 +557,8 @@ export async function calculateFundScenarioSet(
       scenarioSetId,
       sourceConfigId: sourceConfig.id,
       sourceConfigVersion: sourceConfig.version,
-      calculationMode: 'sync_fee_profile',
-      overrideType: 'fee_profile',
+      calculationMode,
+      overrideType,
       inputHash,
       correlationId,
     });
@@ -518,12 +579,12 @@ export async function calculateFundScenarioSet(
     const startedAt = performance.now();
     const variants = scenarioSet.variants.map((variant) => {
       assertWithinSyncDeadline(startedAt);
-      if (variant.override.overrideType !== 'fee_profile') {
+      if (!isSyncScenarioOverride(variant.override)) {
         throw createHttpError(409, 'Use calculate-reserve for reserve-allocation scenario sets', {
           code: 'scenario_calculation_mode_mismatch',
         });
       }
-      const variantConfig = applyFeeProfileOverride(sourceConfigBody, variant.override);
+      const variantConfig = applySyncScenarioOverride(sourceConfigBody, variant.override);
       const economics = runEconomicsModel(variantConfig);
       assertWithinSyncDeadline(startedAt);
 
@@ -543,7 +604,7 @@ export async function calculateFundScenarioSet(
         : 'CURRENT';
     const payload = FundScenarioCalculationPayloadV1Schema.parse({
       version: 'fund-scenarios-v1',
-      calculationMode: 'sync_fee_profile',
+      calculationMode,
       fundId,
       scenarioSetId,
       sourceConfigId: sourceConfig.id,
@@ -562,6 +623,8 @@ export async function calculateFundScenarioSet(
       scenarioSetId,
       sourceConfigId: sourceConfig.id,
       sourceConfigVersion: sourceConfig.version,
+      calculationMode,
+      overrideType,
       correlationId,
       payload,
       inputHash,
@@ -574,7 +637,9 @@ export async function calculateFundScenarioSet(
       eventType: 'calculated',
       actor: normalizeActor(actorInput),
       changeSummary: {
-        headline: 'Calculated fee-profile scenario set',
+        headline: `Calculated ${overrideType.replace('_', '-')} scenario set`,
+        calculation_mode: calculationMode,
+        override_type: overrideType,
         snapshot_id: response.snapshotId,
         variant_count: variants.length,
         source_config_version: sourceConfig.version,

--- a/shared/contracts/fund-scenario-sets-v1.contract.ts
+++ b/shared/contracts/fund-scenario-sets-v1.contract.ts
@@ -12,7 +12,12 @@ import { FundDraftWriteV1Schema } from './fund-draft-write-v1.contract';
 
 const DateTimeStringSchema = z.string().datetime();
 
-export const FundScenarioOverrideTypeV1Schema = z.enum(['fee_profile', 'reserve_allocation']);
+export const FundScenarioOverrideTypeV1Schema = z.enum([
+  'fee_profile',
+  'reserve_allocation',
+  'allocation',
+  'sector_profile',
+]);
 
 const FeeProfileOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
   feeProfiles: true,
@@ -28,6 +33,40 @@ export const FundScenarioFeeProfileOverrideV1Schema = z
   .object({
     overrideType: z.literal('fee_profile'),
     payload: FeeProfileOverridePayloadV1Schema,
+  })
+  .strict();
+
+const AllocationOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
+  allocations: true,
+  capitalPlanAllocations: true,
+})
+  .partial()
+  .strict()
+  .refine((value) => value.allocations != null || value.capitalPlanAllocations != null, {
+    message: 'allocation override requires allocations or capitalPlanAllocations',
+  });
+
+export const FundScenarioAllocationOverrideV1Schema = z
+  .object({
+    overrideType: z.literal('allocation'),
+    payload: AllocationOverridePayloadV1Schema,
+  })
+  .strict();
+
+const SectorProfileOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
+  sectorProfiles: true,
+})
+  .required()
+  .strict()
+  .refine((value) => value.sectorProfiles.length > 0, {
+    message: 'sectorProfiles must include at least one profile',
+    path: ['sectorProfiles'],
+  });
+
+export const FundScenarioSectorProfileOverrideV1Schema = z
+  .object({
+    overrideType: z.literal('sector_profile'),
+    payload: SectorProfileOverridePayloadV1Schema,
   })
   .strict();
 
@@ -55,6 +94,8 @@ export const FundScenarioReserveAllocationOverrideV1Schema = z
 export const FundScenarioVariantOverrideV1Schema = z.discriminatedUnion('overrideType', [
   FundScenarioFeeProfileOverrideV1Schema,
   FundScenarioReserveAllocationOverrideV1Schema,
+  FundScenarioAllocationOverrideV1Schema,
+  FundScenarioSectorProfileOverrideV1Schema,
 ]);
 
 export const CreateFundScenarioVariantV1Schema = z
@@ -220,6 +261,24 @@ export const ScenarioSetFeeProfileVariantResultSummaryV1Schema = z
   })
   .strict();
 
+export const ScenarioSetAllocationVariantResultSummaryV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('allocation'),
+    economicsSummary: EconomicsSummaryV1Schema,
+  })
+  .strict();
+
+export const ScenarioSetSectorProfileVariantResultSummaryV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('sector_profile'),
+    economicsSummary: EconomicsSummaryV1Schema,
+  })
+  .strict();
+
 export const ScenarioSetReserveVariantResultSummaryV1Schema = z
   .object({
     variantId: z.string().uuid(),
@@ -231,6 +290,8 @@ export const ScenarioSetReserveVariantResultSummaryV1Schema = z
 
 export const ScenarioSetVariantResultSummaryV1Schema = z.discriminatedUnion('overrideType', [
   ScenarioSetFeeProfileVariantResultSummaryV1Schema,
+  ScenarioSetAllocationVariantResultSummaryV1Schema,
+  ScenarioSetSectorProfileVariantResultSummaryV1Schema,
   ScenarioSetReserveVariantResultSummaryV1Schema,
 ]);
 
@@ -267,6 +328,8 @@ export const ScenariosSectionPayloadV1Schema = z
 
 export const FundScenarioCalculationModeV1Schema = z.enum([
   'sync_fee_profile',
+  'sync_allocation',
+  'sync_sector_profile',
   'async_reserve_allocation',
 ]);
 
@@ -276,6 +339,26 @@ export const FundScenarioFeeProfileCalculationVariantV1Schema = z
     scenarioSetId: z.string().uuid(),
     name: z.string(),
     overrideType: z.literal('fee_profile'),
+    economics: EconomicsResultV1Schema,
+  })
+  .strict();
+
+export const FundScenarioAllocationCalculationVariantV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    scenarioSetId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('allocation'),
+    economics: EconomicsResultV1Schema,
+  })
+  .strict();
+
+export const FundScenarioSectorProfileCalculationVariantV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    scenarioSetId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('sector_profile'),
     economics: EconomicsResultV1Schema,
   })
   .strict();
@@ -292,6 +375,8 @@ export const FundScenarioReserveCalculationVariantV1Schema = z
 
 export const FundScenarioCalculationVariantV1Schema = z.discriminatedUnion('overrideType', [
   FundScenarioFeeProfileCalculationVariantV1Schema,
+  FundScenarioAllocationCalculationVariantV1Schema,
+  FundScenarioSectorProfileCalculationVariantV1Schema,
   FundScenarioReserveCalculationVariantV1Schema,
 ]);
 
@@ -310,7 +395,13 @@ export const FundScenarioCalculationPayloadV1Schema = z
   .strict()
   .superRefine((value, ctx) => {
     const expectedOverrideType =
-      value.calculationMode === 'sync_fee_profile' ? 'fee_profile' : 'reserve_allocation';
+      value.calculationMode === 'sync_fee_profile'
+        ? 'fee_profile'
+        : value.calculationMode === 'sync_allocation'
+          ? 'allocation'
+          : value.calculationMode === 'sync_sector_profile'
+            ? 'sector_profile'
+            : 'reserve_allocation';
     for (const [index, variant] of value.variants.entries()) {
       if (variant.overrideType !== expectedOverrideType) {
         ctx.addIssue({

--- a/shared/lib/scenarios/scenario-input-envelope.ts
+++ b/shared/lib/scenarios/scenario-input-envelope.ts
@@ -3,8 +3,16 @@ import { canonicalJson, canonicalizeScenarioValue } from './canonicalize';
 export const SCENARIO_INPUT_HASH_VERSION = 'scenario-input-hash-v1' as const;
 export const FUND_SCENARIOS_CONTRACT_VERSION = 'fund-scenarios-v1' as const;
 
-export type ScenarioInputCalculationMode = 'sync_fee_profile' | 'async_reserve_allocation';
-export type ScenarioInputOverrideType = 'fee_profile' | 'reserve_allocation';
+export type ScenarioInputCalculationMode =
+  | 'sync_fee_profile'
+  | 'sync_allocation'
+  | 'sync_sector_profile'
+  | 'async_reserve_allocation';
+export type ScenarioInputOverrideType =
+  | 'fee_profile'
+  | 'allocation'
+  | 'sector_profile'
+  | 'reserve_allocation';
 
 export interface ScenarioInputHashEnvelopeV1 {
   version: typeof SCENARIO_INPUT_HASH_VERSION;

--- a/shared/schema/fund.ts
+++ b/shared/schema/fund.ts
@@ -150,15 +150,13 @@ export const fundSnapshots = pgTable(
       table.type,
       table.createdAt.desc()
     ),
-    scenarioDedupeIdx: uniqueIndex('fund_snapshots_scenarios_dedup_idx')
-      .on(
-        table.fundId,
-        table.scenarioSetId,
-        table.configId,
-        table.configVersion,
-        table.stateHash
-      )
-      .where(sql`
+    scenarioDedupeIdx: uniqueIndex('fund_snapshots_scenarios_dedup_idx').on(
+      table.fundId,
+      table.scenarioSetId,
+      table.configId,
+      table.configVersion,
+      table.stateHash
+    ).where(sql`
         ${table.type} = 'SCENARIOS'
         AND ${table.scenarioSetId} IS NOT NULL
         AND ${table.configId} IS NOT NULL
@@ -222,7 +220,7 @@ export const fundScenarioVariants = pgTable(
     sortOrder: integer('sort_order').notNull().default(0),
     overrideType: varchar('override_type', { length: 32 })
       .notNull()
-      .$type<'fee_profile' | 'reserve_allocation'>(),
+      .$type<'fee_profile' | 'reserve_allocation' | 'allocation' | 'sector_profile'>(),
     overridePayload: jsonb('override_payload').notNull().$type<Record<string, unknown>>(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
@@ -306,12 +304,7 @@ export const fundScenarioCalculationRuns = pgTable(
       table.createdAt.desc()
     ),
     activeDedupeIdx: uniqueIndex('fund_scenario_calc_runs_active_dedup_idx')
-      .on(
-        table.scenarioSetId,
-        table.sourceConfigId,
-        table.sourceConfigVersion,
-        table.inputHash
-      )
+      .on(table.scenarioSetId, table.sourceConfigId, table.sourceConfigVersion, table.inputHash)
       .where(sql`${table.status} IN ('queued', 'running', 'completed')`),
     statusCheck: check(
       'fund_scenario_calculation_runs_status_check',

--- a/tests/helpers/scenario-migrations.ts
+++ b/tests/helpers/scenario-migrations.ts
@@ -8,6 +8,7 @@ export const SCENARIO_MIGRATION_FILES = [
   '0014_fund_scenario_calculated_event.sql',
   '0015_fund_scenario_reserve_allocation.sql',
   '0016_fund_scenario_calculation_runs.sql',
+  '0017_fund_scenario_allocation_sector_overrides.sql',
 ] as const;
 
 export async function applyScenarioMigrations(pool: Pool): Promise<void> {

--- a/tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx
+++ b/tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx
@@ -60,6 +60,26 @@ describe('ScenarioSetsSummary', () => {
     expect(within(reserveCard).getByText('Warnings')).toBeInTheDocument();
     expect(within(reserveCard).getAllByText('1')).toHaveLength(2);
   });
+
+  it('renders allocation and sector-profile scenario cards with economics summaries', () => {
+    render(<ScenarioSetsSummary payload={syncOverridePayload()} />);
+
+    const allocationCard = screen.getByText('Allocation mix').closest('article');
+    if (!(allocationCard instanceof HTMLElement)) {
+      throw new Error('Allocation mix card was not rendered');
+    }
+    expect(within(allocationCard).getByText('Best TVPI')).toBeInTheDocument();
+    expect(within(allocationCard).getByText('2.20x')).toBeInTheDocument();
+    expect(within(allocationCard).getByText('Seed heavy')).toBeInTheDocument();
+
+    const sectorCard = screen.getByText('Sector mix').closest('article');
+    if (!(sectorCard instanceof HTMLElement)) {
+      throw new Error('Sector mix card was not rendered');
+    }
+    expect(within(sectorCard).getByText('Best TVPI')).toBeInTheDocument();
+    expect(within(sectorCard).getByText('2.05x')).toBeInTheDocument();
+    expect(within(sectorCard).getByText('AI infrastructure')).toBeInTheDocument();
+  });
 });
 
 function scenarioPayload(): ScenariosSectionPayloadV1 {
@@ -139,6 +159,51 @@ function reservePayload(): ScenariosSectionPayloadV1 {
               highConfidenceCount: 1,
               warningCount: 1,
             },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function syncOverridePayload(): ScenariosSectionPayloadV1 {
+  return {
+    version: 'fund-scenarios-v1',
+    aggregateStaleness: 'CURRENT',
+    sets: [
+      {
+        scenarioSetId: '00000000-0000-0000-0000-000000000411',
+        name: 'Allocation mix',
+        sourceConfigId: 15,
+        sourceConfigVersion: 7,
+        currentPublishedConfigVersion: 7,
+        calculatedAt: '2026-05-26T12:30:00.000Z',
+        staleness: 'CURRENT',
+        variantCount: 1,
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000412',
+            name: 'Seed heavy',
+            overrideType: 'allocation',
+            economicsSummary: economicsSummary({ finalTvpi: 2.2 }),
+          },
+        ],
+      },
+      {
+        scenarioSetId: '00000000-0000-0000-0000-000000000511',
+        name: 'Sector mix',
+        sourceConfigId: 16,
+        sourceConfigVersion: 7,
+        currentPublishedConfigVersion: 7,
+        calculatedAt: '2026-05-26T12:35:00.000Z',
+        staleness: 'CURRENT',
+        variantCount: 1,
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000512',
+            name: 'AI infrastructure',
+            overrideType: 'sector_profile',
+            economicsSummary: economicsSummary({ finalTvpi: 2.05 }),
           },
         ],
       },

--- a/tests/unit/contract/fund-scenario-sets.test.ts
+++ b/tests/unit/contract/fund-scenario-sets.test.ts
@@ -54,15 +54,49 @@ describe('FundScenarioSetsV1 contract', () => {
     expect(result.data?.variants[0]?.override.overrideType).toBe('fee_profile');
   });
 
-  it('rejects non-fee override types in the first slice', () => {
+  it('accepts allocation overrides for strategy and capital-plan allocations', () => {
     const result = FundScenarioVariantOverrideV1Schema.safeParse({
       overrideType: 'allocation',
       payload: {
-        allocations: [],
+        allocations: [{ id: 'seed-stage', category: 'Seed', percentage: 60 }],
+        capitalPlanAllocations: [
+          {
+            id: 'seed-plan',
+            name: 'Seed plan',
+            entryRound: 'Seed',
+            capitalAllocationPct: 60,
+            initialCheckStrategy: 'amount',
+            initialCheckAmount: 1_000_000,
+            followOnStrategy: 'amount',
+            followOnAmount: 500_000,
+            followOnParticipationPct: 25,
+            investmentHorizonMonths: 48,
+          },
+        ],
       },
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.data?.overrideType).toBe('allocation');
+  });
+
+  it('accepts sector-profile overrides', () => {
+    const result = FundScenarioVariantOverrideV1Schema.safeParse({
+      overrideType: 'sector_profile',
+      payload: {
+        sectorProfiles: [
+          {
+            id: 'ai-infra',
+            name: 'AI Infrastructure',
+            targetPercentage: 35,
+            description: 'Infrastructure software and tooling',
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.overrideType).toBe('sector_profile');
   });
 
   it('accepts reserve-allocation overrides with hard caps lower than planned reserves', () => {
@@ -87,7 +121,7 @@ describe('FundScenarioSetsV1 contract', () => {
 
   it('continues to reject unknown override types', () => {
     const result = FundScenarioVariantOverrideV1Schema.safeParse({
-      overrideType: 'allocation',
+      overrideType: 'waterfall',
       payload: {
         items: [],
       },

--- a/tests/unit/pages/fund-scenario-workspace.test.tsx
+++ b/tests/unit/pages/fund-scenario-workspace.test.tsx
@@ -64,14 +64,27 @@ describe('FundScenarioWorkspacePage', () => {
         return Promise.resolve(jsonResponse(reserveScenarioSetDetail()));
       }
 
+      if (
+        method === 'GET' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000311'
+      ) {
+        return Promise.resolve(jsonResponse(allocationScenarioSetDetail()));
+      }
+
+      if (
+        method === 'GET' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000411'
+      ) {
+        return Promise.resolve(jsonResponse(sectorProfileScenarioSetDetail()));
+      }
+
       if (method === 'GET' && url === '/api/funds/123/results') {
         return Promise.resolve(jsonResponse(fundResultsResponse()));
       }
 
       if (
         method === 'GET' &&
-        url ===
-          '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/comparison'
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/comparison'
       ) {
         return Promise.resolve(jsonResponse(scenarioComparisonResponse()));
       }
@@ -87,13 +100,38 @@ describe('FundScenarioWorkspacePage', () => {
         method === 'GET' &&
         url.endsWith('/scenario-sets/00000000-0000-0000-0000-000000000211/calculation-status')
       ) {
-        return Promise.resolve(jsonResponse(statusResponse('not_requested', null)));
+        return Promise.resolve(
+          jsonResponse(
+            statusResponse('not_requested', null, '00000000-0000-0000-0000-000000000211')
+          )
+        );
+      }
+
+      if (
+        method === 'GET' &&
+        url.endsWith('/scenario-sets/00000000-0000-0000-0000-000000000311/calculation-status')
+      ) {
+        return Promise.resolve(
+          jsonResponse(
+            statusResponse('not_requested', null, '00000000-0000-0000-0000-000000000311')
+          )
+        );
+      }
+
+      if (
+        method === 'GET' &&
+        url.endsWith('/scenario-sets/00000000-0000-0000-0000-000000000411/calculation-status')
+      ) {
+        return Promise.resolve(
+          jsonResponse(
+            statusResponse('not_requested', null, '00000000-0000-0000-0000-000000000411')
+          )
+        );
       }
 
       if (
         method === 'POST' &&
-        url ===
-          '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/calculate'
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000111/calculate'
       ) {
         return Promise.resolve(
           jsonResponse({
@@ -122,6 +160,48 @@ describe('FundScenarioWorkspacePage', () => {
         );
       }
 
+      if (
+        method === 'POST' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000311/calculate'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            snapshotId: 43,
+            correlationId: '00000000-0000-0000-0000-000000000997',
+            source: 'fund_snapshots',
+            payload: syncCalculationPayload({
+              calculationMode: 'sync_allocation',
+              scenarioSetId: '00000000-0000-0000-0000-000000000311',
+              variantId: '00000000-0000-0000-0000-000000000312',
+              overrideType: 'allocation',
+              sourceConfigId: 14,
+              name: 'Seed heavy',
+            }),
+          })
+        );
+      }
+
+      if (
+        method === 'POST' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000411/calculate'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            snapshotId: 44,
+            correlationId: '00000000-0000-0000-0000-000000000996',
+            source: 'fund_snapshots',
+            payload: syncCalculationPayload({
+              calculationMode: 'sync_sector_profile',
+              scenarioSetId: '00000000-0000-0000-0000-000000000411',
+              variantId: '00000000-0000-0000-0000-000000000412',
+              overrideType: 'sector_profile',
+              sourceConfigId: 15,
+              name: 'AI infrastructure',
+            }),
+          })
+        );
+      }
+
       return Promise.reject(new Error(`Unexpected fetch ${method} ${url}`));
     });
   }
@@ -134,19 +214,43 @@ describe('FundScenarioWorkspacePage', () => {
     expect(screen.getByText(/Test Fund \| Vintage 2024/)).toBeInTheDocument();
     expect(screen.getAllByText('Fee sensitivity').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Reserve plan').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Allocation mix').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Sector mix').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByTestId('scenario-sets-summary')).toBeInTheDocument();
     expect(screen.getByTestId('scenario-comparison-table')).toBeInTheDocument();
     expect(screen.getByText('Authoritative baseline')).toBeInTheDocument();
 
-    const feeCard = screen.getByTestId('scenario-workspace-set-00000000-0000-0000-0000-000000000111');
+    const feeCard = screen.getByTestId(
+      'scenario-workspace-set-00000000-0000-0000-0000-000000000111'
+    );
     expect(within(feeCard).getByText('Succeeded')).toBeInTheDocument();
-    expect(within(feeCard).getByRole('button', { name: /calculate fee sensitivity/i })).toBeInTheDocument();
+    expect(
+      within(feeCard).getByRole('button', { name: /calculate fee sensitivity/i })
+    ).toBeInTheDocument();
 
     const reserveCard = screen.getByTestId(
       'scenario-workspace-set-00000000-0000-0000-0000-000000000211'
     );
     expect(within(reserveCard).getByText('Not requested')).toBeInTheDocument();
-    expect(within(reserveCard).getByRole('button', { name: /queue reserve plan/i })).toBeInTheDocument();
+    expect(
+      within(reserveCard).getByRole('button', { name: /queue reserve plan/i })
+    ).toBeInTheDocument();
+
+    const allocationCard = screen.getByTestId(
+      'scenario-workspace-set-00000000-0000-0000-0000-000000000311'
+    );
+    expect(within(allocationCard).getByText('Allocation')).toBeInTheDocument();
+    expect(
+      within(allocationCard).getByRole('button', { name: /calculate allocation mix/i })
+    ).toBeInTheDocument();
+
+    const sectorCard = screen.getByTestId(
+      'scenario-workspace-set-00000000-0000-0000-0000-000000000411'
+    );
+    expect(within(sectorCard).getByText('Sector profile')).toBeInTheDocument();
+    expect(
+      within(sectorCard).getByRole('button', { name: /calculate sector mix/i })
+    ).toBeInTheDocument();
   });
 
   it('uses the fee-profile calculation endpoint for fee scenario sets', async () => {
@@ -177,6 +281,34 @@ describe('FundScenarioWorkspacePage', () => {
     });
   });
 
+  it('uses the sync calculation endpoint for allocation scenario sets', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    fireEvent.click(await screen.findByRole('button', { name: /calculate allocation mix/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000311/calculate',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  it('uses the sync calculation endpoint for sector-profile scenario sets', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    fireEvent.click(await screen.findByRole('button', { name: /calculate sector mix/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000411/calculate',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
   it('rejects invalid fund routes before issuing API requests', () => {
     renderWorkspace('/fund-model-results/latest/scenarios');
 
@@ -193,7 +325,12 @@ function jsonResponse(body: unknown) {
 }
 
 function scenarioSetSummaries(): FundScenarioSetSummaryV1[] {
-  return [scenarioSetSummary('00000000-0000-0000-0000-000000000111', 'Fee sensitivity', 12, 4), scenarioSetSummary('00000000-0000-0000-0000-000000000211', 'Reserve plan', 13, 4)];
+  return [
+    scenarioSetSummary('00000000-0000-0000-0000-000000000111', 'Fee sensitivity', 12, 4),
+    scenarioSetSummary('00000000-0000-0000-0000-000000000211', 'Reserve plan', 13, 4),
+    scenarioSetSummary('00000000-0000-0000-0000-000000000311', 'Allocation mix', 14, 4),
+    scenarioSetSummary('00000000-0000-0000-0000-000000000411', 'Sector mix', 15, 4),
+  ];
 }
 
 function scenarioSetSummary(
@@ -262,6 +399,52 @@ function reserveScenarioSetDetail(): FundScenarioSetDetailV1 {
                 allocationReason: 'Cap the follow-on reserve for concentration control',
               },
             ],
+          },
+        },
+        createdAt: '2026-05-29T12:00:00.000Z',
+        updatedAt: '2026-05-29T12:00:00.000Z',
+      },
+    ],
+  };
+}
+
+function allocationScenarioSetDetail(): FundScenarioSetDetailV1 {
+  return {
+    ...scenarioSetSummary('00000000-0000-0000-0000-000000000311', 'Allocation mix', 14, 4),
+    variants: [
+      {
+        id: '00000000-0000-0000-0000-000000000312',
+        scenarioSetId: '00000000-0000-0000-0000-000000000311',
+        name: 'Seed heavy',
+        description: null,
+        sortOrder: 0,
+        override: {
+          overrideType: 'allocation',
+          payload: {
+            allocations: [{ id: 'seed', category: 'Seed', percentage: 60 }],
+          },
+        },
+        createdAt: '2026-05-29T12:00:00.000Z',
+        updatedAt: '2026-05-29T12:00:00.000Z',
+      },
+    ],
+  };
+}
+
+function sectorProfileScenarioSetDetail(): FundScenarioSetDetailV1 {
+  return {
+    ...scenarioSetSummary('00000000-0000-0000-0000-000000000411', 'Sector mix', 15, 4),
+    variants: [
+      {
+        id: '00000000-0000-0000-0000-000000000412',
+        scenarioSetId: '00000000-0000-0000-0000-000000000411',
+        name: 'AI infrastructure',
+        description: null,
+        sortOrder: 0,
+        override: {
+          overrideType: 'sector_profile',
+          payload: {
+            sectorProfiles: [{ id: 'ai-infra', name: 'AI infrastructure', targetPercentage: 40 }],
           },
         },
         createdAt: '2026-05-29T12:00:00.000Z',
@@ -377,6 +560,42 @@ function scenariosPayload() {
           },
         ],
       },
+      {
+        scenarioSetId: '00000000-0000-0000-0000-000000000311',
+        name: 'Allocation mix',
+        sourceConfigId: 14,
+        sourceConfigVersion: 4,
+        currentPublishedConfigVersion: 4,
+        calculatedAt: '2026-05-29T12:32:00.000Z',
+        staleness: 'CURRENT' as const,
+        variantCount: 1,
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000312',
+            name: 'Seed heavy',
+            overrideType: 'allocation' as const,
+            economicsSummary: economicsSummary(),
+          },
+        ],
+      },
+      {
+        scenarioSetId: '00000000-0000-0000-0000-000000000411',
+        name: 'Sector mix',
+        sourceConfigId: 15,
+        sourceConfigVersion: 4,
+        currentPublishedConfigVersion: 4,
+        calculatedAt: '2026-05-29T12:34:00.000Z',
+        staleness: 'CURRENT' as const,
+        variantCount: 1,
+        variants: [
+          {
+            variantId: '00000000-0000-0000-0000-000000000412',
+            name: 'AI infrastructure',
+            overrideType: 'sector_profile' as const,
+            economicsSummary: economicsSummary(),
+          },
+        ],
+      },
     ],
   };
 }
@@ -463,15 +682,18 @@ function scenarioComparisonResponse(): FundScenarioComparisonV1 {
 
 function statusResponse(
   status: FundScenarioCalculationStatusV1['status'],
-  snapshotId: number | null
+  snapshotId: number | null,
+  scenarioSetId = snapshotId === null
+    ? '00000000-0000-0000-0000-000000000211'
+    : '00000000-0000-0000-0000-000000000111',
+  calculationMode: FundScenarioCalculationStatusV1['calculationMode'] = snapshotId === null
+    ? null
+    : 'sync_fee_profile'
 ): FundScenarioCalculationStatusV1 {
   return {
     fundId: 123,
-    scenarioSetId:
-      snapshotId === null
-        ? '00000000-0000-0000-0000-000000000211'
-        : '00000000-0000-0000-0000-000000000111',
-    calculationMode: snapshotId === null ? null : 'sync_fee_profile',
+    scenarioSetId,
+    calculationMode,
     status,
     jobId: null,
     correlationId: null,
@@ -482,12 +704,37 @@ function statusResponse(
 }
 
 function feeCalculationPayload() {
+  return syncCalculationPayload({
+    calculationMode: 'sync_fee_profile',
+    scenarioSetId: '00000000-0000-0000-0000-000000000111',
+    variantId: '00000000-0000-0000-0000-000000000112',
+    overrideType: 'fee_profile',
+    sourceConfigId: 12,
+    name: 'Lower fee',
+  });
+}
+
+function syncCalculationPayload({
+  calculationMode,
+  scenarioSetId,
+  variantId,
+  overrideType,
+  sourceConfigId,
+  name,
+}: {
+  calculationMode: 'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile';
+  scenarioSetId: string;
+  variantId: string;
+  overrideType: 'fee_profile' | 'allocation' | 'sector_profile';
+  sourceConfigId: number;
+  name: string;
+}) {
   return {
     version: 'fund-scenarios-v1' as const,
-    calculationMode: 'sync_fee_profile' as const,
+    calculationMode,
     fundId: 123,
-    scenarioSetId: '00000000-0000-0000-0000-000000000111',
-    sourceConfigId: 12,
+    scenarioSetId,
+    sourceConfigId,
     sourceConfigVersion: 4,
     staleness: {
       state: 'CURRENT' as const,
@@ -497,10 +744,10 @@ function feeCalculationPayload() {
     calculatedAt: '2026-05-29T12:30:00.000Z',
     variants: [
       {
-        variantId: '00000000-0000-0000-0000-000000000112',
-        scenarioSetId: '00000000-0000-0000-0000-000000000111',
-        name: 'Lower fee',
-        overrideType: 'fee_profile' as const,
+        variantId,
+        scenarioSetId,
+        name,
+        overrideType,
         economics: {
           version: 'v1' as const,
           annual: [],

--- a/tests/unit/phase3/fund-scenario-sets-schema.test.ts
+++ b/tests/unit/phase3/fund-scenario-sets-schema.test.ts
@@ -97,6 +97,20 @@ describe('ADR-022 fund scenario set schema shell', () => {
     expect(migration).toContain("'calculation_failed'");
   });
 
+  it('allocation and sector override migration extends only the variant check constraint', async () => {
+    const migration = await readRepoFile(
+      'server/db/migrations/0017_fund_scenario_allocation_sector_overrides.sql'
+    );
+
+    expect(migration).toContain('fund_scenario_variants_override_type_check');
+    expect(migration).toContain("'fee_profile'");
+    expect(migration).toContain("'reserve_allocation'");
+    expect(migration).toContain("'allocation'");
+    expect(migration).toContain("'sector_profile'");
+    expect(migration).not.toContain('0016');
+    expect(migration).not.toContain('fund_scenario_calculation_runs');
+  });
+
   it('calculation migration adds an audit-visible calculated event type', async () => {
     const migration = await readRepoFile(
       'server/db/migrations/0014_fund_scenario_calculated_event.sql'
@@ -116,9 +130,7 @@ describe('ADR-022 fund scenario set schema shell', () => {
     expect(migration).toContain(
       'DROP INDEX IF EXISTS fund_snapshots_scenario_set_calculation_unique'
     );
-    expect(migration).toContain(
-      'CREATE TABLE IF NOT EXISTS fund_scenario_calculation_runs'
-    );
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS fund_scenario_calculation_runs');
     expect(migration).toContain('fund_scenario_calc_runs_active_dedup_idx');
     expect(migration).toContain('fund_snapshots_scenarios_dedup_idx');
   });

--- a/tests/unit/services/fund-scenario-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-calculation-service.test.ts
@@ -57,6 +57,41 @@ const feeProfileOverride = {
   },
 } as const;
 
+const allocationOverride = {
+  overrideType: 'allocation',
+  payload: {
+    allocations: [{ id: 'seed-stage', category: 'Seed', percentage: 60 }],
+    capitalPlanAllocations: [
+      {
+        id: 'seed-plan',
+        name: 'Seed plan',
+        entryRound: 'Seed',
+        capitalAllocationPct: 60,
+        initialCheckStrategy: 'amount',
+        initialCheckAmount: 1_000_000,
+        followOnStrategy: 'amount',
+        followOnAmount: 500_000,
+        followOnParticipationPct: 25,
+        investmentHorizonMonths: 48,
+      },
+    ],
+  },
+} as const;
+
+const sectorProfileOverride = {
+  overrideType: 'sector_profile',
+  payload: {
+    sectorProfiles: [
+      {
+        id: 'ai-infra',
+        name: 'AI Infrastructure',
+        targetPercentage: 35,
+        description: 'Infrastructure software and tooling',
+      },
+    ],
+  },
+} as const;
+
 const baseConfig = {
   fundName: 'Test Fund',
   fundSize: 100_000_000,
@@ -213,15 +248,15 @@ function scenarioSetRow(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
-function variantRow() {
+function variantRow(override = feeProfileOverride) {
   return {
     id: variantId,
     scenario_set_id: scenarioSetId,
-    name: 'Lower fee',
+    name: 'Scenario variant',
     description: null,
     sort_order: 0,
-    override_type: 'fee_profile',
-    override_payload: feeProfileOverride.payload,
+    override_type: override.overrideType,
+    override_payload: override.payload,
     created_at: new Date('2026-05-26T12:00:00.000Z'),
     updated_at: new Date('2026-05-26T12:00:00.000Z'),
   };
@@ -255,17 +290,24 @@ function snapshotPayload(): FundScenarioCalculationPayloadV1 {
 
 function calculationRunRow(
   status: 'queued' | 'running' | 'completed',
-  snapshotId: number | null = null
+  snapshotId: number | null = null,
+  options: {
+    calculationMode?: 'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile';
+    overrideType?: 'fee_profile' | 'allocation' | 'sector_profile';
+    inputHash?: string;
+  } = {}
 ) {
+  const calculationMode = options.calculationMode ?? 'sync_fee_profile';
+  const overrideType = options.overrideType ?? 'fee_profile';
   return {
     id: '00000000-0000-0000-0000-000000000777',
     fund_id: 1,
     scenario_set_id: scenarioSetId,
     source_config_id: 12,
     source_config_version: 4,
-    calculation_mode: 'sync_fee_profile',
-    override_type: 'fee_profile',
-    input_hash: expectedInputHash(),
+    calculation_mode: calculationMode,
+    override_type: overrideType,
+    input_hash: options.inputHash ?? expectedInputHash(),
     job_id: null,
     correlation_id: correlationId,
     status,
@@ -274,20 +316,28 @@ function calculationRunRow(
 }
 
 function expectedInputHash(): string {
+  return expectedInputHashFor(feeProfileOverride, 'sync_fee_profile', 'fee_profile');
+}
+
+function expectedInputHashFor(
+  override: typeof feeProfileOverride | typeof allocationOverride | typeof sectorProfileOverride,
+  calculationMode: 'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile',
+  overrideType: 'fee_profile' | 'allocation' | 'sector_profile'
+): string {
   return createScenarioInputHash({
     version: SCENARIO_INPUT_HASH_VERSION,
     contractVersion: FUND_SCENARIOS_CONTRACT_VERSION,
     scenarioSetId,
     sourceConfigId: 12,
     sourceConfigVersion: 4,
-    calculationMode: 'sync_fee_profile',
-    overrideType: 'fee_profile',
+    calculationMode,
+    overrideType,
     engineVersion: 'fund-scenarios-v1',
     variants: [
       {
         variantId,
         sortOrder: 0,
-        override: feeProfileOverride,
+        override,
       },
     ],
   });
@@ -295,7 +345,9 @@ function expectedInputHash(): string {
 
 describe('fund scenario calculation service', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    queryMock.mockReset();
+    transactionMock.mockReset();
+    runEconomicsModelMock.mockReset();
     transactionMock.mockImplementation(
       async (callback: (client: { query: typeof queryMock }) => unknown) =>
         callback({ query: queryMock })
@@ -304,7 +356,9 @@ describe('fund scenario calculation service', () => {
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    queryMock.mockReset();
+    transactionMock.mockReset();
+    runEconomicsModelMock.mockReset();
   });
 
   it('applies fee-profile overrides, persists a scenario snapshot, and records an audit event', async () => {
@@ -386,6 +440,155 @@ describe('fund scenario calculation service', () => {
         variant_count: 1,
       }),
     ]);
+  });
+
+  it('applies allocation overrides through the sync scenario calculation path', async () => {
+    const allocationHash = expectedInputHashFor(
+      allocationOverride,
+      'sync_allocation',
+      'allocation'
+    );
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow({ name: 'Allocation sensitivity' })] })
+      .mockResolvedValueOnce({ rows: [variantRow(allocationOverride)] })
+      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config: baseConfig }] })
+      .mockResolvedValueOnce({ rows: [{ version: 4 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          calculationRunRow('queued', null, {
+            calculationMode: 'sync_allocation',
+            overrideType: 'allocation',
+            inputHash: allocationHash,
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          calculationRunRow('running', null, {
+            calculationMode: 'sync_allocation',
+            overrideType: 'allocation',
+            inputHash: allocationHash,
+          }),
+        ],
+      })
+      .mockImplementationOnce((_sql: string, params: unknown[]) => ({
+        rows: [
+          {
+            id: 58,
+            payload: params[1],
+            correlation_id: params[3],
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      }))
+      .mockResolvedValueOnce({
+        rows: [
+          calculationRunRow('completed', 58, {
+            calculationMode: 'sync_allocation',
+            overrideType: 'allocation',
+            inputHash: allocationHash,
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000127' }] });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId);
+    const snapshotInsertCall = queryMock.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO fund_snapshots')
+    );
+    const snapshotInsertParams = snapshotInsertCall?.[1] as unknown[] | undefined;
+
+    expect(result.payload.calculationMode).toBe('sync_allocation');
+    expect(result.payload.variants[0]?.overrideType).toBe('allocation');
+    expect(runEconomicsModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allocations: allocationOverride.payload.allocations,
+        capitalPlanAllocations: allocationOverride.payload.capitalPlanAllocations,
+      })
+    );
+    expect(snapshotInsertParams?.[4]).toMatchObject({
+      input_hash: allocationHash,
+      calculation_mode: 'sync_allocation',
+      override_type: 'allocation',
+    });
+    expect(snapshotInsertParams?.[7]).toBe(allocationHash);
+  });
+
+  it('applies sector-profile overrides through the sync scenario calculation path', async () => {
+    const sectorHash = expectedInputHashFor(
+      sectorProfileOverride,
+      'sync_sector_profile',
+      'sector_profile'
+    );
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow({ name: 'Sector sensitivity' })] })
+      .mockResolvedValueOnce({ rows: [variantRow(sectorProfileOverride)] })
+      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config: baseConfig }] })
+      .mockResolvedValueOnce({ rows: [{ version: 4 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          calculationRunRow('queued', null, {
+            calculationMode: 'sync_sector_profile',
+            overrideType: 'sector_profile',
+            inputHash: sectorHash,
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          calculationRunRow('running', null, {
+            calculationMode: 'sync_sector_profile',
+            overrideType: 'sector_profile',
+            inputHash: sectorHash,
+          }),
+        ],
+      })
+      .mockImplementationOnce((_sql: string, params: unknown[]) => ({
+        rows: [
+          {
+            id: 59,
+            payload: params[1],
+            correlation_id: params[3],
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      }))
+      .mockResolvedValueOnce({
+        rows: [
+          calculationRunRow('completed', 59, {
+            calculationMode: 'sync_sector_profile',
+            overrideType: 'sector_profile',
+            inputHash: sectorHash,
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000128' }] });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId);
+    const snapshotInsertCall = queryMock.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO fund_snapshots')
+    );
+    const snapshotInsertParams = snapshotInsertCall?.[1] as unknown[] | undefined;
+
+    expect(result.payload.calculationMode).toBe('sync_sector_profile');
+    expect(result.payload.variants[0]?.overrideType).toBe('sector_profile');
+    expect(runEconomicsModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectorProfiles: sectorProfileOverride.payload.sectorProfiles,
+      })
+    );
+    expect(snapshotInsertParams?.[4]).toMatchObject({
+      input_hash: sectorHash,
+      calculation_mode: 'sync_sector_profile',
+      override_type: 'sector_profile',
+    });
+    expect(snapshotInsertParams?.[7]).toBe(sectorHash);
   });
 
   it('returns an existing matching scenario snapshot without recalculating', async () => {

--- a/tests/unit/services/fund-scenario-comparison-service.test.ts
+++ b/tests/unit/services/fund-scenario-comparison-service.test.ts
@@ -58,6 +58,28 @@ describe('fund scenario comparison service', () => {
     expect(result.variants).toEqual([]);
   });
 
+  it('returns unsupported_override_type for allocation scenario sets', async () => {
+    mockScenarioSet('allocation');
+
+    const result = await getFundScenarioComparison(123, scenarioSetId);
+
+    expect(result.comparisonStatus).toBe('unsupported_override_type');
+    expect(result.unavailableReason).toBe('UNSUPPORTED_OVERRIDE_TYPE');
+    expect(result.baseline).toBeNull();
+    expect(result.variants).toEqual([]);
+  });
+
+  it('returns unsupported_override_type for sector-profile scenario sets', async () => {
+    mockScenarioSet('sector_profile');
+
+    const result = await getFundScenarioComparison(123, scenarioSetId);
+
+    expect(result.comparisonStatus).toBe('unsupported_override_type');
+    expect(result.unavailableReason).toBe('UNSUPPORTED_OVERRIDE_TYPE');
+    expect(result.baseline).toBeNull();
+    expect(result.variants).toEqual([]);
+  });
+
   it('builds comparable fee-profile variants against the authoritative economics baseline', async () => {
     mockScenarioSet('fee_profile');
     queryMock.mockResolvedValueOnce({ rows: [scenarioSnapshotRow()] });
@@ -101,14 +123,16 @@ function sqlForQueryContaining(fragment: string) {
   return String(call?.[0]);
 }
 
-function mockScenarioSet(overrideType: 'fee_profile' | 'reserve_allocation') {
+function mockScenarioSet(
+  overrideType: 'fee_profile' | 'reserve_allocation' | 'allocation' | 'sector_profile'
+) {
   queryMock.mockResolvedValueOnce({ rows: [{ id: 123 }] });
   queryMock.mockResolvedValueOnce({
     rows: [
       {
         id: scenarioSetId,
         fund_id: 123,
-        name: overrideType === 'fee_profile' ? 'Fee sensitivity' : 'Reserve sensitivity',
+        name: overrideType === 'fee_profile' ? 'Fee sensitivity' : `${overrideType} sensitivity`,
         description: null,
         source_config_id: 12,
         source_config_version: 4,
@@ -130,35 +154,47 @@ function mockScenarioSet(overrideType: 'fee_profile' | 'reserve_allocation') {
       {
         id: variantId,
         scenario_set_id: scenarioSetId,
-        name: overrideType === 'fee_profile' ? 'Lower fee' : 'Constrained reserves',
+        name: overrideType === 'fee_profile' ? 'Lower fee' : `${overrideType} variant`,
         description: null,
         sort_order: 0,
         override_type: overrideType,
-        override_payload:
-          overrideType === 'fee_profile'
-            ? {
-                feeProfiles: [
-                  {
-                    id: 'fee-profile-lower',
-                    name: 'Lower fee',
-                    feeTiers: [
-                      {
-                        id: 'tier-1',
-                        name: 'Management fee',
-                        percentage: 2,
-                        feeBasis: 'committed_capital',
-                        startMonth: 0,
-                      },
-                    ],
-                  },
-                ],
-              }
-            : { items: [{ companyId: 101, plannedReservesCents: 1_000_000 }] },
+        override_payload: overridePayloadFor(overrideType),
         created_at: new Date('2026-05-26T12:00:00.000Z'),
         updated_at: new Date('2026-05-26T12:00:00.000Z'),
       },
     ],
   });
+}
+
+function overridePayloadFor(
+  overrideType: 'fee_profile' | 'reserve_allocation' | 'allocation' | 'sector_profile'
+) {
+  if (overrideType === 'fee_profile') {
+    return {
+      feeProfiles: [
+        {
+          id: 'fee-profile-lower',
+          name: 'Lower fee',
+          feeTiers: [
+            {
+              id: 'tier-1',
+              name: 'Management fee',
+              percentage: 2,
+              feeBasis: 'committed_capital',
+              startMonth: 0,
+            },
+          ],
+        },
+      ],
+    };
+  }
+  if (overrideType === 'reserve_allocation') {
+    return { items: [{ companyId: 101, plannedReservesCents: 1_000_000 }] };
+  }
+  if (overrideType === 'allocation') {
+    return { allocations: [{ id: 'seed', category: 'Seed', percentage: 60 }] };
+  }
+  return { sectorProfiles: [{ id: 'ai', name: 'AI Infrastructure', targetPercentage: 35 }] };
 }
 
 function scenarioSnapshotRow() {


### PR DESCRIPTION
## Scope

- Adds `allocation` and `sector_profile` to the ADR-022 scenario V1 contract, result summaries, calculation payloads, hash-envelope literals, and Drizzle override-type metadata.
- Adds migration `0017_fund_scenario_allocation_sector_overrides.sql` to extend the scenario variant override-type check constraint.
- Generalizes the existing synchronous `/calculate` scenario path so allocation and sector-profile overrides apply to the source draft config before economics calculation.
- Keeps comparison fail-closed for non-fee scenario sets and updates workspace/result summary UI compatibility for the new override labels and economics summaries.
- Adds the focused implementation plan at `docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md`.

## Non-goals

- No reserve optimization workflow changes.
- No forecast modes, actuals, cohort readiness, or methodology guardrail work.
- No canonicalization/hash semantic changes beyond additive enum literals.
- No public URL, auth gate, provider order, persisted key, request ID, or route-contract changes.
- No schema-directory renames, engine dedupe, money utility refactors, config cleanup, route mount normalization, dependencies, or Phoenix-protected docs.

## Verification

- `npx vitest run --config vitest.config.mjs --configLoader native tests/unit/contract/fund-scenario-sets.test.ts tests/unit/phase3/fund-scenario-sets-schema.test.ts tests/unit/services/fund-scenario-calculation-service.test.ts tests/unit/scenarios/scenario-input-hash.test.ts tests/unit/services/fund-scenario-comparison-service.test.ts tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/components/fund-results/ScenarioSetsSummary.test.tsx --project=client --project=server`
- `npm run check`
- `npm run lint`
- `npm run test:scenario-release-gate` (exited 0; local container-backed proof skipped because no working container runtime strategy was available)
- `npm run calc-gate`
- `npm run test:integration:routes`
- `npm run calc-gate:full`
- `npm run docs:routing:generate`
- `git diff --check`
- Pre-push hook passed, including TypeScript baseline and changed-file targeted tests.