### PR TITLE
fix(auth): reject non-canonical fundId at fund-access guard (Slice 0)

### DIFF
--- a/server/lib/auth/jwt.ts
+++ b/server/lib/auth/jwt.ts
@@ -13,6 +13,7 @@ import type { Algorithm, JwtPayload } from 'jsonwebtoken';
 import jwt from 'jsonwebtoken';
 import jwksClient from 'jwks-rsa';
 import type { Request, Response, NextFunction } from 'express';
+import { parseFundIdParam } from '@shared/number';
 import { getConfig } from '../../config';
 import { authMetrics } from '../../telemetry';
 import { firstString } from '../request-values';
@@ -253,20 +254,12 @@ export const requireRole = (role: string) => (req: Request, res: Response, next:
  */
 export const requireFundAccess = (req: Request, res: Response, next: NextFunction) => {
   const fundIdParam = firstString(req.params['fundId']);
+  const fundId = parseFundIdParam(fundIdParam);
 
-  if (!fundIdParam) {
+  if (fundId === null) {
     return res.status(400).json({
       error: 'Bad Request',
-      message: 'Fund ID is required',
-    });
-  }
-
-  const fundId = parseInt(fundIdParam, 10);
-
-  if (isNaN(fundId)) {
-    return res.status(400).json({
-      error: 'Bad Request',
-      message: 'Invalid fund ID',
+      message: fundIdParam ? 'Invalid fund ID' : 'Fund ID is required',
     });
   }
 

--- a/shared/number.ts
+++ b/shared/number.ts
@@ -22,12 +22,20 @@ export interface NumberOptions {
   integer?: boolean;
 }
 
+const CANONICAL_FUND_ID = /^\d+$/;
+
+export function parseFundIdParam(raw: string | undefined): number | null {
+  if (!raw || !CANONICAL_FUND_ID.test(raw)) return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) && n >= 1 ? n : null;
+}
+
 export const toNumber = (v: unknown, label = 'value', options?: NumberOptions): number => {
   const n = typeof v === 'number' ? v : Number(v);
   if (!Number.isFinite(n)) {
     throw new NumberParseError(`${label} must be a finite number`);
   }
-  
+
   if (options) {
     if (options.integer && !Number.isInteger(n)) {
       throw new NumberParseError(`${label} must be an integer`);
@@ -39,6 +47,6 @@ export const toNumber = (v: unknown, label = 'value', options?: NumberOptions): 
       throw new NumberParseError(`${label} must be at most ${options.max}`);
     }
   }
-  
+
   return n;
 };

--- a/tests/unit/auth/requireFundAccess.test.ts
+++ b/tests/unit/auth/requireFundAccess.test.ts
@@ -69,7 +69,7 @@ describe('requireFundAccess Middleware', () => {
       expect(statusMock).not.toHaveBeenCalled();
     });
 
-    it('should handle fundId 0 as a valid numeric ID', () => {
+    it('should reject fundId 0 as invalid', () => {
       req.params = { fundId: '0' };
       req.user = {
         id: 'user-1',
@@ -83,8 +83,12 @@ describe('requireFundAccess Middleware', () => {
 
       requireFundAccess(req as Request, res as Response, next);
 
-      expect(next).toHaveBeenCalledOnce();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'Bad Request',
+        message: 'Invalid fund ID',
+      });
+      expect(next).not.toHaveBeenCalled();
     });
   });
 
@@ -121,6 +125,28 @@ describe('requireFundAccess Middleware', () => {
         ip: '127.0.0.1',
         userAgent: 'test',
         fundIds: [1, 2, 3],
+      };
+
+      requireFundAccess(req as Request, res as Response, next);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'Bad Request',
+        message: 'Invalid fund ID',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should reject non-canonical scientific notation fund IDs', () => {
+      req.params = { fundId: '1e1' };
+      req.user = {
+        id: 'user-1',
+        sub: 'user-1',
+        email: 'user@example.com',
+        roles: ['user'],
+        ip: '127.0.0.1',
+        userAgent: 'test',
+        fundIds: [1],
       };
 
       requireFundAccess(req as Request, res as Response, next);
@@ -312,7 +338,7 @@ describe('requireFundAccess Middleware', () => {
   });
 
   describe('Edge Cases - Numeric Edge Values', () => {
-    it('should correctly parse and authorize access for negative fund IDs', () => {
+    it('should reject negative fund IDs', () => {
       req.params = { fundId: '-1' };
       req.user = {
         id: 'user-1',
@@ -326,8 +352,12 @@ describe('requireFundAccess Middleware', () => {
 
       requireFundAccess(req as Request, res as Response, next);
 
-      expect(next).toHaveBeenCalledOnce();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'Bad Request',
+        message: 'Invalid fund ID',
+      });
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('should correctly parse and deny access for large fund IDs', () => {
@@ -384,9 +414,12 @@ describe('requireFundAccess Middleware', () => {
 
       requireFundAccess(req as Request, res as Response, next);
 
-      // parseInt('123.456', 10) = 123, and user has access to 123
-      expect(next).toHaveBeenCalledOnce();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'Bad Request',
+        message: 'Invalid fund ID',
+      });
+      expect(next).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/routes/performance-api.fund-id-parse.contract.test.ts
+++ b/tests/unit/routes/performance-api.fund-id-parse.contract.test.ts
@@ -1,0 +1,145 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type QueryChain = PromiseLike<unknown[]> & {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+};
+
+const dbState = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+  };
+
+  function next(): unknown[] {
+    return state.selectResults.shift() ?? [];
+  }
+
+  function thenFor(result: unknown[]): QueryChain['then'] {
+    return (onfulfilled, onrejected) => Promise.resolve(result).then(onfulfilled, onrejected);
+  }
+
+  function makeQuery(result: unknown[]): QueryChain {
+    const query = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => Promise.resolve(result)),
+      then: thenFor(result),
+    } as QueryChain;
+    return query;
+  }
+
+  const db = {
+    select: vi.fn(() => makeQuery(next())),
+  };
+
+  return { db, state };
+});
+
+const storageState = vi.hoisted(() => ({
+  getFund: vi.fn(),
+}));
+
+const calculatorState = vi.hoisted(() => ({
+  calculateTimeseries: vi.fn(),
+  calculateBreakdown: vi.fn(),
+  calculateComparison: vi.fn(),
+}));
+
+const metricsState = vi.hoisted(() => ({
+  startTimer: vi.fn(() => () => 0),
+  recordPerformanceRequest: vi.fn(),
+  recordCacheMiss: vi.fn(),
+  recordCalculation: vi.fn(),
+  recordDataPoints: vi.fn(),
+  recordError: vi.fn(),
+}));
+
+const loggerState = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../server/lib/auth/jwt')>()),
+  requireAuth: () => (req: Request, _res: Response, next: NextFunction) => {
+    req.user = {
+      id: 'u1',
+      sub: 'u1',
+      email: 'u@example.com',
+      roles: ['user'],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+      fundIds: [1],
+    };
+    next();
+  },
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+vi.mock('../../../server/storage', () => ({
+  storage: {
+    getFund: storageState.getFund,
+  },
+}));
+
+vi.mock('../../../server/services/performance-calculator', () => ({
+  performanceCalculator: {
+    calculateTimeseries: calculatorState.calculateTimeseries,
+    calculateBreakdown: calculatorState.calculateBreakdown,
+    calculateComparison: calculatorState.calculateComparison,
+  },
+}));
+
+vi.mock('../../../server/observability/performance-metrics', () => ({
+  startTimer: metricsState.startTimer,
+  recordPerformanceRequest: metricsState.recordPerformanceRequest,
+  recordCacheMiss: metricsState.recordCacheMiss,
+  recordCalculation: metricsState.recordCalculation,
+  recordDataPoints: metricsState.recordDataPoints,
+  recordError: metricsState.recordError,
+}));
+
+vi.mock('../../../server/lib/logger.js', () => ({
+  logger: {
+    error: loggerState.error,
+  },
+}));
+
+import performanceApiRouter from '../../../server/routes/performance-api';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(performanceApiRouter);
+  return app;
+}
+
+describe('performance API fundId parse contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.state.selectResults = [];
+  });
+
+  it('GET /api/funds/1e1/performance/metrics rejects before the handler reads', async () => {
+    const response = await request(makeApp()).get('/api/funds/1e1/performance/metrics');
+
+    expect(response.status).toBe(400);
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/funds/1e1/pacing-history rejects before the handler reads', async () => {
+    const response = await request(makeApp()).get('/api/funds/1e1/pacing-history');
+
+    expect(response.status).toBe(400);
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes a **confused-deputy cross-fund leak** in the fund-access guard (found while scoping Slice 0 T3, PR #747).

`requireFundAccess` parsed `:fundId` with `parseInt`, while the route handlers parse the same param with `Number()` (via `toNumber`). These disagree on non-canonical strings:

```
parseInt("1e1", 10) === 1     Number("1e1") === 10
```

So `GET /api/funds/1e1/performance/metrics` from a caller with `fundIds:[1]` was **authorized as fund 1** by the guard yet **read fund 10** in the handler. A fund-F caller could read fund F×10ᵏ. No upstream sanitizer existed.

## Fix

A new shared `parseFundIdParam` (`shared/number.ts`) accepts only canonical positive integer strings (`/^\d+$/` + `Number.isSafeInteger` + `>= 1`) and returns `null` otherwise. `requireFundAccess` uses it and returns **400** for non-canonical ids. Because `parseInt` and `Number` provably agree on canonical integer strings, rejecting at the guard makes guard/handler divergence impossible — and it's safe across **all ~50 routes** that share `requireFundAccess` (rejecting upstream cannot introduce a new divergence, unlike switching the guard's parser, which would have broken `backtesting`'s existing `parseInt` consistency).

The `400`/`403` response bodies are unchanged byte-for-byte.

## Verification

- New shared helper + guard change; **400/403 shapes preserved**.
- `requireFundAccess.test.ts`: three existing cases (`'0'`, `'-1'`, `'123.456'`) now assert **400** (titles updated to match), plus a new `'1e1'` case. The `'0123'` leading-zeros case still resolves to 123.
- New `tests/unit/routes/performance-api.fund-id-parse.contract.test.ts`: real guard + real handler; `GET /api/funds/1e1/{performance/metrics,pacing-history}` returns **400** with **no data read**.
- **Negative-control:** reverting only the guard fix flips 6 tests RED — including both route tests, where `/api/funds/1e1/...` reaches the handler and reads fund 10. This confirms the tests catch the real leak and the fix closes it.
- Full suite: **6441 passed / 90 skipped** (baseline 6438 + 3; zero collateral across the guard-sharing routes).

## Follow-up (recommended fast-follow, not in this PR)

`server/middleware/requireLPAccess.ts:174` uses the identical `parseInt` pattern and its LP handlers use `Number()` — the same latent divergence. Recommend applying the same `parseFundIdParam` helper in a follow-up. Non-guard `parseInt` sites (`enhanced-audit`, `sse-events`, `reallocation`) are not authorization decisions and are out of scope.

## Context

Tranche A Slice 0: T1 #745 (LP-report leak), T2 #746 (shares boundary), T3 #747 (performance-api contract suite — the work that surfaced this gap). This is the Track 2 `fix(auth):` follow-up referenced there.

Dispatched via Hermes (codex executor); verification performed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
