### PR TITLE
test(auth): performance-api fund-scope contracts (Slice 0 T3)

### DIFF
--- a/tests/unit/routes/performance-api.contract.test.ts
+++ b/tests/unit/routes/performance-api.contract.test.ts
@@ -1,0 +1,222 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type QueryChain = PromiseLike<unknown[]> & {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+};
+
+const dbState = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+  };
+
+  function next(): unknown[] {
+    return state.selectResults.shift() ?? [];
+  }
+
+  function thenFor(result: unknown[]): QueryChain['then'] {
+    return (onfulfilled, onrejected) => Promise.resolve(result).then(onfulfilled, onrejected);
+  }
+
+  function makeQuery(result: unknown[]): QueryChain {
+    const query = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => Promise.resolve(result)),
+      then: thenFor(result),
+    } as QueryChain;
+    return query;
+  }
+
+  const db = {
+    select: vi.fn(() => makeQuery(next())),
+  };
+
+  return { db, state };
+});
+
+const {
+  getFundMock,
+  calculateTimeseriesMock,
+  calculateBreakdownMock,
+  calculateComparisonMock,
+  startTimerMock,
+  recordPerformanceRequestMock,
+  recordCacheHitMock,
+  recordCacheMissMock,
+  recordCalculationMock,
+  recordDataPointsMock,
+  recordErrorMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  getFundMock: vi.fn(),
+  calculateTimeseriesMock: vi.fn(),
+  calculateBreakdownMock: vi.fn(),
+  calculateComparisonMock: vi.fn(),
+  startTimerMock: vi.fn(),
+  recordPerformanceRequestMock: vi.fn(),
+  recordCacheHitMock: vi.fn(),
+  recordCacheMissMock: vi.fn(),
+  recordCalculationMock: vi.fn(),
+  recordDataPointsMock: vi.fn(),
+  recordErrorMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../server/lib/auth/jwt')>()),
+  requireAuth: () => (req: Request, _res: Response, next: NextFunction) => {
+    req.user = {
+      id: 'u1',
+      sub: 'u1',
+      email: 'u@example.com',
+      roles: ['user'],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+      fundIds: [1],
+    };
+    next();
+  },
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+vi.mock('../../../server/storage', () => ({
+  storage: {
+    getFund: getFundMock,
+  },
+}));
+
+vi.mock('../../../server/services/performance-calculator', () => ({
+  performanceCalculator: {
+    calculateTimeseries: calculateTimeseriesMock,
+    calculateBreakdown: calculateBreakdownMock,
+    calculateComparison: calculateComparisonMock,
+  },
+}));
+
+vi.mock('../../../server/observability/performance-metrics', () => ({
+  startTimer: startTimerMock,
+  recordPerformanceRequest: recordPerformanceRequestMock,
+  recordCacheHit: recordCacheHitMock,
+  recordCacheMiss: recordCacheMissMock,
+  recordCalculation: recordCalculationMock,
+  recordDataPoints: recordDataPointsMock,
+  recordError: recordErrorMock,
+}));
+
+vi.mock('../../../server/lib/logger.js', () => ({
+  logger: {
+    error: loggerErrorMock,
+  },
+}));
+
+import performanceApiRouter from '../../../server/routes/performance-api';
+
+type RouteCase = readonly [route: string, pathForFund: (fundId: number) => string];
+
+const protectedRoutes = [
+  [
+    '/api/funds/:fundId/performance/metrics',
+    (fundId: number) => `/api/funds/${fundId}/performance/metrics`,
+  ],
+  ['/api/funds/:fundId/pacing-history', (fundId: number) => `/api/funds/${fundId}/pacing-history`],
+  [
+    '/api/funds/:fundId/performance/timeseries',
+    (fundId: number) => `/api/funds/${fundId}/performance/timeseries`,
+  ],
+  [
+    '/api/funds/:fundId/performance/breakdown',
+    (fundId: number) => `/api/funds/${fundId}/performance/breakdown`,
+  ],
+  [
+    '/api/funds/:fundId/performance/comparison',
+    (fundId: number) => `/api/funds/${fundId}/performance/comparison`,
+  ],
+] as const satisfies readonly RouteCase[];
+
+const dataLayerControlRoutes = protectedRoutes.slice(0, 2);
+const validationControlRoutes = protectedRoutes.slice(2);
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(performanceApiRouter);
+  return app;
+}
+
+function resetState() {
+  dbState.state.selectResults = [];
+  dbState.db.select.mockClear();
+
+  getFundMock.mockReset();
+  getFundMock.mockResolvedValue({ id: 1, name: 'Performance Fund' });
+
+  calculateTimeseriesMock.mockReset();
+  calculateBreakdownMock.mockReset();
+  calculateComparisonMock.mockReset();
+
+  startTimerMock.mockReset();
+  startTimerMock.mockReturnValue(() => 5);
+  recordPerformanceRequestMock.mockReset();
+  recordCacheHitMock.mockReset();
+  recordCacheMissMock.mockReset();
+  recordCalculationMock.mockReset();
+  recordDataPointsMock.mockReset();
+  recordErrorMock.mockReset();
+  loggerErrorMock.mockReset();
+}
+
+function expectNoCalculatorCalls() {
+  expect(calculateTimeseriesMock).not.toHaveBeenCalled();
+  expect(calculateBreakdownMock).not.toHaveBeenCalled();
+  expect(calculateComparisonMock).not.toHaveBeenCalled();
+}
+
+describe('performance API fund-access contract', () => {
+  beforeEach(() => resetState());
+
+  it.each(protectedRoutes)(
+    'denies unauthorized fund access for %s',
+    async (_route, pathForFund) => {
+      const response = await request(makeApp()).get(pathForFund(2));
+
+      expect(response.status).toBe(403);
+      expect(response.status).not.toBe(404);
+      expect(response.body.error).toBe('Forbidden');
+      expect(dbState.db.select).not.toHaveBeenCalled();
+      expect(getFundMock).not.toHaveBeenCalled();
+      expectNoCalculatorCalls();
+    }
+  );
+
+  it.each(dataLayerControlRoutes)(
+    'allows authorized fund access for %s',
+    async (_route, pathForFund) => {
+      dbState.state.selectResults.push([]);
+
+      const response = await request(makeApp()).get(pathForFund(1));
+
+      expect(response.status).not.toBe(403);
+      expect(dbState.db.select).toHaveBeenCalled();
+    }
+  );
+
+  it.each(validationControlRoutes)(
+    'lets authorized validation routes pass the guard for %s',
+    async (_route, pathForFund) => {
+      const response = await request(makeApp()).get(pathForFund(1));
+
+      expect(response.status).not.toBe(403);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Tranche A Slice 0 (external-boundary safety net), task **T3** — a **tests-only** contract suite proving the 5 GET `performance-api` endpoints deny cross-fund access. No production code changed.

For each of `/api/funds/:fundId/performance/{metrics,timeseries,breakdown,comparison}` and `/api/funds/:fundId/pacing-history`:

- **Deny (load-bearing):** a `fundIds:[1]` caller requesting fund `2` gets **403** (`error: 'Forbidden'`), **403 not 404**, and **no data is read** (`db.select`, `storage.getFund`, and all calculator methods uncalled).
- **Allow control:** the authorized fund `1` reaches the handler (metrics/pacing reach the data layer; the three query-validated routes pass the guard).

The suite exercises the **real `requireFundAccess`** guard via a partial `vi.mock` that overrides only `requireAuth` — no stubbed/tautological guard.

## Verification

- New suite: **10 tests green**.
- Full suite: **6448 passed / 90 skipped** (baseline 6438 + 10; zero collateral).
- **Negative-control:** removing `requireFundAccess` from a route flips its deny test RED (`200 != 403`) — confirms the test locks the real, wired guard, not a mock.
- `npm run check`: 0 TypeScript errors.

## Follow-up — real boundary gap found (ships separately, NOT in this PR)

While scoping T3, a genuine **cross-fund parse-divergence leak** was identified (confused deputy): the guard parses `:fundId` with `parseInt` while handlers use `Number()`, so `GET /api/funds/1e1/performance/metrics` lets a `fundIds:[1]` caller read fund **10** (a fund-F caller reads fund F x 10^k). This is **not** fixed here (T3 is tests-only and stays green). It ships as a separate **`fix(auth):`** PR — strict canonical fund-id validation at the guard (`requireFundAccess` + sibling `requireLPAccess`), with its own RED-then-green regression test. The fix touches a guard shared by ~50 routes, so it is deliberately isolated from this suite.

## Context

Slice 0: T1 #745 (LP-report leak fix + lp-api self-scoping), T2 #746 (shares boundary). This is T3.

Dispatched via Hermes (codex executor); verification performed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
