### PR TITLE
fix(hermes): correct gemini headless arg (--prompt= for stdin)

### DIFF
--- a/.claude/hermes/model-routing.json
+++ b/.claude/hermes/model-routing.json
@@ -152,7 +152,7 @@
     "gemini": {
       "binEnv": "GEMINI_BIN",
       "defaultBin": "gemini",
-      "args": ["--output-format", "text", "--yolo", "--prompt", ""]
+      "args": ["--output-format", "text", "--yolo", "--prompt="]
     },
     "agy": {
       "binEnv": "AGY_BIN",


### PR DESCRIPTION
## What

PR6-A wired gemini with `args: ["--output-format", "text", "--yolo", "--prompt", ""]`. That separate empty-string arg `""` is **dropped** during the orchestrator's `shell:true` spawn concatenation, so gemini received `--prompt` with no value and errored `Not enough arguments following: prompt`. gemini's lane was non-functional.

## Fix

Use the inline-empty form `--prompt=` (one token, survives shell concatenation). It triggers headless mode while the prompt still rides **stdin** — identical delivery to claude/codex/kimi, so no code change to `executeModel`/`executeModelCapture` is needed.

```diff
-      "args": ["--output-format", "text", "--yolo", "--prompt", ""]
+      "args": ["--output-format", "text", "--yolo", "--prompt="]
```

## Validation

- **Live probe:** `gemini -o text -y --prompt=` with a prompt piped to stdin returns model output, exit 0 (the original `--prompt ""` form returns exit 1 / "Not enough arguments").
- Routing suite green (145); `npm run check` unaffected (config-only).

## Found via

The first real `--live` smoke of the merged PR6-B wiring — capture + fail-closed sentinel plumbing both proved sound; this was the one real bug. (Reviewer-sentinel compliance against a live model is still unvalidated — claude account was out of credits.)

## Follow-up (not in this PR)

A unit guard asserting no command config carries a standalone empty-string arg would catch this class repo-wide; the file-read approach collided with the server suite's mocked `fs`, so it needs a Vite JSON-import form — deferred to keep this fix minimal.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)