### PR TITLE
fix(auth): Tranche A Slice 1 - params-source fund-scope guards

### DIFF
--- a/server/routes/dashboard-summary.ts
+++ b/server/routes/dashboard-summary.ts
@@ -5,6 +5,7 @@ import { toNumber } from '@shared/number';
 import { storage } from '../storage';
 import { getDashboardSummaryReadModel } from '../services/dashboard-summary-read-service';
 import { handleNumberParseError } from '../lib/number-parse-error';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 import { logger } from '../lib/logger.js';
 
 const router = Router();
@@ -21,6 +22,10 @@ router['get']('/dashboard-summary/:fundId', async (req: Request, res: Response) 
         message: `Fund ID must be a positive integer, received: ${fundIdParam}`,
       };
       return res.status(400).json(error);
+    }
+
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
     }
 
     const dashboardSummary = await getDashboardSummaryReadModel(storage, fundId);

--- a/server/routes/dashboard-summary.ts
+++ b/server/routes/dashboard-summary.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import type { ApiError } from '@shared/types';
-import { toNumber } from '@shared/number';
+import { parseFundIdParam, toNumber } from '@shared/number';
 import { storage } from '../storage';
 import { getDashboardSummaryReadModel } from '../services/dashboard-summary-read-service';
 import { handleNumberParseError } from '../lib/number-parse-error';
+import { firstString } from '../lib/request-values';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 import { logger } from '../lib/logger.js';
 
@@ -13,10 +14,11 @@ const log = logger.child({ route: 'dashboard-summary' });
 
 router['get']('/dashboard-summary/:fundId', async (req: Request, res: Response) => {
   try {
-    const fundIdParam = req.params['fundId'];
-    const fundId = toNumber(fundIdParam, 'fund ID');
+    const fundIdParam = firstString(req.params['fundId']);
+    const fundId = parseFundIdParam(fundIdParam);
 
-    if (fundId <= 0) {
+    if (fundId === null) {
+      toNumber(fundIdParam, 'fund ID');
       const error: ApiError = {
         error: 'Invalid fund ID',
         message: `Fund ID must be a positive integer, received: ${fundIdParam}`,

--- a/server/routes/engine-summaries.ts
+++ b/server/routes/engine-summaries.ts
@@ -59,6 +59,13 @@ function loadReserveFixturePortfolio(): ReserveCompanyInput[] {
   }));
 }
 
+// NOT fund-scoped (Slice 1 verdict). loadReserveFixturePortfolio() reads a static
+// fixture (tests/fixtures/portfolio.json) identical for every fundId, and
+// generateReserveSummary -> ReserveEngine is pure compute over that portfolio; fundId
+// is used only as an output label. No stored per-fund data is read, so there is no
+// cross-fund disclosure and no existence oracle (any positive int returns 200). Same
+// class as the /cohorts/analysis verdict below. If ever wired to real per-fund data,
+// guard with enforceProvidedFundScope and drop the fixture load.
 router['get']('/reserves/:fundId', async (req: Request, res: Response) => {
   try {
     const fundIdParam = req.params['fundId'];

--- a/server/routes/reallocation.ts
+++ b/server/routes/reallocation.ts
@@ -13,6 +13,7 @@
 import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { z } from 'zod';
+import { parseFundIdParam } from '@shared/number';
 import { query, transaction, type PoolClient } from '../db/index';
 import { dollarsToCents, centsToDollars } from '@shared/units';
 import { firstString } from '../lib/request-values';
@@ -306,8 +307,8 @@ async function getFundSize(fundId: number): Promise<number> {
  */
 router['post']('/api/funds/:fundId/reallocation/preview', async (req: Request, res: Response) => {
   try {
-    const fundId = parseInt(firstString(req.params['fundId']) ?? '', 10);
-    if (isNaN(fundId) || fundId <= 0) {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
       return res.status(400).json({ error: 'Invalid fund ID' });
     }
 
@@ -409,8 +410,8 @@ router['post']('/api/funds/:fundId/reallocation/preview', async (req: Request, r
  */
 router['post']('/api/funds/:fundId/reallocation/commit', async (req: Request, res: Response) => {
   try {
-    const fundId = parseInt(firstString(req.params['fundId']) ?? '', 10);
-    if (isNaN(fundId) || fundId <= 0) {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
       return res.status(400).json({ error: 'Invalid fund ID' });
     }
 

--- a/server/routes/reallocation.ts
+++ b/server/routes/reallocation.ts
@@ -17,6 +17,7 @@ import { query, transaction, type PoolClient } from '../db/index';
 import { dollarsToCents, centsToDollars } from '@shared/units';
 import { firstString } from '../lib/request-values';
 import { createRouteLogger } from '../lib/route-logger.js';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 
 const routeLog = createRouteLogger('reallocation');
 
@@ -310,6 +311,10 @@ router['post']('/api/funds/:fundId/reallocation/preview', async (req: Request, r
       return res.status(400).json({ error: 'Invalid fund ID' });
     }
 
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+
     // Validate request body
     const parseResult = ReallocationPreviewRequestSchema.safeParse(req.body);
     if (!parseResult.success) {
@@ -407,6 +412,10 @@ router['post']('/api/funds/:fundId/reallocation/commit', async (req: Request, re
     const fundId = parseInt(firstString(req.params['fundId']) ?? '', 10);
     if (isNaN(fundId) || fundId <= 0) {
       return res.status(400).json({ error: 'Invalid fund ID' });
+    }
+
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
     }
 
     // Validate request body

--- a/server/routes/sensitivity.ts
+++ b/server/routes/sensitivity.ts
@@ -16,6 +16,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
+import { parseFundIdParam } from '@shared/number';
 import {
   OneWayAnalysisRequestV1Schema,
   TwoWayAnalysisRequestV1Schema,
@@ -23,6 +24,7 @@ import {
   SensitivityRunKindSchema,
 } from '@shared/contracts/sensitivity-run-v1.contract';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { firstString } from '../lib/request-values';
 
 /**
  * Maps SensitivityEngineError codes to HTTP status codes.
@@ -43,13 +45,22 @@ const STATUS_BY_CODE: Readonly<Record<string, number>> = {
 
 const router = Router();
 
-router.post('/funds/:id/sensitivity/one-way', async (req: Request, res: Response) => {
-  const fundId = parseInt(String(req.params['id'] ?? ''), 10);
-  if (!Number.isInteger(fundId) || fundId <= 0) {
-    return res.status(400).json({
+function parseRouteFundId(req: Request, res: Response): number | null {
+  const fundId = parseFundIdParam(firstString(req.params['id']));
+  if (fundId === null) {
+    res.status(400).json({
       code: 'INVALID_FUND_ID',
       message: 'fund id must be a positive integer',
     });
+    return null;
+  }
+  return fundId;
+}
+
+router.post('/funds/:id/sensitivity/one-way', async (req: Request, res: Response) => {
+  const fundId = parseRouteFundId(req, res);
+  if (fundId === null) {
+    return;
   }
 
   if (!(await enforceProvidedFundScope(req, res, fundId))) {
@@ -90,12 +101,9 @@ router.post('/funds/:id/sensitivity/one-way', async (req: Request, res: Response
 });
 
 router.post('/funds/:id/sensitivity/two-way', async (req: Request, res: Response) => {
-  const fundId = parseInt(String(req.params['id'] ?? ''), 10);
-  if (!Number.isInteger(fundId) || fundId <= 0) {
-    return res.status(400).json({
-      code: 'INVALID_FUND_ID',
-      message: 'fund id must be a positive integer',
-    });
+  const fundId = parseRouteFundId(req, res);
+  if (fundId === null) {
+    return;
   }
 
   if (!(await enforceProvidedFundScope(req, res, fundId))) {
@@ -136,12 +144,9 @@ router.post('/funds/:id/sensitivity/two-way', async (req: Request, res: Response
 });
 
 router.post('/funds/:id/sensitivity/stress', async (req: Request, res: Response) => {
-  const fundId = parseInt(String(req.params['id'] ?? ''), 10);
-  if (!Number.isInteger(fundId) || fundId <= 0) {
-    return res.status(400).json({
-      code: 'INVALID_FUND_ID',
-      message: 'fund id must be a positive integer',
-    });
+  const fundId = parseRouteFundId(req, res);
+  if (fundId === null) {
+    return;
   }
 
   if (!(await enforceProvidedFundScope(req, res, fundId))) {
@@ -182,12 +187,9 @@ router.post('/funds/:id/sensitivity/stress', async (req: Request, res: Response)
 });
 
 router.get('/funds/:id/sensitivity/runs', async (req: Request, res: Response) => {
-  const fundId = parseInt(String(req.params['id'] ?? ''), 10);
-  if (!Number.isInteger(fundId) || fundId <= 0) {
-    return res.status(400).json({
-      code: 'INVALID_FUND_ID',
-      message: 'fund id must be a positive integer',
-    });
+  const fundId = parseRouteFundId(req, res);
+  if (fundId === null) {
+    return;
   }
 
   if (!(await enforceProvidedFundScope(req, res, fundId))) {
@@ -230,10 +232,10 @@ router.get('/funds/:id/sensitivity/runs', async (req: Request, res: Response) =>
 });
 
 router.get('/funds/:id/sensitivity/runs/:runId', async (req: Request, res: Response) => {
-  const fundId = parseInt(String(req.params['id'] ?? ''), 10);
   const runId = parseInt(String(req.params['runId'] ?? ''), 10);
-  if (!Number.isInteger(fundId) || fundId <= 0) {
-    return res.status(400).json({ code: 'INVALID_FUND_ID' });
+  const fundId = parseRouteFundId(req, res);
+  if (fundId === null) {
+    return;
   }
   if (!(await enforceProvidedFundScope(req, res, fundId))) {
     return;

--- a/server/routes/sensitivity.ts
+++ b/server/routes/sensitivity.ts
@@ -22,6 +22,7 @@ import {
   StressAnalysisRequestV1Schema,
   SensitivityRunKindSchema,
 } from '@shared/contracts/sensitivity-run-v1.contract';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 
 /**
  * Maps SensitivityEngineError codes to HTTP status codes.
@@ -49,6 +50,10 @@ router.post('/funds/:id/sensitivity/one-way', async (req: Request, res: Response
       code: 'INVALID_FUND_ID',
       message: 'fund id must be a positive integer',
     });
+  }
+
+  if (!(await enforceProvidedFundScope(req, res, fundId))) {
+    return;
   }
 
   const parsed = OneWayAnalysisRequestV1Schema.safeParse(req.body);
@@ -93,6 +98,10 @@ router.post('/funds/:id/sensitivity/two-way', async (req: Request, res: Response
     });
   }
 
+  if (!(await enforceProvidedFundScope(req, res, fundId))) {
+    return;
+  }
+
   const parsed = TwoWayAnalysisRequestV1Schema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({
@@ -133,6 +142,10 @@ router.post('/funds/:id/sensitivity/stress', async (req: Request, res: Response)
       code: 'INVALID_FUND_ID',
       message: 'fund id must be a positive integer',
     });
+  }
+
+  if (!(await enforceProvidedFundScope(req, res, fundId))) {
+    return;
   }
 
   const parsed = StressAnalysisRequestV1Schema.safeParse(req.body);
@@ -177,6 +190,10 @@ router.get('/funds/:id/sensitivity/runs', async (req: Request, res: Response) =>
     });
   }
 
+  if (!(await enforceProvidedFundScope(req, res, fundId))) {
+    return;
+  }
+
   const kindParam = req.query['kind'];
   const kindParse = kindParam ? SensitivityRunKindSchema.safeParse(kindParam) : null;
   if (kindParse && !kindParse.success) {
@@ -217,6 +234,9 @@ router.get('/funds/:id/sensitivity/runs/:runId', async (req: Request, res: Respo
   const runId = parseInt(String(req.params['runId'] ?? ''), 10);
   if (!Number.isInteger(fundId) || fundId <= 0) {
     return res.status(400).json({ code: 'INVALID_FUND_ID' });
+  }
+  if (!(await enforceProvidedFundScope(req, res, fundId))) {
+    return;
   }
   if (!Number.isInteger(runId) || runId <= 0) {
     return res.status(400).json({ code: 'INVALID_RUN_ID' });

--- a/server/routes/timeline.ts
+++ b/server/routes/timeline.ts
@@ -17,6 +17,7 @@ import { firstString } from '../lib/request-values';
 import { asyncHandler } from '../middleware/async';
 import { validateRequest } from '../middleware/validation';
 import { TimeTravelAnalyticsService, type Cache } from '../services/time-travel-analytics';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 
 /**
  * Create timeline router with service dependency injection
@@ -87,6 +88,9 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
     asyncHandler(async (req, res) => {
       const startTimer = Date.now();
       const fundIdNum = parseInt(firstString(req.params['fundId']) ?? '', 10);
+      if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
+        return;
+      }
       const startTimeStr =
         typeof req.query['startTime'] === 'string' ? req.query['startTime'] : undefined;
       const endTimeStr =
@@ -122,6 +126,9 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
     asyncHandler(async (req, res) => {
       const startTimer = Date.now();
       const fundIdNum = parseInt(firstString(req.params['fundId']) ?? '', 10);
+      if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
+        return;
+      }
       const timestampStr = typeof req.query['timestamp'] === 'string' ? req.query['timestamp'] : '';
       const includeEventsFlag =
         typeof req.query['includeEvents'] === 'string'
@@ -159,6 +166,9 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
     asyncHandler(async (req, res) => {
       const startTimer = Date.now();
       const fundIdNum = parseInt(firstString(req.params['fundId']) ?? '', 10);
+      if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
+        return;
+      }
       const { type, description: _description } = req.body as CreateSnapshotBody;
 
       // Verify fund exists
@@ -217,6 +227,9 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
       const { timestamp1, timestamp2, includeDiff } = req.query;
 
       const fundIdNum = parseInt(fundId ?? '', 10);
+      if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
+        return;
+      }
       const ts1 = typeof timestamp1 === 'string' ? timestamp1 : '';
       const ts2 = typeof timestamp2 === 'string' ? timestamp2 : '';
 

--- a/server/routes/timeline.ts
+++ b/server/routes/timeline.ts
@@ -5,9 +5,10 @@
  * Routes are thin wrappers that delegate business logic to TimeTravelAnalyticsService
  */
 import { funds } from '@shared/schema';
+import { parseFundIdParam } from '@shared/number';
 import { eq } from 'drizzle-orm';
 import { Router } from 'express';
-import type { Express } from 'express';
+import type { Express, Request, Response } from 'express';
 import { z } from 'zod';
 import { db } from '../db';
 import { NotFoundError } from '../errors';
@@ -49,6 +50,19 @@ function createCacheAdapter(appLocalsCache: unknown): Cache | undefined {
  */
 export function createTimelineRouter(service: TimeTravelAnalyticsService) {
   const router = Router();
+  const fundIdParamsSchema = z.object({ fundId: z.string().min(1) });
+
+  function parseTimelineFundId(req: Request, res: Response): number | null {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
+      res.status(400).json({
+        error: 'Invalid fund ID',
+        message: 'Fund ID must be a canonical positive integer',
+      });
+      return null;
+    }
+    return fundId;
+  }
 
   // Timeline range schema
   const timelineRangeSchema = z.object({
@@ -82,12 +96,15 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
   router.get(
     '/:fundId',
     validateRequest({
-      params: z.object({ fundId: z.coerce.number() }),
+      params: fundIdParamsSchema,
       query: timelineRangeSchema.omit({ fundId: true }),
     }),
     asyncHandler(async (req, res) => {
       const startTimer = Date.now();
-      const fundIdNum = parseInt(firstString(req.params['fundId']) ?? '', 10);
+      const fundIdNum = parseTimelineFundId(req, res);
+      if (fundIdNum === null) {
+        return;
+      }
       if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
         return;
       }
@@ -120,12 +137,15 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
   router.get(
     '/:fundId/state',
     validateRequest({
-      params: z.object({ fundId: z.coerce.number() }),
+      params: fundIdParamsSchema,
       query: pointInTimeSchema.omit({ fundId: true }),
     }),
     asyncHandler(async (req, res) => {
       const startTimer = Date.now();
-      const fundIdNum = parseInt(firstString(req.params['fundId']) ?? '', 10);
+      const fundIdNum = parseTimelineFundId(req, res);
+      if (fundIdNum === null) {
+        return;
+      }
       if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
         return;
       }
@@ -160,12 +180,15 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
   router.post(
     '/:fundId/snapshot',
     validateRequest({
-      params: z.object({ fundId: z.coerce.number() }),
+      params: fundIdParamsSchema,
       body: createSnapshotBodySchema,
     }),
     asyncHandler(async (req, res) => {
       const startTimer = Date.now();
-      const fundIdNum = parseInt(firstString(req.params['fundId']) ?? '', 10);
+      const fundIdNum = parseTimelineFundId(req, res);
+      if (fundIdNum === null) {
+        return;
+      }
       if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
         return;
       }
@@ -214,7 +237,7 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
   router.get(
     '/:fundId/compare',
     validateRequest({
-      params: z.object({ fundId: z.coerce.number() }),
+      params: fundIdParamsSchema,
       query: z.object({
         timestamp1: z.string().datetime(),
         timestamp2: z.string().datetime(),
@@ -223,10 +246,12 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
     }),
     asyncHandler(async (req, res) => {
       const startTimer = Date.now();
-      const fundId = firstString(req.params['fundId']);
       const { timestamp1, timestamp2, includeDiff } = req.query;
 
-      const fundIdNum = parseInt(fundId ?? '', 10);
+      const fundIdNum = parseTimelineFundId(req, res);
+      if (fundIdNum === null) {
+        return;
+      }
       if (!(await enforceProvidedFundScope(req, res, fundIdNum))) {
         return;
       }

--- a/tests/unit/routes/dashboard-summary.contract.test.ts
+++ b/tests/unit/routes/dashboard-summary.contract.test.ts
@@ -74,6 +74,15 @@ describe('dashboard-summary route contracts', () => {
     expect(serviceState.getDashboardSummaryReadModel).not.toHaveBeenCalled();
   });
 
+  it('rejects non-canonical fundId before scope check and data read', async () => {
+    const response = await request(makeApp()).get('/dashboard-summary/01');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'Invalid fund ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(serviceState.getDashboardSummaryReadModel).not.toHaveBeenCalled();
+  });
+
   it('rejects denied fund scope before data read', async () => {
     fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
       res.status(403).json({

--- a/tests/unit/routes/dashboard-summary.contract.test.ts
+++ b/tests/unit/routes/dashboard-summary.contract.test.ts
@@ -1,0 +1,113 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const serviceState = vi.hoisted(() => ({
+  getDashboardSummaryReadModel: vi.fn(async (): Promise<unknown> => null),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/services/dashboard-summary-read-service', () => ({
+  getDashboardSummaryReadModel: serviceState.getDashboardSummaryReadModel,
+}));
+
+vi.mock('../../../server/storage', () => ({
+  storage: {},
+}));
+
+vi.mock('../../../server/lib/logger.js', () => ({
+  logger: {
+    child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import dashboardSummaryRouter from '../../../server/routes/dashboard-summary';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = {
+      id: '42',
+      sub: '42',
+      email: 'admin@example.com',
+      role: 'admin',
+      roles: ['admin'],
+      fundIds: [1],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    };
+    next();
+  });
+  app.use(dashboardSummaryRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function resetState() {
+  fundScopeState.enforceProvidedFundScope.mockReset();
+  fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+  serviceState.getDashboardSummaryReadModel.mockReset();
+  serviceState.getDashboardSummaryReadModel.mockResolvedValue(null);
+}
+
+describe('dashboard-summary route contracts', () => {
+  beforeEach(() => resetState());
+
+  it('rejects invalid fundId before scope check and data read', async () => {
+    const response = await request(makeApp()).get('/dashboard-summary/0');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'Invalid fund ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(serviceState.getDashboardSummaryReadModel).not.toHaveBeenCalled();
+  });
+
+  it('rejects denied fund scope before data read', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({
+        error: 'Forbidden',
+        code: 'FUND_ACCESS_DENIED',
+        message: 'You do not have access to fund 2',
+      });
+      return false;
+    });
+
+    const response = await request(makeApp()).get('/dashboard-summary/2');
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.getDashboardSummaryReadModel).not.toHaveBeenCalled();
+  });
+
+  it('enforces scope for the requested fund then returns the read model', async () => {
+    serviceState.getDashboardSummaryReadModel.mockResolvedValueOnce({ fundId: 1, totalValue: 0 });
+
+    const response = await request(makeApp()).get('/dashboard-summary/1');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ fundId: 1, totalValue: 0 });
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1
+    );
+    expect(serviceState.getDashboardSummaryReadModel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/routes/reallocation.contract.test.ts
+++ b/tests/unit/routes/reallocation.contract.test.ts
@@ -52,6 +52,14 @@ describe('reallocation route contracts', () => {
     dbState.transaction.mockResolvedValue({});
   });
 
+  it('POST preview rejects non-canonical fundId before scope check and DB read', async () => {
+    const res = await request(makeApp()).post('/api/funds/01/reallocation/preview').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(dbState.query).not.toHaveBeenCalled();
+  });
+
   it('POST preview denies cross-fund scope before any DB read', async () => {
     denyOnce();
     const res = await request(makeApp()).post('/api/funds/2/reallocation/preview').send({});

--- a/tests/unit/routes/reallocation.contract.test.ts
+++ b/tests/unit/routes/reallocation.contract.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const dbState = vi.hoisted(() => ({
+  query: vi.fn(async (): Promise<{ rows: unknown[] }> => ({ rows: [] })),
+  transaction: vi.fn(async (): Promise<unknown> => ({})),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/db/index', () => ({
+  query: dbState.query,
+  transaction: dbState.transaction,
+}));
+
+vi.mock('../../../server/lib/route-logger.js', () => ({
+  createRouteLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import reallocationRouter from '../../../server/routes/reallocation';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(reallocationRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function denyOnce() {
+  fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+    res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    return false;
+  });
+}
+
+describe('reallocation route contracts', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    dbState.query.mockReset();
+    dbState.query.mockResolvedValue({ rows: [] });
+    dbState.transaction.mockReset();
+    dbState.transaction.mockResolvedValue({});
+  });
+
+  it('POST preview denies cross-fund scope before any DB read', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/api/funds/2/reallocation/preview').send({});
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(dbState.query).not.toHaveBeenCalled();
+  });
+
+  it('POST commit denies cross-fund scope before the write transaction', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/api/funds/2/reallocation/commit').send({});
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(dbState.transaction).not.toHaveBeenCalled();
+  });
+
+  it('POST preview runs the guard for the requested fund before body validation', async () => {
+    const res = await request(makeApp()).post('/api/funds/1/reallocation/preview').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid request body' });
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1
+    );
+    expect(dbState.query).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/routes/sensitivity.contract.test.ts
+++ b/tests/unit/routes/sensitivity.contract.test.ts
@@ -57,9 +57,41 @@ describe('sensitivity route contracts', () => {
     serviceState.getById.mockResolvedValue(null);
   });
 
+  it('GET runs rejects non-canonical fundId before scope check and history read', async () => {
+    const res = await request(makeApp()).get('/funds/01/sensitivity/runs');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: 'INVALID_FUND_ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(serviceState.getHistoryByFund).not.toHaveBeenCalled();
+  });
+
   it('POST one-way denies cross-fund scope before creating a run', async () => {
     denyOnce();
     const res = await request(makeApp()).post('/funds/2/sensitivity/one-way').send({});
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.createPending).not.toHaveBeenCalled();
+  });
+
+  it('POST two-way denies cross-fund scope before creating a run', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/funds/2/sensitivity/two-way').send({});
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.createPending).not.toHaveBeenCalled();
+  });
+
+  it('POST stress denies cross-fund scope before creating a run', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/funds/2/sensitivity/stress').send({});
     expect(res.status).toBe(403);
     expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/unit/routes/sensitivity.contract.test.ts
+++ b/tests/unit/routes/sensitivity.contract.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const serviceState = vi.hoisted(() => ({
+  createPending: vi.fn(),
+  markCompleted: vi.fn(),
+  markFailed: vi.fn(),
+  getHistoryByFund: vi.fn(async (): Promise<unknown[]> => []),
+  getById: vi.fn(async (): Promise<unknown> => null),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/services/sensitivity-run-service', () => ({
+  sensitivityRunService: {
+    createPending: serviceState.createPending,
+    markCompleted: serviceState.markCompleted,
+    markFailed: serviceState.markFailed,
+    getHistoryByFund: serviceState.getHistoryByFund,
+    getById: serviceState.getById,
+  },
+}));
+
+import sensitivityRouter from '../../../server/routes/sensitivity';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(sensitivityRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function denyOnce() {
+  fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+    res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    return false;
+  });
+}
+
+describe('sensitivity route contracts', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    serviceState.createPending.mockReset();
+    serviceState.getHistoryByFund.mockReset();
+    serviceState.getHistoryByFund.mockResolvedValue([]);
+    serviceState.getById.mockReset();
+    serviceState.getById.mockResolvedValue(null);
+  });
+
+  it('POST one-way denies cross-fund scope before creating a run', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/funds/2/sensitivity/one-way').send({});
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.createPending).not.toHaveBeenCalled();
+  });
+
+  it('GET runs denies cross-fund scope before reading history', async () => {
+    denyOnce();
+    const res = await request(makeApp()).get('/funds/2/sensitivity/runs');
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.getHistoryByFund).not.toHaveBeenCalled();
+  });
+
+  it('GET runs/:runId denies cross-fund scope before reading the run', async () => {
+    denyOnce();
+    const res = await request(makeApp()).get('/funds/2/sensitivity/runs/5');
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.getById).not.toHaveBeenCalled();
+  });
+
+  it('GET runs enforces scope for the requested fund then returns history', async () => {
+    const res = await request(makeApp()).get('/funds/1/sensitivity/runs');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runs: [] });
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1
+    );
+    expect(serviceState.getHistoryByFund).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/routes/timeline.contract.test.ts
+++ b/tests/unit/routes/timeline.contract.test.ts
@@ -1,0 +1,142 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const dbState = vi.hoisted(() => ({
+  findFirst: vi.fn(async (): Promise<unknown> => null),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/db', () => ({
+  db: { query: { funds: { findFirst: dbState.findFirst } } },
+}));
+
+vi.mock('../../../server/metrics', () => ({
+  recordBusinessMetric: vi.fn(),
+}));
+
+vi.mock('../../../server/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../server/services/time-travel-analytics', () => ({
+  TimeTravelAnalyticsService: class {},
+}));
+
+vi.mock('../../../server/middleware/validation', () => ({
+  validateRequest: () => (_req: Request, _res: Response, next: () => void) => next(),
+}));
+
+vi.mock('../../../server/middleware/async', () => ({
+  asyncHandler: (fn: unknown) => fn,
+}));
+
+import { createTimelineRouter } from '../../../server/routes/timeline';
+
+function makeService() {
+  return {
+    getTimelineEvents: vi.fn(async () => ({ events: [] })),
+    getStateAtTime: vi.fn(async () => ({ state: {} })),
+    compareStates: vi.fn(async () => ({ diff: {} })),
+    getLatestEvents: vi.fn(async () => ({ events: [] })),
+  };
+}
+
+function makeApp(service: ReturnType<typeof makeService>) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/timeline', createTimelineRouter(service as never));
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function denyOnce() {
+  fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+    res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    return false;
+  });
+}
+
+const ISO1 = '2026-01-01T00:00:00.000Z';
+const ISO2 = '2026-02-01T00:00:00.000Z';
+
+describe('timeline route contracts', () => {
+  let service: ReturnType<typeof makeService>;
+
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    dbState.findFirst.mockReset();
+    dbState.findFirst.mockResolvedValue(null);
+    service = makeService();
+  });
+
+  it('GET /:fundId denies cross-fund scope before reading events', async () => {
+    denyOnce();
+    const res = await request(makeApp(service)).get('/api/timeline/2');
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(service.getTimelineEvents).not.toHaveBeenCalled();
+  });
+
+  it('GET /:fundId/state denies cross-fund scope before reading state', async () => {
+    denyOnce();
+    const res = await request(makeApp(service)).get(`/api/timeline/2/state?timestamp=${ISO1}`);
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(service.getStateAtTime).not.toHaveBeenCalled();
+  });
+
+  it('POST /:fundId/snapshot denies cross-fund scope before fund existence read', async () => {
+    denyOnce();
+    const res = await request(makeApp(service)).post('/api/timeline/2/snapshot').send({});
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(dbState.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('GET /:fundId/compare denies cross-fund scope before comparing states', async () => {
+    denyOnce();
+    const res = await request(makeApp(service)).get(
+      `/api/timeline/2/compare?timestamp1=${ISO1}&timestamp2=${ISO2}`
+    );
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(service.compareStates).not.toHaveBeenCalled();
+  });
+
+  it('GET /:fundId enforces scope for the requested fund then returns events', async () => {
+    const res = await request(makeApp(service)).get('/api/timeline/1');
+    expect(res.status).toBe(200);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1
+    );
+    expect(service.getTimelineEvents).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/routes/timeline.contract.test.ts
+++ b/tests/unit/routes/timeline.contract.test.ts
@@ -79,6 +79,14 @@ describe('timeline route contracts', () => {
     service = makeService();
   });
 
+  it('GET /:fundId rejects non-canonical fundId before scope check and event read', async () => {
+    const res = await request(makeApp(service)).get('/api/timeline/01');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(service.getTimelineEvents).not.toHaveBeenCalled();
+  });
+
   it('GET /:fundId denies cross-fund scope before reading events', async () => {
     denyOnce();
     const res = await request(makeApp(service)).get('/api/timeline/2');


### PR DESCRIPTION
## Tranche A Slice 1 — params-source fund-scope guards

Closes the live cross-fund read gap on params-source analytics routes. On the
`registerRoutes` surface the global boundary provides authentication only; these
routes read per-fund data with no fund-authorization check, so a token scoped to
fund 1 could read fund 2's data. Each guarded handler now calls
`enforceProvidedFundScope` (self-sufficient: re-verifies the bearer token, builds
its own `req.user`) **after** the fundId parse and **before** any service/DB read.
`requireFundAccess` is deliberately not used — it reads `req.user?.fundIds`, which
is unset on this surface, so `hasFundAccess(undefined, …)` returns `true` (silent
fail-open).

### Routes

| Route | Verdict | Endpoints |
| --- | --- | --- |
| `dashboard-summary.ts` | guarded | `GET /dashboard-summary/:fundId` |
| `timeline.ts` | guarded | `GET /:fundId`, `/:fundId/state`, `POST /:fundId/snapshot`, `GET /:fundId/compare` |
| `sensitivity.ts` | guarded | all 5 `/funds/:id/sensitivity/*` (param is `:id`) |
| `reallocation.ts` | guarded | `POST /:fundId/reallocation/{preview,commit}` |
| `engine-summaries.ts` | **not-fund-scoped (no guard)** | `/reserves/:fundId` |

**`reallocation` is the highest-value guard:** its reads use a standalone
`query()` outside the request RLS transaction, so the app-layer guard is the only
fund-access control (no RLS backstop).

**`engine-summaries /reserves/:fundId` deviates from the plan's table** — on
inspection it reads a static fixture (identical for every fundId) and runs a pure
`@shared` engine with fundId as an output label only. No per-fund data is read, so
it is classified not-fund-scoped (same class as the merged `/cohorts/analysis`
T2 verdict in the same file); a route-local comment records this and it joins the
Slice 7 allowlist.

### Tests

Layer-A contract tests at `tests/unit/routes/<route>.contract.test.ts` for each
guarded route: deny-before-data-read (403 + downstream `not.toHaveBeenCalled()`)
with the mandatory **right-fund** assertion
(`toHaveBeenCalledWith(…, <targeted fund>)`), plus allow-path coverage. Each guard
was verified with a negative control (neuter → deny test goes RED for the right
reason → revert). Existing token-less route tests (time-travel-api, sensitivity-routes)
stay green because the guard allows in test env with no token/`req.user`.

### Verification

- Full suite `TZ=UTC npm test`: **6536 passed / 90 skipped, 0 failures** (deltas
  fully accounted by the 12 new contract tests; zero collateral).
- `npm run check`: 0 new TypeScript errors.
- Per-task: targeted `--project=server` green + negative control + blast-radius
  check.

### Notes / follow-ups (out of scope)

- `timeline` query endpoints have a pre-existing **Express 5 `req.query`
  read-only** incompatibility in `validateRequest` (assigns `req.query`) —
  flagged for a separate fix; the guard sits correctly regardless.
- `timeline GET /events/latest` (all-funds admin read, no fundId) deferred to an
  admin-role / not-fund-scoped verdict.