### PR TITLE
design(rollout): page long-tail token migration (variance/LP/nav/wizard) + dead-page audit

### DIFF
--- a/client/src/pages/CapitalStructureStep.tsx
+++ b/client/src/pages/CapitalStructureStep.tsx
@@ -245,11 +245,11 @@ export default function CapitalStructureStep() {
 
         {/* Current Allocations */}
         <div className="space-y-6">
-          <div className="pb-4 border-b border-[#E0D8D1]">
-            <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+          <div className="pb-4 border-b border-beige-200">
+            <h3 className="text-lg font-inter font-bold text-pov-charcoal mb-2">
               Current Allocations
             </h3>
-            <p className="text-[#292929]/70 font-poppins">
+            <p className="text-pov-charcoal/70 font-poppins">
               Your currently defined allocations. Click on + New Allocation to create a new
               allocation or click on any allocation to edit.
             </p>
@@ -263,7 +263,7 @@ export default function CapitalStructureStep() {
               return (
                 <div
                   key={allocation.id}
-                  className="border border-[#E0D8D1] rounded-xl p-4 space-y-4"
+                  className="border border-beige-200 rounded-xl p-4 space-y-4"
                 >
                   {!isEditing ? (
                     // View Mode
@@ -295,38 +295,40 @@ export default function CapitalStructureStep() {
 
                       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm font-poppins">
                         <div>
-                          <span className="text-[#292929]/60">Entry Round:</span>
-                          <div className="font-medium text-[#292929]">{allocation.entryRound}</div>
+                          <span className="text-pov-charcoal/60">Entry Round:</span>
+                          <div className="font-medium text-pov-charcoal">
+                            {allocation.entryRound}
+                          </div>
                         </div>
                         <div>
-                          <span className="text-[#292929]/60">Initial Allocation:</span>
-                          <div className="font-medium text-[#292929]">
+                          <span className="text-pov-charcoal/60">Initial Allocation:</span>
+                          <div className="font-medium text-pov-charcoal">
                             {allocation.capitalAllocationPct}%
                           </div>
                         </div>
                         <div>
-                          <span className="text-[#292929]/60">Initial Capital:</span>
-                          <div className="font-medium text-[#292929]">
+                          <span className="text-pov-charcoal/60">Initial Capital:</span>
+                          <div className="font-medium text-pov-charcoal">
                             ${formatCurrency(calculations.initialCapital)}
                           </div>
                         </div>
                         <div>
-                          <span className="text-[#292929]/60">Follow-On Capital:</span>
-                          <div className="font-medium text-[#292929]">
+                          <span className="text-pov-charcoal/60">Follow-On Capital:</span>
+                          <div className="font-medium text-pov-charcoal">
                             ${formatCurrency(calculations.followOnCapital)}
                           </div>
                         </div>
                       </div>
                       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm font-poppins mt-2">
                         <div>
-                          <span className="text-[#292929]/60">Est. Initial Deals:</span>
-                          <div className="font-medium text-[#292929]">
+                          <span className="text-pov-charcoal/60">Est. Initial Deals:</span>
+                          <div className="font-medium text-pov-charcoal">
                             {calculations.estimatedDeals}
                           </div>
                         </div>
                         <div>
-                          <span className="text-[#292929]/60">Total Required:</span>
-                          <div className="font-medium text-[#292929]">
+                          <span className="text-pov-charcoal/60">Total Required:</span>
+                          <div className="font-medium text-pov-charcoal">
                             ${formatCurrency(calculations.totalCapitalRequired)}
                           </div>
                         </div>
@@ -349,7 +351,7 @@ export default function CapitalStructureStep() {
                       {/* Basic Info */}
                       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Allocation Name
                           </Label>
                           <Input
@@ -358,12 +360,12 @@ export default function CapitalStructureStep() {
                               handleUpdateAllocation(allocation.id, { name: e.target.value })
                             }
                             placeholder="e.g., Seed Investments"
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Sector Profile
                           </Label>
                           <Select
@@ -386,7 +388,7 @@ export default function CapitalStructureStep() {
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Entry Round
                           </Label>
                           <Select
@@ -410,7 +412,7 @@ export default function CapitalStructureStep() {
                       </div>
 
                       <div className="space-y-3">
-                        <Label className="text-sm font-poppins font-medium text-[#292929]">
+                        <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                           Initial Capital Allocation (%)
                         </Label>
                         <Input
@@ -424,22 +426,22 @@ export default function CapitalStructureStep() {
                               capitalAllocationPct: parseFloat(e.target.value) || 0,
                             })
                           }
-                          className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                          className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                         />
-                        <p className="text-sm text-[#292929]/60 font-poppins">
+                        <p className="text-sm text-pov-charcoal/60 font-poppins">
                           Initial Investment Capital: $
                           {formatCurrency((fundSize * allocation.capitalAllocationPct) / 100)}
                         </p>
                       </div>
 
                       {/* Initial Check Strategy */}
-                      <div className="space-y-4 border-t border-[#E0D8D1] pt-6">
-                        <h4 className="text-lg font-inter font-bold text-[#292929]">
+                      <div className="space-y-4 border-t border-beige-200 pt-6">
+                        <h4 className="text-lg font-inter font-bold text-pov-charcoal">
                           Initial Check Strategy
                         </h4>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Strategy Type
                           </Label>
                           <Select
@@ -460,7 +462,7 @@ export default function CapitalStructureStep() {
 
                         {allocation.initialCheckStrategy === 'amount' ? (
                           <div className="space-y-3">
-                            <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                               Initial Check Size ($)
                             </Label>
                             <Input
@@ -478,12 +480,12 @@ export default function CapitalStructureStep() {
                                 })
                               }
                               placeholder="e.g., 500,000"
-                              className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                              className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                             />
                           </div>
                         ) : (
                           <div className="space-y-3">
-                            <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                               Entry Ownership (%)
                             </Label>
                             <Input
@@ -500,7 +502,7 @@ export default function CapitalStructureStep() {
                                 })
                               }
                               placeholder="e.g., 10"
-                              className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                              className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                             />
                           </div>
                         )}
@@ -538,14 +540,14 @@ export default function CapitalStructureStep() {
                       </div>
 
                       {/* Follow-On Strategy */}
-                      <div className="space-y-4 border-t border-[#E0D8D1] pt-6">
-                        <h4 className="text-lg font-inter font-bold text-[#292929]">
+                      <div className="space-y-4 border-t border-beige-200 pt-6">
+                        <h4 className="text-lg font-inter font-bold text-pov-charcoal">
                           Follow-On Strategy
                         </h4>
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                           <div className="space-y-3">
-                            <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                               Follow-On Strategy
                             </Label>
                             <Select
@@ -567,7 +569,7 @@ export default function CapitalStructureStep() {
                           </div>
 
                           <div className="space-y-3">
-                            <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                               Follow-On Participation (%)
                             </Label>
                             <Input
@@ -581,14 +583,14 @@ export default function CapitalStructureStep() {
                                   followOnParticipationPct: parseFloat(e.target.value) || 0,
                                 })
                               }
-                              className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                              className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                             />
                           </div>
                         </div>
 
                         {allocation.followOnStrategy === 'amount' && (
                           <div className="space-y-3">
-                            <Label className="text-sm font-poppins font-medium text-[#292929]">
+                            <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                               Follow-On Check Size ($)
                             </Label>
                             <Input
@@ -606,7 +608,7 @@ export default function CapitalStructureStep() {
                                 })
                               }
                               placeholder="e.g., 1,000,000"
-                              className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                              className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                             />
                           </div>
                         )}
@@ -626,8 +628,8 @@ export default function CapitalStructureStep() {
                       </div>
 
                       {/* Investment Horizon */}
-                      <div className="space-y-3 border-t border-[#E0D8D1] pt-6">
-                        <Label className="text-sm font-poppins font-medium text-[#292929]">
+                      <div className="space-y-3 border-t border-beige-200 pt-6">
+                        <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                           Initial Investment Horizon (months)
                         </Label>
                         <Input
@@ -640,9 +642,9 @@ export default function CapitalStructureStep() {
                               investmentHorizonMonths: parseInt(e.target.value) || 24,
                             })
                           }
-                          className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                          className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                         />
-                        <p className="text-sm text-[#292929]/60 font-poppins">
+                        <p className="text-sm text-pov-charcoal/60 font-poppins">
                           Time period over which you expect to make initial investments in this
                           allocation
                         </p>
@@ -656,7 +658,7 @@ export default function CapitalStructureStep() {
             <Button
               onClick={handleAddAllocation}
               variant="outline"
-              className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+              className="w-full h-12 border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
             >
               <Plus aria-hidden="true" className="h-4 w-4 mr-2" />
               New Allocation
@@ -665,12 +667,12 @@ export default function CapitalStructureStep() {
         </div>
 
         {/* Navigation */}
-        <div className="flex justify-between pt-8 border-t border-[#E0D8D1] mt-8">
+        <div className="flex justify-between pt-8 border-t border-beige-200 mt-8">
           <Button
             data-testid="previous-step"
             variant="outline"
             onClick={() => navigate('/fund-setup?step=2')}
-            className="flex items-center gap-2 px-8 py-3 h-auto border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+            className="flex items-center gap-2 px-8 py-3 h-auto border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
           >
             <ArrowLeft className="h-4 w-4" />
             Previous
@@ -678,7 +680,7 @@ export default function CapitalStructureStep() {
           <Button
             data-testid="next-step"
             onClick={() => navigate('/fund-setup?step=4')}
-            className="flex items-center gap-2 bg-[#292929] hover:bg-[#292929]/90 text-white px-8 py-3 h-auto font-poppins font-medium"
+            className="flex items-center gap-2 bg-pov-charcoal hover:bg-charcoal-700 text-pov-white px-8 py-3 h-auto font-poppins font-medium"
           >
             Next Step
             <ArrowRight className="h-4 w-4" />

--- a/client/src/pages/CashflowManagementStep.tsx
+++ b/client/src/pages/CashflowManagementStep.tsx
@@ -208,10 +208,10 @@ export default function CashflowManagementStep() {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="space-y-2">
-        <h1 className="text-3xl font-inter font-bold text-[#292929]">
+        <h1 className="text-3xl font-inter font-bold text-pov-charcoal">
           Cashflow & Liquidity Management
         </h1>
-        <p className="text-[#292929]/70 font-poppins">
+        <p className="text-pov-charcoal/70 font-poppins">
           Configure cashflow tracking, expense management, and liquidity monitoring for your fund.
         </p>
       </div>
@@ -241,31 +241,35 @@ export default function CashflowManagementStep() {
             </CardHeader>
             <CardContent className="space-y-6">
               {/* Summary */}
-              <div className="grid grid-cols-1 gap-4 p-4 bg-[#F2F2F2] rounded-xl sm:grid-cols-3">
+              <div className="grid grid-cols-1 gap-4 p-4 bg-pov-gray rounded-xl sm:grid-cols-3">
                 <div className="text-center">
-                  <div className="text-2xl font-inter font-bold text-[#292929]">
+                  <div className="text-2xl font-inter font-bold text-pov-charcoal">
                     ${totalAnnualExpenses.toLocaleString()}
                   </div>
-                  <div className="text-sm text-[#292929]/60 font-poppins">Annual Expenses</div>
+                  <div className="text-sm text-pov-charcoal/60 font-poppins">Annual Expenses</div>
                 </div>
                 <div className="text-center">
-                  <div className="text-2xl font-inter font-bold text-[#292929]">
+                  <div className="text-2xl font-inter font-bold text-pov-charcoal">
                     {expenseRatio.toFixed(1)}%
                   </div>
-                  <div className="text-sm text-[#292929]/60 font-poppins">of Fund Size</div>
+                  <div className="text-sm text-pov-charcoal/60 font-poppins">of Fund Size</div>
                 </div>
                 <div className="text-center">
-                  <div className="text-2xl font-inter font-bold text-[#292929]">
+                  <div className="text-2xl font-inter font-bold text-pov-charcoal">
                     {fundExpenses.length}
                   </div>
-                  <div className="text-sm text-[#292929]/60 font-poppins">Expense Categories</div>
+                  <div className="text-sm text-pov-charcoal/60 font-poppins">
+                    Expense Categories
+                  </div>
                 </div>
               </div>
 
               {/* Expense List */}
               <div className="space-y-4">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <h3 className="text-lg font-inter font-bold text-[#292929]">Current Expenses</h3>
+                  <h3 className="text-lg font-inter font-bold text-pov-charcoal">
+                    Current Expenses
+                  </h3>
                   {fundExpenses.length > 0 && (
                     <Button type="button" variant="outline" onClick={handleAddSuggestedExpenses}>
                       <Plus aria-hidden="true" className="h-4 w-4 mr-2" />
@@ -295,23 +299,23 @@ export default function CashflowManagementStep() {
                     {fundExpenses.map((expense, _index) => (
                       <div
                         key={expense.id}
-                        className="flex items-center gap-4 p-3 border border-[#E0D8D1] rounded-xl"
+                        className="flex items-center gap-4 p-3 border border-beige-200 rounded-xl"
                       >
                         <div className="flex-1">
-                          <div className="font-poppins font-medium text-[#292929]">
+                          <div className="font-poppins font-medium text-pov-charcoal">
                             {expense.category}
                           </div>
-                          <div className="text-sm text-[#292929]/60 font-poppins">
+                          <div className="text-sm text-pov-charcoal/60 font-poppins">
                             {expense.endMonth
                               ? `Months ${expense.startMonth}-${expense.endMonth}`
                               : `Starting month ${expense.startMonth}, ongoing`}
                           </div>
                         </div>
                         <div className="text-right">
-                          <div className="font-poppins font-medium text-[#292929]">
+                          <div className="font-poppins font-medium text-pov-charcoal">
                             ${expense.monthlyAmount.toLocaleString()}/mo
                           </div>
-                          <div className="text-sm text-[#292929]/60 font-poppins">
+                          <div className="text-sm text-pov-charcoal/60 font-poppins">
                             ${(expense.monthlyAmount * 12).toLocaleString()}/yr
                           </div>
                         </div>
@@ -330,11 +334,11 @@ export default function CashflowManagementStep() {
               </div>
 
               {/* Add New Expense */}
-              <div className="space-y-4 p-4 border border-[#E0D8D1] rounded-xl">
-                <h3 className="text-lg font-inter font-bold text-[#292929]">Add New Expense</h3>
+              <div className="space-y-4 p-4 border border-beige-200 rounded-xl">
+                <h3 className="text-lg font-inter font-bold text-pov-charcoal">Add New Expense</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                   <div className="space-y-2">
-                    <Label className="font-poppins font-medium text-[#292929]">Category</Label>
+                    <Label className="font-poppins font-medium text-pov-charcoal">Category</Label>
                     <Select
                       value={newExpense.category}
                       onValueChange={(v) =>
@@ -355,7 +359,7 @@ export default function CashflowManagementStep() {
                   </div>
 
                   <div className="space-y-2">
-                    <Label className="font-poppins font-medium text-[#292929]">
+                    <Label className="font-poppins font-medium text-pov-charcoal">
                       Monthly Amount
                     </Label>
                     <Input
@@ -369,12 +373,14 @@ export default function CashflowManagementStep() {
                         }))
                       }
                       aria-label="Monthly expense amount"
-                      className="border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                      className="border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                     />
                   </div>
 
                   <div className="space-y-2">
-                    <Label className="font-poppins font-medium text-[#292929]">Start Month</Label>
+                    <Label className="font-poppins font-medium text-pov-charcoal">
+                      Start Month
+                    </Label>
                     <Input
                       type="number"
                       min="1"
@@ -387,12 +393,12 @@ export default function CashflowManagementStep() {
                         }))
                       }
                       aria-label="Expense start month"
-                      className="border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                      className="border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                     />
                   </div>
 
                   <div className="space-y-2">
-                    <Label className="font-poppins font-medium text-[#292929]">Duration</Label>
+                    <Label className="font-poppins font-medium text-pov-charcoal">Duration</Label>
                     <div className="flex items-center gap-2">
                       <Switch
                         checked={newExpense.isRecurring}
@@ -405,7 +411,7 @@ export default function CashflowManagementStep() {
                         }
                         aria-label="Use ongoing expense duration"
                       />
-                      <span className="text-sm font-poppins text-[#292929]">
+                      <span className="text-sm font-poppins text-pov-charcoal">
                         {newExpense.isRecurring ? 'Ongoing' : 'Fixed term'}
                       </span>
                     </div>
@@ -423,7 +429,7 @@ export default function CashflowManagementStep() {
                           }))
                         }
                         aria-label="Expense end month"
-                        className="border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                        className="border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                       />
                     )}
                   </div>
@@ -432,7 +438,7 @@ export default function CashflowManagementStep() {
                 <Button
                   onClick={handleAddExpense}
                   disabled={!canAddExpense}
-                  className="bg-[#292929] hover:bg-[#292929]/90 font-poppins font-medium"
+                  className="bg-pov-charcoal text-pov-white hover:bg-charcoal-700 font-poppins font-medium"
                 >
                   <Plus className="h-4 w-4 mr-2" />
                   Add Expense
@@ -454,7 +460,7 @@ export default function CashflowManagementStep() {
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
-                  <Label className="font-poppins font-medium text-[#292929]">
+                  <Label className="font-poppins font-medium text-pov-charcoal">
                     Notice Period (Days)
                   </Label>
                   <Input
@@ -468,15 +474,15 @@ export default function CashflowManagementStep() {
                         capitalCallNoticeDays: parseInt(e.target.value) || 10,
                       }))
                     }
-                    className="border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                    className="border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                   />
-                  <p className="text-sm text-[#292929]/60 font-poppins">
+                  <p className="text-sm text-pov-charcoal/60 font-poppins">
                     Days between capital call notice and due date
                   </p>
                 </div>
 
                 <div className="space-y-2">
-                  <Label className="font-poppins font-medium text-[#292929]">
+                  <Label className="font-poppins font-medium text-pov-charcoal">
                     Payment Period (Days)
                   </Label>
                   <Input
@@ -490,20 +496,20 @@ export default function CashflowManagementStep() {
                         capitalCallPaymentDays: parseInt(e.target.value) || 30,
                       }))
                     }
-                    className="border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                    className="border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                   />
-                  <p className="text-sm text-[#292929]/60 font-poppins">
+                  <p className="text-sm text-pov-charcoal/60 font-poppins">
                     Days LPs have to fund capital calls
                   </p>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 border border-[#E0D8D1] rounded-xl">
+              <div className="flex items-center justify-between p-4 border border-beige-200 rounded-xl">
                 <div>
-                  <h4 className="font-poppins font-medium text-[#292929]">
+                  <h4 className="font-poppins font-medium text-pov-charcoal">
                     Automatic Capital Calls
                   </h4>
-                  <p className="text-sm text-[#292929]/60 font-poppins">
+                  <p className="text-sm text-pov-charcoal/60 font-poppins">
                     Generate capital calls automatically based on investment pipeline
                   </p>
                 </div>
@@ -531,7 +537,7 @@ export default function CashflowManagementStep() {
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
-                  <Label className="font-poppins font-medium text-[#292929]">
+                  <Label className="font-poppins font-medium text-pov-charcoal">
                     Minimum Cash Ratio (%)
                   </Label>
                   <Input
@@ -546,15 +552,15 @@ export default function CashflowManagementStep() {
                         minimumCashRatio: parseFloat(e.target.value) || 5,
                       }))
                     }
-                    className="border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                    className="border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                   />
-                  <p className="text-sm text-[#292929]/60 font-poppins">
+                  <p className="text-sm text-pov-charcoal/60 font-poppins">
                     Minimum cash as % of fund size
                   </p>
                 </div>
 
                 <div className="space-y-2">
-                  <Label className="font-poppins font-medium text-[#292929]">
+                  <Label className="font-poppins font-medium text-pov-charcoal">
                     Forecast Horizon (Months)
                   </Label>
                   <Input
@@ -568,9 +574,9 @@ export default function CashflowManagementStep() {
                         forecastHorizonMonths: parseInt(e.target.value) || 12,
                       }))
                     }
-                    className="border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                    className="border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                   />
-                  <p className="text-sm text-[#292929]/60 font-poppins">
+                  <p className="text-sm text-pov-charcoal/60 font-poppins">
                     How far ahead to project cashflows
                   </p>
                 </div>
@@ -578,31 +584,31 @@ export default function CashflowManagementStep() {
 
               {/* Liquidity Alerts */}
               <div className="space-y-3">
-                <h4 className="font-poppins font-medium text-[#292929]">Alert Thresholds</h4>
+                <h4 className="font-poppins font-medium text-pov-charcoal">Alert Thresholds</h4>
                 <div className="space-y-2">
-                  <div className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-xl">
+                  <div className="flex items-center justify-between p-3 border border-beige-200 rounded-xl">
                     <div>
-                      <span className="font-poppins font-medium text-yellow-600">
+                      <span className="font-poppins font-medium text-warning-dark">
                         Low Liquidity Warning
                       </span>
-                      <p className="text-sm text-[#292929]/60 font-poppins">
+                      <p className="text-sm text-pov-charcoal/60 font-poppins">
                         Alert when cash falls below 2% of fund size
                       </p>
                     </div>
-                    <Badge variant="outline" className="text-yellow-600">
+                    <Badge variant="outline" className="text-warning-dark">
                       2%
                     </Badge>
                   </div>
-                  <div className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-xl">
+                  <div className="flex items-center justify-between p-3 border border-beige-200 rounded-xl">
                     <div>
-                      <span className="font-poppins font-medium text-red-600">
+                      <span className="font-poppins font-medium text-error-dark">
                         Critical Liquidity Alert
                       </span>
-                      <p className="text-sm text-[#292929]/60 font-poppins">
+                      <p className="text-sm text-pov-charcoal/60 font-poppins">
                         Alert when cash falls below 1% of fund size
                       </p>
                     </div>
-                    <Badge variant="outline" className="text-red-600">
+                    <Badge variant="outline" className="text-error-dark">
                       1%
                     </Badge>
                   </div>
@@ -623,12 +629,12 @@ export default function CashflowManagementStep() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-4">
-                <div className="flex items-center justify-between p-4 border border-[#E0D8D1] rounded-xl">
+                <div className="flex items-center justify-between p-4 border border-beige-200 rounded-xl">
                   <div>
-                    <h4 className="font-poppins font-medium text-[#292929]">
+                    <h4 className="font-poppins font-medium text-pov-charcoal">
                       Enable Cashflow Tracking
                     </h4>
-                    <p className="text-sm text-[#292929]/60 font-poppins">
+                    <p className="text-sm text-pov-charcoal/60 font-poppins">
                       Track all fund cash inflows and outflows
                     </p>
                   </div>
@@ -641,12 +647,12 @@ export default function CashflowManagementStep() {
                   />
                 </div>
 
-                <div className="flex items-center justify-between p-4 border border-[#E0D8D1] rounded-xl">
+                <div className="flex items-center justify-between p-4 border border-beige-200 rounded-xl">
                   <div>
-                    <h4 className="font-poppins font-medium text-[#292929]">
+                    <h4 className="font-poppins font-medium text-pov-charcoal">
                       Enable Expense Tracking
                     </h4>
-                    <p className="text-sm text-[#292929]/60 font-poppins">
+                    <p className="text-sm text-pov-charcoal/60 font-poppins">
                       Detailed tracking of fund operating expenses
                     </p>
                   </div>
@@ -661,23 +667,25 @@ export default function CashflowManagementStep() {
 
                 {/* Integration Settings */}
                 <div className="space-y-3">
-                  <h4 className="font-poppins font-medium text-[#292929]">Integrations</h4>
+                  <h4 className="font-poppins font-medium text-pov-charcoal">Integrations</h4>
                   <div className="space-y-2">
-                    <div className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-xl">
+                    <div className="flex items-center justify-between p-3 border border-beige-200 rounded-xl">
                       <div>
-                        <span className="font-poppins font-medium text-[#292929]">Banking API</span>
-                        <p className="text-sm text-[#292929]/60 font-poppins">
+                        <span className="font-poppins font-medium text-pov-charcoal">
+                          Banking API
+                        </span>
+                        <p className="text-sm text-pov-charcoal/60 font-poppins">
                           Real-time bank balance sync
                         </p>
                       </div>
                       <Badge variant="outline">Coming Soon</Badge>
                     </div>
-                    <div className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-xl">
+                    <div className="flex items-center justify-between p-3 border border-beige-200 rounded-xl">
                       <div>
-                        <span className="font-poppins font-medium text-[#292929]">
+                        <span className="font-poppins font-medium text-pov-charcoal">
                           Portfolio Company Reporting
                         </span>
-                        <p className="text-sm text-[#292929]/60 font-poppins">
+                        <p className="text-sm text-pov-charcoal/60 font-poppins">
                           Automatic distribution forecasting
                         </p>
                       </div>
@@ -697,7 +705,7 @@ export default function CashflowManagementStep() {
           data-testid="previous-step"
           variant="outline"
           onClick={handlePrevious}
-          className="border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+          className="border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
           Previous
@@ -705,7 +713,7 @@ export default function CashflowManagementStep() {
         <Button
           data-testid="finish-setup"
           onClick={handleNext}
-          className="bg-green-600 hover:bg-green-700 font-poppins font-medium"
+          className="bg-pov-charcoal text-pov-white hover:bg-charcoal-700 font-poppins font-medium"
         >
           Next: Review & Create
           <ArrowRight className="h-4 w-4 ml-2" />

--- a/client/src/pages/DistributionsStep.tsx
+++ b/client/src/pages/DistributionsStep.tsx
@@ -192,11 +192,11 @@ export default function DistributionsStep() {
 
           <TabsContent value="waterfall" className="space-y-6">
             <div className="space-y-6">
-              <div className="pb-4 border-b border-[#E0D8D1]">
-                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+              <div className="pb-4 border-b border-beige-200">
+                <h3 className="text-lg font-inter font-bold text-pov-charcoal mb-2">
                   Distribution Waterfall
                 </h3>
-                <p className="text-[#292929]/70 font-poppins">
+                <p className="text-pov-charcoal/70 font-poppins">
                   Define how distributions flow between LPs and GP
                 </p>
               </div>
@@ -210,17 +210,17 @@ export default function DistributionsStep() {
               </Alert>
 
               <div className="space-y-4">
-                <h4 className="font-inter font-bold text-[#292929]">Waterfall Tiers</h4>
+                <h4 className="font-inter font-bold text-pov-charcoal">Waterfall Tiers</h4>
                 <div className="space-y-4">
                   {waterfallTiers.map((tier: WaterfallTier) => (
-                    <div key={tier.id} className="border border-[#E0D8D1] rounded-xl p-4 space-y-4">
+                    <div key={tier.id} className="border border-beige-200 rounded-xl p-4 space-y-4">
                       <div className="flex items-center justify-between">
                         <h3 className="font-medium">{tier.name}</h3>
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => removeWaterfallTier(tier.id)}
-                          className="text-red-500 hover:text-red-700"
+                          className="text-error hover:text-error-dark"
                           disabled={waterfallTiers.length === 1}
                           aria-label={`Remove ${tier.name} waterfall tier`}
                         >
@@ -230,7 +230,7 @@ export default function DistributionsStep() {
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Tier Name
                           </Label>
                           <Input
@@ -239,12 +239,12 @@ export default function DistributionsStep() {
                               updateWaterfallTier(tier.id, { name: e.target.value })
                             }
                             placeholder="e.g., Preferred Return"
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Condition
                           </Label>
                           <Select
@@ -272,7 +272,7 @@ export default function DistributionsStep() {
 
                       {tier.condition && tier.condition !== 'none' && (
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             {tier.condition === 'irr' ? 'IRR Hurdle (%)' : 'MOIC Hurdle'}
                           </Label>
                           <Input
@@ -288,14 +288,14 @@ export default function DistributionsStep() {
                               })
                             }
                             placeholder={tier.condition === 'irr' ? 'e.g., 8.0' : 'e.g., 1.5'}
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
                       )}
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             LP Split (%)
                           </Label>
                           <Input
@@ -310,20 +310,20 @@ export default function DistributionsStep() {
                                 gpSplit: 100 - lpSplit,
                               });
                             }}
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             GP Split (%)
                           </Label>
                           <div
-                            className="p-3 bg-[#F2F2F2] rounded-xl h-12 flex items-center"
+                            className="p-3 bg-pov-gray rounded-xl h-12 flex items-center"
                             role="status"
                             aria-label={`GP Split is calculated as ${tier.gpSplit}% from LP Split`}
                           >
-                            <span className="text-[#292929] font-poppins">{tier.gpSplit}%</span>
+                            <span className="text-pov-charcoal font-poppins">{tier.gpSplit}%</span>
                           </div>
                         </div>
                       </div>
@@ -333,7 +333,7 @@ export default function DistributionsStep() {
                   <Button
                     onClick={handleAddTier}
                     variant="outline"
-                    className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+                    className="w-full h-12 border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
                   >
                     <Plus className="h-4 w-4 mr-2" />
                     Add Waterfall Tier
@@ -346,11 +346,11 @@ export default function DistributionsStep() {
           <TabsContent value="fees" className="space-y-6">
             {/* Management Fees Section */}
             <div className="space-y-6">
-              <div className="pb-4 border-b border-[#E0D8D1]">
-                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+              <div className="pb-4 border-b border-beige-200">
+                <h3 className="text-lg font-inter font-bold text-pov-charcoal mb-2">
                   Management Fees
                 </h3>
-                <p className="text-[#292929]/70 font-poppins">
+                <p className="text-pov-charcoal/70 font-poppins">
                   Configure fee structures with different basis methods and step-downs
                 </p>
               </div>
@@ -359,11 +359,11 @@ export default function DistributionsStep() {
                 {feeProfiles.map((profile: FeeProfile) => (
                   <div
                     key={profile.id}
-                    className="border border-[#E0D8D1] rounded-xl p-4 space-y-4"
+                    className="border border-beige-200 rounded-xl p-4 space-y-4"
                   >
                     <div className="flex items-center justify-between">
                       <div className="space-y-3 flex-1">
-                        <Label className="text-sm font-poppins font-medium text-[#292929]">
+                        <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                           Fee Profile Name
                         </Label>
                         <Input
@@ -372,7 +372,7 @@ export default function DistributionsStep() {
                             updateFeeProfile(profile.id, { name: e.target.value })
                           }
                           placeholder="e.g., Default Fee Profile"
-                          className="max-w-md h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                          className="max-w-md h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                         />
                       </div>
                       <div className="flex items-center space-x-2">
@@ -389,7 +389,7 @@ export default function DistributionsStep() {
                             variant="ghost"
                             size="sm"
                             onClick={() => removeFeeProfile(profile.id)}
-                            className="text-red-500 hover:text-red-700"
+                            className="text-error hover:text-error-dark"
                             aria-label={`Remove ${profile.name} fee profile`}
                           >
                             <Trash2 aria-hidden="true" className="h-4 w-4" />
@@ -401,14 +401,14 @@ export default function DistributionsStep() {
                     {/* Fee Tiers */}
                     <div className="space-y-4">
                       {profile.feeTiers.map((tier: FeeTier, index: number) => (
-                        <div key={tier.id} className="border-l-4 border-[#E0D8D1] pl-4 space-y-4">
+                        <div key={tier.id} className="border-l-4 border-beige-200 pl-4 space-y-4">
                           <div className="flex items-center justify-between">
                             <h4 className="font-medium">Fee Tier {index + 1}</h4>
                             <Button
                               variant="ghost"
                               size="sm"
                               onClick={() => removeFeeTier(profile.id, tier.id)}
-                              className="text-red-500 hover:text-red-700"
+                              className="text-error hover:text-error-dark"
                               disabled={profile.feeTiers.length === 1}
                               aria-label={`Remove ${tier.name} fee tier`}
                             >
@@ -418,7 +418,7 @@ export default function DistributionsStep() {
 
                           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                              <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                                 Fee Name
                               </Label>
                               <Input
@@ -427,12 +427,12 @@ export default function DistributionsStep() {
                                   updateFeeTier(profile.id, tier.id, { name: e.target.value })
                                 }
                                 placeholder="e.g., Management Fee"
-                                className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                                className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                              <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                                 Fee Percentage (%)
                               </Label>
                               <Input
@@ -447,12 +447,12 @@ export default function DistributionsStep() {
                                   })
                                 }
                                 placeholder="2.0"
-                                className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                                className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                              <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                                 Fee Basis
                               </Label>
                               <Select
@@ -474,7 +474,7 @@ export default function DistributionsStep() {
                                   ))}
                                 </SelectContent>
                               </Select>
-                              <p className="text-xs text-[#292929]/60 font-poppins">
+                              <p className="text-xs text-pov-charcoal/60 font-poppins">
                                 {
                                   feeBasisOptions.find((opt) => opt.value === tier.feeBasis)
                                     ?.description
@@ -483,7 +483,7 @@ export default function DistributionsStep() {
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                              <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                                 Start Month
                               </Label>
                               <Input
@@ -495,12 +495,12 @@ export default function DistributionsStep() {
                                     startMonth: parseInt(e.target.value) || 1,
                                   })
                                 }
-                                className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                                className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                              <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                                 End Month (Optional)
                               </Label>
                               <Input
@@ -515,12 +515,12 @@ export default function DistributionsStep() {
                                   })
                                 }
                                 placeholder="120"
-                                className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                                className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                               />
                             </div>
 
                             <div className="space-y-3">
-                              <Label className="text-sm font-poppins font-medium text-[#292929]">
+                              <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                                 Management Fee Recycling (%)
                               </Label>
                               <Input
@@ -536,9 +536,9 @@ export default function DistributionsStep() {
                                   })
                                 }
                                 placeholder="0"
-                                className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                                className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                               />
-                              <p className="text-xs text-[#292929]/60 font-poppins">
+                              <p className="text-xs text-pov-charcoal/60 font-poppins">
                                 % of fees that can be recycled from this tier
                               </p>
                             </div>
@@ -552,7 +552,7 @@ export default function DistributionsStep() {
                 <Button
                   onClick={handleAddFeeProfile}
                   variant="outline"
-                  className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+                  className="w-full h-12 border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
                 >
                   <Plus className="h-4 w-4 mr-2" />
                   Add Fee Profile
@@ -560,12 +560,12 @@ export default function DistributionsStep() {
               </div>
 
               {/* Fund Expenses Section */}
-              <div className="space-y-6 border-t border-[#E0D8D1] pt-8">
-                <div className="pb-4 border-b border-[#E0D8D1]">
-                  <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+              <div className="space-y-6 border-t border-beige-200 pt-8">
+                <div className="pb-4 border-b border-beige-200">
+                  <h3 className="text-lg font-inter font-bold text-pov-charcoal mb-2">
                     Fund Expenses
                   </h3>
-                  <p className="text-[#292929]/70 font-poppins">
+                  <p className="text-pov-charcoal/70 font-poppins">
                     Define line-item fund expenses with monthly amounts and terms
                   </p>
                 </div>
@@ -574,7 +574,7 @@ export default function DistributionsStep() {
                   {fundExpenses.map((expense: FundExpense) => (
                     <div
                       key={expense.id}
-                      className="border border-[#E0D8D1] rounded-xl p-4 space-y-4"
+                      className="border border-beige-200 rounded-xl p-4 space-y-4"
                     >
                       <div className="flex items-center justify-between">
                         <h4 className="font-medium">Expense: {expense.category}</h4>
@@ -582,7 +582,7 @@ export default function DistributionsStep() {
                           variant="ghost"
                           size="sm"
                           onClick={() => removeFundExpense(expense.id)}
-                          className="text-red-500 hover:text-red-700"
+                          className="text-error hover:text-error-dark"
                           aria-label={`Remove ${expense.category} expense`}
                         >
                           <Trash2 aria-hidden="true" className="h-4 w-4" />
@@ -591,7 +591,7 @@ export default function DistributionsStep() {
 
                       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Expense Category
                           </Label>
                           <Input
@@ -600,12 +600,12 @@ export default function DistributionsStep() {
                               updateFundExpense(expense.id, { category: e.target.value })
                             }
                             placeholder="e.g., Legal Fees"
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Monthly Amount ($)
                           </Label>
                           <Input
@@ -618,12 +618,12 @@ export default function DistributionsStep() {
                               })
                             }
                             placeholder="10000"
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Start Month
                           </Label>
                           <Input
@@ -635,12 +635,12 @@ export default function DistributionsStep() {
                                 startMonth: parseInt(e.target.value) || 1,
                               })
                             }
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
 
                         <div className="space-y-3">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             End Month (Optional)
                           </Label>
                           <Input
@@ -655,7 +655,7 @@ export default function DistributionsStep() {
                               })
                             }
                             placeholder="120"
-                            className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                            className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                           />
                         </div>
                       </div>
@@ -665,7 +665,7 @@ export default function DistributionsStep() {
                   <Button
                     onClick={handleAddExpense}
                     variant="outline"
-                    className="w-full h-12 border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+                    className="w-full h-12 border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
                   >
                     <Plus className="h-4 w-4 mr-2" />
                     Add Expense
@@ -677,25 +677,25 @@ export default function DistributionsStep() {
 
           <TabsContent value="recycling" className="space-y-6">
             <div className="space-y-6">
-              <div className="pb-4 border-b border-[#E0D8D1]">
-                <h3 className="text-lg font-inter font-bold text-[#292929] mb-2">
+              <div className="pb-4 border-b border-beige-200">
+                <h3 className="text-lg font-inter font-bold text-pov-charcoal mb-2">
                   Recycling Provisions
                 </h3>
-                <p className="text-[#292929]/70 font-poppins">
+                <p className="text-pov-charcoal/70 font-poppins">
                   Configure exit proceeds recycling for new investments
                 </p>
               </div>
 
               <div className="space-y-6">
-                <div className="flex items-center justify-between p-4 border border-[#E0D8D1] rounded-xl">
+                <div className="flex items-center justify-between p-4 border border-beige-200 rounded-xl">
                   <div className="space-y-1">
                     <Label
                       htmlFor="recycling-enabled"
-                      className="cursor-pointer font-poppins font-medium text-[#292929]"
+                      className="cursor-pointer font-poppins font-medium text-pov-charcoal"
                     >
                       Enable Exit Recycling
                     </Label>
-                    <p className="text-sm text-[#292929]/60 font-poppins">
+                    <p className="text-sm text-pov-charcoal/60 font-poppins">
                       Allow exit proceeds to be recycled for new investments
                     </p>
                   </div>
@@ -712,7 +712,7 @@ export default function DistributionsStep() {
                     <div className="space-y-3">
                       <Label
                         htmlFor="recycling-type"
-                        className="text-sm font-poppins font-medium text-[#292929]"
+                        className="text-sm font-poppins font-medium text-pov-charcoal"
                       >
                         Recycling Type
                       </Label>
@@ -730,7 +730,7 @@ export default function DistributionsStep() {
                           <SelectItem value="fees">Management Fee Recycling</SelectItem>
                         </SelectContent>
                       </Select>
-                      <p className="text-sm text-[#292929]/60 font-poppins">
+                      <p className="text-sm text-pov-charcoal/60 font-poppins">
                         {recyclingType === 'exits'
                           ? 'Fund can recycle exit proceeds up to a cap (% of committed capital)'
                           : 'Fund can recycle exit proceeds up to the level of management fees earned to date'}
@@ -740,7 +740,7 @@ export default function DistributionsStep() {
                     <div className="space-y-3">
                       <Label
                         htmlFor="exit-recycling"
-                        className="text-sm font-poppins font-medium text-[#292929]"
+                        className="text-sm font-poppins font-medium text-pov-charcoal"
                       >
                         Exit Proceeds Recycling Rate (%)
                       </Label>
@@ -757,9 +757,9 @@ export default function DistributionsStep() {
                         }
                         data-testid="exit-recycling-rate"
                         placeholder="100"
-                        className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                        className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                       />
-                      <p className="text-sm text-[#292929]/60 font-poppins">
+                      <p className="text-sm text-pov-charcoal/60 font-poppins">
                         Percentage of exit proceeds that can be recycled each period (typically
                         100%)
                       </p>
@@ -769,7 +769,7 @@ export default function DistributionsStep() {
                       <div className="space-y-3">
                         <Label
                           htmlFor="recycling-cap-pct"
-                          className="text-sm font-poppins font-medium text-[#292929]"
+                          className="text-sm font-poppins font-medium text-pov-charcoal"
                         >
                           Recycling Cap (% of Committed Capital)
                         </Label>
@@ -787,9 +787,9 @@ export default function DistributionsStep() {
                             });
                           }}
                           placeholder="50"
-                          className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                          className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                         />
-                        <p className="text-sm text-[#292929]/60 font-poppins">
+                        <p className="text-sm text-pov-charcoal/60 font-poppins">
                           Maximum amount that can be recycled as % of committed capital (e.g., 50%
                           cap = half the committed capital)
                         </p>
@@ -799,7 +799,7 @@ export default function DistributionsStep() {
                     <div className="space-y-3">
                       <Label
                         htmlFor="recycling-period"
-                        className="text-sm font-poppins font-medium text-[#292929]"
+                        className="text-sm font-poppins font-medium text-pov-charcoal"
                       >
                         Recycling Term (years)
                       </Label>
@@ -817,14 +817,14 @@ export default function DistributionsStep() {
                           })
                         }
                         placeholder="3"
-                        className="h-12 border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929] font-poppins"
+                        className="h-12 border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40 font-poppins"
                       />
-                      <p className="text-sm text-[#292929]/60 font-poppins">
+                      <p className="text-sm text-pov-charcoal/60 font-poppins">
                         Timeframe over which the fund can recycle exit proceeds
                       </p>
                     </div>
 
-                    <div className="flex items-center space-x-3 p-4 border border-[#E0D8D1] rounded-xl">
+                    <div className="flex items-center space-x-3 p-4 border border-beige-200 rounded-xl">
                       <Switch
                         id="allow-future-recycling"
                         checked={allowFutureRecycling || false}
@@ -836,11 +836,11 @@ export default function DistributionsStep() {
                       <div>
                         <Label
                           htmlFor="allow-future-recycling"
-                          className="cursor-pointer text-sm font-poppins font-medium text-[#292929]"
+                          className="cursor-pointer text-sm font-poppins font-medium text-pov-charcoal"
                         >
                           Allow fund to recycle future exit proceeds ahead of time
                         </Label>
-                        <p className="text-sm text-[#292929]/60 font-poppins mt-1">
+                        <p className="text-sm text-pov-charcoal/60 font-poppins mt-1">
                           If enabled, fund will aggressively invest in anticipation of future exits.
                           If disabled, fund waits for exits before recycling.
                         </p>
@@ -854,12 +854,12 @@ export default function DistributionsStep() {
         </Tabs>
 
         {/* Navigation */}
-        <div className="flex justify-between pt-8 border-t border-[#E0D8D1] mt-8">
+        <div className="flex justify-between pt-8 border-t border-beige-200 mt-8">
           <Button
             data-testid="previous-step"
             variant="outline"
             onClick={() => navigate('/fund-setup?step=4')}
-            className="flex items-center gap-2 px-8 py-3 h-auto border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+            className="flex items-center gap-2 px-8 py-3 h-auto border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
           >
             <ArrowLeft className="h-4 w-4" />
             Previous
@@ -867,7 +867,7 @@ export default function DistributionsStep() {
           <Button
             data-testid="next-step"
             onClick={() => navigate('/fund-setup?step=6')}
-            className="flex items-center gap-2 bg-[#292929] hover:bg-[#292929]/90 text-white px-8 py-3 h-auto font-poppins font-medium"
+            className="flex items-center gap-2 bg-pov-charcoal hover:bg-charcoal-700 text-pov-white px-8 py-3 h-auto font-poppins font-medium"
           >
             Next: Cashflow & Liquidity
             <ArrowRight className="h-4 w-4" />

--- a/client/src/pages/InvestmentStrategyStep.tsx
+++ b/client/src/pages/InvestmentStrategyStep.tsx
@@ -266,9 +266,9 @@ export default function InvestmentStrategyStep() {
       <div className="space-y-8">
         {/* Sector Profiles Section */}
         <div className="space-y-6">
-          <div className="pb-4 border-b border-[#E0D8D1]">
-            <h3 className="text-xl font-inter font-bold text-[#292929] mb-2">Sector Profiles</h3>
-            <p className="font-poppins text-[#292929]/70">
+          <div className="pb-4 border-b border-beige-200">
+            <h3 className="text-xl font-inter font-bold text-pov-charcoal mb-2">Sector Profiles</h3>
+            <p className="font-poppins text-pov-charcoal/70">
               Define macro views on round sizes, valuations, and performance for different sectors.
               A Default profile is created based on proprietary research and publicly available
               datasets.
@@ -284,8 +284,8 @@ export default function InvestmentStrategyStep() {
                   key={profile.id}
                   className={`border rounded-xl p-4 space-y-4 shadow-md transition-all duration-200 ${
                     isEditing
-                      ? 'border-[#292929] bg-[#E0D8D1]/20 shadow-lg ring-2 ring-[#E0D8D1]'
-                      : 'border-[#E0D8D1] bg-white hover:shadow-lg'
+                      ? 'border-pov-charcoal bg-beige/20 shadow-lg ring-2 ring-beige'
+                      : 'border-beige-200 bg-white hover:shadow-lg'
                   }`}
                 >
                   {!isEditing ? (
@@ -293,10 +293,10 @@ export default function InvestmentStrategyStep() {
                     <div>
                       <div className="flex items-center justify-between mb-4">
                         <div>
-                          <h3 className="font-inter font-semibold text-xl text-[#292929]">
+                          <h3 className="font-inter font-semibold text-xl text-pov-charcoal">
                             {profile.name || 'Unnamed Profile'}
                           </h3>
-                          <p className="font-poppins text-sm text-[#292929]/60">
+                          <p className="font-poppins text-sm text-pov-charcoal/60">
                             {profile.stages.length} stages defined
                           </p>
                         </div>
@@ -331,58 +331,58 @@ export default function InvestmentStrategyStep() {
                         <div className="space-y-4 min-w-[1100px]">
                           {/* Header with Fixed Column Grid - Press On Branded */}
                           <div
-                            className="grid text-sm font-poppins font-bold text-white py-4 px-2 bg-[#292929] rounded-xl border border-[#292929]"
+                            className="grid text-sm font-poppins font-bold text-pov-white py-4 px-2 bg-pov-charcoal rounded-xl border border-pov-charcoal"
                             style={{
                               gridTemplateColumns:
                                 '140px 100px 80px 120px 90px 90px 100px 90px 140px',
                             }}
                           >
-                            <div className="text-white px-3">Round</div>
-                            <div className="text-white px-3 text-center">Size ($M)</div>
-                            <div className="text-white px-3 text-center">Type</div>
-                            <div className="text-white px-3 text-center">Valuation ($M)</div>
-                            <div className="text-white px-3 text-center">ESOP (%)</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Grad (%)</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Mo to Grad</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Exit (%)</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Exit Val ($M)</div>
+                            <div className="text-pov-white px-3">Round</div>
+                            <div className="text-pov-white px-3 text-center">Size ($M)</div>
+                            <div className="text-pov-white px-3 text-center">Type</div>
+                            <div className="text-pov-white px-3 text-center">Valuation ($M)</div>
+                            <div className="text-pov-white px-3 text-center">ESOP (%)</div>
+                            <div className="text-beige px-3 text-center">Grad (%)</div>
+                            <div className="text-beige px-3 text-center">Mo to Grad</div>
+                            <div className="text-beige px-3 text-center">Exit (%)</div>
+                            <div className="text-beige px-3 text-center">Exit Val ($M)</div>
                           </div>
 
                           {/* Rows with Matching Fixed Column Grid */}
                           {profile.stages.map((stage) => (
                             <div
                               key={stage.id}
-                              className="grid text-base py-4 px-2 bg-white rounded-xl border border-[#E0D8D1] hover:bg-[#F2F2F2] hover:border-[#292929] hover:shadow-md transition-all duration-200"
+                              className="grid text-base py-4 px-2 bg-white rounded-xl border border-beige-200 hover:bg-pov-gray hover:border-pov-charcoal hover:shadow-md transition-all duration-200"
                               style={{
                                 gridTemplateColumns:
                                   '140px 100px 80px 120px 90px 90px 100px 90px 140px',
                               }}
                             >
-                              <div className="font-inter font-bold text-[#292929] text-lg px-3">
+                              <div className="font-inter font-bold text-pov-charcoal text-lg px-3">
                                 {stage.name}
                               </div>
-                              <div className="font-poppins font-semibold text-[#292929] px-3 text-center tabular-nums">
+                              <div className="font-poppins font-semibold text-pov-charcoal px-3 text-center tabular-nums">
                                 ${stage.roundSize}M
                               </div>
-                              <div className="font-poppins text-[#292929]/70 px-3 text-center">
+                              <div className="font-poppins text-pov-charcoal/70 px-3 text-center">
                                 {stage.valuationType}
                               </div>
-                              <div className="font-poppins font-semibold text-[#292929] px-3 text-center tabular-nums">
+                              <div className="font-poppins font-semibold text-pov-charcoal px-3 text-center tabular-nums">
                                 ${stage.valuation}M
                               </div>
-                              <div className="font-poppins font-semibold text-[#292929] px-3 text-center tabular-nums">
+                              <div className="font-poppins font-semibold text-pov-charcoal px-3 text-center tabular-nums">
                                 {stage.esopPct}%
                               </div>
-                              <div className="font-poppins font-bold text-[#292929] px-3 text-center tabular-nums">
+                              <div className="font-poppins font-bold text-pov-charcoal px-3 text-center tabular-nums">
                                 {stage.graduationRate}%
                               </div>
-                              <div className="font-poppins font-bold text-[#292929] px-3 text-center tabular-nums">
+                              <div className="font-poppins font-bold text-pov-charcoal px-3 text-center tabular-nums">
                                 {stage.monthsToGraduate}mo
                               </div>
-                              <div className="font-poppins font-bold text-[#292929] px-3 text-center tabular-nums">
+                              <div className="font-poppins font-bold text-pov-charcoal px-3 text-center tabular-nums">
                                 {stage.exitRate}%
                               </div>
-                              <div className="font-poppins font-semibold text-[#292929] px-3 text-center tabular-nums">
+                              <div className="font-poppins font-semibold text-pov-charcoal px-3 text-center tabular-nums">
                                 ${stage.exitValuation}M
                               </div>
                             </div>
@@ -402,7 +402,7 @@ export default function InvestmentStrategyStep() {
 
                       {/* Profile Name */}
                       <div className="space-y-3">
-                        <Label className="text-sm font-poppins font-medium text-[#292929]">
+                        <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                           Profile Name
                         </Label>
                         <Input
@@ -411,14 +411,14 @@ export default function InvestmentStrategyStep() {
                             handleUpdateProfile(profile.id, { name: e.target.value })
                           }
                           placeholder="e.g., FinTech, HealthTech, Enterprise SaaS"
-                          className="h-12 font-poppins border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929]"
+                          className="h-12 font-poppins border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40"
                         />
                       </div>
 
                       {/* Stages Header */}
                       <div className="space-y-4">
                         <div className="flex items-center justify-between">
-                          <Label className="text-sm font-poppins font-medium text-[#292929]">
+                          <Label className="text-sm font-poppins font-medium text-pov-charcoal">
                             Investment Stages
                           </Label>
                           <Button
@@ -437,27 +437,27 @@ export default function InvestmentStrategyStep() {
                         <div className="space-y-4 min-w-[1220px]">
                           {/* Column Headers with Fixed Column Grid */}
                           <div
-                            className="grid text-base font-poppins font-bold text-white py-4 px-2 bg-[#292929] rounded-xl border border-[#292929]"
+                            className="grid text-base font-poppins font-bold text-pov-white py-4 px-2 bg-pov-charcoal rounded-xl border border-pov-charcoal"
                             style={{
                               gridTemplateColumns:
                                 '140px 100px 80px 120px 90px 90px 100px 90px 140px 120px',
                             }}
                           >
-                            <div className="text-white px-3">Round</div>
-                            <div className="text-white px-3 text-center">Size ($M)</div>
-                            <div className="text-white px-3 text-center">Type</div>
-                            <div className="text-white px-3 text-center">Valuation ($M)</div>
-                            <div className="text-white px-3 text-center">ESOP (%)</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Grad (%)</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Mo to Grad</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Exit (%)</div>
-                            <div className="text-[#E0D8D1] px-3 text-center">Exit Val ($M)</div>
-                            <div className="text-[#F2F2F2] px-3 text-center">Actions</div>
+                            <div className="text-pov-white px-3">Round</div>
+                            <div className="text-pov-white px-3 text-center">Size ($M)</div>
+                            <div className="text-pov-white px-3 text-center">Type</div>
+                            <div className="text-pov-white px-3 text-center">Valuation ($M)</div>
+                            <div className="text-pov-white px-3 text-center">ESOP (%)</div>
+                            <div className="text-beige px-3 text-center">Grad (%)</div>
+                            <div className="text-beige px-3 text-center">Mo to Grad</div>
+                            <div className="text-beige px-3 text-center">Exit (%)</div>
+                            <div className="text-beige px-3 text-center">Exit Val ($M)</div>
+                            <div className="text-pov-gray px-3 text-center">Actions</div>
                           </div>
                           {profile.stages.map((stage, stageIndex) => (
                             <div
                               key={stage.id}
-                              className="grid items-center py-4 px-2 bg-white rounded-xl border border-[#E0D8D1] shadow-sm hover:shadow-lg hover:border-[#292929] transition-all duration-200"
+                              className="grid items-center py-4 px-2 bg-white rounded-xl border border-beige-200 shadow-sm hover:shadow-lg hover:border-pov-charcoal transition-all duration-200"
                               style={{
                                 gridTemplateColumns:
                                   '140px 100px 80px 120px 90px 90px 100px 90px 140px 120px',
@@ -670,11 +670,11 @@ export default function InvestmentStrategyStep() {
                       </div>
 
                       {/* Important Considerations */}
-                      <div className="bg-warning/10 border border-[#E0D8D1] rounded-xl p-4 shadow-sm">
-                        <h4 className="font-inter font-bold text-[#292929] mb-2">
+                      <div className="bg-warning/10 border border-beige-200 rounded-xl p-4 shadow-sm">
+                        <h4 className="font-inter font-bold text-pov-charcoal mb-2">
                           Important Considerations
                         </h4>
-                        <ul className="font-poppins text-sm text-[#292929]/80 space-y-1">
+                        <ul className="font-poppins text-sm text-pov-charcoal/80 space-y-1">
                           <li>• Graduation Rate + Exit Rate cannot exceed 100% for any stage</li>
                           <li>
                             • The last stage must have a 0% graduation rate (no subsequent stage)
@@ -698,7 +698,7 @@ export default function InvestmentStrategyStep() {
             <Button
               onClick={handleAddProfile}
               variant="outline"
-              className="w-full h-12 font-poppins font-medium border-[#E0D8D1] text-[#292929] hover:bg-[#E0D8D1]/20 hover:border-[#292929] transition-all duration-200"
+              className="w-full h-12 font-poppins font-medium border-beige-200 text-pov-charcoal hover:bg-beige/20 hover:border-pov-charcoal transition-all duration-200"
             >
               <Plus className="h-4 w-4 mr-2" />
               Add Sector Profile
@@ -725,12 +725,12 @@ export default function InvestmentStrategyStep() {
         </div>
 
         {/* Navigation */}
-        <div className="flex justify-between pt-8 border-t border-[#E0D8D1] mt-8">
+        <div className="flex justify-between pt-8 border-t border-beige-200 mt-8">
           <Button
             data-testid="previous-step"
             variant="outline"
             onClick={() => navigate('/fund-setup?step=3')}
-            className="flex items-center gap-2 px-8 py-3 h-auto font-poppins font-medium border-[#E0D8D1] text-[#292929] hover:bg-[#E0D8D1]/20 hover:border-[#292929] transition-all duration-200"
+            className="flex items-center gap-2 px-8 py-3 h-auto font-poppins font-medium border-beige-200 text-pov-charcoal hover:bg-beige/20 hover:border-pov-charcoal transition-all duration-200"
           >
             <ArrowLeft className="h-4 w-4" />
             Previous
@@ -738,7 +738,7 @@ export default function InvestmentStrategyStep() {
           <Button
             data-testid="next-step"
             onClick={() => navigate('/fund-setup?step=5')}
-            className="flex items-center gap-2 bg-[#292929] hover:bg-[#292929]/90 text-white px-8 py-3 h-auto font-poppins font-medium transition-all duration-200"
+            className="flex items-center gap-2 bg-pov-charcoal hover:bg-charcoal-700 text-pov-white px-8 py-3 h-auto font-poppins font-medium transition-all duration-200"
           >
             Next Step
             <ArrowRight className="h-4 w-4" />

--- a/client/src/pages/allocation-manager.tsx
+++ b/client/src/pages/allocation-manager.tsx
@@ -157,7 +157,7 @@ export default function AllocationManager() {
 
   if (selectedAllocation) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-pov-gray">
         <div className="container mx-auto p-6">
           <div className="mb-6">
             <Button variant="ghost" onClick={() => setSelectedAllocation(null)} className="mb-4">
@@ -173,7 +173,7 @@ export default function AllocationManager() {
 
   if (activeTab === 'sector-profiles') {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-pov-gray">
         <div className="container mx-auto p-6">
           <div className="mb-6">
             <Button variant="ghost" onClick={() => setActiveTab('allocations')} className="mb-4">
@@ -188,20 +188,20 @@ export default function AllocationManager() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-pov-gray">
       <div className="container mx-auto p-6">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold text-gray-900">Allocation Manager</h1>
-              <p className="text-gray-600 mt-2">
+              <h1 className="text-3xl font-bold text-pov-charcoal">Allocation Manager</h1>
+              <p className="text-charcoal-600 mt-2">
                 Configure fund allocations with automatic reserve calculation using market-driven
                 methodology
               </p>
             </div>
             <div className="flex items-center gap-3">
-              <Badge variant="outline" className="bg-blue-50 text-blue-700">
+              <Badge variant="outline" className="bg-presson-info/10 text-presson-info">
                 <Calculator className="w-3 h-3 mr-1" />
                 Auto-Calculated Reserves
               </Badge>
@@ -222,10 +222,10 @@ export default function AllocationManager() {
           <Card>
             <CardContent className="p-6">
               <div className="flex items-center">
-                <Target className="w-8 h-8 text-blue-600" />
+                <Target className="w-8 h-8 text-charcoal-600" />
                 <div className="ml-4">
-                  <p className="text-sm font-medium text-gray-600">Total Allocated</p>
-                  <p className="text-2xl font-bold text-gray-900">
+                  <p className="text-sm font-medium text-charcoal-600">Total Allocated</p>
+                  <p className="text-2xl font-bold text-pov-charcoal">
                     {formatCurrency(totalCapitalAllocated)}
                   </p>
                 </div>
@@ -236,10 +236,10 @@ export default function AllocationManager() {
           <Card>
             <CardContent className="p-6">
               <div className="flex items-center">
-                <TrendingUp className="w-8 h-8 text-green-600" />
+                <TrendingUp className="w-8 h-8 text-charcoal-600" />
                 <div className="ml-4">
-                  <p className="text-sm font-medium text-gray-600">Initial Capital</p>
-                  <p className="text-2xl font-bold text-gray-900">
+                  <p className="text-sm font-medium text-charcoal-600">Initial Capital</p>
+                  <p className="text-2xl font-bold text-pov-charcoal">
                     {formatCurrency(totalInitialCapital)}
                   </p>
                 </div>
@@ -250,10 +250,10 @@ export default function AllocationManager() {
           <Card>
             <CardContent className="p-6">
               <div className="flex items-center">
-                <BarChart3 className="w-8 h-8 text-purple-600" />
+                <BarChart3 className="w-8 h-8 text-charcoal-600" />
                 <div className="ml-4">
-                  <p className="text-sm font-medium text-gray-600">Follow-On Reserves</p>
-                  <p className="text-2xl font-bold text-gray-900">
+                  <p className="text-sm font-medium text-charcoal-600">Follow-On Reserves</p>
+                  <p className="text-2xl font-bold text-pov-charcoal">
                     {formatCurrency(totalFollowOnCapital)}
                   </p>
                 </div>
@@ -264,10 +264,10 @@ export default function AllocationManager() {
           <Card>
             <CardContent className="p-6">
               <div className="flex items-center">
-                <Calculator className="w-8 h-8 text-orange-600" />
+                <Calculator className="w-8 h-8 text-charcoal-600" />
                 <div className="ml-4">
-                  <p className="text-sm font-medium text-gray-600">Reserve Ratio</p>
-                  <p className="text-2xl font-bold text-gray-900">
+                  <p className="text-sm font-medium text-charcoal-600">Reserve Ratio</p>
+                  <p className="text-2xl font-bold text-pov-charcoal">
                     {averageReserveRatio.toFixed(1)}%
                   </p>
                 </div>
@@ -286,12 +286,12 @@ export default function AllocationManager() {
           defaultOpen={false}
         >
           <div className="space-y-3">
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-charcoal-600">
               The system calculates your fund's expected reserve ratios instead of having you enter
               them directly. This ensures there is no "left-over" capital and enables you to "build
               up" to the ideal reserve ratio from more granular assumptions.
             </p>
-            <div className="text-sm text-gray-600">
+            <div className="text-sm text-charcoal-600">
               <strong>Follow-on reserves are calculated based on:</strong>
               <ul className="list-disc ml-6 mt-1 space-y-1">
                 <li>Number of graduations (from Sector Profile graduation rates)</li>
@@ -314,34 +314,36 @@ export default function AllocationManager() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b">
-                    <th className="text-left py-3 px-4 font-medium text-gray-600">Allocation</th>
-                    <th className="text-right py-3 px-4 font-medium text-gray-600">
+                    <th className="text-left py-3 px-4 font-medium text-charcoal-600">
+                      Allocation
+                    </th>
+                    <th className="text-right py-3 px-4 font-medium text-charcoal-600">
                       Capital Allocated
                     </th>
-                    <th className="text-right py-3 px-4 font-medium text-gray-600">
+                    <th className="text-right py-3 px-4 font-medium text-charcoal-600">
                       Initial Capital
                     </th>
-                    <th className="text-right py-3 px-4 font-medium text-gray-600">
+                    <th className="text-right py-3 px-4 font-medium text-charcoal-600">
                       Follow-On Reserves
                     </th>
-                    <th className="text-center py-3 px-4 font-medium text-gray-600">
+                    <th className="text-center py-3 px-4 font-medium text-charcoal-600">
                       Reserve Ratio
                     </th>
-                    <th className="text-center py-3 px-4 font-medium text-gray-600">Deals</th>
-                    <th className="text-center py-3 px-4 font-medium text-gray-600">
+                    <th className="text-center py-3 px-4 font-medium text-charcoal-600">Deals</th>
+                    <th className="text-center py-3 px-4 font-medium text-charcoal-600">
                       Expected MOIC
                     </th>
-                    <th className="text-center py-3 px-4 font-medium text-gray-600">Status</th>
-                    <th className="text-center py-3 px-4 font-medium text-gray-600">Actions</th>
+                    <th className="text-center py-3 px-4 font-medium text-charcoal-600">Status</th>
+                    <th className="text-center py-3 px-4 font-medium text-charcoal-600">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {allocations.map((allocation) => (
-                    <tr key={allocation.id} className="border-b hover:bg-gray-50">
+                    <tr key={allocation.id} className="border-b hover:bg-pov-gray">
                       <td className="py-4 px-4">
                         <div>
-                          <div className="font-medium text-gray-900">{allocation.name}</div>
-                          <div className="text-sm text-gray-500">{allocation.stage}</div>
+                          <div className="font-medium text-pov-charcoal">{allocation.name}</div>
+                          <div className="text-sm text-charcoal-500">{allocation.stage}</div>
                         </div>
                       </td>
                       <td className="py-4 px-4 text-right font-medium">
@@ -354,7 +356,7 @@ export default function AllocationManager() {
                         {formatCurrency(allocation.followOnCapital)}
                       </td>
                       <td className="py-4 px-4 text-center">
-                        <Badge variant="outline" className="bg-blue-50 text-blue-700">
+                        <Badge variant="outline" className="bg-pov-gray text-pov-charcoal">
                           {allocation.reserveRatio.toFixed(1)}%
                         </Badge>
                       </td>
@@ -368,7 +370,9 @@ export default function AllocationManager() {
                         <Badge
                           variant={allocation.status === 'active' ? 'default' : 'secondary'}
                           className={
-                            allocation.status === 'active' ? 'bg-green-100 text-green-800' : ''
+                            allocation.status === 'active'
+                              ? 'border-success/50 bg-success/10 text-success-dark'
+                              : ''
                           }
                         >
                           {allocation.status}
@@ -399,17 +403,21 @@ export default function AllocationManager() {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                <h4 className="font-medium text-yellow-800 mb-2">If your reserves are too low:</h4>
-                <ul className="text-sm text-yellow-700 space-y-1">
+              <div className="bg-warning/10 border border-warning/50 rounded-lg p-4">
+                <h4 className="font-medium text-warning-dark mb-2">
+                  If your reserves are too low:
+                </h4>
+                <ul className="text-sm text-warning-dark space-y-1">
                   <li>• Increase the follow-on check sizes</li>
                   <li>• Increase follow-on participation percentages</li>
                 </ul>
               </div>
 
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <h4 className="font-medium text-blue-800 mb-2">If your reserves are too high:</h4>
-                <ul className="text-sm text-blue-700 space-y-1">
+              <div className="bg-presson-info/10 border border-presson-info/50 rounded-lg p-4">
+                <h4 className="font-medium text-presson-info mb-2">
+                  If your reserves are too high:
+                </h4>
+                <ul className="text-sm text-presson-info space-y-1">
                   <li>• Revisit Sector Profiles and adjust Graduation Rates</li>
                   <li>
                     • Adjust Exit Rates (follow-on capital only deployed into graduated companies)

--- a/client/src/pages/lp-reporting/metrics.tsx
+++ b/client/src/pages/lp-reporting/metrics.tsx
@@ -930,7 +930,7 @@ export default function LpReportingMetricsPage() {
 
                 {activeMetricRun ? (
                   <div
-                    className="grid gap-3 rounded-md border border-slate-200 p-3 text-sm md:grid-cols-2"
+                    className="grid gap-3 rounded-md border border-beige-200 p-3 text-sm md:grid-cols-2"
                     data-testid="metric-run-lifecycle-panel"
                   >
                     <div>
@@ -1030,7 +1030,7 @@ export default function LpReportingMetricsPage() {
                     <label className="space-y-1 text-sm font-medium text-charcoal">
                       Evidence source
                       <select
-                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        className="w-full rounded-md border border-beige-200 bg-white px-3 py-2 text-sm"
                         value={evidenceForm.evidenceSource}
                         onChange={(event) =>
                           setEvidenceForm((current) => ({
@@ -1057,7 +1057,7 @@ export default function LpReportingMetricsPage() {
                     <label className="space-y-1 text-sm font-medium text-charcoal">
                       Source date
                       <input
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                        className="w-full rounded-md border border-beige-200 px-3 py-2 text-sm"
                         type="date"
                         required
                         value={evidenceForm.sourceDate}
@@ -1073,7 +1073,7 @@ export default function LpReportingMetricsPage() {
                     <label className="space-y-1 text-sm font-medium text-charcoal">
                       Confidence
                       <select
-                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        className="w-full rounded-md border border-beige-200 bg-white px-3 py-2 text-sm"
                         value={evidenceForm.confidenceLevel}
                         onChange={(event) =>
                           setEvidenceForm((current) => ({
@@ -1091,7 +1091,7 @@ export default function LpReportingMetricsPage() {
                     <label className="space-y-1 text-sm font-medium text-charcoal">
                       Materiality
                       <select
-                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        className="w-full rounded-md border border-beige-200 bg-white px-3 py-2 text-sm"
                         value={evidenceForm.materialityLevel}
                         onChange={(event) =>
                           setEvidenceForm((current) => ({
@@ -1109,7 +1109,7 @@ export default function LpReportingMetricsPage() {
                     <label className="space-y-1 text-sm font-medium text-charcoal">
                       Confidentiality
                       <select
-                        className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                        className="w-full rounded-md border border-beige-200 bg-white px-3 py-2 text-sm"
                         value={evidenceForm.confidentiality}
                         onChange={(event) =>
                           setEvidenceForm((current) => ({
@@ -1141,7 +1141,7 @@ export default function LpReportingMetricsPage() {
                     <label className="space-y-1 text-sm font-medium text-charcoal md:col-span-2">
                       Description
                       <textarea
-                        className="min-h-24 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                        className="min-h-24 w-full rounded-md border border-beige-200 px-3 py-2 text-sm"
                         maxLength={2000}
                         value={evidenceForm.description}
                         onChange={(event) =>
@@ -1187,7 +1187,7 @@ export default function LpReportingMetricsPage() {
                   {evidenceRecords.map((record) => (
                     <div
                       key={record.id}
-                      className="rounded-md border border-slate-200 px-3 py-2"
+                      className="rounded-md border border-beige-200 px-3 py-2"
                       data-testid="metric-run-evidence-record"
                     >
                       <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
@@ -1279,7 +1279,7 @@ export default function LpReportingMetricsPage() {
                     return (
                       <div
                         key={record.narrativeRunId}
-                        className="rounded-md border border-slate-200 px-3 py-3"
+                        className="rounded-md border border-beige-200 px-3 py-3"
                         data-testid="metric-run-narrative-record"
                       >
                         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
@@ -1387,7 +1387,7 @@ export default function LpReportingMetricsPage() {
                     return (
                       <div
                         key={type.value}
-                        className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2"
+                        className="flex items-center justify-between rounded-md border border-beige-200 px-3 py-2"
                       >
                         <span className="text-sm font-medium text-charcoal">{type.label}</span>
                         <Badge variant={status === 'approved' ? 'default' : 'outline'}>
@@ -1420,7 +1420,7 @@ export default function LpReportingMetricsPage() {
                         return (
                           <div
                             key={ref.narrativeType}
-                            className="rounded-md border border-slate-200 px-3 py-2 text-sm"
+                            className="rounded-md border border-beige-200 px-3 py-2 text-sm"
                             data-testid={`metric-run-report-package-ref-${ref.narrativeType}`}
                           >
                             <p className="font-medium text-charcoal">
@@ -1442,7 +1442,7 @@ export default function LpReportingMetricsPage() {
                     </div>
                     {reportPackageRenderModel ? (
                       <div
-                        className="space-y-4 rounded-md border border-slate-200 p-4"
+                        className="space-y-4 rounded-md border border-beige-200 p-4"
                         data-testid="metric-run-report-package-render-preview"
                       >
                         <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
@@ -1464,7 +1464,7 @@ export default function LpReportingMetricsPage() {
                           {reportPackageRenderModel.metricSections.map((section) => (
                             <div
                               key={section.sectionId}
-                              className="rounded-md border border-slate-200 px-3 py-2"
+                              className="rounded-md border border-beige-200 px-3 py-2"
                               data-testid={`metric-run-report-package-render-section-${section.sectionId}`}
                             >
                               <p className="text-sm font-semibold text-charcoal">{section.title}</p>
@@ -1492,7 +1492,7 @@ export default function LpReportingMetricsPage() {
                           {reportPackageRenderModel.narrativeSections.map((section) => (
                             <section
                               key={section.sectionId}
-                              className="rounded-md border border-slate-200 px-3 py-2"
+                              className="rounded-md border border-beige-200 px-3 py-2"
                             >
                               <div className="flex items-center justify-between gap-3">
                                 <h3 className="text-sm font-semibold text-charcoal">
@@ -1642,7 +1642,7 @@ export default function LpReportingMetricsPage() {
                           </Alert>
                         ) : null}
 
-                        <div className="flex flex-col gap-3 border-t border-slate-200 pt-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex flex-col gap-3 border-t border-beige-200 pt-3 sm:flex-row sm:items-center sm:justify-between">
                           <p className="text-sm text-charcoal/70 font-poppins">
                             Create the package JSON handoff for this locked metric run.
                           </p>

--- a/client/src/pages/lp/capital-account.tsx
+++ b/client/src/pages/lp/capital-account.tsx
@@ -11,7 +11,13 @@ import { useLPContext } from '@/contexts/LPContext';
 import { useLPCapitalAccount } from '@/hooks/useLPCapitalAccount';
 import CapitalAccountTable from '@/components/lp/CapitalAccountTable';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -53,8 +59,8 @@ export default function LPCapitalAccount() {
       {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
-          <h1 className="text-3xl font-bold font-inter text-[#292929]">Capital Account</h1>
-          <p className="text-[#292929]/70 font-poppins mt-1">
+          <h1 className="text-3xl font-bold font-inter text-pov-charcoal">Capital Account</h1>
+          <p className="text-charcoal-600 font-poppins mt-1">
             Transaction history and capital flows
           </p>
         </div>
@@ -66,9 +72,9 @@ export default function LPCapitalAccount() {
       </div>
 
       {/* Filters */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="font-inter text-lg text-[#292929]">Filters</CardTitle>
+          <CardTitle className="font-inter text-lg text-pov-charcoal">Filters</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -100,7 +106,7 @@ export default function LPCapitalAccount() {
             <div className="space-y-2">
               <Label htmlFor="start-date">Start Date</Label>
               <div className="relative">
-                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#292929]/50" />
+                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-charcoal-400" />
                 <Input
                   id="start-date"
                   type="date"
@@ -115,7 +121,7 @@ export default function LPCapitalAccount() {
             <div className="space-y-2">
               <Label htmlFor="end-date">End Date</Label>
               <div className="relative">
-                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#292929]/50" />
+                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-charcoal-400" />
                 <Input
                   id="end-date"
                   type="date"
@@ -132,39 +138,39 @@ export default function LPCapitalAccount() {
       {/* Summary */}
       {accountData && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
             <CardContent className="pt-6">
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(accountData.summary.totalCalled)}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Total Called</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Total Called</div>
             </CardContent>
           </Card>
 
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
             <CardContent className="pt-6">
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(accountData.summary.totalDistributed)}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Total Distributed</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Total Distributed</div>
             </CardContent>
           </Card>
 
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
             <CardContent className="pt-6">
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(accountData.summary.currentNav)}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Current NAV</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Current NAV</div>
             </CardContent>
           </Card>
 
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
             <CardContent className="pt-6">
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {accountData.summary.transactionCount}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Transactions</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Transactions</div>
             </CardContent>
           </Card>
         </div>

--- a/client/src/pages/lp/dashboard.tsx
+++ b/client/src/pages/lp/dashboard.tsx
@@ -94,10 +94,10 @@ export default function LPDashboard() {
       {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
-          <h1 className="text-3xl font-bold font-inter text-[#292929]">
+          <h1 className="text-3xl font-bold font-inter text-pov-charcoal">
             {lpProfile?.name || 'LP Dashboard'}
           </h1>
-          <p className="text-[#292929]/70 font-poppins mt-1">
+          <p className="text-charcoal-600 font-poppins mt-1">
             Portfolio overview and performance metrics
           </p>
         </div>
@@ -112,7 +112,7 @@ export default function LPDashboard() {
           >
             <Bell className="h-5 w-5" />
             {unreadCount > 0 && (
-              <span className="absolute -top-1 -right-1 h-5 w-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">
+              <span className="absolute -top-1 -right-1 h-5 w-5 bg-error text-pov-white text-xs rounded-full flex items-center justify-center">
                 {unreadCount > 9 ? '9+' : unreadCount}
               </span>
             )}
@@ -164,13 +164,13 @@ export default function LPDashboard() {
 
       {/* Fund Summaries */}
       {summaryData && summaryData.fundSummaries.length > 0 && (
-        <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+        <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 font-inter text-[#292929]">
-              <Building2 className="h-5 w-5 text-blue-600" />
+            <CardTitle className="flex items-center gap-2 font-inter text-pov-charcoal">
+              <Building2 className="h-5 w-5 text-pov-charcoal" />
               Fund Performance
             </CardTitle>
-            <CardDescription className="font-poppins text-[#292929]/70">
+            <CardDescription className="font-poppins text-charcoal-600">
               Individual fund metrics and returns
             </CardDescription>
           </CardHeader>
@@ -179,20 +179,20 @@ export default function LPDashboard() {
               {summaryData.fundSummaries.map((fund) => (
                 <div
                   key={fund.fundId}
-                  className="border border-[#E0D8D1] rounded-lg p-4 hover:shadow-md transition-shadow cursor-pointer"
+                  className="border border-beige-200 rounded-lg p-4 hover:shadow-md transition-shadow cursor-pointer"
                   onClick={() => navigate(`/lp/fund-detail/${fund.fundId}`)}
                 >
                   <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                     {/* Fund Info */}
                     <div className="flex-1">
                       <div className="flex items-center gap-3">
-                        <h3 className="font-inter font-bold text-lg text-[#292929]">
+                        <h3 className="font-inter font-bold text-lg text-pov-charcoal">
                           {fund.fundName}
                         </h3>
                         <Badge variant="outline">{fund.vintageYear}</Badge>
-                        <ExternalLink className="h-4 w-4 text-[#292929]/50" />
+                        <ExternalLink className="h-4 w-4 text-charcoal-400" />
                       </div>
-                      <div className="flex items-center gap-4 mt-2 text-sm font-poppins text-[#292929]/70">
+                      <div className="flex items-center gap-4 mt-2 text-sm font-poppins text-charcoal-600">
                         <span>Commitment: {formatCurrency(fund.commitment)}</span>
                         <span>Called: {formatCurrency(fund.called)}</span>
                         <span>Distributed: {formatCurrency(fund.distributed)}</span>
@@ -202,28 +202,28 @@ export default function LPDashboard() {
                     {/* Performance Metrics */}
                     <div className="flex items-center gap-6">
                       <div className="text-center">
-                        <div className="text-xs font-poppins text-[#292929]/50">IRR</div>
+                        <div className="text-xs font-poppins text-charcoal-400">IRR</div>
                         <div
-                          className={`text-lg font-bold font-inter ${fund.irr >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                          className={`text-lg font-bold font-inter ${fund.irr >= 0 ? 'text-presson-positive' : 'text-presson-negative'}`}
                         >
                           {formatPercent(fund.irr)}
                         </div>
                       </div>
                       <div className="text-center">
-                        <div className="text-xs font-poppins text-[#292929]/50">TVPI</div>
-                        <div className="text-lg font-bold font-inter text-[#292929]">
+                        <div className="text-xs font-poppins text-charcoal-400">TVPI</div>
+                        <div className="text-lg font-bold font-inter text-pov-charcoal">
                           {fund.tvpi.toFixed(2)}x
                         </div>
                       </div>
                       <div className="text-center">
-                        <div className="text-xs font-poppins text-[#292929]/50">DPI</div>
-                        <div className="text-lg font-bold font-inter text-[#292929]">
+                        <div className="text-xs font-poppins text-charcoal-400">DPI</div>
+                        <div className="text-lg font-bold font-inter text-pov-charcoal">
                           {fund.dpi.toFixed(2)}x
                         </div>
                       </div>
                       <div className="text-center">
-                        <div className="text-xs font-poppins text-[#292929]/50">NAV</div>
-                        <div className="text-lg font-bold font-inter text-[#292929]">
+                        <div className="text-xs font-poppins text-charcoal-400">NAV</div>
+                        <div className="text-lg font-bold font-inter text-pov-charcoal">
                           {formatCurrency(fund.nav)}
                         </div>
                       </div>
@@ -231,7 +231,7 @@ export default function LPDashboard() {
                   </div>
 
                   {/* Last Updated */}
-                  <div className="flex items-center gap-2 mt-3 text-xs text-[#292929]/50 font-poppins">
+                  <div className="flex items-center gap-2 mt-3 text-xs text-charcoal-400 font-poppins">
                     <Calendar className="h-3 w-3" />
                     <span>Last updated: {new Date(fund.lastUpdated).toLocaleDateString()}</span>
                   </div>
@@ -243,9 +243,9 @@ export default function LPDashboard() {
       )}
 
       {/* Quick Actions - Enhanced for Sprint 3 */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="font-inter text-[#292929]">Quick Actions</CardTitle>
+          <CardTitle className="font-inter text-pov-charcoal">Quick Actions</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
@@ -254,7 +254,7 @@ export default function LPDashboard() {
               className="h-auto py-4 flex flex-col items-center gap-2"
               onClick={() => navigate('/lp/capital-calls')}
             >
-              <DollarSign className="h-6 w-6 text-blue-600" />
+              <DollarSign className="h-6 w-6 text-charcoal-600" />
               <span className="font-poppins text-sm">Capital Calls</span>
             </Button>
             <Button
@@ -262,7 +262,7 @@ export default function LPDashboard() {
               className="h-auto py-4 flex flex-col items-center gap-2"
               onClick={() => navigate('/lp/distributions')}
             >
-              <Banknote className="h-6 w-6 text-green-600" />
+              <Banknote className="h-6 w-6 text-charcoal-600" />
               <span className="font-poppins text-sm">Distributions</span>
             </Button>
             <Button
@@ -270,7 +270,7 @@ export default function LPDashboard() {
               className="h-auto py-4 flex flex-col items-center gap-2"
               onClick={() => navigate('/lp/documents')}
             >
-              <FileText className="h-6 w-6 text-indigo-600" />
+              <FileText className="h-6 w-6 text-charcoal-600" />
               <span className="font-poppins text-sm">Documents</span>
             </Button>
             <Button
@@ -278,7 +278,7 @@ export default function LPDashboard() {
               className="h-auto py-4 flex flex-col items-center gap-2"
               onClick={() => navigate('/lp/capital-account')}
             >
-              <TrendingUp className="h-6 w-6 text-orange-600" />
+              <TrendingUp className="h-6 w-6 text-charcoal-600" />
               <span className="font-poppins text-sm">Capital Account</span>
             </Button>
             <Button
@@ -286,7 +286,7 @@ export default function LPDashboard() {
               className="h-auto py-4 flex flex-col items-center gap-2"
               onClick={() => navigate('/lp/performance')}
             >
-              <TrendingUp className="h-6 w-6 text-purple-600" />
+              <TrendingUp className="h-6 w-6 text-charcoal-600" />
               <span className="font-poppins text-sm">Performance</span>
             </Button>
             <Button
@@ -294,7 +294,7 @@ export default function LPDashboard() {
               className="h-auto py-4 flex flex-col items-center gap-2"
               onClick={() => navigate('/lp/reports')}
             >
-              <Building2 className="h-6 w-6 text-amber-600" />
+              <Building2 className="h-6 w-6 text-charcoal-600" />
               <span className="font-poppins text-sm">Reports</span>
             </Button>
           </div>

--- a/client/src/pages/lp/fund-detail.tsx
+++ b/client/src/pages/lp/fund-detail.tsx
@@ -40,7 +40,7 @@ export default function LPFundDetail() {
   if (!detailData) {
     return (
       <div className="p-8 text-center">
-        <p className="text-[#292929]/70 font-poppins">Fund not found</p>
+        <p className="text-charcoal-600 font-poppins">Fund not found</p>
       </div>
     );
   }
@@ -61,48 +61,50 @@ export default function LPFundDetail() {
       <div className="flex items-center justify-between">
         <div>
           <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold font-inter text-[#292929]">{fundDetail.fundName}</h1>
+            <h1 className="text-3xl font-bold font-inter text-pov-charcoal">
+              {fundDetail.fundName}
+            </h1>
             <Badge variant="outline">{fundDetail.vintageYear}</Badge>
           </div>
-          <p className="text-[#292929]/70 font-poppins mt-1">
+          <p className="text-charcoal-600 font-poppins mt-1">
             As of {new Date(fundDetail.asOfDate).toLocaleDateString()}
           </p>
         </div>
       </div>
 
       {/* Fund Overview */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 font-inter text-lg text-[#292929]">
-            <Building2 className="h-5 w-5 text-blue-600" />
+          <CardTitle className="flex items-center gap-2 font-inter text-lg text-pov-charcoal">
+            <Building2 className="h-5 w-5 text-pov-charcoal" />
             Fund Overview
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div>
-              <div className="text-sm font-poppins text-[#292929]/50 mb-1">Your Commitment</div>
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+              <div className="text-sm font-poppins text-charcoal-400 mb-1">Your Commitment</div>
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(fundDetail.commitment)}
               </div>
-              <div className="text-xs font-poppins text-[#292929]/70 mt-1">
+              <div className="text-xs font-poppins text-charcoal-600 mt-1">
                 {formatPercent(fundDetail.percentOfFund)} of fund
               </div>
             </div>
 
             <div>
-              <div className="text-sm font-poppins text-[#292929]/50 mb-1">Fund Size</div>
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+              <div className="text-sm font-poppins text-charcoal-400 mb-1">Fund Size</div>
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(fundDetail.fundSize)}
               </div>
             </div>
 
             <div>
-              <div className="text-sm font-poppins text-[#292929]/50 mb-1">Capital Called</div>
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+              <div className="text-sm font-poppins text-charcoal-400 mb-1">Capital Called</div>
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(fundDetail.called)}
               </div>
-              <div className="text-xs font-poppins text-[#292929]/70 mt-1">
+              <div className="text-xs font-poppins text-charcoal-600 mt-1">
                 {formatPercent(fundDetail.percentCalled)} of commitment
               </div>
             </div>
@@ -119,38 +121,38 @@ export default function LPFundDetail() {
       />
 
       {/* Value Breakdown */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="font-inter text-lg text-[#292929]">Value Breakdown</CardTitle>
+          <CardTitle className="font-inter text-lg text-pov-charcoal">Value Breakdown</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <div className="text-center p-4 bg-gray-50 rounded-lg">
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+            <div className="text-center p-4 bg-pov-gray rounded-lg">
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(fundDetail.distributed)}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Total Distributed</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Total Distributed</div>
             </div>
 
-            <div className="text-center p-4 bg-gray-50 rounded-lg">
-              <div className="text-2xl font-bold font-inter text-[#292929]">
+            <div className="text-center p-4 bg-pov-gray rounded-lg">
+              <div className="text-2xl font-bold font-inter text-pov-charcoal">
                 {formatCurrency(fundDetail.nav)}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Current NAV</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Current NAV</div>
             </div>
 
-            <div className="text-center p-4 bg-gray-50 rounded-lg">
-              <div className="text-2xl font-bold font-inter text-green-600">
+            <div className="text-center p-4 bg-pov-gray rounded-lg">
+              <div className="text-2xl font-bold font-inter text-presson-positive">
                 {formatCurrency(fundDetail.realizedValue)}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Realized Value</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Realized Value</div>
             </div>
 
-            <div className="text-center p-4 bg-gray-50 rounded-lg">
-              <div className="text-2xl font-bold font-inter text-blue-600">
+            <div className="text-center p-4 bg-pov-gray rounded-lg">
+              <div className="text-2xl font-bold font-inter text-presson-info">
                 {formatCurrency(fundDetail.unrealizedValue)}
               </div>
-              <div className="text-sm font-poppins text-[#292929]/70 mt-1">Unrealized Value</div>
+              <div className="text-sm font-poppins text-charcoal-600 mt-1">Unrealized Value</div>
             </div>
           </div>
         </CardContent>
@@ -158,28 +160,32 @@ export default function LPFundDetail() {
 
       {/* Recent Transactions */}
       {detailData.recentTransactions.length > 0 && (
-        <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+        <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
           <CardHeader>
-            <CardTitle className="font-inter text-lg text-[#292929]">Recent Transactions</CardTitle>
+            <CardTitle className="font-inter text-lg text-pov-charcoal">
+              Recent Transactions
+            </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
               {detailData.recentTransactions.slice(0, 5).map((txn) => (
                 <div
                   key={txn.id}
-                  className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-lg"
+                  className="flex items-center justify-between p-3 border border-beige-200 rounded-lg"
                 >
                   <div className="flex items-center gap-3">
-                    <Calendar className="h-4 w-4 text-[#292929]/50" />
+                    <Calendar className="h-4 w-4 text-charcoal-400" />
                     <div>
-                      <div className="font-inter font-medium text-[#292929]">{txn.description}</div>
-                      <div className="text-sm font-poppins text-[#292929]/70">
+                      <div className="font-inter font-medium text-pov-charcoal">
+                        {txn.description}
+                      </div>
+                      <div className="text-sm font-poppins text-charcoal-600">
                         {new Date(txn.transactionDate).toLocaleDateString()}
                       </div>
                     </div>
                   </div>
                   <div
-                    className={`font-mono text-sm font-bold ${txn.amount < 0 ? 'text-red-600' : 'text-green-600'}`}
+                    className={`font-mono text-sm font-bold ${txn.amount < 0 ? 'text-presson-negative' : 'text-presson-positive'}`}
                   >
                     {formatCurrency(txn.amount)}
                   </div>

--- a/client/src/pages/lp/performance.tsx
+++ b/client/src/pages/lp/performance.tsx
@@ -11,13 +11,21 @@ import { useLPContext } from '@/contexts/LPContext';
 import { useLPPerformance, useLPHoldings } from '@/hooks/useLPPerformance';
 import PerformanceMetricsCard from '@/components/lp/PerformanceMetricsCard';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Building2, Download, RefreshCw } from 'lucide-react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/charts/LazyResponsiveContainer';
+import { getChartColor } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 
 // ============================================================================
 // COMPONENT
@@ -29,7 +37,8 @@ export default function LPPerformance() {
   const [activeTab, setActiveTab] = useState('timeseries');
 
   // Use first active fund if none selected
-  const activeFundId = selectedFundId || lpProfile?.commitments.find((c) => c.status === 'active')?.fundId;
+  const activeFundId =
+    selectedFundId || lpProfile?.commitments.find((c) => c.status === 'active')?.fundId;
 
   const {
     data: performanceData,
@@ -78,7 +87,7 @@ export default function LPPerformance() {
   if (!activeFundId) {
     return (
       <div className="p-8 text-center">
-        <p className="text-[#292929]/70 font-poppins">Please select a fund to view performance</p>
+        <p className="text-charcoal-600 font-poppins">Please select a fund to view performance</p>
       </div>
     );
   }
@@ -88,8 +97,8 @@ export default function LPPerformance() {
       {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
-          <h1 className="text-3xl font-bold font-inter text-[#292929]">Performance Analytics</h1>
-          <p className="text-[#292929]/70 font-poppins mt-1">
+          <h1 className="text-3xl font-bold font-inter text-pov-charcoal">Performance Analytics</h1>
+          <p className="text-charcoal-600 font-poppins mt-1">
             Track performance metrics and benchmark comparisons
           </p>
         </div>
@@ -118,7 +127,10 @@ export default function LPPerformance() {
           )}
 
           {/* Granularity */}
-          <Select value={granularity} onValueChange={(v) => setGranularity(v as typeof granularity)}>
+          <Select
+            value={granularity}
+            onValueChange={(v) => setGranularity(v as typeof granularity)}
+          >
             <SelectTrigger className="w-[140px]">
               <SelectValue />
             </SelectTrigger>
@@ -146,7 +158,7 @@ export default function LPPerformance() {
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="bg-white border border-[#E0D8D1]">
+        <TabsList className="bg-white border border-beige-200">
           <TabsTrigger value="timeseries">Performance Over Time</TabsTrigger>
           <TabsTrigger value="holdings">Portfolio Holdings</TabsTrigger>
         </TabsList>
@@ -154,10 +166,12 @@ export default function LPPerformance() {
         {/* Timeseries Tab */}
         <TabsContent value="timeseries" className="space-y-6">
           {/* IRR Chart */}
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
             <CardHeader>
-              <CardTitle className="font-inter text-lg text-[#292929]">IRR Performance</CardTitle>
-              <CardDescription className="font-poppins text-sm text-[#292929]/70">
+              <CardTitle className="font-inter text-lg text-pov-charcoal">
+                IRR Performance
+              </CardTitle>
+              <CardDescription className="font-poppins text-sm text-charcoal-600">
                 Internal rate of return over time
               </CardDescription>
             </CardHeader>
@@ -167,9 +181,22 @@ export default function LPPerformance() {
                   <LineChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="date" tick={{ fontSize: 12 }} />
-                    <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} tick={{ fontSize: 12 }} />
-                    <Tooltip formatter={(value) => value !== undefined ? `${Number(value).toFixed(2)}%` : ''} />
-                    <Line type="monotone" dataKey="irr" stroke="#2563eb" strokeWidth={2} dot={false} />
+                    <YAxis
+                      tickFormatter={(v: number) => `${v.toFixed(0)}%`}
+                      tick={{ fontSize: 12 }}
+                    />
+                    <Tooltip
+                      formatter={(value) =>
+                        value !== undefined ? `${Number(value).toFixed(2)}%` : ''
+                      }
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="irr"
+                      stroke={presson.color.text}
+                      strokeWidth={2}
+                      dot={false}
+                    />
                   </LineChart>
                 </ResponsiveContainer>
               </div>
@@ -177,10 +204,10 @@ export default function LPPerformance() {
           </Card>
 
           {/* Multiples Chart */}
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
             <CardHeader>
-              <CardTitle className="font-inter text-lg text-[#292929]">TVPI & DPI</CardTitle>
-              <CardDescription className="font-poppins text-sm text-[#292929]/70">
+              <CardTitle className="font-inter text-lg text-pov-charcoal">TVPI & DPI</CardTitle>
+              <CardDescription className="font-poppins text-sm text-charcoal-600">
                 Fund multiples over time
               </CardDescription>
             </CardHeader>
@@ -190,11 +217,30 @@ export default function LPPerformance() {
                   <LineChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="date" tick={{ fontSize: 12 }} />
-                    <YAxis tickFormatter={(v: number) => `${v.toFixed(1)}x`} tick={{ fontSize: 12 }} />
-                    <Tooltip formatter={(value) => value !== undefined ? `${Number(value).toFixed(2)}x` : ''} />
+                    <YAxis
+                      tickFormatter={(v: number) => `${v.toFixed(1)}x`}
+                      tick={{ fontSize: 12 }}
+                    />
+                    <Tooltip
+                      formatter={(value) =>
+                        value !== undefined ? `${Number(value).toFixed(2)}x` : ''
+                      }
+                    />
                     <Legend />
-                    <Line type="monotone" dataKey="tvpi" stroke="#059669" strokeWidth={2} name="TVPI" />
-                    <Line type="monotone" dataKey="dpi" stroke="#d97706" strokeWidth={2} name="DPI" />
+                    <Line
+                      type="monotone"
+                      dataKey="tvpi"
+                      stroke={getChartColor(0, true)}
+                      strokeWidth={2}
+                      name="TVPI"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="dpi"
+                      stroke={getChartColor(1, true)}
+                      strokeWidth={2}
+                      name="DPI"
+                    />
                   </LineChart>
                 </ResponsiveContainer>
               </div>
@@ -204,12 +250,14 @@ export default function LPPerformance() {
 
         {/* Holdings Tab */}
         <TabsContent value="holdings" className="space-y-6">
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
             <CardHeader>
               <div className="flex justify-between items-center">
                 <div>
-                  <CardTitle className="font-inter text-lg text-[#292929]">Portfolio Holdings</CardTitle>
-                  <CardDescription className="font-poppins text-sm text-[#292929]/70">
+                  <CardTitle className="font-inter text-lg text-pov-charcoal">
+                    Portfolio Holdings
+                  </CardTitle>
+                  <CardDescription className="font-poppins text-sm text-charcoal-600">
                     Your pro-rata share of fund investments
                   </CardDescription>
                 </div>
@@ -224,29 +272,29 @@ export default function LPPerformance() {
                 <>
                   {/* Summary */}
                   <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {holdingsData.summary.totalCompanies}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Companies</div>
+                      <div className="text-sm font-poppins text-charcoal-600">Companies</div>
                     </div>
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {formatCurrency(holdingsData.summary.totalDeployed)}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Deployed</div>
+                      <div className="text-sm font-poppins text-charcoal-600">Deployed</div>
                     </div>
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {formatCurrency(holdingsData.summary.totalCurrentValue)}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Current Value</div>
+                      <div className="text-sm font-poppins text-charcoal-600">Current Value</div>
                     </div>
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {holdingsData.summary.averageMOIC.toFixed(2)}x
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Avg MOIC</div>
+                      <div className="text-sm font-poppins text-charcoal-600">Avg MOIC</div>
                     </div>
                   </div>
 
@@ -254,28 +302,61 @@ export default function LPPerformance() {
                   <div className="overflow-x-auto">
                     <table className="w-full border-collapse">
                       <thead>
-                        <tr className="border-b border-[#E0D8D1]">
-                          <th className="text-left p-3 font-inter font-bold text-[#292929]">Company</th>
-                          <th className="text-left p-3 font-inter font-bold text-[#292929]">Sector</th>
-                          <th className="text-left p-3 font-inter font-bold text-[#292929]">Stage</th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">Your Share</th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">Current Value</th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">MOIC</th>
-                          <th className="text-center p-3 font-inter font-bold text-[#292929]">Status</th>
+                        <tr className="border-b border-beige-200">
+                          <th className="text-left p-3 font-inter font-bold text-pov-charcoal">
+                            Company
+                          </th>
+                          <th className="text-left p-3 font-inter font-bold text-pov-charcoal">
+                            Sector
+                          </th>
+                          <th className="text-left p-3 font-inter font-bold text-pov-charcoal">
+                            Stage
+                          </th>
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
+                            Your Share
+                          </th>
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
+                            Current Value
+                          </th>
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
+                            MOIC
+                          </th>
+                          <th className="text-center p-3 font-inter font-bold text-pov-charcoal">
+                            Status
+                          </th>
                         </tr>
                       </thead>
                       <tbody>
                         {holdingsData.holdings.map((holding) => (
-                          <tr key={holding.companyId} className="border-b border-[#E0D8D1] hover:bg-[#E0D8D1]/20">
-                            <td className="p-3 font-poppins font-medium text-[#292929]">
+                          <tr
+                            key={holding.companyId}
+                            className="border-b border-beige-200 hover:bg-beige-50"
+                          >
+                            <td className="p-3 font-poppins font-medium text-pov-charcoal">
                               {holding.companyName}
                             </td>
-                            <td className="p-3 font-poppins text-sm text-[#292929]/70">{holding.sector}</td>
-                            <td className="p-3 font-poppins text-sm text-[#292929]/70">{holding.stage}</td>
-                            <td className="p-3 text-right font-mono text-sm">{formatCurrency(holding.lpProRataShare)}</td>
-                            <td className="p-3 text-right font-mono text-sm">{formatCurrency(holding.currentValue)}</td>
+                            <td className="p-3 font-poppins text-sm text-charcoal-600">
+                              {holding.sector}
+                            </td>
+                            <td className="p-3 font-poppins text-sm text-charcoal-600">
+                              {holding.stage}
+                            </td>
+                            <td className="p-3 text-right font-mono text-sm">
+                              {formatCurrency(holding.lpProRataShare)}
+                            </td>
+                            <td className="p-3 text-right font-mono text-sm">
+                              {formatCurrency(holding.currentValue)}
+                            </td>
                             <td className="p-3 text-right">
-                              <Badge variant={holding.moic >= 2 ? 'default' : holding.moic >= 1 ? 'secondary' : 'outline'}>
+                              <Badge
+                                variant={
+                                  holding.moic >= 2
+                                    ? 'default'
+                                    : holding.moic >= 1
+                                      ? 'secondary'
+                                      : 'outline'
+                                }
+                              >
                                 {holding.moic.toFixed(2)}x
                               </Badge>
                             </td>

--- a/client/src/pages/lp/reports.tsx
+++ b/client/src/pages/lp/reports.tsx
@@ -35,12 +35,12 @@ export default function LPReports() {
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'ready':
-        return <CheckCircle className="h-4 w-4 text-green-600" />;
+        return <CheckCircle className="h-4 w-4 text-success-dark" />;
       case 'generating':
       case 'pending':
-        return <Clock className="h-4 w-4 text-amber-600" />;
+        return <Clock className="h-4 w-4 text-warning-dark" />;
       case 'failed':
-        return <AlertCircle className="h-4 w-4 text-red-600" />;
+        return <AlertCircle className="h-4 w-4 text-error-dark" />;
       default:
         return null;
     }
@@ -50,17 +50,17 @@ export default function LPReports() {
     <div className="p-8 space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold font-inter text-[#292929]">Reports</h1>
-        <p className="text-[#292929]/70 font-poppins mt-1">
-          Generate and download LP reports
-        </p>
+        <h1 className="text-3xl font-bold font-inter text-pov-charcoal">Reports</h1>
+        <p className="text-charcoal-600 font-poppins mt-1">Generate and download LP reports</p>
       </div>
 
       {/* Report Generation */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="font-inter text-lg text-[#292929]">Generate New Report</CardTitle>
-          <CardDescription className="font-poppins text-sm text-[#292929]/70">
+          <CardTitle className="font-inter text-lg text-pov-charcoal">
+            Generate New Report
+          </CardTitle>
+          <CardDescription className="font-poppins text-sm text-charcoal-600">
             Create quarterly statements, annual reports, and K-1 tax documents
           </CardDescription>
         </CardHeader>
@@ -101,10 +101,10 @@ export default function LPReports() {
       </Card>
 
       {/* Report History */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="font-inter text-lg text-[#292929]">Report History</CardTitle>
-          <CardDescription className="font-poppins text-sm text-[#292929]/70">
+          <CardTitle className="font-inter text-lg text-pov-charcoal">Report History</CardTitle>
+          <CardDescription className="font-poppins text-sm text-charcoal-600">
             Previously generated reports
           </CardDescription>
         </CardHeader>
@@ -114,15 +114,17 @@ export default function LPReports() {
               {reportsData.reports.map((report) => (
                 <div
                   key={report.id}
-                  className="flex items-center justify-between p-4 border border-[#E0D8D1] rounded-lg hover:shadow-md transition-shadow"
+                  className="flex items-center justify-between p-4 border border-beige-200 rounded-lg hover:shadow-md transition-shadow"
                 >
                   <div className="flex items-center gap-4">
                     {getStatusIcon(report.status)}
                     <div>
-                      <div className="font-inter font-medium text-[#292929]">
-                        {report.reportType.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())}
+                      <div className="font-inter font-medium text-pov-charcoal">
+                        {report.reportType
+                          .replace(/_/g, ' ')
+                          .replace(/\b\w/g, (l) => l.toUpperCase())}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">
+                      <div className="text-sm font-poppins text-charcoal-600">
                         {report.generatedAt
                           ? new Date(report.generatedAt).toLocaleDateString()
                           : 'Processing...'}
@@ -147,7 +149,7 @@ export default function LPReports() {
               ))}
             </div>
           ) : (
-            <div className="text-center py-8 text-[#292929]/50 font-poppins">
+            <div className="text-center py-8 text-charcoal-400 font-poppins">
               No reports generated yet
             </div>
           )}

--- a/client/src/pages/lp/settings.tsx
+++ b/client/src/pages/lp/settings.tsx
@@ -12,7 +12,13 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { AlertCircle, Bell, Monitor, User, Save } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
@@ -74,9 +80,7 @@ export default function LPSettings() {
       toast({
         title: 'Save Failed',
         description:
-          error instanceof Error
-            ? error.message
-            : 'Failed to update notification preferences.',
+          error instanceof Error ? error.message : 'Failed to update notification preferences.',
         variant: 'destructive',
       });
     }
@@ -86,20 +90,18 @@ export default function LPSettings() {
     <div className="p-8 space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold font-inter text-[#292929]">Settings</h1>
-        <p className="text-[#292929]/70 font-poppins mt-1">
-          Manage your LP portal preferences
-        </p>
+        <h1 className="text-3xl font-bold font-inter text-pov-charcoal">Settings</h1>
+        <p className="text-charcoal-600 font-poppins mt-1">Manage your LP portal preferences</p>
       </div>
 
       {/* Profile Information */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 font-inter text-lg text-[#292929]">
-            <User className="h-5 w-5 text-blue-600" />
+          <CardTitle className="flex items-center gap-2 font-inter text-lg text-pov-charcoal">
+            <User className="h-5 w-5 text-pov-charcoal" />
             Profile Information
           </CardTitle>
-          <CardDescription className="font-poppins text-sm text-[#292929]/70">
+          <CardDescription className="font-poppins text-sm text-charcoal-600">
             Your LP account details
           </CardDescription>
         </CardHeader>
@@ -122,26 +124,26 @@ export default function LPSettings() {
               <Input id="tax-id" value={lpProfile?.taxId || 'Not provided'} disabled />
             </div>
           </div>
-          <p className="text-xs text-[#292929]/50 font-poppins">
+          <p className="text-xs text-charcoal-400 font-poppins">
             To update your profile information, please contact your fund manager.
           </p>
         </CardContent>
       </Card>
 
       {/* Notification Preferences */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 font-inter text-lg text-[#292929]">
-            <Bell className="h-5 w-5 text-blue-600" />
+          <CardTitle className="flex items-center gap-2 font-inter text-lg text-pov-charcoal">
+            <Bell className="h-5 w-5 text-pov-charcoal" />
             Email Notifications
           </CardTitle>
-          <CardDescription className="font-poppins text-sm text-[#292929]/70">
+          <CardDescription className="font-poppins text-sm text-charcoal-600">
             Choose which email notifications you receive
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {notificationPreferencesError ? (
-            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            <div className="rounded-md border border-warning/50 bg-warning/10 px-3 py-2 text-sm text-warning-dark">
               <div className="flex items-center gap-2 font-medium">
                 <AlertCircle className="h-4 w-4" />
                 Unable to load persisted notification preferences.
@@ -154,8 +156,10 @@ export default function LPSettings() {
 
           <div className="flex items-center justify-between">
             <div>
-              <Label htmlFor="email-capital-calls" className="font-medium">Capital Calls</Label>
-              <p className="text-sm text-[#292929]/70 font-poppins">
+              <Label htmlFor="email-capital-calls" className="font-medium">
+                Capital Calls
+              </Label>
+              <p className="text-sm text-charcoal-600 font-poppins">
                 Receive notifications for new capital call notices
               </p>
             </div>
@@ -168,8 +172,10 @@ export default function LPSettings() {
 
           <div className="flex items-center justify-between">
             <div>
-              <Label htmlFor="email-distributions" className="font-medium">Distributions</Label>
-              <p className="text-sm text-[#292929]/70 font-poppins">
+              <Label htmlFor="email-distributions" className="font-medium">
+                Distributions
+              </Label>
+              <p className="text-sm text-charcoal-600 font-poppins">
                 Receive notifications for distribution payments
               </p>
             </div>
@@ -182,8 +188,10 @@ export default function LPSettings() {
 
           <div className="flex items-center justify-between">
             <div>
-              <Label htmlFor="email-quarterly" className="font-medium">Quarterly Reports</Label>
-              <p className="text-sm text-[#292929]/70 font-poppins">
+              <Label htmlFor="email-quarterly" className="font-medium">
+                Quarterly Reports
+              </Label>
+              <p className="text-sm text-charcoal-600 font-poppins">
                 Receive quarterly performance reports
               </p>
             </div>
@@ -196,8 +204,10 @@ export default function LPSettings() {
 
           <div className="flex items-center justify-between">
             <div>
-              <Label htmlFor="email-annual" className="font-medium">Annual Reports</Label>
-              <p className="text-sm text-[#292929]/70 font-poppins">
+              <Label htmlFor="email-annual" className="font-medium">
+                Annual Reports
+              </Label>
+              <p className="text-sm text-charcoal-600 font-poppins">
                 Receive annual fund reports and K-1 tax documents
               </p>
             </div>
@@ -210,8 +220,10 @@ export default function LPSettings() {
 
           <div className="flex items-center justify-between">
             <div>
-              <Label htmlFor="email-updates" className="font-medium">Market Updates</Label>
-              <p className="text-sm text-[#292929]/70 font-poppins">
+              <Label htmlFor="email-updates" className="font-medium">
+                Market Updates
+              </Label>
+              <p className="text-sm text-charcoal-600 font-poppins">
                 Receive market insights and portfolio updates
               </p>
             </div>
@@ -225,18 +237,18 @@ export default function LPSettings() {
       </Card>
 
       {/* Display Preferences */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 font-inter text-lg text-[#292929]">
-            <Monitor className="h-5 w-5 text-blue-600" />
+          <CardTitle className="flex items-center gap-2 font-inter text-lg text-pov-charcoal">
+            <Monitor className="h-5 w-5 text-pov-charcoal" />
             Display Preferences
           </CardTitle>
-          <CardDescription className="font-poppins text-sm text-[#292929]/70">
+          <CardDescription className="font-poppins text-sm text-charcoal-600">
             Customize how data is displayed
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+          <div className="rounded-md border border-beige-200 bg-pov-gray px-3 py-2 text-sm text-charcoal-700">
             Display preferences remain local-only in this tranche. This page only persists
             notification settings to the backend today.
           </div>
@@ -292,7 +304,9 @@ export default function LPSettings() {
         <Button
           onClick={handleSave}
           className="px-8"
-          disabled={notificationPreferencesLoading || updateNotificationPreferencesMutation.isPending}
+          disabled={
+            notificationPreferencesLoading || updateNotificationPreferencesMutation.isPending
+          }
         >
           <Save className="h-4 w-4 mr-2" />
           {updateNotificationPreferencesMutation.isPending ? 'Saving…' : 'Save Changes'}

--- a/client/src/pages/pipeline.tsx
+++ b/client/src/pages/pipeline.tsx
@@ -57,14 +57,14 @@ import type { DealOpportunity, PipelineStage } from '@shared/schema';
 
 // Pipeline status configuration
 const PIPELINE_STATUSES = [
-  { key: 'lead', label: 'Lead', color: 'bg-gray-100' },
-  { key: 'qualified', label: 'Qualified', color: 'bg-blue-100' },
-  { key: 'pitch', label: 'Pitch', color: 'bg-purple-100' },
-  { key: 'dd', label: 'Due Diligence', color: 'bg-amber-100' },
-  { key: 'committee', label: 'Committee', color: 'bg-indigo-100' },
-  { key: 'term_sheet', label: 'Term Sheet', color: 'bg-pink-100' },
-  { key: 'closed', label: 'Closed', color: 'bg-green-100' },
-  { key: 'passed', label: 'Passed', color: 'bg-red-100' },
+  { key: 'lead', label: 'Lead', color: 'bg-pov-gray' },
+  { key: 'qualified', label: 'Qualified', color: 'bg-beige' },
+  { key: 'pitch', label: 'Pitch', color: 'bg-beige' },
+  { key: 'dd', label: 'Due Diligence', color: 'bg-beige' },
+  { key: 'committee', label: 'Committee', color: 'bg-beige' },
+  { key: 'term_sheet', label: 'Term Sheet', color: 'bg-beige' },
+  { key: 'closed', label: 'Closed', color: 'bg-success' },
+  { key: 'passed', label: 'Passed', color: 'bg-error' },
 ] as const;
 
 // Type for view mode
@@ -152,7 +152,7 @@ function EmptyPipelineState({
         </h3>
       </CardHeader>
       <CardContent className="text-center">
-        <p className="font-poppins text-sm text-gray-500 mb-6 max-w-md mx-auto">
+        <p className="font-poppins text-sm text-charcoal-500 mb-6 max-w-md mx-auto">
           Add deals to track diligence, scoring, and next steps. Import existing deals from a
           spreadsheet or add them manually.
         </p>
@@ -177,17 +177,17 @@ function EmptyPipelineState({
 // Error state component
 function ErrorState({ onRetry }: { onRetry: () => void }) {
   return (
-    <Card className="border-red-200 bg-red-50">
+    <Card className="border-error/50 bg-error/10">
       <CardContent className="pt-6 text-center">
-        <AlertCircle className="h-10 w-10 text-red-500 mx-auto mb-3" />
-        <h3 className="font-inter font-semibold text-red-900 mb-2">Failed to load deals</h3>
-        <p className="font-poppins text-sm text-red-700 mb-4">
+        <AlertCircle className="h-10 w-10 text-error mx-auto mb-3" />
+        <h3 className="font-inter font-semibold text-error-dark mb-2">Failed to load deals</h3>
+        <p className="font-poppins text-sm text-error-dark mb-4">
           There was an error loading your pipeline. Please try again.
         </p>
         <Button
           onClick={onRetry}
           variant="outline"
-          className="border-red-300 text-red-700 hover:bg-red-100"
+          className="border-error/50 text-error-dark hover:bg-error/10"
         >
           <RefreshCw className="h-4 w-4 mr-2" />
           Retry
@@ -294,7 +294,7 @@ function ListView({
                   onToggleSelect(deal.id);
                 }}
                 onClick={(e) => e.stopPropagation()}
-                className="h-4 w-4 rounded border-gray-300 accent-pov-charcoal"
+                className="h-4 w-4 rounded border-beige-200 accent-pov-charcoal"
                 data-testid={`deal-checkbox-${deal.id}`}
               />
             )}
@@ -303,7 +303,7 @@ function ListView({
             </div>
             <div>
               <h4 className="font-inter font-semibold text-pov-charcoal">{deal.companyName}</h4>
-              <p className="font-poppins text-xs text-gray-500">
+              <p className="font-poppins text-xs text-charcoal-500">
                 {deal.sector} • {deal.stage}
               </p>
             </div>
@@ -316,16 +316,16 @@ function ListView({
               variant="outline"
               className={
                 deal.priority === 'high'
-                  ? 'bg-red-50 text-red-700'
+                  ? 'border-error/50 bg-error/10 text-error-dark'
                   : deal.priority === 'medium'
-                    ? 'bg-yellow-50 text-yellow-700'
-                    : 'bg-green-50 text-green-700'
+                    ? 'border-warning/50 bg-warning/10 text-warning-dark'
+                    : 'border-success/50 bg-success/10 text-success-dark'
               }
             >
               {deal.priority.charAt(0).toUpperCase() + deal.priority.slice(1)}
             </Badge>
             {deal.dealSize && Number.isFinite(parseFloat(String(deal.dealSize))) && (
-              <span className="font-poppins text-sm text-gray-600 hidden sm:block">
+              <span className="font-poppins text-sm text-charcoal-600 hidden sm:block">
                 ${(parseFloat(String(deal.dealSize)) / 1000000).toFixed(1)}M
               </span>
             )}
@@ -533,7 +533,7 @@ export default function PipelinePage() {
   });
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className="min-h-screen bg-pov-gray">
       <POVBrandHeader
         title="Pipeline"
         subtitle="Track deals, diligence progress, and investment decisions"
@@ -545,7 +545,7 @@ export default function PipelinePage() {
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
           <div>
             <h2 className="font-inter text-2xl font-bold text-pov-charcoal">Deal Pipeline</h2>
-            <p className="font-poppins text-sm text-gray-500">
+            <p className="font-poppins text-sm text-charcoal-500">
               {hasDeals
                 ? `${deals.length} deal${deals.length !== 1 ? 's' : ''} in pipeline`
                 : 'Manage your deal flow'}
@@ -577,7 +577,7 @@ export default function PipelinePage() {
         <div className="flex flex-col sm:flex-row gap-2 mb-6" data-testid="pipeline-toolbar">
           {/* Search */}
           <div className="relative flex-1 max-w-sm">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-charcoal-400" />
             <Input
               placeholder="Search deals..."
               value={searchInput}
@@ -591,7 +591,7 @@ export default function PipelinePage() {
                   setSearchInput('');
                   setFilter('q', '');
                 }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-charcoal-400 hover:text-charcoal-600"
                 aria-label="Clear search"
               >
                 <X className="h-4 w-4" />
@@ -665,7 +665,9 @@ export default function PipelinePage() {
               aria-label="Kanban view"
               aria-controls={PIPELINE_VIEW_REGION_ID}
               aria-pressed={viewMode === 'kanban'}
-              className={viewMode === 'kanban' ? 'bg-pov-charcoal text-white' : 'text-gray-600'}
+              className={
+                viewMode === 'kanban' ? 'bg-pov-charcoal text-pov-white' : 'text-pov-charcoal'
+              }
             >
               <LayoutGrid className="h-4 w-4" />
             </Button>
@@ -676,7 +678,9 @@ export default function PipelinePage() {
               aria-label="List view"
               aria-controls={PIPELINE_VIEW_REGION_ID}
               aria-pressed={viewMode === 'list'}
-              className={viewMode === 'list' ? 'bg-pov-charcoal text-white' : 'text-gray-600'}
+              className={
+                viewMode === 'list' ? 'bg-pov-charcoal text-pov-white' : 'text-pov-charcoal'
+              }
             >
               <List className="h-4 w-4" />
             </Button>
@@ -688,7 +692,7 @@ export default function PipelinePage() {
               variant="ghost"
               size="sm"
               onClick={clearFilters}
-              className="text-gray-500 hover:text-gray-700"
+              className="text-charcoal-500 hover:text-charcoal-700"
             >
               <X className="h-3 w-3 mr-1" />
               Clear
@@ -725,16 +729,21 @@ export default function PipelinePage() {
               size="sm"
               onClick={() => bulkArchiveMutation.mutate()}
               disabled={bulkArchiveMutation.isPending}
-              className="border-red-200 text-red-700 hover:bg-red-50"
+              className="border-error/50 text-error-dark hover:bg-error/10"
               data-testid="bulk-archive-btn"
             >
               Archive
             </Button>
-            <Button variant="ghost" size="sm" onClick={clearSelection} className="text-gray-500">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearSelection}
+              className="text-charcoal-500"
+            >
               Clear
             </Button>
             {deals.length > selectedIds.size && (
-              <Button variant="ghost" size="sm" onClick={selectAll} className="text-gray-500">
+              <Button variant="ghost" size="sm" onClick={selectAll} className="text-charcoal-500">
                 Select all ({deals.length})
               </Button>
             )}
@@ -762,9 +771,9 @@ export default function PipelinePage() {
           ) : !hasDeals && hasFilters ? (
             <Card className="border-pov-beige/50 bg-white/50">
               <CardContent className="pt-6 text-center">
-                <Search className="h-8 w-8 text-gray-300 mx-auto mb-3" />
+                <Search className="h-8 w-8 text-charcoal-300 mx-auto mb-3" />
                 <p className="font-inter font-medium text-pov-charcoal mb-1">No matching deals</p>
-                <p className="font-poppins text-sm text-gray-500 mb-4">
+                <p className="font-poppins text-sm text-charcoal-500 mb-4">
                   Try adjusting your filters or search terms.
                 </p>
                 <Button variant="outline" onClick={clearFilters} className="border-pov-beige">
@@ -791,7 +800,7 @@ export default function PipelinePage() {
                 <h3 className="font-inter font-semibold text-sm text-pov-charcoal mb-2">
                   Deal Scoring
                 </h3>
-                <p className="font-poppins text-xs text-gray-500">
+                <p className="font-poppins text-xs text-charcoal-500">
                   Score deals on team, market, product, and traction metrics
                 </p>
               </CardContent>
@@ -801,7 +810,7 @@ export default function PipelinePage() {
                 <h3 className="font-inter font-semibold text-sm text-pov-charcoal mb-2">
                   Diligence Tracking
                 </h3>
-                <p className="font-poppins text-xs text-gray-500">
+                <p className="font-poppins text-xs text-charcoal-500">
                   Track diligence checklist progress and key findings
                 </p>
               </CardContent>
@@ -811,7 +820,7 @@ export default function PipelinePage() {
                 <h3 className="font-inter font-semibold text-sm text-pov-charcoal mb-2">
                   Decision Workflow
                 </h3>
-                <p className="font-poppins text-xs text-gray-500">
+                <p className="font-poppins text-xs text-charcoal-500">
                   Move deals through stages from sourcing to close
                 </p>
               </CardContent>

--- a/client/src/pages/reserves-demo.tsx
+++ b/client/src/pages/reserves-demo.tsx
@@ -1,18 +1,13 @@
- 
- 
- 
- 
- 
-import GraduationReservesDemo from "@/components/reserves/graduation-reserves-demo";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, Calculator, Lightbulb } from "lucide-react";
-import { Link } from "wouter";
-import { Button } from "@/components/ui/button";
+import GraduationReservesDemo from '@/components/reserves/graduation-reserves-demo';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, Calculator, Lightbulb } from 'lucide-react';
+import { Link } from 'wouter';
+import { Button } from '@/components/ui/button';
 
 export default function ReservesDemo() {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-pov-gray">
       <div className="container mx-auto p-6">
         {/* Header */}
         <div className="mb-8">
@@ -25,12 +20,14 @@ export default function ReservesDemo() {
                     Back to Dashboard
                   </Button>
                 </Link>
-                <Badge variant="outline" className="bg-blue-50 text-blue-700">
+                <Badge variant="outline" className="bg-presson-info/10 text-presson-info">
                   Interactive Demo
                 </Badge>
               </div>
-              <h1 className="text-3xl font-bold text-gray-900">Graduation-Driven Reserves Demo</h1>
-              <p className="text-gray-600 mt-2">
+              <h1 className="text-3xl font-bold text-pov-charcoal">
+                Graduation-Driven Reserves Demo
+              </h1>
+              <p className="text-charcoal-600 mt-2">
                 See how different portfolio strategies impact your follow-on reserve requirements
               </p>
             </div>
@@ -41,49 +38,59 @@ export default function ReservesDemo() {
         <Card className="mb-8">
           <CardHeader>
             <CardTitle className="text-xl flex items-center">
-              <Lightbulb className="w-5 h-5 mr-2 text-yellow-600" />
+              <Lightbulb className="w-5 h-5 mr-2 text-presson-warning" />
               How It Works
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              <p className="text-gray-700">
-                The <strong>Graduation-Driven Reserves Engine</strong> calculates your follow-on capital needs 
-                based on expected portfolio company progression through funding stages, rather than using 
-                arbitrary reserve ratio percentages.
+              <p className="text-charcoal-700">
+                The <strong>Graduation-Driven Reserves Engine</strong> calculates your follow-on
+                capital needs based on expected portfolio company progression through funding
+                stages, rather than using arbitrary reserve ratio percentages.
               </p>
-              
+
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="bg-blue-50 p-4 rounded-lg border border-blue-200">
+                <div className="bg-pov-gray p-4 rounded-lg border border-beige-200">
                   <div className="flex items-center mb-2">
-                    <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white font-bold text-sm">1</div>
-                    <span className="ml-3 font-semibold text-blue-800">Graduation Modeling</span>
+                    <div className="w-8 h-8 bg-pov-charcoal rounded-full flex items-center justify-center text-pov-white font-bold text-sm">
+                      1
+                    </div>
+                    <span className="ml-3 font-semibold text-pov-charcoal">
+                      Graduation Modeling
+                    </span>
                   </div>
-                  <p className="text-sm text-blue-700">
-                    Models how many companies will advance from Seed → Series A → Series B → Series C 
-                    based on your sector assumptions and historical data.
+                  <p className="text-sm text-charcoal-600">
+                    Models how many companies will advance from Seed → Series A → Series B → Series
+                    C based on your sector assumptions and historical data.
                   </p>
                 </div>
-                
-                <div className="bg-green-50 p-4 rounded-lg border border-green-200">
+
+                <div className="bg-pov-gray p-4 rounded-lg border border-beige-200">
                   <div className="flex items-center mb-2">
-                    <div className="w-8 h-8 bg-green-600 rounded-full flex items-center justify-center text-white font-bold text-sm">2</div>
-                    <span className="ml-3 font-semibold text-green-800">Follow-on Strategy</span>
+                    <div className="w-8 h-8 bg-pov-charcoal rounded-full flex items-center justify-center text-pov-white font-bold text-sm">
+                      2
+                    </div>
+                    <span className="ml-3 font-semibold text-pov-charcoal">Follow-on Strategy</span>
                   </div>
-                  <p className="text-sm text-green-700">
-                    Applies your follow-on check sizes and participation rates to calculate 
-                    the exact capital needed for each future funding round.
+                  <p className="text-sm text-charcoal-600">
+                    Applies your follow-on check sizes and participation rates to calculate the
+                    exact capital needed for each future funding round.
                   </p>
                 </div>
-                
-                <div className="bg-purple-50 p-4 rounded-lg border border-purple-200">
+
+                <div className="bg-pov-gray p-4 rounded-lg border border-beige-200">
                   <div className="flex items-center mb-2">
-                    <div className="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center text-white font-bold text-sm">3</div>
-                    <span className="ml-3 font-semibold text-purple-800">Reserve Calculation</span>
+                    <div className="w-8 h-8 bg-pov-charcoal rounded-full flex items-center justify-center text-pov-white font-bold text-sm">
+                      3
+                    </div>
+                    <span className="ml-3 font-semibold text-pov-charcoal">
+                      Reserve Calculation
+                    </span>
                   </div>
-                  <p className="text-sm text-purple-700">
-                    Sums up all follow-on capital requirements over your investment horizon 
-                    to determine the optimal reserve ratio for your fund.
+                  <p className="text-sm text-charcoal-600">
+                    Sums up all follow-on capital requirements over your investment horizon to
+                    determine the optimal reserve ratio for your fund.
                   </p>
                 </div>
               </div>
@@ -98,17 +105,17 @@ export default function ReservesDemo() {
         <Card className="mt-8">
           <CardHeader>
             <CardTitle className="text-lg flex items-center">
-              <Calculator className="w-5 h-5 mr-2 text-blue-600" />
+              <Calculator className="w-5 h-5 mr-2 text-charcoal-600" />
               Integration with Fund Management
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="bg-gray-50 p-4 rounded-lg">
-              <p className="text-gray-700 mb-3">
-                This graduation-driven approach has been integrated into your Fund Allocation Manager, 
-                replacing hardcoded reserve ratios with dynamic calculations based on:
+            <div className="bg-pov-gray p-4 rounded-lg">
+              <p className="text-charcoal-700 mb-3">
+                This graduation-driven approach has been integrated into your Fund Allocation
+                Manager, replacing hardcoded reserve ratios with dynamic calculations based on:
               </p>
-              <ul className="text-sm text-gray-600 space-y-1 ml-4">
+              <ul className="text-sm text-charcoal-600 space-y-1 ml-4">
                 <li>• Your fund's target company count and deployment pace</li>
                 <li>• Sector-specific graduation rates and timing assumptions</li>
                 <li>• Follow-on check sizes for Series A, B, and C rounds</li>
@@ -116,9 +123,7 @@ export default function ReservesDemo() {
               </ul>
               <div className="mt-4">
                 <Link href="/allocation-manager">
-                  <Button>
-                    View Allocation Manager
-                  </Button>
+                  <Button>View Allocation Manager</Button>
                 </Link>
               </div>
             </div>
@@ -128,4 +133,3 @@ export default function ReservesDemo() {
     </div>
   );
 }
-

--- a/client/src/pages/shared-dashboard.tsx
+++ b/client/src/pages/shared-dashboard.tsx
@@ -172,13 +172,15 @@ function MetricCard({ metric }: { metric: PublicMetricValue }) {
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-sm font-medium text-gray-600">{metric.label}</CardTitle>
+        <CardTitle className="text-sm font-medium text-charcoal-600">{metric.label}</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className={`text-2xl font-bold ${unavailable ? 'text-gray-500' : 'text-gray-900'}`}>
+        <div
+          className={`text-2xl font-bold ${unavailable ? 'text-charcoal-500' : 'text-pov-charcoal'}`}
+        >
           {formatMetric(metric)}
         </div>
-        <p className="mt-2 text-xs text-gray-500">
+        <p className="mt-2 text-xs text-charcoal-500">
           {unavailable
             ? (metric.unavailableReason ?? 'Source data unavailable')
             : `${metric.source} as of ${new Date(metric.asOfDate).toLocaleDateString()}`}
@@ -230,10 +232,10 @@ const SharedDashboard: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-pov-gray flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading dashboard...</p>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-pov-charcoal mx-auto mb-4"></div>
+          <p className="text-charcoal-600">Loading dashboard...</p>
         </div>
       </div>
     );
@@ -241,14 +243,14 @@ const SharedDashboard: React.FC = () => {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-pov-gray flex items-center justify-center">
         <Card className="w-full max-w-md">
           <CardContent className="pt-6">
             <div className="text-center">
-              <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
-              <h1 className="text-xl font-semibold text-gray-900 mb-2">Access Error</h1>
-              <p className="text-gray-600 mb-4">{error}</p>
-              <p className="text-sm text-gray-500">
+              <AlertCircle className="h-12 w-12 text-error mx-auto mb-4" />
+              <h1 className="text-xl font-semibold text-pov-charcoal mb-2">Access Error</h1>
+              <p className="text-charcoal-600 mb-4">{error}</p>
+              <p className="text-sm text-charcoal-500">
                 Please check your link or contact the fund manager for assistance.
               </p>
             </div>
@@ -260,19 +262,19 @@ const SharedDashboard: React.FC = () => {
 
   if (requiresPasskey) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-pov-gray flex items-center justify-center">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
-            <Shield className="h-12 w-12 text-blue-600 mx-auto mb-4" />
+            <Shield className="h-12 w-12 text-pov-charcoal mx-auto mb-4" />
             <CardTitle>Secure Access Required</CardTitle>
             {shareConfig?.customTitle && (
-              <p className="text-gray-600 mt-2">{shareConfig.customTitle}</p>
+              <p className="text-charcoal-600 mt-2">{shareConfig.customTitle}</p>
             )}
           </CardHeader>
           <CardContent>
             <form onSubmit={handlePasskeySubmit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-charcoal-700 mb-2">
                   Enter Passkey
                 </label>
                 <Input
@@ -283,17 +285,19 @@ const SharedDashboard: React.FC = () => {
                     setPasskeyError(null);
                   }}
                   placeholder="Enter the passkey provided by your fund manager"
-                  className={passkeyError ? 'border-red-500' : ''}
+                  className={passkeyError ? 'border-error' : ''}
                   required
                 />
-                {passkeyError && <p className="text-sm text-red-600 mt-1">{passkeyError}</p>}
+                {passkeyError && <p className="text-sm text-error-dark mt-1">{passkeyError}</p>}
               </div>
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? 'Verifying...' : 'Access Dashboard'}
               </Button>
             </form>
             {shareConfig?.customMessage && (
-              <p className="text-sm text-gray-500 mt-4 text-center">{shareConfig.customMessage}</p>
+              <p className="text-sm text-charcoal-500 mt-4 text-center">
+                {shareConfig.customMessage}
+              </p>
             )}
           </CardContent>
         </Card>
@@ -306,13 +310,13 @@ const SharedDashboard: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 print:bg-white">
+    <div className="min-h-screen bg-pov-gray print:bg-white">
       <div className="bg-white border-b print:border-0">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">{snapshot.title}</h1>
-              {snapshot.message && <p className="text-gray-600 mt-1">{snapshot.message}</p>}
+              <h1 className="text-2xl font-bold text-pov-charcoal">{snapshot.title}</h1>
+              {snapshot.message && <p className="text-charcoal-600 mt-1">{snapshot.message}</p>}
             </div>
             <div className="flex items-center gap-4 no-print">
               <Button
@@ -324,7 +328,7 @@ const SharedDashboard: React.FC = () => {
                 <Printer className="h-4 w-4" />
                 Print
               </Button>
-              <div className="flex items-center gap-2 text-sm text-gray-500">
+              <div className="flex items-center gap-2 text-sm text-charcoal-500">
                 <Eye className="h-4 w-4" />
                 Read-only Access
               </div>
@@ -346,7 +350,7 @@ const SharedDashboard: React.FC = () => {
           </CardHeader>
           <CardContent>
             {snapshot.portfolioCompanies.length === 0 ? (
-              <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+              <div className="rounded-md border border-warning/50 bg-warning/10 p-4 text-sm text-warning-dark">
                 Portfolio company details are unavailable in this public snapshot.
               </div>
             ) : (
@@ -378,10 +382,10 @@ const SharedDashboard: React.FC = () => {
           </CardContent>
         </Card>
 
-        <div className="mt-12 pt-8 border-t text-center text-sm text-gray-500">
+        <div className="mt-12 pt-8 border-t text-center text-sm text-charcoal-500">
           <div className="flex items-center justify-center gap-4">
             <div className="flex items-center gap-1">
-              <CheckCircle className="h-4 w-4 text-green-500" />
+              <CheckCircle className="h-4 w-4 text-success" />
               Server-authorized Snapshot
             </div>
             <div className="flex items-center gap-1">

--- a/client/src/pages/variance-tracking.tsx
+++ b/client/src/pages/variance-tracking.tsx
@@ -596,15 +596,15 @@ export default function VarianceTrackingPage() {
   const getSeverityColor = (severity: string) => {
     switch (severity) {
       case 'critical':
-        return 'bg-red-100 text-red-800 border-red-200';
+        return 'bg-error/10 text-error-dark border-error/50';
       case 'urgent':
-        return 'bg-red-100 text-red-800 border-red-200';
+        return 'bg-error/10 text-error-dark border-error/50';
       case 'warning':
-        return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+        return 'bg-warning/10 text-warning-dark border-warning/50';
       case 'info':
-        return 'bg-blue-100 text-blue-800 border-blue-200';
+        return 'bg-presson-info/10 text-presson-info border-presson-info/20';
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200';
+        return 'bg-pov-gray text-pov-charcoal border-beige-200';
     }
   };
 
@@ -702,33 +702,33 @@ export default function VarianceTrackingPage() {
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <div className="flex items-center justify-between p-4 bg-red-50 border border-red-200 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-error/10 border border-error/50 rounded-lg">
                 <div>
-                  <div className="text-sm font-medium text-red-800">Critical</div>
-                  <div className="text-2xl font-bold text-red-900">{alertCounts.critical}</div>
+                  <div className="text-sm font-medium text-error-dark">Critical</div>
+                  <div className="text-2xl font-bold text-error-dark">{alertCounts.critical}</div>
                 </div>
-                <AlertCircle className="w-8 h-8 text-red-600" />
+                <AlertCircle className="w-8 h-8 text-error-dark" />
               </div>
-              <div className="flex items-center justify-between p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-warning/10 border border-warning/50 rounded-lg">
                 <div>
-                  <div className="text-sm font-medium text-yellow-800">Warning</div>
-                  <div className="text-2xl font-bold text-yellow-900">{alertCounts.warning}</div>
+                  <div className="text-sm font-medium text-warning-dark">Warning</div>
+                  <div className="text-2xl font-bold text-warning-dark">{alertCounts.warning}</div>
                 </div>
-                <AlertTriangle className="w-8 h-8 text-yellow-600" />
+                <AlertTriangle className="w-8 h-8 text-warning-dark" />
               </div>
-              <div className="flex items-center justify-between p-4 bg-blue-50 border border-blue-200 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-presson-info/10 border border-presson-info/20 rounded-lg">
                 <div>
-                  <div className="text-sm font-medium text-blue-800">Info</div>
-                  <div className="text-2xl font-bold text-blue-900">{alertCounts.info}</div>
+                  <div className="text-sm font-medium text-presson-info">Info</div>
+                  <div className="text-2xl font-bold text-presson-info">{alertCounts.info}</div>
                 </div>
-                <Bell className="w-8 h-8 text-blue-600" />
+                <Bell className="w-8 h-8 text-presson-info" />
               </div>
-              <div className="flex items-center justify-between p-4 bg-rose-50 border border-rose-200 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-error/10 border border-error/50 rounded-lg">
                 <div>
-                  <div className="text-sm font-medium text-rose-800">Urgent</div>
-                  <div className="text-2xl font-bold text-rose-900">{alertCounts.urgent}</div>
+                  <div className="text-sm font-medium text-error-dark">Urgent</div>
+                  <div className="text-2xl font-bold text-error-dark">{alertCounts.urgent}</div>
                 </div>
-                <AlertTriangle className="w-8 h-8 text-rose-600" />
+                <AlertTriangle className="w-8 h-8 text-error-dark" />
               </div>
             </div>
           </CardContent>
@@ -742,8 +742,8 @@ export default function VarianceTrackingPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Variance Tracking</h1>
-          <p className="text-gray-600 mt-2">
+          <h1 className="text-3xl font-bold text-pov-charcoal">Variance Tracking</h1>
+          <p className="text-charcoal-600 mt-2">
             Monitor fund performance against baselines and manage alerts.
           </p>
         </div>
@@ -780,9 +780,11 @@ export default function VarianceTrackingPage() {
           {reportsLoading ? (
             <Card>
               <CardContent className="p-12 text-center">
-                <BarChart3 className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">Loading Latest Report</h3>
-                <p className="text-gray-600">Fetching variance report data for this fund.</p>
+                <BarChart3 className="w-12 h-12 text-charcoal-400 mx-auto mb-4" />
+                <h3 className="text-lg font-medium text-pov-charcoal mb-2">
+                  Loading Latest Report
+                </h3>
+                <p className="text-charcoal-600">Fetching variance report data for this fund.</p>
               </CardContent>
             </Card>
           ) : latestReport ? (
@@ -797,20 +799,20 @@ export default function VarianceTrackingPage() {
               <CardContent>
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                   <div className="rounded-lg border p-4">
-                    <div className="text-sm font-medium text-gray-600">Total Variances</div>
-                    <div className="mt-1 text-2xl font-semibold text-gray-900">
+                    <div className="text-sm font-medium text-charcoal-600">Total Variances</div>
+                    <div className="mt-1 text-2xl font-semibold text-pov-charcoal">
                       {latestReport.summary.totalVariances}
                     </div>
                   </div>
                   <div className="rounded-lg border p-4">
-                    <div className="text-sm font-medium text-gray-600">Significant</div>
-                    <div className="mt-1 text-2xl font-semibold text-yellow-700">
+                    <div className="text-sm font-medium text-charcoal-600">Significant</div>
+                    <div className="mt-1 text-2xl font-semibold text-warning-dark">
                       {latestReport.summary.significantVariances}
                     </div>
                   </div>
                   <div className="rounded-lg border p-4">
-                    <div className="text-sm font-medium text-gray-600">Critical</div>
-                    <div className="mt-1 text-2xl font-semibold text-red-700">
+                    <div className="text-sm font-medium text-charcoal-600">Critical</div>
+                    <div className="mt-1 text-2xl font-semibold text-error-dark">
                       {latestReport.summary.criticalVariances}
                     </div>
                   </div>
@@ -820,9 +822,9 @@ export default function VarianceTrackingPage() {
           ) : (
             <Card>
               <CardContent className="p-12 text-center">
-                <BarChart3 className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">No Variance Data Yet</h3>
-                <p className="text-gray-600 mb-4">
+                <BarChart3 className="w-12 h-12 text-charcoal-400 mx-auto mb-4" />
+                <h3 className="text-lg font-medium text-pov-charcoal mb-2">No Variance Data Yet</h3>
+                <p className="text-charcoal-600 mb-4">
                   Create a baseline and run a variance analysis to generate the first report.
                 </p>
                 <Button onClick={handlePerformAnalysis} disabled={isAnalysisRunning}>
@@ -845,61 +847,65 @@ export default function VarianceTrackingPage() {
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                   {Array.from({ length: 3 }).map((_, index) => (
                     <div key={index} className="rounded-lg border p-4">
-                      <div className="h-4 w-32 animate-pulse rounded bg-gray-200" />
-                      <div className="mt-3 h-7 w-40 animate-pulse rounded bg-gray-200" />
+                      <div className="h-4 w-32 animate-pulse rounded bg-pov-gray" />
+                      <div className="mt-3 h-7 w-40 animate-pulse rounded bg-pov-gray" />
                     </div>
                   ))}
                 </div>
               ) : !deploymentPlanStatus ? (
-                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                <div className="rounded-lg border border-warning/50 bg-warning/10 p-4 text-sm text-warning-dark">
                   Deployment-plan context is not available from the unified metrics response right
                   now, so this card is intentionally withheld instead of showing fallback values.
                 </div>
               ) : (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                   <div className="rounded-lg border p-4">
-                    <div className="text-sm font-medium text-gray-600">Remaining deployable</div>
-                    <div className="mt-1 text-2xl font-semibold text-gray-900">
+                    <div className="text-sm font-medium text-charcoal-600">
+                      Remaining deployable
+                    </div>
+                    <div className="mt-1 text-2xl font-semibold text-pov-charcoal">
                       {formatCurrency(remainingDeployableCapital)}
                     </div>
-                    <div className="mt-2 text-xs text-gray-500">
+                    <div className="mt-2 text-xs text-charcoal-500">
                       Actual committed capital minus capital already deployed.
                     </div>
                   </div>
                   <div className="rounded-lg border p-4">
-                    <div className="text-sm font-medium text-gray-600">Plan remaining</div>
-                    <div className="mt-1 text-2xl font-semibold text-gray-900">
+                    <div className="text-sm font-medium text-charcoal-600">Plan remaining</div>
+                    <div className="mt-1 text-2xl font-semibold text-pov-charcoal">
                       {formatCurrency(plannedRemainingDeployableCapital)}
                     </div>
-                    <div className="mt-2 text-xs text-gray-500">
+                    <div className="mt-2 text-xs text-charcoal-500">
                       Current deployment plan implied by target deployed capital for this fund age.
                     </div>
                   </div>
                   <div className="rounded-lg border p-4">
-                    <div className="text-sm font-medium text-gray-600">Gap vs plan</div>
+                    <div className="text-sm font-medium text-charcoal-600">Gap vs plan</div>
                     <div
                       className={cn(
                         'mt-1 text-2xl font-semibold',
-                        (remainingDeployableGap ?? 0) > 0 ? 'text-blue-700' : 'text-amber-700'
+                        (remainingDeployableGap ?? 0) > 0
+                          ? 'text-presson-info'
+                          : 'text-warning-dark'
                       )}
                     >
                       {remainingDeployableGap == null
                         ? '-'
                         : `${remainingDeployableGap > 0 ? '+' : ''}${formatCurrency(remainingDeployableGap)}`}
                     </div>
-                    <div className="mt-2 text-xs text-gray-500">
+                    <div className="mt-2 text-xs text-charcoal-500">
                       Positive means more undeployed capital remains than the plan expects today.
                     </div>
                   </div>
                 </div>
               )}
 
-              <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-4">
-                <div className="text-sm font-medium text-slate-700">Uncalled capital</div>
-                <div className="mt-1 text-xl font-semibold text-slate-900">
+              <div className="mt-4 rounded-lg border border-beige-200 bg-pov-gray p-4">
+                <div className="text-sm font-medium text-charcoal-700">Uncalled capital</div>
+                <div className="mt-1 text-xl font-semibold text-pov-charcoal">
                   {formatCurrency(unifiedMetrics?.actual?.totalUncalled)}
                 </div>
-                <div className="mt-2 text-xs text-slate-600">
+                <div className="mt-2 text-xs text-charcoal-600">
                   Capital that has been committed but not yet called from LPs. This is not the same
                   as remaining deployable capital.
                 </div>
@@ -926,14 +932,14 @@ export default function VarianceTrackingPage() {
                           <AlertTriangle
                             className={cn(
                               'w-5 h-5',
-                              alert.severity === 'critical' && 'text-red-600',
-                              alert.severity === 'warning' && 'text-yellow-600',
-                              alert.severity === 'info' && 'text-blue-600'
+                              alert.severity === 'critical' && 'text-error-dark',
+                              alert.severity === 'warning' && 'text-warning-dark',
+                              alert.severity === 'info' && 'text-presson-info'
                             )}
                           />
                           <div>
                             <div className="font-medium text-sm">{alert.ruleName}</div>
-                            <div className="text-xs text-gray-600">{alert.message}</div>
+                            <div className="text-xs text-charcoal-600">{alert.message}</div>
                           </div>
                         </div>
                         <Badge variant="outline" className={getSeverityColor(alert.severity)}>
@@ -943,7 +949,7 @@ export default function VarianceTrackingPage() {
                     ))}
                   </div>
                 ) : (
-                  <div className="text-center py-4 text-gray-500">No recent alerts</div>
+                  <div className="text-center py-4 text-charcoal-500">No recent alerts</div>
                 )}
               </CardContent>
             </Card>
@@ -963,7 +969,7 @@ export default function VarianceTrackingPage() {
                       >
                         <div>
                           <div className="font-medium text-sm">{baseline.name}</div>
-                          <div className="text-xs text-gray-600">
+                          <div className="text-xs text-charcoal-600">
                             {baseline.baselineType} •{' '}
                             {format(parseISO(baseline.createdAt), 'MMM dd, yyyy')}
                           </div>
@@ -976,7 +982,7 @@ export default function VarianceTrackingPage() {
                     ))}
                   </div>
                 ) : (
-                  <div className="text-center py-4 text-gray-500">No baselines configured</div>
+                  <div className="text-center py-4 text-charcoal-500">No baselines configured</div>
                 )}
               </CardContent>
             </Card>
@@ -986,8 +992,8 @@ export default function VarianceTrackingPage() {
         <TabsContent value="baselines" className="space-y-6">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-2xl font-bold text-gray-900">Baseline Management</h2>
-              <p className="text-gray-600">Configure and manage performance baselines</p>
+              <h2 className="text-2xl font-bold text-pov-charcoal">Baseline Management</h2>
+              <p className="text-charcoal-600">Configure and manage performance baselines</p>
             </div>
 
             <Dialog open={createBaselineDialogOpen} onOpenChange={setCreateBaselineDialogOpen}>
@@ -1097,10 +1103,10 @@ export default function VarianceTrackingPage() {
                         className="animate-pulse flex items-center justify-between p-4 border rounded-lg"
                       >
                         <div className="space-y-2">
-                          <div className="h-4 w-48 bg-gray-200 rounded" />
-                          <div className="h-3 w-32 bg-gray-200 rounded" />
+                          <div className="h-4 w-48 bg-pov-gray rounded" />
+                          <div className="h-3 w-32 bg-pov-gray rounded" />
                         </div>
-                        <div className="w-24 h-8 bg-gray-200 rounded" />
+                        <div className="w-24 h-8 bg-pov-gray rounded" />
                       </div>
                     ))}
                   </div>
@@ -1111,12 +1117,12 @@ export default function VarianceTrackingPage() {
                     <div key={baseline.id} className="p-6 flex items-center justify-between">
                       <div className="flex-1">
                         <div className="flex items-center space-x-3 mb-2">
-                          <h3 className="font-medium text-gray-900">{baseline.name}</h3>
+                          <h3 className="font-medium text-pov-charcoal">{baseline.name}</h3>
                           {baseline.isDefault && <Badge variant="default">Default</Badge>}
                           <Badge variant="outline">{baseline.baselineType}</Badge>
                         </div>
-                        <p className="text-sm text-gray-600 mb-2">{baseline.description}</p>
-                        <div className="text-xs text-gray-500">
+                        <p className="text-sm text-charcoal-600 mb-2">{baseline.description}</p>
+                        <div className="text-xs text-charcoal-500">
                           {format(parseISO(baseline.periodStart), 'MMM dd, yyyy')} -{' '}
                           {format(parseISO(baseline.periodEnd), 'MMM dd, yyyy')}
                         </div>
@@ -1145,7 +1151,7 @@ export default function VarianceTrackingPage() {
                               baselineId: baseline.id,
                             })
                           }
-                          className="text-red-600 border-red-200 hover:bg-red-50"
+                          className="border-beige-200 bg-white text-pov-charcoal hover:bg-pov-gray"
                         >
                           Deactivate
                         </Button>
@@ -1155,9 +1161,9 @@ export default function VarianceTrackingPage() {
                 </div>
               ) : (
                 <div className="p-12 text-center">
-                  <Target className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">No Baselines</h3>
-                  <p className="text-gray-600 mb-4">
+                  <Target className="w-12 h-12 text-charcoal-400 mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-pov-charcoal mb-2">No Baselines</h3>
+                  <p className="text-charcoal-600 mb-4">
                     Create your first baseline to start tracking variance.
                   </p>
                   <Button onClick={() => setCreateBaselineDialogOpen(true)}>
@@ -1172,8 +1178,8 @@ export default function VarianceTrackingPage() {
         <TabsContent value="alerts" className="space-y-6">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-2xl font-bold text-gray-900">Alert Management</h2>
-              <p className="text-gray-600">Monitor and manage variance alerts</p>
+              <h2 className="text-2xl font-bold text-pov-charcoal">Alert Management</h2>
+              <p className="text-charcoal-600">Monitor and manage variance alerts</p>
             </div>
 
             <Dialog open={createAlertDialogOpen} onOpenChange={setCreateAlertDialogOpen}>
@@ -1226,7 +1232,7 @@ export default function VarianceTrackingPage() {
                           ))}
                         </SelectContent>
                       </Select>
-                      <p className="mt-1 text-xs text-gray-500">
+                      <p className="mt-1 text-xs text-charcoal-500">
                         Alert rules currently support threshold checks over the canonical fund-level
                         variance metrics only.
                       </p>
@@ -1294,7 +1300,7 @@ export default function VarianceTrackingPage() {
                         }
                         placeholder="Upper or lower bound"
                       />
-                      <p className="mt-1 text-xs text-gray-500">
+                      <p className="mt-1 text-xs text-charcoal-500">
                         The alert triggers only when the selected metric falls between the primary
                         and secondary thresholds.
                       </p>
@@ -1394,7 +1400,7 @@ export default function VarianceTrackingPage() {
                   </CardDescription>
                 </div>
                 <div className="w-full md:w-56">
-                  <Label className="mb-2 block text-xs font-medium uppercase tracking-wide text-gray-500">
+                  <Label className="mb-2 block text-xs font-medium uppercase tracking-wide text-charcoal-500">
                     Alert Scope
                   </Label>
                   <Select
@@ -1421,10 +1427,10 @@ export default function VarianceTrackingPage() {
                       className="animate-pulse flex items-center justify-between p-4 border rounded-lg"
                     >
                       <div className="space-y-2">
-                        <div className="h-4 w-48 bg-gray-200 rounded" />
-                        <div className="h-3 w-32 bg-gray-200 rounded" />
+                        <div className="h-4 w-48 bg-pov-gray rounded" />
+                        <div className="h-3 w-32 bg-pov-gray rounded" />
                       </div>
-                      <div className="w-24 h-8 bg-gray-200 rounded" />
+                      <div className="w-24 h-8 bg-pov-gray rounded" />
                     </div>
                   ))}
                 </div>
@@ -1439,16 +1445,16 @@ export default function VarianceTrackingPage() {
                         <AlertTriangle
                           className={cn(
                             'w-6 h-6',
-                            alert.severity === 'critical' && 'text-red-600',
-                            alert.severity === 'urgent' && 'text-red-600',
-                            alert.severity === 'warning' && 'text-yellow-600',
-                            alert.severity === 'info' && 'text-blue-600'
+                            alert.severity === 'critical' && 'text-error-dark',
+                            alert.severity === 'urgent' && 'text-error-dark',
+                            alert.severity === 'warning' && 'text-warning-dark',
+                            alert.severity === 'info' && 'text-presson-info'
                           )}
                         />
                         <div>
-                          <div className="font-medium text-gray-900">{alert.ruleName}</div>
-                          <div className="text-sm text-gray-600">{alert.message}</div>
-                          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                          <div className="font-medium text-pov-charcoal">{alert.ruleName}</div>
+                          <div className="text-sm text-charcoal-600">{alert.message}</div>
+                          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-charcoal-500">
                             <span>{format(parseISO(alert.triggeredAt), 'MMM dd, yyyy HH:mm')}</span>
                             {alertBaselineScope === 'all' && alert.baselineName ? (
                               <span>Baseline: {alert.baselineName}</span>
@@ -1457,7 +1463,10 @@ export default function VarianceTrackingPage() {
                             currentDefaultBaseline?.id &&
                             alert.baselineId &&
                             alert.baselineId !== currentDefaultBaseline.id ? (
-                              <Badge variant="outline" className="text-amber-700 border-amber-200">
+                              <Badge
+                                variant="outline"
+                                className="text-warning-dark border-warning/50"
+                              >
                                 Older baseline
                               </Badge>
                             ) : null}
@@ -1492,7 +1501,7 @@ export default function VarianceTrackingPage() {
                                   setActionType('resolve');
                                   setAlertActionDialogOpen(true);
                                 }}
-                                className="text-green-600 border-green-200 hover:bg-green-50"
+                                className="border-beige-200 bg-white text-pov-charcoal hover:bg-pov-gray"
                               >
                                 <XCircle className="w-4 h-4 mr-1" />
                                 Resolve
@@ -1506,13 +1515,13 @@ export default function VarianceTrackingPage() {
                 </div>
               ) : (
                 <div className="text-center py-8">
-                  <Bell className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">
+                  <Bell className="w-12 h-12 text-charcoal-400 mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-pov-charcoal mb-2">
                     {alertBaselineScope === 'current'
                       ? 'No Current-Baseline Alerts'
                       : 'No Open Alerts'}
                   </h3>
-                  <p className="text-gray-600">
+                  <p className="text-charcoal-600">
                     {alertBaselineScope === 'current'
                       ? 'The current default baseline is within acceptable variance ranges.'
                       : 'There are no open incidents across current or historical baselines.'}
@@ -1537,9 +1546,9 @@ export default function VarianceTrackingPage() {
               </DialogHeader>
               <div className="space-y-4">
                 {selectedAlert && (
-                  <div className="p-3 bg-gray-50 rounded-lg">
+                  <div className="p-3 bg-pov-gray rounded-lg">
                     <div className="font-medium">{selectedAlert.ruleName}</div>
-                    <div className="text-sm text-gray-600">{selectedAlert.message}</div>
+                    <div className="text-sm text-charcoal-600">{selectedAlert.message}</div>
                   </div>
                 )}
                 <div>
@@ -1583,8 +1592,8 @@ export default function VarianceTrackingPage() {
         <TabsContent value="reports" className="space-y-6">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-2xl font-bold text-gray-900">Variance Reports</h2>
-              <p className="text-gray-600">Generated variance analysis reports</p>
+              <h2 className="text-2xl font-bold text-pov-charcoal">Variance Reports</h2>
+              <p className="text-charcoal-600">Generated variance analysis reports</p>
             </div>
             <Button
               className="flex items-center space-x-2"
@@ -1606,10 +1615,10 @@ export default function VarianceTrackingPage() {
                         className="animate-pulse flex items-center justify-between p-4 border rounded-lg"
                       >
                         <div className="space-y-2">
-                          <div className="h-4 w-48 bg-gray-200 rounded" />
-                          <div className="h-3 w-32 bg-gray-200 rounded" />
+                          <div className="h-4 w-48 bg-pov-gray rounded" />
+                          <div className="h-3 w-32 bg-pov-gray rounded" />
                         </div>
-                        <div className="w-24 h-8 bg-gray-200 rounded" />
+                        <div className="w-24 h-8 bg-pov-gray rounded" />
                       </div>
                     ))}
                   </div>
@@ -1619,23 +1628,23 @@ export default function VarianceTrackingPage() {
                   {reportsData.data.map((report: VarianceReport) => (
                     <div
                       key={report.id}
-                      className="p-6 flex items-center justify-between cursor-pointer hover:bg-gray-50 transition-colors"
+                      className="p-6 flex items-center justify-between cursor-pointer hover:bg-pov-gray transition-colors"
                       onClick={() => setSelectedReportId(report.id)}
                     >
                       <div className="flex-1">
                         <div className="flex items-center space-x-3 mb-2">
-                          <h3 className="font-medium text-gray-900">{report.reportName}</h3>
+                          <h3 className="font-medium text-pov-charcoal">{report.reportName}</h3>
                           <Badge variant="outline">{report.reportType}</Badge>
                         </div>
-                        <div className="text-sm text-gray-600 mb-1">
+                        <div className="text-sm text-charcoal-600 mb-1">
                           {report.summary.totalVariances} variances
                           {report.summary.criticalVariances > 0 && (
-                            <span className="text-red-600 ml-2">
+                            <span className="text-error-dark ml-2">
                               ({report.summary.criticalVariances} critical)
                             </span>
                           )}
                         </div>
-                        <div className="text-xs text-gray-500">
+                        <div className="text-xs text-charcoal-500">
                           Generated {format(parseISO(report.generatedAt), 'MMM dd, yyyy')}
                         </div>
                       </div>
@@ -1644,9 +1653,11 @@ export default function VarianceTrackingPage() {
                 </div>
               ) : (
                 <div className="p-12 text-center">
-                  <FileText className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">No Reports Generated</h3>
-                  <p className="text-gray-600 mb-4">
+                  <FileText className="w-12 h-12 text-charcoal-400 mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-pov-charcoal mb-2">
+                    No Reports Generated
+                  </h3>
+                  <p className="text-charcoal-600 mb-4">
                     Run a variance analysis to generate your first report.
                   </p>
                   <Button onClick={handlePerformAnalysis} disabled={isAnalysisRunning}>
@@ -1671,24 +1682,24 @@ export default function VarianceTrackingPage() {
               </SheetHeader>
               {reportDetailLoading ? (
                 <div className="flex items-center justify-center py-12">
-                  <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
+                  <Loader2 className="w-8 h-8 animate-spin text-charcoal-400" />
                 </div>
               ) : reportDetail ? (
                 <div className="space-y-6 mt-6">
                   <div className="space-y-2">
-                    <div className="text-sm font-medium text-gray-500">Report Name</div>
-                    <div className="text-gray-900">{reportDetail.reportName}</div>
+                    <div className="text-sm font-medium text-charcoal-500">Report Name</div>
+                    <div className="text-pov-charcoal">{reportDetail.reportName}</div>
                   </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <div className="text-sm font-medium text-gray-500">Type</div>
+                      <div className="text-sm font-medium text-charcoal-500">Type</div>
                       <Badge variant="outline" className="mt-1">
                         {reportDetail.reportType}
                       </Badge>
                     </div>
                     {reportDetail.reportPeriod && (
                       <div>
-                        <div className="text-sm font-medium text-gray-500">Period</div>
+                        <div className="text-sm font-medium text-charcoal-500">Period</div>
                         <Badge variant="outline" className="mt-1">
                           {reportDetail.reportPeriod}
                         </Badge>
@@ -1697,21 +1708,21 @@ export default function VarianceTrackingPage() {
                   </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <div className="text-sm font-medium text-gray-500">As Of Date</div>
-                      <div className="text-gray-900">
+                      <div className="text-sm font-medium text-charcoal-500">As Of Date</div>
+                      <div className="text-pov-charcoal">
                         {format(parseISO(reportDetail.asOfDate), 'MMM dd, yyyy')}
                       </div>
                     </div>
                     <div>
-                      <div className="text-sm font-medium text-gray-500">Generated At</div>
-                      <div className="text-gray-900">
+                      <div className="text-sm font-medium text-charcoal-500">Generated At</div>
+                      <div className="text-pov-charcoal">
                         {format(parseISO(reportDetail.generatedAt), 'MMM dd, yyyy HH:mm')}
                       </div>
                     </div>
                   </div>
 
                   {showHistoricalPortfolioAnalysisUnavailableNotice && (
-                    <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                    <div className="rounded-lg border border-warning/50 bg-warning/10 p-3 text-sm text-warning-dark">
                       <div className="flex items-start gap-2">
                         <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                         <div>
@@ -1724,25 +1735,25 @@ export default function VarianceTrackingPage() {
 
                   {/* Summary cards */}
                   <div>
-                    <div className="text-sm font-medium text-gray-500 mb-2">Summary</div>
+                    <div className="text-sm font-medium text-charcoal-500 mb-2">Summary</div>
                     <div className="grid grid-cols-3 gap-3">
                       <div className="rounded-lg border p-3 text-center">
-                        <div className="text-lg font-semibold text-gray-900">
+                        <div className="text-lg font-semibold text-pov-charcoal">
                           {reportDetail.summary.totalVariances}
                         </div>
-                        <div className="text-xs text-gray-500">Total</div>
+                        <div className="text-xs text-charcoal-500">Total</div>
                       </div>
                       <div className="rounded-lg border p-3 text-center">
-                        <div className="text-lg font-semibold text-yellow-700">
+                        <div className="text-lg font-semibold text-warning-dark">
                           {reportDetail.summary.significantVariances}
                         </div>
-                        <div className="text-xs text-gray-500">Significant</div>
+                        <div className="text-xs text-charcoal-500">Significant</div>
                       </div>
                       <div className="rounded-lg border p-3 text-center">
-                        <div className="text-lg font-semibold text-red-700">
+                        <div className="text-lg font-semibold text-error-dark">
                           {reportDetail.summary.criticalVariances}
                         </div>
-                        <div className="text-xs text-gray-500">Critical</div>
+                        <div className="text-xs text-charcoal-500">Critical</div>
                       </div>
                     </div>
                   </div>
@@ -1750,11 +1761,11 @@ export default function VarianceTrackingPage() {
                   {/* Supplemental variance analysis */}
                   {reportHasSupplementalAnalysis && (
                     <div>
-                      <div className="text-sm font-medium text-gray-500 mb-2">
+                      <div className="text-sm font-medium text-charcoal-500 mb-2">
                         Portfolio Analysis
                       </div>
                       {showHistoricalPortfolioAnalysisNotice && (
-                        <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                        <div className="mb-3 rounded-lg border border-warning/50 bg-warning/10 p-3 text-sm text-warning-dark">
                           <div className="flex items-start gap-2">
                             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                             <div>
@@ -1768,47 +1779,47 @@ export default function VarianceTrackingPage() {
                       <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-sm">
                         {reportDetail.portfolioVariances && (
                           <>
-                            <div className="p-2 bg-gray-50 rounded">
-                              <span className="text-gray-500">Portfolio Count Change</span>
+                            <div className="p-2 bg-pov-gray rounded">
+                              <span className="text-charcoal-500">Portfolio Count Change</span>
                               <span className="block font-medium">
                                 {formatSignedNumber(
                                   reportDetail.portfolioVariances.portfolioCountVariance
                                 )}
                               </span>
                             </div>
-                            <div className="p-2 bg-gray-50 rounded">
-                              <span className="text-gray-500">Companies Analyzed</span>
+                            <div className="p-2 bg-pov-gray rounded">
+                              <span className="text-charcoal-500">Companies Analyzed</span>
                               <span className="block font-medium">{companyVariances.length}</span>
                             </div>
                           </>
                         )}
                         {reportDetail.sectorVariances && (
-                          <div className="p-2 bg-gray-50 rounded">
-                            <span className="text-gray-500">Sectors Tracked</span>
+                          <div className="p-2 bg-pov-gray rounded">
+                            <span className="text-charcoal-500">Sectors Tracked</span>
                             <span className="block font-medium">
                               {Object.keys(reportDetail.sectorVariances).length}
                             </span>
                           </div>
                         )}
                         {reportDetail.stageVariances && (
-                          <div className="p-2 bg-gray-50 rounded">
-                            <span className="text-gray-500">Stages Tracked</span>
+                          <div className="p-2 bg-pov-gray rounded">
+                            <span className="text-charcoal-500">Stages Tracked</span>
                             <span className="block font-medium">
                               {Object.keys(reportDetail.stageVariances).length}
                             </span>
                           </div>
                         )}
                         {reportDetail.reserveVariances && (
-                          <div className="p-2 bg-gray-50 rounded">
-                            <span className="text-gray-500">Reserve Metrics Changed</span>
+                          <div className="p-2 bg-pov-gray rounded">
+                            <span className="text-charcoal-500">Reserve Metrics Changed</span>
                             <span className="block font-medium">
                               {reserveMetricEntries.length + reserveChangeEntries.length}
                             </span>
                           </div>
                         )}
                         {reportDetail.pacingVariances && (
-                          <div className="p-2 bg-gray-50 rounded">
-                            <span className="text-gray-500">Pacing Metrics Changed</span>
+                          <div className="p-2 bg-pov-gray rounded">
+                            <span className="text-charcoal-500">Pacing Metrics Changed</span>
                             <span className="block font-medium">
                               {pacingMetricEntries.length + pacingChangeEntries.length}
                             </span>
@@ -1818,32 +1829,32 @@ export default function VarianceTrackingPage() {
 
                       {companyVariances.length > 0 && (
                         <div className="mt-4">
-                          <div className="text-sm font-medium text-gray-500 mb-2">
+                          <div className="text-sm font-medium text-charcoal-500 mb-2">
                             Company Variances
                           </div>
                           <div className="border rounded-lg overflow-x-auto">
                             <table className="w-full text-sm">
                               <thead>
-                                <tr className="bg-gray-50 border-b">
-                                  <th className="text-left p-2 font-medium text-gray-600">
+                                <tr className="bg-pov-gray border-b">
+                                  <th className="text-left p-2 font-medium text-charcoal-600">
                                     Company
                                   </th>
-                                  <th className="text-left p-2 font-medium text-gray-600">
+                                  <th className="text-left p-2 font-medium text-charcoal-600">
                                     Change
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Baseline
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Current
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Invested
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Delta
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Delta %
                                   </th>
                                 </tr>
@@ -1854,10 +1865,10 @@ export default function VarianceTrackingPage() {
                                     key={`${company.companyId}-${company.changeType ?? 'matched'}`}
                                   >
                                     <td className="p-2 align-top">
-                                      <div className="font-medium text-gray-900">
+                                      <div className="font-medium text-pov-charcoal">
                                         {company.companyName}
                                       </div>
-                                      <div className="text-xs text-gray-500">
+                                      <div className="text-xs text-charcoal-500">
                                         {[company.sector, company.stage]
                                           .filter(Boolean)
                                           .join(' • ') || 'Unclassified'}
@@ -1870,12 +1881,12 @@ export default function VarianceTrackingPage() {
                                           className={cn(
                                             'w-fit',
                                             company.changeType === 'added' &&
-                                              'border-emerald-200 bg-emerald-50 text-emerald-700',
+                                              'border-success/50 bg-success/10 text-success-dark',
                                             company.changeType === 'removed' &&
-                                              'border-rose-200 bg-rose-50 text-rose-700',
+                                              'border-error/50 bg-error/10 text-error-dark',
                                             (!company.changeType ||
                                               company.changeType === 'matched') &&
-                                              'border-slate-200 bg-slate-50 text-slate-700'
+                                              'border-beige-200 bg-pov-gray text-charcoal-700'
                                           )}
                                         >
                                           {company.changeType ?? 'matched'}
@@ -1885,35 +1896,35 @@ export default function VarianceTrackingPage() {
                                           className={cn(
                                             'w-fit',
                                             company.riskLevel === 'critical' &&
-                                              'border-red-200 bg-red-50 text-red-700',
+                                              'border-error/50 bg-error/10 text-error-dark',
                                             company.riskLevel === 'high' &&
-                                              'border-orange-200 bg-orange-50 text-orange-700',
+                                              'border-warning/50 bg-warning/10 text-warning-dark',
                                             company.riskLevel === 'medium' &&
-                                              'border-yellow-200 bg-yellow-50 text-yellow-700',
+                                              'border-warning/50 bg-warning/10 text-warning-dark',
                                             company.riskLevel === 'low' &&
-                                              'border-emerald-200 bg-emerald-50 text-emerald-700'
+                                              'border-success/50 bg-success/10 text-success-dark'
                                           )}
                                         >
                                           {company.riskLevel}
                                         </Badge>
                                       </div>
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatCurrency(company.baselineValuation)}
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatCurrency(company.currentValuation)}
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       <div>{formatCurrency(company.currentInvestedCapital)}</div>
-                                      <div className="text-xs text-gray-500">
+                                      <div className="text-xs text-charcoal-500">
                                         base {formatCurrency(company.baselineInvestedCapital)}
                                       </div>
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatCurrency(company.valuationVariance)}
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatSignedPercent(company.valuationVariancePct)}
                                     </td>
                                   </tr>
@@ -1926,29 +1937,29 @@ export default function VarianceTrackingPage() {
 
                       {sectorVarianceEntries.length > 0 && (
                         <div className="mt-4">
-                          <div className="text-sm font-medium text-gray-500 mb-2">
+                          <div className="text-sm font-medium text-charcoal-500 mb-2">
                             Sector Distribution
                           </div>
                           <div className="border rounded-lg overflow-x-auto">
                             <table className="w-full text-sm">
                               <thead>
-                                <tr className="bg-gray-50 border-b">
-                                  <th className="text-left p-2 font-medium text-gray-600">
+                                <tr className="bg-pov-gray border-b">
+                                  <th className="text-left p-2 font-medium text-charcoal-600">
                                     Sector
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Current
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Baseline
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Count Delta
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Share Delta
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Share Delta %
                                   </th>
                                 </tr>
@@ -1956,16 +1967,20 @@ export default function VarianceTrackingPage() {
                               <tbody className="divide-y">
                                 {sectorVarianceEntries.map(([sector, row]) => (
                                   <tr key={sector}>
-                                    <td className="p-2 text-gray-900">{sector}</td>
-                                    <td className="p-2 text-right text-gray-700">{row.current}</td>
-                                    <td className="p-2 text-right text-gray-700">{row.baseline}</td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-pov-charcoal">{sector}</td>
+                                    <td className="p-2 text-right text-charcoal-700">
+                                      {row.current}
+                                    </td>
+                                    <td className="p-2 text-right text-charcoal-700">
+                                      {row.baseline}
+                                    </td>
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatSignedNumber(row.delta)}
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatSignedPercent(row.countShareDelta)}
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatSignedPercent(row.countShareDeltaPct)}
                                     </td>
                                   </tr>
@@ -1978,27 +1993,29 @@ export default function VarianceTrackingPage() {
 
                       {stageVarianceEntries.length > 0 && (
                         <div className="mt-4">
-                          <div className="text-sm font-medium text-gray-500 mb-2">
+                          <div className="text-sm font-medium text-charcoal-500 mb-2">
                             Stage Distribution
                           </div>
                           <div className="border rounded-lg overflow-x-auto">
                             <table className="w-full text-sm">
                               <thead>
-                                <tr className="bg-gray-50 border-b">
-                                  <th className="text-left p-2 font-medium text-gray-600">Stage</th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                <tr className="bg-pov-gray border-b">
+                                  <th className="text-left p-2 font-medium text-charcoal-600">
+                                    Stage
+                                  </th>
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Current
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Baseline
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Count Delta
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Share Delta
                                   </th>
-                                  <th className="text-right p-2 font-medium text-gray-600">
+                                  <th className="text-right p-2 font-medium text-charcoal-600">
                                     Share Delta %
                                   </th>
                                 </tr>
@@ -2006,16 +2023,20 @@ export default function VarianceTrackingPage() {
                               <tbody className="divide-y">
                                 {stageVarianceEntries.map(([stage, row]) => (
                                   <tr key={stage}>
-                                    <td className="p-2 text-gray-900">{stage}</td>
-                                    <td className="p-2 text-right text-gray-700">{row.current}</td>
-                                    <td className="p-2 text-right text-gray-700">{row.baseline}</td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-pov-charcoal">{stage}</td>
+                                    <td className="p-2 text-right text-charcoal-700">
+                                      {row.current}
+                                    </td>
+                                    <td className="p-2 text-right text-charcoal-700">
+                                      {row.baseline}
+                                    </td>
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatSignedNumber(row.delta)}
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatSignedPercent(row.countShareDelta)}
                                     </td>
-                                    <td className="p-2 text-right text-gray-700">
+                                    <td className="p-2 text-right text-charcoal-700">
                                       {formatSignedPercent(row.countShareDeltaPct)}
                                     </td>
                                   </tr>
@@ -2030,21 +2051,21 @@ export default function VarianceTrackingPage() {
                         <div className="mt-4 grid gap-4 md:grid-cols-2">
                           {reportDetail.reserveVariances && (
                             <div>
-                              <div className="text-sm font-medium text-gray-500 mb-2">
+                              <div className="text-sm font-medium text-charcoal-500 mb-2">
                                 Reserve Variances
                               </div>
                               <div className="space-y-2">
                                 {reserveMetricEntries.map(([metric, delta]) => (
                                   <div
                                     key={metric}
-                                    className="rounded-lg border bg-gray-50 p-3 text-sm"
+                                    className="rounded-lg border bg-pov-gray p-3 text-sm"
                                   >
-                                    <div className="font-medium text-gray-900">{metric}</div>
-                                    <div className="mt-1 text-gray-600">
+                                    <div className="font-medium text-pov-charcoal">{metric}</div>
+                                    <div className="mt-1 text-charcoal-600">
                                       {renderChangeValue(delta.baseline)} to{' '}
                                       {renderChangeValue(delta.current)}
                                     </div>
-                                    <div className="text-gray-700">
+                                    <div className="text-charcoal-700">
                                       delta {formatSignedNumber(delta.delta, 2)} | pct{' '}
                                       {formatSignedPercent(delta.deltaPct)}
                                     </div>
@@ -2052,8 +2073,8 @@ export default function VarianceTrackingPage() {
                                 ))}
                                 {reserveChangeEntries.map(([metric, change]) => (
                                   <div key={metric} className="rounded-lg border p-3 text-sm">
-                                    <div className="font-medium text-gray-900">{metric}</div>
-                                    <div className="text-gray-600">
+                                    <div className="font-medium text-pov-charcoal">{metric}</div>
+                                    <div className="text-charcoal-600">
                                       {renderChangeValue(change.baseline)} to{' '}
                                       {renderChangeValue(change.current)}
                                     </div>
@@ -2065,21 +2086,21 @@ export default function VarianceTrackingPage() {
 
                           {reportDetail.pacingVariances && (
                             <div>
-                              <div className="text-sm font-medium text-gray-500 mb-2">
+                              <div className="text-sm font-medium text-charcoal-500 mb-2">
                                 Pacing Variances
                               </div>
                               <div className="space-y-2">
                                 {pacingMetricEntries.map(([metric, delta]) => (
                                   <div
                                     key={metric}
-                                    className="rounded-lg border bg-gray-50 p-3 text-sm"
+                                    className="rounded-lg border bg-pov-gray p-3 text-sm"
                                   >
-                                    <div className="font-medium text-gray-900">{metric}</div>
-                                    <div className="mt-1 text-gray-600">
+                                    <div className="font-medium text-pov-charcoal">{metric}</div>
+                                    <div className="mt-1 text-charcoal-600">
                                       {renderChangeValue(delta.baseline)} to{' '}
                                       {renderChangeValue(delta.current)}
                                     </div>
-                                    <div className="text-gray-700">
+                                    <div className="text-charcoal-700">
                                       delta {formatSignedNumber(delta.delta, 2)} | pct{' '}
                                       {formatSignedPercent(delta.deltaPct)}
                                     </div>
@@ -2087,8 +2108,8 @@ export default function VarianceTrackingPage() {
                                 ))}
                                 {pacingChangeEntries.map(([metric, change]) => (
                                   <div key={metric} className="rounded-lg border p-3 text-sm">
-                                    <div className="font-medium text-gray-900">{metric}</div>
-                                    <div className="text-gray-600">
+                                    <div className="font-medium text-pov-charcoal">{metric}</div>
+                                    <div className="text-charcoal-600">
                                       {renderChangeValue(change.baseline)} to{' '}
                                       {renderChangeValue(change.current)}
                                     </div>
@@ -2105,28 +2126,32 @@ export default function VarianceTrackingPage() {
                   {/* Variances table */}
                   {reportDetail.variances.length > 0 && (
                     <div>
-                      <div className="text-sm font-medium text-gray-500 mb-2">Variances</div>
+                      <div className="text-sm font-medium text-charcoal-500 mb-2">Variances</div>
                       <div className="border rounded-lg overflow-hidden">
                         <table className="w-full text-sm">
                           <thead>
-                            <tr className="bg-gray-50 border-b">
-                              <th className="text-left p-2 font-medium text-gray-600">Metric</th>
-                              <th className="text-right p-2 font-medium text-gray-600">Value</th>
-                              <th className="text-right p-2 font-medium text-gray-600">Pct</th>
+                            <tr className="bg-pov-gray border-b">
+                              <th className="text-left p-2 font-medium text-charcoal-600">
+                                Metric
+                              </th>
+                              <th className="text-right p-2 font-medium text-charcoal-600">
+                                Value
+                              </th>
+                              <th className="text-right p-2 font-medium text-charcoal-600">Pct</th>
                             </tr>
                           </thead>
                           <tbody className="divide-y">
                             {reportDetail.variances.map((v: unknown, idx: number) => {
                               const row = v as Record<string, unknown>;
                               return (
-                                <tr key={idx} className="hover:bg-gray-50">
-                                  <td className="p-2 text-gray-900">
+                                <tr key={idx} className="hover:bg-pov-gray">
+                                  <td className="p-2 text-pov-charcoal">
                                     {String(row['metric'] ?? row['metricName'] ?? '-')}
                                   </td>
-                                  <td className="p-2 text-right text-gray-700">
+                                  <td className="p-2 text-right text-charcoal-700">
                                     {String(row['value'] ?? row['variance'] ?? '-')}
                                   </td>
-                                  <td className="p-2 text-right text-gray-700">
+                                  <td className="p-2 text-right text-charcoal-700">
                                     {(() => {
                                       const raw = row['pct'] ?? row['percentChange'];
                                       if (raw == null) return '-';
@@ -2146,7 +2171,7 @@ export default function VarianceTrackingPage() {
                   )}
                 </div>
               ) : (
-                <div className="text-center py-12 text-gray-500">Report not found.</div>
+                <div className="text-center py-12 text-charcoal-500">Report not found.</div>
               )}
             </SheetContent>
           </Sheet>
@@ -2226,8 +2251,8 @@ export default function VarianceTrackingPage() {
 
         <TabsContent value="settings" className="space-y-6">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">Variance Settings</h2>
-            <p className="text-gray-600">Configure variance tracking preferences</p>
+            <h2 className="text-2xl font-bold text-pov-charcoal">Variance Settings</h2>
+            <p className="text-charcoal-600">Configure variance tracking preferences</p>
           </div>
 
           <Card>
@@ -2241,7 +2266,7 @@ export default function VarianceTrackingPage() {
                   <Label htmlFor="variance-email-notifications" className="text-base">
                     Email Notifications
                   </Label>
-                  <p className="text-sm text-gray-600">Receive alerts via email</p>
+                  <p className="text-sm text-charcoal-600">Receive alerts via email</p>
                 </div>
                 <Switch
                   id="variance-email-notifications"
@@ -2256,7 +2281,7 @@ export default function VarianceTrackingPage() {
                   <Label htmlFor="variance-realtime-alerts" className="text-base">
                     Real-time Alerts
                   </Label>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-charcoal-600">
                     Immediate notifications for critical alerts
                   </p>
                 </div>
@@ -2271,7 +2296,7 @@ export default function VarianceTrackingPage() {
                   <Label htmlFor="variance-daily-digest" className="text-base">
                     Daily Digest
                   </Label>
-                  <p className="text-sm text-gray-600">Summary of variance activity</p>
+                  <p className="text-sm text-charcoal-600">Summary of variance activity</p>
                 </div>
                 <Switch
                   id="variance-daily-digest"
@@ -2299,7 +2324,7 @@ export default function VarianceTrackingPage() {
                   }
                   className="mt-1"
                 />
-                <p className="text-sm text-gray-600 mt-1">
+                <p className="text-sm text-charcoal-600 mt-1">
                   Default threshold for triggering variance alerts
                 </p>
               </div>
@@ -2326,7 +2351,7 @@ export default function VarianceTrackingPage() {
           </Card>
 
           <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-gray-600" aria-live="polite">
+            <p className="text-sm text-charcoal-600" aria-live="polite">
               {settingsSaveMessage ??
                 'Save settings after changing alert delivery or analysis cadence.'}
             </p>


### PR DESCRIPTION
## Milestone C — page long-tail token migration + dead-page audit

Migrates the **live** page long-tail to canonical Press On Ventures tokens, gated by a
**dead-page audit** so we don't waste effort migrating unrouted code. Independent of
#772 (disjoint files: this touches `client/src/pages/`, #772 touched `components/`).

### Dead-page audit (the gate)
Classified all ~80 page surfaces against the route registry (`app-routes.tsx` +
`app-router.tsx`) and importer graph. **17 pages are unrouted/dead** and were
**EXCLUDED** from migration:
`analytics`, `moic-analysis`, `investments-table`, `investments`, `planning`,
`kpi-submission`, `kpi-manager/*`, `notion-integration`, `secondary-market`,
`partial-sales`, `return-the-fund`, `CustomFields`, `time-travel`, `admin/telemetry`,
`CompanyDetail`, `InvestmentRoundsStep` (V1), and the `portfolio-constructor` page
(type-only consumer).

They are **not deleted** — git history shows a deliberate "quarantine dormant" pattern
(e.g. "quarantine dormant investments detail paths", "Align dormant time-travel truth").
Notably, **#771 had already token-migrated 4 of these dead pages** (analytics,
moic-analysis, CompanyDetail, InvestmentRoundsStep) — wasted effort this audit prevents
repeating. (~256 raw-color occurrences correctly skipped.)

### Migrated — 16 routed/live pages (~741 occurrences)
- **`variance-tracking` (219 classes)** — alert severities mapped by intent
  (critical/urgent → `error`, warning → `warning`, info → `presson-info`, default →
  neutral); charcoal CTAs/tabs.
- **Core nav:** `allocation-manager`, `pipeline`, `shared-dashboard`, `reserves-demo`,
  `lp-reporting/metrics` — pure Tailwind class migration.
- **LP portal:** `lp/{performance,fund-detail,dashboard,settings,capital-account,reports}`
  — arbitrary-value brand hex (`text-[#292929]`, `border-[#E0D8D1]`) tokenized (pixels
  unchanged); `lp/performance` Recharts series routed through `getChartColor` /
  `presson.color.*` (TVPI/DPI stay distinct).
- **Live wizard steps:** `Distributions / Cashflow / CapitalStructure / InvestmentStrategy`
  (the steps #771's partition missed).

### Verification
- `npm run check`: **0 new TypeScript errors** (committed state)
- **230/230** client render tests pass (`tests/unit/pages` + layout + reports)
- Live eyeball: `variance-tracking` + `allocation-manager` on-doctrine (charcoal-dominant,
  correct status/financial colors, no purple/off-doctrine blue)
- Residual off-token sweep clean across all 16 files; shadcn semantic tokens preserved;
  no shadcn over-reach, no `ring-offset-background` deletions

### Notes
- LP portal pages were mostly *already* brand-correct (hardcoded `#292929`/`#E0D8D1`); this
  is token-consistency cleanup, not a visual change.
- Diff size reflects the repo's pre-commit prettier/eslint reformat of touched files.
