### PR TITLE
fix(auth): canonicalize FundIdParamSchema via parseFundIdParam

### DIFF
--- a/shared/schemas/portfolio-route.ts
+++ b/shared/schemas/portfolio-route.ts
@@ -13,16 +13,29 @@
 
 import { z } from 'zod';
 
+import { parseFundIdParam } from '../number';
+
 // =====================
 // REUSABLE PARAM SCHEMAS
 // =====================
 
 /**
  * Fund ID path parameter schema
- * Validates that fundId is a numeric string and transforms to Number
+ * Delegates to the canonical parseFundIdParam so the accepted set matches the
+ * auth guards: rejects '0', leading zeros, '1e1', and non-safe-integer strings.
  */
 export const FundIdParamSchema = z.object({
-  fundId: z.string().regex(/^\d+$/).transform(Number),
+  fundId: z.string().transform((value, ctx) => {
+    const parsed = parseFundIdParam(value);
+    if (parsed === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Fund ID must be a positive integer',
+      });
+      return z.NEVER;
+    }
+    return parsed;
+  }),
 });
 
 // =====================

--- a/tests/unit/shared/fund-id-param-schema.test.ts
+++ b/tests/unit/shared/fund-id-param-schema.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
+
+describe('FundIdParamSchema (canonical fund id)', () => {
+  it.each([
+    ['1', 1],
+    ['42', 42],
+    ['1000000', 1000000],
+  ])('accepts canonical %s and transforms to %i', (input, expected) => {
+    const result = FundIdParamSchema.safeParse({ fundId: input });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fundId).toBe(expected);
+    }
+  });
+
+  it.each(['0', '01', '007', '1e1', 'abc', '-1', '1.5', '', '99999999999999999999'])(
+    'rejects non-canonical %s',
+    (input) => {
+      expect(FundIdParamSchema.safeParse({ fundId: input }).success).toBe(false);
+    }
+  );
+});


### PR DESCRIPTION
## fix(auth): canonicalize FundIdParamSchema via parseFundIdParam

### What

The shared `FundIdParamSchema` (`shared/schemas/portfolio-route.ts`) used
`z.string().regex(/^\d+$/).transform(Number)`, which accepts non-canonical fund
ids — `'0'`, leading zeros (`'01'`), and non-safe-integer strings — that the
canonical `parseFundIdParam` (used by the auth guards) rejects. This delegates
the schema to `parseFundIdParam` so the shared schema and the guards agree on a
single definition of a valid fund id.

### Why

`FundIdParamSchema` is consumed by five live routes (`allocation-scenarios`,
`allocations` ×3, `fund-scenario-sets`, `portfolio/lots`, `portfolio/snapshots`).
The divergence was a latent footgun: e.g. `/api/funds/01/allocations` resolved to
fund `1`, and in `allocation-scenarios` the new `router.param` guard parses
canonically while the handler schema did not (safe only because the guard runs
first). One canonical parser removes the divergence everywhere.

### How

`FundIdParamSchema.fundId` now runs a `z.string().transform` that calls
`parseFundIdParam` and raises a Zod issue when it returns `null`. Output type is
unchanged (`{ fundId: number }`).

**No response-shape change for consumers:** the `safeParse` consumers
(`allocations`, `fund-scenario-sets`, `allocation-scenarios`) only read
`.success` and emit their own `{ error: 'invalid_fund_id', message: 'Fund ID
must be a positive integer' }`; the `.parse()` consumers (`portfolio/lots` →
400, `portfolio/snapshots` → 404) catch `ZodError` by type, which is unchanged.
The accept-set simply tightens (`'0'`/`'01'`/non-safe-int now 400 instead of
silently resolving). `'0'` was already rejected on the `requireFundAccess` auth
path, so this aligns to existing behavior rather than inventing it.

### Tests

New `tests/unit/shared/fund-id-param-schema.test.ts` directly exercises the
schema five routes depend on: accepts `'1'`/`'42'`/`'1000000'`; rejects `'0'`,
`'01'`, `'007'`, `'1e1'`, `'abc'`, `'-1'`, `'1.5'`, `''`, and a
`> MAX_SAFE_INTEGER` string (the last case is why delegation beats a regex
tighten — a regex would accept it).

### Verification

- New test 12/12 green.
- Negative control: a permissive `Number(value)` fallback flips all 9 reject
  cases RED (accepts stay green); reverted exactly.
- `npm run check`: 0 errors — and `baseline:check` compiles `shared` separately,
  confirming the cross-shared `../number` import resolves cleanly (no cycle).
- Full suite: green vs baseline, +12 tests, zero collateral across all five
  live consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
