### PR TITLE
fix(api): validateRequest must not reassign req.query in Express 5

### DIFF
--- a/server/middleware/validation.ts
+++ b/server/middleware/validation.ts
@@ -64,8 +64,15 @@ export function validateRequest(schemas: ValidationSchemas) {
           };
           return res.status(400).json(error);
         }
-        // Use type-safe conversion instead of direct cast
-        req.query = toQueryParams(result.data);
+        // Express 5 makes req.query a getter-only property, so a direct
+        // assignment throws. Define an own data property to shadow the getter
+        // with the validated value for downstream handlers.
+        Object.defineProperty(req, 'query', {
+          value: toQueryParams(result.data),
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
       }
 
       // Validate route parameters

--- a/tests/unit/middleware/validation.test.ts
+++ b/tests/unit/middleware/validation.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { z } from 'zod';
+
+import { validateRequest } from '../../../server/middleware/validation';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.get(
+    '/funds/:fundId/things',
+    validateRequest({
+      params: z.object({ fundId: z.string().regex(/^\d+$/) }),
+      query: z.object({
+        limit: z.coerce.number().int().min(1).max(100).default(20),
+      }),
+    }),
+    (req, res) => {
+      res.status(200).json({ params: req.params, query: req.query });
+    }
+  );
+  return app;
+}
+
+describe('validateRequest query handling (Express 5 getter-only req.query)', () => {
+  it('does not 500 and exposes the validated query to the handler', async () => {
+    const res = await request(makeApp()).get('/funds/7/things?limit=5');
+    expect(res.status).toBe(200);
+    expect(res.body.query).toMatchObject({ limit: 5 });
+    expect(res.body.params).toMatchObject({ fundId: '7' });
+  });
+
+  it('applies query schema defaults to the validated query', async () => {
+    const res = await request(makeApp()).get('/funds/7/things');
+    expect(res.status).toBe(200);
+    expect(res.body.query).toMatchObject({ limit: 20 });
+  });
+
+  it('returns 400 when query validation fails', async () => {
+    const res = await request(makeApp()).get('/funds/7/things?limit=999');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Validation error' });
+  });
+});


### PR DESCRIPTION
## fix(api): validateRequest must not reassign req.query (Express 5)

### What

`server/middleware/validation.ts` reassigned `req.query` after successful query
validation. In **Express 5** `req.query` is a getter-only property, so the
assignment throws `TypeError: Cannot set property query …`, caught by the
middleware's own `try/catch` and returned as a **500**.

### Impact (latent production bug)

Every route using `validateRequest({ query: … })` 500s in production whenever the
query branch runs. Live blast radius: the four `timeline.ts` GET query endpoints
(`/timeline` range, point-in-time, and two others at lines 100/141/241/286).
Existing tests did not catch it because `timeline.contract.test.ts` mocks
`validateRequest` to a pass-through.

`req.params` is unaffected — it remains a writable data property in Express 5
(confirmed empirically by the negative control: a route with both `params:` and
`query:` schemas 500s only on the query assignment).

### Fix

Replace the `req.query = …` assignment with `Object.defineProperty(req, 'query', …)`
defining an own writable/configurable data property that shadows the prototype
getter, so downstream handlers read the validated query. The `req.params`
assignment is left unchanged.

### Tests

New `tests/unit/middleware/validation.test.ts` mounts a **real Express 5 app**
(a mocked `req` would have a settable `query` and hide the bug):

- A `validateRequest({ params, query })` route returns 200 and exposes the
  validated query (and params) to the handler.
- Query schema defaults are applied to the validated query.
- A failing query returns 400.

### Verification

- New test 3/3 green. Blast radius green: `route-error-contracts`,
  `time-travel-api` (real middleware via app), and `timeline.contract` (mocked).
- Negative control: restoring the `req.query = …` assignment turns the two
  200-expecting tests into 500s (the 400 test stays green, since validation
  fails before the assignment); reverted exactly.
- `npm run check`: 0 TypeScript errors.
- Full suite: green vs baseline, +3 tests from this file, zero collateral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
