### PR TITLE
docs: update analytics strategy for current codebase

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,7 +1,7 @@
 ---
 status: ACTIVE
 audience: both
-last_updated: 2026-05-24
+last_updated: 2026-06-02
 categories: [design, analytics, visualization, truthfulness]
 keywords: [design, charts, dashboards, provenance, evidence, visual-truthfulness]
 source_of_truth: false
@@ -22,7 +22,7 @@ This folder captures presentation-layer doctrine for Updog. It does not define c
 
 | Document | Purpose | Use when |
 | --- | --- | --- |
-| [analytics-visualization-principles.md](analytics-visualization-principles.md) | House rules for truthful, comparison-rich analytical displays | Creating or reviewing charts, dashboards, fund results, LP reports, and scenario views |
+| [analytics-visualization-principles.md](analytics-visualization-principles.md) | House rules for truthful, comparison-rich, access-aware analytical displays | Creating or reviewing charts, dashboards, fund results, LP reports, and scenario views |
 | [analytics-visualization-rollout.md](analytics-visualization-rollout.md) | Sequenced implementation plan for applying those rules inside `Updog_restore` | Planning PRs after the doctrine is accepted |
 
 ## Design stance

--- a/docs/design/analytics-visualization-principles.md
+++ b/docs/design/analytics-visualization-principles.md
@@ -19,7 +19,9 @@ keywords:
 source_of_truth: true
 agent_routing:
   priority: 1
-  route_hint: 'Use for any Updog chart, dashboard, report, fund results, scenario comparison, reserve analysis, or LP-facing analytical display.'
+  route_hint:
+    'Use for any Updog chart, dashboard, report, fund results, scenario
+    comparison, reserve analysis, or LP-facing analytical display.'
   use_cases:
     [
       chart_review,
@@ -39,10 +41,10 @@ maintenance:
 
 ## Purpose
 
-This document converts the Tufte-style visualization guidance into Updog-specific
-presentation-layer rules. It is highly relevant to dashboards, charts, reports,
-fund-model results, scenario comparison, reserve planning, MOIC analysis,
-portfolio monitoring, and LP reporting.
+This document converts the Tufte-style visualization guidance into
+Updog-specific presentation-layer rules. It is highly relevant to dashboards,
+charts, reports, fund-model results, scenario comparison, reserve planning, MOIC
+analysis, portfolio monitoring, and LP reporting.
 
 It is intentionally not a rewrite of the calculation engines, persistence layer,
 worker orchestration, schema contracts, or CI architecture. Those systems must
@@ -66,14 +68,30 @@ Every chart, KPI, table, report block, and dashboard panel should answer at
 least one of those questions. The best analytical surfaces answer all five
 without forcing the user into a separate explanation page.
 
+### The trust arc behind the five questions
+
+The five questions are not a checklist; they are the emotional spine of two
+high-stakes moments:
+
+- **GP, fund results.** A GP opens `/fund-model-results/:fundId` minutes before
+  an IC or LP conversation. The felt question is "is this number current, and
+  can I defend it?" The evidence header exists to relieve that anxiety at a
+  glance, not to satisfy an audit.
+- **LP, shared report.** An LP opens a report and silently asks "is this my
+  fund, and is it the latest?" Access-scope + version evidence exist to make the
+  answer obvious before they read a single metric.
+
+Design the surfaces so the relieving evidence arrives _before_ the user has to
+ask. A correct number that arrives without confidence still loses the moment.
+
 ## Non-negotiables
 
 ### 1. Truthfulness beats polish
 
 A polished chart with placeholder, stale, or mock-only data is worse than an
 empty state. Production-facing analytics must clearly distinguish live data,
-demo data, sample data, stale data, unavailable sections, and pending calculation
-states.
+demo data, sample data, stale data, unavailable sections, and pending
+calculation states.
 
 Rules:
 
@@ -117,9 +135,9 @@ Rules:
   commitment scope.
 - Canonical fund ID parsing matters. Do not hand-parse route fund IDs in a way
   that can disagree with the server guard.
-- Native browser `EventSource` cannot send bearer headers. Treat bearer-protected
-  SSE routes as server-side defense-in-depth until an explicit query-token or
-  cookie transport is designed.
+- Native browser `EventSource` cannot send bearer headers. Treat
+  bearer-protected SSE routes as server-side defense-in-depth until an explicit
+  query-token or cookie transport is designed.
 
 ### 4. Evidence must travel with the number
 
@@ -185,8 +203,8 @@ Rules:
   clearly labeled.
 - Axis truncation must be intentional and disclosed.
 - Units must be visible: dollars, cents, %, x, bps, quarters, years.
-- Avoid mixing dollars and multiples on the same axis unless the design makes the
-  encoding unmistakable.
+- Avoid mixing dollars and multiples on the same axis unless the design makes
+  the encoding unmistakable.
 
 ### 8. Compact trend cues should support scanning
 
@@ -200,8 +218,8 @@ Rules:
   excessive.
 - Sparklines should show shape, not decorative noise.
 - Pair sparklines with the current value and, when useful, a short delta.
-- Use them for portfolio-company tables, reserve rankings, KPI rows, LP reporting
-  summaries, and watchlists.
+- Use them for portfolio-company tables, reserve rankings, KPI rows, LP
+  reporting summaries, and watchlists.
 
 Example patterns:
 
@@ -214,18 +232,18 @@ Runway          9 mo   ▃▃▂▂▁
 
 ## Updog surface rules
 
-| Surface | Primary visualization job | Required evidence pattern |
-| --- | --- | --- |
-| `/fund-model-results/:fundId` | Explain authoritative published results | Evidence header per section: config version, run, timestamp, source, status |
-| `/fund-model-results/:fundId/scenarios` | Compare existing scenario sets against the authoritative baseline | Source config, scenario-set status, calculation status, comparison staleness, and fund-scoped endpoints |
-| Scenario builder | Compare changed assumptions and outcomes | Base vs. changed assumptions side by side; identical scales for outcome charts |
-| Reserve planning | Rank follow-on needs and explain why | Table with reserve need, current/planned/deployed reserve, ownership effect, trigger annotation |
-| MOIC / TVPI / DPI / IRR analysis | Show return mechanics, not only headline metrics | Direct labels, assumptions, time horizon, calculation version, stale state |
-| Construction vs. current forecasts | Reveal drift from the original plan | Small multiples or paired charts with shared scales and variance callouts |
-| Portfolio dashboards | Support scanning and triage | KPI tiles with provenance, company tables with sparklines, exception annotations |
-| LP reports / shared dashboards | Build trust with clear evidence | Integrated words/numbers/charts, source notes, export timestamp, version badge, LP commitment scope |
-| Wizard inputs | Explain effect of assumptions | Inline examples, micro-visualizations, and impact previews where possible |
-| SSE / real-time surfaces | Stream state changes without leaking cross-fund events | Auth transport decision, fund-scope validation before stream open, no browser-native consumer until transport is designed |
+| Surface                                 | Primary visualization job                                         | Required evidence pattern                                                                                                 |
+| --------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `/fund-model-results/:fundId`           | Explain authoritative published results                           | Evidence header per section: config version, run, timestamp, source, status                                               |
+| `/fund-model-results/:fundId/scenarios` | Compare existing scenario sets against the authoritative baseline | Source config, scenario-set status, calculation status, comparison staleness, and fund-scoped endpoints                   |
+| Scenario builder                        | Compare changed assumptions and outcomes                          | Base vs. changed assumptions side by side; identical scales for outcome charts                                            |
+| Reserve planning                        | Rank follow-on needs and explain why                              | Table with reserve need, current/planned/deployed reserve, ownership effect, trigger annotation                           |
+| MOIC / TVPI / DPI / IRR analysis        | Show return mechanics, not only headline metrics                  | Direct labels, assumptions, time horizon, calculation version, stale state                                                |
+| Construction vs. current forecasts      | Reveal drift from the original plan                               | Small multiples or paired charts with shared scales and variance callouts                                                 |
+| Portfolio dashboards                    | Support scanning and triage                                       | KPI tiles with provenance, company tables with sparklines, exception annotations                                          |
+| LP reports / shared dashboards          | Build trust with clear evidence                                   | Integrated words/numbers/charts, source notes, export timestamp, version badge, LP commitment scope                       |
+| Wizard inputs                           | Explain effect of assumptions                                     | Inline examples, micro-visualizations, and impact previews where possible                                                 |
+| SSE / real-time surfaces                | Stream state changes without leaking cross-fund events            | Auth transport decision, fund-scope validation before stream open, no browser-native consumer until transport is designed |
 
 ## Evidence header pattern
 
@@ -238,12 +256,81 @@ READY · CONFIG v12 · RUN #148 · CALCULATED 2026-06-02 09:41 PT · SOURCE /api
 State language:
 
 - `READY`: result is current for the published config.
-- `CALCULATING`: result is in progress; keep previous output visible if available
-  and label it as prior.
+- `CALCULATING`: result is in progress; keep previous output visible if
+  available and label it as prior.
 - `STALE`: result belongs to an older config or underlying data version.
 - `FAILED`: calculation failed; show last known result only if clearly labeled.
+- `EMPTY`: the section is supported and current, but has no data yet (e.g., a
+  fund with no scenarios). Distinct from `UNAVAILABLE`. Render a warm zero-state
+  with the primary action, never a bare "No items found."
+- `PARTIAL`: some metrics in the section calculated and others failed or are
+  pending. Render the available metrics plus an inline note for the rest; do not
+  hide the whole section.
 - `UNAVAILABLE`: the section is not supported by the server response.
 - `DEMO`: synthetic or fixture-backed data, visible to users.
+
+### Evidence header hierarchy and responsive behavior
+
+The header is a thin inline rail, not a card. It carries three tiers of weight:
+
+- **Tier 1 — glanceable (always visible at every width):** lifecycle state and
+  access state. Strongest visual weight, leftmost, color-coded (see State visual
+  mapping). This is the trust signal and must never be truncated.
+- **Tier 2 — scannable:** config version and run ID. Medium weight, monospace.
+- **Tier 3 — audit detail:** calculated timestamp and source endpoint. Lowest
+  weight (`--muted`/`--quiet`), shown last.
+
+Responsive rule: below the 960px breakpoint (or when the section panel is
+narrow), keep Tier 1 inline and collapse Tier 2 + Tier 3 behind a single `ⓘ`
+affordance that opens the existing `Tooltip`/popover. Do not let the rail wrap
+into an unranked block.
+
+Example, wide:
+
+```text
+READY · FUND-SCOPED   CONFIG v12 · RUN #148   2026-06-02 09:41 PT · /api/funds/:id/results
+└ Tier 1 (color) ───┘ └ Tier 2 (mono) ─────┘ └ Tier 3 (muted) ──────────────────────────┘
+```
+
+Example, narrow:
+
+```text
+READY · FUND-SCOPED   ⓘ
+```
+
+### State visual mapping (v3.1.1 tokens)
+
+Bind every lifecycle/access state to an existing v3.1.1 semantic token; do not
+introduce new state colors. Always pair color with the text label (color is
+never the only signal).
+
+| State                              | Token               | Treatment                                                                     |
+| ---------------------------------- | ------------------- | ----------------------------------------------------------------------------- |
+| `READY`                            | `--pos` (#127e3d)   | StatusChip, calm; no emphasis needed                                          |
+| `CALCULATING`                      | `--blue` (#3769a6)  | StatusChip + v3.1.1 skeleton/scan motion (reduced-motion degrades to instant) |
+| `STALE`                            | `--warn` (#a95c00)  | StatusChip + visible recalculation action                                     |
+| `FAILED`                           | `--neg` (#b00020)   | StatusChip + explanation; last result only if labeled                         |
+| `EMPTY`                            | `--muted` (#7a7a7a) | Neutral; warm zero-state + primary action                                     |
+| `PARTIAL`                          | `--warn` (#a95c00)  | Available metrics render; inline note for the rest                            |
+| `UNAVAILABLE`                      | `--quiet` (#a8a8a8) | UnavailableSection placeholder                                                |
+| `DEMO`                             | `--warn` (#a95c00)  | Corner ribbon + amber section border (see below)                              |
+| `FUND-SCOPED` / `LP-SCOPED`        | `--pos` (#127e3d)   | AccessScopeNote chip                                                          |
+| `AUTH-ONLY` / `TRANSPORT-DEFERRED` | `--muted` (#7a7a7a) | AccessScopeNote chip                                                          |
+
+### Demo / sample-data treatment
+
+Truthfulness is the product thesis, so the demo signal must be impossible to
+miss and must not depend on the reader noticing a subtle badge.
+
+When a production surface renders sample/fixture data, it must show **both**:
+
+1. A persistent `DEMO` corner ribbon (top-right of the section), `--warn` on a
+   solid fill, using the `.pill.dark` weight so it reads as a deliberate stamp.
+2. A `--warn` (#a95c00) border around the whole section.
+
+The ribbon and border are non-blocking (the user can still interact). A `DEMO`
+pill in the evidence header alone is not sufficient — that is the exact "looks
+production-ready while using sample data" anti-pattern this doctrine forbids.
 
 Access-state language when relevant:
 
@@ -293,6 +380,28 @@ These are conceptual names, not mandates for exact implementation names.
 - `UnavailableSection`: honest placeholder when the server does not support a
   section.
 
+### Design-system binding (v3.1.1)
+
+These primitives are compositions of the existing v3.1.1 shared UI set, not a
+new component library. Build them by binding to current tokens and components:
+
+| Analytics primitive                    | v3.1.1 building blocks                                                                                                                                                                       |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EvidenceHeader`                       | `StatusChip` (Tier 1 state) + mono `.pill`s (Tier 2) + `--muted` text (Tier 3) + `Tooltip` for collapsed detail; tokens `--pos/--blue/--warn/--neg/--muted/--quiet`, `--font-mono`, `--rule` |
+| `AccessScopeNote`                      | `StatusChip` variant; `--pos` for scoped, `--muted` for auth-only/transport-deferred                                                                                                         |
+| `MetricWithProvenance`                 | KPI value + `IconButton`/`Tooltip` trigger; reuses v3.1.1 "source, sync time, assumption version, editor attribution" provenance fields                                                      |
+| `ComparisonBand` / `SmallMultipleGrid` | layout primitives toggled by `SegmentedControl`; share `--radius`, `--shadow-soft`                                                                                                           |
+| `InlineSparkline`                      | new compact element; pairs with the row value + delta (see a11y)                                                                                                                             |
+| `UnavailableSection`                   | `--quiet` placeholder using `--mist` surface + `--rule` border                                                                                                                               |
+
+Motion: `CALCULATING` uses the v3.1.1 skeleton-then-fade and stable-chrome rules
+and must honor `prefers-reduced-motion` (degrade to instant). Do not invent a
+new spinner.
+
+This analytics chart-review checklist composes with — does not replace — the
+v3.1.1 acceptance rubric (truth-first hierarchy, accountable context, keyboard
+parity, purposeful motion, LP-safe sharing). A chart PR must pass both.
+
 ## Anti-patterns
 
 Avoid these unless there is a documented reason:
@@ -309,6 +418,31 @@ Avoid these unless there is a documented reason:
 - Hiding failed, forbidden, or unavailable sections to make a page look cleaner.
 - Exporting LP-facing charts without version, timestamp, and LP-scope evidence.
 
+## Accessibility and responsive requirements
+
+These are requirements, not suggestions. A chart or evidence surface is not done
+until it satisfies them (and the v3.1.1 keyboard-parity rubric).
+
+- **Sparklines.** The `▁▂▃▅▇` glyphs are illustrative only. A real sparkline
+  must be `aria-hidden` with a visually-hidden text alternative naming the value
+  and direction, e.g. "TVPI 2.1x, trending up over 5 quarters." Never expose raw
+  block glyphs to a screen reader.
+- **Evidence trigger / provenance popover.** Keyboard-focusable, opens on
+  Enter/Space, closes on Escape, `aria-expanded` reflects state, focus returns
+  to the trigger on close. Reuse the v3.1.1 `Tooltip` focus behavior.
+- **Contrast.** State colors must meet 4.5:1 against the rail/section
+  background. `--warn` (#a95c00) on light surfaces is the contrast trap — verify
+  STALE/DEMO explicitly.
+- **Touch targets.** Evidence trigger, recalculate, and band/grid/matrix toggles
+  are ≥44px.
+- **Reduced motion.** All CALCULATING/scan motion degrades to instant under
+  `prefers-reduced-motion`, per the v3.1.1 motion grammar.
+- **Responsive.** Evidence header follows the Tier-1-always / Tier-2+3-collapse
+  rule at 960px. Comparison surfaces follow the density thresholds in the
+  rollout plan (≤3 band, 4–8 grid, 9+ matrix).
+- **Color independence.** Every color-encoded state also carries a text label,
+  shape, or ordering cue.
+
 ## Testing implications
 
 This doctrine should produce testable guardrails over time. Start with
@@ -322,8 +456,8 @@ Suggested tests:
   provenance fields.
 - Comparison/small-multiple components share a common domain by default.
 - Stale results show a visible stale warning and recalculation action.
-- Forbidden/unauthenticated states render honest unavailable/access messages, not
-  empty charts.
+- Forbidden/unauthenticated states render honest unavailable/access messages,
+  not empty charts.
 - Charts with color encodings include text labels or non-color cues.
 - LP/report exports include source/version/timestamp evidence and LP-scope
   evidence.

--- a/docs/design/analytics-visualization-principles.md
+++ b/docs/design/analytics-visualization-principles.md
@@ -269,6 +269,16 @@ State language:
 - `UNAVAILABLE`: the section is not supported by the server response.
 - `DEMO`: synthetic or fixture-backed data, visible to users.
 
+State axes (load-bearing for implementation): `READY`, `CALCULATING`, `STALE`,
+`FAILED`, and `UNAVAILABLE` are derived from the calculation-status contract
+(`FundStateReadV1['calculationState']['status']` =
+`ready|submitted|calculating|failed|not_requested`). `EMPTY` and `PARTIAL` are
+NOT new contract states — derive them client-side from the section payload
+(empty payload = `EMPTY`; mixed sourced/unsourced fields = `PARTIAL`). `DEMO` is
+an orthogonal data-source flag ("real vs. sample data"), not a
+calculation-status value. Do not extend the shared calculation-status enum to
+add these.
+
 ### Evidence header hierarchy and responsive behavior
 
 The header is a thin inline rail, not a card. It carries three tiers of weight:
@@ -278,7 +288,7 @@ The header is a thin inline rail, not a card. It carries three tiers of weight:
   mapping). This is the trust signal and must never be truncated.
 - **Tier 2 — scannable:** config version and run ID. Medium weight, monospace.
 - **Tier 3 — audit detail:** calculated timestamp and source endpoint. Lowest
-  weight (`--muted`/`--quiet`), shown last.
+  weight (muted `text-charcoal-400`), shown last.
 
 Responsive rule: below the 960px breakpoint (or when the section panel is
 narrow), keep Tier 1 inline and collapse Tier 2 + Tier 3 behind a single `ⓘ`
@@ -298,24 +308,27 @@ Example, narrow:
 READY · FUND-SCOPED   ⓘ
 ```
 
-### State visual mapping (v3.1.1 tokens)
+### State visual mapping (live Tailwind theme)
 
-Bind every lifecycle/access state to an existing v3.1.1 semantic token; do not
-introduce new state colors. Always pair color with the text label (color is
+Bind every lifecycle/access state to the live Tailwind theme — the same approach
+`EvidenceHeader.tsx` already uses (a `Badge` rail with `emerald/amber/rose` +
+`charcoal/beige`, `font-poppins`). The app has no `--pos/--warn/--neg` CSS
+variables; v3.1.1's palette is realized through this theme (`charcoal` =
+#292929, `beige` = #E0D8D1). Always pair color with the text label (color is
 never the only signal).
 
-| State                              | Token               | Treatment                                                                     |
-| ---------------------------------- | ------------------- | ----------------------------------------------------------------------------- |
-| `READY`                            | `--pos` (#127e3d)   | StatusChip, calm; no emphasis needed                                          |
-| `CALCULATING`                      | `--blue` (#3769a6)  | StatusChip + v3.1.1 skeleton/scan motion (reduced-motion degrades to instant) |
-| `STALE`                            | `--warn` (#a95c00)  | StatusChip + visible recalculation action                                     |
-| `FAILED`                           | `--neg` (#b00020)   | StatusChip + explanation; last result only if labeled                         |
-| `EMPTY`                            | `--muted` (#7a7a7a) | Neutral; warm zero-state + primary action                                     |
-| `PARTIAL`                          | `--warn` (#a95c00)  | Available metrics render; inline note for the rest                            |
-| `UNAVAILABLE`                      | `--quiet` (#a8a8a8) | UnavailableSection placeholder                                                |
-| `DEMO`                             | `--warn` (#a95c00)  | Corner ribbon + amber section border (see below)                              |
-| `FUND-SCOPED` / `LP-SCOPED`        | `--pos` (#127e3d)   | AccessScopeNote chip                                                          |
-| `AUTH-ONLY` / `TRANSPORT-DEFERRED` | `--muted` (#7a7a7a) | AccessScopeNote chip                                                          |
+| State                              | Tailwind classes                                                           | Treatment                                                                                                         |
+| ---------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `READY`                            | `border-emerald-200 bg-emerald-50 text-emerald-800`                        | calm; no emphasis                                                                                                 |
+| `CALCULATING`                      | `border-sky-200 bg-sky-50 text-sky-800`                                    | skeleton/in-progress; reduced-motion degrades to instant. (Live currently reuses amber — distinguish from STALE.) |
+| `STALE`                            | `border-amber-200 bg-amber-50 text-amber-800`                              | + visible recalculation action                                                                                    |
+| `FAILED`                           | `border-rose-200 bg-rose-50 text-rose-800`                                 | + explanation; last result only if labeled                                                                        |
+| `EMPTY`                            | `text-charcoal-500`                                                        | neutral; warm zero-state + primary action                                                                         |
+| `PARTIAL`                          | `border-amber-200 bg-amber-50 text-amber-800`                              | available metrics render; inline note for the rest                                                                |
+| `UNAVAILABLE`                      | `border-beige-200 text-charcoal-500`                                       | UnavailableSection placeholder                                                                                    |
+| `DEMO`                             | solid `bg-amber-600 text-white` ribbon + `border-amber-400` section border | see Demo treatment                                                                                                |
+| `FUND-SCOPED` / `LP-SCOPED`        | `text-emerald-800`                                                         | AccessScopeNote chip                                                                                              |
+| `AUTH-ONLY` / `TRANSPORT-DEFERRED` | `text-charcoal-500`                                                        | AccessScopeNote chip                                                                                              |
 
 ### Demo / sample-data treatment
 
@@ -324,9 +337,9 @@ miss and must not depend on the reader noticing a subtle badge.
 
 When a production surface renders sample/fixture data, it must show **both**:
 
-1. A persistent `DEMO` corner ribbon (top-right of the section), `--warn` on a
-   solid fill, using the `.pill.dark` weight so it reads as a deliberate stamp.
-2. A `--warn` (#a95c00) border around the whole section.
+1. A persistent `DEMO` corner ribbon (top-right of the section): a solid amber
+   `Badge` (`bg-amber-600 text-white`) so it reads as a deliberate stamp.
+2. An `border-amber-400` border around the whole section.
 
 The ribbon and border are non-blocking (the user can still interact). A `DEMO`
 pill in the evidence header alone is not sufficient — that is the exact "looks
@@ -380,27 +393,35 @@ These are conceptual names, not mandates for exact implementation names.
 - `UnavailableSection`: honest placeholder when the server does not support a
   section.
 
-### Design-system binding (v3.1.1)
+### Design-system binding (live theme; v3.1.1 is the north star)
 
-These primitives are compositions of the existing v3.1.1 shared UI set, not a
-new component library. Build them by binding to current tokens and components:
+These primitives extend the live components and Tailwind theme. v3.1.1 is the
+design north star, but the app does not use its CSS variables — bind to what
+ships today.
 
-| Analytics primitive                    | v3.1.1 building blocks                                                                                                                                                                       |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `EvidenceHeader`                       | `StatusChip` (Tier 1 state) + mono `.pill`s (Tier 2) + `--muted` text (Tier 3) + `Tooltip` for collapsed detail; tokens `--pos/--blue/--warn/--neg/--muted/--quiet`, `--font-mono`, `--rule` |
-| `AccessScopeNote`                      | `StatusChip` variant; `--pos` for scoped, `--muted` for auth-only/transport-deferred                                                                                                         |
-| `MetricWithProvenance`                 | KPI value + `IconButton`/`Tooltip` trigger; reuses v3.1.1 "source, sync time, assumption version, editor attribution" provenance fields                                                      |
-| `ComparisonBand` / `SmallMultipleGrid` | layout primitives toggled by `SegmentedControl`; share `--radius`, `--shadow-soft`                                                                                                           |
-| `InlineSparkline`                      | new compact element; pairs with the row value + delta (see a11y)                                                                                                                             |
-| `UnavailableSection`                   | `--quiet` placeholder using `--mist` surface + `--rule` border                                                                                                                               |
+| Analytics primitive                    | Build from                                                                                                                                                                                                      |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EvidenceHeader`                       | EXTEND the live `client/src/components/results/EvidenceHeader.tsx` (a `Badge` rail, `emerald/amber/rose` + `charcoal/beige`, `font-poppins`). Add EMPTY/PARTIAL/DEMO handling client-side. Not a new component. |
+| `AccessScopeNote`                      | NEW — requires a server-emitted access-scope field (see Contract prerequisites in the rollout). Do not infer scope from the route.                                                                              |
+| `MetricWithProvenance`                 | KPI value + `Tooltip`/icon trigger; provenance fields from the fund-results contract.                                                                                                                           |
+| `ComparisonBand` / `SmallMultipleGrid` | NEW layout primitives + a toggle. NOTE: `SegmentedControl` does not exist yet — build a small toggle or add the component.                                                                                      |
+| `InlineSparkline`                      | NEW compact element (today `TVPISparkline` is a stub); pairs with the row value + delta (see a11y).                                                                                                             |
+| `UnavailableSection`                   | muted placeholder using `charcoal/beige` surface + border.                                                                                                                                                      |
 
-Motion: `CALCULATING` uses the v3.1.1 skeleton-then-fade and stable-chrome rules
-and must honor `prefers-reduced-motion` (degrade to instant). Do not invent a
-new spinner.
+Step-1 plumbing (do before breadth): the live `StatusChip` only supports
+`complete|partial|fallback`, so it cannot render lifecycle states — either add
+lifecycle variants to it or keep EvidenceHeader's own `Badge` color map; and
+build the `SegmentedControl`/toggle the comparison layouts need.
 
-This analytics chart-review checklist composes with — does not replace — the
-v3.1.1 acceptance rubric (truth-first hierarchy, accountable context, keyboard
-parity, purposeful motion, LP-safe sharing). A chart PR must pass both.
+Fonts: the rail uses `font-poppins` (live); numerics use the `mono` family (Fira
+Code per tailwind.config), not JetBrains Mono.
+
+Motion: `CALCULATING` uses skeleton-then-fade and must honor
+`prefers-reduced-motion` (degrade to instant). Do not invent a new spinner.
+
+This chart-review checklist composes with — does not replace — the v3.1.1
+acceptance rubric (truth-first hierarchy, accountable context, keyboard parity,
+purposeful motion, LP-safe sharing). A chart PR must pass both.
 
 ## Anti-patterns
 
@@ -431,15 +452,15 @@ until it satisfies them (and the v3.1.1 keyboard-parity rubric).
   Enter/Space, closes on Escape, `aria-expanded` reflects state, focus returns
   to the trigger on close. Reuse the v3.1.1 `Tooltip` focus behavior.
 - **Contrast.** State colors must meet 4.5:1 against the rail/section
-  background. `--warn` (#a95c00) on light surfaces is the contrast trap — verify
-  STALE/DEMO explicitly.
+  background. Amber on light surfaces is the contrast trap (use
+  `text-amber-800`, not a lighter amber) — verify STALE/DEMO explicitly.
 - **Touch targets.** Evidence trigger, recalculate, and band/grid/matrix toggles
   are ≥44px.
 - **Reduced motion.** All CALCULATING/scan motion degrades to instant under
   `prefers-reduced-motion`, per the v3.1.1 motion grammar.
 - **Responsive.** Evidence header follows the Tier-1-always / Tier-2+3-collapse
   rule at 960px. Comparison surfaces follow the density thresholds in the
-  rollout plan (≤3 band, 4–8 grid, 9+ matrix).
+  rollout plan (≤3 band, 4–5 grid, metric×variant matrix).
 - **Color independence.** Every color-encoded state also carries a text label,
   shape, or ordering cue.
 

--- a/docs/design/analytics-visualization-principles.md
+++ b/docs/design/analytics-visualization-principles.md
@@ -1,16 +1,35 @@
 ---
 status: ACTIVE
 audience: both
-last_updated: 2026-05-24
+last_updated: 2026-06-02
 categories: [design, analytics, visualization, truthfulness]
 keywords:
-  [charts, dashboards, tufte, evidence, provenance, comparison, small-multiples, sparklines, fund-results]
+  [
+    charts,
+    dashboards,
+    tufte,
+    evidence,
+    provenance,
+    comparison,
+    fund-scope,
+    small-multiples,
+    sparklines,
+    fund-results,
+  ]
 source_of_truth: true
 agent_routing:
   priority: 1
   route_hint: 'Use for any Updog chart, dashboard, report, fund results, scenario comparison, reserve analysis, or LP-facing analytical display.'
   use_cases:
-    [chart_review, dashboard_review, fund_model_results, scenario_builder, reserve_planning, lp_reporting, visual_truthfulness]
+    [
+      chart_review,
+      dashboard_review,
+      fund_model_results,
+      scenario_builder,
+      reserve_planning,
+      lp_reporting,
+      visual_truthfulness,
+    ]
 maintenance:
   owner: 'Product + Frontend'
   review_cadence: 'P60D'
@@ -20,48 +39,93 @@ maintenance:
 
 ## Purpose
 
-This document converts the Tufte-style visualization guidance into Updog-specific presentation-layer rules. It is highly relevant to dashboards, charts, reports, fund-model results, scenario comparison, reserve planning, MOIC analysis, portfolio monitoring, and LP reporting.
+This document converts the Tufte-style visualization guidance into Updog-specific
+presentation-layer rules. It is highly relevant to dashboards, charts, reports,
+fund-model results, scenario comparison, reserve planning, MOIC analysis,
+portfolio monitoring, and LP reporting.
 
-It is intentionally not a rewrite of the calculation engines, persistence layer, worker orchestration, schema contracts, or CI architecture. Those systems must continue to prioritize truthful first-run results, authoritative contracts, and deterministic validation. The presentation layer then makes those results understandable, comparable, and auditable.
+It is intentionally not a rewrite of the calculation engines, persistence layer,
+worker orchestration, schema contracts, or CI architecture. Those systems must
+continue to prioritize truthful first-run results, authoritative contracts,
+deterministic validation, tenant/fund-scope enforcement, and canonical route
+parsing. The presentation layer then makes those results understandable,
+comparable, access-safe, and auditable.
 
 ## The operating thesis
 
-Updog’s analytical UI is only valuable when users can answer four questions quickly:
+Updog’s analytical UI is only valuable when users can answer five questions
+quickly:
 
 1. What changed?
 2. Compared to what?
 3. Why did it change?
 4. Can I trust the number?
+5. Is this number scoped to the user and entity viewing it?
 
-Every chart, KPI, table, report block, and dashboard panel should answer at least one of those questions. The best analytical surfaces answer all four without forcing the user into a separate explanation page.
+Every chart, KPI, table, report block, and dashboard panel should answer at
+least one of those questions. The best analytical surfaces answer all five
+without forcing the user into a separate explanation page.
 
 ## Non-negotiables
 
 ### 1. Truthfulness beats polish
 
-A polished chart with placeholder, stale, or mock-only data is worse than an empty state. Production-facing analytics must clearly distinguish live data, demo data, sample data, stale data, unavailable sections, and pending calculation states.
+A polished chart with placeholder, stale, or mock-only data is worse than an
+empty state. Production-facing analytics must clearly distinguish live data,
+demo data, sample data, stale data, unavailable sections, and pending calculation
+states.
 
 Rules:
 
-- No production chart should silently import `SAMPLE_DATA`, mock fixtures, or placeholder records.
+- No production chart should silently import `SAMPLE_DATA`, mock fixtures, or
+  placeholder records.
 - Demo/sample states must be visibly labeled in the surface, not only in code.
-- Stale results must show why they are stale and what action recalculates or republishs them.
-- Failed or unavailable sections must remain visible with an explanation rather than disappearing.
+- Stale results must show why they are stale and what action recalculates or
+  republishes them.
+- Failed or unavailable sections must remain visible with an explanation rather
+  than disappearing.
 
 ### 2. Comparison is the default analytical act
 
-A single metric is rarely useful in venture modeling. A fund model is useful because it compares construction vs. current forecast, base vs. upside/downside, planned reserves vs. deployed reserves, initial allocation vs. follow-on demand, and current value vs. cost.
+A single metric is rarely useful in venture modeling. A fund model is useful
+because it compares construction vs. current forecast, base vs. upside/downside,
+planned reserves vs. deployed reserves, initial allocation vs. follow-on demand,
+and current value vs. cost.
 
 Rules:
 
 - Every major number should answer “compared to what?”
-- Scenario views should show cases side by side before asking users to inspect one case deeply.
-- Use common scales when comparing cases, cohorts, years, companies, or scenarios.
+- Scenario views should show cases side by side before asking users to inspect
+  one case deeply.
+- Use common scales when comparing cases, cohorts, years, companies, or
+  scenarios.
 - Prefer small multiples when users need to compare patterns, not just totals.
 
-### 3. Evidence must travel with the number
+### 3. Access scope is part of visual truthfulness
 
-Every material output should carry enough evidence to make it inspectable. The UI does not need to show every field at full volume, but it must expose provenance near the number.
+A chart is not truthful if it can show a correct number to the wrong user.
+Production analytics must be backed by access-scoped routes or workers, not only
+by visually persuasive UI.
+
+Rules:
+
+- Do not build a production dashboard, report, chart, or live stream on an
+  unauthenticated or unscoped route.
+- Fund-scoped analytics should use endpoints guarded by the appropriate
+  fund-access helper before rendering material values.
+- LP-facing analytics should only render fund data that is within the LP’s
+  commitment scope.
+- Canonical fund ID parsing matters. Do not hand-parse route fund IDs in a way
+  that can disagree with the server guard.
+- Native browser `EventSource` cannot send bearer headers. Treat bearer-protected
+  SSE routes as server-side defense-in-depth until an explicit query-token or
+  cookie transport is designed.
+
+### 4. Evidence must travel with the number
+
+Every material output should carry enough evidence to make it inspectable. The
+UI does not need to show every field at full volume, but it must expose
+provenance near the number.
 
 Each major metric or result section should be able to show:
 
@@ -71,54 +135,73 @@ Each major metric or result section should be able to show:
 - Last calculated timestamp.
 - Source endpoint or contract section.
 - Current lifecycle state: ready, calculating, failed, stale, unavailable, demo.
+- Access scope when relevant: GP fund-scope, LP commitment scope, shared-link
+  scope, or authenticated-only stream.
 - Key assumptions or drivers behind the output.
 
-This is especially important for `/fund-model-results/:fundId`, LP reports, shared dashboards, scenario exports, and board/IC-ready summaries.
+This is especially important for `/fund-model-results/:fundId`,
+`/fund-model-results/:fundId/scenarios`, LP reports, shared dashboards, scenario
+exports, real-time/event surfaces, and board/IC-ready summaries.
 
-### 4. Words, numbers, and graphics belong together
+### 5. Words, numbers, and graphics belong together
 
-Do not isolate the chart from the explanation. Labels, annotations, captions, source notes, and assumption callouts should live close to the visual evidence.
+Do not isolate the chart from the explanation. Labels, annotations, captions,
+source notes, and assumption callouts should live close to the visual evidence.
 
 Rules:
 
 - Place labels near the data they describe.
-- Use short interpretive captions under charts: “The fund is two quarters behind plan,” “Upside case depends on a higher Series C conversion rate,” etc.
-- Explain material assumptions inside the chart card or immediately adjacent rail.
+- Use short interpretive captions under charts: “The fund is two quarters behind
+  plan,” “Upside case depends on a higher Series C conversion rate,” etc.
+- Explain material assumptions inside the chart card or immediately adjacent
+  rail.
 - Avoid making tooltips the only place where meaning appears.
 
-### 5. Reduce chart furniture
+### 6. Reduce chart furniture
 
-Remove visual elements that do not carry analytical meaning. Gridlines, legends, borders, gradients, shadows, dual legends, and decorative colors should earn their presence.
+Remove visual elements that do not carry analytical meaning. Gridlines, legends,
+borders, gradients, shadows, dual legends, and decorative colors should earn
+their presence.
 
 Rules:
 
 - Prefer direct labels over legends when the label can sit near the series.
-- Do not show a Recharts/Chart.js legend and then repeat a custom legend below the chart.
-- Use lighter gridlines or fewer gridlines unless the user needs precise reading.
+- Do not show a Recharts/Chart.js legend and then repeat a custom legend below
+  the chart.
+- Use lighter gridlines or fewer gridlines unless the user needs precise
+  reading.
 - Use color to encode meaning, not decoration.
 - Do not rely on color alone; pair it with labels, shapes, ordering, or text.
 
-### 6. Axis integrity is a product requirement
+### 7. Axis integrity is a product requirement
 
-Misleading scales are product bugs. Venture data can easily distort if charts change domains per scenario, truncate baselines without disclosure, or compare values with incompatible units.
+Misleading scales are product bugs. Venture data can easily distort if charts
+change domains per scenario, truncate baselines without disclosure, or compare
+values with incompatible units.
 
 Rules:
 
-- Shared comparison charts must use shared scales unless the difference is clearly labeled.
+- Shared comparison charts must use shared scales unless the difference is
+  clearly labeled.
 - Axis truncation must be intentional and disclosed.
 - Units must be visible: dollars, cents, %, x, bps, quarters, years.
-- Avoid mixing dollars and multiples on the same axis unless the design makes the encoding unmistakable.
+- Avoid mixing dollars and multiples on the same axis unless the design makes the
+  encoding unmistakable.
 
-### 7. Compact trend cues should support scanning
+### 8. Compact trend cues should support scanning
 
-Tables are a primary interface for venture operations. Users often need to scan many companies, investments, LPs, reserves, calls, or assumptions before opening a detail view.
+Tables are a primary interface for venture operations. Users often need to scan
+many companies, investments, LPs, reserves, calls, or assumptions before opening
+a detail view.
 
 Rules:
 
-- Use inline sparklines for row-level trends where a full chart would be excessive.
+- Use inline sparklines for row-level trends where a full chart would be
+  excessive.
 - Sparklines should show shape, not decorative noise.
 - Pair sparklines with the current value and, when useful, a short delta.
-- Use them for portfolio-company tables, reserve rankings, KPI rows, LP reporting summaries, and watchlists.
+- Use them for portfolio-company tables, reserve rankings, KPI rows, LP reporting
+  summaries, and watchlists.
 
 Example patterns:
 
@@ -134,30 +217,42 @@ Runway          9 mo   ▃▃▂▂▁
 | Surface | Primary visualization job | Required evidence pattern |
 | --- | --- | --- |
 | `/fund-model-results/:fundId` | Explain authoritative published results | Evidence header per section: config version, run, timestamp, source, status |
+| `/fund-model-results/:fundId/scenarios` | Compare existing scenario sets against the authoritative baseline | Source config, scenario-set status, calculation status, comparison staleness, and fund-scoped endpoints |
 | Scenario builder | Compare changed assumptions and outcomes | Base vs. changed assumptions side by side; identical scales for outcome charts |
 | Reserve planning | Rank follow-on needs and explain why | Table with reserve need, current/planned/deployed reserve, ownership effect, trigger annotation |
 | MOIC / TVPI / DPI / IRR analysis | Show return mechanics, not only headline metrics | Direct labels, assumptions, time horizon, calculation version, stale state |
 | Construction vs. current forecasts | Reveal drift from the original plan | Small multiples or paired charts with shared scales and variance callouts |
 | Portfolio dashboards | Support scanning and triage | KPI tiles with provenance, company tables with sparklines, exception annotations |
-| LP reports / shared dashboards | Build trust with clear evidence | Integrated words/numbers/charts, source notes, export timestamp, version badge |
+| LP reports / shared dashboards | Build trust with clear evidence | Integrated words/numbers/charts, source notes, export timestamp, version badge, LP commitment scope |
 | Wizard inputs | Explain effect of assumptions | Inline examples, micro-visualizations, and impact previews where possible |
+| SSE / real-time surfaces | Stream state changes without leaking cross-fund events | Auth transport decision, fund-scope validation before stream open, no browser-native consumer until transport is designed |
 
 ## Evidence header pattern
 
 Use an evidence header when a section presents material output.
 
 ```text
-READY · CONFIG v12 · RUN #148 · CALCULATED 2026-05-24 09:41 PT · SOURCE /api/funds/:id/results · CURRENT
+READY · CONFIG v12 · RUN #148 · CALCULATED 2026-06-02 09:41 PT · SOURCE /api/funds/:id/results · CURRENT
 ```
 
 State language:
 
 - `READY`: result is current for the published config.
-- `CALCULATING`: result is in progress; keep previous output visible if available and label it as prior.
+- `CALCULATING`: result is in progress; keep previous output visible if available
+  and label it as prior.
 - `STALE`: result belongs to an older config or underlying data version.
 - `FAILED`: calculation failed; show last known result only if clearly labeled.
 - `UNAVAILABLE`: the section is not supported by the server response.
 - `DEMO`: synthetic or fixture-backed data, visible to users.
+
+Access-state language when relevant:
+
+- `FUND-SCOPED`: route has enforced fund access before returning material data.
+- `LP-SCOPED`: worker or route has verified LP commitment access to requested
+  funds.
+- `AUTH-ONLY`: route requires authentication but does not claim fund binding.
+- `TRANSPORT-DEFERRED`: stream or live surface is intentionally not exposed to a
+  browser consumer yet.
 
 ## Chart review checklist
 
@@ -171,23 +266,32 @@ Before merging a chart or dashboard panel, answer:
 6. Is color encoding meaning rather than decoration?
 7. Is any meaning color-only?
 8. Is the data source, run/version, and freshness visible?
-9. Does the chart use live data, and if not, is demo/sample data visibly labeled?
-10. Would a small multiple, table, or sparkline communicate the same evidence better?
-11. Is there a written takeaway or annotation that explains the main pattern?
-12. Can the chart survive empty, partial, loading, stale, and failed states?
+9. Is the endpoint/worker access-scoped for the user and entity rendering it?
+10. Does the chart use live data, and if not, is demo/sample data visibly
+    labeled?
+11. Would a small multiple, table, or sparkline communicate the same evidence
+    better?
+12. Is there a written takeaway or annotation that explains the main pattern?
+13. Can the chart survive empty, partial, loading, stale, failed, forbidden, and
+    unauthenticated states?
 
 ## Recommended component primitives
 
 These are conceptual names, not mandates for exact implementation names.
 
-- `EvidenceHeader`: status, run, version, timestamp, source, current/stale/demo state.
-- `MetricWithProvenance`: KPI value plus evidence trigger and supporting assumptions.
+- `EvidenceHeader`: status, run, version, timestamp, source, current/stale/demo
+  state.
+- `AccessScopeNote`: compact display of fund-scope, LP-scope, shared-link scope,
+  or transport-deferred state when relevant.
+- `MetricWithProvenance`: KPI value plus evidence trigger and supporting
+  assumptions.
 - `ComparisonBand`: side-by-side base/upside/downside/current/plan snapshots.
 - `SmallMultipleGrid`: repeated charts with shared units and scales.
 - `InlineSparkline`: compact row-level trend cue.
 - `AssumptionCallout`: short explanation of what drove a chart or metric.
 - `SourceNote`: endpoint/contract/version note for LP/reporting contexts.
-- `UnavailableSection`: honest placeholder when the server does not support a section.
+- `UnavailableSection`: honest placeholder when the server does not support a
+  section.
 
 ## Anti-patterns
 
@@ -195,31 +299,43 @@ Avoid these unless there is a documented reason:
 
 - Large single-number hero metrics with no baseline, source, or timestamp.
 - Charts that look production-ready while using sample data.
+- Analytics surfaces built on unauthenticated or unscoped endpoints.
+- Browser-native EventSource dashboards that depend on bearer-only SSE routes.
 - Tooltips that contain essential meaning unavailable elsewhere.
-- Scenario charts with different scales that make outcomes look more comparable than they are.
+- Scenario charts with different scales that make outcomes look more comparable
+  than they are.
 - Duplicate legends.
 - Dense gridlines, shadows, gradients, or decoration that compete with the data.
-- Hiding failed or unavailable sections to make a page look cleaner.
-- Exporting LP-facing charts without version and timestamp evidence.
+- Hiding failed, forbidden, or unavailable sections to make a page look cleaner.
+- Exporting LP-facing charts without version, timestamp, and LP-scope evidence.
 
 ## Testing implications
 
-This doctrine should produce testable guardrails over time. Start with lightweight assertions instead of screenshot-perfect tests.
+This doctrine should produce testable guardrails over time. Start with
+lightweight assertions instead of screenshot-perfect tests.
 
 Suggested tests:
 
-- Production chart components do not import or render `SAMPLE_DATA` without a visible demo/sample label.
-- Each fund results section renders an evidence header when the server supplies provenance fields.
+- Production chart components do not import or render `SAMPLE_DATA` without a
+  visible demo/sample label.
+- Each fund results section renders an evidence header when the server supplies
+  provenance fields.
 - Comparison/small-multiple components share a common domain by default.
 - Stale results show a visible stale warning and recalculation action.
+- Forbidden/unauthenticated states render honest unavailable/access messages, not
+  empty charts.
 - Charts with color encodings include text labels or non-color cues.
-- LP/report exports include source/version/timestamp evidence.
+- LP/report exports include source/version/timestamp evidence and LP-scope
+  evidence.
 
 ## Relationship to Updog Design Philosophy v3.1.1
 
-The broader design philosophy says Updog is dashboard-first, action-near, multi-entity, and provenance-first. This document narrows that philosophy into analytical visualization rules:
+The broader design philosophy says Updog is dashboard-first, action-near,
+multi-entity, and provenance-first. This document narrows that philosophy into
+analytical visualization rules:
 
 - Dashboard-first becomes evidence-first dashboards.
 - Action-near becomes decisions near the supporting comparison.
-- Provenance-first becomes visible run/version/source state.
-- Multi-entity becomes small multiples, ranked tables, and comparable views across funds, SPVs, sidecars, companies, LP groups, and scenarios.
+- Provenance-first becomes visible run/version/source/access state.
+- Multi-entity becomes small multiples, ranked tables, and comparable views
+  across funds, SPVs, sidecars, companies, LP groups, and scenarios.

--- a/docs/design/analytics-visualization-rollout.md
+++ b/docs/design/analytics-visualization-rollout.md
@@ -145,8 +145,13 @@ inside `/fund-model-results/:fundId`.
   portfolio cost/value chart.
 - Add evidence/source bands to scenario comparison cards: source config version,
   scenario set name, comparison status, staleness, and baseline source.
-- Improve comparison density with small-multiple cards or a matrix view when a
-  scenario set has multiple variants.
+- Improve comparison density with explicit count thresholds, toggled via the
+  existing `SegmentedControl`:
+  - **≤3 variants:** `ComparisonBand` (side-by-side).
+  - **4–8 variants:** `SmallMultipleGrid` (shared scales).
+  - **9+ variants:** compact matrix/table view. These thresholds pin the
+    doctrine's "matrix view when multiple variants" rule so it is testable and
+    prevents a default card-grid layout.
 - Keep unsupported reserve-allocation comparisons explicit until reserve
   comparison semantics are implemented.
 - Avoid adding scenario creation/editing or reserve optimization expansion until
@@ -164,20 +169,21 @@ inside `/fund-model-results/:fundId`.
 **Status:** Pilot reset.
 
 The original chart pilot, `portfolio-cost-value-chart.tsx`, was retired because
-it had zero runtime callsites and embedded hard-coded `SAMPLE_DATA`. Refactoring a
-dead component would not have improved the product.
+it had zero runtime callsites and embedded hard-coded `SAMPLE_DATA`. Refactoring
+a dead component would not have improved the product.
 
 **Next pilot candidates:**
 
-1. Scenario comparison cards/workspace, because the contract and route now exist.
+1. Scenario comparison cards/workspace, because the contract and route now
+   exist.
 2. Economics cashflow and J-curve displays inside fund results, because they are
    live authoritative result sections and currently use compact custom visuals.
 3. Publish comparison, because it already supports publish-to-publish deltas and
    drift capability reasons.
 4. LP reports/shared dashboards, after report/source evidence is surfaced.
 
-**Selection rule:** Choose the pilot with active users, server-backed data, and a
-clear decision loop. Do not pick a dead or sample-backed component.
+**Selection rule:** Choose the pilot with active users, server-backed data, and
+a clear decision loop. Do not pick a dead or sample-backed component.
 
 ## Phase 4 — Small multiples and comparison grammar
 
@@ -199,7 +205,8 @@ DPI/IRR analysis, publish comparison.
 **Tests:**
 
 - Small multiples share a common domain unless explicitly overridden.
-- Assumption diffs and outcome deltas are visible in the same comparison surface.
+- Assumption diffs and outcome deltas are visible in the same comparison
+  surface.
 - Scenario labels are visible without relying on color alone.
 
 ## Phase 5 — Reserve planning and ranked tables
@@ -263,17 +270,25 @@ watchlists, capital allocation tables.
 
 ## Candidate implementation order from here
 
-1. Extend `EvidenceHeader` coverage across all material fund-results sections.
-2. Make the scenario workspace the first live visualization-refinement pilot.
-3. Add scenario comparison evidence/source bands and better variant comparison
-   density.
-4. Improve economics cashflow/J-curve displays with direct labels, captions, and
+1. **Lock the `EvidenceHeader` visual contract first:** Tier-1/2/3 hierarchy,
+   state→token color mapping, 960px responsive collapse, and DEMO ribbon+border.
+   Mount it on the two live sections as the reference implementation.
+2. Extend `EvidenceHeader` coverage across all material fund-results sections,
+   building from the locked contract (no per-section re-design).
+3. Make the scenario workspace the first live visualization-refinement pilot.
+4. Add scenario comparison evidence/source bands and the count-threshold density
+   switch (band / grid / matrix).
+5. Improve economics cashflow/J-curve displays with direct labels, captions, and
    evidence notes.
-5. Select a reserve/portfolio ranking table and add sparkline + “why” columns.
-6. Add LP/report provenance and export evidence.
-7. Add static/sample-data guardrails.
-8. Add shared-scale comparison tests after the first small-multiple component
+6. Select a reserve/portfolio ranking table and add sparkline + "why" columns.
+7. Add LP/report provenance and export evidence.
+8. Add static/sample-data guardrails.
+9. Add shared-scale comparison tests after the first small-multiple component
    ships.
+
+Rationale: step 1 previously mounted the header on 5+ sections before its visual
+contract existed, guaranteeing rework. Locking the contract first makes the
+breadth rollout mechanical.
 
 ## Definition of done for an analytics PR
 
@@ -286,6 +301,10 @@ An analytics PR is done when it can answer:
 - Are labels, units, and axes honest?
 - Is any essential meaning hidden only in a tooltip?
 - Is sample data isolated from production paths?
+- What states are supported, including EMPTY (supported, no data) and PARTIAL
+  (mixed success)?
+- Are sparklines and provenance triggers keyboard- and screen-reader-accessible?
+- Do state colors bind to v3.1.1 tokens and meet 4.5:1 contrast?
 
 ## Relationship to the current repo
 

--- a/docs/design/analytics-visualization-rollout.md
+++ b/docs/design/analytics-visualization-rollout.md
@@ -1,13 +1,14 @@
 ---
 status: ACTIVE
 audience: both
-last_updated: 2026-05-24
+last_updated: 2026-06-02
 categories: [design, analytics, rollout, visualization, truthfulness]
 keywords:
   [
     fund-results,
     provenance,
-    chart-refactor,
+    evidence-header,
+    scenario-workspace,
     small-multiples,
     sparklines,
     rollout,
@@ -41,97 +42,154 @@ This plan applies `docs/design/analytics-visualization-principles.md` to the
 authoritative fund-modeling flow from setup to published results.
 
 The rollout is presentation-layer first. It should not modify calculation
-semantics unless a visualization exposes a data-contract gap that must be solved
-at the source.
+semantics unless a visualization exposes a data-contract, provenance, or display
+truthfulness gap that must be solved at the source.
+
+## Current state — 2026-06-02
+
+The first pass has already landed. Treat the next work as refinement of live
+surfaces, not a fresh doctrine exercise.
+
+Delivered since the original proposal:
+
+- Analytics visualization doctrine under `docs/design/`.
+- PR-template checklist for Analytics / Results Truthfulness.
+- Docs-link CI coverage for active docs and PR-template links.
+- `EvidenceHeader` component mounted on selected fund-results sections.
+- Retired `portfolio-cost-value-chart.tsx`, which had zero runtime callsites and
+  hard-coded `SAMPLE_DATA`.
+- Shared scenario-comparison contract and server-backed comparison path.
+- Focused scenario workspace at `/fund-model-results/:fundId/scenarios`.
+- Broader route/worker/live-surface hardening around canonical fund IDs and
+  scoped data visibility.
 
 ## Sequencing principle
 
 Do not launch a cosmetic analytics redesign ahead of the data layer. The correct
-order is:
+order is now:
 
 1. Make the result true.
-2. Make the result traceable.
-3. Make the result comparable.
-4. Make the result beautiful.
+2. Make the result scoped to the right entity.
+3. Make the result traceable.
+4. Make the result comparable.
+5. Make the result beautiful.
 
 ## Phase 0 — Adopt the rule, not the redesign
 
-**Goal:** Establish a shared review standard for analytical displays.
+**Status:** Complete.
 
-**Actions:**
+**Delivered:**
 
-- Add `analytics-visualization-principles.md` to design docs.
-- Route chart/dashboard reviews through its checklist.
-- Treat it as presentation-layer doctrine, not backend architecture guidance.
-- Require any production analytics surface to state whether it is live, stale,
-  unavailable, or demo/sample-backed.
+- Analytics visualization doctrine added under `docs/design/`.
+- PR review checklist added for analytics/results truthfulness.
+- Active documentation links guarded in CI.
 
-**Exit criteria:**
+**Keep doing:**
 
-- The doctrine is discoverable through `docs/design/README.md`.
-- New chart PRs can cite the checklist.
-- Designers and engineers agree that visual truthfulness outranks decorative
-  polish.
+- Use the checklist for every production analytics, report, chart, export, or
+  scenario-view PR.
+- Treat visual truthfulness as a product quality gate, not a design preference.
 
 ## Phase 1 — Fund results evidence headers
 
+**Status:** Partially shipped.
+
 **Surface:** `/fund-model-results/:fundId`
 
-**Why first:** This is the authoritative post-publish destination for the fund
-model. It is where users need the clearest evidence that outputs came from
-server-backed results rather than UI state or local placeholders.
+**Delivered:**
 
-**Actions:**
+- `EvidenceHeader` component.
+- Lifecycle-backed evidence mounted on Reserve Allocation and Deployment Pacing
+  sections.
+- Tests for READY, CALCULATING, FAILED, STALE, and UNAVAILABLE states, including
+  null run/config fallback behavior.
 
-- Introduce an `EvidenceHeader` or equivalent component.
-- Add evidence headers to each major results section when server fields are
-  available.
-- Include calculation status, published config version, run ID, timestamp,
-  source section, and current/stale state.
-- Keep unavailable sections visible with clear explanations.
-- Preserve background polling and lifecycle behavior; do not hide prior results
-  during recalculation unless the prior result is invalid.
+**Next actions:**
 
-**Suggested UI copy:**
-
-```text
-READY · CONFIG v12 · RUN #148 · CALCULATED MAY 24, 2026 09:41 PT · SOURCE /api/funds/:id/results · CURRENT
-```
-
-**Engineering notes:**
-
-- Prefer existing contract fields before expanding API contracts.
-- If a needed provenance field is missing, add a small contract change rather
-  than fabricating UI-only evidence.
-- Keep evidence compact by default; allow expanded details for audit/review
-  workflows.
+- Extend evidence headers to every material result section that presents
+  authoritative outputs, including overview, scenarios, economics, waterfall,
+  carry, and future reserve/pacing detail panels.
+- Add compact source notes where section evidence is more specific than the
+  generic fund-results endpoint.
+- Make stale evidence actions consistent: users should know whether to
+  recalculate, publish, refresh, or wait for polling.
 
 **Tests:**
 
-- Each available results section renders its evidence state.
+- Each available result section renders an evidence state when lifecycle data is
+  present.
 - Stale lifecycle state renders a visible warning and recalculation action.
-- Failed or unavailable sections render an explanatory panel instead of
+- Failed or unavailable sections render explanatory panels instead of
   disappearing.
 
-## Phase 2 — Pilot chart refactor selection
+## Phase 2 — Scenario evidence and comparison workspace
 
-The previously named Phase 2 pilot component was retired after zero callsites
-were confirmed and the implementation was found to depend on doctrine-violating
-`SAMPLE_DATA`. The next pilot will be selected from the remaining named
-candidates in this rollout when implementation begins.
+**Status:** Shipped foundation; visualization refinement remains.
 
-## Phase 3 — Scenario comparison and small multiples
+**Surfaces:** `/fund-model-results/:fundId/scenarios`, scenario summary section
+inside `/fund-model-results/:fundId`.
 
-**Surfaces:** Scenario builder, construction vs. current forecasts,
-MOIC/TVPI/DPI/IRR analysis.
+**Delivered:**
 
-**Why:** Venture modeling is inherently comparative. Users need to see how
-assumptions change outcomes without mentally translating across different
-charts.
+- Strict shared comparison contract:
+  `shared/contracts/fund-scenario-comparison-v1.contract.ts`.
+- Client parsing through shared Zod schemas.
+- Protected scenario workspace route.
+- Route-scoped fund selection for the nested scenario path.
+- Existing scenario-set, status, result, and comparison surfaces wired together
+  with calculate/queue actions for existing sets.
+
+**Next actions:**
+
+- Treat the scenario workspace as the new pilot surface instead of the retired
+  portfolio cost/value chart.
+- Add evidence/source bands to scenario comparison cards: source config version,
+  scenario set name, comparison status, staleness, and baseline source.
+- Improve comparison density with small-multiple cards or a matrix view when a
+  scenario set has multiple variants.
+- Keep unsupported reserve-allocation comparisons explicit until reserve
+  comparison semantics are implemented.
+- Avoid adding scenario creation/editing or reserve optimization expansion until
+  the existing reading experience is solid.
+
+**Tests:**
+
+- Scenario comparison cards expose baseline, variant, source config version, and
+  stale/unavailable states.
+- Unsupported override types remain explicit, not silently hidden.
+- Scenario workspace route keeps route-scoped fund selection working.
+
+## Phase 3 — Retired pilot cleanup and next pilot selection
+
+**Status:** Pilot reset.
+
+The original chart pilot, `portfolio-cost-value-chart.tsx`, was retired because
+it had zero runtime callsites and embedded hard-coded `SAMPLE_DATA`. Refactoring a
+dead component would not have improved the product.
+
+**Next pilot candidates:**
+
+1. Scenario comparison cards/workspace, because the contract and route now exist.
+2. Economics cashflow and J-curve displays inside fund results, because they are
+   live authoritative result sections and currently use compact custom visuals.
+3. Publish comparison, because it already supports publish-to-publish deltas and
+   drift capability reasons.
+4. LP reports/shared dashboards, after report/source evidence is surfaced.
+
+**Selection rule:** Choose the pilot with active users, server-backed data, and a
+clear decision loop. Do not pick a dead or sample-backed component.
+
+## Phase 4 — Small multiples and comparison grammar
+
+**Status:** Next product-design layer.
+
+**Surfaces:** Scenario workspace, construction vs. current forecasts, MOIC/TVPI/
+DPI/IRR analysis, publish comparison.
 
 **Actions:**
 
-- Add `SmallMultipleGrid` or an equivalent layout primitive.
+- Introduce a `SmallMultipleGrid` or equivalent layout primitive only after a
+  live comparison surface needs it.
 - Show base/upside/downside/current/conservative cases side by side where
   applicable.
 - Lock scales across compared charts by default.
@@ -141,17 +199,15 @@ charts.
 **Tests:**
 
 - Small multiples share a common domain unless explicitly overridden.
-- Assumption diffs and outcome deltas are visible in the same comparison
-  surface.
+- Assumption diffs and outcome deltas are visible in the same comparison surface.
 - Scenario labels are visible without relying on color alone.
 
-## Phase 4 — Reserve planning and ranked tables
+## Phase 5 — Reserve planning and ranked tables
+
+**Status:** Strategy pending; keep scoped to evidence-backed surfaces.
 
 **Surfaces:** Reserve planning, optimal reserves ranking, portfolio-company
 watchlists, capital allocation tables.
-
-**Why:** Reserve planning is a ranked decision problem. The UI should explain
-why a company needs follow-on dollars, not just show a static total.
 
 **Actions:**
 
@@ -166,14 +222,13 @@ why a company needs follow-on dollars, not just show a static total.
 
 - Ranking tables expose the ranking basis.
 - Sparklines render with text values and do not encode meaning by color alone.
-- Empty or unsupported ranking inputs show an unavailable state.
+- Empty, unsupported, or stale ranking inputs show a truthful state.
 
-## Phase 5 — LP reports and shared dashboards
+## Phase 6 — LP reports and shared dashboards
+
+**Status:** Presentation work remains.
 
 **Surfaces:** LP reports, shared dashboards, report exports.
-
-**Why:** LP-facing surfaces need high trust and low ambiguity. They should
-integrate words, numbers, charts, and evidence notes.
 
 **Actions:**
 
@@ -188,9 +243,9 @@ integrate words, numbers, charts, and evidence notes.
 - Unsupported sections explain what is missing.
 - LP-facing metrics do not render without evidence or a visible fallback state.
 
-## Phase 6 — Visual truthfulness tests and guardrails
+## Phase 7 — Visual truthfulness tests and guardrails
 
-**Goal:** Convert the doctrine into sustainable lightweight checks.
+**Status:** Started via PR template and docs-link CI; code-level guards remain.
 
 **Actions:**
 
@@ -198,8 +253,7 @@ integrate words, numbers, charts, and evidence notes.
 - Add lint or static checks for suspicious `SAMPLE_DATA` usage in production
   chart components.
 - Add component tests for shared-scale behavior in comparison charts.
-- Add review checklist references to PR templates or design-review notes when
-  appropriate.
+- Keep docs/checklist references link-checked.
 
 **Avoid initially:**
 
@@ -207,20 +261,23 @@ integrate words, numbers, charts, and evidence notes.
 - Broad chart-library migrations.
 - Overly rigid visual linting that blocks legitimate prototypes.
 
-## Candidate implementation order
+## Candidate implementation order from here
 
-1. `docs/design/*` doctrine and README entry point.
-2. `EvidenceHeader` component prototype.
-3. Fund results section evidence headers.
-4. Select the next pilot chart from the remaining candidate surfaces.
-5. Scenario small-multiple primitive.
-6. Reserve ranking table improvements.
-7. LP/report provenance and export evidence.
-8. Static/sample-data guardrails.
+1. Extend `EvidenceHeader` coverage across all material fund-results sections.
+2. Make the scenario workspace the first live visualization-refinement pilot.
+3. Add scenario comparison evidence/source bands and better variant comparison
+   density.
+4. Improve economics cashflow/J-curve displays with direct labels, captions, and
+   evidence notes.
+5. Select a reserve/portfolio ranking table and add sparkline + “why” columns.
+6. Add LP/report provenance and export evidence.
+7. Add static/sample-data guardrails.
+8. Add shared-scale comparison tests after the first small-multiple component
+   ships.
 
-## Definition of done for a chart PR
+## Definition of done for an analytics PR
 
-A chart PR is done when it can answer:
+An analytics PR is done when it can answer:
 
 - What decision does the visual support?
 - What is the baseline comparison?
@@ -234,6 +291,7 @@ A chart PR is done when it can answer:
 
 Use this rollout with existing libraries and components first. The repo already
 includes chart libraries such as Recharts/Chart.js, route-level fund results
-behavior, and lifecycle-aware server-backed results. The first improvements
-should refine evidence, comparison, and labeling rather than introduce a new
-visualization stack.
+behavior, lifecycle-aware server-backed results, scenario comparison contracts,
+and an emerging scenario workspace. The first improvements should refine
+evidence, comparison, and labeling rather than introduce a new visualization
+stack.

--- a/docs/design/analytics-visualization-rollout.md
+++ b/docs/design/analytics-visualization-rollout.md
@@ -106,11 +106,18 @@ order is now:
 
 **Next actions:**
 
-- Extend evidence headers to every material result section that presents
-  authoritative outputs, including overview, scenarios, economics, waterfall,
-  carry, and future reserve/pacing detail panels.
-- Add compact source notes where section evidence is more specific than the
-  generic fund-results endpoint.
+- Extend evidence headers to every material result section. The overview,
+  scenarios, economics, waterfall, and reserve/pacing sections can mount a basic
+  lifecycle header now from the top-level `lifecycle` field in
+  `fund-results-v1.contract.ts` (always present, no backend work). Carry is not
+  a separate section; it renders inside the economics card and inherits its
+  header.
+- Add section-specific source notes where section evidence is more specific than
+  the generic fund-results endpoint. Prerequisite: the overview/scorecard
+  section is payload-only today (`ScorecardSectionSchema` does not use
+  `SectionAvailableSchema`, so it has no section-level `calculatedAt`/`source`).
+  A section source note for overview is therefore a separate small contract
+  sub-task; the basic header does not need it.
 - Make stale evidence actions consistent: users should know whether to
   recalculate, publish, refresh, or wait for polling.
 
@@ -145,17 +152,27 @@ inside `/fund-model-results/:fundId`.
   portfolio cost/value chart.
 - Add evidence/source bands to scenario comparison cards: source config version,
   scenario set name, comparison status, staleness, and baseline source.
-- Improve comparison density with explicit count thresholds, toggled via the
-  existing `SegmentedControl`:
+- Bound the workspace first: it currently fetches detail/status/comparison for
+  every scenario set (`fund-scenario-workspace.tsx`). Variant count is capped at
+  5 but set count is not. Add scenario-set selection/pagination ("one set at a
+  time") before layering density primitives, or the workspace becomes a
+  multi-set comparison wall.
+- Improve comparison density, toggled via a small segmented toggle (no
+  `SegmentedControl` exists yet — build one or use a minimal toggle). Scenario
+  sets are capped at 5 variants (`fund-scenario-sets-v1.contract.ts`,
+  `.max(5)`), each carrying 8 metric deltas, so density is driven by metric
+  breadth, not variant count:
   - **≤3 variants:** `ComparisonBand` (side-by-side).
-  - **4–8 variants:** `SmallMultipleGrid` (shared scales).
-  - **9+ variants:** compact matrix/table view. These thresholds pin the
-    doctrine's "matrix view when multiple variants" rule so it is testable and
-    prevents a default card-grid layout.
+  - **4–5 variants:** `SmallMultipleGrid` (shared scales).
+  - **Dense metric comparison:** a metric×variant cross-tab `matrix` (up to 5 ×
+    8), selectable regardless of variant count.
 - Keep unsupported reserve-allocation comparisons explicit until reserve
   comparison semantics are implemented.
-- Avoid adding scenario creation/editing or reserve optimization expansion until
-  the existing reading experience is solid.
+- Decide the scope of write actions explicitly. The workspace already exposes a
+  "Create optimized reserve plan" action (`fund-scenario-workspace.tsx`), which
+  contradicts "reading-first." Either gate/defer that action or update this
+  scope statement to acknowledge it — do not leave the doc and the live UI
+  disagreeing.
 
 **Tests:**
 
@@ -199,7 +216,10 @@ DPI/IRR analysis, publish comparison.
 - Show base/upside/downside/current/conservative cases side by side where
   applicable.
 - Lock scales across compared charts by default.
-- Place assumption diffs beside outcome deltas.
+- Place assumption diffs beside outcome deltas. Prerequisite: the comparison
+  contract carries no driver/assumption-diff data and locks `overrideType` to
+  `fee_profile` (`fund-scenario-comparison-v1.contract.ts`); broadening it is a
+  contract/server slice that precedes this visual work.
 - Add short captions that explain the mechanism behind the difference.
 
 **Tests:**
@@ -211,7 +231,8 @@ DPI/IRR analysis, publish comparison.
 
 ## Phase 5 — Reserve planning and ranked tables
 
-**Status:** Strategy pending; keep scoped to evidence-backed surfaces.
+**Status:** Future rollout (after this cycle); keep scoped to evidence-backed
+surfaces.
 
 **Surfaces:** Reserve planning, optimal reserves ranking, portfolio-company
 watchlists, capital allocation tables.
@@ -233,7 +254,7 @@ watchlists, capital allocation tables.
 
 ## Phase 6 — LP reports and shared dashboards
 
-**Status:** Presentation work remains.
+**Status:** Future rollout (after this cycle); presentation work remains.
 
 **Surfaces:** LP reports, shared dashboards, report exports.
 
@@ -257,8 +278,10 @@ watchlists, capital allocation tables.
 **Actions:**
 
 - Add unit tests around evidence headers and stale/demo states.
-- Add lint or static checks for suspicious `SAMPLE_DATA` usage in production
-  chart components.
+- Start a demo-data guardrail EARLY (in parallel with step 1, not at the end):
+  first inventory the real demo/mock/sample/fixture patterns in the codebase,
+  then add a static check + allowlist. Do not scope the guard to the single
+  literal `SAMPLE_DATA` identifier — that misses most demo paths.
 - Add component tests for shared-scale behavior in comparison charts.
 - Keep docs/checklist references link-checked.
 
@@ -267,6 +290,23 @@ watchlists, capital allocation tables.
 - Screenshot-perfect tests for every chart.
 - Broad chart-library migrations.
 - Overly rigid visual linting that blocks legitimate prototypes.
+
+## Contract prerequisites (server/data work that precedes the visuals)
+
+These visual goals depend on data the contracts do not carry yet. Sequence the
+contract slice before the matching UI, or the UI ships on missing data.
+
+- **Overview source note:** wrap `ScorecardSectionSchema` in
+  `SectionAvailableSchema` so it carries `calculatedAt`/`source` (basic header
+  works without this).
+- **Access-scope evidence:** add a server-emitted access-scope to the results
+  contract; `EvidenceHeaderLifecycle` has no scope field today.
+  `AccessScopeNote` must be contract-backed, not inferred client-side from the
+  route (self-certifying security is the anti-pattern this doctrine warns
+  against).
+- **Comparison drivers:** broaden `overrideType` beyond `fee_profile` and add
+  assumption-diff/driver data to `fund-scenario-comparison-v1.contract.ts`
+  before Phase 4's "why did it change" comparisons.
 
 ## Candidate implementation order from here
 
@@ -290,19 +330,39 @@ Rationale: step 1 previously mounted the header on 5+ sections before its visual
 contract existed, guaranteeing rework. Locking the contract first makes the
 breadth rollout mechanical.
 
+## Rollout boundary (stop rule)
+
+This rollout is intentionally narrow: **one evidence primitive, one live pilot,
+one contract-dependency list, then stop.**
+
+- **In this cycle:** Phases 0–4 — EvidenceHeader contract + breadth, the
+  scenario workspace pilot, comparison evidence/density, and the contract
+  prerequisites above.
+- **Future rollouts (not now):** Phases 5–7 — reserve/portfolio ranking tables,
+  LP/report provenance and exports, and broad sparkline/guardrail expansion.
+  Sequence them after the contract slices land and the pilot proves the pattern.
+
+Do not start Phase 5+ surfaces before the EvidenceHeader contract and the
+scenario pilot are solid.
+
 ## Definition of done for an analytics PR
 
-An analytics PR is done when it can answer:
+An analytics PR is done when it can answer the questions below. These are the
+PR-time subset of the canonical **Chart review checklist** in
+`analytics-visualization-principles.md`, which is the single source of truth —
+when the checklist changes, update it there, do not fork a new list. The
+PR-template Analytics / Results Truthfulness checklist references the same
+canonical list.
 
 - What decision does the visual support?
 - What is the baseline comparison?
 - What data source/run/version produced the values?
-- What states are supported: loading, empty, partial, stale, failed, demo?
+- What states are supported: loading, EMPTY (supported, no data), PARTIAL (mixed
+  success), stale, failed, demo?
 - Are labels, units, and axes honest?
 - Is any essential meaning hidden only in a tooltip?
-- Is sample data isolated from production paths?
-- What states are supported, including EMPTY (supported, no data) and PARTIAL
-  (mixed success)?
+- Is sample data isolated from production paths, and are EMPTY/PARTIAL/DEMO
+  client states distinct from calc-status?
 - Are sparklines and provenance triggers keyboard- and screen-reader-accessible?
 - Do state colors bind to v3.1.1 tokens and meet 4.5:1 contrast?
 


### PR DESCRIPTION
## Summary

Updates the analytics visualization proposal/strategy to reflect the current codebase after the doctrine was merged and follow-on implementation work landed.

## What changed

- Refreshes `docs/design/analytics-visualization-principles.md` around scoped evidence, scenario workspace, real-time surfaces, and access-state language.
- Refreshes `docs/design/analytics-visualization-rollout.md` from a pre-implementation plan into a current-state rollout:
  - Phase 0 complete: doctrine + checklist + docs-link guardrails
  - Phase 1 partially shipped: `EvidenceHeader` on selected fund-results sections
  - Phase 2 foundation shipped: scenario comparison contract + scenario workspace
  - Phase 3 reset: retired dead sample-backed chart pilot; scenario workspace becomes the new live pilot
- Updates `docs/design/README.md` metadata and description to reflect access-aware analytical displays.

## Codebase developments reflected

- PR #690: analytics visualization doctrine merged
- PR #701: analytics/results truthfulness checklist added to PR template
- PR #705: `EvidenceHeader` shipped for selected fund-results sections
- PR #707: unused sample-backed portfolio chart retired
- PR #716: scenario comparison contract/path repaired
- PR #729: `/fund-model-results/:fundId/scenarios` workspace shipped
- PR #762: latest live-surface/fund-scope hardening reflected at strategy level

## Updated strategy

The strategy shifts from “clean up charts” to “build scoped evidence workspaces.”

Next recommended order:

1. Extend `EvidenceHeader` across all material fund-results sections.
2. Use the scenario workspace as the first live visualization-refinement pilot.
3. Add scenario comparison evidence/source bands and denser variant comparisons.
4. Refine economics cashflow/J-curve displays with direct labels and captions.
5. Add reserve/portfolio ranking tables with sparklines and “why” annotations.
6. Add LP/report provenance and export evidence.
7. Add sample-data/static guardrails and shared-scale tests after a live small-multiple component ships.

## Validation

Docs-only change. No tests run.