### PR TITLE
fix(auth): canonicalize fundId parsing in requireLPFundAccess (Slice 0)

### DIFF
--- a/server/middleware/requireLPAccess.ts
+++ b/server/middleware/requireLPAccess.ts
@@ -16,6 +16,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { db } from '../db';
 import { eq } from 'drizzle-orm';
+import { parseFundIdParam } from '@shared/number';
 import { limitedPartners, lpFundCommitments } from '@shared/schema-lp-reporting';
 import { firstString } from '../lib/request-values';
 import { logger } from '../lib/logger.js';
@@ -171,9 +172,9 @@ export function requireLPFundAccess(req: Request, res: Response, next: NextFunct
     return;
   }
 
-  const fundId = parseInt(fundIdParam, 10);
+  const fundId = parseFundIdParam(fundIdParam);
 
-  if (isNaN(fundId) || fundId <= 0) {
+  if (fundId === null) {
     res.status(400).json({
       error: 'INVALID_PARAMETER',
       message: 'Invalid fund ID',

--- a/shared/number.ts
+++ b/shared/number.ts
@@ -22,7 +22,8 @@ export interface NumberOptions {
   integer?: boolean;
 }
 
-const CANONICAL_FUND_ID = /^\d+$/;
+// Canonical positive integer: no leading zeros, so the string equals String(Number(raw)).
+const CANONICAL_FUND_ID = /^[1-9]\d*$/;
 
 export function parseFundIdParam(raw: string | undefined): number | null {
   if (!raw || !CANONICAL_FUND_ID.test(raw)) return null;

--- a/tests/unit/auth/requireFundAccess.test.ts
+++ b/tests/unit/auth/requireFundAccess.test.ts
@@ -382,8 +382,8 @@ describe('requireFundAccess Middleware', () => {
       expect(next).not.toHaveBeenCalled();
     });
 
-    it('should handle fundId with leading zeros correctly', () => {
-      req.params = { fundId: '0123' }; // parseInt('0123', 10) = 123
+    it('should reject fundId with leading zeros as non-canonical', () => {
+      req.params = { fundId: '0123' };
       req.user = {
         id: 'user-1',
         sub: 'user-1',
@@ -396,8 +396,9 @@ describe('requireFundAccess Middleware', () => {
 
       requireFundAccess(req as Request, res as Response, next);
 
-      expect(next).toHaveBeenCalledOnce();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({ error: 'Bad Request', message: 'Invalid fund ID' });
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('should reject floating point fund IDs (treated as invalid after decimal)', () => {

--- a/tests/unit/auth/requireLPFundAccess.test.ts
+++ b/tests/unit/auth/requireLPFundAccess.test.ts
@@ -57,6 +57,33 @@ describe('requireLPFundAccess Middleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('rejects a leading-zero (non-canonical) fund id the LP would otherwise hold', () => {
+    req = {
+      params: { fundId: '0123' },
+      lpProfile: {
+        id: 1,
+        name: 'Test LP',
+        email: 'lp@example.com',
+        entityType: 'individual',
+        fundIds: [123],
+      },
+    };
+
+    requireLPFundAccess(req as Request, res as Response, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    const body = jsonMock.mock.calls[0]?.[0];
+    expect(body).toEqual(
+      expect.objectContaining({
+        error: 'INVALID_PARAMETER',
+        message: 'Invalid fund ID',
+        field: 'fundId',
+      })
+    );
+    expect(body).toEqual(expect.objectContaining({ timestamp: expect.any(String) }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('calls next() for a valid canonical id the LP holds', () => {
     req = {
       params: { fundId: '123' },

--- a/tests/unit/auth/requireLPFundAccess.test.ts
+++ b/tests/unit/auth/requireLPFundAccess.test.ts
@@ -1,0 +1,175 @@
+/**
+ * requireLPFundAccess Middleware Tests
+ * Tests LP fund-level authorization and canonical fund ID parsing
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { requireLPFundAccess } from '@/server/middleware/requireLPAccess';
+
+describe('requireLPFundAccess Middleware', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  let jsonMock: ReturnType<typeof vi.fn>;
+  let statusMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    jsonMock = vi.fn();
+    statusMock = vi.fn().mockReturnValue({ json: jsonMock });
+
+    req = {
+      params: {},
+    };
+
+    res = {
+      status: statusMock,
+      json: jsonMock,
+    };
+
+    next = vi.fn();
+  });
+
+  it('rejects a non-canonical exponent id before authorization', () => {
+    req = {
+      params: { fundId: '1e1' },
+      lpProfile: {
+        id: 1,
+        name: 'Test LP',
+        email: 'lp@example.com',
+        entityType: 'individual',
+        fundIds: [1],
+      },
+    };
+
+    requireLPFundAccess(req as Request, res as Response, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    const body = jsonMock.mock.calls[0]?.[0];
+    expect(body).toEqual(
+      expect.objectContaining({
+        error: 'INVALID_PARAMETER',
+        message: 'Invalid fund ID',
+        field: 'fundId',
+      })
+    );
+    expect(body).toEqual(expect.objectContaining({ timestamp: expect.any(String) }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() for a valid canonical id the LP holds', () => {
+    req = {
+      params: { fundId: '123' },
+      lpProfile: {
+        id: 1,
+        name: 'Test LP',
+        email: 'lp@example.com',
+        entityType: 'individual',
+        fundIds: [123],
+      },
+    };
+
+    requireLPFundAccess(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(statusMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when fundId parameter is missing', () => {
+    req = {
+      params: {},
+      lpProfile: {
+        id: 1,
+        name: 'Test LP',
+        email: 'lp@example.com',
+        entityType: 'individual',
+        fundIds: [1],
+      },
+    };
+
+    requireLPFundAccess(req as Request, res as Response, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    const body = jsonMock.mock.calls[0]?.[0];
+    expect(body).toEqual(
+      expect.objectContaining({
+        error: 'INVALID_PARAMETER',
+        message: 'Fund ID is required',
+        field: 'fundId',
+      })
+    );
+    expect(body).toEqual(expect.objectContaining({ timestamp: expect.any(String) }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when fundId is non-numeric', () => {
+    req = {
+      params: { fundId: 'abc' },
+      lpProfile: {
+        id: 1,
+        name: 'Test LP',
+        email: 'lp@example.com',
+        entityType: 'individual',
+        fundIds: [1],
+      },
+    };
+
+    requireLPFundAccess(req as Request, res as Response, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    const body = jsonMock.mock.calls[0]?.[0];
+    expect(body).toEqual(
+      expect.objectContaining({
+        error: 'INVALID_PARAMETER',
+        message: 'Invalid fund ID',
+        field: 'fundId',
+      })
+    );
+    expect(body).toEqual(expect.objectContaining({ timestamp: expect.any(String) }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the LP does not hold the canonical fund id', () => {
+    req = {
+      params: { fundId: '99999' },
+      lpProfile: {
+        id: 1,
+        name: 'Test LP',
+        email: 'lp@example.com',
+        entityType: 'individual',
+        fundIds: [1, 2, 3],
+      },
+    };
+
+    requireLPFundAccess(req as Request, res as Response, next);
+
+    expect(statusMock).toHaveBeenCalledWith(403);
+    expect(jsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'FORBIDDEN',
+        message:
+          'You do not have access to fund 99999. LPs can only view funds they have invested in.',
+        timestamp: expect.any(String),
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when called before requireLPAccess', () => {
+    req = {
+      params: { fundId: '1' },
+    };
+
+    requireLPFundAccess(req as Request, res as Response, next);
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'MIDDLEWARE_ERROR',
+        message: 'requireLPFundAccess must be called after requireLPAccess in middleware chain',
+        timestamp: expect.any(String),
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Aligns the LP fund-scope guard `requireLPFundAccess` with the shared canonical
fund-id parser `parseFundIdParam` (`shared/number.ts`), so it rejects
non-canonical `:fundId` strings (e.g. `"1e1"`, `"1.5"`, `"  1"`, `"0123"`) the
same way `requireFundAccess` now does (#748). Guard-only change; the LP route
handlers are untouched.

> **Review follow-up (commit 2):** a review flagged that the parser still
> accepted leading-zero aliases like `"0123"` (returned 123), contradicting the
> canonicalization claim. This was **not a cross-fund leak** — the guard and the
> handlers both resolve `"0123"` to 123, so it was a benign alias for a fund the
> caller already owns, never a path to another fund. Tightened
> `CANONICAL_FUND_ID` from `/^\d+$/` to `/^[1-9]\d*$/` so leading-zero forms are
> rejected (400). Because this is the shared helper it also tightens the merged
> `requireFundAccess` surface: the previously-passing `requireFundAccess`
> "leading zeros" test is flipped to expect 400, and a `"0123"` regression is
> added to the LP guard test (seeded `fundIds:[123]` so the old parser would have
> authorized it). Full suite green, zero collateral across the ~50
> `requireFundAccess` routes.

## Why

`requireLPFundAccess` parsed `:fundId` with `parseInt(x, 10)`, while the LP route
handlers parse the same param with `Number(x)` via `toNumber`. These disagree on
non-canonical strings: `parseInt("1e1", 10) === 1` but `Number("1e1") === 10`.
The guard authorized against `1` while a handler would read `10` — the same
parse-divergence closed for `requireFundAccess` in #748.

**This divergence is NOT an exploitable cross-fund leak today.** Both routes that
mount `requireLPFundAccess` re-validate `(lpId, fundId)` downstream before
returning any data:

- `GET /api/lp/funds/:fundId/detail` re-queries the commitment by
  `(lpId, fundId)` and returns `COMMITMENT_NOT_FOUND` if absent
  (`server/routes/lp-api.ts:415-421`).
- `GET /api/lp/funds/:fundId/holdings` calls
  `lpCalculator.calculateProRataHoldings(lpId, fundId)`, which throws if the LP
  has no commitment to that fund (`server/services/lp-calculator.ts:347-349`).

So an LP authorized for fund `1` who sends `"1e1"` gets a 404/error for fund
`10`, not its data. This fix is **defense-in-depth and consistency**: every fund
guard should reject non-canonical ids via the one canonical parser, so a future
change to a handler's re-scope cannot silently re-open the gap, and guard
behavior no longer diverges from the handler it gates.

## Changes

- `server/middleware/requireLPAccess.ts` — `requireLPFundAccess` now uses
  `parseFundIdParam(fundIdParam)` + `fundId === null` instead of
  `parseInt` + `isNaN || <= 0`. The `!fundIdParam` branch stays first, so the two
  400 response shapes are preserved exactly:
  `{ error: 'INVALID_PARAMETER', message: 'Fund ID is required' | 'Invalid fund ID', field: 'fundId', timestamp }`.
- `tests/unit/auth/requireLPFundAccess.test.ts` (new) — pure middleware unit test
  mirroring `requireFundAccess.test.ts`: non-canonical `"1e1"` (seeded with
  `fundIds:[1]` to prove the guard blocks it, not the deny path), valid canonical
  id, missing param, non-numeric, in-list 403 preserved, and out-of-order
  (missing `lpProfile`) 500.

## Scope

Guard-only, matching #748. The handler-side `toNumber` calls are intentionally
left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
