### PR TITLE
feat(hermes): real debate workflow + structured readiness boundary (PR5)

### DIFF
--- a/.claude/hermes/model-routing.json
+++ b/.claude/hermes/model-routing.json
@@ -38,6 +38,10 @@
       "gate": "npm run lint"
     }
   },
+  "debate": {
+    "comparators": ["claude", "codex", "kimi"],
+    "synthesis": "claude"
+  },
   "longContextModel": "kimi",
   "longContextTriggers": [
     "full repo audit",

--- a/DEV_BRAIN.md
+++ b/DEV_BRAIN.md
@@ -38,6 +38,18 @@ the model-specific governance files remain authoritative.
 | production-financial           | Codex plus specialist | Diff plus truth notes | `npm run calc-gate`                                                                           |
 | distribution                   | Claude                | PR-ready summary      | `npm run lint` plus relevant tests                                                            |
 
+## Workflow Modes
+
+- solo: owner only. pair: owner plus reviewer with a bounded repair loop.
+- chain: owner plus optional specialist plus reviewer (research reviewer is
+  Kimi).
+- debate: N comparators plus a synthesis step (roster in model-routing.json
+  `debate`; default claude, codex, kimi compare and claude synthesizes). Opt-in
+  via `--workflow debate`.
+- review: reviews an existing artifact and never re-runs the owner lane.
+  Distribution ownership has no reviewer, so distribution review is gate-only by
+  design.
+
 ## Specialist Escalation
 
 - Waterfall/carry/clawback: `waterfall-specialist`

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -17,6 +17,11 @@ const WORKFLOW_DEFERRED_BEHAVIOR = [
   'review platform automation',
 ];
 
+const DEFAULT_DEBATE = {
+  comparators: ['claude', 'codex', 'kimi'],
+  synthesis: 'claude',
+};
+
 function normalizeEntrypointPath(value) {
   return String(value || '')
     .replace(/^file:\/\//, '')
@@ -232,6 +237,7 @@ function createWorkflowPlan({
   gate,
   ownership = null,
   risk = 'standard',
+  debate = null,
 }) {
   if (!WORKFLOW_MODES.has(requestedWorkflow)) {
     throw new Error(
@@ -246,7 +252,11 @@ function createWorkflowPlan({
   const artifact = ownership?.artifact || 'artifact';
   const steps = [];
 
-  if (selected !== 'review' && ownerModel) {
+  // 'review' mode reviews an existing artifact, so it never re-runs the owner lane;
+  // because distribution ownership has no reviewer, distribution 'review' is
+  // gate-only by design (the lint gate is the review). 'debate' replaces the single
+  // owner lane with N comparators plus a synthesis step (added below).
+  if (selected !== 'review' && selected !== 'debate' && ownerModel) {
     const role = ownership?.role ? ` ${ownership.role}` : '';
     steps.push({
       role: 'owner',
@@ -274,7 +284,8 @@ function createWorkflowPlan({
     });
   }
 
-  if ((selected === 'chain' || selected === 'debate' || selected === 'pair') && ownership?.audit) {
+  // Debate carries no audit step by design; synthesis is the accountable artifact.
+  if ((selected === 'chain' || selected === 'pair') && ownership?.audit) {
     steps.push({
       role: 'audit',
       model: ownership.audit,
@@ -283,11 +294,26 @@ function createWorkflowPlan({
     });
   }
 
-  if (selected === 'debate' && steps.length === 0 && ownerModel) {
+  if (selected === 'debate') {
+    const debateConfig = debate || DEFAULT_DEBATE;
+    const comparatorModels =
+      Array.isArray(debateConfig.comparators) && debateConfig.comparators.length > 0
+        ? debateConfig.comparators
+        : DEFAULT_DEBATE.comparators;
+    const synthesisModel = debateConfig.synthesis || DEFAULT_DEBATE.synthesis;
+
+    for (const comparatorModel of comparatorModels) {
+      steps.push({
+        role: 'comparator',
+        model: comparatorModel,
+        action: `compare ${effectivePhase} options`,
+      });
+    }
+
     steps.push({
-      role: 'owner',
-      model: ownerModel,
-      action: `compare ${effectivePhase} options`,
+      role: 'synthesis',
+      model: synthesisModel,
+      action: `synthesize ${effectivePhase} options into ${artifact}`,
     });
   }
 
@@ -345,6 +371,7 @@ function createRoutingPlan({
       gate,
       ownership,
       risk,
+      debate: routing.debate || null,
     });
   }
 
@@ -587,6 +614,33 @@ function assertFinancialGate(plan) {
   }
 }
 
+// Structured readiness boundary. assertFinancialGate stays the throwing core; this
+// wraps it so a CLI or report surface can present a not-ready outcome without
+// crashing. When an execution result is supplied, a nonzero exit or an unapproved
+// artifact also blocks readiness.
+function evaluateReadiness(plan, result = null) {
+  if (!plan || typeof plan !== 'object') {
+    return { ready: false, reason: 'evaluateReadiness requires a plan object.' };
+  }
+
+  try {
+    assertFinancialGate(plan);
+  } catch (error) {
+    return { ready: false, reason: error.message };
+  }
+
+  if (result) {
+    if (Number.isInteger(result.exitCode) && result.exitCode !== 0) {
+      return { ready: false, reason: `workflow exited with code ${result.exitCode}` };
+    }
+    if (result.approved === false) {
+      return { ready: false, reason: 'reviewer did not approve the artifact' };
+    }
+  }
+
+  return { ready: true, reason: null };
+}
+
 function shouldRunPostflightGate(plan, code, gates) {
   return gates.postflight && (code === 0 || isProductionFinancial(plan));
 }
@@ -616,6 +670,8 @@ async function executeWorkflow(plan, deps = {}) {
   const specialistStep = stepByRole('specialist');
   const reviewerStep = stepByRole('reviewer');
   const auditStep = stepByRole('audit');
+  const comparatorSteps = workflow.steps.filter((step) => step.role === 'comparator');
+  const synthesisStep = stepByRole('synthesis');
 
   let specialistNotes = null;
   const records = [];
@@ -636,30 +692,42 @@ async function executeWorkflow(plan, deps = {}) {
   let approved = true;
   let repairs = 0;
 
-  if (ownerStep) {
-    const owner = await runRecorded(ownerStep, null, 0);
-    artifact = owner.output ?? '';
-  }
-
-  if (specialistStep) {
-    const specialist = await runRecorded(specialistStep, artifact, 0);
-    specialistNotes = specialist.output ?? null;
-  }
-
-  if (reviewerStep) {
-    let review = await runRecorded(reviewerStep, artifact, 0);
-    approved = Boolean(review.approved);
-    while (!approved && repairs < maxRepairs && ownerStep) {
-      repairs += 1;
-      const repair = await runRecorded(ownerStep, review.output ?? '', repairs);
-      artifact = repair.output ?? artifact;
-      review = await runRecorded(reviewerStep, artifact, repairs);
-      approved = Boolean(review.approved);
+  if (comparatorSteps.length > 0) {
+    const comparatorOutputs = [];
+    for (const comparatorStep of comparatorSteps) {
+      const comparator = await runRecorded(comparatorStep, null, 0);
+      comparatorOutputs.push(comparator.output ?? '');
     }
-  }
+    if (synthesisStep) {
+      const synthesis = await runRecorded(synthesisStep, comparatorOutputs, 0);
+      artifact = synthesis.output ?? '';
+    }
+  } else {
+    if (ownerStep) {
+      const owner = await runRecorded(ownerStep, null, 0);
+      artifact = owner.output ?? '';
+    }
 
-  if (auditStep) {
-    await runRecorded(auditStep, artifact, repairs);
+    if (specialistStep) {
+      const specialist = await runRecorded(specialistStep, artifact, 0);
+      specialistNotes = specialist.output ?? null;
+    }
+
+    if (reviewerStep) {
+      let review = await runRecorded(reviewerStep, artifact, 0);
+      approved = Boolean(review.approved);
+      while (!approved && repairs < maxRepairs && ownerStep) {
+        repairs += 1;
+        const repair = await runRecorded(ownerStep, review.output ?? '', repairs);
+        artifact = repair.output ?? artifact;
+        review = await runRecorded(reviewerStep, artifact, repairs);
+        approved = Boolean(review.approved);
+      }
+    }
+
+    if (auditStep) {
+      await runRecorded(auditStep, artifact, repairs);
+    }
   }
 
   let gate = { command: plan.gate || null, skipped: !plan.gate, status: 0 };
@@ -993,6 +1061,7 @@ export {
   chooseModel,
   createWorkflowPlan,
   createRoutingPlan,
+  evaluateReadiness,
   executeWorkflow,
   generateRunId,
   getGateRunPlan,

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -591,6 +591,119 @@ function shouldRunPostflightGate(plan, code, gates) {
   return gates.postflight && (code === 0 || isProductionFinancial(plan));
 }
 
+function defaultRunStep() {
+  throw new Error(
+    'executeWorkflow requires deps.runStep until live model wiring lands; pass an injected step runner.'
+  );
+}
+
+async function executeWorkflow(plan, deps = {}) {
+  const workflow = plan.workflow;
+  if (!workflow || !Array.isArray(workflow.steps)) {
+    throw new Error('executeWorkflow requires a plan with a workflow.steps array.');
+  }
+
+  const maxRepairs = Number.isInteger(deps.maxRepairs) ? deps.maxRepairs : 2;
+  const runStep = deps.runStep || defaultRunStep;
+  const gateRunner = deps.gateRunner || spawnSync;
+  const assertGate = deps.assertFinancialGate || assertFinancialGate;
+  const ledgerWriter = deps.writeRunLedger === undefined ? null : deps.writeRunLedger;
+  const clock = deps.clock || (() => new Date());
+  const runId = deps.runId || generateRunId(clock());
+
+  const stepByRole = (role) => workflow.steps.find((step) => step.role === role) || null;
+  const ownerStep = stepByRole('owner');
+  const specialistStep = stepByRole('specialist');
+  const reviewerStep = stepByRole('reviewer');
+  const auditStep = stepByRole('audit');
+
+  let specialistNotes = null;
+  const records = [];
+  const runRecorded = async (step, input, attempt) => {
+    const result = await runStep({ step, input, notes: specialistNotes, plan, attempt, runId });
+    records.push({
+      role: step.role,
+      model: step.model,
+      attempt,
+      code: result.code ?? 0,
+      approved: result.approved ?? null,
+      output: result.output ?? '',
+    });
+    return result;
+  };
+
+  let artifact = null;
+  let approved = true;
+  let repairs = 0;
+
+  if (ownerStep) {
+    const owner = await runRecorded(ownerStep, null, 0);
+    artifact = owner.output ?? '';
+  }
+
+  if (specialistStep) {
+    const specialist = await runRecorded(specialistStep, artifact, 0);
+    specialistNotes = specialist.output ?? null;
+  }
+
+  if (reviewerStep) {
+    let review = await runRecorded(reviewerStep, artifact, 0);
+    approved = Boolean(review.approved);
+    while (!approved && repairs < maxRepairs && ownerStep) {
+      repairs += 1;
+      const repair = await runRecorded(ownerStep, review.output ?? '', repairs);
+      artifact = repair.output ?? artifact;
+      review = await runRecorded(reviewerStep, artifact, repairs);
+      approved = Boolean(review.approved);
+    }
+  }
+
+  if (auditStep) {
+    await runRecorded(auditStep, artifact, repairs);
+  }
+
+  let gate = { command: plan.gate || null, skipped: !plan.gate, status: 0 };
+  if (plan.gate) {
+    if (isProductionFinancial(plan)) {
+      assertGate(plan);
+    }
+    gate = runGate(plan.gate, { runner: gateRunner, throwOnFailure: false });
+  }
+
+  let exitCode = 0;
+  if (gate.status && gate.status !== 0) {
+    exitCode = gate.status;
+  } else if (reviewerStep && !approved) {
+    exitCode = 1;
+  }
+
+  const record = {
+    runId,
+    workflow: workflow.selected,
+    phase: plan.phase,
+    risk: plan.risk,
+    approved,
+    repairs,
+    steps: records,
+    gate: {
+      command: gate.command ?? null,
+      status: gate.status ?? 0,
+      skipped: gate.skipped ?? false,
+    },
+    exitCode,
+  };
+
+  if (ledgerWriter) {
+    try {
+      ledgerWriter(record);
+    } catch {
+      // ledger persistence is best-effort; the execution result is still returned
+    }
+  }
+
+  return record;
+}
+
 function printHelp(stdout = process.stdout) {
   stdout.write(`Usage:
   node orchestrate.js --phase <research|production|distribution> --task "<description>"
@@ -880,6 +993,7 @@ export {
   chooseModel,
   createWorkflowPlan,
   createRoutingPlan,
+  executeWorkflow,
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -6,6 +6,7 @@ import {
   chooseModel,
   createWorkflowPlan,
   createRoutingPlan,
+  evaluateReadiness,
   executeWorkflow,
   generateRunId,
   getGateRunPlan,
@@ -454,6 +455,51 @@ describe('Hermes routing helpers', () => {
         action: 'run npm run check',
       },
     ]);
+  });
+
+  test('createWorkflowPlan builds debate comparators and synthesis from routing config', () => {
+    const workflow = createWorkflowPlan({
+      requestedWorkflow: 'debate',
+      phase: 'production',
+      model: 'codex',
+      specialist: null,
+      gate: 'npm run check',
+      ownership: { effectivePhase: 'production', owner: 'codex', reviewer: 'claude' },
+      risk: 'standard',
+      debate: { comparators: ['claude', 'codex', 'kimi'], synthesis: 'claude' },
+    });
+
+    expect(workflow.selected).toBe('debate');
+    expect(workflow.steps.map((step) => step.role)).toEqual([
+      'comparator',
+      'comparator',
+      'comparator',
+      'synthesis',
+      'gate',
+    ]);
+    expect(
+      workflow.steps.filter((step) => step.role === 'comparator').map((step) => step.model)
+    ).toEqual(['claude', 'codex', 'kimi']);
+    const synthesis = workflow.steps.find((step) => step.role === 'synthesis');
+    expect(synthesis?.model).toBe('claude');
+    expect(workflow.steps.some((step) => step.role === 'owner')).toBe(false);
+  });
+
+  test('createWorkflowPlan falls back to the default debate roster when none is provided', () => {
+    const workflow = createWorkflowPlan({
+      requestedWorkflow: 'debate',
+      phase: 'production',
+      model: 'codex',
+      specialist: null,
+      gate: 'npm run check',
+      ownership: { effectivePhase: 'production', owner: 'codex', reviewer: 'claude' },
+      risk: 'standard',
+    });
+
+    expect(
+      workflow.steps.filter((step) => step.role === 'comparator').map((step) => step.model)
+    ).toEqual(['claude', 'codex', 'kimi']);
+    expect(workflow.steps.find((step) => step.role === 'synthesis')?.model).toBe('claude');
   });
 
   test('resolveEffectivePhase promotes financial production work', () => {
@@ -1172,6 +1218,136 @@ describe('Hermes routing helpers', () => {
         'owner',
         'reviewer',
       ]);
+    });
+
+    const debatePlan = {
+      phase: 'production',
+      risk: 'standard',
+      gate: 'npm run check',
+      workflow: {
+        selected: 'debate',
+        steps: [
+          { role: 'comparator', model: 'claude', action: 'compare production options' },
+          { role: 'comparator', model: 'codex', action: 'compare production options' },
+          { role: 'comparator', model: 'kimi', action: 'compare production options' },
+          {
+            role: 'synthesis',
+            model: 'claude',
+            action: 'synthesize production options into diff plus tests',
+          },
+          { role: 'gate', model: null, action: 'run npm run check' },
+        ],
+      },
+    };
+
+    const chainPlan = {
+      phase: 'research',
+      risk: 'standard',
+      gate: 'npm run doctor:quick',
+      workflow: {
+        selected: 'chain',
+        steps: [
+          { role: 'owner', model: 'claude', action: 'execute research leader-coordinator lane' },
+          { role: 'reviewer', model: 'kimi', action: 'review implementation brief' },
+          { role: 'gate', model: null, action: 'run npm run doctor:quick' },
+        ],
+      },
+    };
+
+    // NOTE: the synthesis step receives an ARRAY of comparator outputs as `input`,
+    // unlike every other role which receives a string or null. This test therefore
+    // uses its own inline runStep typed `input: unknown`. Do NOT reuse makeRunner
+    // here and do NOT "fix" the array-vs-string type difference; it is intentional.
+    test('runs every comparator then synthesis for a debate workflow', async () => {
+      const calls: Array<{ role: string; model: string | null; input: unknown }> = [];
+      const runStep = async ({
+        step,
+        input,
+      }: {
+        step: { role: string; model: string | null };
+        input: unknown;
+      }) => {
+        calls.push({ role: step.role, model: step.model, input });
+        return { code: 0, output: `${step.model}-option`, approved: undefined };
+      };
+
+      const record = await executeWorkflow(debatePlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.workflow).toBe('debate');
+      expect(record.exitCode).toBe(0);
+      expect(record.approved).toBe(true);
+      expect(calls.map((call) => call.role)).toEqual([
+        'comparator',
+        'comparator',
+        'comparator',
+        'synthesis',
+      ]);
+      const synthesisCall = calls.find((call) => call.role === 'synthesis');
+      expect(synthesisCall?.input).toEqual(['claude-option', 'codex-option', 'kimi-option']);
+    });
+
+    test('executes a research chain through the generic engine', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'brief' },
+        reviewer: { approved: true },
+      });
+
+      const record = await executeWorkflow(chainPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.workflow).toBe('chain');
+      expect(record.exitCode).toBe(0);
+      expect(record.approved).toBe(true);
+      expect(calls.map((call) => call.role)).toEqual(['owner', 'reviewer']);
+      expect(calls[1].input).toBe('brief');
+    });
+
+    describe('evaluateReadiness', () => {
+      test('is ready for a financial plan that resolves the correct gate', () => {
+        expect(
+          evaluateReadiness({ phase: 'production', risk: 'financial', gate: 'npm run calc-gate' })
+        ).toEqual({ ready: true, reason: null });
+      });
+
+      test('blocks a financial plan whose gate is not the calc gate', () => {
+        const verdict = evaluateReadiness({
+          phase: 'production',
+          risk: 'financial',
+          gate: 'npm run check',
+        });
+        expect(verdict.ready).toBe(false);
+        expect(verdict.reason).toContain('npm run calc-gate');
+      });
+
+      test('is ready for a non-financial plan', () => {
+        expect(
+          evaluateReadiness({ phase: 'production', risk: 'standard', gate: 'npm run check' }).ready
+        ).toBe(true);
+      });
+
+      test('blocks when the execution result has a nonzero exit code', () => {
+        const verdict = evaluateReadiness(
+          { phase: 'production', risk: 'standard', gate: 'npm run check' },
+          { exitCode: 2, approved: true }
+        );
+        expect(verdict.ready).toBe(false);
+        expect(verdict.reason).toContain('2');
+      });
+
+      test('blocks when the reviewer did not approve', () => {
+        const verdict = evaluateReadiness(
+          { phase: 'production', risk: 'standard', gate: 'npm run check' },
+          { exitCode: 0, approved: false }
+        );
+        expect(verdict.ready).toBe(false);
+      });
     });
   });
 });

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -6,6 +6,7 @@ import {
   chooseModel,
   createWorkflowPlan,
   createRoutingPlan,
+  executeWorkflow,
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
@@ -879,6 +880,298 @@ describe('Hermes routing helpers', () => {
       expect(plan.risk).toBe('standard');
       expect(plan.gate).toBe('npm run check');
       expect(() => assertFinancialGate(plan)).not.toThrow();
+    });
+  });
+
+  describe('executeWorkflow', () => {
+    type StepCall = {
+      role: string;
+      model: string | null;
+      input: string | null;
+      notes: string | null;
+      attempt: number;
+    };
+
+    type StepReply = {
+      code?: number;
+      output?: string;
+      approved?: boolean;
+    };
+
+    const makeRunner = (script: Record<string, StepReply | ((attempt: number) => StepReply)>) => {
+      const calls: StepCall[] = [];
+      const runStep = async ({
+        step,
+        input,
+        notes,
+        attempt,
+      }: {
+        step: { role: string; model: string | null };
+        input: string | null;
+        notes: string | null;
+        attempt: number;
+      }) => {
+        calls.push({ role: step.role, model: step.model, input, notes, attempt });
+        const responder = script[step.role];
+        const reply = typeof responder === 'function' ? responder(attempt) : responder || {};
+        return {
+          code: reply.code ?? 0,
+          output: reply.output ?? `${step.role}-${attempt}`,
+          approved: reply.approved,
+        };
+      };
+      return { runStep, calls };
+    };
+
+    const pairPlan = {
+      phase: 'production',
+      risk: 'standard',
+      gate: 'npm run check',
+      workflow: {
+        selected: 'pair',
+        steps: [
+          { role: 'owner', model: 'codex', action: 'execute production worker-executor lane' },
+          { role: 'reviewer', model: 'claude', action: 'review diff plus tests' },
+          { role: 'gate', model: null, action: 'run npm run check' },
+        ],
+      },
+    };
+
+    const financialPairPlan = {
+      phase: 'production',
+      risk: 'financial',
+      gate: 'npm run calc-gate',
+      workflow: {
+        selected: 'pair',
+        steps: [
+          {
+            role: 'owner',
+            model: 'codex',
+            action: 'execute production-financial worker-executor lane',
+          },
+          {
+            role: 'specialist',
+            model: 'precision-specialist',
+            action: 'review financial risk before completion',
+          },
+          { role: 'reviewer', model: 'claude', action: 'review diff plus truth-case notes' },
+          { role: 'audit', model: 'kimi', action: 'audit financial readiness evidence' },
+          { role: 'gate', model: null, action: 'run npm run calc-gate' },
+        ],
+      },
+    };
+
+    test('throws without an injected step runner', async () => {
+      await expect(
+        executeWorkflow(pairPlan, { gateRunner: () => ({ status: 0 }) })
+      ).rejects.toThrow('requires deps.runStep');
+    });
+
+    test('throws when the plan has no workflow steps', async () => {
+      await expect(executeWorkflow({ phase: 'production' }, {})).rejects.toThrow(
+        'workflow.steps array'
+      );
+    });
+
+    test('runs owner then reviewer and passes the gate when the reviewer approves first', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: true },
+      });
+      const gateCalls: string[] = [];
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: (bin: string, args: string[]) => {
+          gateCalls.push([bin, ...args].join(' '));
+          return { status: 0 };
+        },
+        writeRunLedger: null,
+      });
+
+      expect(record.approved).toBe(true);
+      expect(record.repairs).toBe(0);
+      expect(record.exitCode).toBe(0);
+      expect(record.gate).toMatchObject({ command: 'npm run check', status: 0 });
+      expect(gateCalls).toEqual(['npm run check']);
+      expect(calls.map((call) => call.role)).toEqual(['owner', 'reviewer']);
+      expect(calls[1].input).toBe('owner-diff');
+    });
+
+    test('threads review feedback back to the owner across a bounded repair loop', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: (attempt) => ({ output: `owner-diff-${attempt}` }),
+        reviewer: (attempt) => ({
+          approved: attempt >= 1,
+          output: `please-fix-${attempt}`,
+        }),
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.repairs).toBe(1);
+      expect(record.approved).toBe(true);
+      expect(record.exitCode).toBe(0);
+      expect(calls.map((call) => call.role)).toEqual(['owner', 'reviewer', 'owner', 'reviewer']);
+      expect(calls[2].input).toBe('please-fix-0');
+      expect(calls[3].input).toBe('owner-diff-1');
+    });
+
+    test('stops at the repair cap and reports not-ready when the reviewer never approves', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: false, output: 'still-wrong' },
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.repairs).toBe(2);
+      expect(record.approved).toBe(false);
+      expect(record.exitCode).toBe(1);
+      expect(calls.filter((call) => call.role === 'owner')).toHaveLength(3);
+      expect(calls.filter((call) => call.role === 'reviewer')).toHaveLength(3);
+    });
+
+    test('honors a custom repair cap from deps.maxRepairs', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: false, output: 'still-wrong' },
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        maxRepairs: 1,
+        writeRunLedger: null,
+      });
+
+      expect(record.repairs).toBe(1);
+      expect(calls.filter((call) => call.role === 'owner')).toHaveLength(2);
+    });
+
+    test('reports the gate exit code when the gate fails after approval', async () => {
+      const { runStep } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: true },
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 2 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.approved).toBe(true);
+      expect(record.exitCode).toBe(2);
+      expect(record.gate.status).toBe(2);
+    });
+
+    test('runs specialist before and audit after the loop for a financial pair', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        specialist: { output: 'risk-reviewed' },
+        reviewer: { approved: true },
+        audit: { output: 'audited' },
+      });
+      const gateCalls: string[] = [];
+
+      const record = await executeWorkflow(financialPairPlan, {
+        runStep,
+        gateRunner: (bin: string, args: string[]) => {
+          gateCalls.push([bin, ...args].join(' '));
+          return { status: 0 };
+        },
+        writeRunLedger: null,
+      });
+
+      expect(record.exitCode).toBe(0);
+      expect(record.approved).toBe(true);
+      expect(gateCalls).toEqual(['npm run calc-gate']);
+      expect(calls.map((call) => call.role)).toEqual(['owner', 'specialist', 'reviewer', 'audit']);
+    });
+
+    test('routes the owner diff with specialist notes to the reviewer in a financial pair', async () => {
+      const { runStep, calls } = makeRunner({
+        owner: { output: 'owner-diff' },
+        specialist: { output: 'risk-notes' },
+        reviewer: { approved: true },
+        audit: { output: 'audited' },
+      });
+
+      await executeWorkflow(financialPairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      const reviewerCall = calls.find((call) => call.role === 'reviewer');
+      expect(reviewerCall?.input).toBe('owner-diff');
+      expect(reviewerCall?.notes).toBe('risk-notes');
+    });
+
+    test('asserts the financial readiness gate before running it', async () => {
+      const { runStep } = makeRunner({
+        owner: { output: 'owner-diff' },
+        specialist: { output: 'risk-reviewed' },
+        reviewer: { approved: true },
+        audit: { output: 'audited' },
+      });
+
+      const misconfigured = {
+        ...financialPairPlan,
+        gate: 'npm run check',
+      };
+      let gateRan = false;
+
+      await expect(
+        executeWorkflow(misconfigured, {
+          runStep,
+          gateRunner: () => {
+            gateRan = true;
+            return { status: 0 };
+          },
+          writeRunLedger: null,
+        })
+      ).rejects.toThrow('npm run calc-gate');
+
+      expect(gateRan).toBe(false);
+    });
+
+    test('persists a run ledger capturing steps, repairs, gate, and exit code', async () => {
+      const { runStep } = makeRunner({
+        owner: { output: 'owner-diff' },
+        reviewer: { approved: true },
+      });
+      const ledgerCalls: Array<Record<string, unknown>> = [];
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        clock: () => new Date('2026-05-20T18:30:45.123Z'),
+        writeRunLedger: (entry: Record<string, unknown>) => ledgerCalls.push(entry),
+      });
+
+      expect(record.runId).toBe('hermes-2026-05-20T18-30-45-123Z');
+      expect(ledgerCalls).toHaveLength(1);
+      expect(ledgerCalls[0]).toMatchObject({
+        runId: 'hermes-2026-05-20T18-30-45-123Z',
+        workflow: 'pair',
+        approved: true,
+        repairs: 0,
+        exitCode: 0,
+      });
+      expect(record.steps.map((step: { role: string }) => step.role)).toEqual([
+        'owner',
+        'reviewer',
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

PR5 of the Hermes build-out: extend execution beyond pair with a **real debate
mode** and wire the financial **readiness boundary** as a structured,
non-throwing surface. Stacked on PR #737 (PR4 pair execution) — base branch is
`feat/hermes-pair-execution`; rebase onto `main` after #737 merges.

All changes are additive. Execution stays on **injected runners**; the `main()`
live-workflow guard is untouched. No financial calculation logic is touched.

## What changed

- **Real debate** — `createWorkflowPlan` now emits N comparator steps plus a
  synthesis step, replacing the dead degenerate `owner -> gate` branch (the old
  `steps.length === 0` guard could never fire). Roster comes from a new `debate`
  block in `model-routing.json` (claude, codex, kimi compare; claude
  synthesizes) with a hardcoded co-op fallback. Debate skips the owner lane and
  carries **no audit step by design** — synthesis is the accountable artifact.
- **Debate execution** — `executeWorkflow` runs every comparator independently,
  then passes the **array** of comparator outputs to the synthesis step, then
  the gate. solo/pair/chain/review paths are unchanged (verified by a pair
  regression check).
- **Structured readiness** — new `evaluateReadiness(plan, result)` returns
  `{ ready, reason }`, wrapping the still-throwing `assertFinancialGate` core so
  a CLI/report surface can present a not-ready outcome without crashing. Also
  blocks on a nonzero workflow exit or an unapproved artifact.
- **Chain** — proven through the generic engine via an injected-runner test (no
  code change required; it already flowed correctly).
- **Distribution review** — documented as **gate-only by design** (distribution
  ownership has no reviewer); `DEV_BRAIN.md` gains a Workflow Modes section.

## Scope decisions (operator-confirmed)

1. Readiness: structured at the boundary, throw at the core.
2. Execution depth: injected runners, keep the `main()` guard (mirrors PR4).
3. Debate: real 3-comparator + synthesis (claude/codex/kimi -> claude).
4. Distribution review: gate-only by design + documented.

## Files

| File | +/- |
| --- | --- |
| `orchestrate.js` | +94 / -25 |
| `tests/unit/routing/hermes-routing.test.ts` | +176 |
| `.claude/hermes/model-routing.json` | +4 |
| `DEV_BRAIN.md` | +12 |

## Verification (run independently, not trusting the dispatch self-report)

- `node --check orchestrate.js` — OK
- `eslint --max-warnings 0` (changed files) — clean
- `prettier --check` (all 4 files) — clean
- `TZ=UTC vitest run tests/unit/routing/` — **129 passed** (+9 new)
- `npm run check` — **0 new TypeScript errors**
- ESM behavioral re-run — **10/10 PASS**, including a pair-mode regression check
- `git status` — only the 4 intended files changed; no collateral

## Notes

- 9 new deterministic tests: debate planning (config + default-roster fallback),
  debate execution (comparator order + array-to-synthesis threading), chain
  execution through the generic engine, and 5 readiness outcomes.
- The synthesis step intentionally receives an **array** as `input` (every other
  role gets a string/null); a code comment and the test pin this so a later PR
  does not "fix" it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
