### PR TITLE
test(auth): Tranche A Slice 7 - wrong-fund-403 integration gate

### DIFF
--- a/tests/unit/server/route-surface-inventory.test.ts
+++ b/tests/unit/server/route-surface-inventory.test.ts
@@ -391,6 +391,18 @@ async function authorizationHeader() {
   })}`;
 }
 
+// A fund-scoped bearer (non-empty fundIds restricts the caller to those funds).
+// Empty fundIds in authorizationHeader() above means unrestricted/admin.
+async function scopedAuthorizationHeader(fundIds: number[], role = 'user') {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '1',
+    email: 'route-surface-scoped@example.com',
+    role,
+    fundIds,
+  })}`;
+}
+
 async function makeRegisterRoutesApp() {
   configureTestAuthEnv();
   const app = express();
@@ -707,5 +719,63 @@ describe('route surface inventory', () => {
 
     const registerRoutesResponse = await request(registerRoutesApp).get('/api-docs');
     expect(registerRoutesResponse.status).toBe(404);
+  }, 30_000);
+
+  // ==========================================================================
+  // Wrong-fund-403 gate (Tranche A Slice 7)
+  //
+  // The per-route unit contracts (Slices 0-5) mock the fund-scope guard. These
+  // tests prove the guards actually DENY a cross-fund request on the real booted
+  // surfaces with a real scoped token. The set is REPRESENTATIVE, not exhaustive:
+  // allocation-scenarios exercises the makeApp router.param guard and the full
+  // scoped/own-fund/unrestricted discriminator; monte-carlo exercises the inline
+  // enforceProvidedFundScope guard on the registerRoutes surface. Derived-fund
+  // routes (companyId/jobId -> fund) are intentionally excluded here: their deny
+  // depends on memory-storage seed data and they are already covered by their
+  // own unit contracts.
+  // ==========================================================================
+
+  it('denies a scoped token cross-fund, allows its own fund, and allows an unrestricted token', async () => {
+    const makeApp = await makeAppWithTestAuth();
+
+    // Scoped to fund 1, requesting fund 2 -> fund-scope denial before any service.
+    const crossFund = await request(makeApp)
+      .get('/api/funds/2/allocation-scenarios')
+      .set('Authorization', await scopedAuthorizationHeader([1]));
+    expect(crossFund.status).toBe(403);
+    expect(crossFund.body).toMatchObject({ code: 'FUND_ACCESS_DENIED' });
+
+    // Scoped to fund 1, requesting fund 1 -> guard passes. Status may vary on
+    // memory storage (200/4xx/5xx) but it is never a fund denial.
+    const ownFund = await request(makeApp)
+      .get('/api/funds/1/allocation-scenarios')
+      .set('Authorization', await scopedAuthorizationHeader([1]));
+    expect(ownFund.status).not.toBe(403);
+
+    // Unrestricted token (empty fundIds) -> guard passes for any fund.
+    const unrestricted = await request(makeApp)
+      .get('/api/funds/2/allocation-scenarios')
+      .set('Authorization', await authorizationHeader());
+    expect(unrestricted.status).not.toBe(403);
+  }, 30_000);
+
+  it('denies a scoped token cross-fund on the registerRoutes surface', async () => {
+    const { app: registerRoutesApp, server } = await makeRegisterRoutesApp();
+    servers.push(server);
+
+    const crossFund = await request(registerRoutesApp)
+      .get('/api/monte-carlo/funds/2/simulate')
+      .set('Authorization', await scopedAuthorizationHeader([1]));
+    expect(crossFund.status).toBe(403);
+  }, 30_000);
+
+  it('keeps not-fund-scoped routes open to any authenticated caller', async () => {
+    const makeApp = await makeAppWithTestAuth();
+
+    const scopedScenarios = await request(makeApp)
+      .get('/api/backtesting/scenarios')
+      .set('Authorization', await scopedAuthorizationHeader([1]));
+    expect(scopedScenarios.status).toBe(200);
+    expect(scopedScenarios.body).toMatchObject({ scenarios: expect.any(Array) });
   }, 30_000);
 });

--- a/tests/unit/server/route-surface-inventory.test.ts
+++ b/tests/unit/server/route-surface-inventory.test.ts
@@ -767,6 +767,7 @@ describe('route surface inventory', () => {
       .get('/api/monte-carlo/funds/2/simulate')
       .set('Authorization', await scopedAuthorizationHeader([1]));
     expect(crossFund.status).toBe(403);
+    expect(crossFund.body).toMatchObject({ code: 'FUND_ACCESS_DENIED' });
   }, 30_000);
 
   it('keeps not-fund-scoped routes open to any authenticated caller', async () => {


### PR DESCRIPTION
## Tranche A Slice 7 — wrong-fund-403 integration gate

### Why
The per-route unit contracts landed across Slices 0-5 all **mock** the fund-scope
guard, so they prove the route *calls* the guard but not that the guard actually
denies on the real, mounted application. This slice closes that gap with an
integration-level proof: a real scoped JWT against the real booted app (both
`makeApp` and `registerRoutes` surfaces) must not reach a fund it doesn't own.

### What
Extends the authoritative `tests/unit/server/route-surface-inventory.test.ts`
(which already boots both surfaces) — no source/route changes:

- **`scopedAuthorizationHeader(fundIds, role='user')`** — the fixture seam the
  triage identified as missing. `signToken` accepts `fundIds`; a non-empty array
  restricts the caller. (The existing `authorizationHeader()` mints `fundIds:[]` =
  unrestricted, which is exactly why it could never test denial.)
- **3 tests** booting the real app DB-less (MemStorage):
  1. **Discriminator triple on allocation-scenarios (makeApp, `router.param`
     guard):** scoped `[1]` → `GET /api/funds/2/allocation-scenarios` → **403
     `FUND_ACCESS_DENIED`**; scoped `[1]` → fund 1 → **not 403**; unrestricted
     `[]` → fund 2 → **not 403**. This triangulation proves denial requires
     *scoped AND foreign fund* and isolates the `fundIds` claim as the cause.
  2. **registerRoutes surface (inline `enforceProvidedFundScope` guard):** scoped
     `[1]` → `GET /api/monte-carlo/funds/2/simulate` → **403**.
  3. **Not-fund-scoped stays open:** scoped `[1]` → `GET /api/backtesting/scenarios`
     → **200** (intentionally open static catalog).

### Scope (representative, not exhaustive — stated honestly)
Two routes spanning both bootstraps and both guard implementations
(`router.param` middleware vs inline `enforceProvidedFundScope`). Derived-fund
routes (companyId/jobId → fund) are **intentionally excluded**: their deny depends
on memory-storage seed data, and they are already covered by their own unit
contracts (Slices 4/5). A one-line comment in the test records this boundary.

### Verification
- The tests ARE the proof: each deny asserts 403 on the booted surface where the
  guard runs before any service; the own-fund/unrestricted assertions
  (`status !== 403`) prove the guard passes for legitimate access (a 5xx from
  MemStorage still proves the guard was cleared). No source-neuter needed — the
  discriminator triple is the regression control.
- `npm run check`: 0 new TypeScript errors.
- Full suite `TZ=UTC npm test`: green vs main `f8978e23` (6585/90), delta = +3.
