### PR TITLE
feat(hermes): execute pair workflow loop with injected step runners

### DIFF
--- a/orchestrate.js
+++ b/orchestrate.js
@@ -591,6 +591,119 @@ function shouldRunPostflightGate(plan, code, gates) {
   return gates.postflight && (code === 0 || isProductionFinancial(plan));
 }
 
+function defaultRunStep() {
+  throw new Error(
+    'executeWorkflow requires deps.runStep until live model wiring lands; pass an injected step runner.'
+  );
+}
+
+async function executeWorkflow(plan, deps = {}) {
+  const workflow = plan.workflow;
+  if (!workflow || !Array.isArray(workflow.steps)) {
+    throw new Error('executeWorkflow requires a plan with a workflow.steps array.');
+  }
+
+  const maxRepairs = Number.isInteger(deps.maxRepairs) ? deps.maxRepairs : 2;
+  const runStep = deps.runStep || defaultRunStep;
+  const gateRunner = deps.gateRunner || spawnSync;
+  const assertGate = deps.assertFinancialGate || assertFinancialGate;
+  const ledgerWriter = deps.writeRunLedger === undefined ? null : deps.writeRunLedger;
+  const clock = deps.clock || (() => new Date());
+  const runId = deps.runId || generateRunId(clock());
+
+  const stepByRole = (role) => workflow.steps.find((step) => step.role === role) || null;
+  const ownerStep = stepByRole('owner');
+  const specialistStep = stepByRole('specialist');
+  const reviewerStep = stepByRole('reviewer');
+  const auditStep = stepByRole('audit');
+
+  let specialistNotes = null;
+  const records = [];
+  const runRecorded = async (step, input, attempt) => {
+    const result = await runStep({ step, input, notes: specialistNotes, plan, attempt, runId });
+    records.push({
+      role: step.role,
+      model: step.model,
+      attempt,
+      code: result.code ?? 0,
+      approved: result.approved ?? null,
+      output: result.output ?? '',
+    });
+    return result;
+  };
+
+  let artifact = null;
+  let approved = true;
+  let repairs = 0;
+
+  if (ownerStep) {
+    const owner = await runRecorded(ownerStep, null, 0);
+    artifact = owner.output ?? '';
+  }
+
+  if (specialistStep) {
+    const specialist = await runRecorded(specialistStep, artifact, 0);
+    specialistNotes = specialist.output ?? null;
+  }
+
+  if (reviewerStep) {
+    let review = await runRecorded(reviewerStep, artifact, 0);
+    approved = Boolean(review.approved);
+    while (!approved && repairs < maxRepairs && ownerStep) {
+      repairs += 1;
+      const repair = await runRecorded(ownerStep, review.output ?? '', repairs);
+      artifact = repair.output ?? artifact;
+      review = await runRecorded(reviewerStep, artifact, repairs);
+      approved = Boolean(review.approved);
+    }
+  }
+
+  if (auditStep) {
+    await runRecorded(auditStep, artifact, repairs);
+  }
+
+  let gate = { command: plan.gate || null, skipped: !plan.gate, status: 0 };
+  if (plan.gate) {
+    if (isProductionFinancial(plan)) {
+      assertGate(plan);
+    }
+    gate = runGate(plan.gate, { runner: gateRunner, throwOnFailure: false });
+  }
+
+  let exitCode = 0;
+  if (gate.status && gate.status !== 0) {
+    exitCode = gate.status;
+  } else if (reviewerStep && !approved) {
+    exitCode = 1;
+  }
+
+  const record = {
+    runId,
+    workflow: workflow.selected,
+    phase: plan.phase,
+    risk: plan.risk,
+    approved,
+    repairs,
+    steps: records,
+    gate: {
+      command: gate.command ?? null,
+      status: gate.status ?? 0,
+      skipped: gate.skipped ?? false,
+    },
+    exitCode,
+  };
+
+  if (ledgerWriter) {
+    try {
+      ledgerWriter(record);
+    } catch {
+      // ledger persistence is best-effort; the execution result is still returned
+    }
+  }
+
+  return record;
+}
+
 function printHelp(stdout = process.stdout) {
   stdout.write(`Usage:
   node orchestrate.js --phase <research|production|distribution> --task "<description>"
@@ -880,6 +993,7 @@ export {
   chooseModel,
   createWorkflowPlan,
   createRoutingPlan,
+  executeWorkflow,
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -6,6 +6,7 @@ import {
   chooseModel,
   createWorkflowPlan,
   createRoutingPlan,
+  executeWorkflow,
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
@@ -879,6 +880,298 @@ describe('Hermes routing helpers', () => {
       expect(plan.risk).toBe('standard');
       expect(plan.gate).toBe('npm run check');
       expect(() => assertFinancialGate(plan)).not.toThrow();
+    });
+  });
+
+  describe('executeWorkflow', () => {
+    type StepCall = {
+      role: string;
+      model: string | null;
+      input: string | null;
+      notes: string | null;
+      attempt: number;
+    };
+
+    type StepReply = {
+      code?: number;
+      output?: string;
+      approved?: boolean;
+    };
+
+    const makeRunner = (script: Record<string, StepReply | ((attempt: number) => StepReply)>) => {
+      const calls: StepCall[] = [];
+      const runStep = async ({
+        step,
+        input,
+        notes,
+        attempt,
+      }: {
+        step: { role: string; model: string | null };
+        input: string | null;
+        notes: string | null;
+        attempt: number;
+      }) => {
+        calls.push({ role: step.role, model: step.model, input, notes, attempt });
+        const responder = script[step.role];
+        const reply = typeof responder === 'function' ? responder(attempt) : responder || {};
+        return {
+          code: reply.code ?? 0,
+          output: reply.output ?? `${step.role}-${attempt}`,
+          approved: reply.approved,
+        };
+      };
+      return { runStep, calls };
+    };
+
+    const pairPlan = {
+      phase: 'production',
+      risk: 'standard',
+      gate: 'npm run check',
+      workflow: {
+        selected: 'pair',
+        steps: [
+          { role: 'owner', model: 'codex', action: 'execute production worker-executor lane' },
+          { role: 'reviewer', model: 'claude', action: 'review diff plus tests' },
+          { role: 'gate', model: null, action: 'run npm run check' },
+        ],
+      },
+    };
+
+    const financialPairPlan = {
+      phase: 'production',
+      risk: 'financial',
+      gate: 'npm run calc-gate',
+      workflow: {
+        selected: 'pair',
+        steps: [
+          {
+            role: 'owner',
+            model: 'codex',
+            action: 'execute production-financial worker-executor lane',
+          },
+          {
+            role: 'specialist',
+            model: 'precision-specialist',
+            action: 'review financial risk before completion',
+          },
+          { role: 'reviewer', model: 'claude', action: 'review diff plus truth-case notes' },
+          { role: 'audit', model: 'kimi', action: 'audit financial readiness evidence' },
+          { role: 'gate', model: null, action: 'run npm run calc-gate' },
+        ],
+      },
+    };
+
+    test('throws without an injected step runner', async () => {
+      await expect(
+        executeWorkflow(pairPlan, { gateRunner: () => ({ status: 0 }) })
+      ).rejects.toThrow('requires deps.runStep');
+    });
+
+    test('throws when the plan has no workflow steps', async () => {
+      await expect(executeWorkflow({ phase: 'production' }, {})).rejects.toThrow(
+        'workflow.steps array'
+      );
+    });
+
+    test('runs owner then reviewer and passes the gate when the reviewer approves first', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: true },
+      });
+      const gateCalls: string[] = [];
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: (bin: string, args: string[]) => {
+          gateCalls.push([bin, ...args].join(' '));
+          return { status: 0 };
+        },
+        writeRunLedger: null,
+      });
+
+      expect(record.approved).toBe(true);
+      expect(record.repairs).toBe(0);
+      expect(record.exitCode).toBe(0);
+      expect(record.gate).toMatchObject({ command: 'npm run check', status: 0 });
+      expect(gateCalls).toEqual(['npm run check']);
+      expect(calls.map((call) => call.role)).toEqual(['owner', 'reviewer']);
+      expect(calls[1].input).toBe('owner-diff');
+    });
+
+    test('threads review feedback back to the owner across a bounded repair loop', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: (attempt) => ({ output: `owner-diff-${attempt}` }),
+        reviewer: (attempt) => ({
+          approved: attempt >= 1,
+          output: `please-fix-${attempt}`,
+        }),
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.repairs).toBe(1);
+      expect(record.approved).toBe(true);
+      expect(record.exitCode).toBe(0);
+      expect(calls.map((call) => call.role)).toEqual(['owner', 'reviewer', 'owner', 'reviewer']);
+      expect(calls[2].input).toBe('please-fix-0');
+      expect(calls[3].input).toBe('owner-diff-1');
+    });
+
+    test('stops at the repair cap and reports not-ready when the reviewer never approves', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: false, output: 'still-wrong' },
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.repairs).toBe(2);
+      expect(record.approved).toBe(false);
+      expect(record.exitCode).toBe(1);
+      expect(calls.filter((call) => call.role === 'owner')).toHaveLength(3);
+      expect(calls.filter((call) => call.role === 'reviewer')).toHaveLength(3);
+    });
+
+    test('honors a custom repair cap from deps.maxRepairs', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: false, output: 'still-wrong' },
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        maxRepairs: 1,
+        writeRunLedger: null,
+      });
+
+      expect(record.repairs).toBe(1);
+      expect(calls.filter((call) => call.role === 'owner')).toHaveLength(2);
+    });
+
+    test('reports the gate exit code when the gate fails after approval', async () => {
+      const { runStep } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: true },
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 2 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.approved).toBe(true);
+      expect(record.exitCode).toBe(2);
+      expect(record.gate.status).toBe(2);
+    });
+
+    test('runs specialist before and audit after the loop for a financial pair', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        specialist: { output: 'risk-reviewed' },
+        reviewer: { approved: true },
+        audit: { output: 'audited' },
+      });
+      const gateCalls: string[] = [];
+
+      const record = await executeWorkflow(financialPairPlan, {
+        runStep,
+        gateRunner: (bin: string, args: string[]) => {
+          gateCalls.push([bin, ...args].join(' '));
+          return { status: 0 };
+        },
+        writeRunLedger: null,
+      });
+
+      expect(record.exitCode).toBe(0);
+      expect(record.approved).toBe(true);
+      expect(gateCalls).toEqual(['npm run calc-gate']);
+      expect(calls.map((call) => call.role)).toEqual(['owner', 'specialist', 'reviewer', 'audit']);
+    });
+
+    test('routes the owner diff with specialist notes to the reviewer in a financial pair', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        specialist: { output: 'risk-notes' },
+        reviewer: { approved: true },
+        audit: { output: 'audited' },
+      });
+
+      await executeWorkflow(financialPairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      const reviewerCall = calls.find((call) => call.role === 'reviewer');
+      expect(reviewerCall?.input).toBe('owner-diff');
+      expect(reviewerCall?.notes).toBe('risk-notes');
+    });
+
+    test('asserts the financial readiness gate before running it', async () => {
+      const { runStep } = makeRunner({
+        owner: { output: 'owner-diff' },
+        specialist: { output: 'risk-reviewed' },
+        reviewer: { approved: true },
+        audit: { output: 'audited' },
+      });
+
+      const misconfigured = {
+        ...financialPairPlan,
+        gate: 'npm run check',
+      };
+      let gateRan = false;
+
+      await expect(
+        executeWorkflow(misconfigured, {
+          runStep,
+          gateRunner: () => {
+            gateRan = true;
+            return { status: 0 };
+          },
+          writeRunLedger: null,
+        })
+      ).rejects.toThrow('npm run calc-gate');
+
+      expect(gateRan).toBe(false);
+    });
+
+    test('persists a run ledger capturing steps, repairs, gate, and exit code', async () => {
+      const { runStep } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: true },
+      });
+      const ledgerCalls: Array<Record<string, unknown>> = [];
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        clock: () => new Date('2026-05-20T18:30:45.123Z'),
+        writeRunLedger: (entry: Record<string, unknown>) => ledgerCalls.push(entry),
+      });
+
+      expect(record.runId).toBe('hermes-2026-05-20T18-30-45-123Z');
+      expect(ledgerCalls).toHaveLength(1);
+      expect(ledgerCalls[0]).toMatchObject({
+        runId: 'hermes-2026-05-20T18-30-45-123Z',
+        workflow: 'pair',
+        approved: true,
+        repairs: 0,
+        exitCode: 0,
+      });
+      expect(record.steps.map((step: { role: string }) => step.role)).toEqual([
+        'owner',
+        'reviewer',
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `executeWorkflow(plan, deps)` to `orchestrate.js`: the first multi-step Hermes
  workflow that actually executes, driven by a dependency-injected step runner returning
  `{ code, output, approved }`.
- Pair loop: owner implements -> (specialist reviews risk, once) -> bounded owner/reviewer
  repair loop (default 2, early-exit on `approved`) -> (audit, once) -> resolved gate.
  Financial pairs call `assertFinancialGate` to prove the `npm run calc-gate` readiness
  contract before running the gate.
- The reviewer reviews the owner's diff with the specialist's findings threaded as separate
  `notes` (the production-financial "diff plus truth-case notes" ownership contract); the
  specialist no longer overwrites the diff.
- Per-step outputs persist to the existing run ledger (`ai-logs/hermes/runs/`).

## Scope / deferred to PR5

- `executeModel`, `main()`, and the planning-only `--workflow` guard are UNCHANGED. Live
  `--workflow pair` still no-ops (planning-only) by design.
- Live model wiring (capturing real model stdout / git-diff handoff, lifting the `main()`
  guard, in-band delivery of notes to a real reviewer) is deferred to PR5. This PR lands the
  loop on injected runners only, so it is fully deterministic and reviewable.

## Test Plan

- [x] `node --check orchestrate.js`
- [x] `npx eslint orchestrate.js tests/unit/routing/hermes-routing.test.ts --max-warnings 0`
- [x] `npx prettier --check` both files (clean)
- [x] `TZ=UTC npx vitest run tests/unit/routing/` — 120 passed (hermes-routing.test.ts: 52)
- [x] `npm run check` — 0 new TypeScript errors
- [x] Independent `import()` behavioral re-run: repair-loop threading, financial gate
      assertion (throws before gate runs), owner-diff-with-notes threading
- [x] Pre-push baseline gate green (0 new errors, orphan-test check passed)

11 new deterministic tests cover: approve-first, repair-feedback threading, repair cap
(default and custom), gate failure, financial step order, readiness-assert-before-gate,
owner-diff-with-specialist-notes threading, and ledger capture.

Built via Hermes dispatch (Codex implementation + Claude review/verification), per the repo
workflow contract.

Generated with Claude Code
