### PR TITLE
Separate dual forecast actuals from projections

### DIFF
--- a/client/src/components/dashboard/dual-forecast-dashboard.tsx
+++ b/client/src/components/dashboard/dual-forecast-dashboard.tsx
@@ -30,11 +30,11 @@ interface PortfolioChartPoint {
 interface ForecastChartPoint {
   label: string;
   constructionNav: number;
-  currentNav: number;
+  actualNav: number | null;
+  currentForecastNav: number | null;
   constructionCalledCapital: number;
-  currentCalledCapital: number;
-  constructionDistributions: number;
-  currentDistributions: number;
+  actualCalledCapital: number | null;
+  currentForecastCalledCapital: number | null;
 }
 
 function parseNumericValue(value: string | number | null | undefined): number {
@@ -179,11 +179,12 @@ export default function DualForecastDashboard() {
   const forecastData: ForecastChartPoint[] = dualForecast.series.map((point) => ({
     label: point.label,
     constructionNav: toMillions(point.construction.nav),
-    currentNav: toMillions(point.current.nav),
+    actualNav: point.actual ? toMillions(point.actual.nav) : null,
+    currentForecastNav: point.currentMode === 'forecast' ? toMillions(point.current.nav) : null,
     constructionCalledCapital: toMillions(point.construction.calledCapital),
-    currentCalledCapital: toMillions(point.current.calledCapital),
-    constructionDistributions: toMillions(point.construction.distributions),
-    currentDistributions: toMillions(point.current.distributions),
+    actualCalledCapital: point.actual ? toMillions(point.actual.calledCapital) : null,
+    currentForecastCalledCapital:
+      point.currentMode === 'forecast' ? toMillions(point.current.calledCapital) : null,
   }));
 
   // Portfolio allocation data from real API
@@ -261,11 +262,14 @@ export default function DualForecastDashboard() {
                 Construction Plan
               </Badge>
               <Badge variant="secondary" className="text-xs">
+                Actuals
+              </Badge>
+              <Badge variant="secondary" className="text-xs">
                 Current Forecast
               </Badge>
             </CardTitle>
             <CardDescription>
-              Quarterly NAV comparison from the published plan and current forecast.
+              Quarterly NAV comparison from the published plan, API actuals, and current forecast.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -288,7 +292,15 @@ export default function DualForecastDashboard() {
                 />
                 <Line
                   type="monotone"
-                  dataKey="currentNav"
+                  dataKey="actualNav"
+                  stroke="#111827"
+                  strokeWidth={3}
+                  dot={{ r: 4 }}
+                  name="Actuals"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="currentForecastNav"
                   stroke="#2563eb"
                   strokeWidth={3}
                   dot={{ r: 3 }}
@@ -359,7 +371,15 @@ export default function DualForecastDashboard() {
               />
               <Line
                 type="monotone"
-                dataKey="currentCalledCapital"
+                dataKey="actualCalledCapital"
+                stroke="#111827"
+                strokeWidth={3}
+                dot={{ r: 4 }}
+                name="Actuals"
+              />
+              <Line
+                type="monotone"
+                dataKey="currentForecastCalledCapital"
                 stroke="#2563eb"
                 strokeWidth={3}
                 dot={{ r: 4 }}

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -11158,6 +11158,35 @@
         "categories": [
           "planning",
           "scenarios",
+          "forecasting"
+        ],
+        "keywords": [
+          "scenario-release-hardening",
+          "dual-forecast",
+          "forecast-modes",
+          "actuals"
+        ],
+        "last_updated": "2026-05-29",
+        "owner": "Platform Team",
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-05-29",
+      "owner": "Platform Team",
+      "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
+      "staleDays": 0,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "categories": [
+          "planning",
+          "scenarios",
           "guardrails"
         ],
         "keywords": [
@@ -12852,7 +12881,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED": 1,
-      "ACTIVE": 437,
+      "ACTIVE": 438,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETED": 1,
@@ -12873,7 +12902,7 @@
     },
     "missing_frontmatter": 18,
     "stale_docs": 100,
-    "total_docs": 659
+    "total_docs": 660
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-05-29
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 659 |
+| Total Documents | 660 |
 | Stale Documents | 100 |
 | Missing Frontmatter | 18 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-05-29
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 437 |
+| ACTIVE | 438 |
 | UNKNOWN | 126 |
 | DRAFT | 31 |
 | HISTORICAL | 29 |

--- a/docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md
+++ b/docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md
@@ -1,0 +1,85 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-05-29
+owner: "Platform Team"
+review_cadence: P90D
+categories: [planning, scenarios, forecasting]
+keywords: [scenario-release-hardening, dual-forecast, forecast-modes, actuals]
+---
+
+# Scenario Forecast Modes And Actuals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan red-green, then use superpowers:verification-before-completion before committing or opening a PR.
+
+**Goal:** Make the existing dual-forecast surface truthful about forecast modes and actuals by separating as-of actual metrics from forward-looking forecast values without adding new routes, stores, dependencies, or scenario override types.
+
+**Architecture:** Extend the existing `/api/funds/:fundId/dual-forecast` response in a compatibility-preserving way. Keep the existing `construction` and `current` point fields for consumers, but add explicit per-point actual/mode metadata so clients can distinguish `actual_metrics_calculator` values from `projected_metrics_calculator` forecast values. Update the dashboard to render actuals separately from forecast lines.
+
+**Tech Stack:** TypeScript, Express, TanStack Query, React, Recharts, strict shared types, Vitest server/client unit tests.
+
+---
+
+## Inventory Summary
+
+- PR #733 is merged into `main` as `6b6f5baa8dbedfb68df90a9ab11edccf851e7449`, and the post-merge `main` gate is green for CI Unified, CI Gate Status, Security Deep Scan, and CodeQL.
+- `GET /api/funds/:fundId/dual-forecast` is the canonical route. It already preserves auth, fund-access, `Content-Type`, and `Cache-Control: private, max-age=60`.
+- `shared/types/dual-forecast.ts` defines `DualForecastResponse.sources.actual = 'actual_metrics_calculator'`, but `DualForecastPoint` only exposes `construction` and `current`.
+- `server/services/metrics-aggregator.ts#getDualForecast()` calculates actuals first, then maps quarter `0` into `current` and maps future quarters from projected metrics.
+- `client/src/hooks/useDualForecast.ts` fetches the same route with `credentials: 'include'`, query key `['dual-forecast', fundId]`, and a `60_000` stale time aligned with the route cache header.
+- `client/src/components/dashboard/dual-forecast-dashboard.tsx` currently graphs construction plan and current forecast series, while the only visible `API actuals` label belongs to portfolio allocation rather than the dual-forecast series itself.
+- Existing tests already cover route auth/cache, hook fetch/cache identity, dual-forecast aggregation, and dashboard truthfulness labels.
+- Scenario contracts intentionally reject `forecastMode` in scenario override payloads. This follow-on must not widen scenario override contracts or scenario-set persistence.
+
+## Scope
+
+In scope:
+
+- Extend the dual-forecast shared type with explicit actual/mode metadata.
+- Populate that metadata in `metricsAggregator.getDualForecast()`.
+- Update focused route/hook/service/dashboard tests for the new response contract.
+- Update the dashboard chart data and labels so actuals are visibly distinct from forward-looking forecasts.
+- Preserve the existing route URL, auth gates, cache behavior, provider order, query key, and compatibility fields.
+
+Out of scope:
+
+- New route families, stores, dependencies, or persisted keys.
+- Scenario override expansion, methodology guardrails, reserve optimization, cohort readiness, canonical hash semantics, migrations, schema-directory renames, money utility refactors, engine dedupe, route mount normalization, and Phoenix-protected docs.
+- Changing `forecastMode` rejection in scenario contracts.
+
+## Implementation Steps
+
+- [x] Add failing service contract coverage in `tests/unit/services/metrics-aggregator-dual-forecast.test.ts`:
+  - as-of point has `actual` metrics populated from `actual_metrics_calculator`;
+  - as-of point is marked `currentMode: 'actual'`;
+  - future points have `actual: null` and `currentMode: 'forecast'`;
+  - `current` remains populated for compatibility.
+- [x] Add failing client/dashboard coverage in `tests/unit/hooks/useDualForecast.test.tsx` and `tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx`:
+  - fixture includes the explicit actual/mode fields;
+  - UI labels actuals separately from current forecast values;
+  - old misleading live/real-time labels remain absent.
+- [x] Extend `shared/types/dual-forecast.ts` with a narrow mode type and actual field shape.
+- [x] Update `server/services/metrics-aggregator.ts` to build one actual metrics object once, place it in quarter `0`, and mark future points as forecast.
+- [x] Update `client/src/components/dashboard/dual-forecast-dashboard.tsx` to chart actual NAV/called-capital separately from construction and current forecast lines.
+- [x] Keep `server/routes/dual-forecast.ts` unchanged unless tests prove route response validation or error handling needs a local assertion update.
+
+## Verification Plan
+
+Focused:
+
+- `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/services/metrics-aggregator-dual-forecast.test.ts tests/unit/routes/dual-forecast-route.test.ts`
+- `npx vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/hooks/useDualForecast.test.tsx tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx`
+
+Required closeout:
+
+- `npm run check`
+- `npm run lint`
+- `npm run test:scenario-release-gate`
+- `git diff --check`
+- `git status --short --branch`
+
+Conditional:
+
+- `npm run docs:routing:generate` and `npm run docs:routing:check` because this plan is a new tracked docs file.
+- `npm run test:integration:routes` only if route or route integration behavior changes.
+- `npm run calc-gate` only if calculation engine surfaces change.

--- a/server/services/metrics-aggregator.ts
+++ b/server/services/metrics-aggregator.ts
@@ -545,23 +545,43 @@ export class MetricsAggregator {
     const constructionRemainingLength = Math.max(1, constructionLength - constructionStartIndex);
     const horizon = Math.max(1, Math.min(constructionRemainingLength, projectedFutureLength + 1));
 
-    return Array.from({ length: horizon }, (_, quarterIndex) => ({
-      quarterIndex,
-      label: quarterIndex === 0 ? 'As of' : `Q+${quarterIndex}`,
-      date: this.addQuarters(actual.asOfDate, quarterIndex),
-      construction: this.mapConstructionMetrics(
-        constructionForecast,
-        fundSize,
-        config,
-        constructionStartIndex + quarterIndex
-      ),
-      current: this.mapCurrentForecastMetrics(
-        actual,
-        projected,
+    return Array.from({ length: horizon }, (_, quarterIndex) => {
+      const actualPoint = quarterIndex === 0 ? this.mapActualMetrics(actual) : null;
+
+      return {
         quarterIndex,
-        currentProjectionStartIndex
-      ),
-    }));
+        label: quarterIndex === 0 ? 'As of' : `Q+${quarterIndex}`,
+        date: this.addQuarters(actual.asOfDate, quarterIndex),
+        construction: this.mapConstructionMetrics(
+          constructionForecast,
+          fundSize,
+          config,
+          constructionStartIndex + quarterIndex
+        ),
+        actual: actualPoint,
+        currentMode: quarterIndex === 0 ? 'actual' : 'forecast',
+        current:
+          actualPoint ??
+          this.mapCurrentForecastMetrics(
+            actual,
+            projected,
+            quarterIndex,
+            currentProjectionStartIndex
+          ),
+      };
+    });
+  }
+
+  private mapActualMetrics(actual: ActualMetrics): DualForecastMetrics {
+    return {
+      nav: actual.currentNAV,
+      calledCapital: actual.totalCalled,
+      distributions: actual.totalDistributions,
+      tvpi: actual.tvpi,
+      dpi: actual.dpi,
+      rvpi: actual.rvpi,
+      irr: actual.irr,
+    };
   }
 
   private mapConstructionMetrics(
@@ -606,15 +626,7 @@ export class MetricsAggregator {
     projectionStartIndex: number
   ): DualForecastMetrics {
     if (quarterIndex === 0) {
-      return {
-        nav: actual.currentNAV,
-        calledCapital: actual.totalCalled,
-        distributions: actual.totalDistributions,
-        tvpi: actual.tvpi,
-        dpi: actual.dpi,
-        rvpi: actual.rvpi,
-        irr: actual.irr,
-      };
+      return this.mapActualMetrics(actual);
     }
 
     const projectionIndex = projectionStartIndex + quarterIndex - 1;

--- a/shared/types/dual-forecast.ts
+++ b/shared/types/dual-forecast.ts
@@ -27,11 +27,15 @@ export interface DualForecastMetrics {
   irr: number | null;
 }
 
+export type DualForecastPointMode = 'actual' | 'forecast';
+
 export interface DualForecastPoint {
   quarterIndex: number;
   label: string;
   date: string;
   construction: DualForecastMetrics;
+  actual: DualForecastMetrics | null;
+  currentMode: DualForecastPointMode;
   current: DualForecastMetrics;
 }
 

--- a/tests/e2e/qa-audit-latest-route-publish.spec.ts
+++ b/tests/e2e/qa-audit-latest-route-publish.spec.ts
@@ -113,6 +113,16 @@ const ROUTE_DUAL_FORECAST = {
         rvpi: ROUTE_UNIFIED_METRICS.actual.rvpi,
         irr: ROUTE_UNIFIED_METRICS.actual.irr,
       },
+      actual: {
+        nav: ROUTE_UNIFIED_METRICS.actual.currentNAV,
+        calledCapital: ROUTE_UNIFIED_METRICS.actual.totalCalled,
+        distributions: ROUTE_UNIFIED_METRICS.actual.totalDistributions,
+        tvpi: ROUTE_UNIFIED_METRICS.actual.tvpi,
+        dpi: ROUTE_UNIFIED_METRICS.actual.dpi,
+        rvpi: ROUTE_UNIFIED_METRICS.actual.rvpi,
+        irr: ROUTE_UNIFIED_METRICS.actual.irr,
+      },
+      currentMode: 'actual',
       current: {
         nav: ROUTE_UNIFIED_METRICS.actual.currentNAV,
         calledCapital: ROUTE_UNIFIED_METRICS.actual.totalCalled,
@@ -136,6 +146,8 @@ const ROUTE_DUAL_FORECAST = {
         rvpi: 2.82,
         irr: 0.19,
       },
+      actual: null,
+      currentMode: 'forecast',
       current: {
         nav: 47_500_000,
         calledCapital: 14_500_000,

--- a/tests/e2e/route-fund-context-fidelity.spec.ts
+++ b/tests/e2e/route-fund-context-fidelity.spec.ts
@@ -139,6 +139,16 @@ const FIDELITY_DUAL_FORECAST = {
         rvpi: FIDELITY_METRICS.actual.rvpi,
         irr: FIDELITY_METRICS.actual.irr,
       },
+      actual: {
+        nav: FIDELITY_METRICS.actual.currentNAV,
+        calledCapital: FIDELITY_METRICS.actual.totalCalled,
+        distributions: FIDELITY_METRICS.actual.totalDistributions,
+        tvpi: FIDELITY_METRICS.actual.tvpi,
+        dpi: FIDELITY_METRICS.actual.dpi,
+        rvpi: FIDELITY_METRICS.actual.rvpi,
+        irr: FIDELITY_METRICS.actual.irr,
+      },
+      currentMode: 'actual',
       current: {
         nav: FIDELITY_METRICS.actual.currentNAV,
         calledCapital: FIDELITY_METRICS.actual.totalCalled,
@@ -162,6 +172,8 @@ const FIDELITY_DUAL_FORECAST = {
         rvpi: 2.38,
         irr: 0.19,
       },
+      actual: null,
+      currentMode: 'forecast',
       current: {
         nav: 49_000_000,
         calledCapital: 21_500_000,

--- a/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
+++ b/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
@@ -105,6 +105,16 @@ function makeDualForecast() {
           rvpi: 1.2,
           irr: 0.2,
         },
+        actual: {
+          nav: 7_000_000,
+          calledCapital: 5_000_000,
+          distributions: 0,
+          tvpi: 1.4,
+          dpi: 0,
+          rvpi: 1.4,
+          irr: 0.18,
+        },
+        currentMode: 'actual',
         current: {
           nav: 7_000_000,
           calledCapital: 5_000_000,
@@ -128,6 +138,8 @@ function makeDualForecast() {
           rvpi: 1.14,
           irr: 0.2,
         },
+        actual: null,
+        currentMode: 'forecast',
         current: {
           nav: 9_000_000,
           calledCapital: 7_500_000,
@@ -252,6 +264,7 @@ describe('DualForecastDashboard', () => {
 
     expect(await screen.findAllByText('Construction Plan')).not.toHaveLength(0);
     expect(screen.getAllByText('Current Forecast')).not.toHaveLength(0);
+    expect(screen.getAllByText('Actuals')).not.toHaveLength(0);
     expect(screen.getByText('API actuals')).toBeInTheDocument();
     expect(screen.getByText(/quarterly nav comparison/i)).toBeInTheDocument();
     expect(screen.getByText(/cumulative called capital by quarter/i)).toBeInTheDocument();

--- a/tests/unit/hooks/useDualForecast.test.tsx
+++ b/tests/unit/hooks/useDualForecast.test.tsx
@@ -22,6 +22,16 @@ const dualForecast = {
         rvpi: 2,
         irr: 0.2,
       },
+      actual: {
+        nav: 9_000_000,
+        calledCapital: 5_000_000,
+        distributions: 0,
+        tvpi: 1.8,
+        dpi: 0,
+        rvpi: 1.8,
+        irr: 0.18,
+      },
+      currentMode: 'actual',
       current: {
         nav: 9_000_000,
         calledCapital: 5_000_000,

--- a/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
+++ b/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
@@ -157,6 +157,16 @@ describe('MetricsAggregator dual forecast', () => {
       quarterIndex: 0,
       label: 'As of',
       date: '2026-04-01T00:00:00.000Z',
+      currentMode: 'actual',
+      actual: {
+        nav: 30_000_000,
+        calledCapital: 25_000_000,
+        distributions: 2_000_000,
+        tvpi: 1.28,
+        dpi: 0.08,
+        rvpi: 1.2,
+        irr: 0.14,
+      },
       current: {
         nav: 30_000_000,
         calledCapital: 25_000_000,
@@ -169,12 +179,16 @@ describe('MetricsAggregator dual forecast', () => {
     });
     expect(result.series[1]?.label).toBe('Q+1');
     expect(result.series[1]?.date).toBe('2026-07-01T00:00:00.000Z');
+    expect(result.series[1]?.currentMode).toBe('forecast');
+    expect(result.series[1]?.actual).toBeNull();
     expect(result.series[1]?.current).toMatchObject({
       nav: 36_000_000,
       calledCapital: 30_000_000,
       distributions: 3_000_000,
       irr: 0.22,
     });
+    expect(result.series[2]?.currentMode).toBe('forecast');
+    expect(result.series[2]?.actual).toBeNull();
     expect(result.series[2]?.current).toMatchObject({
       nav: 44_000_000,
       calledCapital: 36_000_000,


### PR DESCRIPTION
## Scope

- Adds a focused implementation plan for the Scenario Release Hardening follow-on: Forecast modes and actuals.
- Extends `DualForecastPoint` with explicit `actual` and `currentMode` metadata while preserving the existing `construction` and `current` fields.
- Populates quarter-0 actual metrics from `actual_metrics_calculator` and marks future points as forecast values from `projected_metrics_calculator`.
- Updates the forecasting dashboard to render `Actuals` separately from `Current Forecast` for NAV and called capital.
- Updates focused unit and E2E fixtures for the new dual-forecast response shape.

## Non-goals

- No new route families, stores, dependencies, persisted keys, or request IDs.
- No scenario override expansion and no `forecastMode` scenario contract support; those payloads remain rejected.
- No reserve optimization, methodology guardrail, cohort readiness, canonical hash, migration, schema-directory, money utility, engine dedupe, or route mount normalization changes.
- No Phoenix-protected docs touched.

## Verification

- RED confirmed first:
  - service test failed because `actual` and `currentMode` were missing from dual-forecast points.
  - dashboard test failed because the `Actuals` label was missing.
- `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/services/metrics-aggregator-dual-forecast.test.ts tests/unit/routes/dual-forecast-route.test.ts` PASS: 2 files, 9 tests.
- `npx vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/hooks/useDualForecast.test.tsx tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx` PASS: 2 files, 8 tests.
- `npm run docs:routing:check` PASS.
- `npm run check` PASS: 0 TypeScript errors.
- `npm run lint` PASS, including guardrails.
- `npm run test:scenario-release-gate` exit 0, but local container-backed case skipped: `Could not find a working container runtime strategy`.
- `git diff --check` PASS.

## Caveats

- Container-backed scenario release gate proof is left to CI because this workstation does not have a working container runtime strategy.
- Independent Codex architect verifier attempts via MCP and CLI timed out before returning a verdict; local diff review plus required gates completed cleanly.