### PR TITLE
feat(hermes): enable gemini and agy providers (PR6-A)

### DIFF
--- a/.claude/hermes/model-routing.json
+++ b/.claude/hermes/model-routing.json
@@ -56,7 +56,9 @@
   "manualFlags": {
     "--claude": "claude",
     "--codex": "codex",
-    "--kimi": "kimi"
+    "--kimi": "kimi",
+    "--gemini": "gemini",
+    "--agy": "agy"
   },
   "specialists": {
     "waterfall-specialist": {
@@ -146,6 +148,16 @@
       "binEnv": "KIMI_CODE_BIN",
       "defaultBin": "kimi-cli",
       "args": ["--print", "--input-format", "text", "--final-message-only"]
+    },
+    "gemini": {
+      "binEnv": "GEMINI_BIN",
+      "defaultBin": "gemini",
+      "args": ["--output-format", "text", "--yolo", "--prompt", ""]
+    },
+    "agy": {
+      "binEnv": "AGY_BIN",
+      "defaultBin": "agy",
+      "args": []
     }
   }
 }

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -10,7 +10,7 @@ const ROOT = dirname(__filename);
 const LEGACY_COMMANDS = new Set(['bootstrap', 'smoke', 'enable-algorithms', 'doctor']);
 const DOCTOR_PROVIDERS = ['claude', 'codex', 'kimi-cli', 'gemini', 'agy'];
 const WORKFLOW_MODES = new Set(['auto', 'solo', 'pair', 'chain', 'debate', 'review']);
-const MODEL_OVERRIDES = new Set(['claude', 'codex', 'kimi']);
+const MODEL_OVERRIDES = new Set(['claude', 'codex', 'kimi', 'gemini', 'agy']);
 const WORKFLOW_DEFERRED_BEHAVIOR = [
   'model execution',
   'artifact handoff',
@@ -110,6 +110,10 @@ function parseArgs(argv = []) {
       options.manualModel = 'codex';
     } else if (arg === '--kimi') {
       options.manualModel = 'kimi';
+    } else if (arg === '--gemini') {
+      options.manualModel = 'gemini';
+    } else if (arg === '--agy') {
+      options.manualModel = 'agy';
     }
   }
 

--- a/tests/unit/routing/hermes-doctor.test.ts
+++ b/tests/unit/routing/hermes-doctor.test.ts
@@ -40,4 +40,25 @@ describe('Hermes doctor report', () => {
       { provider: 'agy', bin: 'agy', source: 'default', found: false },
     ]);
   });
+
+  test('resolves gemini and agy bins from configured commands and env overrides', () => {
+    const routing = {
+      commands: {
+        gemini: { binEnv: 'GEMINI_BIN', defaultBin: 'gemini' },
+        agy: { binEnv: 'AGY_BIN', defaultBin: 'agy' },
+      },
+    };
+
+    const report = buildDoctorReport({
+      routing,
+      env: { GEMINI_BIN: 'gemini-local' },
+      providers: ['gemini', 'agy'],
+      commandExists: (bin: string) => bin === 'gemini-local',
+    });
+
+    expect(report).toEqual([
+      { provider: 'gemini', bin: 'gemini-local', source: 'env:GEMINI_BIN', found: true },
+      { provider: 'agy', bin: 'agy', source: 'default', found: false },
+    ]);
+  });
 });

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -99,6 +99,23 @@ describe('Hermes routing helpers', () => {
     expect(chooseModel(args.task, args.phase, routing, args.manualModel)).toBe('kimi');
   });
 
+  test('gemini and agy manual flags route through chooseModel', () => {
+    const geminiArgs = parseArgs(['--phase', 'production', '--task', 'route work', '--gemini']);
+    expect(geminiArgs.manualModel).toBe('gemini');
+    expect(chooseModel(geminiArgs.task, geminiArgs.phase, routing, geminiArgs.manualModel)).toBe(
+      'gemini'
+    );
+
+    const agyArgs = parseArgs(['--phase', 'research', '--task', 'route work', '--agy']);
+    expect(agyArgs.manualModel).toBe('agy');
+    expect(chooseModel(agyArgs.task, agyArgs.phase, routing, agyArgs.manualModel)).toBe('agy');
+  });
+
+  test('--model override accepts gemini and agy providers', () => {
+    expect(parseArgs(['--model', 'gemini']).manualModel).toBe('gemini');
+    expect(parseArgs(['--model', 'agy']).manualModel).toBe('agy');
+  });
+
   test('parseArgs rejects the broad gate skip flag', () => {
     expect(() => parseArgs(['--task', 'fix gate', '--skip-gates'])).toThrow(
       'Use --skip-preflight-gate'


### PR DESCRIPTION
## PR6-A - gemini + agy provider enablement

Sixth unit of the Hermes build-out. Enablement only; live model wiring is PR6-B.

### Changes
- `MODEL_OVERRIDES` + `parseArgs`: add `--gemini`/`--agy` manual flags and `--model gemini|agy` overrides.
- `model-routing.json`: add `gemini`/`agy` to `manualFlags` and `commands{}` (binEnv/defaultBin/args), following the claude/codex/kimi shape. Bin names (`gemini`/`agy`) match what `DOCTOR_PROVIDERS` already detects.
- Tests: manual-flag + `--model` override routing for both providers; doctor env-override resolution. +3 deterministic tests (130 -> 133 in routing suite). No live binary required.

### Scope / safety notes
- Does **not** touch `executeModel` capture or the `main()` planning-only guard (that is PR6-B live wiring).
- `gemini` args use `--yolo` for non-interactive use (trusted-local posture, same rationale as the committed codex `danger-full-access`; **not for shared CI**).
- `gemini` live `--gemini` invocation smoke deferred to PR6-B (no API spend this PR); routing/parse/doctor layers fully covered by deterministic tests.
- `agy` args are a placeholder `[]` pending its binary/CLI contract (doctor reports it missing locally until installed).

### Verification (independent)
- node --check, prettier --check (no reflow), eslint --max-warnings 0 (exit 0)
- TZ=UTC routing suite: 133 passed
- npm run check: 0 new TypeScript errors

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)