### PR TITLE
fix(auth): assert report-generation worker funds are LP commitments

### DIFF
--- a/server/queues/report-generation-queue.ts
+++ b/server/queues/report-generation-queue.ts
@@ -32,6 +32,7 @@ import {
 } from '../services/xlsx-generation-service.js';
 import { registerQueueRuntime, unregisterQueueRuntime } from './registry.js';
 import { getBullMQConnection } from './redis-connection.js';
+import { resolveFundId } from './resolve-fund-id.js';
 import { logger } from '../logger';
 
 // Job types
@@ -109,18 +110,6 @@ interface ReportGenerationContext {
   reportType: ReportGenerationJobData['reportType'];
   dateRange: ReportGenerationJobData['dateRange'];
   reportMetrics: Awaited<ReturnType<typeof prefetchReportMetrics>>;
-}
-
-/** Resolve fundId once from job data or first commitment */
-function resolveFundId(
-  jobFundIds: number[] | undefined,
-  lpData: Awaited<ReturnType<typeof fetchLPReportData>>
-): number {
-  const fundId = jobFundIds?.[0] || lpData.commitments[0]?.fundId;
-  if (!fundId) {
-    throw new Error('No fund ID available for report generation');
-  }
-  return fundId;
 }
 
 /** Extract quarter label from end date */

--- a/server/queues/resolve-fund-id.ts
+++ b/server/queues/resolve-fund-id.ts
@@ -1,0 +1,25 @@
+import type { LPReportData } from '../services/pdf-generation/types.js';
+
+/**
+ * Resolve the fundId for a report job.
+ *
+ * Defense-in-depth: asserts every requested fund is one the LP actually holds a
+ * commitment for. The sole enqueue path already rejects funds outside the LP's
+ * commitment snapshot, so this never fires on legitimate traffic; it guards
+ * against a commitment revoked between enqueue and processing, and against any
+ * future out-of-band enqueue.
+ */
+export function resolveFundId(jobFundIds: number[] | undefined, lpData: LPReportData): number {
+  const commitmentFundIds = lpData.commitments.map((c) => c.fundId);
+  if (jobFundIds) {
+    const unauthorized = jobFundIds.find((id) => !commitmentFundIds.includes(id));
+    if (unauthorized !== undefined) {
+      throw new Error(`Report job requested fund ${unauthorized} outside the LP's commitments`);
+    }
+  }
+  const fundId = jobFundIds?.[0] || commitmentFundIds[0];
+  if (!fundId) {
+    throw new Error('No fund ID available for report generation');
+  }
+  return fundId;
+}

--- a/tests/unit/queues/resolve-fund-id.test.ts
+++ b/tests/unit/queues/resolve-fund-id.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveFundId } from '../../../server/queues/resolve-fund-id';
+import type { LPReportData } from '../../../server/services/pdf-generation/types';
+
+function lpDataWithFunds(fundIds: number[]): LPReportData {
+  return {
+    lp: { id: 1, name: 'Acme LP', email: 'lp@example.com' },
+    commitments: fundIds.map((fundId, index) => ({
+      commitmentId: index + 1,
+      fundId,
+      fundName: `Fund ${fundId}`,
+      commitmentAmount: 1000,
+      ownershipPercentage: 10,
+    })),
+    transactions: [],
+  };
+}
+
+describe('resolveFundId', () => {
+  it('returns the first job fundId when it is a held commitment', () => {
+    expect(resolveFundId([2], lpDataWithFunds([1, 2]))).toBe(2);
+  });
+
+  it('falls back to the first commitment when no job fundIds are provided', () => {
+    expect(resolveFundId(undefined, lpDataWithFunds([3, 4]))).toBe(3);
+  });
+
+  it('throws when a requested fund is not one of the LP commitments', () => {
+    expect(() => resolveFundId([9], lpDataWithFunds([1, 2]))).toThrow(
+      /outside the LP's commitments/
+    );
+  });
+
+  it('throws when any requested fund is unauthorized, even if another is held', () => {
+    expect(() => resolveFundId([1, 9], lpDataWithFunds([1, 2]))).toThrow(
+      /outside the LP's commitments/
+    );
+  });
+
+  it('throws when there is no fund available at all', () => {
+    expect(() => resolveFundId(undefined, lpDataWithFunds([]))).toThrow(/No fund ID available/);
+  });
+});


### PR DESCRIPTION
## hardening: report-generation worker asserts requested funds are LP commitments

### What

`resolveFundId` in the LP report-generation worker took the first
`job.data.fundIds` entry without verifying the LP actually holds a commitment to
that fund. This PR extracts `resolveFundId` into a pure, testable module
(`server/queues/resolve-fund-id.ts`) and adds a defense-in-depth assertion: every
requested fund must be one of the LP's commitments, else the job fails closed.

### Severity: defense-in-depth (not a live leak)

The **sole** enqueue path (`lp-api` POST reports, the only caller of
`enqueueReportGeneration`; the queue is module-private) already rejects
`config.fundIds` outside the LP's commitment snapshot with a 403 before
enqueueing. So this guard never fires on legitimate traffic. It hardens against:

- a commitment **revoked between enqueue and processing** (TOCTOU), and
- any **future out-of-band enqueue** that bypasses the lp-api check.

Because `fetchLPReportData(lpId, jobFundIds)` returns the LP's *real* commitments
filtered to the requested funds, `jobFundIds ⊆ commitments` is equivalent to
"every requested fund is a genuine commitment" — correct, and a no-op for valid
jobs. Closing this also scopes the downstream
`getPortfolioCompanies(resolvedFundId)` roster fetch to an authorized fund.

### Changes

- New `server/queues/resolve-fund-id.ts` — pure `resolveFundId(jobFundIds, lpData)`
  with the commitment-subset assertion. No DB/BullMQ imports, so it is unit
  testable in isolation.
- `server/queues/report-generation-queue.ts` — import the extracted function;
  delete the inlined one. Call site unchanged.
- New `tests/unit/queues/resolve-fund-id.test.ts` (5 tests).

### Verification

- New test 5/5 green.
- Negative control: replacing the unauthorized-fund predicate with a no-op flips
  exactly the two "throws when unauthorized" tests RED (the held-commitment,
  no-fundIds-fallback, and no-fund-available tests stay green); reverted exactly.
- `npm run check`: 0 TypeScript errors.
- Full suite: green vs baseline, +5 tests from this file, zero collateral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
