### PR TITLE
Keep cohort out of authoritative readiness until evidence exists

### DIFF
--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -11158,6 +11158,34 @@
         "categories": [
           "planning",
           "scenarios",
+          "cohorts"
+        ],
+        "keywords": [
+          "scenario-release-hardening",
+          "cohort-readiness",
+          "authoritative-calculations"
+        ],
+        "last_updated": "2026-05-29",
+        "owner": "Platform Team",
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-05-29",
+      "owner": "Platform Team",
+      "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
+      "staleDays": 0,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "categories": [
+          "planning",
+          "scenarios",
           "forecasting"
         ],
         "keywords": [
@@ -12881,7 +12909,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED": 1,
-      "ACTIVE": 438,
+      "ACTIVE": 439,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETED": 1,
@@ -12902,7 +12930,7 @@
     },
     "missing_frontmatter": 18,
     "stale_docs": 100,
-    "total_docs": 660
+    "total_docs": 661
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-05-29
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 660 |
+| Total Documents | 661 |
 | Stale Documents | 100 |
 | Missing Frontmatter | 18 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-05-29
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 438 |
+| ACTIVE | 439 |
 | UNKNOWN | 126 |
 | DRAFT | 31 |
 | HISTORICAL | 29 |

--- a/docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md
+++ b/docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md
@@ -1,0 +1,93 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-05-29
+owner: "Platform Team"
+review_cadence: P90D
+categories: [planning, scenarios, cohorts]
+keywords: [scenario-release-hardening, cohort-readiness, authoritative-calculations]
+---
+
+# Scenario Cohort Release Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan red-green, then use superpowers:verification-before-completion before committing or opening a PR.
+
+**Goal:** Make cohort release readiness truthful by locking cohort as an experimental calculation surface that cannot satisfy or block authoritative fund readiness until it writes authoritative snapshots with migration/backfill proof.
+
+**Architecture:** Keep the existing `/api/cohorts` route, cohort worker queue, and Analysis Cohort shared boundary intact. Harden the shared calculation-engine catalog as the single source of truth for authoritative versus experimental engines, mirror that authority into queue registry metadata, and add focused regression tests that prove cohort remains excluded from readiness and completion gates.
+
+**Tech Stack:** TypeScript, shared contracts, BullMQ queue registry metadata, Express route inventory, Vitest server unit tests, docs routing generation.
+
+---
+
+## Inventory Summary
+
+- PR #734 is merged into `main` as `836e59a44afb461ec1177668308d08e140e0b1ce`, and post-merge main checks are green for Documentation Routing Check, CI Unified, CI Gate Status, CodeQL, Security Deep Scan, and pages-build-deployment.
+- `server/routes.ts` mounts cohort analysis at `/api/cohorts`; `server/app.ts` has the same legacy app mount. This plan must preserve that public URL and not normalize route mounts.
+- `docs/adr/ADR-020-analysis-cohort-boundary.md` separates Analysis Cohort logic in `shared/core/cohorts/analysis/` from the legacy Exit Cohort Model surface in `CohortEngine`.
+- `workers/cohort-worker.ts` still processes mock companies, returns attribution fields, and does not write authoritative `fund_snapshots` rows.
+- `shared/contracts/fund-authoritative-calculations.contract.ts` currently classifies reserve and pacing as authoritative, while cohort and economics are experimental.
+- `shared/contracts/fund-state-read-v1.contract.ts` derives `EXPECTED_SNAPSHOT_TYPES` from authoritative snapshot types; current authoritative readiness is `RESERVE` plus `PACING`.
+- `server/services/fund-persistence-service.ts#getEnginesForConfig()` dispatches authoritative engines only by default and adds economics only when its feature flag and assumptions are present.
+- `server/services/calc-run-tracking.ts#markCalcRunCompletedIfReady()` completes a run only when authoritative snapshot types are present.
+- Existing tests already prove derivation ignores `COHORT` for ready, but there is no explicit experimental-engine export or cross-registry authority drift test.
+
+## Scope
+
+In scope:
+
+- Add explicit experimental calculation exports/helpers to the shared engine catalog.
+- Add regression tests proving cohort is experimental, is excluded from authoritative readiness arrays, and is excluded from calc-run completion coverage.
+- Derive queue registry calculation authority from the shared engine catalog instead of duplicating literals.
+- Keep docs routing artifacts in sync with this new plan.
+
+Out of scope:
+
+- Cohort snapshot writer, cohort backfill migration, authoritative cohort graduation, new route families, new stores, new dependencies, forecast modes, reserve optimization, methodology guardrails, override expansion, canonical hash semantics, schema-directory renames, money utility refactors, engine dedupe, route mount normalization, and Phoenix-protected docs.
+
+## Implementation Steps
+
+- [x] Add failing shared-contract tests in `tests/unit/contract/fund-authoritative-calculations.test.ts`:
+  - assert `EXPERIMENTAL_ENGINE_KEYS` includes `cohort`;
+  - assert `AUTHORITATIVE_ENGINE_KEYS` equals `['reserve', 'pacing']`;
+  - assert `AUTHORITATIVE_SNAPSHOT_TYPES` excludes `COHORT`;
+  - assert `getCalculationEngineDescriptorByQueueKey('cohort-calc')` returns an experimental cohort descriptor.
+- [x] Add a failing queue-registry drift test in `tests/unit/phase2a/config-invariants.test.ts`:
+  - for every lifecycle calculation queue entry with `fundCalculationAuthority`, compare the registry value against `getCalculationEngineDescriptorByQueueKey(entry.queueName).authority`.
+- [x] Add calc-run completion coverage in `tests/unit/services/post-calc-trigger.test.ts`:
+  - `RESERVE + COHORT` must not complete a run without `PACING`.
+- [x] Implement the shared catalog helpers in `shared/contracts/fund-authoritative-calculations.contract.ts`:
+  - derive authoritative and experimental descriptor arrays from `FUND_CALCULATION_ENGINE_CATALOG`;
+  - export `EXPERIMENTAL_ENGINE_KEYS`, `EXPERIMENTAL_SNAPSHOT_TYPES`, and `getCalculationEngineDescriptorByQueueKey`;
+  - keep public authoritative exports compatible.
+- [x] Update `server/queues/registry.ts` to source `fundCalculationAuthority` from `getCalculationEngineDescriptorByQueueKey()`.
+- [x] Run focused tests:
+  - `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/contract/fund-authoritative-calculations.test.ts tests/unit/phase2a/config-invariants.test.ts tests/unit/services/post-calc-trigger.test.ts tests/unit/phase2b/lifecycle-derivation.test.ts tests/unit/phase2a/calc-runs-publish.test.ts`
+- [x] Run docs routing generation/check because this plan is a new tracked docs file.
+
+## Verification Plan
+
+Focused:
+
+- `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/contract/fund-authoritative-calculations.test.ts tests/unit/phase2a/config-invariants.test.ts tests/unit/services/post-calc-trigger.test.ts tests/unit/phase2b/lifecycle-derivation.test.ts tests/unit/phase2a/calc-runs-publish.test.ts`
+
+Required closeout:
+
+- `npm run check`
+- `npm run lint`
+- `npm run test:scenario-release-gate`
+- `npm run docs:routing:generate`
+- `npm run docs:routing:check`
+- `git diff --check`
+- `git status --short --branch`
+
+Conditional:
+
+- `npm run test:integration:routes` only if route or route-integration behavior changes.
+- `npm run calc-gate` only if calculation engine behavior changes beyond catalog metadata.
+
+## Self-Review
+
+- Spec coverage: The plan addresses cohort release readiness as a truthfulness and drift-prevention slice while preserving current cohort analysis route reachability and avoiding authoritative cohort graduation.
+- Placeholder scan: The plan names exact files, expected assertions, and commands.
+- Type consistency: Engine keys, snapshot types, queue keys, and authority values all come from `shared/contracts/fund-authoritative-calculations.contract.ts`.

--- a/server/queues/registry.ts
+++ b/server/queues/registry.ts
@@ -1,5 +1,9 @@
 import type { Queue, Worker } from 'bullmq';
-import type { FundCalculationAuthority } from '@shared/contracts/fund-authoritative-calculations.contract';
+import {
+  getCalculationEngineDescriptorByQueueKey,
+  type FundCalculationAuthority,
+  type FundCalculationQueueKey,
+} from '@shared/contracts/fund-authoritative-calculations.contract';
 
 export type QueueRegistryKey =
   | 'simulation'
@@ -27,6 +31,10 @@ export interface RegisteredQueueRuntime {
   getQueue: () => Queue | null;
   getWorker?: () => Worker | null;
   isInitialized: () => boolean;
+}
+
+function authorityForCalculationQueue(queueKey: FundCalculationQueueKey): FundCalculationAuthority {
+  return getCalculationEngineDescriptorByQueueKey(queueKey).authority;
 }
 
 export const QUEUE_CATALOG: readonly QueueCatalogEntry[] = [
@@ -57,7 +65,7 @@ export const QUEUE_CATALOG: readonly QueueCatalogEntry[] = [
     displayName: 'Reserve Calculations',
     healthMode: 'producer',
     owner: 'route',
-    fundCalculationAuthority: 'authoritative',
+    fundCalculationAuthority: authorityForCalculationQueue('reserve-calc'),
   },
   {
     key: 'fund-scenario-calc',
@@ -73,7 +81,7 @@ export const QUEUE_CATALOG: readonly QueueCatalogEntry[] = [
     displayName: 'Pacing Calculations',
     healthMode: 'producer',
     owner: 'route',
-    fundCalculationAuthority: 'authoritative',
+    fundCalculationAuthority: authorityForCalculationQueue('pacing-calc'),
   },
   {
     key: 'cohort-calc',
@@ -81,7 +89,7 @@ export const QUEUE_CATALOG: readonly QueueCatalogEntry[] = [
     displayName: 'Cohort Calculations',
     healthMode: 'producer',
     owner: 'route',
-    fundCalculationAuthority: 'experimental',
+    fundCalculationAuthority: authorityForCalculationQueue('cohort-calc'),
   },
   {
     key: 'economics-calc',
@@ -89,7 +97,7 @@ export const QUEUE_CATALOG: readonly QueueCatalogEntry[] = [
     displayName: 'GP Economics Calculations',
     healthMode: 'producer',
     owner: 'route',
-    fundCalculationAuthority: 'experimental',
+    fundCalculationAuthority: authorityForCalculationQueue('economics-calc'),
   },
 ] as const;
 

--- a/shared/contracts/fund-authoritative-calculations.contract.ts
+++ b/shared/contracts/fund-authoritative-calculations.contract.ts
@@ -35,19 +35,53 @@ export type FundCalculationEngineKey = FundCalculationEngineDescriptor['engine']
 export type FundCalculationSnapshotType = FundCalculationEngineDescriptor['snapshotType'];
 export type FundCalculationQueueKey = FundCalculationEngineDescriptor['queueKey'];
 export type FundCalculationAuthority = FundCalculationEngineDescriptor['authority'];
+export type AuthoritativeCalculationEngineDescriptor = Extract<
+  FundCalculationEngineDescriptor,
+  { authority: 'authoritative' }
+>;
+export type ExperimentalCalculationEngineDescriptor = Extract<
+  FundCalculationEngineDescriptor,
+  { authority: 'experimental' }
+>;
 
 export const AUTHORITATIVE_CALCULATION_ENGINES = FUND_CALCULATION_ENGINE_CATALOG.filter(
-  (engine) => engine.authority === 'authoritative'
-);
+  (engine): engine is AuthoritativeCalculationEngineDescriptor =>
+    engine.authority === 'authoritative'
+) as readonly AuthoritativeCalculationEngineDescriptor[];
+export const EXPERIMENTAL_CALCULATION_ENGINES = FUND_CALCULATION_ENGINE_CATALOG.filter(
+  (engine): engine is ExperimentalCalculationEngineDescriptor => engine.authority === 'experimental'
+) as readonly ExperimentalCalculationEngineDescriptor[];
 
-export const AUTHORITATIVE_ENGINE_KEYS = ['reserve', 'pacing'] as const;
-export const AUTHORITATIVE_SNAPSHOT_TYPES = ['RESERVE', 'PACING'] as const;
+export const AUTHORITATIVE_ENGINE_KEYS = AUTHORITATIVE_CALCULATION_ENGINES.map(
+  (engine) => engine.engine
+) as readonly AuthoritativeCalculationEngineDescriptor['engine'][];
+export const AUTHORITATIVE_SNAPSHOT_TYPES = AUTHORITATIVE_CALCULATION_ENGINES.map(
+  (engine) => engine.snapshotType
+) as readonly AuthoritativeCalculationEngineDescriptor['snapshotType'][];
+export const EXPERIMENTAL_ENGINE_KEYS = EXPERIMENTAL_CALCULATION_ENGINES.map(
+  (engine) => engine.engine
+) as readonly ExperimentalCalculationEngineDescriptor['engine'][];
+export const EXPERIMENTAL_SNAPSHOT_TYPES = EXPERIMENTAL_CALCULATION_ENGINES.map(
+  (engine) => engine.snapshotType
+) as readonly ExperimentalCalculationEngineDescriptor['snapshotType'][];
 
 export type AuthoritativeEngineKey = (typeof AUTHORITATIVE_ENGINE_KEYS)[number];
 export type AuthoritativeSnapshotType = (typeof AUTHORITATIVE_SNAPSHOT_TYPES)[number];
+export type ExperimentalEngineKey = (typeof EXPERIMENTAL_ENGINE_KEYS)[number];
+export type ExperimentalSnapshotType = (typeof EXPERIMENTAL_SNAPSHOT_TYPES)[number];
 
 export function isAuthoritativeEngineKey(engineKey: string): engineKey is AuthoritativeEngineKey {
-  return AUTHORITATIVE_ENGINE_KEYS.includes(engineKey as AuthoritativeEngineKey);
+  return (AUTHORITATIVE_ENGINE_KEYS as readonly string[]).includes(engineKey);
+}
+
+export function isAuthoritativeSnapshotType(
+  snapshotType: string
+): snapshotType is AuthoritativeSnapshotType {
+  return (AUTHORITATIVE_SNAPSHOT_TYPES as readonly string[]).includes(snapshotType);
+}
+
+export function isFundCalculationQueueKey(queueKey: string): queueKey is FundCalculationQueueKey {
+  return FUND_CALCULATION_ENGINE_CATALOG.some((engine) => engine.queueKey === queueKey);
 }
 
 export function getCalculationEngineDescriptor(
@@ -56,6 +90,16 @@ export function getCalculationEngineDescriptor(
   const descriptor = FUND_CALCULATION_ENGINE_CATALOG.find((engine) => engine.engine === engineKey);
   if (!descriptor) {
     throw new Error(`Unknown fund calculation engine: ${engineKey}`);
+  }
+  return descriptor;
+}
+
+export function getCalculationEngineDescriptorByQueueKey(
+  queueKey: FundCalculationQueueKey
+): FundCalculationEngineDescriptor {
+  const descriptor = FUND_CALCULATION_ENGINE_CATALOG.find((engine) => engine.queueKey === queueKey);
+  if (!descriptor) {
+    throw new Error(`Unknown fund calculation queue key: ${queueKey}`);
   }
   return descriptor;
 }

--- a/tests/unit/contract/fund-authoritative-calculations.test.ts
+++ b/tests/unit/contract/fund-authoritative-calculations.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUTHORITATIVE_ENGINE_KEYS,
+  AUTHORITATIVE_SNAPSHOT_TYPES,
+  EXPERIMENTAL_ENGINE_KEYS,
+  EXPERIMENTAL_SNAPSHOT_TYPES,
+  getCalculationEngineDescriptor,
+  getCalculationEngineDescriptorByQueueKey,
+  isAuthoritativeEngineKey,
+  isAuthoritativeSnapshotType,
+} from '@shared/contracts/fund-authoritative-calculations.contract';
+
+describe('fund calculation authority catalog', () => {
+  it('keeps readiness limited to authoritative reserve and pacing engines', () => {
+    expect([...AUTHORITATIVE_ENGINE_KEYS]).toEqual(['reserve', 'pacing']);
+    expect([...AUTHORITATIVE_SNAPSHOT_TYPES]).toEqual(['RESERVE', 'PACING']);
+
+    expect(isAuthoritativeEngineKey('reserve')).toBe(true);
+    expect(isAuthoritativeEngineKey('pacing')).toBe(true);
+    expect(isAuthoritativeEngineKey('cohort')).toBe(false);
+    expect(isAuthoritativeSnapshotType('RESERVE')).toBe(true);
+    expect(isAuthoritativeSnapshotType('PACING')).toBe(true);
+    expect(isAuthoritativeSnapshotType('COHORT')).toBe(false);
+  });
+
+  it('classifies cohort as experimental until it has authoritative snapshots', () => {
+    const cohort = getCalculationEngineDescriptor('cohort');
+
+    expect(cohort).toMatchObject({
+      engine: 'cohort',
+      snapshotType: 'COHORT',
+      queueKey: 'cohort-calc',
+      authority: 'experimental',
+      syncCapable: false,
+    });
+    expect([...EXPERIMENTAL_ENGINE_KEYS]).toContain('cohort');
+    expect([...EXPERIMENTAL_SNAPSHOT_TYPES]).toContain('COHORT');
+    expect([...AUTHORITATIVE_ENGINE_KEYS]).not.toContain('cohort');
+    expect([...AUTHORITATIVE_SNAPSHOT_TYPES]).not.toContain('COHORT');
+  });
+
+  it('resolves queue keys through the same catalog used for readiness', () => {
+    expect(getCalculationEngineDescriptorByQueueKey('reserve-calc').authority).toBe(
+      'authoritative'
+    );
+    expect(getCalculationEngineDescriptorByQueueKey('pacing-calc').authority).toBe(
+      'authoritative'
+    );
+    expect(getCalculationEngineDescriptorByQueueKey('cohort-calc').authority).toBe(
+      'experimental'
+    );
+  });
+});

--- a/tests/unit/phase2a/config-invariants.test.ts
+++ b/tests/unit/phase2a/config-invariants.test.ts
@@ -11,6 +11,10 @@
 import { describe, it, expect } from 'vitest';
 import { fundConfigs, fundSnapshots } from '@shared/schema';
 import { QUEUE_CATALOG } from '../../../server/queues/registry';
+import {
+  getCalculationEngineDescriptorByQueueKey,
+  isFundCalculationQueueKey,
+} from '@shared/contracts/fund-authoritative-calculations.contract';
 
 // ============================================================================
 // Item 1: Config invariant constraint documentation
@@ -71,6 +75,18 @@ describe('Queue name consistency', () => {
     expect(calcQueues.length).toBe(5);
     for (const entry of calcQueues) {
       expect(entry.queueName).toMatch(/^[a-z]+(?:-[a-z]+)*-calc$/);
+    }
+  });
+
+  it('mirrors calculation authority from the shared engine catalog', () => {
+    const calculationQueues = QUEUE_CATALOG.filter(
+      (entry) =>
+        entry.fundCalculationAuthority !== undefined && isFundCalculationQueueKey(entry.queueName)
+    );
+
+    for (const entry of calculationQueues) {
+      const descriptor = getCalculationEngineDescriptorByQueueKey(entry.queueName);
+      expect(entry.fundCalculationAuthority).toBe(descriptor.authority);
     }
   });
 });

--- a/tests/unit/services/post-calc-trigger.test.ts
+++ b/tests/unit/services/post-calc-trigger.test.ts
@@ -121,6 +121,18 @@ describe('post calc-run trigger (Decision 0.1b)', () => {
       expect(result).toBe(false);
       expect(mockDb.update).not.toHaveBeenCalled();
     });
+
+    it('does not treat cohort snapshots as authoritative pacing coverage', async () => {
+      mockDb.query.fundSnapshots.findMany.mockResolvedValue([
+        { type: 'RESERVE' },
+        { type: 'COHORT' },
+      ]);
+
+      const result = await markCalcRunCompletedIfReady(42);
+
+      expect(result).toBe(false);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
   });
 
   describe('handler invocation', () => {


### PR DESCRIPTION
## Scope

- Adds a focused implementation plan for cohort release readiness.
- Derives authoritative and experimental calculation metadata from the shared fund calculation catalog.
- Mirrors lifecycle queue authority from the shared catalog for reserve, pacing, cohort, and economics calculation queues.
- Adds regression coverage proving cohort remains experimental and cannot satisfy authoritative readiness or calc-run completion coverage.
- Commits regenerated discovery-routing artifacts for the new tracked plan document.

## Non-goals

- No cohort snapshot writer, backfill migration, or authoritative cohort graduation.
- No route changes, route mount normalization, new stores, or new dependencies.
- No changes to forecast modes, reserve optimization, methodology guardrails, override expansion, canonical hash semantics, schema-directory naming, money utilities, engine dedupe, Phoenix-protected docs, or scenario comparison behavior.

## Verification

- `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/contract/fund-authoritative-calculations.test.ts tests/unit/phase2a/config-invariants.test.ts tests/unit/services/post-calc-trigger.test.ts tests/unit/phase2b/lifecycle-derivation.test.ts tests/unit/phase2a/calc-runs-publish.test.ts` passed: 5 files, 77 tests.
- `npm run check` passed with 0 baseline/current TypeScript errors.
- `npm run lint` passed.
- `npm run docs:routing:generate` passed and generated routing artifact updates are committed.
- `npm run docs:routing:check` passed.
- `npm run calc-gate` passed.
- `npm run test:scenario-release-gate` exited 0, but the container-backed integration test skipped locally because no working Testcontainers/container runtime strategy was available.
- `git diff --check` passed.
- PR GitHub Actions for `fe3f4e5e` are green, including Documentation Routing Check, CI Unified, CodeQL, Security Deep Scan, Bundle Size Check, Skip Counter, and Claude Code Review.

## CI follow-up

The initial Documentation Routing failure was caused by generating routing artifacts before the new plan file was tracked. The follow-up commit regenerates the artifacts after the plan is tracked, moving the generated inventory from 660 to 661 docs.
