### PR TITLE
fix(auth): Tranche A Slice 2 - allocation-scenarios route-param fund-scope guard

### DIFF
--- a/server/routes/allocation-scenarios.ts
+++ b/server/routes/allocation-scenarios.ts
@@ -20,6 +20,9 @@ import {
 } from '@shared/contracts/reserve-ic-decision-v1.contract';
 import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
 import { sendBodyValidationError } from '../lib/validation-response.js';
+import { parseFundIdParam } from '@shared/number';
+import { firstString } from '../lib/request-values';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 
 interface HttpError extends Error {
   statusCode?: number;
@@ -52,6 +55,32 @@ interface DecisionAuditFields {
 }
 
 const router = Router();
+
+// Fund-scope guard: every route on this router is keyed on :fundId and reads or
+// writes stored per-fund data. Enforce fund scope once, at the param boundary,
+// before any handler runs. The canonical parse (parseFundIdParam) runs here, so
+// handlers never observe a non-canonical fundId. enforceProvidedFundScope
+// re-verifies the bearer token and writes its own 401/403; it is used instead of
+// requireFundAccess, which fails open on the registerRoutes surface (global auth
+// sets req.context, not req.user).
+router.param('fundId', async (req: Request, res: Response, next: NextFunction, value: string) => {
+  try {
+    const fundId = parseFundIdParam(firstString(value));
+    if (fundId === null) {
+      res.status(400).json({
+        error: 'invalid_fund_id',
+        message: 'Fund ID must be a positive integer',
+      });
+      return;
+    }
+    if (await enforceProvidedFundScope(req, res, fundId)) {
+      next();
+    }
+    // on deny, enforceProvidedFundScope already wrote 401/403
+  } catch (error) {
+    next(error);
+  }
+});
 
 function routeHandler(
   handler: (req: Request, res: Response, next: NextFunction) => Promise<unknown>

--- a/tests/unit/routes/allocation-scenarios.contract.test.ts
+++ b/tests/unit/routes/allocation-scenarios.contract.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const serviceState = vi.hoisted(() => ({
+  listAllocationScenarios: vi.fn(async () => []),
+  getAllocationScenario: vi.fn(async () => ({})),
+  getAllocationScenarioApplyPreview: vi.fn(async () => ({})),
+  createAllocationScenario: vi.fn(async () => ({})),
+  createReserveIcDecision: vi.fn(async () => ({})),
+  listReserveIcDecisions: vi.fn(async () => []),
+  syncAllocationScenario: vi.fn(async () => ({})),
+  applyAllocationScenario: vi.fn(async () => ({})),
+  updateReserveIcDecision: vi.fn(async () => ({})),
+  updateAllocationScenario: vi.fn(async () => ({})),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/services/allocation-scenario-service.js', () => ({
+  listAllocationScenarios: serviceState.listAllocationScenarios,
+  getAllocationScenario: serviceState.getAllocationScenario,
+  getAllocationScenarioApplyPreview: serviceState.getAllocationScenarioApplyPreview,
+  createAllocationScenario: serviceState.createAllocationScenario,
+  createReserveIcDecision: serviceState.createReserveIcDecision,
+  listReserveIcDecisions: serviceState.listReserveIcDecisions,
+  syncAllocationScenario: serviceState.syncAllocationScenario,
+  applyAllocationScenario: serviceState.applyAllocationScenario,
+  updateReserveIcDecision: serviceState.updateReserveIcDecision,
+  updateAllocationScenario: serviceState.updateAllocationScenario,
+}));
+
+import allocationScenarioRouter from '../../../server/routes/allocation-scenarios';
+
+const SCENARIO_ID = '00000000-0000-0000-0000-000000000101';
+const DECISION_ID = '00000000-0000-0000-0000-000000000301';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(allocationScenarioRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function denyOnce() {
+  fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+    res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    return false;
+  });
+}
+
+describe('allocation-scenarios route fund-scope contracts', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    serviceState.listAllocationScenarios.mockReset();
+    serviceState.listAllocationScenarios.mockResolvedValue([]);
+    serviceState.createAllocationScenario.mockReset();
+    serviceState.createAllocationScenario.mockResolvedValue({});
+    serviceState.updateReserveIcDecision.mockReset();
+    serviceState.updateReserveIcDecision.mockResolvedValue({});
+    serviceState.applyAllocationScenario.mockReset();
+    serviceState.applyAllocationScenario.mockResolvedValue({});
+  });
+
+  it('rejects a non-canonical fundId before the scope check and the service', async () => {
+    const res = await request(makeApp()).get('/funds/01/allocation-scenarios');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_fund_id' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(serviceState.listAllocationScenarios).not.toHaveBeenCalled();
+  });
+
+  it('denies cross-fund scope on the list read before the service', async () => {
+    denyOnce();
+    const res = await request(makeApp()).get('/funds/2/allocation-scenarios');
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.listAllocationScenarios).not.toHaveBeenCalled();
+  });
+
+  it('denies cross-fund scope on scenario create before the write', async () => {
+    denyOnce();
+    const res = await request(makeApp())
+      .post('/funds/2/allocation-scenarios')
+      .send({
+        name: 'probe',
+        snapshot_items: [
+          {
+            company_id: 1,
+            planned_reserves_cents: 0,
+            allocation_cap_cents: null,
+            allocation_reason: null,
+          },
+        ],
+      });
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.createAllocationScenario).not.toHaveBeenCalled();
+  });
+
+  it('denies cross-fund scope on the nested decision write before the service', async () => {
+    denyOnce();
+    const res = await request(makeApp())
+      .patch(`/funds/2/allocation-scenarios/${SCENARIO_ID}/decisions/${DECISION_ID}`)
+      .send({ decisionStatus: 'approved' });
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.updateReserveIcDecision).not.toHaveBeenCalled();
+  });
+
+  it('denies cross-fund scope on scenario apply before the write', async () => {
+    denyOnce();
+    const res = await request(makeApp())
+      .post(`/funds/2/allocation-scenarios/${SCENARIO_ID}/apply`)
+      .send({ preview_token: 'a'.repeat(64) });
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(serviceState.applyAllocationScenario).not.toHaveBeenCalled();
+  });
+
+  it('runs the guard for the requested fund before body validation', async () => {
+    const res = await request(makeApp()).post('/funds/1/allocation-scenarios').send({});
+    expect(res.status).toBe(400);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1
+    );
+    expect(serviceState.createAllocationScenario).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Tranche A Slice 2 — allocation-scenarios route-param fund-scope guard

### What

Adds a single `router.param('fundId', …)` guard to
`server/routes/allocation-scenarios.ts` that enforces provided fund scope before
**any** of the router's 10 fund-keyed handlers run.

### Why (severity: live cross-fund leak, not defense-in-depth)

The route had **no** fund-scope guard and is mounted live at `/api`. Any
authenticated user could read or write **any** fund's allocation scenarios and
Reserve IC decisions by changing the `:fundId` path segment (list/get/preview/
decisions reads; create/update/sync/apply writes; nested decision create/update).

### How

- A single `router.param('fundId')` covers all 10 handlers uniformly — no
  per-handler edits, and any future `:fundId` route on this router is
  auto-covered.
- Canonical parse (`parseFundIdParam`, `/^[1-9]\d*$/`) runs at the param
  boundary, returning `400 { error: 'invalid_fund_id' }` for non-canonical ids
  before the scope check or any handler — so handlers never observe a
  non-canonical `fundId`.
- `enforceProvidedFundScope` re-verifies the bearer token and writes its own
  401/403. It is used instead of `requireFundAccess`, which fails open on the
  `registerRoutes` surface (global auth sets `req.context`, not `req.user`).
- `FundIdParamSchema` (shared) and the existing `parseFundRoute` helpers are
  left untouched; the guard runs first, so the handler's own parse only ever
  sees canonical input.

### Tests

New `tests/unit/routes/allocation-scenarios.contract.test.ts` (6 tests):

- Non-canonical `fundId` → 400 before scope check and before the service.
- Cross-fund deny (403) **before the service** on: list read, scenario create
  (valid payload), nested decision write, and scenario apply — each asserting
  `enforceProvidedFundScope` was called with the **targeted** fund (Layer-A
  right-fund assertion).
- Guard runs for the requested fund **before** body validation.

### Verification

- Targeted: 6/6 green; existing `allocation-scenarios-api.test.ts` 16/16 green
  (unchanged — runs the real guard and passes: canonical ids + no restricting
  `fundIds` on `req.user` ⇒ allow).
- Negative control: neutering only the enforce gate flips all **4** deny tests
  RED on `service.not.toHaveBeenCalled()`, while the parse-400 and
  body-ordering tests stay green; reverted exactly.
- `npm run check`: 0 TypeScript errors.
- Full suite: 6548 passed / 90 skipped, 0 failures (+6 from this file, zero
  collateral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
