### PR TITLE
fix(auth): Tranche A Slice 5 - scenario-analysis company-fund-scope guard

### DIFF
--- a/server/lib/auth/company-fund-scope.ts
+++ b/server/lib/auth/company-fund-scope.ts
@@ -1,0 +1,64 @@
+import type { Request, Response } from 'express';
+
+import { storage } from '../../storage';
+
+import { getVerifiedFundScope } from './provided-fund-scope';
+
+/**
+ * Resolve a portfolio company's owning fund. Returns the fundId when the company
+ * is attributed to a fund, null when the company exists but has no fund
+ * (fund_id NULL), or undefined when no such company exists. Kept separate from
+ * the scenario data read so the fund-scope guard composes over a single source
+ * of truth and stays unit-testable via the storage mock.
+ */
+export async function resolveCompanyFundId(companyId: number): Promise<number | null | undefined> {
+  const company = await storage.getPortfolioCompany(companyId);
+  if (!company) {
+    return undefined;
+  }
+  return company.fundId;
+}
+
+/**
+ * Enforce that the caller may access the fund that owns `companyId`, for routes
+ * that key off a portfolio company rather than a fundId param. Writes its own
+ * 404 (no such company), 401 (unverifiable token), or 403 (out-of-scope fund, or
+ * an unattributed company for a restricted caller) and returns false on denial.
+ * Unrestricted (admin/service) callers pass for any existing company. Mirrors
+ * enforceProvidedFundScope's deny semantics (403 FUND_ACCESS_DENIED).
+ */
+export async function enforceCompanyFundScope(
+  req: Request,
+  res: Response,
+  companyId: number
+): Promise<boolean> {
+  const fundId = await resolveCompanyFundId(companyId);
+  if (fundId === undefined) {
+    res.status(404).json({ error: 'Company not found' });
+    return false;
+  }
+
+  const scope = await getVerifiedFundScope(req);
+  if (!scope) {
+    res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Invalid authorization token',
+    });
+    return false;
+  }
+
+  if (scope.unrestricted) {
+    return true;
+  }
+
+  if (fundId === null || !scope.fundIds.includes(fundId)) {
+    res.status(403).json({
+      error: 'Forbidden',
+      code: 'FUND_ACCESS_DENIED',
+      message: `You do not have access to fund ${fundId ?? 'unassigned'}`,
+    });
+    return false;
+  }
+
+  return true;
+}

--- a/server/routes/scenario-analysis.ts
+++ b/server/routes/scenario-analysis.ts
@@ -21,10 +21,24 @@ import type { ScenarioAnalysisResponse, ScenarioCase } from '@shared/types/scena
 import { requireAuth } from '../lib/auth/jwt';
 import { firstString } from '../lib/request-values';
 import { createRouteLogger } from '../lib/route-logger.js';
+import { enforceCompanyFundScope } from '../lib/auth/company-fund-scope';
 
 const routeLog = createRouteLogger('scenario-analysis');
 
 const router = Router();
+
+/**
+ * Parse a :companyId route param as a positive integer, or null when absent or
+ * non-canonical. Parsed once per request and reused for both the fund-scope
+ * resolution and the scenario query so the two can never diverge.
+ */
+function parseCompanyIdParam(raw: string | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : null;
+}
 
 // ============================================================================
 // Validation Schemas
@@ -119,6 +133,14 @@ router['get'](
         return res.status(400).json({ error: 'Missing required parameters' });
       }
 
+      const companyIdNum = parseCompanyIdParam(companyId);
+      if (companyIdNum === null) {
+        return res.status(400).json({ error: 'Invalid company ID' });
+      }
+      if (!(await enforceCompanyFundScope(req, res, companyIdNum))) {
+        return;
+      }
+
       const include = firstString(req.query['include'])?.split(',') || [
         'cases',
         'weighted_summary',
@@ -127,7 +149,7 @@ router['get'](
       const scenario = await db
         .select()
         .from(scenarios)
-        .where(and(eq(scenarios.id, scenarioId), eq(scenarios.companyId, parseInt(companyId))))
+        .where(and(eq(scenarios.id, scenarioId), eq(scenarios.companyId, companyIdNum)))
         .limit(1);
 
       if (!scenario || scenario.length === 0 || !scenario[0]) {
@@ -224,6 +246,14 @@ router['post'](
         return res.status(400).json({ error: 'Missing company ID' });
       }
 
+      const companyIdNum = parseCompanyIdParam(companyId);
+      if (companyIdNum === null) {
+        return res.status(400).json({ error: 'Invalid company ID' });
+      }
+      if (!(await enforceCompanyFundScope(req, res, companyIdNum))) {
+        return;
+      }
+
       // Validate request body before destructuring to preserve types
       const { name, description } = CreateScenarioSchema.parse(req.body);
       const userId = (req as ScenarioRequest).userId;
@@ -231,7 +261,7 @@ router['post'](
       const scenario = await db
         .insert(scenarios)
         .values({
-          companyId: parseInt(companyId),
+          companyId: companyIdNum,
           name: name || 'New Scenario',
           description,
           version: 1,
@@ -277,13 +307,21 @@ router['patch'](
         return res.status(400).json({ error: 'Missing required parameters' });
       }
 
+      const companyIdNum = parseCompanyIdParam(companyId);
+      if (companyIdNum === null) {
+        return res.status(400).json({ error: 'Invalid company ID' });
+      }
+      if (!(await enforceCompanyFundScope(req, res, companyIdNum))) {
+        return;
+      }
+
       const body = UpdateScenarioRequestSchema.parse(req.body);
 
       // Fetch current scenario
       const currentScenario = await db
         .select()
         .from(scenarios)
-        .where(and(eq(scenarios.id, scenarioId), eq(scenarios.companyId, parseInt(companyId))))
+        .where(and(eq(scenarios.id, scenarioId), eq(scenarios.companyId, companyIdNum)))
         .limit(1);
 
       if (!currentScenario || currentScenario.length === 0 || !currentScenario[0]) {
@@ -420,10 +458,18 @@ router['delete'](
         return res.status(400).json({ error: 'Missing required parameters' });
       }
 
+      const companyIdNum = parseCompanyIdParam(companyId);
+      if (companyIdNum === null) {
+        return res.status(400).json({ error: 'Invalid company ID' });
+      }
+      if (!(await enforceCompanyFundScope(req, res, companyIdNum))) {
+        return;
+      }
+
       const scenarioResult = await db
         .select()
         .from(scenarios)
-        .where(and(eq(scenarios.id, scenarioId), eq(scenarios.companyId, parseInt(companyId))))
+        .where(and(eq(scenarios.id, scenarioId), eq(scenarios.companyId, companyIdNum)))
         .limit(1);
 
       if (!scenarioResult || scenarioResult.length === 0 || !scenarioResult[0]) {
@@ -477,6 +523,18 @@ router['post'](
   async (req: Request, res: Response) => {
     try {
       const companyId = firstString(req.params['companyId']);
+
+      if (!companyId) {
+        return res.status(400).json({ error: 'Missing company ID' });
+      }
+
+      const companyIdNum = parseCompanyIdParam(companyId);
+      if (companyIdNum === null) {
+        return res.status(400).json({ error: 'Invalid company ID' });
+      }
+      if (!(await enforceCompanyFundScope(req, res, companyIdNum))) {
+        return;
+      }
 
       // Validate request body before destructuring to preserve types
       const { scenario_id } = ReserveSuggestionsSchema.parse(req.body);

--- a/tests/unit/auth/company-fund-scope.test.ts
+++ b/tests/unit/auth/company-fund-scope.test.ts
@@ -1,0 +1,117 @@
+import type { Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storageState = vi.hoisted(() => ({
+  getPortfolioCompany: vi.fn(),
+}));
+
+const scopeState = vi.hoisted(() => ({
+  getVerifiedFundScope: vi.fn(),
+}));
+
+vi.mock('../../../server/storage', () => ({
+  storage: storageState,
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  getVerifiedFundScope: scopeState.getVerifiedFundScope,
+}));
+
+import {
+  enforceCompanyFundScope,
+  resolveCompanyFundId,
+} from '../../../server/lib/auth/company-fund-scope';
+
+function mockRes() {
+  const res = {} as Response;
+  res.status = vi.fn(() => res) as unknown as Response['status'];
+  res.json = vi.fn(() => res) as unknown as Response['json'];
+  return res;
+}
+
+function resetState() {
+  storageState.getPortfolioCompany.mockReset();
+  scopeState.getVerifiedFundScope.mockReset();
+}
+
+describe('resolveCompanyFundId', () => {
+  beforeEach(() => resetState());
+
+  it('returns the fundId of an attributed company', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: 7 });
+    await expect(resolveCompanyFundId(1)).resolves.toBe(7);
+  });
+
+  it('returns null for a company with no fund', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: null });
+    await expect(resolveCompanyFundId(1)).resolves.toBeNull();
+  });
+
+  it('returns undefined when the company does not exist', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce(undefined);
+    await expect(resolveCompanyFundId(1)).resolves.toBeUndefined();
+  });
+});
+
+describe('enforceCompanyFundScope', () => {
+  beforeEach(() => resetState());
+
+  it('404s and skips the scope check when the company does not exist', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce(undefined);
+    const res = mockRes();
+    const ok = await enforceCompanyFundScope({} as Request, res, 1);
+    expect(ok).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(scopeState.getVerifiedFundScope).not.toHaveBeenCalled();
+  });
+
+  it('401s when the token cannot be verified', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: 7 });
+    scopeState.getVerifiedFundScope.mockResolvedValueOnce(null);
+    const res = mockRes();
+    const ok = await enforceCompanyFundScope({} as Request, res, 1);
+    expect(ok).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('allows an unrestricted caller for any existing company', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: 7 });
+    scopeState.getVerifiedFundScope.mockResolvedValueOnce({ unrestricted: true, fundIds: [] });
+    const res = mockRes();
+    await expect(enforceCompanyFundScope({} as Request, res, 1)).resolves.toBe(true);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows an unrestricted caller even for an unattributed company', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: null });
+    scopeState.getVerifiedFundScope.mockResolvedValueOnce({ unrestricted: true, fundIds: [] });
+    const res = mockRes();
+    await expect(enforceCompanyFundScope({} as Request, res, 1)).resolves.toBe(true);
+  });
+
+  it('allows a restricted caller whose scope includes the fund', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: 7 });
+    scopeState.getVerifiedFundScope.mockResolvedValueOnce({ unrestricted: false, fundIds: [7, 9] });
+    const res = mockRes();
+    await expect(enforceCompanyFundScope({} as Request, res, 1)).resolves.toBe(true);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('403s a restricted caller whose scope excludes the fund', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: 7 });
+    scopeState.getVerifiedFundScope.mockResolvedValueOnce({ unrestricted: false, fundIds: [9] });
+    const res = mockRes();
+    const ok = await enforceCompanyFundScope({} as Request, res, 1);
+    expect(ok).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('403s a restricted caller for an unattributed company', async () => {
+    storageState.getPortfolioCompany.mockResolvedValueOnce({ id: 1, fundId: null });
+    scopeState.getVerifiedFundScope.mockResolvedValueOnce({ unrestricted: false, fundIds: [9] });
+    const res = mockRes();
+    const ok = await enforceCompanyFundScope({} as Request, res, 1);
+    expect(ok).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});

--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -1,0 +1,169 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceCompanyFundScope: vi.fn(async (_req: Request, _res: Response, _companyId: number) => true),
+}));
+
+// Chain-safe db stub: every builder method is a spy; terminal awaits resolve to
+// empty/benign values so a neutered guard (negative control) falls through to a
+// harmless 404 instead of throwing mid-chain before the assertion runs.
+const dbState = vi.hoisted(() => {
+  const selectChain: Record<string, unknown> = {};
+  selectChain['from'] = vi.fn(() => selectChain);
+  selectChain['where'] = vi.fn(() => selectChain);
+  selectChain['limit'] = vi.fn(async () => [] as unknown[]);
+
+  const insertChain: Record<string, unknown> = {};
+  insertChain['values'] = vi.fn(() => insertChain);
+  insertChain['returning'] = vi.fn(async () => [{ id: '00000000-0000-0000-0000-000000000999' }]);
+
+  const deleteChain: Record<string, unknown> = {};
+  deleteChain['where'] = vi.fn(async () => undefined);
+
+  const select = vi.fn(() => selectChain);
+  const insert = vi.fn(() => insertChain);
+  const remove = vi.fn(() => deleteChain);
+  const transaction = vi.fn(async () => undefined);
+  const findFirst = vi.fn(async () => undefined);
+  return { select, insert, remove, transaction, findFirst };
+});
+
+vi.mock('../../../server/lib/auth/company-fund-scope', () => ({
+  enforceCompanyFundScope: fundScopeState.enforceCompanyFundScope,
+}));
+
+vi.mock('../../../server/lib/auth/jwt', () => ({
+  requireAuth: () => (_req: Request, _res: Response, next: () => void) => next(),
+}));
+
+vi.mock('../../../server/db', () => ({
+  db: {
+    select: dbState.select,
+    insert: dbState.insert,
+    delete: dbState.remove,
+    transaction: dbState.transaction,
+    query: { scenarios: { findFirst: dbState.findFirst } },
+  },
+}));
+
+import scenarioAnalysisRouter from '../../../server/routes/scenario-analysis';
+
+const SCENARIO_ID = '00000000-0000-0000-0000-000000000101';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', scenarioAnalysisRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function denyOnce() {
+  fundScopeState.enforceCompanyFundScope.mockImplementationOnce(
+    async (_req: Request, res: Response) => {
+      res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      return false;
+    }
+  );
+}
+
+function resetState() {
+  fundScopeState.enforceCompanyFundScope.mockReset();
+  fundScopeState.enforceCompanyFundScope.mockResolvedValue(true);
+  dbState.select.mockClear();
+  dbState.insert.mockClear();
+  dbState.remove.mockClear();
+  dbState.transaction.mockClear();
+  dbState.findFirst.mockClear();
+}
+
+describe('scenario-analysis route fund-scope contracts', () => {
+  beforeEach(() => resetState());
+
+  it('denies a cross-fund scenario read before any db read', async () => {
+    denyOnce();
+    const res = await request(makeApp()).get(`/api/companies/7/scenarios/${SCENARIO_ID}`);
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceCompanyFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      7
+    );
+    expect(dbState.select).not.toHaveBeenCalled();
+  });
+
+  it('denies a cross-fund scenario create before the write', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/api/companies/7/scenarios').send({ name: 'probe' });
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceCompanyFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      7
+    );
+    expect(dbState.insert).not.toHaveBeenCalled();
+  });
+
+  it('denies a cross-fund scenario update before the read or write', async () => {
+    denyOnce();
+    const res = await request(makeApp())
+      .patch(`/api/companies/7/scenarios/${SCENARIO_ID}`)
+      .send({ scenario_id: SCENARIO_ID, cases: [] });
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceCompanyFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      7
+    );
+    expect(dbState.select).not.toHaveBeenCalled();
+    expect(dbState.transaction).not.toHaveBeenCalled();
+  });
+
+  it('denies a cross-fund scenario delete before the read or write', async () => {
+    denyOnce();
+    const res = await request(makeApp()).delete(`/api/companies/7/scenarios/${SCENARIO_ID}`);
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceCompanyFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      7
+    );
+    expect(dbState.select).not.toHaveBeenCalled();
+    expect(dbState.remove).not.toHaveBeenCalled();
+  });
+
+  it('denies a cross-fund reserves optimize before the read', async () => {
+    denyOnce();
+    const res = await request(makeApp())
+      .post('/api/companies/7/reserves/optimize')
+      .send({ scenario_id: SCENARIO_ID });
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceCompanyFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      7
+    );
+    expect(dbState.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-canonical companyId before the scope check and any read', async () => {
+    const res = await request(makeApp()).get(`/api/companies/0/scenarios/${SCENARIO_ID}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid company ID' });
+    expect(fundScopeState.enforceCompanyFundScope).not.toHaveBeenCalled();
+    expect(dbState.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric companyId on create before the scope check and any write', async () => {
+    const res = await request(makeApp())
+      .post('/api/companies/abc/scenarios')
+      .send({ name: 'probe' });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid company ID' });
+    expect(fundScopeState.enforceCompanyFundScope).not.toHaveBeenCalled();
+    expect(dbState.insert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Tranche A Slice 5 — scenario-analysis company-fund-scope guard

### Problem
The scenario-analysis routes (mounted on the `makeApp`/prod surface at `/api`)
were `requireAuth()`-only and queried by `companyId` alone — **no fund or
ownership filter**. Any authenticated user could read, create, update, or delete
scenarios for any portfolio company across funds, and invoke `reserves/optimize`
on any company. Confirmed live IDOR.

### Fix
New `server/lib/auth/company-fund-scope.ts`:
- `resolveCompanyFundId(companyId)` — resolves a portfolio company to its owning
  fund via `storage.getPortfolioCompany` (matches the `activities.ts`
  storage-based precedent; keeps the auth module db-free). Returns the fundId,
  `null` (company exists, unattributed), or `undefined` (no such company).
- `enforceCompanyFundScope(req, res, companyId)` — composes the resolver with
  `getVerifiedFundScope` (re-verifies the bearer; never trusts an upstream
  `req.user`). Writes its own **404** (no company) / **401** (unverifiable token)
  / **403** (out-of-scope fund, or unattributed company for a restricted caller).
  Unrestricted (admin/service) callers pass for any existing company.

`server/routes/scenario-analysis.ts` — the guard runs in all 5 handlers
(GET / POST create / PATCH / DELETE / reserves-optimize) **before any scenario
read/write and before body validation**. `companyId` is parsed once
(`parseCompanyIdParam`, positive-int) and reused for both fund resolution and the
scenario query, so the resolution key and the data key can never diverge.

**Deny semantics (Q5):** 403 for a forbidden fund, 404 for a genuinely-absent
company — matching `denyFundAccess` (`FUND_ACCESS_DENIED`). `requireAuth()` is
retained on all routes; the guard's no-token branch is defensive, not a
replacement.

### Tests (+17)
- `tests/unit/routes/scenario-analysis.contract.test.ts` (7): per-route cross-fund
  deny → 403 with **no db read/write**; non-canonical `companyId` → 400 before the
  guard. Guard module + `jwt.requireAuth` + `db` mocked.
- `tests/unit/auth/company-fund-scope.test.ts` (10): resolver
  (fundId / null / undefined) and guard branches
  (404 / 401 / 403 / null-fundId / unrestricted / in-scope).

### Verification
- `npm run check`: 0 new TypeScript errors.
- **Negative control**: neutering the 5 guard call-sites (keep the call, drop the
  `if/return`) flips **exactly the 5 deny tests RED** (the handler reaches `db`)
  while the 2 parse tests stay green. Guard proven load-bearing. Reverted.
- Full suite `TZ=UTC npm test`, both measured this session:
  - `main` @ `abd80eed` (clean): **6568 passed / 90 skipped**.
  - this branch: **6585 passed / 90 skipped, 0 failed**.
  - Delta = **exactly +17** (the 7 contract + 10 guard-unit tests added here),
    skipped count unchanged. The handoff's quoted 6542 was a stale forwarded
    number, not a measurement of `abd80eed`. Zero collateral.
- Blast radius: `route-surface-inventory.test.ts` green (route registration
  unchanged).

### Deferred (intentional)
`reserves/optimize` is a placeholder returning hardcoded suggestions. The guard
scopes it on the URL `companyId`; its `findFirst`-by-`scenario_id` read returns no
scenario data to the response, so no cross-fund data leaks. Binding that read to
`companyId` was deferred (YAGNI on a placeholder slated for rewrite).
