### PR TITLE
test(auth): lp-reporting fund-scope deny contracts (Slice 0 T5)

### DIFF
--- a/tests/unit/routes/lp-reporting-imports.contract.test.ts
+++ b/tests/unit/routes/lp-reporting-imports.contract.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Real-guard contract: requireAuth is mocked to inject req.user; requireFundAccess is the REAL guard. Deny = caller fundIds [1] targeting fund 2. The exact toBe(403) (not just not-200) ensures the :fundId reached the guard; a 400 would mean it did not.
+ */
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbState = vi.hoisted(() => {
+  const calls = { select: 0, insert: 0, update: 0, delete: 0 };
+
+  function chain() {
+    const p = new Proxy(function chainTarget() {}, {
+      get(_target, prop: string | symbol) {
+        if (prop === 'then') {
+          return (resolve: (value: unknown[]) => void) => resolve([]);
+        }
+        return () => p;
+      },
+      apply() {
+        return p;
+      },
+    });
+    return p;
+  }
+
+  const db = {
+    select: (..._args: unknown[]) => {
+      calls.select += 1;
+      return chain();
+    },
+    insert: (..._args: unknown[]) => {
+      calls.insert += 1;
+      return chain();
+    },
+    update: (..._args: unknown[]) => {
+      calls.update += 1;
+      return chain();
+    },
+    delete: (..._args: unknown[]) => {
+      calls.delete += 1;
+      return chain();
+    },
+  };
+
+  return { db, calls };
+});
+
+const importServiceMock = vi.hoisted(() => ({
+  runLedgerDryRun: vi.fn(),
+  runValuationMarkDryRun: vi.fn(),
+  commitLedgerImport: vi.fn(),
+  commitValuationMarkImport: vi.fn(),
+}));
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, _res: Response, next: NextFunction) => {
+      req.user = {
+        id: 'u1',
+        sub: 'u1',
+        email: 'u@example.com',
+        roles: ['user'],
+        ip: '127.0.0.1',
+        userAgent: 'vitest',
+        fundIds: [1],
+      };
+      next();
+    },
+  };
+});
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+vi.mock('../../../server/services/lp-reporting/import-reconciliation-service', () => ({
+  runLedgerDryRun: importServiceMock.runLedgerDryRun,
+  runValuationMarkDryRun: importServiceMock.runValuationMarkDryRun,
+}));
+
+vi.mock('../../../server/services/lp-reporting/import-commit-service', () => {
+  class ImportCommitError extends Error {
+    readonly status: number;
+    readonly code: string;
+    readonly details?: unknown;
+
+    constructor(status: number, code: string, message: string, details?: unknown) {
+      super(message);
+      this.name = 'ImportCommitError';
+      this.status = status;
+      this.code = code;
+      this.details = details;
+    }
+  }
+
+  return {
+    commitLedgerImport: importServiceMock.commitLedgerImport,
+    commitValuationMarkImport: importServiceMock.commitValuationMarkImport,
+    ImportCommitError,
+  };
+});
+
+import importsRouter from '../../../server/routes/lp-reporting/imports';
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(importsRouter);
+  return app;
+}
+
+function resetDbCalls() {
+  dbState.calls.select = 0;
+  dbState.calls.insert = 0;
+  dbState.calls.update = 0;
+  dbState.calls.delete = 0;
+}
+
+describe('lp-reporting imports fund-scope guard contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbCalls();
+  });
+
+  it.each([
+    '/api/funds/2/imports/ledger/dry-run',
+    '/api/funds/2/imports/valuation-marks/dry-run',
+    '/api/funds/2/imports/ledger/commit',
+    '/api/funds/2/imports/valuation-marks/commit',
+  ])('denies cross-fund POST %s before service or db work', async (path) => {
+    const res = await request(makeApp()).post(path).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        error: 'Forbidden',
+        message: 'You do not have access to fund 2',
+      })
+    );
+    expect(importServiceMock.runLedgerDryRun).not.toHaveBeenCalled();
+    expect(importServiceMock.runValuationMarkDryRun).not.toHaveBeenCalled();
+    expect(importServiceMock.commitLedgerImport).not.toHaveBeenCalled();
+    expect(importServiceMock.commitValuationMarkImport).not.toHaveBeenCalled();
+    expect(dbState.calls.select).toBe(0);
+    expect(dbState.calls.insert).toBe(0);
+    expect(dbState.calls.update).toBe(0);
+  });
+
+  it('allows same-fund import requests past the guard', async () => {
+    const res = await request(makeApp()).post('/api/funds/1/imports/ledger/dry-run').send({});
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/tests/unit/routes/lp-reporting-metric-runs.contract.test.ts
+++ b/tests/unit/routes/lp-reporting-metric-runs.contract.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Real-guard contract: requireAuth is mocked to inject req.user; requireFundAccess is the REAL guard. Deny = caller fundIds [1] targeting fund 2. The exact toBe(403) (not just not-200) ensures the :fundId reached the guard; a 400 would mean it did not.
+ */
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbState = vi.hoisted(() => {
+  const calls = { select: 0, insert: 0, update: 0, delete: 0 };
+
+  function chain() {
+    const p = new Proxy(function chainTarget() {}, {
+      get(_target, prop: string | symbol) {
+        if (prop === 'then') {
+          return (resolve: (value: unknown[]) => void) => resolve([]);
+        }
+        return () => p;
+      },
+      apply() {
+        return p;
+      },
+    });
+    return p;
+  }
+
+  const db = {
+    select: (..._args: unknown[]) => {
+      calls.select += 1;
+      return chain();
+    },
+    insert: (..._args: unknown[]) => {
+      calls.insert += 1;
+      return chain();
+    },
+    update: (..._args: unknown[]) => {
+      calls.update += 1;
+      return chain();
+    },
+    delete: (..._args: unknown[]) => {
+      calls.delete += 1;
+      return chain();
+    },
+  };
+
+  return { db, calls };
+});
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, _res: Response, next: NextFunction) => {
+      req.user = {
+        id: 'u1',
+        sub: 'u1',
+        email: 'u@example.com',
+        roles: ['user'],
+        ip: '127.0.0.1',
+        userAgent: 'vitest',
+        fundIds: [1],
+      };
+      next();
+    },
+  };
+});
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+import metricRunsRouter from '../../../server/routes/lp-reporting/metric-runs';
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(metricRunsRouter);
+  return app;
+}
+
+function resetDbCalls() {
+  dbState.calls.select = 0;
+  dbState.calls.insert = 0;
+  dbState.calls.update = 0;
+  dbState.calls.delete = 0;
+}
+
+type DeniedEndpoint =
+  | { method: 'POST'; path: string; body: Record<string, never> }
+  | { method: 'GET'; path: string }
+  | { method: 'PATCH'; path: string; body: Record<string, never> };
+
+async function requestEndpoint(endpoint: DeniedEndpoint) {
+  const app = makeApp();
+
+  if (endpoint.method === 'GET') {
+    return request(app).get(endpoint.path);
+  }
+  if (endpoint.method === 'POST') {
+    return request(app).post(endpoint.path).send(endpoint.body);
+  }
+  return request(app).patch(endpoint.path).send(endpoint.body);
+}
+
+describe('lp-reporting metric-runs fund-scope guard contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbCalls();
+  });
+
+  it.each<DeniedEndpoint>([
+    { method: 'POST', path: '/api/funds/2/metric-runs/commit', body: {} },
+    { method: 'GET', path: '/api/funds/2/metric-runs/123' },
+    { method: 'GET', path: '/api/funds/2/metric-runs/123/evidence-records' },
+    {
+      method: 'PATCH',
+      path: '/api/funds/2/metric-runs/123/narrative-runs/456',
+      body: {},
+    },
+  ])('denies cross-fund $method $path before db work', async (endpoint) => {
+    const res = await requestEndpoint(endpoint);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        error: 'Forbidden',
+        message: 'You do not have access to fund 2',
+      })
+    );
+    expect(dbState.calls.select).toBe(0);
+    expect(dbState.calls.insert).toBe(0);
+    expect(dbState.calls.update).toBe(0);
+    expect(dbState.calls.delete).toBe(0);
+  });
+
+  it('allows same-fund metric-run requests past the guard', async () => {
+    const res = await request(makeApp()).get('/api/funds/1/metric-runs/latest');
+
+    expect(res.status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 0 **T5** — adds two contract tests confirming the `requireFundAccess`
guard denies cross-fund access on the LP-reporting import and metric-run
surfaces, using the **real** guard (not a mock-to-403 toggle). Tests only — no
production code changed.

Both routers chain `requireAuth() -> requireFundAccess` on every route, and
`requireFundAccess` reads `:fundId` from the URL. A caller with `fundIds:[1]`
hitting `:fundId = 2` must get `403 { error: 'Forbidden', message: 'You do not
have access to fund 2' }` before any handler/db/service work.

- `tests/unit/routes/lp-reporting-imports.contract.test.ts` — deny on all 4
  `/api/funds/:fundId/imports/...` endpoints (ledger/valuation × dry-run/commit):
  `403`, no import-service call (`runLedgerDryRun`, `runValuationMarkDryRun`,
  `commitLedgerImport`, `commitValuationMarkImport`), no db call. The dry-run
  services are pure (no db), so they are spied directly. Plus one allow case
  (`!== 403`).
- `tests/unit/routes/lp-reporting-metric-runs.contract.test.ts` — deny on 4
  representative endpoints (create `POST /commit`, read `GET /:metricRunId`,
  list `GET /:metricRunId/evidence-records`, mutation `PATCH
  /:metricRunId/narrative-runs/:narrativeRunId`): `403` with no db call. (24
  routes total; spot-checked per the spec given the count.) Plus one allow case.

Both files assert **exactly** `toBe(403)` (not just non-200) so a stray `400`
(the `:fundId` never reaching the guard) is caught, not absorbed. The real
guard is exercised via a partial jwt mock overriding only `requireAuth`.

## Findings

- Both routers are mounted and live (`routes.ts:131-132` lazy, `app.ts:39-40`
  eager).
- No production gap surfaced — all deny tests pass against unchanged code.

## Verification

- All deny tests + allow cases green against unchanged production code.
- Negative control: dropping `requireFundAccess` from one route flips that
  endpoint's deny `403` → non-`403`, then reverted (no production diff).
- `npm run check` clean; full `npm test` vs baseline, zero collateral.

## T6 (Q7) — LP-siblings mount audit (finding, no code change)

Recording the Slice 0 T6 mount-audit verdict here (last Slice 0 PR), per the
spec's Definition of Done.

**Verdict: all four LP-sibling routers are DEAD (not mounted) → defer. Resolves Q7.**

| Router | Guard scaffold | Mounted? |
| --- | --- | --- |
| `lp-distributions.ts` | `requireAuth` + `requireLPAccess`, handlers read `req.lpProfile.id` | No |
| `lp-documents.ts` | `requireLPAccess` (some routes lack an explicit route-local `requireAuth()`) | No |
| `lp-capital-calls.ts` | `requireAuth` + `requireLPAccess`, `req.lpProfile.id` | No |
| `lp-notifications.ts` | `requireLPAccess` | No |

Each is a mountable `export default` router (4–6 routes), but none is wired in:
zero references across `server/` outside its own file (no `app.use`, no
`routes.ts` entry), and there is **no dynamic/glob router loader** in
`routes.ts`/`app.ts`. A whole-repo grep of the four basenames returns only the
four route files, one mock-data-shape test (`tests/api/lp-documents.test.ts`,
which does not import the router or exercise the guard), and four client hooks
(`useLPDistributions`/`useLPDocuments`/`useLPCapitalCalls`/`useLPNotifications`).

Because they are unmounted, there is **no live external exposure** — no
cross-fund/cross-LP risk today, and no T1-style tests are required yet.

Adjacent observation (not a security finding, out of T6 scope): client hooks
*reference* these unmounted endpoints — either planned-but-unwired features or
dead client code (unverified; existence of the hooks is confirmed, a live caller
is not). **When any of these routers is mounted, it must first get T1-style
LP-scoping deny contract tests** (and a per-route guard-chain check — a few
`lp-documents`/`lp-notifications` routes use `requireLPAccess` without an
explicit route-local `requireAuth()`, relying on a global auth layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
