### PR TITLE
Fix reserve worker metric registry reloads

### DIFF
--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,54 +1,69 @@
 import { register, Counter, Histogram, Gauge } from 'prom-client';
-import { logger } from './logger';
 
-// Initialize metrics
-const engineLatency = new Histogram({
-  name: 'engine_calculation_duration_seconds',
-  help: 'Duration of engine calculations in seconds',
-  labelNames: ['engine', 'status'],
-  buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60],
-});
+function getMetric<T>(name: string): T | undefined {
+  return register.getSingleMetric(name) as T | undefined;
+}
 
-const engineErrors = new Counter({
-  name: 'engine_calculation_errors_total',
-  help: 'Total number of engine calculation errors',
-  labelNames: ['engine', 'error_type'],
-});
+function getOrCreateHistogram(
+  name: string,
+  help: string,
+  labelNames: string[],
+  buckets: number[]
+): Histogram<string> {
+  const existing = getMetric<Histogram<string>>(name);
+  if (existing) return existing;
+  return new Histogram({ name, help, labelNames, buckets });
+}
 
-const queueDepth = new Gauge({
-  name: 'queue_depth',
-  help: 'Current depth of job queues',
-  labelNames: ['queue_name', 'job_type'],
-});
+function getOrCreateCounter(name: string, help: string, labelNames: string[]): Counter<string> {
+  const existing = getMetric<Counter<string>>(name);
+  if (existing) return existing;
+  return new Counter({ name, help, labelNames });
+}
 
-const snapshotWrites = new Counter({
-  name: 'snapshot_writes_total',
-  help: 'Total number of snapshot writes',
-  labelNames: ['type', 'status'],
-});
+function getOrCreateGauge(name: string, help: string, labelNames: string[]): Gauge<string> {
+  const existing = getMetric<Gauge<string>>(name);
+  if (existing) return existing;
+  return new Gauge({ name, help, labelNames });
+}
 
-// Register all metrics
-register.registerMetric(engineLatency);
-register.registerMetric(engineErrors);
-register.registerMetric(queueDepth);
-register.registerMetric(snapshotWrites);
+const engineLatency = getOrCreateHistogram(
+  'engine_calculation_duration_seconds',
+  'Duration of engine calculations in seconds',
+  ['engine', 'status'],
+  [0.1, 0.5, 1, 2, 5, 10, 30, 60]
+);
+
+const engineErrors = getOrCreateCounter(
+  'engine_calculation_errors_total',
+  'Total number of engine calculation errors',
+  ['engine', 'error_type']
+);
+
+const queueDepth = getOrCreateGauge('queue_depth', 'Current depth of job queues', [
+  'queue_name',
+  'job_type',
+]);
+
+const snapshotWrites = getOrCreateCounter(
+  'snapshot_writes_total',
+  'Total number of snapshot writes',
+  ['type', 'status']
+);
 
 // Metrics wrapper function
-export async function withMetrics<T>(
-  engineName: string,
-  fn: () => Promise<T>
-): Promise<T> {
+export async function withMetrics<T>(engineName: string, fn: () => Promise<T>): Promise<T> {
   const timer = engineLatency.startTimer({ engine: engineName });
-  
+
   try {
     const result = await fn();
     timer({ status: 'success' });
     return result;
   } catch (error) {
     timer({ status: 'error' });
-    engineErrors.inc({ 
-      engine: engineName, 
-      error_type: error instanceof Error ? error.constructor.name : 'unknown' 
+    engineErrors.inc({
+      engine: engineName,
+      error_type: error instanceof Error ? error.constructor.name : 'unknown',
     });
     throw error;
   }
@@ -65,12 +80,12 @@ export const metrics = {
   engineErrors,
   queueDepth,
   snapshotWrites,
-  
+
   // Helper methods
   recordQueueDepth: (queueName: string, jobType: string, depth: number) => {
     queueDepth.set({ queue_name: queueName, job_type: jobType }, depth);
   },
-  
+
   recordSnapshotWrite: (type: string, success: boolean) => {
     snapshotWrites.inc({ type, status: success ? 'success' : 'failure' });
   },

--- a/tests/unit/lib/metrics-registration.test.ts
+++ b/tests/unit/lib/metrics-registration.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { register } from 'prom-client';
+
+describe('worker metrics registration', () => {
+  beforeEach(() => {
+    register.clear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    register.clear();
+    vi.resetModules();
+  });
+
+  it('reuses existing prom-client metrics when the module is reloaded', async () => {
+    const firstImport = await import('../../../lib/metrics');
+    firstImport.metrics.recordQueueDepth('fund-scenario-calc', 'reserve', 1);
+
+    vi.resetModules();
+
+    await expect(import('../../../lib/metrics')).resolves.toMatchObject({
+      metrics: expect.any(Object),
+    });
+  });
+});


### PR DESCRIPTION
## Scope
- Fixes the main-branch `CI Unified` failure in `Test integration` caused by duplicate `prom-client` registration of `engine_calculation_duration_seconds`.
- Makes `lib/metrics.ts` reuse existing global registry metrics across `vi.resetModules()` / module reload cycles.
- Adds a regression test that imports the worker metrics module, resets modules, and imports it again.

## Non-goals
- No metric names, label sets, queue behavior, reserve calculations, or worker lifecycle semantics changed.
- No dependency changes.

## Verification
- `npx vitest run tests/unit/lib/metrics-registration.test.ts --project=server` failed before the fix with the same duplicate metric error, then passed after the fix.
- `npx vitest run tests/unit/lib/metrics-registration.test.ts tests/unit/workers/fund-scenario-calc-worker.test.ts --project=server`
- `npm run test:integration -- tests/integration/fund-scenario-reserve-worker.test.ts`
  - Local caveat: this machine has no working container runtime, so the Testcontainers-backed reserve-worker tests were skipped locally.
- `npm run check`
- `npm run lint`
- `npm run test:unit`
- `git diff --check`

## Local integration caveat
`npm run test:integration` is not a clean local signal in this Windows workspace: it fails on pre-existing local schema/setup issues such as missing `reserve_approvals`, `limited_partners`, `funds.deployed_capital`, and `portfoliocompanies.current_valuation`. The GitHub main run being fixed had only the reserve-worker metric-registration failure in the integration job.