### PR TITLE
fix(auth): block cross-fund portfolio disclosure via LP report generation + LP-API self-scoping (Slice 0)

### DIFF
--- a/server/routes/lp-api.ts
+++ b/server/routes/lp-api.ts
@@ -778,6 +778,24 @@ router.post(
       // Validate request body
       const config = ReportConfigSchema.parse(req.body);
 
+      // SECURITY: LPs may only generate reports for funds they are committed to.
+      // req.lpProfile.fundIds is the cached commitment snapshot from requireLPAccess.
+      const lpFundIds = req.lpProfile?.fundIds ?? [];
+      const unauthorizedFundId = config.fundIds?.find((id) => !lpFundIds.includes(id));
+      if (unauthorizedFundId !== undefined) {
+        const duration = endTimer();
+        recordLPRequest(endpoint, 'POST', 403, duration, lpId);
+        recordError(endpoint, 'FUND_ACCESS_DENIED', 403);
+        return res
+          .status(403)
+          .json(
+            createErrorResponse(
+              'FORBIDDEN',
+              `You do not have access to fund ${unauthorizedFundId}. LPs can only generate reports for funds they have invested in.`
+            )
+          );
+      }
+
       // Create report record
       const reportId = uuidv4();
       const idempotencyKey = `lp_${lpId}_report_${Date.now()}`;

--- a/tests/unit/routes/lp-api.contract.test.ts
+++ b/tests/unit/routes/lp-api.contract.test.ts
@@ -442,4 +442,20 @@ describe('LP API route contracts', () => {
       settings: { display: { currency: 'EUR', numberFormat: 'EU' } },
     });
   });
+
+  it('POST /api/lp/reports/generate rejects funds the LP is not committed to', async () => {
+    const response = await request(makeApp())
+      .post('/api/lp/reports/generate')
+      .send({
+        reportType: 'quarterly',
+        dateRange: { startDate: '2026-01-01', endDate: '2026-03-31' },
+        format: 'pdf',
+        fundIds: [99],
+        sections: ['summary'],
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ error: 'FORBIDDEN' });
+    expect(dbState.state.insertValues).toHaveLength(0);
+  });
 });

--- a/tests/unit/routes/lp-api.contract.test.ts
+++ b/tests/unit/routes/lp-api.contract.test.ts
@@ -54,6 +54,8 @@ const calculatorState = vi.hoisted(() => ({
   calculatePerformance: vi.fn(),
 }));
 
+const lpAccessState = vi.hoisted(() => ({ mode: 'lp' as 'lp' | 'non-lp' }));
+
 vi.mock('express-rate-limit', () => ({
   default: () => (_req: Request, _res: Response, next: NextFunction) => next(),
 }));
@@ -76,7 +78,13 @@ vi.mock('../../../server/lib/auth/jwt', () => ({
 }));
 
 vi.mock('../../../server/middleware/requireLPAccess', () => ({
-  requireLPAccess: (req: Request, _res: Response, next: NextFunction) => {
+  requireLPAccess: (req: Request, res: Response, next: NextFunction) => {
+    if (lpAccessState.mode === 'non-lp') {
+      return res.status(403).json({
+        error: 'FORBIDDEN',
+        message: 'LP access required. This endpoint is only available to Limited Partners.',
+      });
+    }
     req.lpProfile = {
       id: 9001,
       name: 'Contract LP',
@@ -84,7 +92,7 @@ vi.mock('../../../server/middleware/requireLPAccess', () => ({
       entityType: 'institution',
       fundIds: [7],
     };
-    next();
+    return next();
   },
   requireLPFundAccess: (req: Request, res: Response, next: NextFunction) => {
     const fundId = Number(req.params['fundId']);
@@ -185,6 +193,7 @@ function resetState() {
   calculatorState.calculateCapitalAccount.mockReset();
   calculatorState.calculateProRataHoldings.mockReset();
   calculatorState.calculatePerformance.mockReset();
+  lpAccessState.mode = 'lp';
 }
 
 function transaction(overrides: Record<string, unknown> = {}) {
@@ -458,4 +467,198 @@ describe('LP API route contracts', () => {
     expect(response.body).toMatchObject({ error: 'FORBIDDEN' });
     expect(dbState.state.insertValues).toHaveLength(0);
   });
+});
+
+describe('LP API self-scoping negative controls', () => {
+  beforeEach(() => resetState());
+
+  const nonLpRoutes = [
+    ['get', '/api/lp/profile'],
+    ['get', '/api/lp/summary'],
+    ['get', '/api/lp/capital-account'],
+    ['get', '/api/lp/funds/7/detail'],
+    ['get', '/api/lp/funds/7/holdings'],
+    ['get', '/api/lp/performance'],
+    ['get', '/api/lp/performance/benchmark'],
+    [
+      'post',
+      '/api/lp/reports/generate',
+      {
+        reportType: 'quarterly',
+        dateRange: { startDate: '2026-01-01', endDate: '2026-03-31' },
+        format: 'pdf',
+        fundIds: [7],
+        sections: ['summary'],
+      },
+    ],
+    ['get', '/api/lp/reports'],
+    ['get', '/api/lp/reports/report-123'],
+    ['get', '/api/lp/reports/report-123/download'],
+    ['get', '/api/lp/settings'],
+    ['put', '/api/lp/settings', {}],
+  ] as const;
+
+  function issueRequest(method: 'get' | 'post' | 'put', path: string, body?: unknown) {
+    const app = request(makeApp());
+    if (method === 'get') return app.get(path);
+    const pendingRequest = method === 'post' ? app.post(path) : app.put(path);
+    return body === undefined ? pendingRequest : pendingRequest.send(body);
+  }
+
+  it.each(nonLpRoutes)(
+    '%s %s rejects non-LP callers before data reads',
+    async (method, path, body) => {
+      lpAccessState.mode = 'non-lp';
+
+      const response = await issueRequest(method, path, body);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('FORBIDDEN');
+      expect(dbState.db.select).not.toHaveBeenCalled();
+      expect(dbState.db.insert).not.toHaveBeenCalled();
+      expect(calculatorState.calculateSummary).not.toHaveBeenCalled();
+      expect(calculatorState.calculateCapitalAccount).not.toHaveBeenCalled();
+      expect(calculatorState.calculateProRataHoldings).not.toHaveBeenCalled();
+      expect(calculatorState.calculatePerformance).not.toHaveBeenCalled();
+    }
+  );
+
+  function collectPredicateAtoms(node: unknown, params: unknown[], cols: string[]): void {
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+    if ('value' in n && !('queryChunks' in n)) params.push((n as { value: unknown }).value);
+    if (typeof (n as { name?: unknown }).name === 'string') cols.push((n as { name: string }).name);
+    const chunks = (n as { queryChunks?: unknown }).queryChunks;
+    if (Array.isArray(chunks)) for (const c of chunks) collectPredicateAtoms(c, params, cols);
+    const inner = n as { sql?: unknown; left?: unknown; right?: unknown };
+    if (inner.sql) collectPredicateAtoms(inner.sql, params, cols);
+    if (inner.left) collectPredicateAtoms(inner.left, params, cols);
+    if (inner.right) collectPredicateAtoms(inner.right, params, cols);
+  }
+
+  function wherePredicateAtoms(selectCallIndex = 0): { params: unknown[]; cols: string[] } {
+    const queryObj = dbState.db.select.mock.results[selectCallIndex]?.value as
+      | { where?: { mock?: { calls?: unknown[][] } } }
+      | undefined;
+    const pred = queryObj?.where?.mock?.calls?.[0]?.[0];
+    const params: unknown[] = [];
+    const cols: string[] = [];
+    collectPredicateAtoms(pred, params, cols);
+    return { params, cols };
+  }
+
+  function expectLpPredicateScope(selectCallIndex = 0): void {
+    const { params, cols } = wherePredicateAtoms(selectCallIndex);
+    expect(params.length).toBeGreaterThan(0);
+    expect(params).toContain(9001);
+    expect(params).not.toContain(8888);
+    expect(cols.some((c) => /lp_?id/i.test(c))).toBe(true);
+  }
+
+  it('GET /api/lp/summary passes the authenticated LP id to the calculator', async () => {
+    calculatorState.calculateSummary.mockResolvedValueOnce({
+      lpId: 9001,
+      lpName: 'Contract LP',
+      totalCommittedCents: BigInt(0),
+      totalCalledCents: BigInt(0),
+      totalDistributedCents: BigInt(0),
+      totalNAVCents: BigInt(0),
+      totalUnfundedCents: BigInt(0),
+      fundCount: 1,
+      irr: 0,
+      moic: 0,
+    });
+
+    const response = await request(makeApp()).get('/api/lp/summary');
+
+    expect(response.status).toBe(200);
+    expect(calculatorState.calculateSummary).toHaveBeenCalledWith(9001);
+  });
+
+  it('GET /api/lp/funds/7/holdings passes the authenticated LP id and fund id to the calculator', async () => {
+    calculatorState.calculateProRataHoldings.mockResolvedValueOnce([]);
+
+    const response = await request(makeApp()).get('/api/lp/funds/7/holdings');
+
+    expect(response.status).toBe(200);
+    expect(calculatorState.calculateProRataHoldings).toHaveBeenCalledWith(9001, 7);
+  });
+
+  it('GET /api/lp/capital-account scopes the commitment lookup by authenticated LP id', async () => {
+    dbState.state.selectResults.push([{ id: 'c1', lpId: 9001, fundId: 7 }]);
+    calculatorState.calculateCapitalAccount.mockResolvedValueOnce([]);
+
+    const response = await request(makeApp()).get('/api/lp/capital-account?limit=2');
+
+    expect(response.status).toBe(200);
+    expectLpPredicateScope();
+  });
+
+  it('GET /api/lp/funds/7/detail scopes the commitment lookup by authenticated LP id', async () => {
+    dbState.state.selectResults.push([
+      {
+        id: 'c7',
+        lpId: 9001,
+        fundId: 7,
+        commitmentAmountCents: BigInt(0),
+        commitmentDate: new Date('2024-01-01T00:00:00.000Z'),
+        status: 'active',
+      },
+    ]);
+    calculatorState.calculateCapitalAccount.mockResolvedValueOnce([]);
+
+    const response = await request(makeApp()).get('/api/lp/funds/7/detail');
+
+    expect(response.status).toBe(200);
+    expectLpPredicateScope();
+  });
+
+  it('GET /api/lp/performance scopes the commitment lookup by authenticated LP id', async () => {
+    dbState.state.selectResults.push([{ id: 'c1', lpId: 9001, fundId: 7 }]);
+    calculatorState.calculatePerformance.mockResolvedValueOnce([]);
+
+    const response = await request(makeApp()).get('/api/lp/performance?fundId=7');
+
+    expect(response.status).toBe(200);
+    expectLpPredicateScope();
+  });
+
+  it('GET /api/lp/performance/benchmark scopes the commitment lookup by authenticated LP id', async () => {
+    dbState.state.selectResults.push([{ id: 'c1', lpId: 9001, fundId: 7 }]);
+    calculatorState.calculatePerformance.mockResolvedValueOnce([]);
+
+    const response = await request(makeApp()).get('/api/lp/performance/benchmark?fundId=7');
+
+    expect(response.status).toBe(200);
+    expectLpPredicateScope();
+  });
+
+  it('GET /api/lp/reports scopes the report list lookup by authenticated LP id', async () => {
+    dbState.state.selectResults.push([]);
+
+    const response = await request(makeApp()).get('/api/lp/reports');
+
+    expect(response.status).toBe(200);
+    expectLpPredicateScope();
+  });
+
+  it('GET /api/lp/reports/report-123 scopes the report status lookup by authenticated LP id', async () => {
+    dbState.state.selectResults.push([]);
+
+    const response = await request(makeApp()).get('/api/lp/reports/report-123');
+
+    expect(response.status).toBe(404);
+    expectLpPredicateScope();
+  });
+
+  it('GET /api/lp/reports/report-123/download scopes the report download lookup by authenticated LP id', async () => {
+    dbState.state.selectResults.push([]);
+
+    const response = await request(makeApp()).get('/api/lp/reports/report-123/download');
+
+    expect(response.status).toBe(404);
+    expectLpPredicateScope();
+  });
+
+  // Profile and settings are static/echo endpoints covered by the existing shape-lock tests.
 });

--- a/tests/unit/routes/lp-api.contract.test.ts
+++ b/tests/unit/routes/lp-api.contract.test.ts
@@ -173,6 +173,10 @@ vi.mock('../../../server/storage', () => ({
   },
 }));
 
+import {
+  enqueueReportGeneration,
+  isReportQueueAvailable,
+} from '../../../server/queues/report-generation-queue';
 import lpApiRouter from '../../../server/routes/lp-api';
 
 function makeApp() {
@@ -193,6 +197,10 @@ function resetState() {
   calculatorState.calculateCapitalAccount.mockReset();
   calculatorState.calculateProRataHoldings.mockReset();
   calculatorState.calculatePerformance.mockReset();
+  vi.mocked(isReportQueueAvailable).mockClear();
+  vi.mocked(isReportQueueAvailable).mockReturnValue(true);
+  vi.mocked(enqueueReportGeneration).mockClear();
+  vi.mocked(enqueueReportGeneration).mockResolvedValue({ jobId: 'job-1', estimatedWaitMs: 0 });
   lpAccessState.mode = 'lp';
 }
 
@@ -404,6 +412,25 @@ describe('LP API route contracts', () => {
       message: 'Report generation queued',
     });
     expect(dbState.state.insertValues).toHaveLength(1);
+    expect(enqueueReportGeneration).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST /api/lp/reports/generate accepts omitted fundIds as all LP-owned funds', async () => {
+    const response = await request(makeApp())
+      .post('/api/lp/reports/generate')
+      .send({
+        reportType: 'quarterly',
+        dateRange: { startDate: '2026-01-01', endDate: '2026-03-31' },
+        format: 'pdf',
+        sections: ['summary', 'capital_account'],
+      });
+
+    expect(response.status).toBe(202);
+    expect(dbState.state.insertValues).toHaveLength(1);
+    expect(enqueueReportGeneration).toHaveBeenCalledTimes(1);
+    const [queuedPayload] = vi.mocked(enqueueReportGeneration).mock.calls[0] ?? [];
+    expect(queuedPayload).toBeDefined();
+    expect(queuedPayload).not.toHaveProperty('fundIds');
   });
 
   it('POST /api/lp/reports/generate preserves validation-error envelope', async () => {
@@ -466,6 +493,24 @@ describe('LP API route contracts', () => {
     expect(response.status).toBe(403);
     expect(response.body).toMatchObject({ error: 'FORBIDDEN' });
     expect(dbState.state.insertValues).toHaveLength(0);
+    expect(enqueueReportGeneration).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/lp/reports/generate rejects mixed allowed and unauthorized funds', async () => {
+    const response = await request(makeApp())
+      .post('/api/lp/reports/generate')
+      .send({
+        reportType: 'quarterly',
+        dateRange: { startDate: '2026-01-01', endDate: '2026-03-31' },
+        format: 'pdf',
+        fundIds: [7, 99],
+        sections: ['summary'],
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ error: 'FORBIDDEN' });
+    expect(dbState.state.insertValues).toHaveLength(0);
+    expect(enqueueReportGeneration).not.toHaveBeenCalled();
   });
 });
 
@@ -523,36 +568,75 @@ describe('LP API self-scoping negative controls', () => {
     }
   );
 
-  function collectPredicateAtoms(node: unknown, params: unknown[], cols: string[]): void {
+  type PredicateComparison = { col: string; value: unknown };
+
+  function nodeColumnName(node: unknown): string | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const name = (node as { name?: unknown }).name;
+    return typeof name === 'string' ? name : undefined;
+  }
+
+  function nodeParamValue(node: unknown): { found: boolean; value: unknown } {
+    if (!node || typeof node !== 'object') return { found: false, value: undefined };
+    const n = node as Record<string, unknown>;
+    if ('value' in n && !('queryChunks' in n)) return { found: true, value: n['value'] };
+    return { found: false, value: undefined };
+  }
+
+  function collectPredicateAtoms(
+    node: unknown,
+    params: unknown[],
+    cols: string[],
+    comparisons: PredicateComparison[]
+  ): void {
     if (!node || typeof node !== 'object') return;
     const n = node as Record<string, unknown>;
     if ('value' in n && !('queryChunks' in n)) params.push((n as { value: unknown }).value);
     if (typeof (n as { name?: unknown }).name === 'string') cols.push((n as { name: string }).name);
     const chunks = (n as { queryChunks?: unknown }).queryChunks;
-    if (Array.isArray(chunks)) for (const c of chunks) collectPredicateAtoms(c, params, cols);
+    if (Array.isArray(chunks)) {
+      const directCols = chunks.flatMap((chunk) => {
+        const col = nodeColumnName(chunk);
+        return col ? [col] : [];
+      });
+      const directParams = chunks.flatMap((chunk) => {
+        const param = nodeParamValue(chunk);
+        return param.found ? [param.value] : [];
+      });
+      for (const col of directCols) {
+        for (const value of directParams) comparisons.push({ col, value });
+      }
+      for (const c of chunks) collectPredicateAtoms(c, params, cols, comparisons);
+    }
     const inner = n as { sql?: unknown; left?: unknown; right?: unknown };
-    if (inner.sql) collectPredicateAtoms(inner.sql, params, cols);
-    if (inner.left) collectPredicateAtoms(inner.left, params, cols);
-    if (inner.right) collectPredicateAtoms(inner.right, params, cols);
+    if (inner.sql) collectPredicateAtoms(inner.sql, params, cols, comparisons);
+    if (inner.left) collectPredicateAtoms(inner.left, params, cols, comparisons);
+    if (inner.right) collectPredicateAtoms(inner.right, params, cols, comparisons);
   }
 
-  function wherePredicateAtoms(selectCallIndex = 0): { params: unknown[]; cols: string[] } {
+  function wherePredicateAtoms(selectCallIndex = 0): {
+    params: unknown[];
+    cols: string[];
+    comparisons: PredicateComparison[];
+  } {
     const queryObj = dbState.db.select.mock.results[selectCallIndex]?.value as
       | { where?: { mock?: { calls?: unknown[][] } } }
       | undefined;
     const pred = queryObj?.where?.mock?.calls?.[0]?.[0];
     const params: unknown[] = [];
     const cols: string[] = [];
-    collectPredicateAtoms(pred, params, cols);
-    return { params, cols };
+    const comparisons: PredicateComparison[] = [];
+    collectPredicateAtoms(pred, params, cols, comparisons);
+    return { params, cols, comparisons };
   }
 
   function expectLpPredicateScope(selectCallIndex = 0): void {
-    const { params, cols } = wherePredicateAtoms(selectCallIndex);
+    const { params, cols, comparisons } = wherePredicateAtoms(selectCallIndex);
     expect(params.length).toBeGreaterThan(0);
     expect(params).toContain(9001);
     expect(params).not.toContain(8888);
     expect(cols.some((c) => /lp_?id/i.test(c))).toBe(true);
+    expect(comparisons.some(({ col, value }) => /lp_?id/i.test(col) && value === 9001)).toBe(true);
   }
 
   it('GET /api/lp/summary passes the authenticated LP id to the calculator', async () => {


### PR DESCRIPTION
## Summary

Tranche A **Slice 0** (external boundary verification). This PR closes a
confirmed cross-fund disclosure on the LP portal surface and adds the LP-API
self-scoping negative-control test suite. Tests-only was the plan; one boundary
`fix(auth)` is included because verification surfaced a real, externally
triggerable leak (Slice 0's escalation rule).

Branch is the first slice; **T2-T6 (shares, performance-api, cohort-analysis,
lp-reporting, LP-sibling mount audit) are follow-ups**, not in this PR.

## Security fix: cross-fund portfolio disclosure via LP report generation

`POST /api/lp/reports/generate` accepted a caller-supplied `fundIds` array and
enqueued it **without checking commitment membership**. End-to-end chain:

1. **Boundary** (`server/routes/lp-api.ts`): `ReportConfigSchema.fundIds` is
   `array(number.int.positive).min(1)` with no membership check; `config.fundIds`
   flows into the job verbatim.
2. **Worker** (`server/queues/report-generation-queue.ts`): `resolveFundId` takes
   `fundIds[0]` verbatim -> `prefetchReportMetrics(lpId, <requested fund>)`.
3. **Fetch** (`server/services/pdf-generation/data-fetchers.ts`):
   `getFundPerformance` is correctly commitment-scoped (returns null for a
   non-committed fund), **but** `storage.getPortfolioCompanies(<fund>)` is
   fund-level / not LP-scoped, and the `if (!perf && companies.length === 0)`
   guard passes through because `companies.length > 0`.
4. **Render** (`data-builders.ts` -> `quarterly-document.tsx` `PortfolioTable`):
   the roster (company name, invested, value, MOIC) is rendered into the
   downloadable quarterly PDF.

**Impact:** any authenticated LP could obtain **any fund's** portfolio-company
roster via `reportType:'quarterly', fundIds:[<arbitrary fund>]`. The LP's own
position data was always safe (`fetchLPReportData` re-scopes by `lpId`); this is
other-fund data via a report parameter. Internal tool, authenticated-LP actor ->
roughly **medium** severity; higher if LP logins are broadly provisioned.

**Fix (boundary):** validate `config.fundIds` is a subset of
`req.lpProfile.fundIds` and return `403` (fail-closed, mirrors
`requireLPFundAccess`). `fundIds` is optional (omitted = all of the LP's own
funds, unchanged). Boundary-only by design.

### Worker-layer residuals (follow-up, NOT in this PR)

Defense-in-depth, no longer externally exploitable after the boundary fix:
- `resolveFundId` trusts `fundIds[0]` verbatim.
- `storage.getPortfolioCompanies` has no LP scope; `prefetchReportMetrics` should
  re-check commitment before including a fund's roster.

## Tests (T1 self-scoping negative controls)

Appended to `tests/unit/routes/lp-api.contract.test.ts` (existing shape-locks
unchanged). 37/37 green.

- **Non-LP caller -> 403 before any data read**, swept over all 13 routes
  (configurable `requireLPAccess` mock; default behavior preserved).
- **Per-endpoint LP-self-scope** at each handler's real narrowing point:
  - calculator-arg: `summary` -> `calculateSummary(9001)`; `holdings` ->
    `calculateProRataHoldings(9001, 7)`.
  - `db.where` endpoints (capital-account, fund detail, performance, benchmark,
    reports list/status/download): assert the recorded Drizzle `where` predicate
    pairs the `lpId` column with `9001` (guards: `length > 0`, `toContain(9001)`,
    `not.toContain(8888)`, column-paired-to-value), so a broken extractor fails
    loudly rather than passing vacuously.
- **Report-gen gating**: `enqueueReportGeneration` fires on 202, never on 403;
  omitted `fundIds` -> 202 with no `fundIds` in the job payload; mixed
  `fundIds:[7,99]` -> 403 (any unauthorized fund rejected).
- `profile`/`settings` are static/echo (no per-LP read) -> covered by shape-locks.

## lp-api route/auth matrix (verified against current main)

13 route registrations (the rollout-plan prose says 14 - corrected here).

| Endpoint | Guards | LP scope narrowing |
| --- | --- | --- |
| `GET /profile`, `/summary`, `/capital-account`, `/performance`, `/performance/benchmark`, `/reports`, `/reports/:id`, `/reports/:id/download`, `/settings`; `PUT /settings`; `POST /reports/generate` | `requireAuth + requireLPAccess` | `req.lpProfile.id` (service arg, `db.where(lpId)`, insert payload, or static) |
| `GET /funds/:fundId/detail`, `/funds/:fundId/holdings` | `+ requireLPFundAccess` | param `:fundId` checked against LP commitments |

`/performance` and `/performance/benchmark` take a query `fundId` but filter it
within the LP's own commitments (empty result for a non-committed fund - no
leak). No standalone `requireLPAccess` middleware unit test exists (the contract
test is the only coverage) - recorded for follow-up.

## Verification

- `TZ=UTC npx vitest run tests/unit/routes/lp-api.contract.test.ts` -> 37/37.
- Full `npm test` unit suite -> 6392 passed, 0 failures.
- `npm run check` (client/server/shared tsc) -> 0 new errors; ESLint clean;
  `git diff --check` clean. Pre-push hook passed.

## Commits

- `fix(auth)`: boundary membership check + regression test.
- `test(auth)`: T1 self-scoping suite.
- `test(auth)`: T1 hardening (enqueue gating, mixed-fund, lpId<->value pairing).

Generated with [Claude Code](https://claude.com/claude-code)
