### PR TITLE
fix(auth): protect SSE event routes with bearer fund-scope (ADR-022)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -25,6 +25,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-019: Operational Guardrails, Pino Standardization, and Policy Exclusions](#adr-019-operational-guardrails-pino-standardization-and-policy-exclusions)
 - [ADR-020: Phase 3C Track B Go/No-Go Deadline](#adr-020-phase-3c-track-b-gono-go-deadline)
 - [ADR-021: Single Required CI Gate with Internal Conditional Jobs](#adr-021-single-required-ci-gate-with-internal-conditional-jobs)
+- [ADR-022: SSE Event Routes Protected by Bearer Fund-Scope; Native EventSource Transport Deferred](#adr-022-sse-event-routes-protected-by-bearer-fund-scope-native-eventsource-transport-deferred)
 
 ---
 
@@ -4950,3 +4951,60 @@ changes.
 - `.github/actions/setup-node-env/action.yml`
 - `scripts/control-plane/git-safety.mjs`
 - `docs/workflows/README.md`
+
+---
+
+## ADR-022: SSE Event Routes Protected by Bearer Fund-Scope; Native EventSource Transport Deferred
+
+**Date:** 2026-06-02 **Status:** [IMPLEMENTED] Implemented **Decision:** Guard
+the unused server-sent-events routes (`/api/events/fund/:fundId`,
+`/api/events/simulation/:simulationId`) with the existing bearer-token
+fund-scope helper and defer a browser-native EventSource auth transport
+(query-token or cookie) until a real consumer exists.
+
+### Context
+
+`server/routes/sse-events.ts` exposed two SSE routes with zero authentication.
+The fund route could stream any fund's real-time events to any caller (a latent
+cross-fund leak). Both routes are mounted on the `registerRoutes` surface only
+(not the canonical `makeApp`/prod surface), have no client or server consumer
+(the only frontend `EventSource` targets `/api/agents/stream/:runId`), and have
+no production broadcaster, so today they emit only `connected`/`heartbeat`. The
+standard guard helpers verify a bearer token, but a browser `EventSource` cannot
+send an `Authorization` header -- which is why these routes were deferred during
+the Tranche A fund-scope rollout.
+
+### Decision
+
+Apply `getVerifiedFundScope` (bearer re-verification) inside both handlers
+before any SSE headers are flushed: 401 when the token is missing or invalid,
+403 `FUND_ACCESS_DENIED` when a restricted caller requests a fund outside its
+scope. The simulation route enforces authentication only (it carries no fund
+binding in the route; full fund-scoping is a follow-up that needs a
+`simulationId -> fundId` resolver). This closes the unauthenticated exposure
+with the smallest reversible change and matches the semantics used by every
+other Tranche A route.
+
+### Alternatives Considered
+
+- **Query-param token (`?access_token=`):** works with native EventSource and is
+  the lightest transport, but puts a JWT in URLs (access/proxy logs, history,
+  Referer). Acceptable only with a short-TTL, single-purpose SSE token.
+  Deferred.
+- **Cookie-based token:** no URL leak and cheap for a same-origin deployment,
+  but introduces cookie/CSRF/CORS infrastructure the app does not currently use
+  (credentialed CORS is incompatible with the existing
+  `Access-Control-Allow-Origin: *`). Deferred.
+- **Delete/quarantine the routes:** defensible given no consumer, but the
+  `broadcast*` exports are a public surface a future feature may wire up;
+  removal is a larger dead-code sweep. Not done.
+
+### Consequences
+
+- The unauthenticated cross-fund exposure is closed now, consistent with the
+  rest of Tranche A; no current consumer breaks (there are none).
+- A browser-native EventSource consumer cannot use these routes until the
+  query-token or cookie transport is designed. That decision is intentionally
+  deferred to when a real consumer's requirements exist.
+- The simulation route gains auth-required immediately; full simulation
+  fund-scoping remains a follow-up.

--- a/server/routes/sse-events.ts
+++ b/server/routes/sse-events.ts
@@ -9,6 +9,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { logger } from '../logger';
 import { firstString } from '../lib/request-values';
+import { getVerifiedFundScope, type VerifiedFundScope } from '../lib/auth/provided-fund-scope';
 
 const router = Router();
 
@@ -34,12 +35,34 @@ export type SSEEventType =
   | 'heartbeat';
 
 /**
+ * Verify the caller before opening a stream. getVerifiedFundScope re-verifies the
+ * bearer token; a missing token throws outside development and an invalid token
+ * returns null -- both are treated as unauthenticated (401) here so a stream is
+ * never opened for an unverified caller. Returns the verified scope on success.
+ */
+async function resolveStreamScope(req: Request, res: Response): Promise<VerifiedFundScope | null> {
+  try {
+    const scope = await getVerifiedFundScope(req);
+    if (scope) {
+      return scope;
+    }
+  } catch {
+    // Missing bearer token outside development throws; treat as unauthenticated.
+  }
+  res.status(401).json({
+    error: 'Unauthorized',
+    message: 'Authentication is required for event streams',
+  });
+  return null;
+}
+
+/**
  * GET /api/events/fund/:fundId
  *
  * Establish an SSE connection for real-time fund events
  * Client will receive events as they occur
  */
-router['get']('/api/events/fund/:fundId', (req: Request, res: Response) => {
+router['get']('/api/events/fund/:fundId', async (req: Request, res: Response) => {
   const fundIdParam = firstString(req.params['fundId']);
   const fundId = parseInt(fundIdParam || '0', 10);
 
@@ -47,6 +70,22 @@ router['get']('/api/events/fund/:fundId', (req: Request, res: Response) => {
     return res.status(400).json({
       error: 'Invalid fund ID',
       message: 'Fund ID must be a positive integer',
+    });
+  }
+
+  // Authenticate and fund-scope before establishing the stream. Native
+  // EventSource cannot send a bearer token, so browser consumers are deferred to
+  // a future transport (query-token/cookie) decision; until then these routes are
+  // protected, not publicly streamable.
+  const scope = await resolveStreamScope(req, res);
+  if (!scope) {
+    return;
+  }
+  if (!scope.unrestricted && !scope.fundIds.includes(fundId)) {
+    return res.status(403).json({
+      error: 'Forbidden',
+      code: 'FUND_ACCESS_DENIED',
+      message: `You do not have access to fund ${fundId}`,
     });
   }
 
@@ -122,7 +161,7 @@ router['get']('/api/events/fund/:fundId', (req: Request, res: Response) => {
  * SSE stream for Monte Carlo simulation progress
  * Streams progress updates and final results
  */
-router['get']('/api/events/simulation/:simulationId', (req: Request, res: Response) => {
+router['get']('/api/events/simulation/:simulationId', async (req: Request, res: Response) => {
   const simulationId = firstString(req.params['simulationId']);
 
   if (!simulationId) {
@@ -130,6 +169,15 @@ router['get']('/api/events/simulation/:simulationId', (req: Request, res: Respon
       error: 'Invalid simulation ID',
       message: 'Simulation ID is required',
     });
+  }
+
+  // Authentication is required before streaming. This route is not fund-scoped:
+  // simulationId is not bound to a fund here, so it enforces auth only. Full
+  // fund-scoping is a follow-up requiring a reliable simulationId -> fundId
+  // resolver (e.g. the simulation queue job record).
+  const scope = await resolveStreamScope(req, res);
+  if (!scope) {
+    return;
   }
 
   // Set SSE headers

--- a/tests/unit/routes/sse-events-api.test.ts
+++ b/tests/unit/routes/sse-events-api.test.ts
@@ -7,6 +7,10 @@ const { loggerInfoMock, loggerDebugMock, loggerErrorMock } = vi.hoisted(() => ({
   loggerErrorMock: vi.fn(),
 }));
 
+const { getVerifiedFundScopeMock } = vi.hoisted(() => ({
+  getVerifiedFundScopeMock: vi.fn(),
+}));
+
 vi.mock('../../../server/logger', () => ({
   logger: {
     info: loggerInfoMock,
@@ -15,9 +19,13 @@ vi.mock('../../../server/logger', () => ({
   },
 }));
 
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  getVerifiedFundScope: getVerifiedFundScopeMock,
+}));
+
 import sseRouter, { broadcastFundEvent, getSSEStats } from '../../../server/routes/sse-events';
 
-type RouteHandler = (req: Request, res: Response) => void;
+type RouteHandler = (req: Request, res: Response) => void | Promise<void>;
 
 type RouterLayer = {
   route?: {
@@ -96,13 +104,15 @@ function createMockResponse(): MockResponse {
 describe('SSE routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: an authenticated, unrestricted caller (lets the stream open).
+    getVerifiedFundScopeMock.mockResolvedValue({ unrestricted: true, fundIds: [] });
 
     const stats = getSSEStats();
     expect(stats.totalFundConnections).toBe(0);
     expect(stats.totalSimulationConnections).toBe(0);
   });
 
-  it('returns 400 for invalid fund ids', () => {
+  it('returns 400 for invalid fund ids before the auth check', async () => {
     const handler = getRouteHandler('/api/events/fund/:fundId');
     const response = createMockResponse();
     const request: MockRequest = {
@@ -111,16 +121,90 @@ describe('SSE routes', () => {
       on: vi.fn(),
     };
 
-    handler(request as Request, response as unknown as Response);
+    await handler(request as Request, response as unknown as Response);
 
     expect(response.statusCode).toBe(400);
     expect(response.jsonBody).toEqual({
       error: 'Invalid fund ID',
       message: 'Fund ID must be a positive integer',
     });
+    expect(getVerifiedFundScopeMock).not.toHaveBeenCalled();
   });
 
-  it('broadcasts only events allowed by the connection filter and cleans up on close', () => {
+  it('rejects an unauthenticated fund stream with 401 before opening the connection', async () => {
+    getVerifiedFundScopeMock.mockResolvedValueOnce(null);
+    const handler = getRouteHandler('/api/events/fund/:fundId');
+    const response = createMockResponse();
+    const request: MockRequest = {
+      params: { fundId: '42' },
+      query: {},
+      on: vi.fn(),
+    };
+
+    await handler(request as Request, response as unknown as Response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers['Content-Type']).toBeUndefined();
+    expect(getSSEStats().totalFundConnections).toBe(0);
+  });
+
+  it('treats a missing bearer token (thrown) as unauthenticated', async () => {
+    getVerifiedFundScopeMock.mockRejectedValueOnce(new Error('missing token'));
+    const handler = getRouteHandler('/api/events/fund/:fundId');
+    const response = createMockResponse();
+    const request: MockRequest = {
+      params: { fundId: '42' },
+      query: {},
+      on: vi.fn(),
+    };
+
+    await handler(request as Request, response as unknown as Response);
+
+    expect(response.statusCode).toBe(401);
+    expect(getSSEStats().totalFundConnections).toBe(0);
+  });
+
+  it('denies a fund outside the caller scope with 403 before opening the connection', async () => {
+    getVerifiedFundScopeMock.mockResolvedValueOnce({ unrestricted: false, fundIds: [1] });
+    const handler = getRouteHandler('/api/events/fund/:fundId');
+    const response = createMockResponse();
+    const request: MockRequest = {
+      params: { fundId: '2' },
+      query: {},
+      on: vi.fn(),
+    };
+
+    await handler(request as Request, response as unknown as Response);
+
+    expect(response.statusCode).toBe(403);
+    expect(response.jsonBody).toMatchObject({ code: 'FUND_ACCESS_DENIED' });
+    expect(response.headers['Content-Type']).toBeUndefined();
+    expect(getSSEStats().totalFundConnections).toBe(0);
+  });
+
+  it('opens the fund stream for an in-scope caller', async () => {
+    getVerifiedFundScopeMock.mockResolvedValueOnce({ unrestricted: false, fundIds: [42] });
+    const handler = getRouteHandler('/api/events/fund/:fundId');
+    const response = createMockResponse();
+    let closeHandler: (() => void) | undefined;
+    const request: MockRequest = {
+      params: { fundId: '42' },
+      query: {},
+      on: (_event, handlerFn) => {
+        closeHandler = handlerFn;
+      },
+    };
+
+    await handler(request as Request, response as unknown as Response);
+
+    expect(response.headers['Content-Type']).toBe('text/event-stream');
+    expect(getSSEStats().totalFundConnections).toBe(1);
+
+    closeHandler?.();
+    expect(getSSEStats().totalFundConnections).toBe(0);
+  });
+
+  it('broadcasts only events allowed by the connection filter and cleans up on close', async () => {
     const handler = getRouteHandler('/api/events/fund/:fundId');
     const response = createMockResponse();
     let closeHandler: (() => void) | undefined;
@@ -133,7 +217,7 @@ describe('SSE routes', () => {
       },
     };
 
-    handler(request as Request, response as unknown as Response);
+    await handler(request as Request, response as unknown as Response);
 
     expect(getSSEStats().totalFundConnections).toBe(1);
     response.writes = [];
@@ -148,5 +232,58 @@ describe('SSE routes', () => {
 
     closeHandler?.();
     expect(getSSEStats().totalFundConnections).toBe(0);
+  });
+
+  it('returns 400 for a missing simulation id before the auth check', async () => {
+    const handler = getRouteHandler('/api/events/simulation/:simulationId');
+    const response = createMockResponse();
+    const request: MockRequest = {
+      params: { simulationId: undefined },
+      query: {},
+      on: vi.fn(),
+    };
+
+    await handler(request as Request, response as unknown as Response);
+
+    expect(response.statusCode).toBe(400);
+    expect(getVerifiedFundScopeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthenticated simulation stream with 401 before opening the connection', async () => {
+    getVerifiedFundScopeMock.mockResolvedValueOnce(null);
+    const handler = getRouteHandler('/api/events/simulation/:simulationId');
+    const response = createMockResponse();
+    const request: MockRequest = {
+      params: { simulationId: 'sim-1' },
+      query: {},
+      on: vi.fn(),
+    };
+
+    await handler(request as Request, response as unknown as Response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers['Content-Type']).toBeUndefined();
+    expect(getSSEStats().totalSimulationConnections).toBe(0);
+  });
+
+  it('opens the simulation stream for an authenticated caller', async () => {
+    const handler = getRouteHandler('/api/events/simulation/:simulationId');
+    const response = createMockResponse();
+    let closeHandler: (() => void) | undefined;
+    const request: MockRequest = {
+      params: { simulationId: 'sim-1' },
+      query: {},
+      on: (_event, handlerFn) => {
+        closeHandler = handlerFn;
+      },
+    };
+
+    await handler(request as Request, response as unknown as Response);
+
+    expect(response.headers['Content-Type']).toBe('text/event-stream');
+    expect(getSSEStats().totalSimulationConnections).toBe(1);
+
+    closeHandler?.();
+    expect(getSSEStats().totalSimulationConnections).toBe(0);
   });
 });


### PR DESCRIPTION
## Goal 1 — protect SSE event routes with bearer fund-scope (ADR-022)

Closes the last open item in the Tranche A fund-scope lane.

### Problem
`server/routes/sse-events.ts` exposed two SSE routes with **zero authentication**:
- `GET /api/events/fund/:fundId` could stream any fund's real-time events
  (`metrics:update`, `allocation:changed`, `scenario:updated`, ...) to any caller —
  a latent cross-fund leak.
- `GET /api/events/simulation/:simulationId` streamed simulation progress with no
  auth.

These were deferred during Tranche A because native `EventSource` cannot send an
`Authorization` header. Verified facts that make a bearer guard the right immediate
move (see ADR-022): both routes are `registerRoutes`-only (not on the prod
`makeApp` surface), have **no consumer** anywhere (the only frontend `EventSource`
targets `/api/agents/stream/:runId`), and have **no production broadcaster** (today
they emit only `connected`/`heartbeat`).

### Fix (Option C — bearer defense-in-depth; transport deferred)
- `resolveStreamScope(req, res)` re-verifies the bearer via `getVerifiedFundScope`
  before any SSE header flush. A missing token (throws outside dev) and an invalid
  token (null) are both treated as **401**; the helper writes its own 401.
- `GET /api/events/fund/:fundId`: 401 unauthenticated, **403 `FUND_ACCESS_DENIED`**
  for a restricted caller requesting an out-of-scope fund, before opening the
  stream.
- `GET /api/events/simulation/:simulationId`: **auth-required** only — it carries
  no fund binding in the route, so it does not claim fund-scope (full scoping is a
  follow-up needing a `simulationId -> fundId` resolver).
- **No query-token or cookie transport** in this slice. A browser-native consumer
  cannot use these routes until that transport is designed — deferred to when a
  real consumer exists (the A-vs-B analysis is recorded in ADR-022).

### Tests
`tests/unit/routes/sse-events-api.test.ts` rewritten (2 -> 9 tests): mocks
`getVerifiedFundScope`; proves 401 (unauthenticated + thrown-no-token), 403
(cross-fund), and 400 (bad id) all occur **before** the stream opens (no
`Content-Type: text/event-stream`, no registered connection), plus the in-scope /
unrestricted / simulation allow paths and the existing broadcast-filter behavior.

### Verification
- `npm run check`: 0 new TypeScript errors.
- **Negative control**: neutering `resolveStreamScope` to always return a
  permissive scope flips the deny tests RED (the first fails cleanly on its own
  `expect(statusCode).toBe(401)`); reverted.
- Full suite `TZ=UTC npm test`: **6617 passed / 90 skipped, 0 failed**. The change
  is additive to a single test file (`sse-events-api.test.ts` 2 -> 9 tests, +7);
  zero collateral (a regression would surface as a failure, and there are none).
  Main `98c900f6` was not re-measured this turn, so the exact +N vs main is derived.
- `DECISIONS.md`: ADR-022 records the decision and the deferred query-token /
  cookie transport alternatives.
