### PR TITLE
design(rollout): batch 1 — JetBrains Mono + canonical token migration across dashboard/fund-model-results/portfolio + chart palette

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-06-02
+last_updated: 2026-06-03
 ---
 
 # Design System — Updog / Press On Ventures
@@ -166,9 +166,16 @@ The three design artifacts disagreed on a few values. Resolved, with
 2. **Body font: Inter heading + Poppins body (unchanged).** The v3.1.1 doc's
    Inter-only rendering was page styling, not a mandate. No migration.
 3. **Warning: `#9C6F19`** (canonical) over v3.1.1's `#a95c00`. Applied
-   2026-06-03 (T-H) to `pov.warning` + `warning.DEFAULT`; `semantic.warning`
-   ramp + `confidence.low` left amber for ramp coherence (full unification
-   pending).
+   2026-06-03 (T-H) to `pov.warning` + `warning.DEFAULT`. **Resolved 2026-06-03
+   as two roles** (the success/positive pattern): brand `warning` `#9C6F19` is
+   the status-warning token (now used across the migrated dashboard /
+   fund-model- results surfaces); `semantic.warning` deliberately stays amber as
+   the AI-confidence-low color. Its only consumers are
+   `.ai-confidence-badge.low` (`design-system.css`) and
+   `.ai-confidence-indicator` low state (`tailwind.config.ts`), which must stay
+   amber for confidence-ramp coherence with `confidence.low`. No general/status
+   surface consumes `semantic.warning`, so no code change was required — the
+   roles are already cleanly separated.
 4. **Card radius: canonical scale** (`md 10` / `lg 16`); cards map to `lg`. No
    `14px` token unless brand requires it.
 

--- a/client/src/components/portfolio/PortfolioTabs.tsx
+++ b/client/src/components/portfolio/PortfolioTabs.tsx
@@ -119,7 +119,7 @@ export function PortfolioTabs({
           onOpenChange={setIsReallocationExpanded}
           className="border border-pov-beige rounded-lg bg-white"
         >
-          <CollapsibleTrigger className="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors rounded-lg">
+          <CollapsibleTrigger className="w-full flex items-center justify-between p-4 hover:bg-pov-gray transition-colors rounded-lg">
             <div className="flex items-center gap-3">
               {isReallocationExpanded ? (
                 <ChevronDown className="h-5 w-5 text-pov-charcoal" />
@@ -130,7 +130,7 @@ export function PortfolioTabs({
                 <h3 className="font-inter font-semibold text-sm text-pov-charcoal">
                   Reallocation Tools
                 </h3>
-                <p className="font-poppins text-xs text-gray-500">
+                <p className="font-poppins text-xs text-charcoal-500">
                   Adjust reserve allocations across portfolio companies
                 </p>
               </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Roboto+Mono:wght@300;400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 /* Agent 2: Mobile Executive Dashboard Optimizations */
 @import './styles/mobile-optimizations.css';
 /* Agent 3: Enhanced Design System and Micro-interactions */

--- a/client/src/pages/dashboard-modern.tsx
+++ b/client/src/pages/dashboard-modern.tsx
@@ -34,17 +34,17 @@ function formatMultiple(value: number | null | undefined): string {
 
 function MetricTile({ label, value, detail }: { label: string; value: string; detail: string }) {
   return (
-    <div className="rounded-md border border-slate-200 bg-white p-4">
-      <p className="text-sm text-slate-600">{label}</p>
-      <p className="mt-2 text-2xl font-semibold text-slate-950">{value}</p>
-      <p className="mt-1 text-xs text-slate-500">{detail}</p>
+    <div className="rounded-md border border-pov-beige bg-white p-4">
+      <p className="text-sm text-charcoal-600">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-pov-charcoal">{value}</p>
+      <p className="mt-1 text-xs text-charcoal-500">{detail}</p>
     </div>
   );
 }
 
 function MetricsUnavailable({ error }: { error: Error | null | undefined }) {
   return (
-    <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+    <div className="rounded-md border border-warning/30 bg-warning-light p-4 text-sm text-warning-dark">
       <p className="font-medium">Dashboard metrics are temporarily unavailable.</p>
       <p className="mt-1">
         {error?.message || 'The unified metrics layer did not return a supported snapshot.'}
@@ -63,7 +63,7 @@ function OverviewMetricsPanel({
   error: Error | null | undefined;
 }) {
   if (isLoading) {
-    return <p className="text-sm text-slate-600">Loading dashboard metrics...</p>;
+    return <p className="text-sm text-charcoal-600">Loading dashboard metrics...</p>;
   }
 
   if (error || !metrics) {
@@ -106,7 +106,7 @@ function PerformanceMetricsPanel({
   error: Error | null | undefined;
 }) {
   if (isLoading) {
-    return <p className="text-sm text-slate-600">Loading dashboard metrics...</p>;
+    return <p className="text-sm text-charcoal-600">Loading dashboard metrics...</p>;
   }
 
   if (error || !metrics) {
@@ -137,8 +137,8 @@ function PerformanceMetricsPanel({
           detail="Residual value to paid-in"
         />
       </div>
-      <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
-        <p className="font-medium text-slate-900">Benchmark and attribution unavailable</p>
+      <div className="rounded-md border border-pov-beige bg-pov-gray p-4 text-sm text-charcoal-700">
+        <p className="font-medium text-pov-charcoal">Benchmark and attribution unavailable</p>
         <p className="mt-1">
           Public benchmark rank, attribution, and quartile claims remain hidden until an
           authoritative benchmark source is wired.
@@ -205,7 +205,7 @@ export default function ModernDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className="min-h-screen bg-pov-gray">
       <POVBrandHeader
         title="Dashboard"
         subtitle="Fund workspace and truthful live surfaces"

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -1117,12 +1117,12 @@ function formatHistoryRunStatus(status: LifecycleStatus | null) {
 function historyBadgeClasses(status: LifecycleStatus | null) {
   switch (status) {
     case 'ready':
-      return 'bg-emerald-100 text-emerald-800 border-emerald-200';
+      return 'bg-success-light text-success-dark border-success/30';
     case 'failed':
-      return 'bg-rose-100 text-rose-800 border-rose-200';
+      return 'bg-error-light text-error-dark border-error/30';
     case 'submitted':
     case 'calculating':
-      return 'bg-amber-100 text-amber-800 border-amber-200';
+      return 'bg-warning-light text-warning-dark border-warning/30';
     default:
       return 'bg-beige-100 text-charcoal-600 border-beige-200';
   }
@@ -1207,11 +1207,11 @@ function hasStaleEvidence(lifecycle: FundStateReadV1) {
 function diagnosticAlertClasses(tone: 'neutral' | 'warning' | 'danger' | 'success') {
   switch (tone) {
     case 'danger':
-      return 'border-rose-200 bg-rose-50';
+      return 'border-error/30 bg-error-light';
     case 'warning':
-      return 'border-amber-200 bg-amber-50';
+      return 'border-warning/30 bg-warning-light';
     case 'success':
-      return 'border-emerald-200 bg-emerald-50';
+      return 'border-success/30 bg-success-light';
     default:
       return 'border-beige-200 bg-beige-50';
   }
@@ -1278,10 +1278,10 @@ function ConfigDiffBanner({ lifecycle }: { lifecycle: FundStateReadV1 }) {
   if (!hasStaleEvidence(lifecycle)) return null;
 
   return (
-    <Alert className="border-amber-200 bg-amber-50">
-      <AlertCircle className="h-4 w-4 text-amber-700" />
+    <Alert className="border-warning/30 bg-warning-light">
+      <AlertCircle className="h-4 w-4 text-warning" />
       <AlertTitle>Results are stale</AlertTitle>
-      <AlertDescription className="font-poppins text-amber-900">
+      <AlertDescription className="font-poppins text-warning-dark">
         Latest published configuration is v{lifecycle.configState.publishedVersion}, but the current
         calculation is still on v{lifecycle.calculationState.configVersion}. Recalculate to refresh
         the published results.

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -924,12 +924,12 @@ function EconomicsCashflowChart({ rows }: { rows: EconomicsResultV1['annual'] })
   );
   const series = [
     { key: 'lpCapitalCalls', label: 'LP Calls', color: 'bg-charcoal-300' },
-    { key: 'gpCommitmentCalls', label: 'GP Calls', color: 'bg-stone-400' },
-    { key: 'lpDistributions', label: 'LP Distributions', color: 'bg-green-600' },
-    { key: 'gpInvestmentDistributions', label: 'GP Investment', color: 'bg-blue-500' },
-    { key: 'gpCarryDistributed', label: 'GP Carry', color: 'bg-purple-500' },
-    { key: 'feesPaidToManager', label: 'Fees', color: 'bg-amber-500' },
-    { key: 'expensesPaid', label: 'Expenses', color: 'bg-red-400' },
+    { key: 'gpCommitmentCalls', label: 'GP Calls', color: 'bg-charcoal-500' },
+    { key: 'lpDistributions', label: 'LP Distributions', color: 'bg-presson-positive' },
+    { key: 'gpInvestmentDistributions', label: 'GP Investment', color: 'bg-presson-info' },
+    { key: 'gpCarryDistributed', label: 'GP Carry', color: 'bg-success' },
+    { key: 'feesPaidToManager', label: 'Fees', color: 'bg-presson-warning' },
+    { key: 'expensesPaid', label: 'Expenses', color: 'bg-presson-negative' },
   ] as const;
 
   return (
@@ -970,8 +970,8 @@ function EconomicsCashflowChart({ rows }: { rows: EconomicsResultV1['annual'] })
 function EconomicsJCurveChart({ rows }: { rows: EconomicsResultV1['annual'] }) {
   const maxMultiple = Math.max(1, ...rows.map((row) => Math.max(row.dpi, row.rvpi, row.tvpi)));
   const metrics = [
-    { key: 'dpi', label: 'DPI', color: 'bg-green-600' },
-    { key: 'rvpi', label: 'RVPI', color: 'bg-blue-500' },
+    { key: 'dpi', label: 'DPI', color: 'bg-presson-positive' },
+    { key: 'rvpi', label: 'RVPI', color: 'bg-presson-info' },
     { key: 'tvpi', label: 'TVPI', color: 'bg-charcoal-500' },
   ] as const;
 

--- a/client/src/pages/portfolio-modern.tsx
+++ b/client/src/pages/portfolio-modern.tsx
@@ -1,11 +1,6 @@
- 
- 
- 
- 
- 
 import React from 'react';
-import { POVBrandHeader } from "@/components/ui/POVLogo";
-import { PortfolioTabs } from "@/components/portfolio/PortfolioTabs";
+import { POVBrandHeader } from '@/components/ui/POVLogo';
+import { PortfolioTabs } from '@/components/portfolio/PortfolioTabs';
 
 /**
  * ModernPortfolio - Main Portfolio Page with Tab Navigation
@@ -17,9 +12,8 @@ import { PortfolioTabs } from "@/components/portfolio/PortfolioTabs";
  * Phase 1c implementation with URL state management
  */
 export default function ModernPortfolio() {
-
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className="min-h-screen bg-pov-gray">
       <POVBrandHeader
         title="Portfolio"
         subtitle="Monitor and manage your portfolio companies and allocations"
@@ -32,4 +26,3 @@ export default function ModernPortfolio() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary

Theme 2 (design-system rollout) — batch 1. Routes the three named live workspace
surfaces (`/dashboard`, `/fund-model-results`, `/portfolio`) onto the canonical
`presson` / `pov` token system per `DESIGN.md`, fixes the mono webfont, adopts a
semantic-financial chart palette, and resolves the two open design reconcile
items. Six commits, each a single concern.

### 1. fix: load JetBrains Mono webfont (`index.css`)

Only Inter/Poppins/Roboto Mono were imported, so the canonical mono silently fell
back. Swapped Roboto Mono -> JetBrains Mono (URL verified: 24 `@font-face`
blocks).

### 2. refactor: `/dashboard` neutrals (`dashboard-modern.tsx`)

`slate-*` / `amber-*` -> `pov` / `charcoal` / `warning` tokens.

### 3. refactor: `/fund-model-results` status colors (`fund-model-results.tsx`)

`emerald-*` / `rose-*` / `amber-*` status -> `success` / `error` / `warning`.

### 4. refactor: `/portfolio` neutrals (`portfolio-modern.tsx`, `PortfolioTabs.tsx`)

`slate-*` / `gray-*` -> `pov-gray` / `charcoal-500`.

### 5. refactor: fund-model-results chart palette (`fund-model-results.tsx`)

Cashflow + J-curve series adopt a **semantic-financial** palette (contributions
-> charcoal; gains -> `presson-positive` / `presson-info` / `success`; costs ->
`presson-warning` / `presson-negative`). Resolves the `bg-purple-500` doctrine
violation — the file is now fully canonical (no raw Tailwind palette colors).

### 6. docs: `semantic.warning` two-role resolution (`DESIGN.md`)

Reconcile item #3 resolved as two roles (success/positive pattern): brand
`warning` `#9C6F19` = status; `semantic.warning` amber = AI-confidence-low only
(its sole consumers). No code change — roles were already separated; documented.

## Verification

- `npm run check` (baseline:check; client/server/shared): 0 new TS errors
- `dashboard-modern.test.tsx` 5/5; `fund-model-results.test.tsx` 55/55 (after both FMR commits)
- pre-push targeted suites green at every push
- grep: migrated surfaces carry no raw `slate-`/`gray-`/`amber-`/`emerald-`/`rose-`/`green-`/`blue-`/`purple-`/`stone-`/`red-` color classes

## Not verified (follow-up)

- **In-browser visual eyeball** — everything was gated by tsc + unit tests, not
  screenshotted (no dev server in session). Recommend a `/design-review` pass on
  the three surfaces to confirm: JetBrains Mono actually loads; the warm-sand/ink
  neutrals read well; and the semantic-financial chart palette is legible at
  small swatch/bar size (the LP forest-green vs GP carry emerald-green are
  adjacent in hue — the main thing to eyeball).

## Notes

- Code edits dispatched via Hermes/Codex (worker), reviewed by Claude.
  Design decisions made by the user; DESIGN.md decision recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
