### PR TITLE
docs(design): fix hyphen-wrap nit in DESIGN.md reconcile #3

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,9 +168,9 @@ The three design artifacts disagreed on a few values. Resolved, with
 3. **Warning: `#9C6F19`** (canonical) over v3.1.1's `#a95c00`. Applied
    2026-06-03 (T-H) to `pov.warning` + `warning.DEFAULT`. **Resolved 2026-06-03
    as two roles** (the success/positive pattern): brand `warning` `#9C6F19` is
-   the status-warning token (now used across the migrated dashboard /
-   fund-model- results surfaces); `semantic.warning` deliberately stays amber as
-   the AI-confidence-low color. Its only consumers are
+   the status-warning token (now used across the migrated `dashboard` and
+   `fund-model-results` surfaces); `semantic.warning` deliberately stays amber
+   as the AI-confidence-low color. Its only consumers are
    `.ai-confidence-badge.low` (`design-system.css`) and
    `.ai-confidence-indicator` low state (`tailwind.config.ts`), which must stay
    amber for confidence-ramp coherence with `confidence.low`. No general/status


### PR DESCRIPTION
Cosmetic follow-up to #769. prettier (`proseWrap: always`, printWidth 80 for markdown) split `fund-model-results` across a line break, rendering it as "fund-model- results". Backticked the route names (`dashboard`, `fund-model-results`) so the compound stays atomic and prettier can't break it.

Docs-only; no code change.