### PR TITLE
feat(hermes): live workflow execution behind --live gate (PR6-B)

### DIFF
--- a/orchestrate.js
+++ b/orchestrate.js
@@ -54,6 +54,7 @@ function parseArgs(argv = []) {
     gateSkipReason: null,
     workflow: 'auto',
     workflowProvided: false,
+    live: false,
     manualModel: null,
     legacyCommand: null,
   };
@@ -72,6 +73,8 @@ function parseArgs(argv = []) {
       options.dryRun = true;
     } else if (arg === '--json') {
       options.json = true;
+    } else if (arg === '--live') {
+      options.live = true;
     } else if (arg === '--skip-gates') {
       throw new Error('Use --skip-preflight-gate with --skip-reason instead of --skip-gates.');
     } else if (arg === '--skip-preflight-gate') {
@@ -554,6 +557,113 @@ function executeModel(model, prompt, routing, env = process.env) {
   });
 }
 
+// Sibling of executeModel that PIPES stdout so a step's output can be captured
+// and fed back into executeWorkflow. executeModel is left untouched so the
+// non-workflow path keeps inheriting stdout.
+function executeModelCapture(
+  model,
+  prompt,
+  routing,
+  env = process.env,
+  { spawn: spawnImpl = spawn } = {}
+) {
+  const commandConfig = routing.commands?.[model];
+  if (!commandConfig) {
+    throw new Error(`No command config for model: ${model}`);
+  }
+
+  const bin = env[commandConfig.binEnv] || commandConfig.defaultBin;
+  if (!commandExists(bin)) {
+    throw new Error(
+      `Command not found for model "${model}": ${bin}. Set ${commandConfig.binEnv} or install the CLI.`
+    );
+  }
+
+  return new Promise((resolvePromise, reject) => {
+    const child = spawnImpl(bin, commandConfig.args || [], {
+      stdio: ['pipe', 'pipe', 'inherit'],
+      shell: process.platform === 'win32',
+      env,
+    });
+
+    let output = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    child.stdin.write(prompt);
+    child.stdin.end();
+    child.on('error', reject);
+    child.on('close', (code) => resolvePromise({ code: code || 0, output }));
+  });
+}
+
+const APPROVAL_SENTINEL = 'APPROVED';
+const REJECTION_SENTINEL = 'CHANGES REQUESTED';
+
+// Fail-closed, line-anchored. Approval requires a line that is EXACTLY the
+// approval sentinel; any line beginning with the rejection sentinel wins, and an
+// absent or ambiguous response is treated as not approved.
+function parseApprovalSignal(output) {
+  const lines = String(output || '')
+    .split('\n')
+    .map((line) => line.trim());
+  if (lines.some((line) => line.startsWith(REJECTION_SENTINEL))) {
+    return false;
+  }
+  return lines.some((line) => line === APPROVAL_SENTINEL);
+}
+
+function formatStepInput(input) {
+  if (Array.isArray(input)) {
+    return input.map((entry, index) => `--- INPUT ${index + 1} ---\n${entry ?? ''}`).join('\n\n');
+  }
+  return input == null ? '' : String(input);
+}
+
+// Live step runner injected into executeWorkflow. Composes a per-step prompt from
+// the base task prompt plus role/action context, prior output, and specialist
+// notes, runs the step's model with stdout captured, and (for reviewer steps)
+// derives a fail-closed approval verdict. Prompt composition is intentionally a
+// minimal v1; refine as real-model output patterns are observed.
+function createLiveRunStep({
+  routing,
+  basePrompt = '',
+  env = process.env,
+  executor = executeModelCapture,
+} = {}) {
+  return async function liveRunStep({ step, input, notes }) {
+    const sections = [
+      basePrompt,
+      '',
+      '--- WORKFLOW STEP ---',
+      `ROLE: ${step.role}`,
+      `ACTION: ${step.action}`,
+    ];
+    if (notes) {
+      sections.push('', 'SPECIALIST NOTES:', String(notes));
+    }
+    const formattedInput = formatStepInput(input);
+    if (formattedInput) {
+      sections.push('', 'PRIOR OUTPUT:', formattedInput);
+    }
+    if (step.role === 'reviewer') {
+      sections.push(
+        '',
+        `Reply with exactly "${APPROVAL_SENTINEL}" on its own line if the artifact is ready to ship.`,
+        `Otherwise emit a line beginning "${REJECTION_SENTINEL}" followed by the required changes.`,
+        'An absent or ambiguous response is treated as changes requested.'
+      );
+    }
+
+    const { code, output } = await executor(step.model, sections.join('\n'), routing, env);
+    const result = { code, output };
+    if (step.role === 'reviewer') {
+      result.approved = parseApprovalSignal(output);
+    }
+    return result;
+  };
+}
+
 function runGate(
   gate,
   { runner = spawnSync, env = process.env, stdio = 'inherit', throwOnFailure = true } = {}
@@ -813,6 +923,8 @@ Output:
 Workflow planning:
   --workflow <auto|solo|pair|chain|debate|review>
                  Add a planning-only workflow recommendation to dry-run output.
+  --live         Execute the planned workflow live (spawns real model CLIs).
+                 Without --live, --workflow stays planning-only.
 
 Gate controls:
   --skip-preflight-gate --skip-reason "<reason>"
@@ -950,8 +1062,10 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
     throw new Error('--task is required. Use --help for usage.');
   }
 
-  if (options.workflowProvided && !options.dryRun && !options.json) {
-    throw new Error('--workflow is planning-only; use --dry-run or --json.');
+  const liveExecution = options.live || env.HERMES_LIVE === '1' || env.HERMES_LIVE === 'true';
+
+  if (options.workflowProvided && !options.dryRun && !options.json && !liveExecution) {
+    throw new Error('--workflow is planning-only; use --dry-run or --json. Add --live to execute.');
   }
 
   const routingPath =
@@ -984,6 +1098,18 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
     io.stdout.write('\n=== PROMPT ===\n');
     io.stdout.write(`${prompt}\n`);
     return 0;
+  }
+
+  if (options.workflowProvided && liveExecution && plan.workflow) {
+    const runStep = deps.runStep || createLiveRunStep({ routing, basePrompt: prompt, env });
+    const record = await executeWorkflow(plan, {
+      runStep,
+      gateRunner,
+      writeRunLedger: ledgerWriter,
+      clock,
+      runId,
+    });
+    return record.exitCode;
   }
 
   const ledger = {
@@ -1074,15 +1200,18 @@ export {
   buildDoctorReport,
   buildPrompt,
   chooseModel,
+  createLiveRunStep,
   createWorkflowPlan,
   createRoutingPlan,
   evaluateReadiness,
+  executeModelCapture,
   executeWorkflow,
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
   isProductionFinancial,
   main,
+  parseApprovalSignal,
   parseArgs,
   recommendWorkflow,
   resolveEffectivePhase,

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -789,16 +789,15 @@ async function executeWorkflow(plan, deps = {}) {
 
   let specialistNotes = null;
   const records = [];
-  let debateStepFailureCode = 0;
+  // First nonzero exit from ANY model step (owner, specialist, reviewer, audit,
+  // comparator, synthesis). A crashed CLI must not be reported as success just
+  // because the postflight gate passes.
+  let stepFailureCode = 0;
   const runRecorded = async (step, input, attempt) => {
     const result = await runStep({ step, input, notes: specialistNotes, plan, attempt, runId });
     const code = result.code ?? 0;
-    if (
-      debateStepFailureCode === 0 &&
-      (step.role === 'comparator' || step.role === 'synthesis') &&
-      code !== 0
-    ) {
-      debateStepFailureCode = code;
+    if (stepFailureCode === 0 && code !== 0) {
+      stepFailureCode = code;
     }
     records.push({
       role: step.role,
@@ -864,8 +863,8 @@ async function executeWorkflow(plan, deps = {}) {
   let exitCode = 0;
   if (gate.status && gate.status !== 0) {
     exitCode = gate.status;
-  } else if (debateStepFailureCode !== 0) {
-    exitCode = debateStepFailureCode;
+  } else if (stepFailureCode !== 0) {
+    exitCode = stepFailureCode;
   } else if (reviewerStep && !approved) {
     exitCode = 1;
   }
@@ -1101,6 +1100,28 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
   }
 
   if (options.workflowProvided && liveExecution && plan.workflow) {
+    // Preflight gate parity with the non-workflow path: a failing gate (e.g.
+    // npm run check) must abort BEFORE spawning the owner/reviewer CLIs, unless
+    // explicitly skipped. executeWorkflow only runs the gate postflight.
+    const gates = getGateRunPlan(plan, options);
+    if (gates.preflight) {
+      const preflight = runGate(plan.gate, {
+        env,
+        runner: gateRunner,
+        throwOnFailure: false,
+      });
+      if (preflight.status !== 0) {
+        io.stderr.write(
+          `[hermes] preflight gate "${plan.gate}" failed with exit code ${preflight.status}; aborting live workflow before model execution.\n`
+        );
+        return preflight.status;
+      }
+    } else if (plan.gate && options.skipPreflightGate) {
+      io.stderr.write(
+        `[hermes] WARNING: skipping preflight gate "${plan.gate}"; reason: ${options.gateSkipReason}\n`
+      );
+    }
+
     const runStep = deps.runStep || createLiveRunStep({ routing, basePrompt: prompt, env });
     const record = await executeWorkflow(plan, {
       runStep,

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -4,14 +4,17 @@ import {
   assertFinancialGate,
   buildPrompt,
   chooseModel,
+  createLiveRunStep,
   createWorkflowPlan,
   createRoutingPlan,
   evaluateReadiness,
+  executeModelCapture,
   executeWorkflow,
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
   main,
+  parseApprovalSignal,
   parseArgs,
   recommendWorkflow,
   resolveEffectivePhase,
@@ -114,6 +117,128 @@ describe('Hermes routing helpers', () => {
   test('--model override accepts gemini and agy providers', () => {
     expect(parseArgs(['--model', 'gemini']).manualModel).toBe('gemini');
     expect(parseArgs(['--model', 'agy']).manualModel).toBe('agy');
+  });
+
+  test('parseArgs recognizes the live execution flag', () => {
+    expect(parseArgs(['--task', 'run it', '--workflow', 'pair', '--live']).live).toBe(true);
+    expect(parseArgs(['--task', 'run it']).live).toBe(false);
+  });
+
+  describe('parseApprovalSignal', () => {
+    test('approves only on an exact sentinel line', () => {
+      expect(parseApprovalSignal('looks good\nAPPROVED')).toBe(true);
+      expect(parseApprovalSignal('  APPROVED  ')).toBe(true);
+    });
+
+    test('rejects when changes are requested, even alongside an approval line', () => {
+      expect(parseApprovalSignal('CHANGES REQUESTED: rename the variable')).toBe(false);
+      expect(parseApprovalSignal('APPROVED\nCHANGES REQUESTED: one more thing')).toBe(false);
+    });
+
+    test('fails closed on absent or inline-only mentions', () => {
+      expect(parseApprovalSignal('I have not APPROVED this yet')).toBe(false);
+      expect(parseApprovalSignal('')).toBe(false);
+      expect(parseApprovalSignal('the diff is fine')).toBe(false);
+    });
+  });
+
+  describe('createLiveRunStep', () => {
+    test('derives reviewer approval from captured output and threads context into the prompt', async () => {
+      const seen = [];
+      const executor = async (model, stepPrompt) => {
+        seen.push({ model, stepPrompt });
+        return { code: 0, output: 'APPROVED' };
+      };
+      const runStep = createLiveRunStep({ routing, basePrompt: 'BASE', executor });
+
+      const review = await runStep({
+        step: { role: 'reviewer', model: 'claude', action: 'review diff plus tests' },
+        input: 'owner-diff',
+        notes: 'specialist note',
+      });
+
+      expect(review).toMatchObject({ code: 0, output: 'APPROVED', approved: true });
+      expect(seen[0].model).toBe('claude');
+      expect(seen[0].stepPrompt).toContain('ROLE: reviewer');
+      expect(seen[0].stepPrompt).toContain('PRIOR OUTPUT:');
+      expect(seen[0].stepPrompt).toContain('owner-diff');
+      expect(seen[0].stepPrompt).toContain('specialist note');
+    });
+
+    test('attaches no verdict to non-reviewer roles and formats array input', async () => {
+      const seen = [];
+      const executor = async (model, stepPrompt) => {
+        seen.push(stepPrompt);
+        return { code: 0, output: 'synthesis-result' };
+      };
+      const runStep = createLiveRunStep({ routing, basePrompt: 'BASE', executor });
+
+      const result = await runStep({
+        step: { role: 'synthesis', model: 'claude', action: 'synthesize options' },
+        input: ['option-a', 'option-b'],
+        notes: null,
+      });
+
+      expect(result).toEqual({ code: 0, output: 'synthesis-result' });
+      expect(result.approved).toBeUndefined();
+      expect(seen[0]).toContain('option-a');
+      expect(seen[0]).toContain('option-b');
+    });
+  });
+
+  test('executeModelCapture captures child stdout and resolves the exit code', async () => {
+    const events = {};
+    const fakeChild = {
+      stdin: { write: () => undefined, end: () => undefined },
+      stdout: {
+        on: (event, cb) => {
+          if (event === 'data') cb(Buffer.from('captured-output'));
+        },
+      },
+      on: (event, cb) => {
+        events[event] = cb;
+      },
+    };
+    const spawnImpl = () => {
+      queueMicrotask(() => events.close && events.close(0));
+      return fakeChild;
+    };
+    const captureRouting = {
+      commands: { stub: { binEnv: 'STUB_BIN', defaultBin: 'node' } },
+    };
+
+    const result = await executeModelCapture('stub', 'prompt', captureRouting, process.env, {
+      spawn: spawnImpl,
+    });
+
+    expect(result).toEqual({ code: 0, output: 'captured-output' });
+  });
+
+  test('main executes a live workflow through executeWorkflow and returns its exit code', async () => {
+    const roles = [];
+    const code = await main(
+      ['--phase', 'production', '--task', 'ship the change', '--workflow', 'pair', '--live'],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+        runStep: async ({ step }) => {
+          roles.push(step.role);
+          return { code: 0, output: `${step.role}-output`, approved: step.role === 'reviewer' };
+        },
+      }
+    );
+
+    expect(code).toBe(0);
+    expect(roles).toContain('owner');
+    expect(roles).toContain('reviewer');
   });
 
   test('parseArgs rejects the broad gate skip flag', () => {

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -241,6 +241,84 @@ describe('Hermes routing helpers', () => {
     expect(roles).toContain('reviewer');
   });
 
+  test('main aborts a live workflow when the preflight gate fails, before any model runs', async () => {
+    const roles: string[] = [];
+    const gateCalls: string[] = [];
+
+    const code = await main(
+      ['--phase', 'production', '--task', 'ship the change', '--workflow', 'pair', '--live'],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        gateRunner: (bin: string, args: string[]) => {
+          gateCalls.push([bin, ...args].join(' '));
+          return { status: 2 };
+        },
+        writeRunLedger: null,
+        runStep: async ({ step }: { step: { role: string } }) => {
+          roles.push(step.role);
+          return { code: 0, output: `${step.role}-output`, approved: step.role === 'reviewer' };
+        },
+      }
+    );
+
+    expect(code).toBe(2);
+    // Gate ran exactly once (preflight) and no model steps were spawned.
+    expect(gateCalls).toEqual(['npm run check']);
+    expect(roles).toEqual([]);
+  });
+
+  test('main skips the live preflight gate when --skip-preflight-gate is set', async () => {
+    const roles: string[] = [];
+    const gateCalls: string[] = [];
+
+    const code = await main(
+      [
+        '--phase',
+        'production',
+        '--task',
+        'ship the change',
+        '--workflow',
+        'pair',
+        '--live',
+        '--skip-preflight-gate',
+        '--skip-reason',
+        'iterating on the gate itself',
+      ],
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        gateRunner: (bin: string, args: string[]) => {
+          gateCalls.push([bin, ...args].join(' '));
+          return { status: 0 };
+        },
+        writeRunLedger: null,
+        runStep: async ({ step }: { step: { role: string } }) => {
+          roles.push(step.role);
+          return { code: 0, output: `${step.role}-output`, approved: step.role === 'reviewer' };
+        },
+      }
+    );
+
+    expect(code).toBe(0);
+    // Preflight skipped; only the postflight gate inside executeWorkflow runs.
+    expect(gateCalls).toEqual(['npm run check']);
+    expect(roles).toContain('owner');
+    expect(roles).toContain('reviewer');
+  });
+
   test('parseArgs rejects the broad gate skip flag', () => {
     expect(() => parseArgs(['--task', 'fix gate', '--skip-gates'])).toThrow(
       'Use --skip-preflight-gate'
@@ -1331,6 +1409,45 @@ describe('Hermes routing helpers', () => {
       ).rejects.toThrow('npm run calc-gate');
 
       expect(gateRan).toBe(false);
+    });
+
+    test('propagates a failed owner step exit code even when the gate passes', async () => {
+      const { runStep } = makeRunner({
+        owner: { code: 3, output: 'owner-crashed' },
+        reviewer: { approved: true },
+      });
+
+      const record = await executeWorkflow(pairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.exitCode).toBe(3);
+      expect(record.gate.status).toBe(0);
+      expect(record.steps.find((step) => step.role === 'owner')?.code).toBe(3);
+      expect(evaluateReadiness(pairPlan, record)).toEqual({
+        ready: false,
+        reason: 'workflow exited with code 3',
+      });
+    });
+
+    test('propagates a failed audit step exit code in a financial pair', async () => {
+      const { runStep } = makeRunner({
+        owner: { output: 'owner-diff' },
+        specialist: { output: 'risk-reviewed' },
+        reviewer: { approved: true },
+        audit: { code: 5, output: 'audit-crashed' },
+      });
+
+      const record = await executeWorkflow(financialPairPlan, {
+        runStep,
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+      });
+
+      expect(record.exitCode).toBe(5);
+      expect(record.steps.find((step) => step.role === 'audit')?.code).toBe(5);
     });
 
     test('persists a run ledger capturing steps, repairs, gate, and exit code', async () => {


### PR DESCRIPTION
## PR6-B - live model workflow wiring

Stacked on **#739** (PR6-A). Lifts the planning-only guard *only* behind an explicit `--live`/`HERMES_LIVE` flag, so bare `--workflow` behavior is unchanged by default. Retarget this PR to `main` after #739 merges.

### Changes (orchestrate.js + routing tests only)
- **`executeModelCapture`** — sibling of `executeModel` that pipes stdout (`['pipe','pipe','inherit']`) so a step's output feeds back into `executeWorkflow`. `executeModel` is left untouched (non-workflow path keeps inheriting stdout).
- **`parseApprovalSignal`** — reviewer approval contract: **line-anchored, fail-closed**. A trimmed line `=== "APPROVED"` approves; any line starting `CHANGES REQUESTED` rejects (wins ties); absent/ambiguous => not approved.
- **`createLiveRunStep`** — composes a per-step prompt (base + role/action + prior output + specialist notes, array-aware for synthesis), runs the step model captured, derives the reviewer verdict. Prompt composition is a deliberate **v1**.
- **`--live` / `HERMES_LIVE` gate** — `main()` routes `--workflow` through `executeWorkflow` only when live; otherwise the planning-only guard still throws.

### Verification (independent)
- node --check, prettier --check (cosmetic reflow only), eslint --max-warnings 0
- TZ=UTC routing suite: **141 passed** (+8 B tests; the two planning-only guard tests stay green)
- npm run check: 0 new TypeScript errors
- CLI smoke: bare `--workflow` still refuses (planning-only); `--help` documents `--live`

### NOT covered (honest scope)
- **Live model invocation is unsmoked.** Tests inject the executor/spawn, so real `gemini`/`codex`/`kimi` runs — including PR6-A's provisional `gemini --prompt ""` + stdin interaction — are not exercised here. This PR verifies the **wiring** (guard, capture, sentinel, executeWorkflow integration), not that a real model run produces usable output.
- Live `--workflow` spawns real CLIs under the trusted-local `danger-full-access` codex posture; **not for shared CI**.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)