### PR TITLE
design(rollout): shared-layer token migration (ui/layout/charts/dashboard/common)

### DIFF
--- a/client/src/components/charts/CapitalCallOptimizationChart.tsx
+++ b/client/src/components/charts/CapitalCallOptimizationChart.tsx
@@ -9,13 +9,15 @@ import {
   ResponsiveContainer,
   ComposedChart,
   Area,
-  Line
+  Line,
 } from 'recharts';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { CalendarDays, TrendingUp, DollarSign, Clock, Target } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { CalendarDays, TrendingUp, DollarSign, Clock, Target } from 'lucide-react';
 import type { OptimizedCapitalCallSchedule } from '@/core/LiquidityEngine';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 interface CapitalCallOptimizationChartProps {
   schedule: OptimizedCapitalCallSchedule | null;
@@ -28,9 +30,8 @@ export default function CapitalCallOptimizationChart({
   schedule,
   onOptimize,
   isOptimizing = false,
-  className = ''
+  className = '',
 }: CapitalCallOptimizationChartProps) {
-
   // Prepare timeline data for visualization
   const timelineData = useMemo(() => {
     if (!schedule?.calls) return [];
@@ -54,7 +55,7 @@ export default function CapitalCallOptimizationChart({
     if (!timelineData.length) return [];
 
     let cumulative = 0;
-    return timelineData.map(call => {
+    return timelineData.map((call) => {
       cumulative += call.amount;
       return {
         callNumber: call.callNumber,
@@ -77,7 +78,7 @@ export default function CapitalCallOptimizationChart({
       date: 'Current',
       cash: currentCash,
       committed: schedule.totalAmount / 1000000,
-      type: 'current'
+      type: 'current',
     });
 
     schedule.calls.forEach((call, index) => {
@@ -87,9 +88,12 @@ export default function CapitalCallOptimizationChart({
       data.push({
         date: call.dueDate.toLocaleDateString('en-US', { month: 'short' }),
         cash: currentCash,
-        committed: (schedule.totalAmount - (call.amount + schedule.calls.slice(0, index).reduce((sum, c) => sum + c.amount, 0))) / 1000000,
+        committed:
+          (schedule.totalAmount -
+            (call.amount + schedule.calls.slice(0, index).reduce((sum, c) => sum + c.amount, 0))) /
+          1000000,
         type: 'call',
-        callAmount: call.amount / 1000000
+        callAmount: call.amount / 1000000,
       });
 
       // Assume deployment of ~80% of called capital over the next month
@@ -98,8 +102,12 @@ export default function CapitalCallOptimizationChart({
         data.push({
           date: `${call.dueDate.toLocaleDateString('en-US', { month: 'short' })}+`,
           cash: currentCash,
-          committed: (schedule.totalAmount - (call.amount + schedule.calls.slice(0, index).reduce((sum, c) => sum + c.amount, 0))) / 1000000,
-          type: 'deployment'
+          committed:
+            (schedule.totalAmount -
+              (call.amount +
+                schedule.calls.slice(0, index).reduce((sum, c) => sum + c.amount, 0))) /
+            1000000,
+          type: 'deployment',
         });
       }
     });
@@ -124,9 +132,7 @@ export default function CapitalCallOptimizationChart({
         </CardHeader>
         <CardContent className="flex flex-col items-center justify-center py-12">
           <div className="text-center space-y-4">
-            <div className="text-muted-foreground">
-              No optimization schedule available
-            </div>
+            <div className="text-muted-foreground">No optimization schedule available</div>
             {onOptimize && (
               <Button onClick={onOptimize} disabled={isOptimizing}>
                 {isOptimizing ? (
@@ -169,7 +175,9 @@ export default function CapitalCallOptimizationChart({
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Total Amount</p>
-                <p className="text-2xl font-bold">{formatCurrency(schedule.totalAmount / 1000000)}</p>
+                <p className="text-2xl font-bold">
+                  {formatCurrency(schedule.totalAmount / 1000000)}
+                </p>
               </div>
               <DollarSign className="h-8 w-8 text-muted-foreground" />
             </div>
@@ -181,7 +189,9 @@ export default function CapitalCallOptimizationChart({
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Avg Call Size</p>
-                <p className="text-2xl font-bold">{formatCurrency(schedule.averageCallSize / 1000000)}</p>
+                <p className="text-2xl font-bold">
+                  {formatCurrency(schedule.averageCallSize / 1000000)}
+                </p>
               </div>
               <Target className="h-8 w-8 text-muted-foreground" />
             </div>
@@ -198,8 +208,20 @@ export default function CapitalCallOptimizationChart({
               <TrendingUp className="h-8 w-8 text-muted-foreground" />
             </div>
             <div className="mt-2">
-              <Badge variant={schedule.efficiency >= 90 ? 'default' : schedule.efficiency >= 75 ? 'secondary' : 'destructive'}>
-                {schedule.efficiency >= 90 ? 'Excellent' : schedule.efficiency >= 75 ? 'Good' : 'Needs Improvement'}
+              <Badge
+                variant={
+                  schedule.efficiency >= 90
+                    ? 'default'
+                    : schedule.efficiency >= 75
+                      ? 'secondary'
+                      : 'destructive'
+                }
+              >
+                {schedule.efficiency >= 90
+                  ? 'Excellent'
+                  : schedule.efficiency >= 75
+                    ? 'Good'
+                    : 'Needs Improvement'}
               </Badge>
             </div>
           </CardContent>
@@ -210,9 +232,7 @@ export default function CapitalCallOptimizationChart({
       <Card>
         <CardHeader>
           <CardTitle>Capital Call Timeline</CardTitle>
-          <CardDescription>
-            Optimized schedule showing call amounts and timing
-          </CardDescription>
+          <CardDescription>Optimized schedule showing call amounts and timing</CardDescription>
         </CardHeader>
         <CardContent>
           <ResponsiveContainer width="100%" height={300}>
@@ -222,19 +242,19 @@ export default function CapitalCallOptimizationChart({
                 dataKey="callNumber"
                 label={{ value: 'Capital Call #', position: 'insideBottom', offset: -5 }}
               />
-              <YAxis
-                label={{ value: 'Amount ($M)', angle: -90, position: 'insideLeft' }}
-              />
+              <YAxis label={{ value: 'Amount ($M)', angle: -90, position: 'insideLeft' }} />
               <Tooltip
                 formatter={(value, name) => [
                   value !== undefined
-                    ? (name === 'amount' ? formatCurrency(Number(value)) : formatPercent(Number(value)))
+                    ? name === 'amount'
+                      ? formatCurrency(Number(value))
+                      : formatPercent(Number(value))
                     : '',
-                  name === 'amount' ? 'Call Amount' : 'Utilization Rate'
+                  name === 'amount' ? 'Call Amount' : 'Utilization Rate',
                 ]}
                 labelFormatter={(label) => `Capital Call #${label}`}
               />
-              <Bar dataKey="amount" fill="#3b82f6" name="amount" />
+              <Bar dataKey="amount" fill={presson.color.info} name="amount" />
             </BarChart>
           </ResponsiveContainer>
         </CardContent>
@@ -255,20 +275,20 @@ export default function CapitalCallOptimizationChart({
               <XAxis dataKey="date" />
               <YAxis label={{ value: 'Amount ($M)', angle: -90, position: 'insideLeft' }} />
               <Tooltip
-                formatter={(value) => value !== undefined ? formatCurrency(Number(value)) : ''}
+                formatter={(value) => (value !== undefined ? formatCurrency(Number(value)) : '')}
               />
               <Area
                 type="monotone"
                 dataKey="committed"
-                fill="#8b5cf6"
+                fill={getChartColor(0)}
                 fillOpacity={0.3}
-                stroke="#8b5cf6"
+                stroke={getChartColor(0)}
                 name="Remaining Commitments"
               />
               <Line
                 type="monotone"
                 dataKey="cash"
-                stroke="#10b981"
+                stroke={presson.color.positive}
                 strokeWidth={3}
                 name="Available Cash"
               />
@@ -281,21 +301,23 @@ export default function CapitalCallOptimizationChart({
       <Card>
         <CardHeader>
           <CardTitle>Detailed Call Schedule</CardTitle>
-          <CardDescription>
-            Complete breakdown of optimized capital calls
-          </CardDescription>
+          <CardDescription>Complete breakdown of optimized capital calls</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
             {schedule.calls.map((call, index) => (
-              <div key={call.id} className="flex items-center justify-between p-4 border rounded-lg">
+              <div
+                key={call.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
                 <div className="flex-1">
                   <div className="flex items-center gap-3">
                     <Badge variant="outline">Call #{index + 1}</Badge>
                     <div>
                       <h4 className="font-medium">{call.purpose}</h4>
                       <p className="text-sm text-muted-foreground">
-                        {call.investments.length} investment{call.investments.length !== 1 ? 's' : ''}
+                        {call.investments.length} investment
+                        {call.investments.length !== 1 ? 's' : ''}
                       </p>
                     </div>
                   </div>
@@ -317,7 +339,11 @@ export default function CapitalCallOptimizationChart({
                 </div>
 
                 <div className="text-right">
-                  <Badge variant={call.priority <= 1 ? 'default' : call.priority <= 3 ? 'secondary' : 'outline'}>
+                  <Badge
+                    variant={
+                      call.priority <= 1 ? 'default' : call.priority <= 3 ? 'secondary' : 'outline'
+                    }
+                  >
                     Priority {call.priority}
                   </Badge>
                 </div>
@@ -347,16 +373,25 @@ export default function CapitalCallOptimizationChart({
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Timeline Duration:</span>
                   <span className="font-medium">
-                    {Math.ceil((schedule.timeline.lastCall.getTime() - schedule.timeline.firstCall.getTime()) / (1000 * 60 * 60 * 24))} days
+                    {Math.ceil(
+                      (schedule.timeline.lastCall.getTime() -
+                        schedule.timeline.firstCall.getTime()) /
+                        (1000 * 60 * 60 * 24)
+                    )}{' '}
+                    days
                   </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Average Time Between Calls:</span>
                   <span className="font-medium">
-                    {schedule.calls.length > 1 ?
-                      Math.ceil((schedule.timeline.lastCall.getTime() - schedule.timeline.firstCall.getTime()) /
-                               (1000 * 60 * 60 * 24 * (schedule.calls.length - 1))) :
-                      0} days
+                    {schedule.calls.length > 1
+                      ? Math.ceil(
+                          (schedule.timeline.lastCall.getTime() -
+                            schedule.timeline.firstCall.getTime()) /
+                            (1000 * 60 * 60 * 24 * (schedule.calls.length - 1))
+                        )
+                      : 0}{' '}
+                    days
                   </span>
                 </div>
               </div>

--- a/client/src/components/charts/LazyResponsiveContainer.tsx
+++ b/client/src/components/charts/LazyResponsiveContainer.tsx
@@ -82,7 +82,7 @@ export function LazyResponsiveContainer({
 
   const fallback = (
     <div
-      className="animate-pulse rounded bg-gray-100"
+      className="animate-pulse rounded bg-pov-gray"
       style={{
         width: '100%',
         height: '100%',

--- a/client/src/components/charts/MobileOptimizedCharts.tsx
+++ b/client/src/components/charts/MobileOptimizedCharts.tsx
@@ -10,6 +10,12 @@
 
 import React, { useState, useRef, useEffect, memo } from 'react';
 import { cn } from '@/lib/utils';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
+
+const DEFAULT_CHART_COLOR = getChartColor(0);
+const getSegmentColor = (color: string | undefined, index: number) =>
+  color ?? getChartColor(index, true);
 
 // Types for chart data
 export interface ChartDataPoint {
@@ -62,7 +68,7 @@ export const MobileLineChart = memo(function MobileLineChart({
   data,
   height = 120,
   width = 300,
-  color = '#3b82f6',
+  color = DEFAULT_CHART_COLOR,
   showPoints = false,
   animateOnLoad = true,
   className,
@@ -82,7 +88,7 @@ export const MobileLineChart = memo(function MobileLineChart({
     return (
       <div
         ref={chartRef}
-        className={cn('bg-slate-100 rounded animate-pulse', className)}
+        className={cn('bg-pov-gray rounded animate-pulse', className)}
         style={{ height, width }}
       />
     );
@@ -121,7 +127,7 @@ export const MobileLineChart = memo(function MobileLineChart({
               <path
                 d="M 20 0 L 0 0 0 20"
                 fill="none"
-                stroke="#e2e8f0"
+                stroke={presson.color.surfaceSubtle}
                 strokeWidth="0.5"
                 opacity="0.5"
               />
@@ -161,7 +167,7 @@ export const MobileLineChart = memo(function MobileLineChart({
                   cy={y}
                   r="3"
                   fill={color}
-                  stroke="white"
+                  stroke={presson.color.surface}
                   strokeWidth="2"
                   className="opacity-0 animate-fadeIn"
                   style={{ animationDelay: `${index * 100}ms` }}
@@ -223,7 +229,7 @@ export const MobileDonutChart = memo(function MobileDonutChart({
     return (
       <div
         ref={chartRef}
-        className={cn('bg-slate-100 rounded-full animate-pulse', className)}
+        className={cn('bg-pov-gray rounded-full animate-pulse', className)}
         style={{ width: size, height: size }}
       />
     );
@@ -253,7 +259,7 @@ export const MobileDonutChart = memo(function MobileDonutChart({
                   cy={center}
                   r={radius}
                   fill="transparent"
-                  stroke={item.color || `hsl(${index * 137.508}, 50%, 50%)`}
+                  stroke={getSegmentColor(item.color, index)}
                   strokeWidth={selectedSegment === index ? strokeWidth + 2 : strokeWidth}
                   strokeDasharray={strokeDasharray}
                   strokeDashoffset={strokeDashoffset}
@@ -292,18 +298,18 @@ export const MobileDonutChart = memo(function MobileDonutChart({
                   key={index}
                   className={cn(
                     'flex items-center gap-2 p-2 rounded transition-colors cursor-pointer',
-                    selectedSegment === index ? 'bg-slate-100' : 'hover:bg-slate-50'
+                    selectedSegment === index ? 'bg-pov-gray' : 'hover:bg-pov-gray'
                   )}
                   onClick={() => setSelectedSegment(selectedSegment === index ? null : index)}
                 >
                   <div
                     className="w-3 h-3 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: item.color || `hsl(${index * 137.508}, 50%, 50%)` }}
+                    style={{ backgroundColor: getSegmentColor(item.color, index) }}
                   />
-                  <span className="font-poppins text-sm text-slate-700 flex-grow">
+                  <span className="font-poppins text-sm text-charcoal-700 flex-grow">
                     {item.label}
                   </span>
-                  <span className="font-mono text-xs text-slate-500">
+                  <span className="font-mono text-xs text-charcoal-500">
                     {((item.value / total) * 100).toFixed(1)}%
                   </span>
                 </div>
@@ -329,7 +335,7 @@ interface MobileBarChartProps {
 export const MobileBarChart = memo(function MobileBarChart({
   data,
   height = 200,
-  color = '#3b82f6',
+  color = DEFAULT_CHART_COLOR,
   showValues = false,
   horizontal: _horizontal = false,
   className,
@@ -358,7 +364,7 @@ export const MobileBarChart = memo(function MobileBarChart({
     return (
       <div
         ref={chartRef}
-        className={cn('bg-slate-100 rounded animate-pulse', className)}
+        className={cn('bg-pov-gray rounded animate-pulse', className)}
         style={{ height }}
       />
     );
@@ -376,12 +382,14 @@ export const MobileBarChart = memo(function MobileBarChart({
           return (
             <div key={index} className="space-y-1">
               <div className="flex justify-between items-center">
-                <span className="font-poppins text-sm text-slate-700 truncate">{item.label}</span>
+                <span className="font-poppins text-sm text-charcoal-700 truncate">
+                  {item.label}
+                </span>
                 {showValues && (
-                  <span className="font-mono text-xs text-slate-500 ml-2">{item.value}</span>
+                  <span className="font-mono text-xs text-charcoal-500 ml-2">{item.value}</span>
                 )}
               </div>
-              <div className="bg-slate-200 rounded-full h-2 overflow-hidden">
+              <div className="bg-pov-gray rounded-full h-2 overflow-hidden">
                 <div
                   className="h-full rounded-full transition-all duration-1000 ease-out"
                   style={{
@@ -411,7 +419,7 @@ export const Sparkline = memo(function Sparkline({
   data,
   width = 80,
   height = 24,
-  color = '#3b82f6',
+  color = DEFAULT_CHART_COLOR,
   trend,
   className,
 }: SparklineProps) {
@@ -429,7 +437,9 @@ export const Sparkline = memo(function Sparkline({
     })
     .join(' ');
 
-  const trendColor = trend === 'up' ? '#10b981' : trend === 'down' ? '#ef4444' : color;
+  // TODO(a11y): sole-color direction
+  const trendColor =
+    trend === 'up' ? presson.color.positive : trend === 'down' ? presson.color.negative : color;
 
   return (
     <svg
@@ -473,13 +483,13 @@ export function ChartSkeleton({
       {type === 'line' && (
         <div className="space-y-4">
           <div className="flex justify-between">
-            <div className="h-4 bg-slate-200 rounded w-1/4"></div>
-            <div className="h-4 bg-slate-200 rounded w-1/6"></div>
+            <div className="h-4 bg-pov-gray rounded w-1/4"></div>
+            <div className="h-4 bg-pov-gray rounded w-1/6"></div>
           </div>
-          <div className="h-32 bg-slate-200 rounded"></div>
+          <div className="h-32 bg-pov-gray rounded"></div>
           <div className="flex justify-between">
             {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="h-3 bg-slate-200 rounded w-8"></div>
+              <div key={i} className="h-3 bg-pov-gray rounded w-8"></div>
             ))}
           </div>
         </div>
@@ -489,8 +499,8 @@ export function ChartSkeleton({
         <div className="space-y-3">
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="space-y-2">
-              <div className="h-3 bg-slate-200 rounded w-1/3"></div>
-              <div className="h-2 bg-slate-200 rounded"></div>
+              <div className="h-3 bg-pov-gray rounded w-1/3"></div>
+              <div className="h-2 bg-pov-gray rounded"></div>
             </div>
           ))}
         </div>
@@ -498,12 +508,12 @@ export function ChartSkeleton({
 
       {type === 'donut' && (
         <div className="flex flex-col items-center space-y-4">
-          <div className="w-32 h-32 bg-slate-200 rounded-full"></div>
+          <div className="w-32 h-32 bg-pov-gray rounded-full"></div>
           <div className="space-y-2">
             {Array.from({ length: 3 }).map((_, i) => (
               <div key={i} className="flex items-center space-x-2">
-                <div className="w-3 h-3 bg-slate-200 rounded-full"></div>
-                <div className="h-3 bg-slate-200 rounded w-16"></div>
+                <div className="w-3 h-3 bg-pov-gray rounded-full"></div>
+                <div className="h-3 bg-pov-gray rounded w-16"></div>
               </div>
             ))}
           </div>

--- a/client/src/components/charts/chart-container.tsx
+++ b/client/src/components/charts/chart-container.tsx
@@ -1,10 +1,5 @@
- 
- 
- 
- 
- 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import type { ReactNode } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { ReactNode } from 'react';
 
 interface ChartContainerProps {
   title: string;
@@ -14,19 +9,19 @@ interface ChartContainerProps {
   className?: string;
 }
 
-export default function ChartContainer({ 
-  title, 
-  description, 
-  children, 
-  height = 400, 
-  className = "" 
+export default function ChartContainer({
+  title,
+  description,
+  children,
+  height = 400,
+  className = '',
 }: ChartContainerProps) {
   return (
     <Card className={className}>
       <CardHeader>
-        <CardTitle className="text-lg font-semibold text-gray-800">{title}</CardTitle>
+        <CardTitle className="text-lg font-semibold text-pov-charcoal">{title}</CardTitle>
         {description && (
-          <CardDescription className="text-sm text-gray-600">{description}</CardDescription>
+          <CardDescription className="text-sm text-charcoal-600">{description}</CardDescription>
         )}
       </CardHeader>
       <CardContent>

--- a/client/src/components/charts/chart-gallery.tsx
+++ b/client/src/components/charts/chart-gallery.tsx
@@ -29,7 +29,7 @@ const chartTypes: ChartType[] = [
     description: 'Time series data',
     category: 'basic',
     icon: LineChartIcon,
-    color: 'text-blue-500',
+    color: 'text-pov-charcoal',
   },
   {
     id: 'bar',
@@ -37,7 +37,7 @@ const chartTypes: ChartType[] = [
     description: 'Categorical comparison',
     category: 'basic',
     icon: BarChart3,
-    color: 'text-cyan-500',
+    color: 'text-pov-charcoal',
   },
   {
     id: 'pie',
@@ -45,7 +45,7 @@ const chartTypes: ChartType[] = [
     description: 'Proportional data',
     category: 'basic',
     icon: PieChartIcon,
-    color: 'text-green-500',
+    color: 'text-pov-charcoal',
   },
   {
     id: 'area',
@@ -53,7 +53,7 @@ const chartTypes: ChartType[] = [
     description: 'Volume over time',
     category: 'basic',
     icon: AreaChart,
-    color: 'text-orange-500',
+    color: 'text-pov-charcoal',
   },
   {
     id: 'sankey',
@@ -61,7 +61,7 @@ const chartTypes: ChartType[] = [
     description: 'Flow visualization',
     category: 'flow',
     icon: Workflow,
-    color: 'text-purple-500',
+    color: 'text-pov-charcoal',
   },
   {
     id: 'treemap',
@@ -69,7 +69,7 @@ const chartTypes: ChartType[] = [
     description: 'Hierarchical data',
     category: 'hierarchical',
     icon: TreePine,
-    color: 'text-blue-500',
+    color: 'text-pov-charcoal',
   },
   {
     id: 'heatmap',
@@ -77,7 +77,7 @@ const chartTypes: ChartType[] = [
     description: 'Pattern analysis',
     category: 'statistical',
     icon: Grid,
-    color: 'text-red-500',
+    color: 'text-pov-charcoal',
   },
   {
     id: 'network',
@@ -85,7 +85,7 @@ const chartTypes: ChartType[] = [
     description: 'Relationship mapping',
     category: 'advanced',
     icon: Share2,
-    color: 'text-teal-500',
+    color: 'text-pov-charcoal',
   },
 ];
 
@@ -108,10 +108,10 @@ export default function ChartGallery() {
     <Card className="mb-8">
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle className="text-lg font-semibold text-gray-800">
+          <CardTitle className="text-lg font-semibold text-pov-charcoal">
             AntV Chart Capabilities
           </CardTitle>
-          <p className="text-sm text-gray-600">25+ Chart Types Available</p>
+          <p className="text-sm text-charcoal-600">25+ Chart Types Available</p>
         </div>
       </CardHeader>
       <CardContent>
@@ -124,7 +124,7 @@ export default function ChartGallery() {
               onClick={() => setSelectedCategory(category.id)}
               className={
                 selectedCategory === category.id
-                  ? 'povc-bg-primary-light text-blue-700 border-blue-200'
+                  ? 'bg-pov-charcoal text-pov-white border-beige-200'
                   : ''
               }
             >
@@ -139,13 +139,13 @@ export default function ChartGallery() {
             return (
               <div
                 key={chart.id}
-                className="bg-gray-50 rounded-lg p-4 text-center hover:bg-gray-100 transition-colors cursor-pointer"
+                className="bg-pov-gray/50 rounded-lg p-4 text-center hover:bg-pov-gray transition-colors cursor-pointer"
               >
                 <div className="h-24 flex items-center justify-center mb-3">
                   <Icon className={`h-8 w-8 ${chart.color}`} />
                 </div>
-                <p className="font-medium text-gray-800 text-sm">{chart.name}</p>
-                <p className="text-xs text-gray-600 mt-1">{chart.description}</p>
+                <p className="font-medium text-pov-charcoal text-sm">{chart.name}</p>
+                <p className="text-xs text-charcoal-600 mt-1">{chart.description}</p>
               </div>
             );
           })}

--- a/client/src/components/charts/cohort-analysis-chart.tsx
+++ b/client/src/components/charts/cohort-analysis-chart.tsx
@@ -1,12 +1,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 // Chart libraries removed for bundle optimization
 const ChartPlaceholder = ({ title }: { title: string }) => (
-  <div className="h-64 bg-gray-50 rounded-lg flex flex-col items-center justify-center">
-    <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center mb-4">
-      <div className="h-8 w-8 text-gray-400">[chart]</div>
+  <div className="h-64 bg-pov-gray rounded-lg flex flex-col items-center justify-center">
+    <div className="w-16 h-16 bg-white rounded-full flex items-center justify-center mb-4">
+      <div className="h-8 w-8 text-charcoal-400">[chart]</div>
     </div>
-    <p className="text-gray-500 font-medium">{title}</p>
-    <p className="text-gray-400 text-sm mt-1">Chart placeholder - data available via API</p>
+    <p className="text-charcoal-500 font-medium">{title}</p>
+    <p className="text-charcoal-400 text-sm mt-1">Chart placeholder - data available via API</p>
   </div>
 );
 
@@ -20,7 +20,7 @@ export default function CohortAnalysisChart() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-lg font-semibold text-gray-800">Cohort Analysis</CardTitle>
+        <CardTitle className="text-lg font-semibold text-pov-charcoal">Cohort Analysis</CardTitle>
       </CardHeader>
       <CardContent>
         <ChartPlaceholder title="Cohort Analysis Chart" />
@@ -28,8 +28,8 @@ export default function CohortAnalysisChart() {
         <div className="grid grid-cols-3 gap-4 text-center">
           {cohortData.map((cohort, index) => (
             <div key={index}>
-              <p className="text-sm text-gray-600">{cohort.vintage} Vintage</p>
-              <p className="text-lg font-bold text-gray-800">{cohort.irr}% IRR</p>
+              <p className="text-sm text-charcoal-600">{cohort.vintage} Vintage</p>
+              <p className="text-lg font-bold text-pov-charcoal">{cohort.irr}% IRR</p>
             </div>
           ))}
         </div>

--- a/client/src/components/charts/enhanced-performance-chart.tsx
+++ b/client/src/components/charts/enhanced-performance-chart.tsx
@@ -9,6 +9,8 @@ import { Area } from 'recharts/es6/cartesian/Area';
 import { AreaChart } from 'recharts/es6/chart/AreaChart';
 import ChartContainer from './chart-container';
 import { createDynamicFormatter } from '@/lib/chart-formatters';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 interface PerformanceData {
   date: string;
@@ -55,7 +57,7 @@ export default function EnhancedPerformanceChart({
         description="Track IRR, multiple, DPI, and TVPI performance over time"
         height={height}
       >
-        <div className="flex items-center justify-center h-full text-gray-500">
+        <div className="flex items-center justify-center h-full text-charcoal-500">
           No performance data available
         </div>
       </ChartContainer>
@@ -70,30 +72,34 @@ export default function EnhancedPerformanceChart({
     >
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <CartesianGrid strokeDasharray="3 3" stroke={presson.color.surfaceSubtle} />
           <XAxis
             dataKey="date"
             axisLine={false}
             tickLine={false}
-            tick={{ fontSize: 12, fill: '#666' }}
+            tick={{ fontSize: 12, fill: presson.color.text }}
           />
-          <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#666' }} />
+          <YAxis
+            axisLine={false}
+            tickLine={false}
+            tick={{ fontSize: 12, fill: presson.color.text }}
+          />
           <Tooltip
             formatter={formatTooltipValue}
-            labelStyle={{ color: '#333', fontWeight: 'bold' }}
+            labelStyle={{ color: presson.color.text, fontWeight: 'bold' }}
             contentStyle={{
-              backgroundColor: '#fff',
-              border: '1px solid #e0e0e0',
+              backgroundColor: presson.color.surface,
+              border: `1px solid ${presson.color.borderSubtle}`,
               borderRadius: '8px',
-              boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+              boxShadow: presson.shadow.card,
             }}
           />
           <Legend wrapperStyle={{ paddingTop: '20px' }} iconType="line" />
           <Area
             type="monotone"
             dataKey="irr"
-            stroke="#3b82f6"
-            fill="#3b82f6"
+            stroke={getChartColor(0)}
+            fill={getChartColor(0)}
             fillOpacity={0.1}
             strokeWidth={2}
             name="IRR"
@@ -101,8 +107,8 @@ export default function EnhancedPerformanceChart({
           <Area
             type="monotone"
             dataKey="multiple"
-            stroke="#10b981"
-            fill="#10b981"
+            stroke={getChartColor(1)}
+            fill={getChartColor(1)}
             fillOpacity={0.1}
             strokeWidth={2}
             name="Multiple"
@@ -110,20 +116,20 @@ export default function EnhancedPerformanceChart({
           <Line
             type="monotone"
             dataKey="dpi"
-            stroke="#f59e0b"
+            stroke={getChartColor(2)}
             strokeWidth={2}
             name="DPI"
-            dot={{ r: 4, fill: '#f59e0b' }}
-            activeDot={{ r: 6, fill: '#f59e0b' }}
+            dot={{ r: 4, fill: getChartColor(2) }}
+            activeDot={{ r: 6, fill: getChartColor(2) }}
           />
           <Line
             type="monotone"
             dataKey="tvpi"
-            stroke="#ef4444"
+            stroke={getChartColor(3)}
             strokeWidth={2}
             name="TVPI"
-            dot={{ r: 4, fill: '#ef4444' }}
-            activeDot={{ r: 6, fill: '#ef4444' }}
+            dot={{ r: 4, fill: getChartColor(3) }}
+            activeDot={{ r: 6, fill: getChartColor(3) }}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/client/src/components/charts/fund-expense-charts.tsx
+++ b/client/src/components/charts/fund-expense-charts.tsx
@@ -12,6 +12,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Download, Info, DollarSign, Percent, TrendingUp } from 'lucide-react';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 interface ExpenseData {
   date: string;
@@ -149,16 +151,16 @@ export default function FundExpenseCharts({ className }: FundExpenseChartsProps)
           total: item.totalRatio,
         }));
 
-  // Color scheme for expense categories
+  // TODO(design): expense charts exceed the six-token categorical palette.
   const expenseColors = {
-    legal: '#60a5fa', // Blue
-    administration: '#1e293b', // Dark slate
-    tax: '#94a3b8', // Light slate
-    audit: '#fb923c', // Orange
-    software: '#22c55e', // Green
-    setup: '#a855f7', // Purple
-    other: '#ef4444', // Red
-    total: '#fbbf24', // Yellow
+    legal: getChartColor(0, true),
+    administration: getChartColor(1, true),
+    tax: getChartColor(2, true),
+    audit: getChartColor(3, true),
+    software: getChartColor(4, true),
+    setup: getChartColor(5, true),
+    other: getChartColor(6, true),
+    total: presson.color.info,
   };
 
   const formatCurrency = (value: number) => {
@@ -191,9 +193,9 @@ export default function FundExpenseCharts({ className }: FundExpenseChartsProps)
       const totalValue = currentData.total;
 
       return (
-        <div className="bg-white p-4 border border-gray-200 rounded-lg shadow-lg max-w-xs">
+        <div className="bg-white p-4 border border-beige-200 rounded-lg shadow-lg max-w-xs">
           <p className="font-medium mb-2">{label ? formatDate(label) : ''}</p>
-          <p className="font-bold text-yellow-600 mb-2">
+          <p className="font-bold text-presson-info mb-2">
             Total:{' '}
             {viewType === 'expenses' ? formatCurrency(totalValue) : formatPercent(totalValue)}
           </p>
@@ -235,7 +237,7 @@ export default function FundExpenseCharts({ className }: FundExpenseChartsProps)
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold flex items-center space-x-2">
-            <DollarSign className="h-6 w-6 text-blue-600" />
+            <DollarSign className="h-6 w-6 text-presson-info" />
             <span>Fund Expenses</span>
           </h2>
           <p className="text-muted-foreground">
@@ -423,13 +425,13 @@ export default function FundExpenseCharts({ className }: FundExpenseChartsProps)
 
       {/* Summary Statistics */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="border-blue-200 bg-blue-50">
+        <Card className="border-beige-200 bg-white">
           <CardContent className="pt-6">
             <div className="flex items-center space-x-3">
-              <DollarSign className="h-8 w-8 text-blue-600" />
+              <DollarSign className="h-8 w-8 text-presson-info" />
               <div>
-                <div className="text-sm text-blue-800">Total Expenses</div>
-                <div className="font-bold text-blue-900">
+                <div className="text-sm text-charcoal-600">Total Expenses</div>
+                <div className="font-bold text-pov-charcoal">
                   {formatCurrency(expenseData[expenseData.length - 1]?.total || 0)}
                 </div>
               </div>
@@ -437,13 +439,13 @@ export default function FundExpenseCharts({ className }: FundExpenseChartsProps)
           </CardContent>
         </Card>
 
-        <Card className="border-green-200 bg-green-50">
+        <Card className="border-beige-200 bg-white">
           <CardContent className="pt-6">
             <div className="flex items-center space-x-3">
-              <Percent className="h-8 w-8 text-green-600" />
+              <Percent className="h-8 w-8 text-pov-charcoal" />
               <div>
-                <div className="text-sm text-green-800">Total Expense Ratio</div>
-                <div className="font-bold text-green-900">
+                <div className="text-sm text-charcoal-600">Total Expense Ratio</div>
+                <div className="font-bold text-pov-charcoal">
                   {formatPercent(expenseRatioData[expenseRatioData.length - 1]?.totalRatio || 0)}
                 </div>
               </div>
@@ -451,27 +453,27 @@ export default function FundExpenseCharts({ className }: FundExpenseChartsProps)
           </CardContent>
         </Card>
 
-        <Card className="border-orange-200 bg-orange-50">
+        <Card className="border-beige-200 bg-white">
           <CardContent className="pt-6">
             <div className="flex items-center space-x-3">
-              <TrendingUp className="h-8 w-8 text-orange-600" />
+              <TrendingUp className="h-8 w-8 text-pov-charcoal" />
               <div>
-                <div className="text-sm text-orange-800">Largest Category</div>
-                <div className="font-bold text-orange-900">Administration</div>
-                <div className="text-xs text-orange-700">0.75% ratio</div>
+                <div className="text-sm text-charcoal-600">Largest Category</div>
+                <div className="font-bold text-pov-charcoal">Administration</div>
+                <div className="text-xs text-charcoal-500">0.75% ratio</div>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="border-purple-200 bg-purple-50">
+        <Card className="border-beige-200 bg-white">
           <CardContent className="pt-6">
             <div className="flex items-center space-x-3">
-              <Info className="h-8 w-8 text-purple-600" />
+              <Info className="h-8 w-8 text-presson-info" />
               <div>
-                <div className="text-sm text-purple-800">Active Categories</div>
-                <div className="font-bold text-purple-900">7</div>
-                <div className="text-xs text-purple-700">Expense types</div>
+                <div className="text-sm text-charcoal-600">Active Categories</div>
+                <div className="font-bold text-pov-charcoal">7</div>
+                <div className="text-xs text-charcoal-500">Expense types</div>
               </div>
             </div>
           </CardContent>

--- a/client/src/components/charts/investment-breakdown-chart.tsx
+++ b/client/src/components/charts/investment-breakdown-chart.tsx
@@ -5,6 +5,8 @@ import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/cha
 import { Tooltip } from 'recharts/es6/component/Tooltip';
 import ChartContainer from './chart-container';
 import { createPayloadFormatter } from '@/lib/chart-formatters';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 interface SectorData {
   name: string;
@@ -15,10 +17,10 @@ interface SectorData {
 }
 
 const sectorData: SectorData[] = [
-  { name: 'Fintech', value: 35, color: '#3b82f6', amount: 52.5 },
-  { name: 'Healthcare', value: 28, color: '#06b6d4', amount: 42.0 },
-  { name: 'SaaS', value: 22, color: '#10b981', amount: 33.0 },
-  { name: 'Other', value: 15, color: '#f59e0b', amount: 22.5 },
+  { name: 'Fintech', value: 35, color: getChartColor(0), amount: 52.5 },
+  { name: 'Healthcare', value: 28, color: getChartColor(1), amount: 42.0 },
+  { name: 'SaaS', value: 22, color: getChartColor(2), amount: 33.0 },
+  { name: 'Other', value: 15, color: getChartColor(3), amount: 22.5 },
 ];
 
 interface InvestmentBreakdownChartProps {
@@ -47,7 +49,7 @@ export default function InvestmentBreakdownChart({
         description="Investment distribution across sectors"
         height={height}
       >
-        <div className="flex items-center justify-center h-full text-gray-500">
+        <div className="flex items-center justify-center h-full text-charcoal-500">
           No allocation data available
         </div>
       </ChartContainer>
@@ -73,7 +75,7 @@ export default function InvestmentBreakdownChart({
                 dataKey="value"
                 label={({ value }) => `${value}%`}
                 labelLine={false}
-                stroke="#fff"
+                stroke={presson.color.surface}
                 strokeWidth={2}
               >
                 {data.map((entry: SectorData, index: number) => (
@@ -83,17 +85,17 @@ export default function InvestmentBreakdownChart({
               <Tooltip
                 formatter={formatTooltipValue}
                 contentStyle={{
-                  backgroundColor: '#fff',
-                  border: '1px solid #e0e0e0',
+                  backgroundColor: presson.color.surface,
+                  border: `1px solid ${presson.color.borderSubtle}`,
                   borderRadius: '8px',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                  boxShadow: presson.shadow.card,
                 }}
               />
             </PieChart>
           </ResponsiveContainer>
         </div>
 
-        <div className="space-y-3 pt-4 border-t border-gray-100">
+        <div className="space-y-3 pt-4 border-t border-charcoal/7">
           {data.map((sector: SectorData, index: number) => (
             <div key={index} className="flex items-center justify-between text-sm">
               <div className="flex items-center space-x-3">
@@ -101,11 +103,13 @@ export default function InvestmentBreakdownChart({
                   className="w-4 h-4 rounded-full shadow-sm"
                   style={{ backgroundColor: sector.color }}
                 ></div>
-                <span className="text-gray-700 font-medium">{sector.name}</span>
+                <span className="text-charcoal-700 font-medium">{sector.name}</span>
               </div>
               <div className="text-right">
-                <span className="font-semibold text-gray-800">{sector.value}%</span>
-                {sector.amount && <div className="text-xs text-gray-500">${sector.amount}M</div>}
+                <span className="font-semibold text-pov-charcoal">{sector.value}%</span>
+                {sector.amount && (
+                  <div className="text-xs text-charcoal-500">${sector.amount}M</div>
+                )}
               </div>
             </div>
           ))}

--- a/client/src/components/charts/nivo-allocation-pie.tsx
+++ b/client/src/components/charts/nivo-allocation-pie.tsx
@@ -12,7 +12,7 @@ import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/cha
 import { Tooltip } from 'recharts/es6/component/Tooltip';
 import { Legend } from 'recharts/es6/component/Legend';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { getChartColor } from '@/lib/chart-theme';
+import { getChartColor } from '@/lib/brand-tokens';
 
 interface AllocationData {
   id: string;
@@ -41,7 +41,7 @@ const CustomTooltip = ({
     const total = payload[0]!.payload.total || 0;
     const percentage = total > 0 ? ((data.value / total) * 100).toFixed(1) : '0';
     return (
-      <div className="bg-white p-2 border border-gray-200 rounded shadow-lg">
+      <div className="bg-white p-2 border border-beige-200 rounded shadow-lg">
         <p className="font-semibold">{data.name}</p>
         <p className="text-sm">
           ${(data.value / 1000000).toFixed(1)}M ({percentage}%)
@@ -83,7 +83,7 @@ export default function NivoAllocationPie({ title, data, height = 400 }: NivoAll
                 return `${name}: ${percentage}%`;
               }}
               outerRadius={80}
-              fill="#8884d8"
+              fill={getChartColor(0)}
               dataKey="value"
             >
               {chartData.map((entry: { fill: string }, index: number) => (

--- a/client/src/components/charts/nivo-moic-scatter.tsx
+++ b/client/src/components/charts/nivo-moic-scatter.tsx
@@ -11,6 +11,7 @@ import {
   ZAxis,
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getChartColor } from '@/lib/brand-tokens';
 
 type MOICDatum = {
   x: number; // IRR
@@ -55,7 +56,6 @@ const NivoMOICScatter = memo(function NivoMOICScatter({
   data,
   height = 400,
 }: NivoMOICScatterProps) {
-  const colors = useMemo(() => ['#2563eb', '#dc2626', '#16a34a', '#ca8a04'], []);
   const chartSeries = useMemo(
     () =>
       data.map((series) => ({
@@ -100,9 +100,9 @@ const NivoMOICScatter = memo(function NivoMOICScatter({
                   }
 
                   return (
-                    <div className="bg-white p-3 border border-gray-200 rounded-lg shadow-lg">
+                    <div className="bg-white p-3 border border-beige-200 rounded-lg shadow-lg">
                       <div className="font-semibold">{point.company || 'Company'}</div>
-                      <div className="text-sm text-gray-600">
+                      <div className="text-sm text-charcoal-600">
                         <div>IRR: {point.x.toFixed(1)}%</div>
                         <div>MOIC: {point.y.toFixed(2)}x</div>
                         {point.investment != null && (
@@ -119,7 +119,7 @@ const NivoMOICScatter = memo(function NivoMOICScatter({
                   key={series.id}
                   name={series.id}
                   data={series.data}
-                  fill={colors[index % colors.length] ?? colors[0]!}
+                  fill={getChartColor(index)}
                 />
               ))}
             </ScatterChart>

--- a/client/src/components/charts/nivo-performance-chart.tsx
+++ b/client/src/components/charts/nivo-performance-chart.tsx
@@ -10,6 +10,8 @@ import {
   YAxis,
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 interface PerformanceData {
   id: string;
@@ -30,7 +32,6 @@ const NivoPerformanceChart = memo(function NivoPerformanceChart({
   data,
   height = 400,
 }: NivoPerformanceChartProps) {
-  const colors = useMemo(() => ['#2563eb', '#dc2626', '#16a34a', '#ca8a04'], []);
   const chartRows = useMemo(() => {
     const rows = new Map<string, Record<string, number | string>>();
 
@@ -58,12 +59,12 @@ const NivoPerformanceChart = memo(function NivoPerformanceChart({
               <XAxis
                 dataKey="period"
                 tick={{ fontSize: 12 }}
-                tickLine={{ stroke: '#e5e7eb' }}
+                tickLine={{ stroke: presson.color.surfaceSubtle }}
                 label={{ value: 'Time Period', position: 'insideBottom', offset: -10 }}
               />
               <YAxis
                 tick={{ fontSize: 12 }}
-                tickLine={{ stroke: '#e5e7eb' }}
+                tickLine={{ stroke: presson.color.surfaceSubtle }}
                 tickFormatter={(value: number) => `$${(value / 1000000).toFixed(1)}M`}
                 label={{ value: 'Value ($M)', angle: -90, position: 'insideLeft' }}
               />
@@ -80,7 +81,7 @@ const NivoPerformanceChart = memo(function NivoPerformanceChart({
                   type="monotone"
                   dataKey={series.id}
                   name={series.id}
-                  stroke={colors[index % colors.length] ?? colors[0]!}
+                  stroke={getChartColor(index)}
                   strokeWidth={2}
                   dot={{ r: 4 }}
                   activeDot={{ r: 6 }}

--- a/client/src/components/charts/pacing-timeline-chart.tsx
+++ b/client/src/components/charts/pacing-timeline-chart.tsx
@@ -9,6 +9,8 @@ import { Bar } from 'recharts/es6/cartesian/Bar';
 import { usePacingData } from '@/hooks/use-engine-data';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { AlertCircle, Calendar, TrendingUp } from 'lucide-react';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 export default function PacingTimelineChart() {
   const { data: pacingData, loading, error } = usePacingData();
@@ -21,7 +23,7 @@ export default function PacingTimelineChart() {
         </CardHeader>
         <CardContent>
           <div className="animate-pulse space-y-4">
-            <div className="h-64 bg-gray-200 rounded"></div>
+            <div className="h-64 bg-pov-gray rounded"></div>
           </div>
         </CardContent>
       </Card>
@@ -35,7 +37,7 @@ export default function PacingTimelineChart() {
           <CardTitle className="text-lg font-semibent">Deployment Pacing</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-center h-64 text-red-500">
+          <div className="flex items-center justify-center h-64 text-error-dark">
             <AlertCircle className="h-6 w-6 mr-2" />
             <span>Error loading pacing data: {error}</span>
           </div>
@@ -76,10 +78,10 @@ export default function PacingTimelineChart() {
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={chartData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                <XAxis dataKey="quarter" stroke="#666" fontSize={12} />
+                <CartesianGrid strokeDasharray="3 3" stroke={presson.color.surfaceSubtle} />
+                <XAxis dataKey="quarter" stroke={presson.color.text} fontSize={12} />
                 <YAxis
-                  stroke="#666"
+                  stroke={presson.color.text}
                   fontSize={12}
                   label={{ value: 'Deployment ($M)', angle: -90, position: 'insideLeft' }}
                 />
@@ -90,11 +92,11 @@ export default function PacingTimelineChart() {
                   ]}
                   labelFormatter={(label) => `Quarter: ${String(label)}`}
                 />
-                <Bar dataKey="deployment" fill="#3b82f6" name="deployment" />
+                <Bar dataKey="deployment" fill={getChartColor(0)} name="deployment" />
                 <Line
                   type="monotone"
                   dataKey="cumulative"
-                  stroke="#10b981"
+                  stroke={getChartColor(1)}
                   strokeWidth={3}
                   name="cumulative"
                 />
@@ -110,13 +112,13 @@ export default function PacingTimelineChart() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-gray-600 text-sm font-medium">Total Fund Size</p>
-                <p className="text-2xl font-bold text-gray-800 mt-1">
+                <p className="text-charcoal-600 text-sm font-medium">Total Fund Size</p>
+                <p className="text-2xl font-bold text-pov-charcoal mt-1">
                   ${(fundSize / 1000000).toFixed(0)}M
                 </p>
               </div>
-              <div className="w-12 h-12 bg-blue-50 rounded-lg flex items-center justify-center">
-                <TrendingUp className="h-6 w-6 text-blue-500" />
+              <div className="w-12 h-12 bg-pov-gray rounded-lg flex items-center justify-center">
+                <TrendingUp className="h-6 w-6 text-presson-info" />
               </div>
             </div>
           </CardContent>
@@ -126,14 +128,14 @@ export default function PacingTimelineChart() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-gray-600 text-sm font-medium">Avg Quarterly</p>
-                <p className="text-2xl font-bold text-gray-800 mt-1">
+                <p className="text-charcoal-600 text-sm font-medium">Avg Quarterly</p>
+                <p className="text-2xl font-bold text-pov-charcoal mt-1">
                   ${(avgQuarterlyDeployment / 1000000).toFixed(1)}M
                 </p>
-                <p className="text-sm text-gray-500 mt-1">{totalQuarters} quarters</p>
+                <p className="text-sm text-charcoal-500 mt-1">{totalQuarters} quarters</p>
               </div>
-              <div className="w-12 h-12 bg-green-50 rounded-lg flex items-center justify-center">
-                <Calendar className="h-6 w-6 text-green-500" />
+              <div className="w-12 h-12 bg-pov-gray rounded-lg flex items-center justify-center">
+                <Calendar className="h-6 w-6 text-pov-charcoal" />
               </div>
             </div>
           </CardContent>
@@ -143,14 +145,14 @@ export default function PacingTimelineChart() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-gray-600 text-sm font-medium">Market Condition</p>
-                <p className="text-2xl font-bold text-gray-800 mt-1">
+                <p className="text-charcoal-600 text-sm font-medium">Market Condition</p>
+                <p className="text-2xl font-bold text-pov-charcoal mt-1">
                   {marketCondition.charAt(0).toUpperCase() + marketCondition.slice(1)}
                 </p>
-                <p className="text-sm text-gray-500 mt-1">Baseline pacing</p>
+                <p className="text-sm text-charcoal-500 mt-1">Baseline pacing</p>
               </div>
-              <div className="w-12 h-12 bg-orange-50 rounded-lg flex items-center justify-center">
-                <Calendar className="h-6 w-6 text-orange-500" />
+              <div className="w-12 h-12 bg-pov-gray rounded-lg flex items-center justify-center">
+                <Calendar className="h-6 w-6 text-presson-warning" />
               </div>
             </div>
           </CardContent>
@@ -167,15 +169,15 @@ export default function PacingTimelineChart() {
             {chartData.map((item, index) => (
               <div
                 key={index}
-                className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                className="flex items-center justify-between p-3 bg-pov-gray/50 rounded-lg"
               >
                 <div className="flex-1">
-                  <p className="font-medium text-gray-800">{item.quarter} Deployment</p>
-                  <p className="text-sm text-gray-600">{item.note}</p>
+                  <p className="font-medium text-pov-charcoal">{item.quarter} Deployment</p>
+                  <p className="text-sm text-charcoal-600">{item.note}</p>
                 </div>
                 <div className="text-right">
-                  <p className="font-semibold text-gray-800">${item.deployment.toFixed(1)}M</p>
-                  <p className="text-sm text-gray-500">
+                  <p className="font-semibold text-pov-charcoal">${item.deployment.toFixed(1)}M</p>
+                  <p className="text-sm text-charcoal-500">
                     Cumulative: ${item.cumulative.toFixed(1)}M
                   </p>
                 </div>

--- a/client/src/components/charts/performance-optimizer.tsx
+++ b/client/src/components/charts/performance-optimizer.tsx
@@ -6,6 +6,7 @@ import { CartesianGrid } from 'recharts/es6/cartesian/CartesianGrid';
 import { Tooltip } from 'recharts/es6/component/Tooltip';
 import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/charts/LazyResponsiveContainer';
 import { memo } from 'react';
+import { getChartColor } from '@/lib/brand-tokens';
 
 interface PerformanceDataPoint {
   month: string;
@@ -31,7 +32,7 @@ const PerformanceOptimizer = memo(function PerformanceOptimizer({
         <Line
           type="monotone"
           dataKey="value"
-          stroke="#3b82f6"
+          stroke={getChartColor(0)}
           strokeWidth={2}
           dot={false} // Remove dots for better performance
         />

--- a/client/src/components/charts/portfolio-performance-chart.tsx
+++ b/client/src/components/charts/portfolio-performance-chart.tsx
@@ -15,10 +15,9 @@ import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/cha
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
-import {
-  rechartsProps,
-  getChartColor,
-} from '@/lib/chart-theme';
+import { rechartsProps } from '@/lib/chart-theme';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 interface PerformanceData {
   month: string;
@@ -50,7 +49,7 @@ export default function PortfolioPerformanceChart() {
     <Card className="lg:col-span-2">
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle className="text-lg font-semibold text-gray-800">
+          <CardTitle className="text-lg font-semibold text-pov-charcoal">
             Portfolio Performance
           </CardTitle>
           <div className="flex space-x-2">
@@ -61,7 +60,7 @@ export default function PortfolioPerformanceChart() {
                 size="sm"
                 onClick={() => setTimeRange(range)}
                 className={
-                  timeRange === range ? 'povc-bg-primary-light text-blue-700 border-blue-200' : ''
+                  timeRange === range ? 'bg-pov-charcoal text-pov-white border-beige-200' : ''
                 }
               >
                 {range}
@@ -97,7 +96,12 @@ export default function PortfolioPerformanceChart() {
                 strokeWidth={2}
                 name="Portfolio Value ($M)"
                 dot={{ r: 4, fill: portfolioValueColor }}
-                activeDot={{ r: 6, stroke: portfolioValueColor, strokeWidth: 2, fill: '#FFFFFF' }}
+                activeDot={{
+                  r: 6,
+                  stroke: portfolioValueColor,
+                  strokeWidth: 2,
+                  fill: presson.color.surface,
+                }}
               />
               <Line
                 yAxisId="right"
@@ -107,7 +111,12 @@ export default function PortfolioPerformanceChart() {
                 strokeWidth={2}
                 name="IRR (%)"
                 dot={{ r: 4, fill: irrColor }}
-                activeDot={{ r: 6, stroke: irrColor, strokeWidth: 2, fill: '#FFFFFF' }}
+                activeDot={{
+                  r: 6,
+                  stroke: irrColor,
+                  strokeWidth: 2,
+                  fill: presson.color.surface,
+                }}
               />
             </LineChart>
           </ResponsiveContainer>

--- a/client/src/components/charts/reserve-allocation-chart.tsx
+++ b/client/src/components/charts/reserve-allocation-chart.tsx
@@ -18,7 +18,7 @@ export default function ReserveAllocationChart({ fundId }: ReserveAllocationChar
         </CardHeader>
         <CardContent>
           <div className="animate-pulse space-y-4">
-            <div className="h-64 bg-gray-200 rounded"></div>
+            <div className="h-64 bg-pov-gray rounded"></div>
           </div>
         </CardContent>
       </Card>
@@ -32,7 +32,7 @@ export default function ReserveAllocationChart({ fundId }: ReserveAllocationChar
           <CardTitle className="text-lg font-semibold">Reserve Allocations</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-center h-64 text-red-500">
+          <div className="flex items-center justify-center h-64 text-error-dark">
             <AlertCircle className="h-6 w-6 mr-2" />
             <span>Error loading reserve data: {error}</span>
           </div>
@@ -70,13 +70,13 @@ export default function ReserveAllocationChart({ fundId }: ReserveAllocationChar
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-gray-600 text-sm font-medium">Total Reserves</p>
-                <p className="text-2xl font-bold text-gray-800 mt-1">
+                <p className="text-charcoal-600 text-sm font-medium">Total Reserves</p>
+                <p className="text-2xl font-bold text-pov-charcoal mt-1">
                   ${(totalAllocation / 1000000).toFixed(1)}M
                 </p>
               </div>
-              <div className="w-12 h-12 bg-blue-50 rounded-lg flex items-center justify-center">
-                <TrendingUp className="h-6 w-6 text-blue-500" />
+              <div className="w-12 h-12 bg-pov-gray rounded-lg flex items-center justify-center">
+                <TrendingUp className="h-6 w-6 text-presson-info" />
               </div>
             </div>
           </CardContent>
@@ -86,18 +86,18 @@ export default function ReserveAllocationChart({ fundId }: ReserveAllocationChar
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-gray-600 text-sm font-medium">Avg Confidence</p>
-                <p className="text-2xl font-bold text-gray-800 mt-1">
+                <p className="text-charcoal-600 text-sm font-medium">Avg Confidence</p>
+                <p className="text-2xl font-bold text-pov-charcoal mt-1">
                   {(avgConfidence * 100).toFixed(0)}%
                 </p>
                 <div className="flex items-center mt-2">
                   {avgConfidence >= 0.7 ? (
-                    <TrendingUp className="h-4 w-4 text-green-500 mr-1" />
+                    <TrendingUp className="h-4 w-4 text-success-dark mr-1" />
                   ) : (
-                    <TrendingDown className="h-4 w-4 text-orange-500 mr-1" />
+                    <TrendingDown className="h-4 w-4 text-warning-dark mr-1" />
                   )}
                   <span
-                    className={`text-sm font-medium ${avgConfidence >= 0.7 ? 'text-green-600' : 'text-orange-600'}`}
+                    className={`text-sm font-medium ${avgConfidence >= 0.7 ? 'text-success-dark' : 'text-warning-dark'}`}
                   >
                     {avgConfidence >= 0.7 ? 'High confidence' : 'Cold-start mode'}
                   </span>
@@ -111,11 +111,11 @@ export default function ReserveAllocationChart({ fundId }: ReserveAllocationChar
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-gray-600 text-sm font-medium">High Confidence</p>
-                <p className="text-2xl font-bold text-gray-800 mt-1">
+                <p className="text-charcoal-600 text-sm font-medium">High Confidence</p>
+                <p className="text-2xl font-bold text-pov-charcoal mt-1">
                   {highConfidenceCount}/{allocationCount}
                 </p>
-                <p className="text-sm text-gray-500 mt-1">
+                <p className="text-sm text-charcoal-500 mt-1">
                   {allocationCount > 0
                     ? ((highConfidenceCount / allocationCount) * 100).toFixed(0)
                     : 0}
@@ -137,21 +137,21 @@ export default function ReserveAllocationChart({ fundId }: ReserveAllocationChar
             {reserveData?.allocations.map((item, index) => (
               <div
                 key={index}
-                className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                className="flex items-center justify-between p-3 bg-pov-gray/50 rounded-lg"
               >
                 <div className="flex-1">
-                  <p className="font-medium text-gray-800">Company {index + 1}</p>
-                  <p className="text-sm text-gray-600">{item.rationale}</p>
+                  <p className="font-medium text-pov-charcoal">Company {index + 1}</p>
+                  <p className="text-sm text-charcoal-600">{item.rationale}</p>
                 </div>
                 <div className="text-right">
-                  <p className="font-semibold text-gray-800">
+                  <p className="font-semibold text-pov-charcoal">
                     ${(item.allocation / 1000000).toFixed(1)}M
                   </p>
                   <div
                     className={`px-2 py-1 rounded-full text-xs font-medium inline-block ${
                       item.confidence >= 0.7
-                        ? 'bg-green-50 text-green-700'
-                        : 'bg-orange-50 text-orange-700'
+                        ? 'bg-success/10 text-success-dark'
+                        : 'bg-warning/10 text-warning-dark'
                     }`}
                   >
                     {(item.confidence * 100).toFixed(0)}% confidence

--- a/client/src/components/common/ExportCsvButton.tsx
+++ b/client/src/components/common/ExportCsvButton.tsx
@@ -1,19 +1,34 @@
 import React from 'react';
 
 export function ExportCsvButton({
-  rows, filename = 'export.csv'
-}: { rows: Array<Record<string, unknown>>; filename?: string }) {
+  rows,
+  filename = 'export.csv',
+}: {
+  rows: Array<Record<string, unknown>>;
+  filename?: string;
+}) {
   const onExport = async () => {
     if (!rows?.length) return;
 
     // Lazy load papaparse only when needed (~45KB bundle savings)
-    const { unparse } = await import('papaparse').then(m => m.default || m);
+    const { unparse } = await import('papaparse').then((m) => m.default || m);
 
     const csv = unparse(rows, { header: true });
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a'); a.href = url; a.download = filename; a.click();
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
     URL.revokeObjectURL(url);
   };
-  return <button onClick={onExport} style={{ padding:'6px 10px', border:'1px solid #ddd', borderRadius:6 }}>Export CSV</button>;
+  return (
+    <button
+      onClick={onExport}
+      className="border border-beige-200 bg-white text-pov-charcoal hover:bg-pov-gray"
+      style={{ padding: '6px 10px', borderRadius: 6 }}
+    >
+      Export CSV
+    </button>
+  );
 }

--- a/client/src/components/common/ResultsHeader.tsx
+++ b/client/src/components/common/ResultsHeader.tsx
@@ -1,35 +1,31 @@
-import React from "react";
-import { useQueryParam } from "@/utils/useQueryParam";
-import type { Status } from "@/components/common/StatusChip";
-import { StatusChip } from "@/components/common/StatusChip";
+import React from 'react';
+import { useQueryParam } from '@/utils/useQueryParam';
+import type { Status } from '@/components/common/StatusChip';
+import { StatusChip } from '@/components/common/StatusChip';
 
-const ALLOWED = new Set(["construction", "current"]);
+const ALLOWED = new Set(['construction', 'current']);
 
-export function ResultsHeader({
-  status,
-  title = "Results",
-}: {
-  status: Status;
-  title?: string;
-}) {
-  const [view, setView] = useQueryParam("view", "current");
-  const safeView = ALLOWED.has(view) ? view : "current";
+export function ResultsHeader({ status, title = 'Results' }: { status: Status; title?: string }) {
+  const [view, setView] = useQueryParam('view', 'current');
+  const safeView = ALLOWED.has(view) ? view : 'current';
 
-  const next = safeView === "current" ? "construction" : "current";
+  const next = safeView === 'current' ? 'construction' : 'current';
 
   return (
     <div className="flex items-center justify-between gap-3">
       <div className="flex items-center gap-3">
-        <h2 className="text-xl font-semibold">{title} ({safeView})</h2>
+        <h2 className="text-xl font-semibold">
+          {title} ({safeView})
+        </h2>
         <StatusChip status={status} />
       </div>
       <button
         type="button"
         onClick={() => setView(next)}
-        className="px-3 py-1 rounded border bg-white hover:bg-gray-50 text-sm"
+        className="px-3 py-1 rounded border border-beige-200 bg-white text-pov-charcoal hover:bg-pov-gray text-sm"
         aria-label={`switch to ${next}`}
       >
-        {safeView === "current" ? "Switch to Construction" : "Switch to Current"}
+        {safeView === 'current' ? 'Switch to Construction' : 'Switch to Current'}
       </button>
     </div>
   );

--- a/client/src/components/common/StatusChip.tsx
+++ b/client/src/components/common/StatusChip.tsx
@@ -1,27 +1,27 @@
-import React from "react";
+import React from 'react';
 
-export type Status = "complete" | "partial" | "fallback";
+export type Status = 'complete' | 'partial' | 'fallback';
 
 export function StatusChip({ status }: { status: Status }) {
   const cls =
-    status === "complete"
-      ? "bg-green-100 text-green-700 ring-green-200"
-      : status === "partial"
-      ? "bg-amber-100 text-amber-700 ring-amber-200"
-      : "bg-gray-100 text-gray-700 ring-gray-200";
+    status === 'complete'
+      ? 'bg-success/10 text-success-dark border-success/50'
+      : status === 'partial'
+        ? 'bg-warning/10 text-warning-dark border-warning/50'
+        : 'bg-pov-gray text-charcoal-700 border-charcoal/7';
 
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ring-1 ${cls}`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium border ${cls}`}
       aria-label={`status: ${status}`}
     >
       <span
         className={`inline-block w-1.5 h-1.5 rounded-full ${
-          status === "complete"
-            ? "bg-green-600"
-            : status === "partial"
-            ? "bg-amber-600"
-            : "bg-gray-500"
+          status === 'complete'
+            ? 'bg-success'
+            : status === 'partial'
+              ? 'bg-warning'
+              : 'bg-charcoal-500'
         }`}
       />
       {status}

--- a/client/src/components/common/ToastQueue.tsx
+++ b/client/src/components/common/ToastQueue.tsx
@@ -4,12 +4,20 @@ type ToastType = 'success' | 'error' | 'info';
 type Toast = { id: string; type: ToastType; message: string; at: number; ttl: number };
 type ToastAddDetail = Pick<Toast, 'message' | 'type' | 'ttl'>;
 
+const TOAST_COLOR_CLASSES: Record<ToastType, string> = {
+  success: 'bg-success/10 text-success-dark border-success/50',
+  error: 'bg-error/10 text-error-dark border-error/50',
+  info: 'bg-presson-info/10 text-presson-info border-presson-info/30',
+};
+
 const MAX_TOASTS = 3;
 const DEFAULT_TTL = 3000;
 const bus = new EventTarget();
 
 export function pushToast(message: string, type: ToastType = 'info', ttl = DEFAULT_TTL) {
-  bus.dispatchEvent(new CustomEvent<ToastAddDetail>('toast:add', { detail: { message, type, ttl } }));
+  bus.dispatchEvent(
+    new CustomEvent<ToastAddDetail>('toast:add', { detail: { message, type, ttl } })
+  );
 }
 export const toastSuccess = (m: string) => pushToast(m, 'success');
 export const toastError = (m: string) => pushToast(m, 'error');
@@ -21,7 +29,13 @@ export function ToastViewport() {
   React.useEffect(() => {
     function onAdd(e: Event) {
       const { message, type, ttl } = (e as CustomEvent<ToastAddDetail>).detail;
-      const t: Toast = { id: Math.random().toString(36).slice(2), type, message, at: Date.now(), ttl };
+      const t: Toast = {
+        id: Math.random().toString(36).slice(2),
+        type,
+        message,
+        at: Date.now(),
+        ttl,
+      };
       setToasts((prev) => {
         const next = [...prev, t];
         return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
@@ -34,16 +48,33 @@ export function ToastViewport() {
 
   if (!toasts.length) return null;
   return (
-    <div aria-live="polite" aria-atomic="true" role="status"
-         style={{ position:'fixed', right:16, top:16, display:'flex', flexDirection:'column', gap:8, zIndex:9999 }}>
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      role="status"
+      style={{
+        position: 'fixed',
+        right: 16,
+        top: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        zIndex: 9999,
+      }}
+    >
       {toasts.map((t) => (
-        <div key={t.id}
-             style={{
-               minWidth:260, maxWidth:420, padding:'10px 12px', borderRadius:8,
-               color:'#111', background: t.type==='error' ? '#fecaca' : t.type==='success' ? '#bbf7d0' : '#e5e7eb',
-               border:'1px solid rgba(0,0,0,.08)', boxShadow:'0 8px 20px rgba(0,0,0,.08)'
-             }}>
-          <strong style={{marginRight:6}}>
+        <div
+          key={t.id}
+          className={`border ${TOAST_COLOR_CLASSES[t.type]}`}
+          style={{
+            minWidth: 260,
+            maxWidth: 420,
+            padding: '10px 12px',
+            borderRadius: 8,
+            boxShadow: '0 8px 20px rgba(0,0,0,.08)',
+          }}
+        >
+          <strong style={{ marginRight: 6 }}>
             {t.type === 'error' ? 'Error' : t.type === 'success' ? 'Saved' : 'Notice'}:
           </strong>
           <span>{t.message}</span>

--- a/client/src/components/dashboard/CashflowDashboard.tsx
+++ b/client/src/components/dashboard/CashflowDashboard.tsx
@@ -1,10 +1,16 @@
 import React, { useState, useMemo } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   AreaChart,
   Area,
@@ -18,7 +24,7 @@ import {
   Line,
   PieChart,
   Pie,
-  Cell
+  Cell,
 } from 'recharts';
 import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/charts/LazyResponsiveContainer';
 import {
@@ -32,10 +38,26 @@ import {
   Activity,
   RefreshCw,
   Download,
-  Zap
-} from "lucide-react";
-import { useLiquidityAnalytics, useLiquidityAlerts, useLiquidityMetrics } from '@/hooks/useLiquidityAnalytics';
+  Zap,
+} from 'lucide-react';
+import {
+  useLiquidityAnalytics,
+  useLiquidityAlerts,
+  useLiquidityMetrics,
+} from '@/hooks/useLiquidityAnalytics';
 import { useFundContext } from '@/contexts/FundContext';
+import { presson } from '@/theme/presson.tokens';
+import { colors as brandColors, getChartColor } from '@/lib/brand-tokens';
+
+const STATUS_SUCCESS = brandColors.success;
+const CASHFLOW_CHART_COLORS = {
+  positive: presson.color.positive,
+  negative: presson.color.negative,
+  warning: presson.color.warning,
+  info: presson.color.info,
+  text: presson.color.text,
+  success: STATUS_SUCCESS,
+} as const;
 
 interface CashflowDashboardProps {
   fundId: string;
@@ -62,24 +84,33 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
 
   // Use additional hooks
   const { alerts } = useLiquidityAlerts(
-    analytics.liquidityForecast ? {
-      fundId,
-      asOfDate: new Date(),
-      bankAccounts: [],
-      totalCash: analytics.liquidityForecast.openingCash,
-      totalCommitted: analytics.liquidityForecast.openingCommitted,
-      totalDeployed: fundSize * 1000000 - analytics.liquidityForecast.openingCommitted,
-      availableLiquidity: analytics.liquidityForecast.openingCash,
-      pendingInflows: analytics.liquidityForecast.plannedCapitalCalls + analytics.liquidityForecast.expectedDistributions,
-      pendingOutflows: analytics.liquidityForecast.plannedInvestments + analytics.liquidityForecast.plannedExpenses,
-      netPending: (analytics.liquidityForecast.plannedCapitalCalls + analytics.liquidityForecast.expectedDistributions) -
-                  (analytics.liquidityForecast.plannedInvestments + analytics.liquidityForecast.plannedExpenses),
-      dryPowder: analytics.liquidityForecast.openingCash * 0.8,
-      reserveRequirement: fundSize * 1000000 * 0.15,
-      availableInvestment: analytics.liquidityForecast.openingCash * 0.8,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    } : null,
+    analytics.liquidityForecast
+      ? {
+          fundId,
+          asOfDate: new Date(),
+          bankAccounts: [],
+          totalCash: analytics.liquidityForecast.openingCash,
+          totalCommitted: analytics.liquidityForecast.openingCommitted,
+          totalDeployed: fundSize * 1000000 - analytics.liquidityForecast.openingCommitted,
+          availableLiquidity: analytics.liquidityForecast.openingCash,
+          pendingInflows:
+            analytics.liquidityForecast.plannedCapitalCalls +
+            analytics.liquidityForecast.expectedDistributions,
+          pendingOutflows:
+            analytics.liquidityForecast.plannedInvestments +
+            analytics.liquidityForecast.plannedExpenses,
+          netPending:
+            analytics.liquidityForecast.plannedCapitalCalls +
+            analytics.liquidityForecast.expectedDistributions -
+            (analytics.liquidityForecast.plannedInvestments +
+              analytics.liquidityForecast.plannedExpenses),
+          dryPowder: analytics.liquidityForecast.openingCash * 0.8,
+          reserveRequirement: fundSize * 1000000 * 0.15,
+          availableInvestment: analytics.liquidityForecast.openingCash * 0.8,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }
+      : null,
     analytics.liquidityForecast
   );
 
@@ -89,7 +120,7 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
   const cashFlowChartData = useMemo(() => {
     if (!analytics.cashFlowAnalysis) return [];
 
-    return analytics.cashFlowAnalysis.byMonth.map(month => ({
+    return analytics.cashFlowAnalysis.byMonth.map((month) => ({
       month: month.month,
       inflows: month.totalInflow / 1000000, // Convert to millions
       outflows: month.totalOutflow / 1000000,
@@ -109,13 +140,18 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
       date.setMonth(date.getMonth() + i);
 
       // Simple linear projection for demonstration
-      const cashDecline = (analytics.liquidityForecast.openingCash - analytics.liquidityForecast.projectedCash) / months;
-      const projectedCash = analytics.liquidityForecast.openingCash - (cashDecline * i);
+      const cashDecline =
+        (analytics.liquidityForecast.openingCash - analytics.liquidityForecast.projectedCash) /
+        months;
+      const projectedCash = analytics.liquidityForecast.openingCash - cashDecline * i;
 
       data.push({
         month: date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' }),
         cash: Math.max(0, projectedCash / 1000000),
-        committed: (analytics.liquidityForecast.openingCommitted - (analytics.liquidityForecast.plannedCapitalCalls * i / months)) / 1000000,
+        committed:
+          (analytics.liquidityForecast.openingCommitted -
+            (analytics.liquidityForecast.plannedCapitalCalls * i) / months) /
+          1000000,
       });
     }
 
@@ -128,7 +164,7 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
     const expenses = Object.entries(analytics.cashFlowAnalysis.byType)
       .filter(([_type, amount]) => amount < 0)
       .map(([type, amount]) => ({
-        type: type.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase()),
+        type: type.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
         amount: Math.abs(amount / 1000000),
         color: getColorForExpenseType(type),
       }));
@@ -147,7 +183,9 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
       <div className="flex justify-between items-center">
         <div>
           <h2 className="text-2xl font-bold">Cashflow & Liquidity Management</h2>
-          <p className="text-muted-foreground">Real-time liquidity monitoring and cash flow forecasting</p>
+          <p className="text-muted-foreground">
+            Real-time liquidity monitoring and cash flow forecasting
+          </p>
         </div>
         <div className="flex items-center gap-3">
           <Select value={timeframe} onValueChange={setTimeframe}>
@@ -166,19 +204,25 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
             onClick={analytics.refreshAll}
             disabled={analytics.isLoadingAnalysis || analytics.isLoadingForecast}
           >
-            <RefreshCw className={`h-4 w-4 mr-2 ${analytics.isLoadingAnalysis || analytics.isLoadingForecast ? 'animate-spin' : ''}`} />
+            <RefreshCw
+              className={`h-4 w-4 mr-2 ${analytics.isLoadingAnalysis || analytics.isLoadingForecast ? 'animate-spin' : ''}`}
+            />
             Refresh
           </Button>
-          <Button variant="outline" size="sm" onClick={async () => {
-            const data = await analytics.exportData();
-            const blob = new Blob([data], { type: 'application/json' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `cashflow-analysis-${fundId}-${new Date().toISOString().split('T')[0]}.json`;
-            a.click();
-            URL.revokeObjectURL(url);
-          }}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={async () => {
+              const data = await analytics.exportData();
+              const blob = new Blob([data], { type: 'application/json' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = `cashflow-analysis-${fundId}-${new Date().toISOString().split('T')[0]}.json`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+          >
             <Download className="h-4 w-4 mr-2" />
             Export
           </Button>
@@ -188,7 +232,7 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
       {/* Alerts */}
       {alerts.length > 0 && (
         <div className="space-y-2">
-          {alerts.map(alert => (
+          {alerts.map((alert) => (
             <Alert key={alert.id} variant={alert.type === 'error' ? 'destructive' : 'default'}>
               <AlertTriangle className="h-4 w-4" />
               <AlertDescription>
@@ -203,44 +247,85 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <MetricCard
           title="Available Cash"
-          value={analytics.liquidityForecast?.openingCash ? formatCurrencyShort(analytics.liquidityForecast.openingCash / 1000000) : '--'}
-          {...(analytics.cashFlowAnalysis?.summary.netCashFlow ? {
-            change: `${analytics.cashFlowAnalysis.summary.netCashFlow > 0 ? '+' : ''}${formatCurrencyShort(analytics.cashFlowAnalysis.summary.netCashFlow / 1000000)} this month`
-          } : {})}
-          {...(analytics.cashFlowAnalysis?.patterns.netFlowTrend ? { trend: analytics.cashFlowAnalysis.patterns.netFlowTrend } : {})}
+          value={
+            analytics.liquidityForecast?.openingCash
+              ? formatCurrencyShort(analytics.liquidityForecast.openingCash / 1000000)
+              : '--'
+          }
+          {...(analytics.cashFlowAnalysis?.summary.netCashFlow
+            ? {
+                change: `${analytics.cashFlowAnalysis.summary.netCashFlow > 0 ? '+' : ''}${formatCurrencyShort(analytics.cashFlowAnalysis.summary.netCashFlow / 1000000)} this month`,
+              }
+            : {})}
+          {...(analytics.cashFlowAnalysis?.patterns.netFlowTrend
+            ? { trend: analytics.cashFlowAnalysis.patterns.netFlowTrend }
+            : {})}
           icon={DollarSign as React.ComponentType<{ className?: string }>}
           loading={analytics.isLoadingAnalysis}
         />
 
         <MetricCard
           title="Liquidity Ratio"
-          value={analytics.liquidityForecast?.liquidityRatio ? analytics.liquidityForecast.liquidityRatio.toFixed(2) : '--'}
-          {...(analytics.liquidityForecast?.liquidityRatio ? {
-            change: `${analytics.liquidityForecast.liquidityRatio >= 1.5 ? 'Healthy' : 'Low'}`
-          } : {})}
-          trend={analytics.liquidityForecast?.liquidityRatio && analytics.liquidityForecast.liquidityRatio >= 1.5 ? 'stable' : 'decreasing'}
+          value={
+            analytics.liquidityForecast?.liquidityRatio
+              ? analytics.liquidityForecast.liquidityRatio.toFixed(2)
+              : '--'
+          }
+          {...(analytics.liquidityForecast?.liquidityRatio
+            ? {
+                change: `${analytics.liquidityForecast.liquidityRatio >= 1.5 ? 'Healthy' : 'Low'}`,
+              }
+            : {})}
+          trend={
+            analytics.liquidityForecast?.liquidityRatio &&
+            analytics.liquidityForecast.liquidityRatio >= 1.5
+              ? 'stable'
+              : 'decreasing'
+          }
           icon={Target as React.ComponentType<{ className?: string }>}
           loading={analytics.isLoadingForecast}
         />
 
         <MetricCard
           title="Burn Rate"
-          value={analytics.liquidityForecast?.burnRate ? `${formatCurrencyShort(analytics.liquidityForecast.burnRate / 1000000)  }/mo` : '--'}
-          {...(liquidityMetrics?.deploymentRate ? {
-            change: `${(liquidityMetrics.deploymentRate * 100).toFixed(1)}% deployment rate`
-          } : {})}
-          {...(analytics.cashFlowAnalysis?.patterns.outflowTrend ? { trend: analytics.cashFlowAnalysis.patterns.outflowTrend } : {})}
+          value={
+            analytics.liquidityForecast?.burnRate
+              ? `${formatCurrencyShort(analytics.liquidityForecast.burnRate / 1000000)}/mo`
+              : '--'
+          }
+          {...(liquidityMetrics?.deploymentRate
+            ? {
+                change: `${(liquidityMetrics.deploymentRate * 100).toFixed(1)}% deployment rate`,
+              }
+            : {})}
+          {...(analytics.cashFlowAnalysis?.patterns.outflowTrend
+            ? { trend: analytics.cashFlowAnalysis.patterns.outflowTrend }
+            : {})}
           icon={Activity as React.ComponentType<{ className?: string }>}
           loading={analytics.isLoadingAnalysis}
         />
 
         <MetricCard
           title="Cash Runway"
-          value={analytics.liquidityForecast?.runwayMonths ? `${analytics.liquidityForecast.runwayMonths.toFixed(1)}mo` : '--'}
-          {...(analytics.liquidityForecast?.runwayMonths ? {
-            change: `${analytics.liquidityForecast.runwayMonths >= 12 ? 'Excellent' : analytics.liquidityForecast.runwayMonths >= 6 ? 'Good' : 'Critical'}`
-          } : {})}
-          trend={analytics.liquidityForecast?.runwayMonths && analytics.liquidityForecast.runwayMonths >= 12 ? 'increasing' : analytics.liquidityForecast?.runwayMonths && analytics.liquidityForecast.runwayMonths >= 6 ? 'stable' : 'decreasing'}
+          value={
+            analytics.liquidityForecast?.runwayMonths
+              ? `${analytics.liquidityForecast.runwayMonths.toFixed(1)}mo`
+              : '--'
+          }
+          {...(analytics.liquidityForecast?.runwayMonths
+            ? {
+                change: `${analytics.liquidityForecast.runwayMonths >= 12 ? 'Excellent' : analytics.liquidityForecast.runwayMonths >= 6 ? 'Good' : 'Critical'}`,
+              }
+            : {})}
+          trend={
+            analytics.liquidityForecast?.runwayMonths &&
+            analytics.liquidityForecast.runwayMonths >= 12
+              ? 'increasing'
+              : analytics.liquidityForecast?.runwayMonths &&
+                  analytics.liquidityForecast.runwayMonths >= 6
+                ? 'stable'
+                : 'decreasing'
+          }
           icon={Clock as React.ComponentType<{ className?: string }>}
           loading={analytics.isLoadingForecast}
         />
@@ -269,9 +354,27 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="month" />
                     <YAxis />
-                    <Tooltip formatter={(value) => value !== undefined ? formatCurrencyShort(Number(value)) : ''} />
-                    <Area type="monotone" dataKey="inflows" stackId="1" stroke="#10b981" fill="#10b981" fillOpacity={0.6} />
-                    <Area type="monotone" dataKey="outflows" stackId="2" stroke="#ef4444" fill="#ef4444" fillOpacity={0.6} />
+                    <Tooltip
+                      formatter={(value) =>
+                        value !== undefined ? formatCurrencyShort(Number(value)) : ''
+                      }
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="inflows"
+                      stackId="1"
+                      stroke={CASHFLOW_CHART_COLORS.positive}
+                      fill={CASHFLOW_CHART_COLORS.positive}
+                      fillOpacity={0.6}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="outflows"
+                      stackId="2"
+                      stroke={CASHFLOW_CHART_COLORS.negative}
+                      fill={CASHFLOW_CHART_COLORS.negative}
+                      fillOpacity={0.6}
+                    />
                   </AreaChart>
                 </ResponsiveContainer>
               </CardContent>
@@ -288,8 +391,12 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="month" />
                     <YAxis />
-                    <Tooltip formatter={(value) => value !== undefined ? formatCurrencyShort(Number(value)) : ''} />
-                    <Bar dataKey="netFlow" fill="#3b82f6" />
+                    <Tooltip
+                      formatter={(value) =>
+                        value !== undefined ? formatCurrencyShort(Number(value)) : ''
+                      }
+                    />
+                    <Bar dataKey="netFlow" fill={CASHFLOW_CHART_COLORS.info} />
                   </BarChart>
                 </ResponsiveContainer>
               </CardContent>
@@ -302,7 +409,9 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
           <Card>
             <CardHeader>
               <CardTitle>Liquidity Forecast</CardTitle>
-              <CardDescription>Projected cash and committed capital over {timeframe}</CardDescription>
+              <CardDescription>
+                Projected cash and committed capital over {timeframe}
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={400}>
@@ -310,9 +419,26 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="month" />
                   <YAxis />
-                  <Tooltip formatter={(value) => value !== undefined ? formatCurrencyShort(Number(value)) : ''} />
-                  <Line type="monotone" dataKey="cash" stroke="#3b82f6" strokeWidth={3} name="Available Cash" />
-                  <Line type="monotone" dataKey="committed" stroke="#8b5cf6" strokeWidth={2} strokeDasharray="5 5" name="Undrawn Commitments" />
+                  <Tooltip
+                    formatter={(value) =>
+                      value !== undefined ? formatCurrencyShort(Number(value)) : ''
+                    }
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="cash"
+                    stroke={CASHFLOW_CHART_COLORS.info}
+                    strokeWidth={3}
+                    name="Available Cash"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="committed"
+                    stroke={CASHFLOW_CHART_COLORS.text}
+                    strokeWidth={2}
+                    strokeDasharray="5 5"
+                    name="Undrawn Commitments"
+                  />
                 </LineChart>
               </ResponsiveContainer>
             </CardContent>
@@ -323,19 +449,28 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
             <Card>
               <CardHeader>
                 <CardTitle>Scenario Analysis</CardTitle>
-                <CardDescription>Different liquidity scenarios and their probabilities</CardDescription>
+                <CardDescription>
+                  Different liquidity scenarios and their probabilities
+                </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
                   {analytics.liquidityForecast.scenarios.map((scenario, index) => (
-                    <div key={index} className="flex items-center justify-between p-4 border rounded-lg">
+                    <div
+                      key={index}
+                      className="flex items-center justify-between p-4 border rounded-lg"
+                    >
                       <div className="flex-1">
                         <h4 className="font-medium">{scenario.name}</h4>
                         <p className="text-sm text-muted-foreground">{scenario.notes}</p>
                       </div>
                       <div className="text-right">
-                        <div className="font-medium">{formatCurrencyShort(scenario.projectedCash / 1000000)}</div>
-                        <div className="text-sm text-muted-foreground">{(scenario.probability * 100).toFixed(0)}% probability</div>
+                        <div className="font-medium">
+                          {formatCurrencyShort(scenario.projectedCash / 1000000)}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          {(scenario.probability * 100).toFixed(0)}% probability
+                        </div>
                       </div>
                     </div>
                   ))}
@@ -361,14 +496,18 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                       cx="50%"
                       cy="50%"
                       outerRadius={100}
-                      fill="#8884d8"
+                      fill={CASHFLOW_CHART_COLORS.text}
                       dataKey="amount"
                     >
                       {expenseBreakdownData.map((entry, index) => (
                         <Cell key={`cell-${index}`} fill={entry.color} />
                       ))}
                     </Pie>
-                    <Tooltip formatter={(value) => value !== undefined ? formatCurrencyShort(Number(value)) : ''} />
+                    <Tooltip
+                      formatter={(value) =>
+                        value !== undefined ? formatCurrencyShort(Number(value)) : ''
+                      }
+                    />
                   </PieChart>
                 </ResponsiveContainer>
               </CardContent>
@@ -388,15 +527,21 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                     </div>
                     <div className="flex justify-between items-center">
                       <span className="text-sm font-medium">Deployment Rate</span>
-                      <span className="text-sm">{(liquidityMetrics.deploymentRate * 100).toFixed(1)}%</span>
+                      <span className="text-sm">
+                        {(liquidityMetrics.deploymentRate * 100).toFixed(1)}%
+                      </span>
                     </div>
                     <div className="flex justify-between items-center">
                       <span className="text-sm font-medium">Avg Cycle Time</span>
-                      <span className="text-sm">{liquidityMetrics.avgCycleTime.toFixed(0)} days</span>
+                      <span className="text-sm">
+                        {liquidityMetrics.avgCycleTime.toFixed(0)} days
+                      </span>
                     </div>
                     <div className="flex justify-between items-center">
                       <span className="text-sm font-medium">Cash Flow Volatility</span>
-                      <span className="text-sm">{formatCurrencyShort(liquidityMetrics.cashFlowVolatility / 1000000)}</span>
+                      <span className="text-sm">
+                        {formatCurrencyShort(liquidityMetrics.cashFlowVolatility / 1000000)}
+                      </span>
                     </div>
                   </div>
                 ) : (
@@ -421,20 +566,33 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                 <div className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div className="text-center p-4 border rounded-lg">
-                      <div className="text-2xl font-bold text-green-600">
-                        {analytics.stressTestResult.scenarios.filter(s => s.endingCash > 0).length}
+                      <div className="text-2xl font-bold text-success-dark">
+                        {
+                          analytics.stressTestResult.scenarios.filter((s) => s.endingCash > 0)
+                            .length
+                        }
                       </div>
                       <div className="text-sm text-muted-foreground">Scenarios Pass</div>
                     </div>
                     <div className="text-center p-4 border rounded-lg">
-                      <div className="text-2xl font-bold text-red-600">
-                        {analytics.stressTestResult.scenarios.filter(s => s.endingCash <= 0).length}
+                      <div className="text-2xl font-bold text-error-dark">
+                        {
+                          analytics.stressTestResult.scenarios.filter((s) => s.endingCash <= 0)
+                            .length
+                        }
                       </div>
                       <div className="text-sm text-muted-foreground">Scenarios Fail</div>
                     </div>
                     <div className="text-center p-4 border rounded-lg">
-                      <div className={`text-2xl font-bold ${analytics.stressTestResult.riskLevel === 'low' ? 'text-green-600' :
-                                                           analytics.stressTestResult.riskLevel === 'medium' ? 'text-yellow-600' : 'text-red-600'}`}>
+                      <div
+                        className={`text-2xl font-bold ${
+                          analytics.stressTestResult.riskLevel === 'low'
+                            ? 'text-success-dark'
+                            : analytics.stressTestResult.riskLevel === 'medium'
+                              ? 'text-warning-dark'
+                              : 'text-error-dark'
+                        }`}
+                      >
                         {analytics.stressTestResult.riskLevel.toUpperCase()}
                       </div>
                       <div className="text-sm text-muted-foreground">Risk Level</div>
@@ -444,17 +602,29 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                   <div className="space-y-3">
                     <h4 className="font-medium">Stress Test Scenarios</h4>
                     {analytics.stressTestResult.scenarios.map((scenario, index) => (
-                      <div key={index} className="flex items-center justify-between p-4 border rounded-lg">
+                      <div
+                        key={index}
+                        className="flex items-center justify-between p-4 border rounded-lg"
+                      >
                         <div className="flex-1">
                           <h5 className="font-medium">{scenario.name}</h5>
                           <p className="text-sm text-muted-foreground">{scenario.description}</p>
                         </div>
                         <div className="text-right">
-                          <div className={`font-medium ${scenario.endingCash > 0 ? 'text-green-600' : 'text-red-600'}`}>
+                          <div
+                            className={`font-medium ${scenario.endingCash > 0 ? 'text-presson-positive' : 'text-presson-negative'}`}
+                          >
                             {formatCurrencyShort(scenario.endingCash / 1000000)}
                           </div>
-                          <Badge variant={scenario.impactRating === 'high' ? 'destructive' :
-                                          scenario.impactRating === 'medium' ? 'default' : 'secondary'}>
+                          <Badge
+                            variant={
+                              scenario.impactRating === 'high'
+                                ? 'destructive'
+                                : scenario.impactRating === 'medium'
+                                  ? 'default'
+                                  : 'secondary'
+                            }
+                          >
                             {scenario.impactRating} impact
                           </Badge>
                         </div>
@@ -467,7 +637,10 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                       <h4 className="font-medium">Recommendations</h4>
                       <ul className="space-y-1">
                         {analytics.stressTestResult.recommendations.map((rec, index) => (
-                          <li key={index} className="text-sm text-muted-foreground flex items-start gap-2">
+                          <li
+                            key={index}
+                            className="text-sm text-muted-foreground flex items-start gap-2"
+                          >
                             <ArrowUpRight className="h-4 w-4 mt-0.5 flex-shrink-0" />
                             {rec}
                           </li>
@@ -478,7 +651,10 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                 </div>
               ) : (
                 <div className="text-center py-8">
-                  <Button onClick={() => analytics.runStressTest()} disabled={analytics.isLoadingStressTest}>
+                  <Button
+                    onClick={() => analytics.runStressTest()}
+                    disabled={analytics.isLoadingStressTest}
+                  >
                     {analytics.isLoadingStressTest ? (
                       <>
                         <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
@@ -524,11 +700,15 @@ function MetricCard({ title, value, change, trend, icon: Icon, loading }: Metric
             <span className="text-sm font-medium text-muted-foreground">{title}</span>
           </div>
           {trend && (
-            <div className={`p-1 rounded ${
-              trend === 'increasing' ? 'bg-green-100 text-green-600' :
-              trend === 'decreasing' ? 'bg-red-100 text-red-600' :
-              'bg-gray-100 text-gray-600'
-            }`}>
+            <div
+              className={`p-1 rounded ${
+                trend === 'increasing'
+                  ? 'bg-success/10 text-success-dark'
+                  : trend === 'decreasing'
+                    ? 'bg-error/10 text-error-dark'
+                    : 'bg-pov-gray text-charcoal-600'
+              }`}
+            >
               {trend === 'increasing' ? (
                 <TrendingUp className="h-3 w-3" />
               ) : trend === 'decreasing' ? (
@@ -542,15 +722,13 @@ function MetricCard({ title, value, change, trend, icon: Icon, loading }: Metric
         <div className="mt-3">
           {loading ? (
             <div className="animate-pulse">
-              <div className="h-8 bg-gray-200 rounded w-24"></div>
-              <div className="h-4 bg-gray-200 rounded w-32 mt-2"></div>
+              <div className="h-8 bg-pov-gray rounded w-24"></div>
+              <div className="h-4 bg-pov-gray rounded w-32 mt-2"></div>
             </div>
           ) : (
             <>
               <div className="text-2xl font-bold">{value}</div>
-              {change && (
-                <div className="text-sm text-muted-foreground mt-1">{change}</div>
-              )}
+              {change && <div className="text-sm text-muted-foreground mt-1">{change}</div>}
             </>
           )}
         </div>
@@ -563,14 +741,17 @@ function MetricCard({ title, value, change, trend, icon: Icon, loading }: Metric
 // HELPER FUNCTIONS
 // =============================================================================
 
+// Expense types are NEUTRAL categories (all cash movements, not gain/loss), so they
+// use the monochrome brand categorical palette — avoids implying financial direction.
+const EXPENSE_TYPE_ORDER = [
+  'expense',
+  'management_fee',
+  'investment',
+  'follow_on',
+  'bridge_loan',
+  'other',
+];
 function getColorForExpenseType(type: string): string {
-  const colors: Record<string, string> = {
-    'expense': '#ef4444',
-    'management_fee': '#f97316',
-    'investment': '#3b82f6',
-    'follow_on': '#8b5cf6',
-    'bridge_loan': '#06b6d4',
-    'other': '#6b7280',
-  };
-  return colors[type] || '#6b7280';
+  const idx = EXPENSE_TYPE_ORDER.indexOf(type);
+  return getChartColor(idx >= 0 ? idx : EXPENSE_TYPE_ORDER.length, true);
 }

--- a/client/src/components/dashboard/DashboardCard.tsx
+++ b/client/src/components/dashboard/DashboardCard.tsx
@@ -1,8 +1,3 @@
- 
- 
- 
- 
- 
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -21,44 +16,30 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
   change,
   changeLabel,
   metric,
-  icon
+  icon,
 }) => {
-  const changeColor = change && change > 0 ? 'text-green-600' : 'text-red-600';
+  const changeColor = change && change > 0 ? 'text-presson-positive' : 'text-presson-negative';
   const changeIcon = change && change > 0 ? '↗' : '↘';
 
   return (
-    <Card className="bg-white rounded-lg border border-lightGray shadow-card hover:shadow-elevated transition-all duration-200">
+    <Card className="bg-white rounded-lg border border-beige-200 shadow-card hover:shadow-elevated transition-all duration-200">
       <CardContent className="p-6">
         <div className="flex items-center justify-between">
           <div className="flex-1">
             <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-medium text-charcoal/70 font-poppins">
-                {title}
-              </h3>
-              {icon && (
-                <div className="p-2 bg-beige/20 rounded-full text-charcoal">
-                  {icon}
-                </div>
-              )}
+              <h3 className="text-sm font-medium text-charcoal-500 font-poppins">{title}</h3>
+              {icon && <div className="p-2 bg-pov-gray rounded-full text-pov-charcoal">{icon}</div>}
             </div>
             <div className="flex items-baseline space-x-2">
-              <span className="text-2xl font-bold text-charcoal font-inter">
-                {value}
-              </span>
-              {metric && (
-                <span className="text-sm font-medium text-charcoal/70">
-                  {metric}
-                </span>
-              )}
+              <span className="text-2xl font-bold text-pov-charcoal font-inter">{value}</span>
+              {metric && <span className="text-sm font-medium text-charcoal-500">{metric}</span>}
             </div>
             {change !== undefined && changeLabel && (
               <div className="flex items-center mt-2">
                 <span className={`text-sm font-medium ${changeColor} mr-1`}>
                   {changeIcon} {Math.abs(change)}%
                 </span>
-                <span className="text-xs text-charcoal/70">
-                  {changeLabel}
-                </span>
+                <span className="text-xs text-charcoal-500">{changeLabel}</span>
               </div>
             )}
           </div>

--- a/client/src/components/dashboard/dashboard.tsx
+++ b/client/src/components/dashboard/dashboard.tsx
@@ -20,9 +20,30 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { TrendingUp, Building2, Target } from 'lucide-react';
 import PortfolioConcentration from './portfolio-concentration';
+import { presson } from '@/theme/presson.tokens';
+import { colors as brandColors } from '@/lib/brand-tokens';
 
 type DashboardViewType = 'construction' | 'current';
 type DashboardTab = 'fund' | 'performance' | 'exits' | 'rounds' | 'lp' | 'insights' | 'visualizer';
+
+const STATUS_SUCCESS = brandColors.success;
+const DASHBOARD_CHART_COLORS = {
+  text: presson.color.text,
+  grid: presson.color.surfaceSubtle,
+  positive: presson.color.positive,
+  info: presson.color.info,
+  warning: presson.color.warning,
+  negative: presson.color.negative,
+  success: STATUS_SUCCESS,
+} as const;
+const CATEGORY_SERIES_COLORS = [
+  DASHBOARD_CHART_COLORS.text,
+  DASHBOARD_CHART_COLORS.positive,
+  DASHBOARD_CHART_COLORS.info,
+  DASHBOARD_CHART_COLORS.success,
+  DASHBOARD_CHART_COLORS.warning,
+  DASHBOARD_CHART_COLORS.negative,
+] as const;
 
 const formatMillionsTick = (value: number | string): string => {
   const numericValue = typeof value === 'number' ? value : Number(value);
@@ -38,8 +59,8 @@ export default function Dashboard() {
     return (
       <div className="flex-1 overflow-y-auto p-6 custom-scrollbar">
         <div className="animate-pulse space-y-8">
-          <div className="h-20 bg-gray-200 rounded-xl"></div>
-          <div className="h-96 bg-gray-200 rounded-xl"></div>
+          <div className="h-20 bg-pov-gray rounded-xl"></div>
+          <div className="h-96 bg-pov-gray rounded-xl"></div>
         </div>
       </div>
     );
@@ -99,13 +120,13 @@ export default function Dashboard() {
         <Card className="bg-white border-0 shadow-card">
           <CardContent className="p-6">
             <div className="text-center">
-              <div className="text-3xl font-inter font-bold text-charcoal">
+              <div className="text-3xl font-inter font-bold text-pov-charcoal">
                 ${(investableCapital / 1000000).toFixed(1)}M
               </div>
-              <div className="text-beige/80 font-medium mt-1">
+              <div className="text-charcoal-600 font-medium mt-1">
                 {((investableCapital / committedCapital) * 100).toFixed(2)}%
               </div>
-              <div className="text-sm text-charcoal/70 mt-2">Investable Capital</div>
+              <div className="text-sm text-charcoal-500 mt-2">Investable Capital</div>
             </div>
           </CardContent>
         </Card>
@@ -114,22 +135,22 @@ export default function Dashboard() {
           <CardContent className="p-6">
             <div className="grid grid-cols-2 gap-4">
               <div className="text-center">
-                <div className="text-2xl font-inter font-bold text-charcoal">
+                <div className="text-2xl font-inter font-bold text-pov-charcoal">
                   ${(initialCapital / 1000000).toFixed(1)}M
                 </div>
-                <div className="text-beige/80 font-medium">
+                <div className="text-charcoal-600 font-medium">
                   {((initialCapital / investableCapital) * 100).toFixed(2)}%
                 </div>
-                <div className="text-sm text-charcoal/70 mt-1">Projected Initial</div>
+                <div className="text-sm text-charcoal-500 mt-1">Projected Initial</div>
               </div>
               <div className="text-center">
-                <div className="text-2xl font-inter font-bold text-charcoal">
+                <div className="text-2xl font-inter font-bold text-pov-charcoal">
                   ${(followOnCapital / 1000000).toFixed(1)}M
                 </div>
-                <div className="text-beige/80 font-medium">
+                <div className="text-charcoal-600 font-medium">
                   {((followOnCapital / investableCapital) * 100).toFixed(2)}%
                 </div>
-                <div className="text-sm text-charcoal/70 mt-1">Projected Follow-On</div>
+                <div className="text-sm text-charcoal-500 mt-1">Projected Follow-On</div>
               </div>
             </div>
           </CardContent>
@@ -138,19 +159,19 @@ export default function Dashboard() {
         <Card className="bg-white border-0 shadow-card">
           <CardContent className="p-6">
             <div className="text-center">
-              <div className="text-3xl font-inter font-bold text-charcoal">
+              <div className="text-3xl font-inter font-bold text-pov-charcoal">
                 {projectedInvestments}
               </div>
-              <div className="text-charcoal/70 font-medium mt-1">Projected</div>
-              <div className="text-sm text-charcoal/70 mt-2">Number of Initial Investments</div>
+              <div className="text-charcoal-500 font-medium mt-1">Projected</div>
+              <div className="text-sm text-charcoal-500 mt-2">Number of Initial Investments</div>
               <div className="flex justify-center space-x-4 mt-4">
                 <div className="text-center">
-                  <div className="text-lg font-bold text-charcoal">27</div>
-                  <div className="text-xs text-charcoal/50">By Entry Round</div>
+                  <div className="text-lg font-bold text-pov-charcoal">27</div>
+                  <div className="text-xs text-charcoal-400">By Entry Round</div>
                 </div>
                 <div className="text-center">
-                  <div className="text-lg font-bold text-charcoal">26</div>
-                  <div className="text-xs text-charcoal/50">By Allocations</div>
+                  <div className="text-lg font-bold text-pov-charcoal">26</div>
+                  <div className="text-xs text-charcoal-400">By Allocations</div>
                 </div>
               </div>
             </div>
@@ -162,38 +183,38 @@ export default function Dashboard() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <Card className="bg-white border-0 shadow-card">
           <CardHeader>
-            <CardTitle className="text-lg font-inter text-charcoal">
+            <CardTitle className="text-lg font-inter text-pov-charcoal">
               Investable Capital Breakdown
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
               <div className="flex justify-between items-center">
-                <span className="text-charcoal/70">Committed Capital</span>
-                <span className="font-mono text-charcoal">
+                <span className="text-charcoal-500">Committed Capital</span>
+                <span className="font-mono text-pov-charcoal">
                   ${(committedCapital / 1000000).toFixed(0)}M
                 </span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-charcoal/70">Cashless Commit</span>
-                <span className="font-mono text-red-600">($0.8M)</span>
+                <span className="text-charcoal-500">Cashless Commit</span>
+                <span className="font-mono text-presson-negative">($0.8M)</span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-charcoal/70">Management Fees</span>
-                <span className="font-mono text-red-600">($30.5M)</span>
+                <span className="text-charcoal-500">Management Fees</span>
+                <span className="font-mono text-presson-negative">($30.5M)</span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-charcoal/70">Fund Expenses</span>
-                <span className="font-mono text-red-600">($3.4M)</span>
+                <span className="text-charcoal-500">Fund Expenses</span>
+                <span className="font-mono text-presson-negative">($3.4M)</span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-charcoal/70">Exit Proceeds Recycled</span>
-                <span className="font-mono text-green-600">$40.0M</span>
+                <span className="text-charcoal-500">Exit Proceeds Recycled</span>
+                <span className="font-mono text-presson-positive">$40.0M</span>
               </div>
-              <div className="border-t border-charcoal/20 pt-4">
+              <div className="border-t border-charcoal/7 pt-4">
                 <div className="flex justify-between items-center font-bold">
-                  <span className="text-charcoal">Total Investable</span>
-                  <span className="font-mono text-charcoal">
+                  <span className="text-pov-charcoal">Total Investable</span>
+                  <span className="font-mono text-pov-charcoal">
                     ${(investableCapital / 1000000).toFixed(1)}M
                   </span>
                 </div>
@@ -204,7 +225,7 @@ export default function Dashboard() {
 
         <Card className="bg-white border-0 shadow-card">
           <CardHeader>
-            <CardTitle className="text-lg font-inter text-charcoal">
+            <CardTitle className="text-lg font-inter text-pov-charcoal">
               Capital Allocation by Entry Round
             </CardTitle>
           </CardHeader>
@@ -214,11 +235,22 @@ export default function Dashboard() {
                 data={investableCapitalData}
                 margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="#f2f2f2" />
-                <XAxis dataKey="name" tick={{ fill: '#292929' }} />
-                <YAxis tick={{ fill: '#292929' }} tickFormatter={formatMillionsTick} />
-                <Bar dataKey="initial" fill="#292929" name="Initial Investments" />
-                <Bar dataKey="followOn" fill="#E0D8D1" name="Follow-On Investments" />
+                <CartesianGrid strokeDasharray="3 3" stroke={DASHBOARD_CHART_COLORS.grid} />
+                <XAxis dataKey="name" tick={{ fill: DASHBOARD_CHART_COLORS.text }} />
+                <YAxis
+                  tick={{ fill: DASHBOARD_CHART_COLORS.text }}
+                  tickFormatter={formatMillionsTick}
+                />
+                <Bar
+                  dataKey="initial"
+                  fill={CATEGORY_SERIES_COLORS[0]}
+                  name="Initial Investments"
+                />
+                <Bar
+                  dataKey="followOn"
+                  fill={CATEGORY_SERIES_COLORS[1]}
+                  name="Follow-On Investments"
+                />
               </BarChart>
             </ResponsiveContainer>
           </CardContent>
@@ -241,11 +273,11 @@ export default function Dashboard() {
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="period" />
                 <YAxis />
-                <Bar dataKey="inPeriod" fill="#3b82f6" name="In-Period" />
+                <Bar dataKey="inPeriod" fill={CATEGORY_SERIES_COLORS[0]} name="In-Period" />
                 <Line
                   type="monotone"
                   dataKey="cumulative"
-                  stroke="#1d4ed8"
+                  stroke={CATEGORY_SERIES_COLORS[1]}
                   strokeWidth={2}
                   name="Cumulative"
                 />
@@ -269,8 +301,8 @@ export default function Dashboard() {
                   type="monotone"
                   dataKey="cumulative"
                   stackId="1"
-                  stroke="#1d4ed8"
-                  fill="#3b82f6"
+                  stroke={CATEGORY_SERIES_COLORS[0]}
+                  fill={CATEGORY_SERIES_COLORS[1]}
                 />
               </AreaChart>
             </ResponsiveContainer>
@@ -289,19 +321,19 @@ export default function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="mb-4">
-            <div className="text-2xl font-bold text-blue-600">$199,200,000</div>
-            <div className="text-gray-600">Total Projected</div>
+            <div className="text-2xl font-bold text-presson-info">$199,200,000</div>
+            <div className="text-charcoal-600">Total Projected</div>
           </div>
           <ResponsiveContainer width="100%" height={400}>
             <ComposedChart data={capitalCallsData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="period" />
               <YAxis tickFormatter={formatMillionsTick} />
-              <Bar dataKey="amount" fill="#3b82f6" name="In Period" />
+              <Bar dataKey="amount" fill={CATEGORY_SERIES_COLORS[0]} name="In Period" />
               <Line
                 type="monotone"
                 dataKey="cumulative"
-                stroke="#1d4ed8"
+                stroke={CATEGORY_SERIES_COLORS[1]}
                 strokeWidth={3}
                 name="Cumulative"
               />
@@ -315,52 +347,56 @@ export default function Dashboard() {
   return (
     <div className="flex-1 overflow-y-auto p-6 custom-scrollbar bg-white font-poppins">
       {/* Fund Header */}
-      <div className="bg-lightGray rounded-lg shadow-card border-0 p-6 mb-8">
+      <div className="bg-pov-gray rounded-lg shadow-card border-0 p-6 mb-8">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between space-y-4 lg:space-y-0">
           <div>
-            <h1 className="text-2xl font-inter font-bold text-charcoal">{currentFund.name}</h1>
+            <h1 className="text-2xl font-inter font-bold text-pov-charcoal">{currentFund.name}</h1>
             <div className="flex items-center space-x-8 mt-4">
               <div>
-                <div className="text-sm text-charcoal/70">Capital</div>
+                <div className="text-sm text-charcoal-500">Capital</div>
                 <div className="grid grid-cols-3 gap-6 mt-2">
                   <div>
-                    <div className="text-sm font-medium text-charcoal/70">Committed</div>
-                    <div className="text-lg font-bold text-charcoal">
+                    <div className="text-sm font-medium text-charcoal-500">Committed</div>
+                    <div className="text-lg font-bold text-pov-charcoal">
                       ${(committedCapital / 1000000).toFixed(0)}M
                     </div>
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-charcoal/70">Investable</div>
-                    <div className="text-lg font-bold text-charcoal">
+                    <div className="text-sm font-medium text-charcoal-500">Investable</div>
+                    <div className="text-lg font-bold text-pov-charcoal">
                       ${(investableCapital / 1000000).toFixed(1)}M
                     </div>
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-charcoal/70">Reserve Ratio</div>
-                    <div className="text-lg font-bold text-charcoal">{reserveRatio}%</div>
+                    <div className="text-sm font-medium text-charcoal-500">Reserve Ratio</div>
+                    <div className="text-lg font-bold text-pov-charcoal">{reserveRatio}%</div>
                   </div>
                 </div>
               </div>
               <div>
-                <div className="text-sm text-charcoal/70">Investments</div>
-                <div className="text-lg font-bold mt-2 text-charcoal">{projectedInvestments}</div>
+                <div className="text-sm text-charcoal-500">Investments</div>
+                <div className="text-lg font-bold mt-2 text-pov-charcoal">
+                  {projectedInvestments}
+                </div>
               </div>
               <div>
-                <div className="text-sm text-charcoal/70">Fund Returns</div>
+                <div className="text-sm text-charcoal-500">Fund Returns</div>
                 <div className="grid grid-cols-3 gap-4 mt-2">
                   <div>
-                    <div className="text-sm font-medium text-charcoal/70">Projected Fund Value</div>
-                    <div className="text-lg font-bold text-charcoal">
+                    <div className="text-sm font-medium text-charcoal-500">
+                      Projected Fund Value
+                    </div>
+                    <div className="text-lg font-bold text-pov-charcoal">
                       ${(projectedFundValue / 1000000).toFixed(0)}M
                     </div>
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-charcoal/70">Gross Multiple</div>
-                    <div className="text-lg font-bold text-charcoal">{grossMultiple}x</div>
+                    <div className="text-sm font-medium text-charcoal-500">Gross Multiple</div>
+                    <div className="text-lg font-bold text-pov-charcoal">{grossMultiple}x</div>
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-charcoal/70">TVPI</div>
-                    <div className="text-lg font-bold text-charcoal">{tvpi}x</div>
+                    <div className="text-sm font-medium text-charcoal-500">TVPI</div>
+                    <div className="text-lg font-bold text-pov-charcoal">{tvpi}x</div>
                   </div>
                 </div>
               </div>
@@ -369,7 +405,7 @@ export default function Dashboard() {
 
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
-              <Label htmlFor="view-toggle" className="text-sm font-medium text-charcoal">
+              <Label htmlFor="view-toggle" className="text-sm font-medium text-pov-charcoal">
                 View Actual
               </Label>
               <Switch
@@ -385,8 +421,8 @@ export default function Dashboard() {
                 variant={viewType === 'construction' ? 'default' : 'secondary'}
                 className={
                   viewType === 'construction'
-                    ? 'bg-charcoal text-white'
-                    : 'bg-white text-charcoal border-charcoal/20'
+                    ? 'bg-pov-charcoal text-pov-white'
+                    : 'bg-white text-pov-charcoal border-beige-200'
                 }
               >
                 Construction Forecast
@@ -395,8 +431,8 @@ export default function Dashboard() {
                 variant={viewType === 'current' ? 'default' : 'secondary'}
                 className={
                   viewType === 'current'
-                    ? 'bg-charcoal text-white'
-                    : 'bg-white text-charcoal border-charcoal/20'
+                    ? 'bg-pov-charcoal text-pov-white'
+                    : 'bg-white text-pov-charcoal border-beige-200'
                 }
               >
                 Current Forecast
@@ -405,7 +441,7 @@ export default function Dashboard() {
             <Button
               variant="outline"
               size="sm"
-              className="border-charcoal/20 text-charcoal hover:bg-charcoal hover:text-white transition-colors"
+              className="border-beige-200 bg-white text-pov-charcoal hover:bg-pov-gray transition-colors"
             >
               Construction Parameters
             </Button>
@@ -459,7 +495,9 @@ export default function Dashboard() {
                   <CardTitle>Commitment Analysis</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-gray-500">LP commitment details and analysis coming soon...</p>
+                  <p className="text-charcoal-500">
+                    LP commitment details and analysis coming soon...
+                  </p>
                 </CardContent>
               </Card>
             </TabsContent>
@@ -470,7 +508,7 @@ export default function Dashboard() {
                   <CardTitle>Exit Proceeds Recycling</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-gray-500">Recycling analysis and management tools...</p>
+                  <p className="text-charcoal-500">Recycling analysis and management tools...</p>
                 </CardContent>
               </Card>
             </TabsContent>
@@ -481,7 +519,7 @@ export default function Dashboard() {
                   <CardTitle>Fund Expenses</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-gray-500">Expense tracking and budget management...</p>
+                  <p className="text-charcoal-500">Expense tracking and budget management...</p>
                 </CardContent>
               </Card>
             </TabsContent>
@@ -492,7 +530,7 @@ export default function Dashboard() {
                   <CardTitle>Line of Credit</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-gray-500">Credit facility management and utilization...</p>
+                  <p className="text-charcoal-500">Credit facility management and utilization...</p>
                 </CardContent>
               </Card>
             </TabsContent>
@@ -505,7 +543,7 @@ export default function Dashboard() {
               <CardTitle>Fund Performance Analytics</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-500">Performance metrics and analysis coming soon...</p>
+              <p className="text-charcoal-500">Performance metrics and analysis coming soon...</p>
             </CardContent>
           </Card>
         </TabsContent>
@@ -516,7 +554,7 @@ export default function Dashboard() {
               <CardTitle>Exit Analysis</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-500">Exit performance and distribution analysis...</p>
+              <p className="text-charcoal-500">Exit performance and distribution analysis...</p>
             </CardContent>
           </Card>
         </TabsContent>
@@ -527,7 +565,7 @@ export default function Dashboard() {
               <CardTitle>Round Analysis</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-500">Investment round tracking and analysis...</p>
+              <p className="text-charcoal-500">Investment round tracking and analysis...</p>
             </CardContent>
           </Card>
         </TabsContent>
@@ -538,7 +576,7 @@ export default function Dashboard() {
               <CardTitle>Limited Partner Dashboard</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-500">LP reporting and relationship management...</p>
+              <p className="text-charcoal-500">LP reporting and relationship management...</p>
             </CardContent>
           </Card>
         </TabsContent>
@@ -555,32 +593,32 @@ export default function Dashboard() {
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
-                  <div className="flex items-center justify-between p-3 bg-blue-50 rounded-lg">
+                  <div className="flex items-center justify-between p-3 bg-pov-gray rounded-lg">
                     <div>
-                      <p className="font-medium text-blue-900">Top Performing Sector</p>
-                      <p className="text-sm text-blue-700">
+                      <p className="font-medium text-pov-charcoal">Top Performing Sector</p>
+                      <p className="text-sm text-charcoal-600">
                         SaaS companies showing 3.2x average MOIC
                       </p>
                     </div>
-                    <TrendingUp className="h-5 w-5 text-blue-600" />
+                    <TrendingUp className="h-5 w-5 text-charcoal-600" />
                   </div>
-                  <div className="flex items-center justify-between p-3 bg-green-50 rounded-lg">
+                  <div className="flex items-center justify-between p-3 bg-pov-gray rounded-lg">
                     <div>
-                      <p className="font-medium text-green-900">Geographic Performance</p>
-                      <p className="text-sm text-green-700">
+                      <p className="font-medium text-pov-charcoal">Geographic Performance</p>
+                      <p className="text-sm text-charcoal-600">
                         SF Bay Area leading with 28% portfolio value
                       </p>
                     </div>
-                    <Building2 className="h-5 w-5 text-green-600" />
+                    <Building2 className="h-5 w-5 text-charcoal-600" />
                   </div>
-                  <div className="flex items-center justify-between p-3 bg-amber-50 rounded-lg">
+                  <div className="flex items-center justify-between p-3 bg-pov-gray rounded-lg">
                     <div>
-                      <p className="font-medium text-amber-900">Stage Distribution</p>
-                      <p className="text-sm text-amber-700">
+                      <p className="font-medium text-pov-charcoal">Stage Distribution</p>
+                      <p className="text-sm text-charcoal-600">
                         42% concentrated in Seed stage investments
                       </p>
                     </div>
-                    <Target className="h-5 w-5 text-amber-600" />
+                    <Target className="h-5 w-5 text-charcoal-600" />
                   </div>
                 </div>
               </CardContent>
@@ -594,7 +632,7 @@ export default function Dashboard() {
               <CardTitle>Data Visualizer</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-500">Interactive data visualization tools...</p>
+              <p className="text-charcoal-500">Interactive data visualization tools...</p>
             </CardContent>
           </Card>
         </TabsContent>

--- a/client/src/components/dashboard/dual-forecast-dashboard.tsx
+++ b/client/src/components/dashboard/dual-forecast-dashboard.tsx
@@ -16,8 +16,14 @@ import type { NameType, ValueType } from 'recharts/types/component/DefaultToolti
 import type { DashboardSummary } from '@/types/fund';
 import { useFundContext } from '@/contexts/FundContext';
 import { useDualForecast } from '@/hooks/useDualForecast';
+import { presson } from '@/theme/presson.tokens';
 
 const MILLION = 1_000_000;
+const FORECAST_SERIES_COLORS = [
+  presson.color.text,
+  presson.color.positive,
+  presson.color.info,
+] as const;
 
 interface PortfolioChartPoint {
   name: string;
@@ -141,18 +147,18 @@ export default function DualForecastDashboard() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="animate-pulse">
           <CardHeader>
-            <div className="h-6 bg-gray-200 rounded w-3/4"></div>
+            <div className="h-6 bg-pov-gray rounded w-3/4"></div>
           </CardHeader>
           <CardContent>
-            <div className="h-48 bg-gray-200 rounded"></div>
+            <div className="h-48 bg-pov-gray rounded"></div>
           </CardContent>
         </Card>
         <Card className="animate-pulse">
           <CardHeader>
-            <div className="h-6 bg-gray-200 rounded w-3/4"></div>
+            <div className="h-6 bg-pov-gray rounded w-3/4"></div>
           </CardHeader>
           <CardContent>
-            <div className="h-48 bg-gray-200 rounded"></div>
+            <div className="h-48 bg-pov-gray rounded"></div>
           </CardContent>
         </Card>
       </div>
@@ -164,7 +170,7 @@ export default function DualForecastDashboard() {
       <Card>
         <CardContent className="pt-6">
           <div className="text-center py-8">
-            <p className="text-red-600 font-medium">Unable to load forecast data</p>
+            <p className="text-error-dark font-medium">Unable to load forecast data</p>
             <p className="text-muted-foreground mt-2">Please check API connectivity</p>
           </div>
         </CardContent>
@@ -207,7 +213,7 @@ export default function DualForecastDashboard() {
                 <p className="text-sm font-medium text-muted-foreground">Current AUM</p>
                 <p className="text-2xl font-bold">${(baseValue / MILLION).toFixed(1)}M</p>
               </div>
-              <DollarSign className="h-8 w-8 text-blue-600" />
+              <DollarSign className="h-8 w-8 text-charcoal-600" />
             </div>
           </CardContent>
         </Card>
@@ -219,7 +225,7 @@ export default function DualForecastDashboard() {
                 <p className="text-sm font-medium text-muted-foreground">IRR</p>
                 <p className="text-2xl font-bold">{(currentIRR * 100).toFixed(1)}%</p>
               </div>
-              <TrendingUp className="h-8 w-8 text-green-600" />
+              <TrendingUp className="h-8 w-8 text-charcoal-600" />
             </div>
           </CardContent>
         </Card>
@@ -231,7 +237,7 @@ export default function DualForecastDashboard() {
                 <p className="text-sm font-medium text-muted-foreground">Portfolio Cos</p>
                 <p className="text-2xl font-bold">{dashboardData.portfolioCompanies.length}</p>
               </div>
-              <PieChart className="h-8 w-8 text-purple-600" />
+              <PieChart className="h-8 w-8 text-charcoal-600" />
             </div>
           </CardContent>
         </Card>
@@ -245,7 +251,7 @@ export default function DualForecastDashboard() {
                   {dashboardData.summary.deploymentRate.toFixed(0)}%
                 </p>
               </div>
-              <Target className="h-8 w-8 text-orange-600" />
+              <Target className="h-8 w-8 text-charcoal-600" />
             </div>
           </CardContent>
         </Card>
@@ -285,7 +291,7 @@ export default function DualForecastDashboard() {
                 <Line
                   type="monotone"
                   dataKey="constructionNav"
-                  stroke="#0f766e"
+                  stroke={FORECAST_SERIES_COLORS[0]}
                   strokeWidth={3}
                   dot={{ r: 3 }}
                   name="Construction Plan"
@@ -293,7 +299,7 @@ export default function DualForecastDashboard() {
                 <Line
                   type="monotone"
                   dataKey="actualNav"
-                  stroke="#111827"
+                  stroke={FORECAST_SERIES_COLORS[1]}
                   strokeWidth={3}
                   dot={{ r: 4 }}
                   name="Actuals"
@@ -301,7 +307,7 @@ export default function DualForecastDashboard() {
                 <Line
                   type="monotone"
                   dataKey="currentForecastNav"
-                  stroke="#2563eb"
+                  stroke={FORECAST_SERIES_COLORS[2]}
                   strokeWidth={3}
                   dot={{ r: 3 }}
                   name="Current Forecast"
@@ -335,8 +341,8 @@ export default function DualForecastDashboard() {
                   ]}
                 />
                 <Legend />
-                <Bar dataKey="investment" fill="#94a3b8" name="Investment" />
-                <Bar dataKey="value" fill="#3b82f6" name="Current Value" />
+                <Bar dataKey="investment" fill={FORECAST_SERIES_COLORS[0]} name="Investment" />
+                <Bar dataKey="value" fill={FORECAST_SERIES_COLORS[1]} name="Current Value" />
               </BarChart>
             </ResponsiveContainer>
           </CardContent>
@@ -364,7 +370,7 @@ export default function DualForecastDashboard() {
               <Line
                 type="monotone"
                 dataKey="constructionCalledCapital"
-                stroke="#0f766e"
+                stroke={FORECAST_SERIES_COLORS[0]}
                 strokeWidth={3}
                 dot={{ r: 4 }}
                 name="Construction Plan"
@@ -372,7 +378,7 @@ export default function DualForecastDashboard() {
               <Line
                 type="monotone"
                 dataKey="actualCalledCapital"
-                stroke="#111827"
+                stroke={FORECAST_SERIES_COLORS[1]}
                 strokeWidth={3}
                 dot={{ r: 4 }}
                 name="Actuals"
@@ -380,7 +386,7 @@ export default function DualForecastDashboard() {
               <Line
                 type="monotone"
                 dataKey="currentForecastCalledCapital"
-                stroke="#2563eb"
+                stroke={FORECAST_SERIES_COLORS[2]}
                 strokeWidth={3}
                 dot={{ r: 4 }}
                 name="Current Forecast"

--- a/client/src/components/dashboard/fund-overview.tsx
+++ b/client/src/components/dashboard/fund-overview.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useFundContext } from '@/contexts/FundContext';
 import { DollarSign, BarChart3, Users, TrendingUp } from 'lucide-react';
 import { getChartColor } from '@/lib/chart-theme';
+import { presson } from '@/theme/presson.tokens';
 
 // Sample data matching target UI
 const areaChartData = [
@@ -35,7 +36,7 @@ const areaChartData = [
   { name: 'Sep', value: 32 },
   { name: 'Oct', value: 38 },
   { name: 'Nov', value: 42 },
-  { name: 'Dec', value: 45 }
+  { name: 'Dec', value: 45 },
 ];
 
 const pieChartData = [
@@ -43,7 +44,7 @@ const pieChartData = [
   { name: 'Fintech', value: 25 },
   { name: 'Healthcare', value: 20 },
   { name: 'Consumer', value: 15 },
-  { name: 'Enterprise', value: 5 }
+  { name: 'Enterprise', value: 5 },
 ];
 
 // Removed hardcoded COLORS - now using getChartColor() from chart-theme
@@ -67,12 +68,8 @@ export default function FundOverview() {
     <div className="space-y-6 p-6 bg-white font-poppins">
       {/* Title Section */}
       <div>
-        <h1 className="text-2xl font-inter font-bold text-charcoal">
-          Fund Dashboard
-        </h1>
-        <p className="text-charcoal/70 mt-1">
-          Overview of your fund's performance and metrics
-        </p>
+        <h1 className="text-2xl font-inter font-bold text-pov-charcoal">Fund Dashboard</h1>
+        <p className="text-charcoal-500 mt-1">Overview of your fund's performance and metrics</p>
       </div>
 
       {/* Key Metrics */}
@@ -82,7 +79,7 @@ export default function FundOverview() {
           value={`$${(fundSize / 1000000).toFixed(0)}M`}
           change={8.2}
           changeLabel="vs last quarter"
-          icon={<DollarSign size={20} className="text-charcoal" />}
+          icon={<DollarSign size={20} className="text-pov-charcoal" />}
         />
         <DashboardCard
           title="Committed Capital"
@@ -90,21 +87,21 @@ export default function FundOverview() {
           metric="(65%)"
           change={12.4}
           changeLabel="vs last quarter"
-          icon={<BarChart3 size={20} className="text-charcoal" />}
+          icon={<BarChart3 size={20} className="text-pov-charcoal" />}
         />
         <DashboardCard
           title="Active LPs"
           value={activeLPs.toString()}
           change={2}
           changeLabel="new this month"
-          icon={<Users size={20} className="text-charcoal" />}
+          icon={<Users size={20} className="text-pov-charcoal" />}
         />
         <DashboardCard
           title="IRR"
           value={`${irr}%`}
           change={-2.3}
           changeLabel="vs target"
-          icon={<TrendingUp size={20} className="text-charcoal" />}
+          icon={<TrendingUp size={20} className="text-pov-charcoal" />}
         />
       </div>
 
@@ -113,8 +110,8 @@ export default function FundOverview() {
         {/* Fund Performance Chart */}
         <Card className="lg:col-span-2 bg-white border-0 shadow-card">
           <CardHeader>
-            <CardTitle className="font-inter text-charcoal">Fund Performance</CardTitle>
-            <p className="text-sm text-charcoal/70">Capital deployment over time</p>
+            <CardTitle className="font-inter text-pov-charcoal">Fund Performance</CardTitle>
+            <p className="text-sm text-charcoal-500">Capital deployment over time</p>
           </CardHeader>
           <CardContent>
             <div className="h-80">
@@ -122,38 +119,42 @@ export default function FundOverview() {
                 <AreaChart data={areaChartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
                   <defs>
                     <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#E0D8D1" stopOpacity={0.8} />
-                      <stop offset="95%" stopColor="#E0D8D1" stopOpacity={0} />
+                      <stop offset="5%" stopColor={presson.color.highlight} stopOpacity={0.8} />
+                      <stop offset="95%" stopColor={presson.color.highlight} stopOpacity={0} />
                     </linearGradient>
                   </defs>
-                  <XAxis 
-                    dataKey="name" 
-                    axisLine={false} 
-                    tickLine={false} 
-                    tick={{ fill: '#292929' }} 
+                  <XAxis
+                    dataKey="name"
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fill: presson.color.text }}
                   />
-                  <YAxis 
-                    axisLine={false} 
-                    tickLine={false} 
-                    tick={{ fill: '#292929' }} 
-                    tickFormatter={value => `$${value}M`} 
+                  <YAxis
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fill: presson.color.text }}
+                    tickFormatter={(value) => `$${value}M`}
                   />
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f2f2f2" />
-                  <Tooltip 
-                    formatter={value => [`$${value}M`, 'Capital Deployed']} 
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={presson.color.surfaceSubtle}
+                  />
+                  <Tooltip
+                    formatter={(value) => [`$${value}M`, 'Capital Deployed']}
                     contentStyle={{
-                      backgroundColor: '#fff',
-                      border: '1px solid #f2f2f2',
+                      backgroundColor: presson.color.surface,
+                      border: `1px solid ${presson.color.borderSubtle}`,
                       borderRadius: '4px',
-                      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)'
-                    }} 
+                      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)',
+                    }}
                   />
-                  <Area 
-                    type="monotone" 
-                    dataKey="value" 
-                    stroke="#292929" 
-                    fillOpacity={1} 
-                    fill="url(#colorValue)" 
+                  <Area
+                    type="monotone"
+                    dataKey="value"
+                    stroke={presson.color.text}
+                    fillOpacity={1}
+                    fill="url(#colorValue)"
                   />
                 </AreaChart>
               </ResponsiveContainer>
@@ -164,20 +165,20 @@ export default function FundOverview() {
         {/* Sector Allocation */}
         <Card className="bg-white border-0 shadow-card">
           <CardHeader>
-            <CardTitle className="font-inter text-charcoal">Sector Allocation</CardTitle>
-            <p className="text-sm text-charcoal/70">Current portfolio distribution</p>
+            <CardTitle className="font-inter text-pov-charcoal">Sector Allocation</CardTitle>
+            <p className="text-sm text-charcoal-500">Current portfolio distribution</p>
           </CardHeader>
           <CardContent>
             <div className="h-80 flex flex-col justify-center">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
-                  <Pie 
-                    data={pieChartData} 
-                    cx="50%" 
-                    cy="50%" 
-                    innerRadius={60} 
-                    outerRadius={90} 
-                    paddingAngle={2} 
+                  <Pie
+                    data={pieChartData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={60}
+                    outerRadius={90}
+                    paddingAngle={2}
                     dataKey="value"
                     label={(props: SectorLabelProps) => {
                       const percent = props.percent ?? 0;
@@ -190,14 +191,14 @@ export default function FundOverview() {
                       <Cell key={`cell-${index}`} fill={getChartColor(index)} />
                     ))}
                   </Pie>
-                  <Tooltip 
-                    formatter={value => [`${value}%`, 'Allocation']} 
+                  <Tooltip
+                    formatter={(value) => [`${value}%`, 'Allocation']}
                     contentStyle={{
-                      backgroundColor: '#fff',
-                      border: '1px solid #f2f2f2',
+                      backgroundColor: presson.color.surface,
+                      border: `1px solid ${presson.color.borderSubtle}`,
                       borderRadius: '4px',
-                      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)'
-                    }} 
+                      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)',
+                    }}
                   />
                 </PieChart>
               </ResponsiveContainer>

--- a/client/src/components/dashboard/metric-cards.tsx
+++ b/client/src/components/dashboard/metric-cards.tsx
@@ -1,11 +1,11 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { DollarSign, TrendingUp, Building, Percent } from "lucide-react";
-import type { FundMetrics } from "@/types/fund";
+import { Card, CardContent } from '@/components/ui/card';
+import { DollarSign, TrendingUp, Building, Percent } from 'lucide-react';
+import type { FundMetrics } from '@/types/fund';
 
-type MetricIcon = "dollar" | "trending" | "building" | "percent";
-type MetricColor = "blue" | "cyan" | "green" | "orange";
+type MetricIcon = 'dollar' | 'trending' | 'building' | 'percent';
+type MetricColor = 'neutral';
 
-type DashboardMetric = Omit<FundMetrics, "icon" | "color"> & {
+type DashboardMetric = Omit<FundMetrics, 'icon' | 'color'> & {
   icon: MetricIcon;
   color: MetricColor;
 };
@@ -33,7 +33,7 @@ export default function MetricCards({ fundData }: MetricCardsProps) {
         {SKELETON_CARD_KEYS.map((index) => (
           <Card key={index} className="animate-pulse">
             <CardContent className="pt-6">
-              <div className="h-20 bg-gray-200 rounded"></div>
+              <div className="h-20 bg-pov-gray rounded"></div>
             </CardContent>
           </Card>
         ))}
@@ -43,56 +43,60 @@ export default function MetricCards({ fundData }: MetricCardsProps) {
 
   const metrics: DashboardMetric[] = [
     {
-      label: "Total Fund Size",
+      label: 'Total Fund Size',
       value: `$${(parseFloat(fundData.fund.size) / 1000000).toFixed(0)}M`,
-      change: "+12.5%",
-      changeType: "positive",
-      icon: "dollar",
-      color: "blue"
+      change: '+12.5%',
+      changeType: 'positive',
+      icon: 'dollar',
+      color: 'neutral',
     },
     {
-      label: "Deployed Capital", 
+      label: 'Deployed Capital',
       value: `$${(parseFloat(fundData.fund.deployedCapital) / 1000000).toFixed(1)}M`,
       change: `${fundData.summary.deploymentRate.toFixed(1)}%`,
-      changeType: "positive",
-      icon: "trending",
-      color: "cyan"
+      changeType: 'positive',
+      icon: 'trending',
+      color: 'neutral',
     },
     {
-      label: "Portfolio Companies",
+      label: 'Portfolio Companies',
       value: fundData.summary.totalCompanies.toString(),
-      change: "+3",
-      changeType: "positive", 
-      icon: "building",
-      color: "green"
+      change: '+3',
+      changeType: 'positive',
+      icon: 'building',
+      color: 'neutral',
     },
     {
-      label: "Current IRR",
+      label: 'Current IRR',
       value: `${fundData.summary.currentIRR.toFixed(1)}%`,
-      change: "+2.1%",
-      changeType: "positive",
-      icon: "percent",
-      color: "orange"
-    }
+      change: '+2.1%',
+      changeType: 'positive',
+      icon: 'percent',
+      color: 'neutral',
+    },
   ];
 
   const getIcon = (iconType: MetricIcon) => {
     switch (iconType) {
-      case 'dollar': return DollarSign;
-      case 'trending': return TrendingUp;
-      case 'building': return Building;
-      case 'percent': return Percent;
-      default: return DollarSign;
+      case 'dollar':
+        return DollarSign;
+      case 'trending':
+        return TrendingUp;
+      case 'building':
+        return Building;
+      case 'percent':
+        return Percent;
+      default:
+        return DollarSign;
     }
   };
 
   const getIconColor = (color: MetricColor) => {
     switch (color) {
-      case 'blue': return 'text-blue-500 bg-blue-50';
-      case 'cyan': return 'text-cyan-500 bg-cyan-50';
-      case 'green': return 'text-green-500 bg-green-50';
-      case 'orange': return 'text-orange-500 bg-orange-50';
-      default: return 'text-blue-500 bg-blue-50';
+      case 'neutral':
+        return 'text-charcoal-600 bg-pov-gray';
+      default:
+        return 'text-charcoal-600 bg-pov-gray';
     }
   };
 
@@ -101,28 +105,24 @@ export default function MetricCards({ fundData }: MetricCardsProps) {
       {metrics.map((metric, index) => {
         const Icon = getIcon(metric.icon);
         const iconColorClass = getIconColor(metric.color);
-        
+
         return (
-          <Card key={index} className="border border-gray-200">
+          <Card key={index} className="border border-beige-200">
             <CardContent className="pt-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-gray-600 text-sm font-medium">
-                    {metric.label}
-                  </p>
-                  <p className="text-2xl font-bold text-gray-800 mt-1">
-                    {metric.value}
-                  </p>
+                  <p className="text-charcoal-500 text-sm font-medium">{metric.label}</p>
+                  <p className="text-2xl font-bold text-pov-charcoal mt-1">{metric.value}</p>
                   <div className="flex items-center mt-2">
-                    <span className="text-green-600 text-sm font-medium">
+                    <span className="text-presson-positive text-sm font-medium">
                       {metric.change}
                     </span>
-                    <span className="text-gray-500 text-xs ml-1">
-                      vs last quarter
-                    </span>
+                    <span className="text-charcoal-500 text-xs ml-1">vs last quarter</span>
                   </div>
                 </div>
-                <div className={`w-12 h-12 ${iconColorClass} rounded-lg flex items-center justify-center`}>
+                <div
+                  className={`w-12 h-12 ${iconColorClass} rounded-lg flex items-center justify-center`}
+                >
                   <Icon className="h-6 w-6" />
                 </div>
               </div>

--- a/client/src/components/dashboard/portfolio-concentration.tsx
+++ b/client/src/components/dashboard/portfolio-concentration.tsx
@@ -8,62 +8,78 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MoreHorizontal } from 'lucide-react';
+import { presson } from '@/theme/presson.tokens';
+import { colors as brandColors } from '@/lib/brand-tokens';
+
+const STATUS_SUCCESS = brandColors.success;
+const CATEGORY_SERIES_COLORS = [
+  presson.color.text,
+  presson.color.positive,
+  presson.color.info,
+  STATUS_SUCCESS,
+  presson.color.warning,
+  presson.color.negative,
+] as const;
+
+const getCategorySeriesColor = (index: number): string =>
+  CATEGORY_SERIES_COLORS[index % CATEGORY_SERIES_COLORS.length];
 
 // Sample concentration data by different metrics
+// TODO(design): sector and company charts exceed the six-token categorical palette.
 const concentrationBySector = [
-  { name: 'SaaS', value: 18.5, companies: 8, color: '#3b82f6' },
-  { name: 'Fintech', value: 16.2, companies: 6, color: '#06b6d4' },
-  { name: 'Healthcare', value: 14.8, companies: 5, color: '#10b981' },
-  { name: 'E-commerce', value: 12.3, companies: 4, color: '#f59e0b' },
-  { name: 'AI/ML', value: 10.7, companies: 3, color: '#8b5cf6' },
-  { name: 'Marketplace', value: 9.2, companies: 3, color: '#ef4444' },
-  { name: 'Proptech', value: 8.1, companies: 2, color: '#84cc16' },
-  { name: 'Edtech', value: 6.4, companies: 2, color: '#f97316' },
-  { name: 'Other', value: 3.8, companies: 2, color: '#6b7280' },
+  { name: 'SaaS', value: 18.5, companies: 8, color: getCategorySeriesColor(0) },
+  { name: 'Fintech', value: 16.2, companies: 6, color: getCategorySeriesColor(1) },
+  { name: 'Healthcare', value: 14.8, companies: 5, color: getCategorySeriesColor(2) },
+  { name: 'E-commerce', value: 12.3, companies: 4, color: getCategorySeriesColor(3) },
+  { name: 'AI/ML', value: 10.7, companies: 3, color: getCategorySeriesColor(4) },
+  { name: 'Marketplace', value: 9.2, companies: 3, color: getCategorySeriesColor(5) },
+  { name: 'Proptech', value: 8.1, companies: 2, color: getCategorySeriesColor(6) },
+  { name: 'Edtech', value: 6.4, companies: 2, color: getCategorySeriesColor(7) },
+  { name: 'Other', value: 3.8, companies: 2, color: getCategorySeriesColor(8) },
 ];
 
 const concentrationByStage = [
-  { name: 'Seed', value: 42.3, companies: 12, color: '#3b82f6' },
-  { name: 'Series A', value: 28.7, companies: 8, color: '#06b6d4' },
-  { name: 'Series B', value: 18.9, companies: 5, color: '#10b981' },
-  { name: 'Pre-Seed', value: 6.8, companies: 3, color: '#f59e0b' },
-  { name: 'Series C+', value: 3.3, companies: 2, color: '#8b5cf6' },
+  { name: 'Seed', value: 42.3, companies: 12, color: getCategorySeriesColor(0) },
+  { name: 'Series A', value: 28.7, companies: 8, color: getCategorySeriesColor(1) },
+  { name: 'Series B', value: 18.9, companies: 5, color: getCategorySeriesColor(2) },
+  { name: 'Pre-Seed', value: 6.8, companies: 3, color: getCategorySeriesColor(3) },
+  { name: 'Series C+', value: 3.3, companies: 2, color: getCategorySeriesColor(4) },
 ];
 
 const concentrationByGeography = [
-  { name: 'San Francisco', value: 32.4, companies: 12, color: '#3b82f6' },
-  { name: 'New York', value: 24.1, companies: 8, color: '#06b6d4' },
-  { name: 'Los Angeles', value: 16.8, companies: 6, color: '#10b981' },
-  { name: 'Austin', value: 12.2, companies: 4, color: '#f59e0b' },
-  { name: 'Boston', value: 8.7, companies: 3, color: '#8b5cf6' },
-  { name: 'Seattle', value: 5.8, companies: 2, color: '#ef4444' },
+  { name: 'San Francisco', value: 32.4, companies: 12, color: getCategorySeriesColor(0) },
+  { name: 'New York', value: 24.1, companies: 8, color: getCategorySeriesColor(1) },
+  { name: 'Los Angeles', value: 16.8, companies: 6, color: getCategorySeriesColor(2) },
+  { name: 'Austin', value: 12.2, companies: 4, color: getCategorySeriesColor(3) },
+  { name: 'Boston', value: 8.7, companies: 3, color: getCategorySeriesColor(4) },
+  { name: 'Seattle', value: 5.8, companies: 2, color: getCategorySeriesColor(5) },
 ];
 
 const concentrationByOwnership = [
-  { name: 'High (>15%)', value: 28.4, companies: 4, color: '#ef4444' },
-  { name: 'Medium (5-15%)', value: 45.2, companies: 12, color: '#f59e0b' },
-  { name: 'Low (<5%)', value: 26.4, companies: 14, color: '#10b981' },
+  { name: 'High (>15%)', value: 28.4, companies: 4, color: presson.color.negative },
+  { name: 'Medium (5-15%)', value: 45.2, companies: 12, color: presson.color.warning },
+  { name: 'Low (<5%)', value: 26.4, companies: 14, color: STATUS_SUCCESS },
 ];
 
 const concentrationByCheckSize = [
-  { name: '$2M+', value: 34.7, companies: 6, color: '#3b82f6' },
-  { name: '$1M-$2M', value: 28.3, companies: 8, color: '#06b6d4' },
-  { name: '$500K-$1M', value: 22.1, companies: 10, color: '#10b981' },
-  { name: '$250K-$500K', value: 10.4, companies: 4, color: '#f59e0b' },
-  { name: '<$250K', value: 4.5, companies: 2, color: '#8b5cf6' },
+  { name: '$2M+', value: 34.7, companies: 6, color: getCategorySeriesColor(0) },
+  { name: '$1M-$2M', value: 28.3, companies: 8, color: getCategorySeriesColor(1) },
+  { name: '$500K-$1M', value: 22.1, companies: 10, color: getCategorySeriesColor(2) },
+  { name: '$250K-$500K', value: 10.4, companies: 4, color: getCategorySeriesColor(3) },
+  { name: '<$250K', value: 4.5, companies: 2, color: getCategorySeriesColor(4) },
 ];
 
 const concentrationByPortfolioCompany = [
-  { name: 'TechCorp Inc.', value: 8.7, companies: 1, color: '#3b82f6' },
-  { name: 'DataFlow Solutions', value: 7.9, companies: 1, color: '#06b6d4' },
-  { name: 'AI Dynamics', value: 7.2, companies: 1, color: '#10b981' },
-  { name: 'FinanceFlow', value: 6.8, companies: 1, color: '#f59e0b' },
-  { name: 'HealthTech Pro', value: 6.1, companies: 1, color: '#8b5cf6' },
-  { name: 'EduConnect', value: 5.4, companies: 1, color: '#ef4444' },
-  { name: 'PropTech Hub', value: 4.9, companies: 1, color: '#84cc16' },
-  { name: 'RetailNext', value: 4.3, companies: 1, color: '#f97316' },
-  { name: 'CloudSecure', value: 3.8, companies: 1, color: '#6366f1' },
-  { name: 'Other (21 companies)', value: 44.9, companies: 21, color: '#6b7280' },
+  { name: 'TechCorp Inc.', value: 8.7, companies: 1, color: getCategorySeriesColor(0) },
+  { name: 'DataFlow Solutions', value: 7.9, companies: 1, color: getCategorySeriesColor(1) },
+  { name: 'AI Dynamics', value: 7.2, companies: 1, color: getCategorySeriesColor(2) },
+  { name: 'FinanceFlow', value: 6.8, companies: 1, color: getCategorySeriesColor(3) },
+  { name: 'HealthTech Pro', value: 6.1, companies: 1, color: getCategorySeriesColor(4) },
+  { name: 'EduConnect', value: 5.4, companies: 1, color: getCategorySeriesColor(5) },
+  { name: 'PropTech Hub', value: 4.9, companies: 1, color: getCategorySeriesColor(6) },
+  { name: 'RetailNext', value: 4.3, companies: 1, color: getCategorySeriesColor(7) },
+  { name: 'CloudSecure', value: 3.8, companies: 1, color: getCategorySeriesColor(8) },
+  { name: 'Other (21 companies)', value: 44.9, companies: 21, color: getCategorySeriesColor(9) },
 ];
 
 interface ConcentrationData {
@@ -83,18 +99,18 @@ const CustomTooltip = ({ active, payload }: TooltipProps) => {
   if (active && payload && payload.length && payload[0]) {
     const data = payload[0].payload;
     return (
-      <div className="bg-white p-3 border border-gray-300 rounded-lg shadow-lg">
+      <div className="bg-white p-3 border border-beige-200 rounded-lg shadow-lg">
         <div className="flex items-center space-x-2 mb-2">
           <div className="w-3 h-3 rounded-full" style={{ backgroundColor: data.color }}></div>
-          <span className="font-medium text-gray-900">{data.name}</span>
+          <span className="font-medium text-pov-charcoal">{data.name}</span>
         </div>
         <div className="text-sm space-y-1">
           <div className="flex justify-between">
-            <span className="text-gray-600">Percentage:</span>
+            <span className="text-charcoal-600">Percentage:</span>
             <span className="font-medium">{data.value}%</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-600">Companies:</span>
+            <span className="text-charcoal-600">Companies:</span>
             <span className="font-medium">{data.companies}</span>
           </div>
         </div>
@@ -141,11 +157,11 @@ const ConcentrationChart = ({
                 className="w-3 h-3 rounded-full flex-shrink-0"
                 style={{ backgroundColor: entry.color }}
               ></div>
-              <span className="text-gray-700 truncate" title={entry.name}>
+              <span className="text-charcoal-700 truncate" title={entry.name}>
                 {entry.name}
               </span>
             </div>
-            <div className="flex items-center space-x-3 text-gray-600">
+            <div className="flex items-center space-x-3 text-charcoal-600">
               <span>{entry.value}%</span>
               <span className="text-xs">({entry.companies})</span>
             </div>
@@ -201,7 +217,7 @@ export default function PortfolioConcentration() {
     <Card className="w-full">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
-          <CardTitle className="text-lg font-medium text-gray-900">
+          <CardTitle className="text-lg font-medium text-pov-charcoal">
             Concentration Analysis
           </CardTitle>
           <Button variant="ghost" size="sm">
@@ -241,35 +257,35 @@ export default function PortfolioConcentration() {
         </Tabs>
 
         {/* Summary Statistics */}
-        <div className="mt-6 pt-4 border-t border-gray-200">
+        <div className="mt-6 pt-4 border-t border-beige-200">
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
             <div className="text-center">
-              <div className="text-lg font-semibold text-blue-600">
+              <div className="text-lg font-semibold text-pov-charcoal">
                 {getTabData(activeTab).length}
               </div>
-              <div className="text-gray-600">Categories</div>
+              <div className="text-charcoal-500">Categories</div>
             </div>
             <div className="text-center">
-              <div className="text-lg font-semibold text-blue-600">
+              <div className="text-lg font-semibold text-pov-charcoal">
                 {getTabData(activeTab)[0]?.value}%
               </div>
-              <div className="text-gray-600">Top Category</div>
+              <div className="text-charcoal-500">Top Category</div>
             </div>
             <div className="text-center">
-              <div className="text-lg font-semibold text-blue-600">
+              <div className="text-lg font-semibold text-pov-charcoal">
                 {getTabData(activeTab).reduce((sum, item) => sum + item.companies, 0)}
               </div>
-              <div className="text-gray-600">Total Companies</div>
+              <div className="text-charcoal-500">Total Companies</div>
             </div>
             <div className="text-center">
-              <div className="text-lg font-semibold text-blue-600">
+              <div className="text-lg font-semibold text-pov-charcoal">
                 {getTabData(activeTab)
                   .slice(0, 3)
                   .reduce((sum, item) => sum + item.value, 0)
                   .toFixed(1)}
                 %
               </div>
-              <div className="text-gray-600">Top 3 Concentration</div>
+              <div className="text-charcoal-500">Top 3 Concentration</div>
             </div>
           </div>
         </div>

--- a/client/src/components/dashboard/real-time-metrics.tsx
+++ b/client/src/components/dashboard/real-time-metrics.tsx
@@ -60,7 +60,7 @@ export default function RealTimeMetrics() {
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold">Real-Time Metrics</h3>
         <div className="flex items-center space-x-2">
-          <div className={`w-2 h-2 rounded-full ${isLive ? 'bg-green-500' : 'bg-gray-400'}`} />
+          <div className={`w-2 h-2 rounded-full ${isLive ? 'bg-success' : 'bg-pov-gray'}`} />
           <span className="text-sm text-muted-foreground">
             Last updated: {lastUpdate.toLocaleTimeString()}
           </span>

--- a/client/src/components/layout/EmptyFundHeader.tsx
+++ b/client/src/components/layout/EmptyFundHeader.tsx
@@ -30,45 +30,37 @@ export function EmptyFundHeader({
   fundSize,
   targetTVPI,
   projectedTVPI,
-  className = ''
+  className = '',
 }: EmptyFundHeaderProps) {
   return (
     <div className={`bg-white rounded-lg shadow p-6 ${className}`}>
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{fundName}</h2>
-          <p className="text-sm text-gray-600">
-            ${(fundSize / 1_000_000).toFixed(0)}M Fund
-          </p>
+          <h2 className="text-2xl font-bold text-pov-charcoal">{fundName}</h2>
+          <p className="text-sm text-charcoal-600">${(fundSize / 1_000_000).toFixed(0)}M Fund</p>
         </div>
         <SourceBadge source="construction_forecast" />
       </div>
 
-      <div className="border-t border-gray-200 pt-4">
-        <div className="bg-blue-50 border border-blue-200 rounded p-4 mb-4">
-          <h3 className="text-sm font-semibold text-blue-900 mb-2">
-            Construction View
-          </h3>
-          <p className="text-sm text-blue-700">
-            This fund has no investments yet. Metrics shown are based on J-curve
-            mathematical forecasting using industry-standard assumptions.
+      <div className="border-t border-beige-200 pt-4">
+        <div className="bg-pov-gray border border-beige-200 rounded p-4 mb-4">
+          <h3 className="text-sm font-semibold text-presson-info mb-2">Construction View</h3>
+          <p className="text-sm text-charcoal-600">
+            This fund has no investments yet. Metrics shown are based on J-curve mathematical
+            forecasting using industry-standard assumptions.
           </p>
         </div>
 
         <div className="grid grid-cols-2 gap-4">
-          <div className="bg-gray-50 rounded p-3">
-            <p className="text-xs text-gray-600 mb-1">Target TVPI</p>
-            <p className="text-2xl font-bold text-gray-900">
-              {targetTVPI.toFixed(2)}x
-            </p>
+          <div className="bg-pov-gray rounded p-3">
+            <p className="text-xs text-charcoal-600 mb-1">Target TVPI</p>
+            <p className="text-2xl font-bold text-pov-charcoal">{targetTVPI.toFixed(2)}x</p>
           </div>
 
           {projectedTVPI !== undefined && (
-            <div className="bg-gray-50 rounded p-3">
-              <p className="text-xs text-gray-600 mb-1">Projected TVPI</p>
-              <p className="text-2xl font-bold text-gray-900">
-                {projectedTVPI.toFixed(2)}x
-              </p>
+            <div className="bg-pov-gray rounded p-3">
+              <p className="text-xs text-charcoal-600 mb-1">Projected TVPI</p>
+              <p className="text-2xl font-bold text-pov-charcoal">{projectedTVPI.toFixed(2)}x</p>
             </div>
           )}
         </div>

--- a/client/src/components/layout/HeaderKpis.tsx
+++ b/client/src/components/layout/HeaderKpis.tsx
@@ -47,7 +47,7 @@ export default function HeaderKpis() {
 
   return (
     <div
-      className="flex min-w-0 flex-col gap-2 border-b border-slate-200 bg-white px-3 py-2 sm:flex-row sm:items-center sm:gap-4 sm:px-6"
+      className="flex min-w-0 flex-col gap-2 border-b border-beige-200 bg-white px-3 py-2 sm:flex-row sm:items-center sm:gap-4 sm:px-6"
       data-testid="header-kpis"
     >
       <div
@@ -63,7 +63,7 @@ export default function HeaderKpis() {
         ))}
       </div>
 
-      <div className="min-w-0 truncate text-xs text-slate-600 sm:ml-auto sm:text-sm">
+      <div className="min-w-0 truncate text-xs text-charcoal-600 sm:ml-auto sm:text-sm">
         {viewModel.fundName}
       </div>
     </div>

--- a/client/src/components/layout/HeaderMetricCard.tsx
+++ b/client/src/components/layout/HeaderMetricCard.tsx
@@ -31,8 +31,8 @@ const HEADER_ICON_COMPONENTS: Record<HeaderMetricIcon, LucideIcon> = {
 };
 
 const CARD_CLASS_NAMES: Record<HeaderMetricTheme, string> = {
-  white: 'bg-white border-charcoal-200',
-  beige: 'bg-beige-50 border-beige-300',
+  white: 'bg-white border-beige-200',
+  beige: 'bg-pov-gray/50 border-beige-200',
 };
 
 const LABEL_CLASS_NAMES: Record<HeaderMetricTheme, string> = {
@@ -65,7 +65,7 @@ export function HeaderMetricCard({
           <div className="min-w-0">
             <p className={`text-xs ${LABEL_CLASS_NAMES[card.theme]} font-medium`}>{card.title}</p>
             <p
-              className="truncate text-sm font-bold leading-tight text-charcoal-900 tabular-nums"
+              className="truncate text-sm font-bold leading-tight text-pov-charcoal tabular-nums"
               title={card.titleText}
             >
               {card.displayValue}

--- a/client/src/components/layout/ResponsiveLayout.tsx
+++ b/client/src/components/layout/ResponsiveLayout.tsx
@@ -16,12 +16,12 @@ import { cn } from '@/lib/utils';
 
 // Breakpoint definitions aligned with Tailwind CSS
 export const BREAKPOINTS = {
-  xs: 320,   // Small phones
-  sm: 640,   // Large phones / small tablets
-  md: 768,   // Tablets
-  lg: 1024,  // Small desktops
-  xl: 1280,  // Large desktops
-  '2xl': 1536 // Very large screens
+  xs: 320, // Small phones
+  sm: 640, // Large phones / small tablets
+  md: 768, // Tablets
+  lg: 1024, // Small desktops
+  xl: 1280, // Large desktops
+  '2xl': 1536, // Very large screens
 } as const;
 
 export type Breakpoint = keyof typeof BREAKPOINTS;
@@ -54,7 +54,7 @@ const DEFAULT_CONFIG: ResponsiveConfig = {
     spacing: 'tight',
     cardSize: 'compact',
     showSidebar: false,
-    navigationStyle: 'tabs'
+    navigationStyle: 'tabs',
   },
   tablet: {
     maxColumns: 2,
@@ -62,7 +62,7 @@ const DEFAULT_CONFIG: ResponsiveConfig = {
     spacing: 'normal',
     cardSize: 'normal',
     showSidebar: false,
-    navigationStyle: 'pills'
+    navigationStyle: 'pills',
   },
   desktop: {
     maxColumns: 4,
@@ -70,8 +70,8 @@ const DEFAULT_CONFIG: ResponsiveConfig = {
     spacing: 'loose',
     cardSize: 'large',
     showSidebar: true,
-    navigationStyle: 'full'
-  }
+    navigationStyle: 'full',
+  },
 };
 
 // Hook to track viewport size and breakpoints
@@ -133,7 +133,7 @@ export function useResponsiveBreakpoint() {
     isMobile: viewport === 'mobile',
     isTablet: viewport === 'tablet',
     isDesktop: viewport === 'desktop',
-    isTouch: viewport === 'mobile' || viewport === 'tablet'
+    isTouch: viewport === 'mobile' || viewport === 'tablet',
   };
 }
 
@@ -170,14 +170,14 @@ export function ResponsiveGrid({
   config,
   className,
   gap = 'md',
-  children
+  children,
 }: ResponsiveGridProps) {
   const { viewport, isMobile, isTablet, isDesktop } = useResponsiveBreakpoint();
   const layoutConfig = { ...DEFAULT_CONFIG, ...config };
   const currentConfig = layoutConfig[viewport];
 
   // Filter items based on priority for current viewport
-  const visibleItems = items.filter(item =>
+  const visibleItems = items.filter((item) =>
     currentConfig.contentPriority.includes(item.priority)
   );
 
@@ -187,7 +187,7 @@ export function ResponsiveGrid({
     sm: 'gap-2 md:gap-3',
     md: 'gap-3 md:gap-4 lg:gap-6',
     lg: 'gap-4 md:gap-6 lg:gap-8',
-    xl: 'gap-6 md:gap-8 lg:gap-12'
+    xl: 'gap-6 md:gap-8 lg:gap-12',
   };
 
   // Grid column configuration
@@ -195,22 +195,18 @@ export function ResponsiveGrid({
     1: 'grid-cols-1',
     2: 'grid-cols-1 md:grid-cols-2',
     3: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
-    4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+    4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
   };
 
-  const gridClass = gridColsClasses[currentConfig.maxColumns as keyof typeof gridColsClasses] || 'grid-cols-1';
+  const gridClass =
+    gridColsClasses[currentConfig.maxColumns as keyof typeof gridColsClasses] || 'grid-cols-1';
 
   return (
     <div
-      className={cn(
-        'grid w-full',
-        gridClass,
-        spacingClasses[gap],
-        className
-      )}
+      className={cn('grid w-full', gridClass, spacingClasses[gap], className)}
       style={{
         // Ensure proper touch targets on mobile
-        minHeight: isMobile ? 'auto' : undefined
+        minHeight: isMobile ? 'auto' : undefined,
       }}
     >
       {visibleItems.map((item) => {
@@ -271,7 +267,7 @@ export function ResponsiveContainer({
   padding = 'md',
   className,
   enableVirtualScrolling = false,
-  lazyLoadThreshold = 100
+  lazyLoadThreshold = 100,
 }: ResponsiveContainerProps) {
   const { isMobile, dimensions } = useResponsiveBreakpoint();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -287,7 +283,7 @@ export function ResponsiveContainer({
       },
       {
         threshold: 0.1,
-        rootMargin: `${lazyLoadThreshold}px`
+        rootMargin: `${lazyLoadThreshold}px`,
       }
     );
 
@@ -301,7 +297,7 @@ export function ResponsiveContainer({
     lg: 'max-w-lg',
     xl: 'max-w-xl',
     '2xl': 'max-w-2xl',
-    full: 'max-w-full'
+    full: 'max-w-full',
   };
 
   const paddingClasses = {
@@ -309,7 +305,7 @@ export function ResponsiveContainer({
     sm: 'p-2 md:p-3',
     md: 'p-3 md:p-4 lg:p-6',
     lg: 'p-4 md:p-6 lg:p-8',
-    xl: 'p-6 md:p-8 lg:p-12'
+    xl: 'p-6 md:p-8 lg:p-12',
   };
 
   return (
@@ -329,12 +325,14 @@ export function ResponsiveContainer({
         // Optimize for mobile performance
         WebkitOverflowScrolling: 'touch',
         // Ensure content doesn't overflow on small screens
-        maxWidth: isMobile ? `${dimensions.width}px` : undefined
+        maxWidth: isMobile ? `${dimensions.width}px` : undefined,
       }}
     >
-      {(!enableVirtualScrolling || isVisible) ? children : (
+      {!enableVirtualScrolling || isVisible ? (
+        children
+      ) : (
         <div className="flex items-center justify-center min-h-[200px]">
-          <div className="animate-pulse text-slate-400">Loading...</div>
+          <div className="animate-pulse text-charcoal-400">Loading...</div>
         </div>
       )}
     </div>
@@ -353,7 +351,7 @@ export function ResponsiveStack({
   children,
   spacing = 'md',
   alignment = 'stretch',
-  className
+  className,
 }: ResponsiveStackProps) {
   const { isMobile } = useResponsiveBreakpoint();
 
@@ -363,14 +361,14 @@ export function ResponsiveStack({
     sm: 'space-y-2 md:space-y-3',
     md: 'space-y-3 md:space-y-4 lg:space-y-6',
     lg: 'space-y-4 md:space-y-6 lg:space-y-8',
-    xl: 'space-y-6 md:space-y-8 lg:space-y-12'
+    xl: 'space-y-6 md:space-y-8 lg:space-y-12',
   };
 
   const alignmentClasses = {
     start: 'items-start',
     center: 'items-center',
     end: 'items-end',
-    stretch: 'items-stretch'
+    stretch: 'items-stretch',
   };
 
   return (
@@ -407,7 +405,7 @@ export function ResponsiveFlex({
   justify = 'start',
   align = 'stretch',
   gap = 'md',
-  className
+  className,
 }: ResponsiveFlexProps) {
   const { isMobile } = useResponsiveBreakpoint();
 
@@ -415,7 +413,7 @@ export function ResponsiveFlex({
     row: 'flex-row',
     col: 'flex-col',
     'row-mobile-col': isMobile ? 'flex-col' : 'flex-row',
-    'col-mobile-row': isMobile ? 'flex-row' : 'flex-col'
+    'col-mobile-row': isMobile ? 'flex-row' : 'flex-col',
   };
 
   const justifyClasses = {
@@ -424,14 +422,14 @@ export function ResponsiveFlex({
     end: 'justify-end',
     between: 'justify-between',
     around: 'justify-around',
-    evenly: 'justify-evenly'
+    evenly: 'justify-evenly',
   };
 
   const alignClasses = {
     start: 'items-start',
     center: 'items-center',
     end: 'items-end',
-    stretch: 'items-stretch'
+    stretch: 'items-stretch',
   };
 
   const gapClasses = {
@@ -440,7 +438,7 @@ export function ResponsiveFlex({
     sm: 'gap-2 md:gap-3',
     md: 'gap-3 md:gap-4 lg:gap-6',
     lg: 'gap-4 md:gap-6 lg:gap-8',
-    xl: 'gap-6 md:gap-8 lg:gap-12'
+    xl: 'gap-6 md:gap-8 lg:gap-12',
   };
 
   return (
@@ -467,10 +465,12 @@ export function ResponsiveLayoutDebugger({ enabled = false }: { enabled?: boolea
   if (!enabled) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 bg-black/80 text-white p-2 rounded text-xs font-mono z-50">
+    <div className="fixed bottom-4 right-4 bg-pov-charcoal text-pov-white p-2 rounded text-xs font-mono z-50">
       <div>Viewport: {viewport}</div>
       <div>Breakpoint: {breakpoint}</div>
-      <div>Size: {dimensions.width}×{dimensions.height}</div>
+      <div>
+        Size: {dimensions.width}×{dimensions.height}
+      </div>
     </div>
   );
 }
@@ -481,5 +481,5 @@ export default {
   ResponsiveStack,
   ResponsiveFlex,
   ResponsiveLayoutDebugger,
-  useResponsiveBreakpoint
+  useResponsiveBreakpoint,
 };

--- a/client/src/components/layout/dynamic-fund-header.tsx
+++ b/client/src/components/layout/dynamic-fund-header.tsx
@@ -45,17 +45,17 @@ export default function DynamicFundHeader() {
 
   return (
     <div
-      className="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm"
+      className="sticky top-0 z-50 bg-white border-b border-beige-200 shadow-sm"
       data-testid="dynamic-fund-header"
     >
       <div className="px-3 py-3 sm:px-6">
         <div className="mb-3 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex min-w-0 items-center">
             <div className="min-w-0">
-              <h1 className="truncate text-xl font-bold text-gray-900 sm:text-2xl">
+              <h1 className="truncate text-xl font-bold text-pov-charcoal sm:text-2xl">
                 {currentFund.name}
               </h1>
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-charcoal-600">
                 <span className="tabular-nums">Fund Size: {viewModel.fundSizeText}</span>
                 <Separator orientation="vertical" className="h-4" />
                 <span>Vintage: {viewModel.vintageText}</span>
@@ -66,11 +66,11 @@ export default function DynamicFundHeader() {
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-300">
+            <Badge variant="outline" className="bg-success/10 text-success-dark border-success/50">
               <Activity className="h-3 w-3 mr-1" />
               Active
             </Badge>
-            <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-300">
+            <Badge variant="outline" className="bg-pov-gray text-charcoal-700 border-charcoal/7">
               {viewModel.deploymentBadgeText}
             </Badge>
           </div>
@@ -82,7 +82,7 @@ export default function DynamicFundHeader() {
           ))}
         </div>
 
-        <div className="mt-3 flex items-center justify-between text-xs text-gray-500">
+        <div className="mt-3 flex items-center justify-between text-xs text-charcoal-500">
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
             <span>{viewModel.lastUpdatedText}</span>
             <div className="flex items-center space-x-1">

--- a/client/src/components/layout/expandable-sidebar.tsx
+++ b/client/src/components/layout/expandable-sidebar.tsx
@@ -128,25 +128,25 @@ export default function ExpandableSidebar({
   return (
     <aside
       className={cn(
-        'bg-gray-900 text-white shadow-lg border-r border-gray-800 flex-shrink-0 flex flex-col transition-all duration-300 ease-in-out overflow-hidden',
+        'bg-white text-pov-charcoal shadow-lg border-r border-beige-200 flex-shrink-0 flex flex-col transition-all duration-300 ease-in-out overflow-hidden',
         isExpanded ? 'w-64' : 'w-16'
       )}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
       {/* Header */}
-      <div className="p-4 border-b border-gray-800">
+      <div className="p-4 border-b border-beige-200">
         <div className="flex items-center space-x-3">
-          <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center flex-shrink-0">
-            <BarChart3 className="text-white h-5 w-5" />
+          <div className="w-8 h-8 bg-pov-charcoal rounded-lg flex items-center justify-center flex-shrink-0">
+            <BarChart3 className="text-pov-white h-5 w-5" />
           </div>
           {isExpanded && (
             <div className="flex-1 min-w-0">
-              <h1 className="text-lg font-bold text-white">{BRANDING.app.name}</h1>
+              <h1 className="text-lg font-bold text-pov-charcoal">{BRANDING.app.name}</h1>
               {currentFund ? (
-                <p className="text-sm text-gray-300 truncate">{currentFund.name}</p>
+                <p className="text-sm text-charcoal-600 truncate">{currentFund.name}</p>
               ) : (
-                <p className="text-sm text-gray-300">Venture Fund</p>
+                <p className="text-sm text-charcoal-600">Venture Fund</p>
               )}
             </div>
           )}
@@ -162,8 +162,9 @@ export default function ExpandableSidebar({
               variant="ghost"
               size="sm"
               className={cn(
-                'w-full justify-start text-gray-300 hover:text-white hover:bg-gray-800',
-                activeModule === 'dashboard' && 'bg-gray-800 text-white',
+                'w-full justify-start text-pov-charcoal hover:text-charcoal-700 hover:bg-pov-gray',
+                activeModule === 'dashboard' &&
+                  'bg-pov-charcoal text-pov-white hover:bg-charcoal-700',
                 !isExpanded && 'px-2'
               )}
               onClick={() => onModuleChange('dashboard')}
@@ -174,21 +175,21 @@ export default function ExpandableSidebar({
           </Link>
 
           <div className="flex items-center space-x-2 px-2 py-1">
-            <div className="w-6 h-6 bg-gray-700 rounded flex items-center justify-center flex-shrink-0">
-              <Users className="h-3 w-3 text-gray-400" />
+            <div className="w-6 h-6 bg-pov-gray rounded flex items-center justify-center flex-shrink-0">
+              <Users className="h-3 w-3 text-charcoal-500" />
             </div>
-            {isExpanded && <span className="text-sm text-gray-400">Account</span>}
+            {isExpanded && <span className="text-sm text-charcoal-500">Account</span>}
           </div>
 
           <div className="flex items-center space-x-2 px-2 py-1">
-            <div className="w-6 h-6 bg-gray-700 rounded flex items-center justify-center flex-shrink-0">
-              <HelpCircle className="h-3 w-3 text-gray-400" />
+            <div className="w-6 h-6 bg-pov-gray rounded flex items-center justify-center flex-shrink-0">
+              <HelpCircle className="h-3 w-3 text-charcoal-500" />
             </div>
-            {isExpanded && <span className="text-sm text-gray-400">Logout</span>}
+            {isExpanded && <span className="text-sm text-charcoal-500">Logout</span>}
           </div>
         </div>
 
-        {isExpanded && <Separator className="bg-gray-800 mb-4" />}
+        {isExpanded && <Separator className="bg-pov-gray mb-4" />}
 
         {/* Main Navigation Sections */}
         {(Object.entries(NAVIGATION_STRUCTURE) as NavigationSectionEntry[]).map(
@@ -197,7 +198,7 @@ export default function ExpandableSidebar({
               {isExpanded && (
                 <button
                   onClick={() => toggleSection(sectionKey)}
-                  className="w-full flex items-center justify-between px-2 py-2 text-sm font-medium text-gray-400 hover:text-white transition-colors"
+                  className="w-full flex items-center justify-between px-2 py-2 text-sm font-medium text-charcoal-500 hover:text-charcoal-700 transition-colors"
                 >
                   <div className="flex items-center space-x-2">
                     <section.icon className="h-4 w-4" />
@@ -226,9 +227,9 @@ export default function ExpandableSidebar({
                           size="sm"
                           disabled={isDisabled}
                           className={cn(
-                            'w-full justify-start text-gray-300 hover:text-white hover:bg-gray-800',
-                            isActive && 'bg-blue-600 text-white hover:bg-blue-700',
-                            isDisabled && 'text-gray-500 cursor-not-allowed',
+                            'w-full justify-start text-pov-charcoal hover:text-charcoal-700 hover:bg-pov-gray',
+                            isActive && 'bg-pov-charcoal text-pov-white hover:bg-charcoal-700',
+                            isDisabled && 'text-charcoal-300 cursor-not-allowed',
                             !isExpanded && 'px-2'
                           )}
                           onClick={() => !isDisabled && onModuleChange(item.id)}
@@ -252,7 +253,7 @@ export default function ExpandableSidebar({
         {/* Additional Tools */}
         {isExpanded && (
           <div className="space-y-1">
-            <Separator className="bg-gray-800 mb-2" />
+            <Separator className="bg-pov-gray mb-2" />
 
             {/* Sensitivity Analysis - New Addition */}
             <Link href="/sensitivity-analysis">
@@ -260,9 +261,9 @@ export default function ExpandableSidebar({
                 variant="ghost"
                 size="sm"
                 className={cn(
-                  'w-full justify-start text-gray-300 hover:text-white hover:bg-gray-800',
+                  'w-full justify-start text-pov-charcoal hover:text-charcoal-700 hover:bg-pov-gray',
                   activeModule === 'sensitivity-analysis' &&
-                    'bg-blue-600 text-white hover:bg-blue-700'
+                    'bg-pov-charcoal text-pov-white hover:bg-charcoal-700'
                 )}
                 onClick={() => onModuleChange('sensitivity-analysis')}
               >
@@ -280,8 +281,9 @@ export default function ExpandableSidebar({
                 variant="ghost"
                 size="sm"
                 className={cn(
-                  'w-full justify-start text-gray-300 hover:text-white hover:bg-gray-800',
-                  activeModule === 'cash-management' && 'bg-blue-600 text-white hover:bg-blue-700'
+                  'w-full justify-start text-pov-charcoal hover:text-charcoal-700 hover:bg-pov-gray',
+                  activeModule === 'cash-management' &&
+                    'bg-pov-charcoal text-pov-white hover:bg-charcoal-700'
                 )}
                 onClick={() => onModuleChange('cash-management')}
               >
@@ -296,9 +298,9 @@ export default function ExpandableSidebar({
                 variant="ghost"
                 size="sm"
                 className={cn(
-                  'w-full justify-start text-gray-300 hover:text-white hover:bg-gray-800',
+                  'w-full justify-start text-pov-charcoal hover:text-charcoal-700 hover:bg-pov-gray',
                   activeModule === 'portfolio-analytics' &&
-                    'bg-blue-600 text-white hover:bg-blue-700'
+                    'bg-pov-charcoal text-pov-white hover:bg-charcoal-700'
                 )}
                 onClick={() => onModuleChange('portfolio-analytics')}
               >
@@ -312,9 +314,9 @@ export default function ExpandableSidebar({
 
       {/* Footer */}
       {isExpanded && (
-        <div className="p-4 border-t border-gray-800">
-          <div className="flex items-center space-x-2 text-xs text-gray-400">
-            <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+        <div className="p-4 border-t border-beige-200">
+          <div className="flex items-center space-x-2 text-xs text-charcoal-500">
+            <div className="w-2 h-2 bg-success rounded-full"></div>
             <span>Connected</span>
           </div>
         </div>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -30,32 +30,32 @@ export default function Header({ currentModule }: HeaderProps) {
   return (
     <>
       {/* Top Header with Updog branding */}
-      <header className="bg-charcoal text-white py-4 px-6 flex items-center justify-between font-poppins">
+      <header className="bg-pov-charcoal text-pov-white py-4 px-6 flex items-center justify-between font-poppins">
         <div className="flex items-center">
           <Link to="/dashboard" className="flex items-center">
             <div className="font-inter font-bold text-2xl mr-2">
-              <span className="text-beige">U</span>pdawg
+              <span className="text-pov-white">U</span>pdawg
             </div>
-            <span className="text-sm text-white/70">by Press On Ventures</span>
+            <span className="text-sm text-charcoal-300">by Press On Ventures</span>
           </Link>
         </div>
         <div className="flex items-center space-x-6">
           {currentFund && (
             <div className="relative">
-              <button className="flex items-center space-x-2 bg-charcoal/30 rounded-md px-3 py-2 hover:bg-charcoal/50 transition-colors">
+              <button className="flex items-center space-x-2 bg-white/10 rounded-md px-3 py-2 hover:bg-white/20 transition-colors">
                 <span>{currentFund.name}</span>
                 <ChevronDown size={16} />
               </button>
             </div>
           )}
           <div className="relative">
-            <Bell size={20} className="text-white/70 hover:text-white cursor-pointer" />
+            <Bell size={20} className="text-charcoal-300 cursor-pointer" />
           </div>
           <div className="flex items-center space-x-2">
-            <UserCircle2 size={32} className="text-beige" />
+            <UserCircle2 size={32} className="text-charcoal-300" />
             <div className="flex flex-col">
               <span className="text-sm font-medium">Fund Manager</span>
-              <span className="text-xs text-white/70">Press On Ventures</span>
+              <span className="text-xs text-charcoal-300">Press On Ventures</span>
             </div>
             <ChevronDown size={16} />
           </div>
@@ -63,24 +63,24 @@ export default function Header({ currentModule }: HeaderProps) {
       </header>
 
       {/* Module Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200 px-6 py-4 font-poppins">
+      <div className="bg-white shadow-sm border-b border-beige-200 px-6 py-4 font-poppins">
         <div className="flex items-center justify-between">
           <div className="flex-1">
             <div className="flex items-center space-x-4">
               <div>
-                <h2 className="text-2xl font-inter font-bold text-charcoal">
+                <h2 className="text-2xl font-inter font-bold text-pov-charcoal">
                   {currentModule.title}
                 </h2>
-                <p className="text-charcoal/70 mt-1">{currentModule.description}</p>
+                <p className="text-charcoal-600 mt-1">{currentModule.description}</p>
               </div>
               {currentFund && (
-                <div className="flex items-center space-x-2 bg-lightGray border border-gray-300 rounded-lg px-4 py-2">
-                  <DollarSign className="h-4 w-4 text-charcoal" />
+                <div className="flex items-center space-x-2 bg-pov-gray border border-beige-200 rounded-lg px-4 py-2">
+                  <DollarSign className="h-4 w-4 text-pov-charcoal" />
                   <div className="text-sm">
-                    <div className="font-semibold text-charcoal">
+                    <div className="font-semibold text-pov-charcoal">
                       ${(currentFund.size / 1000000).toFixed(0)}M Fund
                     </div>
-                    <div className="text-charcoal/70">Active Portfolio</div>
+                    <div className="text-charcoal-600">Active Portfolio</div>
                   </div>
                 </div>
               )}
@@ -89,7 +89,7 @@ export default function Header({ currentModule }: HeaderProps) {
           <div className="flex items-center space-x-3">
             <Button
               onClick={handleExport}
-              className="bg-charcoal hover:bg-charcoal/90 text-white shadow-card"
+              className="bg-pov-charcoal hover:bg-charcoal-700 text-pov-white shadow-card"
             >
               <Download className="h-4 w-4 mr-2" />
               Export
@@ -98,7 +98,7 @@ export default function Header({ currentModule }: HeaderProps) {
               variant="outline"
               onClick={handleRefresh}
               disabled={isRefreshing}
-              className="border-charcoal/20 text-charcoal hover:bg-lightGray"
+              className="border-beige-200 text-pov-charcoal hover:bg-pov-gray"
             >
               <RefreshCw className={`h-4 w-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`} />
               Refresh

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -21,13 +21,13 @@ interface SidebarProps {
 
 function baseNavClassName(isHovered: boolean, isActive: boolean, isDisabled: boolean): string {
   return cn(
-    'w-full flex items-center rounded-md transition-colors font-poppins relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-beige focus-visible:ring-offset-2',
+    'w-full flex items-center rounded-md transition-colors font-poppins relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal/40 focus-visible:ring-offset-2',
     isHovered ? 'space-x-3 px-3 py-2.5' : 'justify-center p-2.5',
     isDisabled
-      ? 'text-charcoal/40 cursor-not-allowed bg-lightGray'
+      ? 'text-charcoal-300 cursor-not-allowed bg-pov-gray'
       : isActive
-        ? 'bg-beige/30 text-charcoal font-medium'
-        : 'text-charcoal/70 hover:bg-lightGray'
+        ? 'bg-pov-charcoal text-pov-white font-medium'
+        : 'text-pov-charcoal hover:bg-pov-gray'
   );
 }
 
@@ -52,7 +52,7 @@ function NavItemContent({
       )}
 
       {!isHovered && (
-        <div className="absolute left-full ml-2 px-2 py-1 bg-charcoal text-white text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50">
+        <div className="absolute left-full ml-2 px-2 py-1 bg-pov-charcoal text-pov-white text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50">
           {item.label}
         </div>
       )}
@@ -81,7 +81,7 @@ function FooterNavItemContent({
       )}
 
       {!isHovered && (
-        <div className="absolute left-full ml-2 px-2 py-1 bg-charcoal text-white text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50">
+        <div className="absolute left-full ml-2 px-2 py-1 bg-pov-charcoal text-pov-white text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50">
           {item.label}
         </div>
       )}
@@ -110,13 +110,13 @@ function NavigationButton({
   const disabledReasonId = disabledReason ? `sidebar-disabled-reason-${item.id}` : undefined;
   const className = compact
     ? cn(
-        'w-full flex items-center rounded-md transition-colors font-poppins relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-beige focus-visible:ring-offset-2',
+        'w-full flex items-center rounded-md transition-colors font-poppins relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal/40 focus-visible:ring-offset-2',
         isHovered ? 'space-x-3 px-3 py-2' : 'justify-center p-2',
         isActive
-          ? 'bg-beige/30 text-charcoal font-medium'
+          ? 'bg-pov-charcoal text-pov-white font-medium'
           : isDisabled
-            ? 'text-charcoal/40 cursor-not-allowed bg-lightGray'
-            : 'text-charcoal/60 hover:bg-lightGray hover:text-charcoal'
+            ? 'text-charcoal-300 cursor-not-allowed bg-pov-gray'
+            : 'text-pov-charcoal hover:bg-pov-gray hover:text-charcoal-700'
       )
     : baseNavClassName(isHovered, isActive, isDisabled);
 
@@ -180,14 +180,14 @@ export default function Sidebar({ activeModule, className }: SidebarProps) {
   return (
     <aside
       className={cn(
-        'bg-white shadow-card border-r border-lightGray flex-shrink-0 flex flex-col transition-all duration-300 ease-in-out',
+        'bg-white shadow-card border-r border-beige-200 flex-shrink-0 flex flex-col transition-all duration-300 ease-in-out',
         isHovered ? 'w-64' : 'w-16',
         className
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className="p-3 border-b border-lightGray bg-charcoal">
+      <div className="p-3 border-b border-charcoal/7 bg-pov-charcoal">
         <div className="flex items-center mb-4">
           <div className="flex items-center justify-center w-10 h-10">
             <POVIcon variant="white" size="md" />
@@ -195,18 +195,20 @@ export default function Sidebar({ activeModule, className }: SidebarProps) {
           <div
             className={`ml-3 transition-opacity duration-300 ${isHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'} overflow-hidden`}
           >
-            <h1 className="font-inter font-bold text-lg text-white whitespace-nowrap">
+            <h1 className="font-inter font-bold text-lg text-pov-white whitespace-nowrap">
               {BRANDING.app.nameStyled}
             </h1>
-            <p className="font-poppins text-xs text-slate-300 whitespace-nowrap">Fund Management</p>
+            <p className="font-poppins text-xs text-charcoal-300 whitespace-nowrap">
+              Fund Management
+            </p>
           </div>
         </div>
         {currentFund && isHovered && (
-          <div className="bg-charcoal/30 rounded-lg p-3 border border-beige/30 transition-all duration-300">
-            <p className="font-poppins font-medium text-sm text-white truncate">
+          <div className="bg-white/10 rounded-lg p-3 border border-white/10 transition-all duration-300">
+            <p className="font-poppins font-medium text-sm text-pov-white truncate">
               {currentFund.name}
             </p>
-            <p className="font-mono text-xs text-white/70 mt-1">
+            <p className="font-mono text-xs text-charcoal-300 mt-1">
               ${(currentFund.size / 1000000).toFixed(0)}M Fund
             </p>
           </div>
@@ -215,19 +217,19 @@ export default function Sidebar({ activeModule, className }: SidebarProps) {
 
       <nav className="flex-1 p-2 overflow-y-auto custom-scrollbar bg-white">
         {needsSetup && isHovered && (
-          <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4 transition-all duration-300">
+          <div className="bg-warning/10 border border-warning/50 rounded-lg p-3 mb-4 transition-all duration-300">
             <div className="flex items-center space-x-2 mb-2">
-              <Plus className="h-4 w-4 text-amber-700" />
-              <span className="font-poppins text-sm font-medium text-amber-800">
+              <Plus className="h-4 w-4 text-warning-dark" />
+              <span className="font-poppins text-sm font-medium text-warning-dark">
                 Setup Required
               </span>
             </div>
-            <p className="font-poppins text-xs text-amber-600 mb-3">
+            <p className="font-poppins text-xs text-warning-dark mb-3">
               Configure your fund to access all features
             </p>
             <Link
               href="/fund-setup"
-              className="block w-full bg-amber-600 text-white px-3 py-2 rounded-md text-sm font-medium hover:bg-amber-700 transition-all duration-200 text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-800 focus-visible:ring-offset-2"
+              className="block w-full bg-pov-charcoal text-pov-white px-3 py-2 rounded-md text-sm font-medium hover:bg-charcoal-700 transition-all duration-200 text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal/40 focus-visible:ring-offset-2"
             >
               Start Fund Setup
             </Link>
@@ -256,7 +258,7 @@ export default function Sidebar({ activeModule, className }: SidebarProps) {
       </nav>
 
       {footerItems.length > 0 && (
-        <div className="border-t border-lightGray p-2 bg-gray-50">
+        <div className="border-t border-beige-200 p-2 bg-pov-gray">
           <ul className="space-y-1">
             {footerItems.map((item) => {
               const href = resolveNavigationHref(item, navigationContext);

--- a/client/src/components/ui/AllocationSliders.tsx
+++ b/client/src/components/ui/AllocationSliders.tsx
@@ -126,7 +126,7 @@ export function AllocationSliders({ initial, onChange, className }: AllocationSl
           <div key={allocation.id} className="space-y-3">
             <div className="flex items-center gap-3">
               <div className="flex-1">
-                <Label className="text-sm font-medium text-[#292929]">{allocation.label}</Label>
+                <Label className="text-sm font-medium text-pov-charcoal">{allocation.label}</Label>
                 <Input
                   value={allocation.label}
                   onChange={(e) => handleLabelChange(allocation.id, e.target.value)}
@@ -136,7 +136,7 @@ export function AllocationSliders({ initial, onChange, className }: AllocationSl
                 />
               </div>
               <div className="w-24">
-                <Label className="text-sm font-medium text-[#292929]">%</Label>
+                <Label className="text-sm font-medium text-pov-charcoal">%</Label>
                 <Input
                   type="number"
                   min="0"
@@ -153,7 +153,7 @@ export function AllocationSliders({ initial, onChange, className }: AllocationSl
                   variant="ghost"
                   size="sm"
                   onClick={() => handleRemoveAllocation(allocation.id)}
-                  className="mt-6 text-red-500 hover:text-red-700 hover:bg-red-50"
+                  className="mt-6 text-error-dark hover:bg-pov-gray"
                   aria-label={`Remove ${allocation.label || 'allocation'}`}
                 >
                   <Trash2 aria-hidden="true" className="h-4 w-4" />
@@ -181,8 +181,8 @@ export function AllocationSliders({ initial, onChange, className }: AllocationSl
         className={cn(
           'p-4 rounded-lg border-2 transition-colors',
           isValid
-            ? 'bg-green-50 border-green-200 text-green-800'
-            : 'bg-amber-50 border-amber-200 text-amber-800'
+            ? 'bg-success/10 border-success/50 text-success-dark'
+            : 'bg-warning/10 border-warning/50 text-warning-dark'
         )}
       >
         <div className="flex items-center justify-between">

--- a/client/src/components/ui/DataTable.tsx
+++ b/client/src/components/ui/DataTable.tsx
@@ -24,17 +24,14 @@ interface SortState<T> {
   direction: SortDirection;
 }
 
-export function DataTable<T extends object>({
-  columns,
-  rows
-}: DataTableProps<T>) {
+export function DataTable<T extends object>({ columns, rows }: DataTableProps<T>) {
   const [sortState, setSortState] = React.useState<SortState<T>>({
     column: null,
-    direction: null
+    direction: null,
   });
 
   const handleSort = (columnKey: keyof T) => {
-    setSortState(prev => {
+    setSortState((prev) => {
       if (prev.column !== columnKey) {
         return { column: columnKey, direction: 'asc' };
       }
@@ -76,38 +73,38 @@ export function DataTable<T extends object>({
       return null;
     }
     return (
-      <span className="ml-1 text-[#292929]">
-        {sortState.direction === 'asc' ? '▲' : '▼'}
-      </span>
+      <span className="ml-1 text-pov-charcoal">{sortState.direction === 'asc' ? '▲' : '▼'}</span>
     );
   };
 
   const isNumericColumn = (columnKey: keyof T): boolean => {
     // Check if first non-null value is a number
-    const firstValue = rows.find(row => row[columnKey] != null)?.[columnKey];
+    const firstValue = rows.find((row) => row[columnKey] != null)?.[columnKey];
     return typeof firstValue === 'number';
   };
 
   return (
-    <div className="border border-[#E0D8D1] rounded-lg overflow-hidden">
+    <div className="border border-beige-200 rounded-lg overflow-hidden">
       <div className="relative w-full overflow-auto">
         <table className="w-full caption-bottom text-sm">
-          <thead className="sticky top-0 bg-[#F2F2F2] z-10">
-            <tr className="border-b border-[#E0D8D1]">
-              {columns.map(column => (
+          <thead className="sticky top-0 bg-pov-gray z-10">
+            <tr className="border-b border-beige-200">
+              {columns.map((column) => (
                 <th
                   key={String(column.key)}
                   className={cn(
-                    'h-12 px-4 align-middle font-poppins font-bold text-[#292929]',
-                    'cursor-pointer select-none hover:bg-[#E8E8E8] transition-colors',
+                    'h-12 px-4 align-middle font-poppins font-bold text-pov-charcoal',
+                    'cursor-pointer select-none hover:bg-pov-gray transition-colors',
                     column.align === 'right' ? 'text-right' : 'text-left'
                   )}
                   onClick={() => handleSort(column.key)}
                 >
-                  <div className={cn(
-                    'flex items-center gap-1',
-                    column.align === 'right' ? 'justify-end' : 'justify-start'
-                  )}>
+                  <div
+                    className={cn(
+                      'flex items-center gap-1',
+                      column.align === 'right' ? 'justify-end' : 'justify-start'
+                    )}
+                  >
                     {column.label}
                     {renderSortIndicator(column.key)}
                   </div>
@@ -122,11 +119,11 @@ export function DataTable<T extends object>({
                 <tr
                   key={rowIndex}
                   className={cn(
-                    'border-b border-[#E0D8D1] last:border-b-0',
-                    isEvenRow ? 'bg-white' : 'bg-[#F2F2F2]'
+                    'border-b border-beige-200 last:border-b-0',
+                    isEvenRow ? 'bg-white' : 'bg-pov-gray'
                   )}
                 >
-                  {columns.map(column => {
+                  {columns.map((column) => {
                     const value = row[column.key];
                     const isNumeric = isNumericColumn(column.key);
 

--- a/client/src/components/ui/POVLogo.tsx
+++ b/client/src/components/ui/POVLogo.tsx
@@ -92,21 +92,21 @@ export function POVBrandHeader({
   variant?: 'light' | 'dark' | 'beige';
 }) {
   const backgroundClasses = {
-    light: 'bg-white text-slate-900 border-slate-200',
-    dark: 'bg-slate-900 text-white border-slate-700',
-    beige: 'bg-slate-50 text-slate-900 border-slate-200',
+    light: 'bg-white text-pov-charcoal border-beige-200',
+    dark: 'bg-pov-charcoal text-pov-white border-beige-200',
+    beige: 'bg-pov-gray text-pov-charcoal border-beige-200',
   };
 
   const subtitleClasses = {
-    light: 'text-slate-600',
-    dark: 'text-slate-300',
-    beige: 'text-slate-600',
+    light: 'text-charcoal-600',
+    dark: 'text-charcoal-300',
+    beige: 'text-charcoal-600',
   };
 
   const iconFrameClasses = {
-    light: 'border-slate-200 bg-slate-50',
-    dark: 'border-white/15 bg-white/10',
-    beige: 'border-slate-200 bg-white',
+    light: 'border-beige-200 bg-pov-gray',
+    dark: 'border-beige-200 bg-white/10',
+    beige: 'border-beige-200 bg-white',
   };
 
   const logoVariant = variant === 'dark' ? 'white' : 'dark';

--- a/client/src/components/ui/PageHeader.tsx
+++ b/client/src/components/ui/PageHeader.tsx
@@ -15,8 +15,8 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <div className="flex items-center justify-between">
       <div>
-        <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
-        {description && <p className="text-gray-600 mt-1">{description}</p>}
+        <h1 className="text-3xl font-bold text-pov-charcoal">{title}</h1>
+        {description && <p className="text-charcoal-600 mt-1">{description}</p>}
       </div>
       {actions && <div className="flex items-center gap-2">{actions}</div>}
     </div>

--- a/client/src/components/ui/PremiumCard.tsx
+++ b/client/src/components/ui/PremiumCard.tsx
@@ -1,10 +1,5 @@
- 
- 
- 
- 
- 
 import React from 'react';
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils';
 
 interface PremiumCardProps {
   title?: string;
@@ -23,14 +18,15 @@ export function PremiumCard({
   className = '',
   headerActions,
   variant = 'default',
-  loading = false
+  loading = false,
 }: PremiumCardProps) {
   const cardClasses = cn(
-    "bg-white rounded-xl transition-all duration-200 ease-out",
+    'bg-white rounded-xl transition-all duration-200 ease-out',
     {
-      'shadow-lg hover:shadow-xl border border-gray-200/80': variant === 'default',
-      'shadow-xl border-2 border-slate-300 bg-gradient-to-br from-white to-slate-50': variant === 'highlight',
-      'border-2 border-gray-300 shadow-md hover:shadow-lg': variant === 'outlined',
+      'shadow-lg hover:shadow-xl border border-beige-200': variant === 'default',
+      'shadow-xl border-2 border-beige-200 bg-gradient-to-br from-white to-pov-gray':
+        variant === 'highlight',
+      'border-2 border-beige-200 shadow-md hover:shadow-lg': variant === 'outlined',
     },
     className
   );
@@ -54,33 +50,27 @@ export function PremiumCard({
   return (
     <div className={cardClasses}>
       {(title || subtitle || headerActions) && (
-        <div className="px-6 py-4 border-b border-gray-200 bg-slate-50">
+        <div className="px-6 py-4 border-b border-beige-200 bg-pov-gray">
           <div className="flex items-center justify-between">
             <div className="flex-1">
               {title && (
-                <h3 className="font-inter font-bold text-lg text-slate-900 leading-tight">
+                <h3 className="font-inter font-bold text-lg text-pov-charcoal leading-tight">
                   {title}
                 </h3>
               )}
               {subtitle && (
-                <p className="font-poppins text-sm text-slate-600 mt-1">
-                  {subtitle}
-                </p>
+                <p className="font-poppins text-sm text-charcoal-600 mt-1">{subtitle}</p>
               )}
             </div>
             {headerActions && (
-              <div className="flex items-center space-x-2 ml-4">
-                {headerActions}
-              </div>
+              <div className="flex items-center space-x-2 ml-4">{headerActions}</div>
             )}
           </div>
         </div>
       )}
 
       <div className="p-6">
-        <div className="font-poppins text-slate-700">
-          {children}
-        </div>
+        <div className="font-poppins text-charcoal-700">{children}</div>
       </div>
     </div>
   );
@@ -89,7 +79,9 @@ export function PremiumCard({
 // Loading skeleton variant
 export function PremiumCardSkeleton({ className = '' }: { className?: string }) {
   return (
-    <div className={cn("bg-pov-white rounded-lg shadow-card border border-pov-gray/50 p-6", className)}>
+    <div
+      className={cn('bg-pov-white rounded-lg shadow-card border border-pov-gray/50 p-6', className)}
+    >
       <div className="animate-pulse space-y-4">
         <div className="h-4 bg-pov-gray rounded w-1/3"></div>
         <div className="space-y-2">
@@ -101,4 +93,3 @@ export function PremiumCardSkeleton({ className = '' }: { className?: string }) 
     </div>
   );
 }
-

--- a/client/src/components/ui/SourceBadge.tsx
+++ b/client/src/components/ui/SourceBadge.tsx
@@ -7,11 +7,11 @@
 import React from 'react';
 
 export type MetricSource =
-  | 'actual'               // Real portfolio data
-  | 'model'                // Monte Carlo / projection
+  | 'actual' // Real portfolio data
+  | 'model' // Monte Carlo / projection
   | 'construction_forecast' // J-curve construction forecast
-  | 'forecast'             // Generic forecast
-  | 'N/A';                 // No data available
+  | 'forecast' // Generic forecast
+  | 'N/A'; // No data available
 
 interface SourceBadgeProps {
   source: MetricSource;
@@ -43,14 +43,14 @@ export function SourceBadge({ source, className = '' }: SourceBadgeProps) {
 function getSourceStyles(source: MetricSource): string {
   switch (source) {
     case 'actual':
-      return 'bg-green-100 text-green-800 border border-green-300';
+      return 'bg-success/10 text-success-dark border border-success/50';
     case 'model':
-      return 'bg-blue-100 text-blue-800 border border-blue-300';
+      return 'bg-presson-info/10 text-presson-info border border-presson-info/30';
     case 'construction_forecast':
     case 'forecast':
-      return 'bg-orange-100 text-orange-800 border border-orange-300';
+      return 'bg-warning/10 text-warning-dark border border-warning/50';
     case 'N/A':
-      return 'bg-gray-100 text-gray-600 border border-gray-300';
+      return 'bg-pov-gray text-charcoal-500 border border-beige-200';
   }
 }
 

--- a/client/src/components/ui/SwipeableMetricCards.tsx
+++ b/client/src/components/ui/SwipeableMetricCards.tsx
@@ -63,35 +63,35 @@ function MetricCard({
 
   const severityConfig = {
     success: {
-      bg: 'bg-green-50',
-      border: 'border-green-200',
-      text: 'text-green-800',
-      iconBg: 'bg-green-100',
+      bg: 'bg-success/10',
+      border: 'border-success/50',
+      text: 'text-success-dark',
+      iconBg: 'bg-success/10',
     },
     warning: {
-      bg: 'bg-yellow-50',
-      border: 'border-yellow-200',
-      text: 'text-yellow-800',
-      iconBg: 'bg-yellow-100',
+      bg: 'bg-warning/10',
+      border: 'border-warning/50',
+      text: 'text-warning-dark',
+      iconBg: 'bg-warning/10',
     },
     critical: {
-      bg: 'bg-red-50',
-      border: 'border-red-200',
-      text: 'text-red-800',
-      iconBg: 'bg-red-100',
+      bg: 'bg-error/10',
+      border: 'border-error/50',
+      text: 'text-error-dark',
+      iconBg: 'bg-error/10',
     },
     neutral: {
-      bg: 'bg-slate-50',
-      border: 'border-slate-200',
-      text: 'text-slate-800',
-      iconBg: 'bg-slate-100',
+      bg: 'bg-pov-gray',
+      border: 'border-beige-200',
+      text: 'text-charcoal-700',
+      iconBg: 'bg-white',
     },
   };
 
   const trendConfig = {
-    up: { symbol: '^', color: 'text-green-600' },
-    down: { symbol: 'v', color: 'text-red-600' },
-    stable: { symbol: '>', color: 'text-slate-500' },
+    up: { symbol: '^', color: 'text-presson-positive' },
+    down: { symbol: 'v', color: 'text-presson-negative' },
+    stable: { symbol: '>', color: 'text-charcoal-500' },
   };
 
   const config = severityConfig[metric.severity];
@@ -105,7 +105,7 @@ function MetricCard({
         'min-h-[120px]', // Ensure proper touch target
         config.bg,
         config.border,
-        isActive && 'ring-2 ring-blue-500 ring-offset-2 shadow-lg',
+        isActive && 'ring-2 ring-charcoal/40 ring-offset-2 shadow-lg',
         compactMode && 'min-h-[100px]',
         className
       )}
@@ -150,7 +150,7 @@ function MetricCard({
         {/* Active indicator */}
         {isActive && (
           <div className="mt-2 flex justify-center">
-            <div className="w-8 h-1 bg-blue-500 rounded-full" />
+            <div className="w-8 h-1 bg-pov-charcoal rounded-full" />
           </div>
         )}
       </CardContent>
@@ -348,7 +348,7 @@ export function SwipeableMetricCards({
       {/* Header with title and navigation */}
       {showNavigation && (
         <div className="flex items-center justify-between">
-          <h3 className="font-inter font-semibold text-lg text-slate-900">Key Metrics</h3>
+          <h3 className="font-inter font-semibold text-lg text-pov-charcoal">Key Metrics</h3>
           <div className="flex items-center gap-2">
             <Button
               variant="ghost"
@@ -368,7 +368,9 @@ export function SwipeableMetricCards({
                     key={index}
                     className={cn(
                       'w-2 h-2 rounded-full transition-all duration-300',
-                      index === currentIndex ? 'bg-blue-600 w-4' : 'bg-slate-300 hover:bg-slate-400'
+                      index === currentIndex
+                        ? 'bg-pov-charcoal w-4'
+                        : 'bg-pov-gray hover:bg-pov-gray'
                     )}
                     onClick={() => handleIndexChange(index)}
                     aria-label={`Go to metric ${index + 1}`}

--- a/client/src/components/ui/chart-core.tsx
+++ b/client/src/components/ui/chart-core.tsx
@@ -1,125 +1,104 @@
- 
-"use client"
+'use client';
 
-import * as React from "react"
-import { cn } from "@/lib/utils"
+import * as React from 'react';
+import { cn } from '@/lib/utils';
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-export const THEMES = { light: "", dark: ".dark" } as const
+export const THEMES = { light: '', dark: '.dark' } as const;
 
 export type ChartConfig = {
   [_k in string]: {
-    label?: React.ReactNode
-    icon?: React.ComponentType
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
-  )
-}
+  );
+};
 
 type ChartContextProps = {
-  config: ChartConfig
-}
+  config: ChartConfig;
+};
 
-const ChartContext = React.createContext<ChartContextProps | null>(null)
+const ChartContext = React.createContext<ChartContextProps | null>(null);
 
 export function useChart() {
-  const context = React.useContext(ChartContext)
+  const context = React.useContext(ChartContext);
 
   if (!context) {
-    throw new Error("useChart must be used within a <ChartContainer />")
+    throw new Error('useChart must be used within a <ChartContainer />');
   }
 
-  return context
+  return context;
 }
 
 // Skeleton loader for chart loading state
 export function ChartSkeleton({ height = 400 }: { height?: number }) {
-  return (
-    <div 
-      className="w-full animate-pulse rounded-md bg-muted"
-      style={{ height }}
-    />
-  )
+  return <div className="w-full animate-pulse rounded-md bg-muted" style={{ height }} />;
 }
 
 // Lazy-loaded Recharts bundle
-const RechartsBundle = React.lazy(() => import('./recharts-bundle'))
+const RechartsBundle = React.lazy(() => import('./recharts-bundle'));
 
 interface ChartContainerProps extends React.HTMLAttributes<HTMLDivElement> {
-  config: ChartConfig
-  children: React.ReactNode
+  config: ChartConfig;
+  children: React.ReactNode;
 }
 
-export const ChartContainer = React.forwardRef<
-  HTMLDivElement,
-  ChartContainerProps
->(({ className, children, config, ...props }, ref) => {
-  // Prevent accidental server-side or critical path execution
-  if (typeof window === 'undefined' || !children) {
-    return <div className="h-40 w-full bg-muted rounded-md" />
+export const ChartContainer = React.forwardRef<HTMLDivElement, ChartContainerProps>(
+  ({ className, children, config, ...props }, ref) => {
+    // Prevent accidental server-side or critical path execution
+    if (typeof window === 'undefined' || !children) {
+      return <div className="h-40 w-full bg-muted rounded-md" />;
+    }
+
+    return (
+      <ChartContext.Provider value={{ config }}>
+        {/* TODO(design): Recharts vendor hex selectors match emitted SVG attributes; these do not emit colors. */}
+        <div
+          ref={ref}
+          className={cn(
+            "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+            className
+          )}
+          {...props}
+        >
+          <React.Suspense fallback={<ChartSkeleton />}>
+            <RechartsBundle config={config}>{children}</RechartsBundle>
+          </React.Suspense>
+        </div>
+      </ChartContext.Provider>
+    );
   }
+);
 
-  return (
-    <ChartContext.Provider value={{ config }}>
-      <div
-        ref={ref}
-        className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
-          className
-        )}
-        {...props}
-      >
-        <React.Suspense fallback={<ChartSkeleton />}>
-          <RechartsBundle config={config}>
-            {children}
-          </RechartsBundle>
-        </React.Suspense>
-      </div>
-    </ChartContext.Provider>
-  )
-})
-
-ChartContainer.displayName = "ChartContainer"
+ChartContainer.displayName = 'ChartContainer';
 
 // Re-export types and utilities that don't depend on Recharts
-export type { ChartContextProps }
+export type { ChartContextProps };
 
 // Helper to extract item config from a payload
-export function getPayloadConfigFromPayload(
-  config: ChartConfig,
-  payload: unknown,
-  key: string
-) {
-  if (typeof payload !== "object" || payload === null) {
-    return undefined
+export function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined;
   }
 
   const payloadPayload =
-    "payload" in payload &&
-    typeof payload.payload === "object" &&
-    payload.payload !== null
+    'payload' in payload && typeof payload.payload === 'object' && payload.payload !== null
       ? payload.payload
-      : undefined
+      : undefined;
 
-  let configLabelKey: string = key
+  let configLabelKey: string = key;
 
-  if (
-    key in payload &&
-    typeof payload[key as keyof typeof payload] === "string"
-  ) {
-    configLabelKey = payload[key as keyof typeof payload] as string
+  if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
+    configLabelKey = payload[key as keyof typeof payload] as string;
   } else if (
     payloadPayload &&
     key in payloadPayload &&
-    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+    typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
   ) {
-    configLabelKey = payloadPayload[
-      key as keyof typeof payloadPayload
-    ] as string
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
   }
 
-  return configLabelKey in config
-    ? config[configLabelKey]
-    : config[key as keyof typeof config]
+  return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
 }

--- a/client/src/components/ui/contextual-tooltip.tsx
+++ b/client/src/components/ui/contextual-tooltip.tsx
@@ -6,12 +6,7 @@
  */
 
 import React, { useState } from 'react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -24,7 +19,7 @@ import {
   BarChart3,
   PieChart,
   Calculator,
-  Lightbulb
+  Lightbulb,
 } from 'lucide-react';
 
 export type ConceptCategory =
@@ -64,131 +59,159 @@ const VC_CONCEPTS: Record<string, VCConcept> = {
     id: 'power-law',
     term: 'Power Law Distribution',
     shortDefinition: 'A few investments drive most returns in VC portfolios',
-    detailedExplanation: 'In venture capital, returns follow a power law where a small number of investments (typically 1-3% of portfolio) generate 50-70% of total returns. This means most investments fail or return modest amounts, while rare "unicorns" create outsized value.',
-    businessContext: 'Understanding power law distributions is crucial for portfolio construction, reserve allocation, and investment strategy. It explains why VCs need large portfolios and why concentration risk can be both dangerous and necessary.',
+    detailedExplanation:
+      'In venture capital, returns follow a power law where a small number of investments (typically 1-3% of portfolio) generate 50-70% of total returns. This means most investments fail or return modest amounts, while rare "unicorns" create outsized value.',
+    businessContext:
+      'Understanding power law distributions is crucial for portfolio construction, reserve allocation, and investment strategy. It explains why VCs need large portfolios and why concentration risk can be both dangerous and necessary.',
     category: 'distribution',
     relatedTerms: ['unicorn', 'series-a-chasm', 'portfolio-construction'],
     benchmarks: [
       { label: 'Top 1% of investments', value: '50-70%', context: 'of total portfolio returns' },
       { label: 'Typical failure rate', value: '70-80%', context: 'of early-stage investments' },
-      { label: 'Home run rate', value: '2-5%', context: 'investments returning 10x+' }
+      { label: 'Home run rate', value: '2-5%', context: 'investments returning 10x+' },
     ],
-    marketInsight: '2024-2025 data shows even more extreme power law dynamics due to increased competition and later-stage capital abundance.',
-    actionableAdvice: 'Build larger portfolios (25+ investments) and maintain 25-30% reserves for follow-on investments in breakout companies.'
+    marketInsight:
+      '2024-2025 data shows even more extreme power law dynamics due to increased competition and later-stage capital abundance.',
+    actionableAdvice:
+      'Build larger portfolios (25+ investments) and maintain 25-30% reserves for follow-on investments in breakout companies.',
   },
 
   'series-a-chasm': {
     id: 'series-a-chasm',
     term: 'Series A Chasm',
     shortDefinition: 'The difficult transition from seed to Series A funding',
-    detailedExplanation: 'The Series A Chasm refers to the significant challenge startups face transitioning from seed funding to Series A. Many companies that raise seed rounds struggle to achieve the metrics and traction needed for institutional Series A investment.',
-    businessContext: 'This phenomenon creates high failure rates (70%+) and requires careful reserve management. Companies need substantial product-market fit, revenue growth, and market validation to cross this chasm.',
+    detailedExplanation:
+      'The Series A Chasm refers to the significant challenge startups face transitioning from seed funding to Series A. Many companies that raise seed rounds struggle to achieve the metrics and traction needed for institutional Series A investment.',
+    businessContext:
+      'This phenomenon creates high failure rates (70%+) and requires careful reserve management. Companies need substantial product-market fit, revenue growth, and market validation to cross this chasm.',
     category: 'stages',
     relatedTerms: ['seed-stage', 'product-market-fit', 'reserve-allocation'],
     benchmarks: [
-      { label: 'Seed to Series A conversion', value: '20-30%', context: 'of seed companies raise Series A' },
+      {
+        label: 'Seed to Series A conversion',
+        value: '20-30%',
+        context: 'of seed companies raise Series A',
+      },
       { label: 'Typical timing', value: '18-24 months', context: 'from seed to Series A attempt' },
-      { label: 'Bridge funding rate', value: '40-50%', context: 'of companies need bridge rounds' }
+      { label: 'Bridge funding rate', value: '40-50%', context: 'of companies need bridge rounds' },
     ],
-    marketInsight: 'Post-2023 market correction has made the Series A Chasm even more challenging, with higher bars for revenue and growth metrics.',
-    actionableAdvice: 'Reserve 30-40% of fund for follow-on investments to help portfolio companies bridge the Series A gap.'
+    marketInsight:
+      'Post-2023 market correction has made the Series A Chasm even more challenging, with higher bars for revenue and growth metrics.',
+    actionableAdvice:
+      'Reserve 30-40% of fund for follow-on investments to help portfolio companies bridge the Series A gap.',
   },
 
-  'irr': {
+  irr: {
     id: 'irr',
     term: 'IRR (Internal Rate of Return)',
     shortDefinition: 'Annualized return rate that makes NPV of cash flows equal zero',
-    detailedExplanation: 'IRR measures the annualized rate of return on an investment, accounting for the timing of cash flows. In VC, IRR is crucial because it captures both the magnitude of returns and the time to achieve them.',
-    businessContext: 'VC funds typically target 20-25% net IRR. Higher IRRs indicate better performance, but can be skewed by early exits or small sample sizes. Should be evaluated alongside MOIC and DPI.',
+    detailedExplanation:
+      'IRR measures the annualized rate of return on an investment, accounting for the timing of cash flows. In VC, IRR is crucial because it captures both the magnitude of returns and the time to achieve them.',
+    businessContext:
+      'VC funds typically target 20-25% net IRR. Higher IRRs indicate better performance, but can be skewed by early exits or small sample sizes. Should be evaluated alongside MOIC and DPI.',
     category: 'metrics',
     relatedTerms: ['moic', 'dpi', 'cash-flows'],
     calculations: {
       formula: 'IRR = (Ending Value / Beginning Value)^(1/years) - 1',
       description: 'Rate at which NPV of all cash flows equals zero',
-      example: 'Investment: $1M → Exit: $10M in 5 years → IRR = 58%'
+      example: 'Investment: $1M → Exit: $10M in 5 years → IRR = 58%',
     },
     benchmarks: [
       { label: 'Top quartile VC funds', value: '25%+', context: 'net IRR to LPs' },
       { label: 'Median VC funds', value: '12-15%', context: 'net IRR to LPs' },
-      { label: 'Individual unicorns', value: '50-100%+', context: 'gross IRR from investment' }
+      { label: 'Individual unicorns', value: '50-100%+', context: 'gross IRR from investment' },
     ],
-    actionableAdvice: 'Focus on time to exit alongside multiple. A 5x return in 3 years (71% IRR) beats 10x in 8 years (33% IRR).'
+    actionableAdvice:
+      'Focus on time to exit alongside multiple. A 5x return in 3 years (71% IRR) beats 10x in 8 years (33% IRR).',
   },
 
-  'moic': {
+  moic: {
     id: 'moic',
     term: 'MOIC (Multiple of Invested Capital)',
     shortDefinition: 'Total value returned divided by total capital invested',
-    detailedExplanation: 'MOIC measures how many times an investment returns the original capital invested. Unlike IRR, MOIC ignores timing and focuses purely on the multiple of returns achieved.',
-    businessContext: 'VC funds typically target 3-5x MOIC at the fund level. MOIC is easier to understand and compare than IRR, but doesn\'t account for the time value of money.',
+    detailedExplanation:
+      'MOIC measures how many times an investment returns the original capital invested. Unlike IRR, MOIC ignores timing and focuses purely on the multiple of returns achieved.',
+    businessContext:
+      "VC funds typically target 3-5x MOIC at the fund level. MOIC is easier to understand and compare than IRR, but doesn't account for the time value of money.",
     category: 'metrics',
     relatedTerms: ['irr', 'dpi', 'unrealized-value'],
     calculations: {
       formula: 'MOIC = Total Value / Total Invested Capital',
       description: 'Simple multiple of returns vs. investment',
-      example: 'Investment: $2M → Current Value: $20M → MOIC = 10x'
+      example: 'Investment: $2M → Current Value: $20M → MOIC = 10x',
     },
     benchmarks: [
       { label: 'Top quartile funds', value: '4-6x', context: 'fund-level MOIC' },
       { label: 'Median funds', value: '2-3x', context: 'fund-level MOIC' },
-      { label: 'Unicorn investments', value: '50-200x', context: 'individual investment MOIC' }
+      { label: 'Unicorn investments', value: '50-200x', context: 'individual investment MOIC' },
     ],
-    actionableAdvice: 'Target portfolio construction that can achieve 3-4x fund MOIC even with 70% failure rate through a few high-multiple outcomes.'
+    actionableAdvice:
+      'Target portfolio construction that can achieve 3-4x fund MOIC even with 70% failure rate through a few high-multiple outcomes.',
   },
 
-  'dpi': {
+  dpi: {
     id: 'dpi',
     term: 'DPI (Distributions to Paid-in Capital)',
     shortDefinition: 'Actual cash returned to investors divided by capital called',
-    detailedExplanation: 'DPI measures actual cash distributions received by LPs, not paper valuations. It\'s the most concrete performance metric as it reflects real money returned to investors.',
-    businessContext: 'DPI increases over fund life as companies exit. Early-stage funds may have low DPI for years while building portfolio value. DPI combined with RVPI gives total fund performance.',
+    detailedExplanation:
+      "DPI measures actual cash distributions received by LPs, not paper valuations. It's the most concrete performance metric as it reflects real money returned to investors.",
+    businessContext:
+      'DPI increases over fund life as companies exit. Early-stage funds may have low DPI for years while building portfolio value. DPI combined with RVPI gives total fund performance.',
     category: 'metrics',
     relatedTerms: ['rvpi', 'cash-flows', 'fund-lifecycle'],
     calculations: {
       formula: 'DPI = Cumulative Distributions / Paid-in Capital',
       description: 'Cash actually returned vs. cash invested',
-      example: 'Fund: $100M raised, $150M distributed → DPI = 1.5x'
+      example: 'Fund: $100M raised, $150M distributed → DPI = 1.5x',
     },
     benchmarks: [
       { label: 'Mature funds (8-10yr)', value: '2-4x', context: 'DPI for top quartile' },
       { label: 'Mid-stage funds (4-6yr)', value: '0.5-1.5x', context: 'partial distributions' },
-      { label: 'Young funds (1-3yr)', value: '0-0.3x', context: 'limited exits' }
+      { label: 'Young funds (1-3yr)', value: '0-0.3x', context: 'limited exits' },
     ],
-    actionableAdvice: 'Focus on building DPI through partial exits, secondaries, and dividend recaps, not just waiting for full exits.'
+    actionableAdvice:
+      'Focus on building DPI through partial exits, secondaries, and dividend recaps, not just waiting for full exits.',
   },
 
   'portfolio-construction': {
     id: 'portfolio-construction',
     term: 'Portfolio Construction',
     shortDefinition: 'Strategic approach to building a diversified VC portfolio',
-    detailedExplanation: 'Portfolio construction in VC involves balancing risk and return through diversification across stages, sectors, and investment sizes while accounting for power law dynamics.',
-    businessContext: 'Given high failure rates and power law returns, VCs need enough investments to capture outliers while maintaining sufficient capital for follow-ons in winners.',
+    detailedExplanation:
+      'Portfolio construction in VC involves balancing risk and return through diversification across stages, sectors, and investment sizes while accounting for power law dynamics.',
+    businessContext:
+      'Given high failure rates and power law returns, VCs need enough investments to capture outliers while maintaining sufficient capital for follow-ons in winners.',
     category: 'strategies',
     relatedTerms: ['power-law', 'reserve-allocation', 'diversification'],
     benchmarks: [
       { label: 'Portfolio size', value: '20-30', context: 'investments for early-stage funds' },
       { label: 'Reserve ratio', value: '25-40%', context: 'of fund for follow-ons' },
-      { label: 'Sector concentration', value: '<30%', context: 'in any single sector' }
+      { label: 'Sector concentration', value: '<30%', context: 'in any single sector' },
     ],
-    actionableAdvice: 'Build portfolios of 25+ investments with 30% reserves, diversified across sectors but concentrated in your expertise areas.'
+    actionableAdvice:
+      'Build portfolios of 25+ investments with 30% reserves, diversified across sectors but concentrated in your expertise areas.',
   },
 
-  'unicorn': {
+  unicorn: {
     id: 'unicorn',
     term: 'Unicorn',
     shortDefinition: 'Private company valued at $1 billion or more',
-    detailedExplanation: 'Unicorns are rare, high-growth companies that achieve billion-dollar valuations while still private. They typically drive the majority of VC fund returns due to power law dynamics.',
-    businessContext: 'While rare (1-3% of investments), unicorns are essential for top-tier VC returns. The key is identifying and supporting potential unicorns early in their journey.',
+    detailedExplanation:
+      'Unicorns are rare, high-growth companies that achieve billion-dollar valuations while still private. They typically drive the majority of VC fund returns due to power law dynamics.',
+    businessContext:
+      'While rare (1-3% of investments), unicorns are essential for top-tier VC returns. The key is identifying and supporting potential unicorns early in their journey.',
     category: 'market',
     relatedTerms: ['power-law', 'decacorn', 'ipo'],
     benchmarks: [
       { label: 'Global unicorns', value: '1,200+', context: 'as of 2024' },
       { label: 'Unicorn rate', value: '1-3%', context: 'of VC-backed companies' },
-      { label: 'Value creation', value: '50-70%', context: 'of fund returns from unicorns' }
+      { label: 'Value creation', value: '50-70%', context: 'of fund returns from unicorns' },
     ],
-    marketInsight: 'Unicorn creation has slowed post-2022 but companies are staying private longer, creating more opportunities for VC investors.',
-    actionableAdvice: 'Focus on large market opportunities with network effects, winner-take-all dynamics, and exceptional founding teams.'
-  }
+    marketInsight:
+      'Unicorn creation has slowed post-2022 but companies are staying private longer, creating more opportunities for VC investors.',
+    actionableAdvice:
+      'Focus on large market opportunities with network effects, winner-take-all dynamics, and exceptional founding teams.',
+  },
 };
 
 interface ContextualTooltipProps {
@@ -201,12 +224,12 @@ interface ContextualTooltipProps {
 }
 
 const CATEGORY_CONFIG = {
-  distribution: { icon: BarChart3, color: 'text-purple-600', bg: 'bg-purple-50' },
-  metrics: { icon: Calculator, color: 'text-blue-600', bg: 'bg-blue-50' },
-  stages: { icon: Target, color: 'text-green-600', bg: 'bg-green-50' },
-  strategies: { icon: TrendingUp, color: 'text-orange-600', bg: 'bg-orange-50' },
-  risk: { icon: AlertTriangle, color: 'text-red-600', bg: 'bg-red-50' },
-  market: { icon: PieChart, color: 'text-indigo-600', bg: 'bg-indigo-50' }
+  distribution: { icon: BarChart3, color: 'text-pov-charcoal', bg: 'bg-pov-gray' },
+  metrics: { icon: Calculator, color: 'text-presson-info', bg: 'bg-presson-info/10' },
+  stages: { icon: Target, color: 'text-success-dark', bg: 'bg-success/10' },
+  strategies: { icon: TrendingUp, color: 'text-warning-dark', bg: 'bg-warning/10' },
+  risk: { icon: AlertTriangle, color: 'text-error-dark', bg: 'bg-error/10' },
+  market: { icon: PieChart, color: 'text-presson-info', bg: 'bg-presson-info/10' },
 };
 
 function DetailedConceptCard({ concept }: { concept: VCConcept }) {
@@ -218,11 +241,11 @@ function DetailedConceptCard({ concept }: { concept: VCConcept }) {
     <Card className="w-80 max-w-sm border-0 shadow-lg">
       <CardHeader className="pb-3">
         <div className="flex items-start gap-3">
-          <div className={cn("p-2 rounded-lg", categoryConfig.bg)}>
-            <IconComponent className={cn("w-5 h-5", categoryConfig.color)} />
+          <div className={cn('p-2 rounded-lg', categoryConfig.bg)}>
+            <IconComponent className={cn('w-5 h-5', categoryConfig.color)} />
           </div>
           <div className="flex-1">
-            <h3 className="font-semibold font-inter text-slate-900 leading-tight">
+            <h3 className="font-semibold font-inter text-pov-charcoal leading-tight">
               {concept.term}
             </h3>
             <Badge variant="outline" className="mt-1 text-xs capitalize">
@@ -235,14 +258,14 @@ function DetailedConceptCard({ concept }: { concept: VCConcept }) {
       <CardContent className="space-y-4">
         {/* Short Definition */}
         <div>
-          <p className="text-sm font-medium text-slate-800 font-poppins leading-relaxed">
+          <p className="text-sm font-medium text-charcoal-700 font-poppins leading-relaxed">
             {concept.shortDefinition}
           </p>
         </div>
 
         {/* Detailed Explanation */}
         <div>
-          <p className="text-sm text-slate-600 font-poppins leading-relaxed">
+          <p className="text-sm text-charcoal-600 font-poppins leading-relaxed">
             {concept.detailedExplanation}
           </p>
         </div>
@@ -250,16 +273,16 @@ function DetailedConceptCard({ concept }: { concept: VCConcept }) {
         {/* Benchmarks */}
         {concept.benchmarks && concept.benchmarks.length > 0 && (
           <div className="space-y-2">
-            <h4 className="text-xs font-semibold text-slate-700 uppercase tracking-wide">
+            <h4 className="text-xs font-semibold text-charcoal-700 uppercase tracking-wide">
               Key Benchmarks
             </h4>
             <div className="space-y-2">
               {concept.benchmarks.map((benchmark, index) => (
                 <div key={index} className="flex justify-between items-center text-sm">
-                  <span className="text-slate-600">{benchmark.label}</span>
+                  <span className="text-charcoal-600">{benchmark.label}</span>
                   <div className="text-right">
-                    <span className="font-semibold text-slate-800">{benchmark.value}</span>
-                    <div className="text-xs text-slate-500">{benchmark.context}</div>
+                    <span className="font-semibold text-charcoal-700">{benchmark.value}</span>
+                    <div className="text-xs text-charcoal-500">{benchmark.context}</div>
                   </div>
                 </div>
               ))}
@@ -280,18 +303,16 @@ function DetailedConceptCard({ concept }: { concept: VCConcept }) {
               {showCalculation ? 'Hide' : 'Show'} Calculation
             </Button>
             {showCalculation && (
-              <div className="p-3 bg-slate-50 rounded-lg space-y-2">
+              <div className="p-3 bg-pov-gray rounded-lg space-y-2">
                 <div>
-                  <div className="text-xs font-semibold text-slate-700">Formula:</div>
+                  <div className="text-xs font-semibold text-charcoal-700">Formula:</div>
                   <code className="text-xs bg-white px-2 py-1 rounded border font-mono">
                     {concept.calculations.formula}
                   </code>
                 </div>
-                <div className="text-xs text-slate-600">
-                  {concept.calculations.description}
-                </div>
+                <div className="text-xs text-charcoal-600">{concept.calculations.description}</div>
                 {concept.calculations.example && (
-                  <div className="text-xs text-slate-600 italic">
+                  <div className="text-xs text-charcoal-600 italic">
                     Example: {concept.calculations.example}
                   </div>
                 )}
@@ -302,14 +323,12 @@ function DetailedConceptCard({ concept }: { concept: VCConcept }) {
 
         {/* Market Insight */}
         {concept.marketInsight && (
-          <div className="p-3 bg-blue-50 rounded-lg border border-blue-200">
+          <div className="p-3 bg-presson-info/10 rounded-lg border border-presson-info/30">
             <div className="flex items-start gap-2">
-              <Lightbulb className="w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0" />
+              <Lightbulb className="w-4 h-4 text-presson-info mt-0.5 flex-shrink-0" />
               <div>
-                <div className="text-xs font-semibold text-blue-800 mb-1">Market Insight</div>
-                <p className="text-xs text-blue-700 leading-relaxed">
-                  {concept.marketInsight}
-                </p>
+                <div className="text-xs font-semibold text-presson-info mb-1">Market Insight</div>
+                <p className="text-xs text-presson-info leading-relaxed">{concept.marketInsight}</p>
               </div>
             </div>
           </div>
@@ -317,12 +336,14 @@ function DetailedConceptCard({ concept }: { concept: VCConcept }) {
 
         {/* Actionable Advice */}
         {concept.actionableAdvice && (
-          <div className="p-3 bg-green-50 rounded-lg border border-green-200">
+          <div className="p-3 bg-presson-info/10 rounded-lg border border-presson-info/30">
             <div className="flex items-start gap-2">
-              <Target className="w-4 h-4 text-green-600 mt-0.5 flex-shrink-0" />
+              <Target className="w-4 h-4 text-presson-info mt-0.5 flex-shrink-0" />
               <div>
-                <div className="text-xs font-semibold text-green-800 mb-1">Actionable Advice</div>
-                <p className="text-xs text-green-700 leading-relaxed">
+                <div className="text-xs font-semibold text-presson-info mb-1">
+                  Actionable Advice
+                </div>
+                <p className="text-xs text-presson-info leading-relaxed">
                   {concept.actionableAdvice}
                 </p>
               </div>
@@ -333,9 +354,9 @@ function DetailedConceptCard({ concept }: { concept: VCConcept }) {
         {/* Related Terms */}
         {concept.relatedTerms.length > 0 && (
           <div className="pt-2 border-t">
-            <div className="text-xs font-semibold text-slate-700 mb-2">Related Concepts</div>
+            <div className="text-xs font-semibold text-charcoal-700 mb-2">Related Concepts</div>
             <div className="flex flex-wrap gap-1">
-              {concept.relatedTerms.map(term => (
+              {concept.relatedTerms.map((term) => (
                 <Badge key={term} variant="secondary" className="text-xs">
                   {term.replace('-', ' ')}
                 </Badge>
@@ -354,7 +375,7 @@ export function ContextualTooltip({
   variant = 'default',
   showIcon = true,
   className,
-  side = 'top'
+  side = 'top',
 }: ContextualTooltipProps) {
   const conceptData = VC_CONCEPTS[concept];
 
@@ -363,7 +384,7 @@ export function ContextualTooltip({
     return (
       <span className={className}>
         {children}
-        {showIcon && <HelpCircle className="w-4 h-4 text-gray-400 ml-1 inline" />}
+        {showIcon && <HelpCircle className="w-4 h-4 text-charcoal-400 ml-1 inline" />}
       </span>
     );
   }
@@ -375,11 +396,13 @@ export function ContextualTooltip({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className={cn(
-              "underline decoration-dotted cursor-help",
-              categoryConfig.color,
-              className
-            )}>
+            <span
+              className={cn(
+                'underline decoration-dotted cursor-help',
+                categoryConfig.color,
+                className
+              )}
+            >
               {children}
               {showIcon && <HelpCircle className="w-4 h-4 ml-1 inline opacity-60" />}
             </span>
@@ -399,9 +422,9 @@ export function ContextualTooltip({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className={cn("cursor-help", className)}>
+          <span className={cn('cursor-help', className)}>
             {children}
-            {showIcon && <HelpCircle className="w-4 h-4 text-gray-400 ml-1 inline" />}
+            {showIcon && <HelpCircle className="w-4 h-4 text-charcoal-400 ml-1 inline" />}
           </span>
         </TooltipTrigger>
         <TooltipContent side={side} className="p-0 border-0">
@@ -413,24 +436,40 @@ export function ContextualTooltip({
 }
 
 // Convenience components for common VC terms
-export const PowerLawTooltip = ({ children, ...props }: Omit<ContextualTooltipProps, 'concept'>) => (
-  <ContextualTooltip concept="power-law" {...props}>{children}</ContextualTooltip>
+export const PowerLawTooltip = ({
+  children,
+  ...props
+}: Omit<ContextualTooltipProps, 'concept'>) => (
+  <ContextualTooltip concept="power-law" {...props}>
+    {children}
+  </ContextualTooltip>
 );
 
-export const SeriesAChasmTooltip = ({ children, ...props }: Omit<ContextualTooltipProps, 'concept'>) => (
-  <ContextualTooltip concept="series-a-chasm" {...props}>{children}</ContextualTooltip>
+export const SeriesAChasmTooltip = ({
+  children,
+  ...props
+}: Omit<ContextualTooltipProps, 'concept'>) => (
+  <ContextualTooltip concept="series-a-chasm" {...props}>
+    {children}
+  </ContextualTooltip>
 );
 
 export const IRRTooltip = ({ children, ...props }: Omit<ContextualTooltipProps, 'concept'>) => (
-  <ContextualTooltip concept="irr" {...props}>{children}</ContextualTooltip>
+  <ContextualTooltip concept="irr" {...props}>
+    {children}
+  </ContextualTooltip>
 );
 
 export const MOICTooltip = ({ children, ...props }: Omit<ContextualTooltipProps, 'concept'>) => (
-  <ContextualTooltip concept="moic" {...props}>{children}</ContextualTooltip>
+  <ContextualTooltip concept="moic" {...props}>
+    {children}
+  </ContextualTooltip>
 );
 
 export const DPITooltip = ({ children, ...props }: Omit<ContextualTooltipProps, 'concept'>) => (
-  <ContextualTooltip concept="dpi" {...props}>{children}</ContextualTooltip>
+  <ContextualTooltip concept="dpi" {...props}>
+    {children}
+  </ContextualTooltip>
 );
 
 export default ContextualTooltip;

--- a/client/src/components/ui/demo-banner.tsx
+++ b/client/src/components/ui/demo-banner.tsx
@@ -7,7 +7,7 @@ export function DemoBanner() {
 
   React.useEffect(() => {
     isStubMode()
-      .then(stubEnabled => {
+      .then((stubEnabled) => {
         setShowBanner(stubEnabled);
         setLoading(false);
       })
@@ -20,8 +20,8 @@ export function DemoBanner() {
   // Simple loading state for MVP
   if (loading) {
     return (
-      <div className="bg-gray-100 border-b border-gray-200 px-4 py-2 text-center">
-        <span className="text-gray-600 text-sm">Loading...</span>
+      <div className="bg-pov-gray border-b border-beige-200 px-4 py-2 text-center">
+        <span className="text-charcoal-600 text-sm">Loading...</span>
       </div>
     );
   }
@@ -29,9 +29,9 @@ export function DemoBanner() {
   if (!showBanner) return null;
 
   return (
-    <div className="bg-amber-100 border-b border-amber-200 px-4 py-2 text-center">
-      <span className="text-amber-800 text-sm font-medium">
-        🚀 Demo Mode Active - Synthetic Data
+    <div className="bg-warning/10 border-b border-warning/50 px-4 py-2 text-center">
+      <span className="text-warning-dark text-sm font-medium">
+        Demo Mode Active - Synthetic Data
       </span>
     </div>
   );

--- a/client/src/components/ui/error-boundary.tsx
+++ b/client/src/components/ui/error-boundary.tsx
@@ -1,8 +1,3 @@
- 
- 
- 
- 
- 
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -39,10 +34,10 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
       if (this.props.fallback) {
         const FallbackComponent = this.props.fallback;
-        return <FallbackComponent {...spreadIfDefined("error", this.state.error)} reset={reset} />;
+        return <FallbackComponent {...spreadIfDefined('error', this.state.error)} reset={reset} />;
       }
 
-      return <DefaultErrorFallback {...spreadIfDefined("error", this.state.error)} reset={reset} />;
+      return <DefaultErrorFallback {...spreadIfDefined('error', this.state.error)} reset={reset} />;
     }
 
     return this.props.children;
@@ -51,9 +46,9 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
 function DefaultErrorFallback({ error, reset }: { error?: Error; reset: () => void }) {
   return (
-    <Card className="border-red-200">
+    <Card className="border-error/50">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-red-600">
+        <CardTitle className="flex items-center gap-2 text-error-dark">
           <AlertTriangle className="h-5 w-5" />
           Something went wrong
         </CardTitle>
@@ -63,8 +58,8 @@ function DefaultErrorFallback({ error, reset }: { error?: Error; reset: () => vo
       </CardHeader>
       <CardContent className="space-y-4">
         {error && (
-          <div className="bg-red-50 p-3 rounded-md">
-            <p className="text-sm text-red-800 font-mono">{error.message}</p>
+          <div className="bg-error/10 p-3 rounded-md">
+            <p className="text-sm text-error-dark font-mono">{error.message}</p>
           </div>
         )}
         <Button onClick={reset} variant="outline" className="w-full">

--- a/client/src/components/ui/intelligent-skeleton.tsx
+++ b/client/src/components/ui/intelligent-skeleton.tsx
@@ -10,14 +10,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { spreadIfDefined } from '@/lib/ts/spreadIfDefined';
-import {
-  BarChart3,
-  PieChart,
-  TrendingUp,
-  DollarSign,
-  Target,
-  Calculator
-} from 'lucide-react';
+import { BarChart3, PieChart, TrendingUp, DollarSign, Target, Calculator } from 'lucide-react';
 
 type ChartType = 'bar' | 'line' | 'pie' | 'scatter' | 'area';
 
@@ -50,20 +43,20 @@ function DashboardSkeleton({ animated = true }: { animated?: boolean }) {
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <div className="space-y-2">
-            <Skeleton className={cn("h-8 w-64", animated && "animate-pulse")} />
-            <Skeleton className={cn("h-4 w-96", animated && "animate-pulse")} />
+            <Skeleton className={cn('h-8 w-64', animated && 'animate-pulse')} />
+            <Skeleton className={cn('h-4 w-96', animated && 'animate-pulse')} />
           </div>
           <div className="flex items-center gap-2">
-            <Skeleton className={cn("h-10 w-32", animated && "animate-pulse")} />
-            <Skeleton className={cn("h-10 w-10", animated && "animate-pulse")} />
+            <Skeleton className={cn('h-10 w-32', animated && 'animate-pulse')} />
+            <Skeleton className={cn('h-10 w-10', animated && 'animate-pulse')} />
           </div>
         </div>
 
         {/* Breadcrumb skeleton */}
         <div className="flex items-center gap-2">
-          <Skeleton className={cn("h-6 w-16", animated && "animate-pulse")} />
-          <span className="text-gray-300">/</span>
-          <Skeleton className={cn("h-6 w-24", animated && "animate-pulse")} />
+          <Skeleton className={cn('h-6 w-16', animated && 'animate-pulse')} />
+          <span className="text-charcoal-300">/</span>
+          <Skeleton className={cn('h-6 w-24', animated && 'animate-pulse')} />
         </div>
       </div>
 
@@ -73,17 +66,17 @@ function DashboardSkeleton({ animated = true }: { animated?: boolean }) {
           { icon: DollarSign, label: 'Fund Size' },
           { icon: TrendingUp, label: 'Portfolio IRR' },
           { icon: Target, label: 'MOIC' },
-          { icon: PieChart, label: 'Allocation' }
+          { icon: PieChart, label: 'Allocation' },
         ].map((metric, index) => (
           <Card key={index} className="relative overflow-hidden">
             <CardContent className="p-6">
               <div className="flex items-center justify-between mb-4">
-                <metric.icon className="h-5 w-5 text-gray-300" />
-                <Skeleton className={cn("h-4 w-8", animated && "animate-pulse")} />
+                <metric.icon className="h-5 w-5 text-charcoal-300" />
+                <Skeleton className={cn('h-4 w-8', animated && 'animate-pulse')} />
               </div>
               <div className="space-y-2">
-                <Skeleton className={cn("h-8 w-20", animated && "animate-pulse")} />
-                <Skeleton className={cn("h-3 w-16", animated && "animate-pulse")} />
+                <Skeleton className={cn('h-8 w-20', animated && 'animate-pulse')} />
+                <Skeleton className={cn('h-3 w-16', animated && 'animate-pulse')} />
               </div>
             </CardContent>
             {/* Shimmer effect */}
@@ -107,7 +100,7 @@ function DashboardSkeleton({ animated = true }: { animated?: boolean }) {
 function ChartSkeleton({
   animated = true,
   chartType = 'bar',
-  height = 'h-64'
+  height = 'h-64',
 }: {
   animated?: boolean;
   chartType?: ChartType;
@@ -118,18 +111,18 @@ function ChartSkeleton({
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <div className="space-y-2">
-            <Skeleton className={cn("h-5 w-32", animated && "animate-pulse")} />
-            <Skeleton className={cn("h-3 w-48", animated && "animate-pulse")} />
+            <Skeleton className={cn('h-5 w-32', animated && 'animate-pulse')} />
+            <Skeleton className={cn('h-3 w-48', animated && 'animate-pulse')} />
           </div>
           <div className="flex items-center gap-2">
-            <Skeleton className={cn("h-8 w-8", animated && "animate-pulse")} />
-            <Skeleton className={cn("h-8 w-8", animated && "animate-pulse")} />
+            <Skeleton className={cn('h-8 w-8', animated && 'animate-pulse')} />
+            <Skeleton className={cn('h-8 w-8', animated && 'animate-pulse')} />
           </div>
         </div>
       </CardHeader>
 
       <CardContent>
-        <div className={cn("relative", height, "bg-gray-50 rounded-lg p-4")}>
+        <div className={cn('relative', height, 'bg-pov-gray/50 rounded-lg p-4')}>
           {/* Chart-specific skeleton patterns */}
           {chartType === 'bar' && <BarChartPattern animated={animated} />}
           {chartType === 'line' && <LineChartPattern animated={animated} />}
@@ -139,7 +132,7 @@ function ChartSkeleton({
 
           {/* Loading indicator */}
           <div className="absolute inset-0 flex items-center justify-center">
-            <div className="flex items-center gap-2 text-gray-400">
+            <div className="flex items-center gap-2 text-charcoal-400">
               <BarChart3 className="h-6 w-6" />
               <span className="text-sm font-medium">Loading chart data...</span>
             </div>
@@ -148,10 +141,10 @@ function ChartSkeleton({
 
         {/* Legend skeleton */}
         <div className="flex items-center justify-center gap-4 mt-4">
-          {[1, 2, 3].map(i => (
+          {[1, 2, 3].map((i) => (
             <div key={i} className="flex items-center gap-2">
-              <Skeleton className={cn("h-3 w-3 rounded-full", animated && "animate-pulse")} />
-              <Skeleton className={cn("h-3 w-16", animated && "animate-pulse")} />
+              <Skeleton className={cn('h-3 w-3 rounded-full', animated && 'animate-pulse')} />
+              <Skeleton className={cn('h-3 w-16', animated && 'animate-pulse')} />
             </div>
           ))}
         </div>
@@ -170,13 +163,13 @@ function BarChartPattern({ animated }: { animated: boolean }) {
         <div
           key={index}
           className={cn(
-            "bg-gray-300 rounded-t-sm transition-all duration-1000",
-            animated && "animate-pulse"
+            'bg-pov-gray rounded-t-sm transition-all duration-1000',
+            animated && 'animate-pulse'
           )}
           style={{
             height: `${height * 100}%`,
             width: '12%',
-            animationDelay: `${index * 0.1}s`
+            animationDelay: `${index * 0.1}s`,
           }}
         />
       ))}
@@ -189,10 +182,10 @@ function LineChartPattern({ animated }: { animated: boolean }) {
     <div className="relative h-full">
       {/* Grid lines */}
       <div className="absolute inset-0">
-        {[0, 25, 50, 75, 100].map(percent => (
+        {[0, 25, 50, 75, 100].map((percent) => (
           <div
             key={percent}
-            className="absolute w-full border-b border-gray-200"
+            className="absolute w-full border-b border-beige-200"
             style={{ top: `${percent}%` }}
           />
         ))}
@@ -205,7 +198,7 @@ function LineChartPattern({ animated }: { animated: boolean }) {
           stroke="currentColor"
           strokeWidth="3"
           fill="none"
-          className={cn("text-gray-300", animated && "animate-pulse")}
+          className={cn('text-charcoal-300', animated && 'animate-pulse')}
           strokeDasharray="5,5"
         />
         {/* Data points */}
@@ -215,7 +208,7 @@ function LineChartPattern({ animated }: { animated: boolean }) {
             cx={x}
             cy={[80, 20, 40, 35, 30][index]}
             r="4"
-            className={cn("fill-gray-300", animated && "animate-pulse")}
+            className={cn('fill-charcoal-300', animated && 'animate-pulse')}
             style={{ animationDelay: `${index * 0.2}s` }}
           />
         ))}
@@ -248,7 +241,7 @@ function PieChartPattern({ animated }: { animated: boolean }) {
             `M 50 50`,
             `L ${x1} ${y1}`,
             `A 40 40 0 ${largeArcFlag} 1 ${x2} ${y2}`,
-            'Z'
+            'Z',
           ].join(' ');
 
           cumulativeAngle += angle;
@@ -257,13 +250,10 @@ function PieChartPattern({ animated }: { animated: boolean }) {
             <path
               key={index}
               d={pathData}
-              className={cn(
-                "fill-gray-300 stroke-white stroke-2",
-                animated && "animate-pulse"
-              )}
+              className={cn('fill-charcoal-300 stroke-white stroke-2', animated && 'animate-pulse')}
               style={{
-                opacity: 0.3 + (index * 0.15),
-                animationDelay: `${index * 0.1}s`
+                opacity: 0.3 + index * 0.15,
+                animationDelay: `${index * 0.1}s`,
               }}
             />
           );
@@ -277,7 +267,7 @@ function ScatterChartPattern({ animated }: { animated: boolean }) {
   const points = Array.from({ length: 20 }, () => ({
     x: Math.random() * 90 + 5,
     y: Math.random() * 90 + 5,
-    size: Math.random() * 4 + 2
+    size: Math.random() * 4 + 2,
   }));
 
   return (
@@ -289,7 +279,7 @@ function ScatterChartPattern({ animated }: { animated: boolean }) {
             cx={point.x}
             cy={point.y}
             r={point.size}
-            className={cn("fill-gray-300", animated && "animate-pulse")}
+            className={cn('fill-charcoal-300', animated && 'animate-pulse')}
             style={{ animationDelay: `${index * 0.05}s` }}
           />
         ))}
@@ -311,14 +301,14 @@ function AreaChartPattern({ animated }: { animated: boolean }) {
         <path
           d="M0,80 Q75,20 150,40 T300,30 L300,100 L0,100 Z"
           fill="url(#areaSkeleton)"
-          className={cn("text-gray-300", animated && "animate-pulse")}
+          className={cn('text-charcoal-300', animated && 'animate-pulse')}
         />
         <path
           d="M0,80 Q75,20 150,40 T300,30"
           stroke="currentColor"
           strokeWidth="2"
           fill="none"
-          className={cn("text-gray-400", animated && "animate-pulse")}
+          className={cn('text-charcoal-400', animated && 'animate-pulse')}
         />
       </svg>
     </div>
@@ -330,7 +320,7 @@ function TableSkeleton({
   rows = 5,
   columns = 4,
   showHeaders = true,
-  animated = true
+  animated = true,
 }: {
   rows?: number;
   columns?: number;
@@ -344,10 +334,10 @@ function TableSkeleton({
           {/* Table header skeleton */}
           {showHeaders && (
             <div className="flex items-center justify-between">
-              <Skeleton className={cn("h-6 w-32", animated && "animate-pulse")} />
+              <Skeleton className={cn('h-6 w-32', animated && 'animate-pulse')} />
               <div className="flex items-center gap-2">
-                <Skeleton className={cn("h-8 w-24", animated && "animate-pulse")} />
-                <Skeleton className={cn("h-8 w-8", animated && "animate-pulse")} />
+                <Skeleton className={cn('h-8 w-24', animated && 'animate-pulse')} />
+                <Skeleton className={cn('h-8 w-8', animated && 'animate-pulse')} />
               </div>
             </div>
           )}
@@ -357,7 +347,7 @@ function TableSkeleton({
             {Array.from({ length: columns }).map((_, index) => (
               <Skeleton
                 key={index}
-                className={cn("h-4 w-full", animated && "animate-pulse")}
+                className={cn('h-4 w-full', animated && 'animate-pulse')}
                 style={{ animationDelay: `${index * 0.1}s` }}
               />
             ))}
@@ -375,9 +365,9 @@ function TableSkeleton({
                   <Skeleton
                     key={colIndex}
                     className={cn(
-                      "h-4",
-                      colIndex === 0 ? "w-3/4" : colIndex === columns - 1 ? "w-1/2" : "w-full",
-                      animated && "animate-pulse"
+                      'h-4',
+                      colIndex === 0 ? 'w-3/4' : colIndex === columns - 1 ? 'w-1/2' : 'w-full',
+                      animated && 'animate-pulse'
                     )}
                     style={{ animationDelay: `${(rowIndex * columns + colIndex) * 0.05}s` }}
                   />
@@ -395,34 +385,34 @@ function TableSkeleton({
 function InsightsSkeleton({ animated = true }: { animated?: boolean }) {
   return (
     <div className="space-y-4">
-      {[1, 2, 3].map(index => (
+      {[1, 2, 3].map((index) => (
         <Card key={index} className="relative overflow-hidden">
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between">
               <div className="flex items-center gap-3">
-                <Skeleton className={cn("h-10 w-10 rounded-lg", animated && "animate-pulse")} />
+                <Skeleton className={cn('h-10 w-10 rounded-lg', animated && 'animate-pulse')} />
                 <div className="space-y-2">
-                  <Skeleton className={cn("h-5 w-40", animated && "animate-pulse")} />
+                  <Skeleton className={cn('h-5 w-40', animated && 'animate-pulse')} />
                   <div className="flex items-center gap-2">
-                    <Skeleton className={cn("h-4 w-16", animated && "animate-pulse")} />
-                    <Skeleton className={cn("h-4 w-20", animated && "animate-pulse")} />
+                    <Skeleton className={cn('h-4 w-16', animated && 'animate-pulse')} />
+                    <Skeleton className={cn('h-4 w-20', animated && 'animate-pulse')} />
                   </div>
                 </div>
               </div>
-              <Skeleton className={cn("h-8 w-16", animated && "animate-pulse")} />
+              <Skeleton className={cn('h-8 w-16', animated && 'animate-pulse')} />
             </div>
           </CardHeader>
 
           <CardContent>
             <div className="space-y-3">
-              <Skeleton className={cn("h-4 w-full", animated && "animate-pulse")} />
-              <Skeleton className={cn("h-4 w-5/6", animated && "animate-pulse")} />
-              <Skeleton className={cn("h-4 w-4/6", animated && "animate-pulse")} />
+              <Skeleton className={cn('h-4 w-full', animated && 'animate-pulse')} />
+              <Skeleton className={cn('h-4 w-5/6', animated && 'animate-pulse')} />
+              <Skeleton className={cn('h-4 w-4/6', animated && 'animate-pulse')} />
 
               {/* Metrics skeleton */}
               <div className="flex items-center justify-between pt-2 border-t">
-                <Skeleton className={cn("h-3 w-20", animated && "animate-pulse")} />
-                <Skeleton className={cn("h-3 w-12", animated && "animate-pulse")} />
+                <Skeleton className={cn('h-3 w-20', animated && 'animate-pulse')} />
+                <Skeleton className={cn('h-3 w-12', animated && 'animate-pulse')} />
               </div>
             </div>
           </CardContent>
@@ -444,7 +434,7 @@ export function IntelligentSkeleton({
   variant,
   className,
   animated = true,
-  preview
+  preview,
 }: IntelligentSkeletonProps) {
   const skeletonComponents = {
     dashboard: <DashboardSkeleton animated={animated} />,
@@ -466,28 +456,26 @@ export function IntelligentSkeleton({
     metrics: <DashboardSkeleton animated={animated} />,
     insights: <InsightsSkeleton animated={animated} />,
     portfolio: <DashboardSkeleton animated={animated} />,
-    analysis: <InsightsSkeleton animated={animated} />
+    analysis: <InsightsSkeleton animated={animated} />,
   };
 
   return (
-    <div className={cn("space-y-4", className)}>
+    <div className={cn('space-y-4', className)}>
       {preview && (
-        <div className="text-center p-4 bg-slate-50 rounded-lg border border-dashed">
-          <div className="flex items-center justify-center gap-2 text-slate-600">
+        <div className="text-center p-4 bg-pov-gray rounded-lg border border-dashed">
+          <div className="flex items-center justify-center gap-2 text-charcoal-600">
             <Calculator className="h-5 w-5" />
             <span className="text-sm font-medium">
               {preview.title && `Loading ${preview.title}`}
               {preview.dataType && ` • ${preview.dataType}`}
             </span>
           </div>
-          {preview.subtitle && (
-            <p className="text-xs text-slate-500 mt-1">{preview.subtitle}</p>
-          )}
+          {preview.subtitle && <p className="text-xs text-charcoal-500 mt-1">{preview.subtitle}</p>}
         </div>
       )}
 
       {skeletonComponents[variant.type] || (
-        <div className="p-8 text-center text-gray-500">
+        <div className="p-8 text-center text-charcoal-500">
           <BarChart3 className="h-8 w-8 mx-auto mb-2" />
           <p>Loading content...</p>
         </div>

--- a/client/src/components/ui/label.tsx
+++ b/client/src/components/ui/label.tsx
@@ -1,30 +1,19 @@
- 
- 
- 
- 
- 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 font-poppins text-[#292929]"
-)
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 font-poppins text-pov-charcoal'
+);
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
-
+export { Label };

--- a/client/src/components/ui/lazy-chart.tsx
+++ b/client/src/components/ui/lazy-chart.tsx
@@ -15,12 +15,9 @@ type LazyChartVariantProps = Omit<LazyChartProps, 'component'>;
 // Loading fallback for charts
 export function ChartSkeleton({ height = 300 }: { height?: number }) {
   return (
-    <div 
-      className="animate-pulse bg-gray-100 rounded-lg" 
-      style={{ height: `${height}px` }}
-    >
+    <div className="animate-pulse bg-pov-gray rounded-lg" style={{ height: `${height}px` }}>
       <div className="flex items-center justify-center h-full">
-        <div className="text-gray-400">
+        <div className="text-charcoal-400">
           <svg
             className="w-8 h-8 animate-spin"
             xmlns="http://www.w3.org/2000/svg"
@@ -48,12 +45,7 @@ export function ChartSkeleton({ height = 300 }: { height?: number }) {
 }
 
 // Wrapper component for lazy-loaded charts
-export function LazyChart({ 
-  component, 
-  height = 300, 
-  children, 
-  ...props 
-}: LazyChartProps) {
+export function LazyChart({ component, height = 300, children, ...props }: LazyChartProps) {
   return (
     <Suspense fallback={<ChartSkeleton height={height} />}>
       <RechartsBundle component={component} {...props}>

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -1,45 +1,31 @@
- 
- 
- 
- 
- 
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
-))
-Table.displayName = "Table"
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+);
+Table.displayName = 'Table';
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("bg-[#292929] [&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+  <thead ref={ref} className={cn('bg-pov-charcoal [&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-))
-TableBody.displayName = "TableBody"
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -47,29 +33,25 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
+    className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
     {...props}
   />
-))
-TableFooter.displayName = "TableFooter"
+));
+TableFooter.displayName = 'TableFooter';
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b border-[#E0D8D1] transition-colors hover:bg-[#F2F2F2] data-[state=selected]:bg-muted",
-      className
-    )}
-    {...props}
-  />
-))
-TableRow.displayName = "TableRow"
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'border-b border-beige-200 transition-colors hover:bg-pov-gray data-[state=selected]:bg-muted',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = 'TableRow';
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -78,13 +60,13 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-poppins font-bold text-white [&:has([role=checkbox])]:pr-0",
+      'h-12 px-4 text-left align-middle font-poppins font-bold text-white [&:has([role=checkbox])]:pr-0',
       className
     )}
     {...props}
   />
-))
-TableHead.displayName = "TableHead"
+));
+TableHead.displayName = 'TableHead';
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -92,32 +74,18 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
     {...props}
   />
-))
-TableCell.displayName = "TableCell"
+));
+TableCell.displayName = 'TableCell';
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
   React.HTMLAttributes<HTMLTableCaptionElement>
 >(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-TableCaption.displayName = "TableCaption"
+  <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+));
+TableCaption.displayName = 'TableCaption';
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
-
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -1,16 +1,11 @@
- 
- 
- 
- 
- 
-import * as React from "react"
-import * as ToastPrimitives from "@radix-ui/react-toast"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from 'react';
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const ToastProvider = ToastPrimitives.Provider
+const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
@@ -19,34 +14,33 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
       className
     )}
     {...props}
   />
-))
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
+        default: 'border bg-background text-foreground',
         destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground",
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   }
-)
+);
 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
-    VariantProps<typeof toastVariants>
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
   return (
     <ToastPrimitives.Root
@@ -54,9 +48,9 @@ const Toast = React.forwardRef<
       className={cn(toastVariants({ variant }), className)}
       {...props}
     />
-  )
-})
-Toast.displayName = ToastPrimitives.Root.displayName
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
 
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
@@ -65,13 +59,13 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
       className
     )}
     {...props}
   />
-))
-ToastAction.displayName = ToastPrimitives.Action.displayName
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
 
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
@@ -80,7 +74,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-destructive-foreground/70 group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-error group-[.destructive]:focus:ring-offset-background',
       className
     )}
     toast-close=""
@@ -88,20 +82,16 @@ const ToastClose = React.forwardRef<
   >
     <X className="h-4 w-4" />
   </ToastPrimitives.Close>
-))
-ToastClose.displayName = ToastPrimitives.Close.displayName
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
 
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Title
-    ref={ref}
-    className={cn("text-sm font-semibold", className)}
-    {...props}
-  />
-))
-ToastTitle.displayName = ToastPrimitives.Title.displayName
+  <ToastPrimitives.Title ref={ref} className={cn('text-sm font-semibold', className)} {...props} />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
@@ -109,15 +99,15 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
-    className={cn("text-sm opacity-90", className)}
+    className={cn('text-sm opacity-90', className)}
     {...props}
   />
-))
-ToastDescription.displayName = ToastPrimitives.Description.displayName
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 
-type ToastActionElement = React.ReactElement<typeof ToastAction>
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
   type ToastProps,
@@ -129,5 +119,4 @@ export {
   ToastDescription,
   ToastClose,
   ToastAction,
-}
-
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -19,7 +19,7 @@
   --card-foreground: hsl(20, 14.3%, 4.1%);
   --border: hsl(20, 5.9%, 90%);
   --input: hsl(20, 5.9%, 90%);
-  --primary: hsl(207, 90%, 54%);
+  --primary: hsl(0, 0%, 16%); /* charcoal #292929 per DESIGN.md doctrine (was azure blue) */
   --primary-foreground: hsl(211, 100%, 99%);
   --secondary: hsl(60, 4.8%, 95.9%);
   --secondary-foreground: hsl(24, 9.8%, 10%);


### PR DESCRIPTION
## Milestone A — shared-layer Theme-2 token migration

Completes the Theme-2 design-token rollout's cross-cutting **shared layer**
(`components/{ui,layout,charts,dashboard,common}`) — the contention zone the
parallel waves (#769, #771) deliberately deferred. Migrates raw Tailwind/hex
colors to canonical Press On Ventures tokens per `DESIGN.md` doctrine.

### STEP 1 — the global accent flip (1 line, highest leverage)
`--primary` in `index.css` flipped from azure blue `hsl(207,90%,54%)` to charcoal
`hsl(0,0%,16%)` (#292929). This recolors **every shadcn primitive** (checkbox,
button, switch, tabs, focus rings) app-wide through the theming layer — that was
the last visible blue (e.g. the `/sensitivity-analysis` checkboxes). The dead
`.dark` block is left untouched (no `dark` class is ever applied) to avoid a
latent dark-on-dark regression.

### STEP 2 — raw-color migration across 5 dirs (~378 occurrences)
Tokens chosen by **semantic intent, not hue** (8-rule precedence, first match wins):

- **Action** → charcoal, never blue. Button **weight preserved** (filled CTA stays
  filled; outlined/secondary stays outlined — no promotion to competing primaries).
- **Two greens by role** — `success` = UI state, `presson-positive` = financial gain.
- **Financial direction** → `presson-positive`/`presson-negative`/`presson-warning`/`presson-info`.
- **Categorical chart series** → monochrome `getChartColor()` (avoids adjacent-green
  collision and false gain/loss meaning); chart chrome → neutral `presson.color.*`.
- **shadcn semantic tokens preserved** (`bg-primary`, `bg-muted`, `bg-accent`, etc.) —
  they already resolve to charcoal/neutral via the CSS var; rewriting them is churn.
- Purple/violet and off-doctrine blue removed throughout.

### Process note (for the reviewer)
The migration was driven by Hermes/Codex per directory, reviewed line-by-line. The
first `ui` pass over-reached (rewrote ~44 shadcn primitives' semantic tokens) and was
**fully reverted**, the spec hardened to exclude shadcn tokens, and re-run clean
(16 files). Two `layout` contrast regressions (solidified translucent overlays on
charcoal chrome) were corrected. The dashboard expense pie was refined from a
financial-token mix to monochrome categorical.

### Verification
- `npm run check`: **0 new TypeScript errors**
- **405/405** client component tests pass (`tests/unit/components`)
- Live eyeball (`/dashboard`, cashflow tab, `/sensitivity-analysis`): on-doctrine,
  financial direction (green inflows / red outflows) legible, zero blue/purple accents
- Residual off-token sweep: clean across all 5 dirs

### Intentional exclusions / known items
- `ui/BrandShowcase.tsx` — unrouted demo, raw colors left as illustrative
- `layout/{header,sidebar}.tsx` contrast fixes are on legacy/unmounted files (correct but not live)
- Net-cash-flow bars use sanctioned `presson-info` (blue) for neutral $; one pre-existing
  sole-color a11y case flagged `// TODO(a11y)` (fix deferred — out of color-migration scope)
- Diff size reflects the repo's pre-commit prettier/eslint reformat of touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
