### PR TITLE
Tranche A Slice 3: body/query fund-scope helpers + route guards

### DIFF
--- a/server/lib/auth/provided-fund-scope.ts
+++ b/server/lib/auth/provided-fund-scope.ts
@@ -1,4 +1,6 @@
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+
+import { parseFundIdParam } from '@shared/number';
 
 import { hasFundAccess, userFromClaims, verifyAccessTokenAsync } from './jwt';
 
@@ -59,5 +61,87 @@ export async function enforceProvidedFundScope(
       message: 'Invalid authorization token',
     });
     return false;
+  }
+}
+
+/**
+ * Canonical fund-id parse for body/query sources. Strings must be canonical
+ * positive integers (parseFundIdParam: /^[1-9]\d*$/), matching the params-source
+ * contract hardened in #748/#749; JSON numbers must be safe positive integers.
+ * Arrays, floats, '1e1', and '0123' all return null. The typeof gate also blocks
+ * the Number(['1']) === 1 array-coercion hole.
+ */
+function parseProvidedFundId(raw: unknown): number | null {
+  if (typeof raw === 'number') {
+    return Number.isSafeInteger(raw) && raw >= 1 ? raw : null;
+  }
+  if (typeof raw === 'string') {
+    return parseFundIdParam(raw);
+  }
+  return null;
+}
+
+/**
+ * Middleware: read fundId from req.body or req.query and enforce fund scope via
+ * enforceProvidedFundScope, which re-verifies the bearer token and builds its own
+ * req.user. It deliberately never delegates to requireFundAccess: on the
+ * registerRoutes surface global auth sets req.context (not req.user), so a guard
+ * that reads req.user?.fundIds sees undefined and hasFundAccess(undefined, ...)
+ * returns true -- a silent fail-open.
+ */
+export function requireProvidedFundScopeFrom(source: 'body' | 'query') {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const container = req[source] as Record<string, unknown> | undefined;
+    const fundId = parseProvidedFundId(container?.['fundId']);
+    if (fundId === null) {
+      res.status(400).json({
+        error: 'invalid_fund_id',
+        message: 'Fund ID must be a positive integer',
+      });
+      return;
+    }
+    if (await enforceProvidedFundScope(req, res, fundId)) {
+      next();
+    }
+    // on deny, enforceProvidedFundScope already wrote 401/403
+  };
+}
+
+export interface VerifiedFundScope {
+  unrestricted: boolean;
+  fundIds: number[];
+}
+
+/**
+ * Return the caller's VERIFIED fund scope by re-verifying the bearer token; never
+ * trusts an upstream-set req.user for a restricted decision. Mirrors
+ * enforceProvidedFundScope's no-token contract: throws outside development/test,
+ * and in development/test falls back to the upstream user (or an unrestricted dev
+ * bypass when none is present). Returns null only for an invalid or expired token
+ * so the caller can respond 401. unrestricted === true means empty fundIds
+ * (privileged admin/service scope).
+ */
+export async function getVerifiedFundScope(req: Request): Promise<VerifiedFundScope | null> {
+  const token = bearerToken(req);
+  if (token === undefined) {
+    assertTokenRequiredOutsideDevelopment();
+    if (req.user) {
+      const fundIds = req.user.fundIds ?? [];
+      return { unrestricted: fundIds.length === 0, fundIds };
+    }
+    return { unrestricted: true, fundIds: [] };
+  }
+
+  try {
+    const claims = await verifyAccessTokenAsync(token);
+    const verifiedUser = userFromClaims(req, claims);
+    req.user = {
+      ...req.user,
+      ...verifiedUser,
+    };
+    const fundIds = verifiedUser.fundIds ?? [];
+    return { unrestricted: fundIds.length === 0, fundIds };
+  } catch {
+    return null;
   }
 }

--- a/server/routes/activities.ts
+++ b/server/routes/activities.ts
@@ -4,6 +4,7 @@ import { insertActivitySchema, type Activity } from '@shared/schema';
 import type { ApiError } from '@shared/types';
 import { toNumber } from '@shared/number';
 import { handleNumberParseError } from '../lib/number-parse-error';
+import { enforceProvidedFundScope, getVerifiedFundScope } from '../lib/auth/provided-fund-scope';
 import { storage } from '../storage';
 
 const router = Router();
@@ -11,9 +12,10 @@ const router = Router();
 router['get']('/activities', async (req: Request, res: Response) => {
   try {
     const fundIdQuery = req.query['fundId'];
-    let fundId: number | undefined;
 
+    let activities: Activity[];
     if (fundIdQuery) {
+      // Explicit fund: parse, then enforce the caller's scope before reading.
       const parsedId = toNumber(fundIdQuery as string, 'fund ID');
       if (parsedId <= 0) {
         const error: ApiError = {
@@ -22,10 +24,26 @@ router['get']('/activities', async (req: Request, res: Response) => {
         };
         return res.status(400).json(error);
       }
-      fundId = parsedId;
+      if (!(await enforceProvidedFundScope(req, res, parsedId))) {
+        return;
+      }
+      activities = await storage.getActivities(parsedId);
+    } else {
+      // No fund specified: re-verify the caller's scope and read only their funds.
+      // getActivities(undefined) would return ALL funds' activities (cross-fund leak).
+      const scope = await getVerifiedFundScope(req);
+      if (!scope) {
+        const error: ApiError = {
+          error: 'Unauthorized',
+          message: 'Valid authorization is required to list activities',
+        };
+        return res.status(401).json(error);
+      }
+      activities = scope.unrestricted
+        ? await storage.getActivities()
+        : await storage.getActivities(scope.fundIds);
     }
 
-    const activities = await storage.getActivities(fundId);
     const sortedActivities = activities.sort((left: Activity, right: Activity) => {
       const dateA = left.activityDate ? new Date(left.activityDate).getTime() : 0;
       const dateB = right.activityDate ? new Date(right.activityDate).getTime() : 0;

--- a/server/routes/cashflow.ts
+++ b/server/routes/cashflow.ts
@@ -16,6 +16,7 @@ import {
 } from '@shared/types';
 import { getRouteErrorMessage } from '../lib/errorHandling';
 import { createRouteLogger } from '../lib/route-logger.js';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 
 const routeLog = createRouteLogger('cashflow');
 
@@ -85,6 +86,11 @@ const generateId = () => `${Date.now()}-${Math.random().toString(36).substr(2, 9
 router['get']('/:fundId/transactions', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
+
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const queryParams = TransactionQueryParams.parse(req.query);
 
     // Filter transactions by fund
@@ -162,6 +168,11 @@ router['get']('/:fundId/transactions', async (req: Request, res: Response) => {
 router['post']('/:fundId/transactions', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
+
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const transactionData = CreateTransactionRequest.parse(req.body);
 
     const transaction: CashTransaction = {
@@ -195,6 +206,11 @@ router['post']('/:fundId/transactions', async (req: Request, res: Response) => {
 router['put']('/:fundId/transactions/:transactionId', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
+
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const { transactionId } = z.object({ transactionId: z.string() }).parse(req.params);
     const updates = UpdateTransactionRequest.parse(req.body);
 
@@ -240,6 +256,11 @@ router['put']('/:fundId/transactions/:transactionId', async (req: Request, res: 
 router['delete']('/:fundId/transactions/:transactionId', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
+
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const { transactionId } = z.object({ transactionId: z.string() }).parse(req.params);
 
     const existingTransaction = transactions.get(transactionId);
@@ -278,6 +299,10 @@ router['get']('/:fundId/capital-calls', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
 
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const fundCapitalCalls = Array.from(capitalCalls.values())
       .filter((cc) => cc.fundId === fundId)
       .sort((a, b) => new Date(b.noticeDate).getTime() - new Date(a.noticeDate).getTime());
@@ -312,6 +337,11 @@ router['get']('/:fundId/capital-calls', async (req: Request, res: Response) => {
 router['post']('/:fundId/capital-calls', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
+
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const capitalCallData = CreateCapitalCallRequest.parse(req.body);
 
     const capitalCall: CapitalCall = {
@@ -349,6 +379,11 @@ router['post']('/:fundId/capital-calls', async (req: Request, res: Response) => 
 router['get']('/:fundId/liquidity-forecast', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
+
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const { months = 12 } = z
       .object({
         months: z.coerce.number().int().min(1).max(60).optional(),
@@ -452,6 +487,10 @@ router['get']('/:fundId/cash-position', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
 
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const position = cashPositions.get(fundId) || {
       fundId,
       asOfDate: new Date(),
@@ -534,6 +573,10 @@ router['get']('/:fundId/recurring-expenses', async (req: Request, res: Response)
   try {
     const { fundId } = FundIdParams.parse(req.params);
 
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const fundExpenses = Array.from(recurringExpenses.values())
       .filter((e) => e.fundId === fundId)
       .filter((e) => e.isActive);
@@ -578,6 +621,11 @@ router['get']('/:fundId/recurring-expenses', async (req: Request, res: Response)
 router['post']('/:fundId/recurring-expenses', async (req: Request, res: Response) => {
   try {
     const { fundId } = FundIdParams.parse(req.params);
+
+    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+      return;
+    }
+
     const expenseData = CreateRecurringExpenseRequest.parse(req.body);
 
     const expense: RecurringExpense = {

--- a/server/routes/cashflow.ts
+++ b/server/routes/cashflow.ts
@@ -14,6 +14,7 @@ import {
   groupTransactionsByType,
   calculateLiquidityMetrics,
 } from '@shared/types';
+import { parseFundIdParam } from '@shared/number';
 import { getRouteErrorMessage } from '../lib/errorHandling';
 import { createRouteLogger } from '../lib/route-logger.js';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
@@ -29,6 +30,28 @@ const router = Router();
 const FundIdParams = z.object({
   fundId: z.string().min(1),
 });
+
+async function requireScopedRouteFund(
+  req: Request,
+  res: Response
+): Promise<{ fundId: string } | null> {
+  const parsedParams = FundIdParams.safeParse(req.params);
+  const rawFundId = parsedParams.success ? parsedParams.data.fundId : undefined;
+  const numericFundId = parseFundIdParam(rawFundId);
+  if (numericFundId === null) {
+    res.status(400).json({
+      error: 'Invalid request parameters',
+      message: 'Fund ID must be a canonical positive integer',
+    });
+    return null;
+  }
+
+  if (!(await enforceProvidedFundScope(req, res, numericFundId))) {
+    return null;
+  }
+
+  return { fundId: String(numericFundId) };
+}
 
 const TransactionQueryParams = z.object({
   startDate: z.string().optional(),
@@ -85,11 +108,11 @@ const generateId = () => `${Date.now()}-${Math.random().toString(36).substr(2, 9
  */
 router['get']('/:fundId/transactions', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const queryParams = TransactionQueryParams.parse(req.query);
 
@@ -167,11 +190,11 @@ router['get']('/:fundId/transactions', async (req: Request, res: Response) => {
  */
 router['post']('/:fundId/transactions', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const transactionData = CreateTransactionRequest.parse(req.body);
 
@@ -205,11 +228,11 @@ router['post']('/:fundId/transactions', async (req: Request, res: Response) => {
  */
 router['put']('/:fundId/transactions/:transactionId', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const { transactionId } = z.object({ transactionId: z.string() }).parse(req.params);
     const updates = UpdateTransactionRequest.parse(req.body);
@@ -255,11 +278,11 @@ router['put']('/:fundId/transactions/:transactionId', async (req: Request, res: 
  */
 router['delete']('/:fundId/transactions/:transactionId', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const { transactionId } = z.object({ transactionId: z.string() }).parse(req.params);
 
@@ -297,11 +320,11 @@ router['delete']('/:fundId/transactions/:transactionId', async (req: Request, re
  */
 router['get']('/:fundId/capital-calls', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const fundCapitalCalls = Array.from(capitalCalls.values())
       .filter((cc) => cc.fundId === fundId)
@@ -336,11 +359,11 @@ router['get']('/:fundId/capital-calls', async (req: Request, res: Response) => {
  */
 router['post']('/:fundId/capital-calls', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const capitalCallData = CreateCapitalCallRequest.parse(req.body);
 
@@ -378,11 +401,11 @@ router['post']('/:fundId/capital-calls', async (req: Request, res: Response) => 
  */
 router['get']('/:fundId/liquidity-forecast', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const { months = 12 } = z
       .object({
@@ -485,11 +508,11 @@ router['get']('/:fundId/liquidity-forecast', async (req: Request, res: Response)
  */
 router['get']('/:fundId/cash-position', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const position = cashPositions.get(fundId) || {
       fundId,
@@ -571,11 +594,11 @@ router['get']('/:fundId/cash-position', async (req: Request, res: Response) => {
  */
 router['get']('/:fundId/recurring-expenses', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const fundExpenses = Array.from(recurringExpenses.values())
       .filter((e) => e.fundId === fundId)
@@ -620,11 +643,11 @@ router['get']('/:fundId/recurring-expenses', async (req: Request, res: Response)
  */
 router['post']('/:fundId/recurring-expenses', async (req: Request, res: Response) => {
   try {
-    const { fundId } = FundIdParams.parse(req.params);
-
-    if (!(await enforceProvidedFundScope(req, res, Number(fundId)))) {
+    const scopedFund = await requireScopedRouteFund(req, res);
+    if (!scopedFund) {
       return;
     }
+    const { fundId } = scopedFund;
 
     const expenseData = CreateRecurringExpenseRequest.parse(req.body);
 

--- a/server/routes/engine-summaries.ts
+++ b/server/routes/engine-summaries.ts
@@ -149,6 +149,12 @@ router['get']('/pacing/summary', async (req: Request, res: Response) => {
   }
 });
 
+// NOT fund-scoped (Slice 3 T2 verdict). generateCohortSummary -> CohortEngine is
+// pure synthetic compute: it builds mock companies from { vintageYear, cohortSize }
+// with Math.random() and uses fundId only as a label in `cohort-${fundId}-${vintageYear}`.
+// No stored per-fund data is read, so there is no cross-fund disclosure and the
+// DEFAULT_FUND_ID fallback is safe. If this scaffold is ever wired to real per-fund
+// data, guard it with requireProvidedFundScopeFrom('query') and drop the default.
 router['get']('/cohorts/analysis', async (req: Request, res: Response) => {
   try {
     const fundIdQuery = req.query['fundId'];

--- a/server/routes/liquidity.ts
+++ b/server/routes/liquidity.ts
@@ -2,6 +2,15 @@
  * Liquidity Engine API Routes
  *
  * Endpoints for cashflow analysis, liquidity forecasting, and stress testing.
+ *
+ * NOT fund-scoped (Slice 3 T4 verdict). All four POSTs (/analyze, /forecast,
+ * /stress-test, /optimize-calls) build a LiquidityEngine purely from body-supplied
+ * inputs (fundId, fundSize, transactions, currentPosition, plannedInvestments) and
+ * compute over that request data. The engine reads no stored per-fund data: its
+ * constructor only retains fundId/fundSize and echoes fundId back in the output, so
+ * a caller can only analyze data it already provided and no cross-fund disclosure is
+ * possible. If any endpoint is ever changed to read stored fund data, guard it with
+ * enforceProvidedFundScope(req, res, Number(fundId)).
  */
 
 import { Router } from 'express';
@@ -104,14 +113,8 @@ router.post(
 router.post(
   '/forecast',
   asyncHandler(async (req: Request, res: Response) => {
-    const {
-      fundId,
-      fundSize,
-      currentPosition,
-      transactions,
-      recurringExpenses,
-      months,
-    } = liquidityForecastSchema.parse(req.body);
+    const { fundId, fundSize, currentPosition, transactions, recurringExpenses, months } =
+      liquidityForecastSchema.parse(req.body);
 
     const engine = new LiquidityEngine(fundId, fundSize);
     const forecast = engine.generateLiquidityForecast(
@@ -156,7 +159,8 @@ router.post(
 router.post(
   '/optimize-calls',
   asyncHandler(async (req: Request, res: Response) => {
-    const { fundId, fundSize, currentPosition, plannedInvestments, constraints } = optimizeCallsSchema.parse(req.body);
+    const { fundId, fundSize, currentPosition, plannedInvestments, constraints } =
+      optimizeCallsSchema.parse(req.body);
 
     // Default constraints if not provided
     const callConstraints: CapitalCallConstraints = {

--- a/server/routes/monte-carlo.ts
+++ b/server/routes/monte-carlo.ts
@@ -21,6 +21,7 @@ import { recordHttpMetrics } from '../metrics';
 import { toNumber } from '@shared/number';
 import { sanitizeInput } from '../utils/sanitizer.js';
 import { firstString } from '../lib/request-values';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 import {
   enqueueSimulation,
   getJobStatus,
@@ -300,6 +301,10 @@ router['post'](
       }
       const simulationConfig = built.config;
 
+      if (!(await enforceProvidedFundScope(req, res, simulationConfig.fundId))) {
+        return;
+      }
+
       logger.info(
         { correlationId, runs: simulationConfig.runs, fundId: simulationConfig.fundId },
         '[MONTE_CARLO] Starting simulation'
@@ -365,6 +370,10 @@ router['post'](
         return;
       }
       const simulationConfig = built.config;
+
+      if (!(await enforceProvidedFundScope(req, res, simulationConfig.fundId))) {
+        return;
+      }
 
       // Check if queue is available
       if (!isQueueInitialized()) {
@@ -566,6 +575,9 @@ router['post'](
         if (!built.ok) {
           return;
         }
+        if (!(await enforceProvidedFundScope(req, res, built.config.fundId))) {
+          return;
+        }
         normalizedConfigs.push(built.config);
       }
 
@@ -636,6 +648,10 @@ router['post'](
         getRequestCreatedBy(req)
       );
       if (!built.ok) {
+        return;
+      }
+
+      if (!(await enforceProvidedFundScope(req, res, built.config.fundId))) {
         return;
       }
 
@@ -748,6 +764,11 @@ router['get']('/performance', async (req: Request, res: Response) => {
 router['get']('/funds/:fundId/simulate', async (req: Request, res: Response) => {
   try {
     const fundId = toNumber(req.params['fundId'], 'Fund ID');
+
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+
     const runs = parseInt((req.query['runs'] as string) || '1000');
     const timeHorizonYears = parseInt((req.query['timeHorizonYears'] as string) || '8');
     const engine = (req.query['engine'] as 'streaming' | 'traditional' | 'auto') || 'auto';

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -21,7 +21,7 @@ import {
   type InsertUser,
 } from '../schema/src/index.js';
 import { db } from './db';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import {
   getProfessionalDemoRuntimeConfigurationError,
   getStorageConfigurationError,
@@ -114,7 +114,7 @@ export interface IStorage {
   createFundMetrics(_metrics: InsertFundMetrics): Promise<FundMetrics>;
 
   // Activity methods
-  getActivities(fundId?: number): Promise<Activity[]>;
+  getActivities(fundId?: number | number[]): Promise<Activity[]>;
   createActivity(_activity: InsertActivity): Promise<Activity>;
 }
 
@@ -456,8 +456,13 @@ export class MemStorage implements IStorage {
   }
 
   // Activity methods
-  async getActivities(fundId?: number): Promise<Activity[]> {
+  async getActivities(fundId?: number | number[]): Promise<Activity[]> {
     const activities = Array.from(this.activities.values());
+    if (Array.isArray(fundId)) {
+      if (fundId.length === 0) return [];
+      const ids = new Set(fundId);
+      return activities.filter((a) => a.fundId != null && ids.has(a.fundId));
+    }
     return fundId ? activities.filter((a) => a.fundId === fundId) : activities;
   }
 
@@ -622,7 +627,11 @@ export class DatabaseStorage implements IStorage {
     return metrics;
   }
 
-  async getActivities(fundId?: number): Promise<Activity[]> {
+  async getActivities(fundId?: number | number[]): Promise<Activity[]> {
+    if (Array.isArray(fundId)) {
+      if (fundId.length === 0) return [];
+      return await db.select().from(activities).where(inArray(activities.fundId, fundId));
+    }
     if (fundId) {
       return await db.select().from(activities).where(eq(activities.fundId, fundId));
     }

--- a/tests/unit/auth/providedFundScope.test.ts
+++ b/tests/unit/auth/providedFundScope.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 
 const TEST_SECRET = 'provided-scope-test-secret-minimum-32-chars';
@@ -266,5 +266,284 @@ describe('enforceProvidedFundScope', () => {
       lpId: 42,
       fundIds: [77],
     });
+  });
+});
+
+describe('requireProvidedFundScopeFrom', () => {
+  const originalEnv = new Map<EnvKey, string | undefined>();
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  function makeScopedRequest(
+    source: 'body' | 'query',
+    fundId: unknown,
+    authorization?: string
+  ): Request {
+    const req = makeRequest(authorization);
+    (req as unknown as Record<string, unknown>)[source] = { fundId };
+    return req;
+  }
+
+  it('allows a canonical body fundId that matches the token scope', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [7] });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status } = makeResponse();
+    const next = vi.fn();
+
+    await requireProvidedFundScopeFrom('body')(
+      makeScopedRequest('body', 7, `Bearer ${token}`),
+      res,
+      next as unknown as NextFunction
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('allows a canonical numeric-string query fundId that matches the token scope', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [7] });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status } = makeResponse();
+    const next = vi.fn();
+
+    await requireProvidedFundScopeFrom('query')(
+      makeScopedRequest('query', '7', `Bearer ${token}`),
+      res,
+      next as unknown as NextFunction
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing fundId with 400 and does not call next', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [7] });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status, json } = makeResponse();
+    const next = vi.fn();
+
+    await requireProvidedFundScopeFrom('body')(
+      makeScopedRequest('body', undefined, `Bearer ${token}`),
+      res,
+      next as unknown as NextFunction
+    );
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({
+      error: 'invalid_fund_id',
+      message: 'Fund ID must be a positive integer',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects zero and negative fundIds with 400', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [7] });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const next = vi.fn();
+
+    for (const bad of [0, -1, '0', '-3']) {
+      const { res, status } = makeResponse();
+      await requireProvidedFundScopeFrom('query')(
+        makeScopedRequest('query', bad, `Bearer ${token}`),
+        res,
+        next as unknown as NextFunction
+      );
+      expect(status).toHaveBeenCalledWith(400);
+    }
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-canonical fundIds (1e1, leading zero, float, array) with 400', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [10] });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const next = vi.fn();
+
+    for (const bad of ['1e1', '0123', '1.5', [10]]) {
+      const { res, status } = makeResponse();
+      await requireProvidedFundScopeFrom('query')(
+        makeScopedRequest('query', bad, `Bearer ${token}`),
+        res,
+        next as unknown as NextFunction
+      );
+      expect(status).toHaveBeenCalledWith(400);
+    }
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 without calling next when the token is scoped to another fund', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [8] });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status, json } = makeResponse();
+    const next = vi.fn();
+
+    await requireProvidedFundScopeFrom('query')(
+      makeScopedRequest('query', '7', `Bearer ${token}`),
+      res,
+      next as unknown as NextFunction
+    );
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      code: 'FUND_ACCESS_DENIED',
+      message: 'You do not have access to fund 7',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next for an empty-scope (admin) token', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [] });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status } = makeResponse();
+    const next = vi.fn();
+
+    await requireProvidedFundScopeFrom('body')(
+      makeScopedRequest('body', 12345, `Bearer ${token}`),
+      res,
+      next as unknown as NextFunction
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 without calling next for an invalid token', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [7] }, { secret: OTHER_SECRET });
+    const { requireProvidedFundScopeFrom } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status } = makeResponse();
+    const next = vi.fn();
+
+    await requireProvidedFundScopeFrom('query')(
+      makeScopedRequest('query', '7', `Bearer ${token}`),
+      res,
+      next as unknown as NextFunction
+    );
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('getVerifiedFundScope', () => {
+  const originalEnv = new Map<EnvKey, string | undefined>();
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('maps an empty-scope token to unrestricted', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [] });
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+
+    await expect(getVerifiedFundScope(makeRequest(`Bearer ${token}`))).resolves.toEqual({
+      unrestricted: true,
+      fundIds: [],
+    });
+  });
+
+  it('maps a scoped token to its fund list', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [1, 2] });
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+
+    await expect(getVerifiedFundScope(makeRequest(`Bearer ${token}`))).resolves.toEqual({
+      unrestricted: false,
+      fundIds: [1, 2],
+    });
+  });
+
+  it('returns null for an invalid (wrong-secret) token', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [1] }, { secret: OTHER_SECRET });
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+
+    await expect(getVerifiedFundScope(makeRequest(`Bearer ${token}`))).resolves.toBeNull();
+  });
+
+  it('returns null for an expired token', async () => {
+    setJwtEnv();
+    const token = signToken({ fundIds: [1] }, { expiresIn: '-1s' });
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+
+    await expect(getVerifiedFundScope(makeRequest(`Bearer ${token}`))).resolves.toBeNull();
+  });
+
+  it('mirrors the dev bypass: no token in development resolves to unrestricted', async () => {
+    setJwtEnv('development');
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+
+    await expect(getVerifiedFundScope(makeRequest())).resolves.toEqual({
+      unrestricted: true,
+      fundIds: [],
+    });
+  });
+
+  it('honors an upstream user scope when no token is present in test mode', async () => {
+    setJwtEnv();
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+    const req = makeRequest(undefined, {
+      id: 'upstream',
+      sub: 'upstream',
+      email: 'upstream@example.com',
+      roles: [],
+      fundIds: [99],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    });
+
+    await expect(getVerifiedFundScope(req)).resolves.toEqual({
+      unrestricted: false,
+      fundIds: [99],
+    });
+  });
+
+  it('throws on a missing token outside development/test (production)', async () => {
+    setJwtEnv('production');
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+
+    await expect(getVerifiedFundScope(makeRequest())).rejects.toThrow(
+      'Missing bearer token while enforcing provided fund scope in production'
+    );
   });
 });

--- a/tests/unit/routes/activities.contract.test.ts
+++ b/tests/unit/routes/activities.contract.test.ts
@@ -1,0 +1,131 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(),
+  getVerifiedFundScope: vi.fn(),
+}));
+
+const storageState = vi.hoisted(() => ({
+  getActivities: vi.fn(),
+  createActivity: vi.fn(),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+  getVerifiedFundScope: fundScopeState.getVerifiedFundScope,
+}));
+
+vi.mock('../../../server/storage', () => ({
+  storage: storageState,
+}));
+
+import activitiesRouter from '../../../server/routes/activities';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', activitiesRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function activityRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    fundId: 1,
+    companyId: 1,
+    type: 'investment',
+    title: 'Activity',
+    description: null,
+    amount: null,
+    activityDate: new Date('2026-01-01T00:00:00.000Z'),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function resetState() {
+  fundScopeState.enforceProvidedFundScope.mockReset();
+  fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+  fundScopeState.getVerifiedFundScope.mockReset();
+  fundScopeState.getVerifiedFundScope.mockResolvedValue({ unrestricted: true, fundIds: [] });
+  storageState.getActivities.mockReset();
+  storageState.getActivities.mockResolvedValue([]);
+  storageState.createActivity.mockReset();
+}
+
+describe('activities route contracts', () => {
+  beforeEach(() => resetState());
+
+  it('GET /api/activities denies an out-of-scope explicit fundId before any read', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementationOnce(
+      async (_req: Request, res: Response) => {
+        res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+        return false;
+      }
+    );
+
+    const response = await request(makeApp()).get('/api/activities?fundId=2');
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    expect(storageState.getActivities).not.toHaveBeenCalled();
+  });
+
+  it('GET /api/activities reads only the in-scope explicit fundId', async () => {
+    storageState.getActivities.mockResolvedValueOnce([activityRow({ fundId: 5 })]);
+
+    const response = await request(makeApp()).get('/api/activities?fundId=5');
+
+    expect(response.status).toBe(200);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      5
+    );
+    expect(storageState.getActivities).toHaveBeenCalledWith(5);
+  });
+
+  it('GET /api/activities rejects an invalid fundId before scope or read', async () => {
+    const response = await request(makeApp()).get('/api/activities?fundId=0');
+
+    expect(response.status).toBe(400);
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(storageState.getActivities).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/activities without fundId reads only a restricted caller's funds", async () => {
+    fundScopeState.getVerifiedFundScope.mockResolvedValueOnce({
+      unrestricted: false,
+      fundIds: [1, 3],
+    });
+    storageState.getActivities.mockResolvedValueOnce([activityRow({ fundId: 1 })]);
+
+    const response = await request(makeApp()).get('/api/activities');
+
+    expect(response.status).toBe(200);
+    expect(storageState.getActivities).toHaveBeenCalledWith([1, 3]);
+  });
+
+  it('GET /api/activities without fundId reads all funds for an unrestricted admin', async () => {
+    fundScopeState.getVerifiedFundScope.mockResolvedValueOnce({ unrestricted: true, fundIds: [] });
+    storageState.getActivities.mockResolvedValueOnce([activityRow()]);
+
+    const response = await request(makeApp()).get('/api/activities');
+
+    expect(response.status).toBe(200);
+    expect(storageState.getActivities).toHaveBeenCalledWith();
+  });
+
+  it('GET /api/activities without fundId returns 401 when scope cannot be verified', async () => {
+    fundScopeState.getVerifiedFundScope.mockResolvedValueOnce(null);
+
+    const response = await request(makeApp()).get('/api/activities');
+
+    expect(response.status).toBe(401);
+    expect(storageState.getActivities).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/routes/cashflow-real-auth.test.ts
+++ b/tests/unit/routes/cashflow-real-auth.test.ts
@@ -1,0 +1,112 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+
+const TEST_SECRET = 'cashflow-route-auth-test-secret-minimum-32-chars';
+const TEST_ISSUER = 'updog-test';
+const TEST_AUDIENCE = 'updog-app-test';
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'REQUIRE_AUTH',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+] as const;
+
+type EnvKey = (typeof ENV_KEYS)[number];
+
+function setJwtEnv(): void {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.REQUIRE_AUTH = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = TEST_SECRET;
+  process.env._EXPLICIT_JWT_SECRET = TEST_SECRET;
+  process.env.JWT_ISSUER = TEST_ISSUER;
+  process.env._EXPLICIT_JWT_ISSUER = TEST_ISSUER;
+  process.env.JWT_AUDIENCE = TEST_AUDIENCE;
+  process.env._EXPLICIT_JWT_AUDIENCE = TEST_AUDIENCE;
+}
+
+function signToken(payload: Record<string, unknown>): string {
+  return jwt.sign(
+    {
+      sub: 'cashflow-route-user',
+      email: 'cashflow-route@example.com',
+      role: 'user',
+      ...payload,
+    },
+    TEST_SECRET,
+    {
+      algorithm: 'HS256',
+      issuer: TEST_ISSUER,
+      audience: TEST_AUDIENCE,
+      expiresIn: '1h',
+    }
+  );
+}
+
+async function makeApp() {
+  const { default: cashflowRouter } = await import('../../../server/routes/cashflow');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/cashflow', cashflowRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+describe('cashflow route real bearer fund scope', () => {
+  const originalEnv = new Map<EnvKey, string | undefined>();
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    setJwtEnv();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('denies an out-of-scope fund using the real bearer-token helper', async () => {
+    const app = await makeApp();
+    const token = signToken({ fundIds: [1] });
+
+    const response = await request(app)
+      .get('/api/cashflow/2/transactions')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+  });
+
+  it('rejects a non-canonical route fundId instead of authorizing its numeric alias', async () => {
+    const app = await makeApp();
+    const token = signToken({ fundIds: [1] });
+
+    const response = await request(app)
+      .get('/api/cashflow/01/transactions')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain('canonical positive integer');
+  });
+});

--- a/tests/unit/routes/cashflow.contract.test.ts
+++ b/tests/unit/routes/cashflow.contract.test.ts
@@ -1,0 +1,127 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+import cashflowRouter from '../../../server/routes/cashflow';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/cashflow', cashflowRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+type Method = 'get' | 'post' | 'put' | 'delete';
+
+function call(method: Method, path: string, body?: unknown) {
+  const agent = request(makeApp());
+  switch (method) {
+    case 'get':
+      return agent.get(path);
+    case 'post':
+      return agent.post(path).send(body ?? {});
+    case 'put':
+      return agent.put(path).send(body ?? {});
+    case 'delete':
+      return agent.delete(path);
+  }
+}
+
+const denyImpl = async (_req: Request, res: Response) => {
+  res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+  return false;
+};
+
+function resetState() {
+  fundScopeState.enforceProvidedFundScope.mockReset();
+  fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+}
+
+const guardedEndpoints: Array<{ name: string; method: Method; path: string }> = [
+  { name: 'GET /:fundId/transactions', method: 'get', path: '/api/cashflow/2/transactions' },
+  { name: 'POST /:fundId/transactions', method: 'post', path: '/api/cashflow/2/transactions' },
+  {
+    name: 'PUT /:fundId/transactions/:transactionId',
+    method: 'put',
+    path: '/api/cashflow/2/transactions/tx-1',
+  },
+  {
+    name: 'DELETE /:fundId/transactions/:transactionId',
+    method: 'delete',
+    path: '/api/cashflow/2/transactions/tx-1',
+  },
+  { name: 'GET /:fundId/capital-calls', method: 'get', path: '/api/cashflow/2/capital-calls' },
+  { name: 'POST /:fundId/capital-calls', method: 'post', path: '/api/cashflow/2/capital-calls' },
+  {
+    name: 'GET /:fundId/liquidity-forecast',
+    method: 'get',
+    path: '/api/cashflow/2/liquidity-forecast',
+  },
+  { name: 'GET /:fundId/cash-position', method: 'get', path: '/api/cashflow/2/cash-position' },
+  {
+    name: 'GET /:fundId/recurring-expenses',
+    method: 'get',
+    path: '/api/cashflow/2/recurring-expenses',
+  },
+  {
+    name: 'POST /:fundId/recurring-expenses',
+    method: 'post',
+    path: '/api/cashflow/2/recurring-expenses',
+  },
+];
+
+describe('cashflow route fund-scope contracts', () => {
+  beforeEach(() => resetState());
+
+  describe.each(guardedEndpoints)('$name', ({ method, path }) => {
+    it('denies an out-of-scope fund with 403 before any store access', async () => {
+      fundScopeState.enforceProvidedFundScope.mockImplementationOnce(denyImpl);
+
+      const response = await call(method, path);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        2
+      );
+    });
+  });
+
+  it('allows an in-scope fund to read transactions (guard called with numeric fundId)', async () => {
+    const response = await call('get', '/api/cashflow/7/transactions');
+
+    expect(response.status).toBe(200);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      7
+    );
+  });
+
+  it('does not persist a transaction when the fund scope is denied', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementationOnce(denyImpl);
+    const denied = await call('post', '/api/cashflow/8/transactions', {
+      type: 'capital_call',
+      amount: 1000,
+      plannedDate: '2026-01-01T00:00:00.000Z',
+      status: 'planned',
+    });
+    expect(denied.status).toBe(403);
+
+    const read = await call('get', '/api/cashflow/8/transactions');
+    expect(read.status).toBe(200);
+    expect(read.body.data.transactions).toHaveLength(0);
+  });
+});

--- a/tests/unit/routes/cashflow.contract.test.ts
+++ b/tests/unit/routes/cashflow.contract.test.ts
@@ -110,6 +110,13 @@ describe('cashflow route fund-scope contracts', () => {
     );
   });
 
+  it('rejects a non-canonical fundId before scope or store access', async () => {
+    const response = await call('get', '/api/cashflow/01/transactions');
+
+    expect(response.status).toBe(400);
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+  });
+
   it('does not persist a transaction when the fund scope is denied', async () => {
     fundScopeState.enforceProvidedFundScope.mockImplementationOnce(denyImpl);
     const denied = await call('post', '/api/cashflow/8/transactions', {

--- a/tests/unit/routes/monte-carlo-api.test.ts
+++ b/tests/unit/routes/monte-carlo-api.test.ts
@@ -6,25 +6,35 @@ const {
   enqueueSimulationMock,
   isQueueInitializedMock,
   runSimulationMock,
+  runBatchSimulationsMock,
+  runMultiEnvironmentSimulationMock,
   getStageValidationModeMock,
   parseStageDistributionMock,
+  enforceProvidedFundScopeMock,
 } = vi.hoisted(() => ({
   enqueueSimulationMock: vi.fn(),
   isQueueInitializedMock: vi.fn(() => false),
   runSimulationMock: vi.fn(),
+  runBatchSimulationsMock: vi.fn(),
+  runMultiEnvironmentSimulationMock: vi.fn(),
   getStageValidationModeMock: vi.fn(),
   parseStageDistributionMock: vi.fn(),
+  enforceProvidedFundScopeMock: vi.fn(),
 }));
 
 vi.mock('../../../server/services/monte-carlo-service-unified', () => ({
   unifiedMonteCarloService: {
     runSimulation: runSimulationMock,
-    runBatchSimulations: vi.fn(),
-    runMultiEnvironmentSimulation: vi.fn(),
+    runBatchSimulations: runBatchSimulationsMock,
+    runMultiEnvironmentSimulation: runMultiEnvironmentSimulationMock,
     healthCheck: vi.fn(),
     getPerformanceStats: vi.fn(),
     getOptimizationRecommendations: vi.fn(),
   },
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: enforceProvidedFundScopeMock,
 }));
 
 vi.mock('../../../server/queues/simulation-queue', () => ({
@@ -144,6 +154,9 @@ describe('Monte Carlo routes', () => {
     runSimulationMock.mockResolvedValue(createSimulationResult());
     enqueueSimulationMock.mockResolvedValue({ jobId: 'job-1', estimatedWaitMs: 5000 });
     isQueueInitializedMock.mockReturnValue(false);
+    enforceProvidedFundScopeMock.mockResolvedValue(true);
+    runBatchSimulationsMock.mockResolvedValue([createSimulationResult()]);
+    runMultiEnvironmentSimulationMock.mockResolvedValue({ bull: createSimulationResult() });
   });
 
   it('validates stageDistribution as a percentage record before calling the service', async () => {
@@ -256,6 +269,125 @@ describe('Monte Carlo routes', () => {
 
     expect(response.body.error).toBe('INVALID_STAGE_DISTRIBUTION');
     expect(response.headers['x-stage-warning']).toContain('unknown-stage');
+    expect(runSimulationMock).not.toHaveBeenCalled();
+  });
+
+  it('enforces fund scope with the body fundId on POST /simulate before reading', async () => {
+    await request(app).post('/simulate').send({ fundId: 7 }).expect(200);
+
+    expect(enforceProvidedFundScopeMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      7
+    );
+    expect(runSimulationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies POST /simulate for an out-of-scope fund before running the simulation', async () => {
+    enforceProvidedFundScopeMock.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      return false;
+    });
+
+    const response = await request(app).post('/simulate').send({ fundId: 2 }).expect(403);
+
+    expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    expect(enforceProvidedFundScopeMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(runSimulationMock).not.toHaveBeenCalled();
+  });
+
+  it('denies POST /simulate/async for an out-of-scope fund before queueing', async () => {
+    isQueueInitializedMock.mockReturnValue(true);
+    enforceProvidedFundScopeMock.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      return false;
+    });
+
+    await request(app).post('/simulate/async').send({ fundId: 2 }).expect(403);
+
+    expect(enforceProvidedFundScopeMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(enqueueSimulationMock).not.toHaveBeenCalled();
+    expect(runSimulationMock).not.toHaveBeenCalled();
+  });
+
+  it('denies POST /batch on the first out-of-scope config in a mixed-fund batch', async () => {
+    enforceProvidedFundScopeMock
+      .mockImplementationOnce(async () => true)
+      .mockImplementationOnce(async (_req, res) => {
+        res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+        return false;
+      });
+
+    await request(app)
+      .post('/batch')
+      .send({ simulations: [{ fundId: 1 }, { fundId: 2 }] })
+      .expect(403);
+
+    expect(enforceProvidedFundScopeMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.anything(),
+      1
+    );
+    expect(enforceProvidedFundScopeMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(runBatchSimulationsMock).not.toHaveBeenCalled();
+  });
+
+  it('denies POST /multi-environment for an out-of-scope fund before running', async () => {
+    enforceProvidedFundScopeMock.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      return false;
+    });
+
+    await request(app)
+      .post('/multi-environment')
+      .send({
+        baseConfig: { fundId: 2 },
+        environments: [
+          {
+            scenario: 'bull',
+            exitMultipliers: { mean: 1, volatility: 1 },
+            failureRate: 0.1,
+            followOnProbability: 0.1,
+          },
+        ],
+      })
+      .expect(403);
+
+    expect(enforceProvidedFundScopeMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(runMultiEnvironmentSimulationMock).not.toHaveBeenCalled();
+  });
+
+  it('denies GET /funds/:fundId/simulate for an out-of-scope fund before reading', async () => {
+    enforceProvidedFundScopeMock.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      return false;
+    });
+
+    await request(app).get('/funds/2/simulate?runs=1000').expect(403);
+
+    expect(enforceProvidedFundScopeMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
     expect(runSimulationMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/server/storage-get-activities.test.ts
+++ b/tests/unit/server/storage-get-activities.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { MemStorage } from '../../../server/storage';
+
+describe('MemStorage.getActivities fund-scope overload', () => {
+  it('returns all seeded activities when no fundId is provided', async () => {
+    const storage = new MemStorage();
+    const all = await storage.getActivities();
+    expect(all.length).toBeGreaterThan(0);
+  });
+
+  it('filters by a single fundId', async () => {
+    const storage = new MemStorage();
+    const fund1 = await storage.getActivities(1);
+    expect(fund1.length).toBeGreaterThan(0);
+    expect(fund1.every((a) => a.fundId === 1)).toBe(true);
+    expect(await storage.getActivities(999)).toHaveLength(0);
+  });
+
+  it('filters by an array of fundIds (inArray-equivalent)', async () => {
+    const storage = new MemStorage();
+    const some = await storage.getActivities([1, 999]);
+    const single = await storage.getActivities(1);
+    expect(some.every((a) => a.fundId === 1)).toBe(true);
+    expect(some.length).toBe(single.length);
+  });
+
+  it('returns [] for an empty fundId array without leaking all funds', async () => {
+    const storage = new MemStorage();
+    const empty = await storage.getActivities([]);
+    const all = await storage.getActivities();
+    expect(empty).toEqual([]);
+    expect(empty.length).not.toBe(all.length);
+  });
+});


### PR DESCRIPTION
## Tranche A — Slice 3: body/query fund-scope helpers + route guards

Guards fund-scoped routes whose `fundId` arrives via request **body or query** (and
the params-source cashflow router) using self-sufficient helpers that **cannot fail
open** on the `registerRoutes` surface, where global auth sets `req.context` (not
`req.user`) so a `req.user?.fundIds` read sees `undefined` and `hasFundAccess`
returns `true`. Every guard re-verifies the bearer token itself.

Spec: `docs/plans/tranche-a/slice-3-bodyquery-fund-scope.md`.

### Tasks

| Task | Commit | What |
| --- | --- | --- |
| T0 | feat(auth) | `requireProvidedFundScopeFrom('body'\|'query')` + `getVerifiedFundScope(req)` in `provided-fund-scope.ts`; 15 token-based tests |
| T1 | fix(auth) | Guard 5 monte-carlo endpoints (`runSimulation`/batch/multi-env read arbitrary fund data) |
| T2 | docs(auth) | Verdict: cohorts analysis **not fund-scoped** |
| T3 | fix(auth) | Close live `GET /activities` cross-fund leak via `getVerifiedFundScope` + storage `number[]` overload |
| T4 | docs(auth) | Verdict: liquidity routes **not fund-scoped** |
| T5 | fix(auth) | Guard all 10 `/api/cashflow/:fundId` endpoints (process-memory Maps) |

### Helpers (T0)

- `requireProvidedFundScopeFrom(source)` — middleware: parse `fundId` from body/query,
  enforce via `enforceProvidedFundScope`. Canonical parse: `parseFundIdParam` for
  strings (`/^[1-9]\d*$/`, matching #748/#749), `Number.isSafeInteger >= 1` for JSON
  numbers; the `typeof` gate also blocks the `Number(['1']) === 1` array-coercion hole.
  **Note:** this middleware ships **without a route consumer yet** — it is the
  body/query helper layer for future use. T1 uses the in-handler `enforceProvidedFundScope`
  (fundId derived post-`buildSimulationConfig`); T2 resolved not-fund-scoped. It is
  exercised directly by the T0 unit tests, not orphaned.
- `getVerifiedFundScope(req)` — re-verifies the bearer token; mirrors
  `enforceProvidedFundScope`'s no-token contract (throws outside dev/test; dev/test
  falls back to upstream user or unrestricted bypass); `null` only on invalid/expired
  token. Consumed by T3.

Tests extend `tests/unit/auth/providedFundScope.test.ts` (the real Layer-B home; the
spec named `tests/unit/lib/provided-fund-scope.test.ts`) with the existing
dynamic-import pattern.

### Not-fund-scoped verdicts

- **T2 cohorts analysis** (`GET /api/engine-summaries/cohorts/analysis`):
  `generateCohortSummary` → `CohortEngine` is pure synthetic compute
  (`generateMockCompanies` via `Math.random()`); `fundId` is only a label in
  `cohort-<fundId>-<vintageYear>`. No stored per-fund read → `DEFAULT_FUND_ID` fallback
  is safe.
- **T4 liquidity** (4 POSTs): each builds `LiquidityEngine` purely from body-supplied
  inputs; the engine reads no stored fund data (constructor retains `fundId`/`fundSize`,
  echoes `fundId`). A caller only analyzes data it supplied.

Both recorded as in-code comments (no Slice 7 allowlist file exists yet).

### Deferred findings (out of scope; not holes)

- **jobs IDOR:** `GET /api/monte-carlo/jobs/:jobId(/stream)` are object-reference
  (jobId) based, a different vuln class from fundId scope — deferred.
- **Non-canonical fundId on params routes:** `monte-carlo GET /funds/:fundId/simulate`,
  `activities` present-fundId path, and `cashflow Number(fundId)` still accept
  `'1e1'`/`'0123'` where #748/#749 reject them. Single parse feeds both guard and read
  (no confused-deputy / no divergence), so it is a cross-codebase consistency gap, not a
  leak. Canonical tightening deferred.

### Verification

- Per task: diff review (only intended files), targeted suite green (TZ=UTC,
  `--project=server`), **negative control** (neuter the guard → the deny contract goes
  RED for the right reason → reverted), `npm run check` clean, full `npm test`
  zero collateral.
- Final full suite: **6518 passed / 90 skipped**, zero failures. `npm run check` clean.
  ESLint clean on all touched files.
- DoD: no route routes a scope decision through `req.user` (the one `req.user` read,
  `monte-carlo.ts` `getRequestCreatedBy`, is for the audit `createdBy`, never `fundIds`).

### CI to eyeball

`tests/integration/portfolio-activity-routes.test.ts` is the only line exercising the
real no-token `/activities` wiring (DB-gated, skipped locally). It returns 200 today on
a token-less call, which proves that surface sets no restricting `req.user`; post-change
that path resolves to unrestricted → `getActivities()` → all → still 200. Expected to
pass; worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
