### PR TITLE
chore(skills): add skills:index/skills:check scripts + pre-push freshness gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "docs:routing:generate": "npx tsx scripts/generate-discovery-map.ts",
     "docs:routing:check": "npx tsx scripts/generate-discovery-map.ts --check",
     "docs:routing:query": "npx tsx scripts/routeQueryFast.ts",
+    "skills:index": "npx tsx scripts/generate-skill-index.ts",
+    "skills:check": "npx tsx scripts/generate-skill-index.ts --check",
     "capabilities:sync": "node scripts/sync-capabilities.mjs",
     "capabilities:sync:apply": "node scripts/sync-capabilities.mjs --apply"
   },

--- a/scripts/pre-push.mjs
+++ b/scripts/pre-push.mjs
@@ -96,6 +96,12 @@ if (!changed) {
   process.exit(0);
 }
 
+const changedSkillFiles = splitLines(changed).filter((file) => file.startsWith('.claude/skills/'));
+if (changedSkillFiles.length > 0) {
+  console.log('Skill files changed; verifying skill index freshness...');
+  run('npm', ['run', 'skills:check']);
+}
+
 const classification = output('node', ['scripts/pre-push-classification.mjs'], {
   input: `${changed}\n`,
 });


### PR DESCRIPTION
## What

Wires the existing skill-index generator (`scripts/generate-skill-index.ts`) into npm scripts and the pre-push hook, so a stale `.claude/skills/_index.json` is caught automatically.

## Changes
- **package.json** — two scripts (mirroring the `docs:routing:*` pattern):
  - `skills:index` → `npx tsx scripts/generate-skill-index.ts` (regenerate)
  - `skills:check` → `npx tsx scripts/generate-skill-index.ts --check` (verify freshness)
- **scripts/pre-push.mjs** — runs `skills:check` when any `.claude/skills/` file changed, **before** the docs-only classification skip (skill `.md` edits classify as docs-only and would otherwise bypass the freshness check).

## Why the placement
`pre-push.mjs` exits early on `docs-only-skip`. Since skill files are markdown, a skill edit hits that skip — so the freshness gate is inserted ahead of it, conditioned on `.claude/skills/` being in the changed set (no overhead otherwise).

## Verification (independent)
- `npm run skills:check` → PASS (index fresh, 41 skills); `npm run skills:index` regenerates cleanly
- `node --check scripts/pre-push.mjs`, prettier `--check`, baseline `npm run check` → 0 new TS errors
- **Dogfooded:** this push exercised the new pre-push code itself — full suite ran (6361 passed / 90 skipped); the skills gate correctly self-skipped (no skill files in this diff)

Note: the prior `npm run skills:check`/`skills:index` commands never existed; this adds them.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)