### PR TITLE
design(rollout): milestone B + D-carryovers token migration

### DIFF
--- a/client/src/components/cap-table/cap-table-calculator.tsx
+++ b/client/src/components/cap-table/cap-table-calculator.tsx
@@ -211,19 +211,19 @@ export default function CapTableCalculator() {
   const getShareholderTypeColor = (type: string) => {
     switch (type) {
       case 'founder':
-        return 'bg-blue-100 text-blue-800';
+        return 'bg-[#cfe7df] text-[#145c43]';
       case 'employee':
-        return 'bg-green-100 text-green-800';
+        return 'bg-[#ddd6f5] text-[#4f4381]';
       case 'investor':
-        return 'bg-purple-100 text-purple-800';
+        return 'bg-[#f2d7dc] text-[#8d1f2f]';
       case 'safe':
-        return 'bg-orange-100 text-orange-800';
+        return 'bg-[#efd9bd] text-[#7a4a00]';
       case 'note':
-        return 'bg-red-100 text-red-800';
+        return 'bg-pov-gray text-charcoal-700';
       case 'option-pool':
-        return 'bg-gray-100 text-gray-800';
+        return 'bg-pov-gray text-charcoal-700';
       default:
-        return 'bg-gray-100 text-gray-800';
+        return 'bg-pov-gray text-charcoal-700';
     }
   };
 
@@ -233,7 +233,7 @@ export default function CapTableCalculator() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Cap Table Calculator</h1>
-          <p className="text-gray-600">Model SAFE/Note conversions and next round dilution</p>
+          <p className="text-charcoal-600">Model SAFE/Note conversions and next round dilution</p>
         </div>
         <div className="flex items-center space-x-2">
           <Button variant="outline">
@@ -252,9 +252,9 @@ export default function CapTableCalculator() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Users className="h-5 w-5 text-blue-600" />
+              <Users className="h-5 w-5 text-charcoal-600" />
               <div>
-                <p className="text-sm text-gray-600">Fully Diluted Shares</p>
+                <p className="text-sm text-charcoal-600">Fully Diluted Shares</p>
                 <p className="text-lg font-bold">{formatShares(metrics.fullyDilutedShares)}</p>
               </div>
             </div>
@@ -264,9 +264,9 @@ export default function CapTableCalculator() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <DollarSign className="h-5 w-5 text-green-600" />
+              <DollarSign className="h-5 w-5 text-charcoal-600" />
               <div>
-                <p className="text-sm text-gray-600">Price per Share</p>
+                <p className="text-sm text-charcoal-600">Price per Share</p>
                 <p className="text-lg font-bold">{formatCurrency(metrics.pricePerShare)}</p>
               </div>
             </div>
@@ -276,9 +276,9 @@ export default function CapTableCalculator() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <TrendingUp className="h-5 w-5 text-purple-600" />
+              <TrendingUp className="h-5 w-5 text-charcoal-600" />
               <div>
-                <p className="text-sm text-gray-600">Post-Money Valuation</p>
+                <p className="text-sm text-charcoal-600">Post-Money Valuation</p>
                 <p className="text-lg font-bold">{formatCurrency(metrics.postMoneyValuation)}</p>
               </div>
             </div>
@@ -288,9 +288,9 @@ export default function CapTableCalculator() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <Percent className="h-5 w-5 text-orange-600" />
+              <Percent className="h-5 w-5 text-charcoal-600" />
               <div>
-                <p className="text-sm text-gray-600">SAFEs/Notes Total</p>
+                <p className="text-sm text-charcoal-600">SAFEs/Notes Total</p>
                 <p className="text-lg font-bold">{formatCurrency(totalSAFEsNotes)}</p>
               </div>
             </div>
@@ -315,7 +315,7 @@ export default function CapTableCalculator() {
                 type="number"
                 value={preMoneyValuation}
                 onChange={(e) => setPreMoneyValuation(Number(e.target.value))}
-                className="border-yellow-300 bg-yellow-50"
+                className="border-beige-300 bg-beige-100"
               />
             </div>
 
@@ -326,7 +326,7 @@ export default function CapTableCalculator() {
                 type="number"
                 value={roundSize}
                 onChange={(e) => setRoundSize(Number(e.target.value))}
-                className="border-yellow-300 bg-yellow-50"
+                className="border-beige-300 bg-beige-100"
               />
             </div>
 
@@ -337,7 +337,7 @@ export default function CapTableCalculator() {
                 type="number"
                 value={optionPoolIncrease}
                 onChange={(e) => setOptionPoolIncrease(Number(e.target.value))}
-                className="border-yellow-300 bg-yellow-50"
+                className="border-beige-300 bg-beige-100"
               />
             </div>
 
@@ -345,15 +345,15 @@ export default function CapTableCalculator() {
 
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <span className="text-gray-600">New Investor Shares:</span>
+                <span className="text-charcoal-600">New Investor Shares:</span>
                 <span className="font-medium">{formatShares(metrics.newInvestorShares)}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-600">Price per Share:</span>
+                <span className="text-charcoal-600">Price per Share:</span>
                 <span className="font-medium">{formatCurrency(metrics.pricePerShare)}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-600">Post-Money:</span>
+                <span className="text-charcoal-600">Post-Money:</span>
                 <span className="font-medium">{formatCurrency(metrics.postMoneyValuation)}</span>
               </div>
             </div>
@@ -427,7 +427,9 @@ export default function CapTableCalculator() {
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle>Pro Forma Cap Table</CardTitle>
-                  <p className="text-sm text-gray-600">Pro Forma Cap Table after conversions.</p>
+                  <p className="text-sm text-charcoal-600">
+                    Pro Forma Cap Table after conversions.
+                  </p>
                 </div>
                 <div className="flex items-center space-x-2">
                   <Button variant="outline" size="sm" onClick={() => setConsolidate(!consolidate)}>
@@ -469,7 +471,7 @@ export default function CapTableCalculator() {
                   ))}
 
                   {/* Summary Rows */}
-                  <TableRow className="border-t-2 border-gray-300">
+                  <TableRow className="border-t-2 border-beige-200">
                     <TableCell className="font-bold">Total Shares Excluding Options</TableCell>
                     <TableCell className="text-right font-bold">
                       {formatShares(
@@ -503,7 +505,7 @@ export default function CapTableCalculator() {
                     <TableCell></TableCell>
                   </TableRow>
 
-                  <TableRow className="border-t border-gray-300">
+                  <TableRow className="border-t border-beige-200">
                     <TableCell className="font-bold">Total</TableCell>
                     <TableCell className="text-right font-bold">
                       {formatShares(proFormaCapTable.reduce((sum, sh) => sum + sh.shares, 0))}

--- a/client/src/components/cap-table/safe-note-editor.tsx
+++ b/client/src/components/cap-table/safe-note-editor.tsx
@@ -5,12 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Plus, Edit, Trash2, Calculator } from 'lucide-react';
 
 interface SAFENote {
@@ -35,7 +30,11 @@ interface SAFENoteEditorProps {
   pricePerShare?: number;
 }
 
-export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePerShare }: SAFENoteEditorProps) {
+export default function SAFENoteEditor({
+  safesNotes,
+  onSafesNotesChange,
+  pricePerShare,
+}: SAFENoteEditorProps) {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [editingInstrument, setEditingInstrument] = useState<SAFENote | null>(null);
   const defaultDate = new Date().toISOString().split('T')[0];
@@ -43,7 +42,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
     type: 'safe',
     principal: 0,
     valuationCap: 0,
-    discount: 0.20,
+    discount: 0.2,
     holderName: '',
     ...(defaultDate && { investmentDate: defaultDate }),
     mostFavoredNation: true,
@@ -63,7 +62,9 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
       ...(formData.discount !== undefined ? { discount: formData.discount } : {}),
       ...(formData.interestRate !== undefined ? { interestRate: formData.interestRate } : {}),
       ...(formData.maturityDate !== undefined ? { maturityDate: formData.maturityDate } : {}),
-      ...(formData.mostFavoredNation !== undefined ? { mostFavoredNation: formData.mostFavoredNation } : {}),
+      ...(formData.mostFavoredNation !== undefined
+        ? { mostFavoredNation: formData.mostFavoredNation }
+        : {}),
       ...(formData.proRataRights !== undefined ? { proRataRights: formData.proRataRights } : {}),
     };
 
@@ -74,7 +75,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
       type: 'safe',
       principal: 0,
       valuationCap: 0,
-      discount: 0.20,
+      discount: 0.2,
       holderName: '',
       ...(resetDate && { investmentDate: resetDate }),
       mostFavoredNation: true,
@@ -91,10 +92,8 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
   const handleUpdate = () => {
     if (!editingInstrument || !formData.principal || !formData.holderName) return;
 
-    const updatedInstruments = safesNotes.map(inst => 
-      inst.id === editingInstrument.id 
-        ? { ...inst, ...formData } as SAFENote
-        : inst
+    const updatedInstruments = safesNotes.map((inst) =>
+      inst.id === editingInstrument.id ? ({ ...inst, ...formData } as SAFENote) : inst
     );
 
     onSafesNotesChange(updatedInstruments);
@@ -105,7 +104,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
       type: 'safe',
       principal: 0,
       valuationCap: 0,
-      discount: 0.20,
+      discount: 0.2,
       holderName: '',
       ...(resetDate && { investmentDate: resetDate }),
       mostFavoredNation: true,
@@ -114,17 +113,17 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
   };
 
   const handleDelete = (id: string) => {
-    onSafesNotesChange(safesNotes.filter(inst => inst.id !== id));
+    onSafesNotesChange(safesNotes.filter((inst) => inst.id !== id));
   };
 
   const calculateConversion = (instrument: SAFENote, pricePerShare: number) => {
     // Calculate cap-based price
-    const capBasedPrice = instrument.valuationCap ? 
-      instrument.valuationCap / 10000000 : Infinity; // Assuming 10M fully diluted shares
+    const capBasedPrice = instrument.valuationCap ? instrument.valuationCap / 10000000 : Infinity; // Assuming 10M fully diluted shares
 
-    // Calculate discount-based price  
-    const discountBasedPrice = instrument.discount ? 
-      pricePerShare * (1 - instrument.discount) : Infinity;
+    // Calculate discount-based price
+    const discountBasedPrice = instrument.discount
+      ? pricePerShare * (1 - instrument.discount)
+      : Infinity;
 
     // Take the lower of the two (better for investor)
     const conversionPrice = Math.min(capBasedPrice, discountBasedPrice);
@@ -134,7 +133,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
       conversionPrice,
       shares,
       usedCap: conversionPrice === capBasedPrice,
-      usedDiscount: conversionPrice === discountBasedPrice
+      usedDiscount: conversionPrice === discountBasedPrice,
     };
   };
 
@@ -156,7 +155,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
       <div className="flex items-center justify-between">
         <div>
           <h3 className="text-lg font-semibold">SAFEs & Convertible Notes</h3>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-charcoal-600">
             Manage securities that will convert in the next funding round
           </p>
         </div>
@@ -169,13 +168,19 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {safesNotes.map((instrument) => {
           const conversion = pricePerShare ? calculateConversion(instrument, pricePerShare) : null;
-          
+
           return (
             <Card key={instrument.id} className="relative">
               <CardHeader className="pb-3">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-2">
-                    <Badge className={instrument.type === 'safe' ? 'bg-orange-100 text-orange-800' : 'bg-red-100 text-red-800'}>
+                    <Badge
+                      className={
+                        instrument.type === 'safe'
+                          ? 'bg-[#efd9bd] text-[#7a4a00]'
+                          : 'bg-pov-gray text-charcoal-700'
+                      }
+                    >
                       {instrument.type.toUpperCase()}
                     </Badge>
                     <span className="font-medium">{instrument.holderName}</span>
@@ -190,28 +195,34 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                   </div>
                 </div>
               </CardHeader>
-              
+
               <CardContent className="space-y-3">
                 <div className="grid grid-cols-2 gap-3 text-sm">
                   <div>
-                    <span className="text-gray-500">Principal:</span>
+                    <span className="text-charcoal-500">Principal:</span>
                     <div className="font-medium">{formatCurrency(instrument.principal)}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Investment Date:</span>
-                    <div className="font-medium">{new Date(instrument.investmentDate).toLocaleDateString()}</div>
+                    <span className="text-charcoal-500">Investment Date:</span>
+                    <div className="font-medium">
+                      {new Date(instrument.investmentDate).toLocaleDateString()}
+                    </div>
                   </div>
                 </div>
 
                 {instrument.valuationCap && (
                   <div className="grid grid-cols-2 gap-3 text-sm">
                     <div>
-                      <span className="text-gray-500">Valuation Cap:</span>
+                      <span className="text-charcoal-500">Valuation Cap:</span>
                       <div className="font-medium">{formatCurrency(instrument.valuationCap)}</div>
                     </div>
                     <div>
-                      <span className="text-gray-500">Discount:</span>
-                      <div className="font-medium">{instrument.discount ? `${(instrument.discount * 100).toFixed(0)}%` : 'None'}</div>
+                      <span className="text-charcoal-500">Discount:</span>
+                      <div className="font-medium">
+                        {instrument.discount
+                          ? `${(instrument.discount * 100).toFixed(0)}%`
+                          : 'None'}
+                      </div>
                     </div>
                   </div>
                 )}
@@ -219,13 +230,17 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                 {instrument.interestRate && (
                   <div className="grid grid-cols-2 gap-3 text-sm">
                     <div>
-                      <span className="text-gray-500">Interest Rate:</span>
-                      <div className="font-medium">{(instrument.interestRate * 100).toFixed(1)}%</div>
+                      <span className="text-charcoal-500">Interest Rate:</span>
+                      <div className="font-medium">
+                        {(instrument.interestRate * 100).toFixed(1)}%
+                      </div>
                     </div>
                     {instrument.maturityDate && (
                       <div>
-                        <span className="text-gray-500">Maturity:</span>
-                        <div className="font-medium">{new Date(instrument.maturityDate).toLocaleDateString()}</div>
+                        <span className="text-charcoal-500">Maturity:</span>
+                        <div className="font-medium">
+                          {new Date(instrument.maturityDate).toLocaleDateString()}
+                        </div>
                       </div>
                     )}
                   </div>
@@ -234,29 +249,33 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                 {conversion && (
                   <div className="border-t pt-3 space-y-2">
                     <div className="flex items-center space-x-2">
-                      <Calculator className="h-4 w-4 text-blue-600" />
-                      <span className="text-sm font-medium text-blue-600">Conversion Preview</span>
+                      <Calculator className="h-4 w-4 text-charcoal-600" />
+                      <span className="text-sm font-medium text-charcoal-600">
+                        Conversion Preview
+                      </span>
                     </div>
-                    
+
                     <div className="grid grid-cols-2 gap-3 text-sm">
                       <div>
-                        <span className="text-gray-500">Conversion Price:</span>
-                        <div className="font-medium">{formatCurrency(conversion.conversionPrice)}</div>
+                        <span className="text-charcoal-500">Conversion Price:</span>
+                        <div className="font-medium">
+                          {formatCurrency(conversion.conversionPrice)}
+                        </div>
                       </div>
                       <div>
-                        <span className="text-gray-500">Shares:</span>
+                        <span className="text-charcoal-500">Shares:</span>
                         <div className="font-medium">{formatShares(conversion.shares)}</div>
                       </div>
                     </div>
 
                     <div className="flex items-center space-x-2 text-xs">
                       {conversion.usedCap && (
-                        <Badge variant="outline" className="text-green-700 border-green-300">
+                        <Badge variant="outline" className="text-charcoal-700 border-beige-300">
                           Uses Cap
                         </Badge>
                       )}
                       {conversion.usedDiscount && (
-                        <Badge variant="outline" className="text-blue-700 border-blue-300">
+                        <Badge variant="outline" className="text-charcoal-700 border-beige-300">
                           Uses Discount
                         </Badge>
                       )}
@@ -264,7 +283,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                   </div>
                 )}
 
-                <div className="flex items-center space-x-2 text-xs text-gray-500">
+                <div className="flex items-center space-x-2 text-xs text-charcoal-500">
                   {instrument.mostFavoredNation && <span>MFN</span>}
                   {instrument.proRataRights && <span>Pro Rata</span>}
                 </div>
@@ -282,14 +301,19 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
               {editingInstrument ? 'Edit' : 'Add'} {formData.type?.toUpperCase()}
             </DialogTitle>
           </DialogHeader>
-          
+
           <div className="space-y-6">
-            <Tabs value={formData.type ?? 'safe'} onValueChange={(value) => setFormData({ ...formData, type: value as 'safe' | 'note' })}>
+            <Tabs
+              value={formData.type ?? 'safe'}
+              onValueChange={(value) =>
+                setFormData({ ...formData, type: value as 'safe' | 'note' })
+              }
+            >
               <TabsList className="grid w-full grid-cols-2">
                 <TabsTrigger value="safe">SAFE</TabsTrigger>
                 <TabsTrigger value="note">Convertible Note</TabsTrigger>
               </TabsList>
-              
+
               <TabsContent value="safe" className="mt-4 space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
@@ -299,7 +323,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       value={formData.holderName}
                       onChange={(e) => setFormData({ ...formData, holderName: e.target.value })}
                       placeholder="Angel Investor"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                   <div>
@@ -308,9 +332,11 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       id="principal"
                       type="number"
                       value={formData.principal}
-                      onChange={(e) => setFormData({ ...formData, principal: Number(e.target.value) })}
+                      onChange={(e) =>
+                        setFormData({ ...formData, principal: Number(e.target.value) })
+                      }
                       placeholder="500000"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                 </div>
@@ -322,9 +348,11 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       id="valuation-cap"
                       type="number"
                       value={formData.valuationCap}
-                      onChange={(e) => setFormData({ ...formData, valuationCap: Number(e.target.value) })}
+                      onChange={(e) =>
+                        setFormData({ ...formData, valuationCap: Number(e.target.value) })
+                      }
                       placeholder="8000000"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                   <div>
@@ -335,14 +363,16 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       step="0.01"
                       max="1"
                       value={formData.discount ? formData.discount * 100 : ''}
-                      onChange={(e) => setFormData({ ...formData, discount: Number(e.target.value) / 100 })}
+                      onChange={(e) =>
+                        setFormData({ ...formData, discount: Number(e.target.value) / 100 })
+                      }
                       placeholder="20"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                 </div>
               </TabsContent>
-              
+
               <TabsContent value="note" className="mt-4 space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
@@ -352,7 +382,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       value={formData.holderName}
                       onChange={(e) => setFormData({ ...formData, holderName: e.target.value })}
                       placeholder="Note Holder"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                   <div>
@@ -361,9 +391,11 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       id="note-principal"
                       type="number"
                       value={formData.principal}
-                      onChange={(e) => setFormData({ ...formData, principal: Number(e.target.value) })}
+                      onChange={(e) =>
+                        setFormData({ ...formData, principal: Number(e.target.value) })
+                      }
                       placeholder="750000"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                 </div>
@@ -376,9 +408,11 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       type="number"
                       step="0.01"
                       value={formData.interestRate ? formData.interestRate * 100 : ''}
-                      onChange={(e) => setFormData({ ...formData, interestRate: Number(e.target.value) / 100 })}
+                      onChange={(e) =>
+                        setFormData({ ...formData, interestRate: Number(e.target.value) / 100 })
+                      }
                       placeholder="8"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                   <div>
@@ -388,9 +422,11 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       type="number"
                       step="0.01"
                       value={formData.discount ? formData.discount * 100 : ''}
-                      onChange={(e) => setFormData({ ...formData, discount: Number(e.target.value) / 100 })}
+                      onChange={(e) =>
+                        setFormData({ ...formData, discount: Number(e.target.value) / 100 })
+                      }
                       placeholder="25"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                   <div>
@@ -400,7 +436,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       type="date"
                       value={formData.maturityDate}
                       onChange={(e) => setFormData({ ...formData, maturityDate: e.target.value })}
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                 </div>
@@ -412,9 +448,11 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       id="note-cap"
                       type="number"
                       value={formData.valuationCap}
-                      onChange={(e) => setFormData({ ...formData, valuationCap: Number(e.target.value) })}
+                      onChange={(e) =>
+                        setFormData({ ...formData, valuationCap: Number(e.target.value) })
+                      }
                       placeholder="12000000"
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                   <div>
@@ -424,7 +462,7 @@ export default function SAFENoteEditor({ safesNotes, onSafesNotesChange, pricePe
                       type="date"
                       value={formData.investmentDate}
                       onChange={(e) => setFormData({ ...formData, investmentDate: e.target.value })}
-                      className="border-yellow-300 bg-yellow-50"
+                      className="border-beige-300 bg-beige-100"
                     />
                   </div>
                 </div>

--- a/client/src/components/sensitivity/StressPanel.tsx
+++ b/client/src/components/sensitivity/StressPanel.tsx
@@ -30,6 +30,7 @@ import {
 import { cn } from '@/lib/utils';
 import { useStressRun, useSensitivityHistory } from '@/hooks/useSensitivityRuns';
 import type { SensitivityHookError } from '@/hooks/useSensitivityRuns';
+import { presson } from '@/theme/presson.tokens';
 import {
   SUPPORTED_STRESS_SCENARIOS,
   SUPPORTED_METRICS,
@@ -57,9 +58,9 @@ interface DeltaBarStyle {
 
 function deltaBarStyle(delta: number, maxAbsDelta: number): DeltaBarStyle {
   const widthPct = maxAbsDelta === 0 ? 0 : (Math.abs(delta) / maxAbsDelta) * 100;
-  // Red for negative (downside), emerald for positive (upside).
+  // Loss (negative) vs gain (positive) via PoV financial tokens.
   // TODO(a11y): baseline delta bar needs a non-color direction cue.
-  const backgroundColor = delta < 0 ? 'rgb(239, 68, 68)' : 'rgb(16, 185, 129)';
+  const backgroundColor = delta < 0 ? presson.color.negative : presson.color.positive;
   return { width: `${widthPct}%`, backgroundColor };
 }
 

--- a/client/src/components/sensitivity/TwoWayPanel.tsx
+++ b/client/src/components/sensitivity/TwoWayPanel.tsx
@@ -48,10 +48,10 @@ import { SensitivityRunErrorCard } from './SensitivityRunErrorCard';
 // =====================
 
 function interpolateCellColor(value: number, min: number, max: number): string {
-  if (max === min) return 'rgb(148, 163, 184)'; // slate-400 midpoint
+  if (max === min) return 'rgb(160, 160, 160)'; // charcoal-400 midpoint
   const t = (value - min) / (max - min);
-  const lo = { r: 248, g: 250, b: 252 }; // slate-50
-  const hi = { r: 15, g: 23, b: 42 }; // slate-900
+  const lo = { r: 248, g: 248, b: 248 }; // charcoal-50
+  const hi = { r: 41, g: 41, b: 41 }; // charcoal-900 (#292929)
   const r = Math.round(lo.r + (hi.r - lo.r) * t);
   const g = Math.round(lo.g + (hi.g - lo.g) * t);
   const b = Math.round(lo.b + (hi.b - lo.b) * t);
@@ -59,9 +59,9 @@ function interpolateCellColor(value: number, min: number, max: number): string {
 }
 
 function cellTextColor(value: number, min: number, max: number): string {
-  if (max === min) return '#0f172a';
+  if (max === min) return '#292929'; // charcoal-900
   const t = (value - min) / (max - min);
-  return t > 0.5 ? '#f8fafc' : '#0f172a';
+  return t > 0.5 ? '#f8f8f8' : '#292929'; // charcoal-50 / charcoal-900
 }
 
 // =====================

--- a/tests/unit/components/sensitivity/StressPanel.test.tsx
+++ b/tests/unit/components/sensitivity/StressPanel.test.tsx
@@ -249,7 +249,7 @@ describe('StressPanel', () => {
     expect(within(results).getByText('Range')).toBeInTheDocument();
   });
 
-  it('applies a red delta bar background to negative-delta rows and emerald to positive', () => {
+  it('applies a loss-colored delta bar background to negative-delta rows and a gain-colored one to positive', () => {
     installMutationState({
       isSuccess: true,
       data: { result: makeFixtureResult() },
@@ -258,9 +258,9 @@ describe('StressPanel', () => {
 
     const negBar = screen.getByTestId('stress-delta-bar-mild_downside') as HTMLElement;
     const posBar = screen.getByTestId('stress-delta-bar-best_case') as HTMLElement;
-    // Red = rgb(239, 68, 68) for negative baselineDelta.
-    expect(negBar.style.backgroundColor).toBe('rgb(239, 68, 68)');
-    // Emerald = rgb(16, 185, 129) for positive baselineDelta.
-    expect(posBar.style.backgroundColor).toBe('rgb(16, 185, 129)');
+    // presson.color.negative (#B00020) for negative baselineDelta; DOM normalizes to rgb.
+    expect(negBar.style.backgroundColor).toBe('rgb(176, 0, 32)');
+    // presson.color.positive (#127E3D) for positive baselineDelta; DOM normalizes to rgb.
+    expect(posBar.style.backgroundColor).toBe('rgb(18, 126, 61)');
   });
 });


### PR DESCRIPTION
## Theme-2 token rollout — Milestone B (cap-table) + D-carryovers (sensitivity)

Final wave of the raw-color → Press On Ventures design-token migration. Branches off
`main`; disjoint from the in-flight #772 (shared layer) and #773 (page long-tail).

### Scope (4 files)
**Milestone B — cap-table (live via `/cap-tables`)**
- `cap-table-calculator.tsx` — neutral text/icons → charcoal; editable-input highlight
  yellow → warm beige; `getShareholderTypeColor` rainbow → sanctioned muted-tag palette.
- `safe-note-editor.tsx` — same neutral/icon/input rules; instrument badge → muted tag
  (safe = orange, note = neutral); "Uses Cap"/"Uses Discount" → neutral outline badges.

**D-carryovers — sensitivity (live via `/sensitivity-analysis`)**
- `TwoWayPanel.tsx` — heatmap cell ramp slate → charcoal (monochrome sequential).
- `StressPanel.tsx` — delta-bar red/emerald → `presson.color.negative/positive`
  (financial direction). Existing `// TODO(a11y)` non-color-cue note retained.

### Token decisions (reviewer-owned — gates only prove "compiles + no raw classes")
- Categorical shareholder/instrument badges → muted-tag palette (teal/lavender/pink/
  orange), matching the canonical live pattern in `AllocationsTable.tsx:127-130`. Chosen
  over flattening to preserve per-type distinction and stay cohesive with that surface
  (AC#5). `option-pool`/`note`/`default` stay neutral (`bg-pov-gray text-charcoal-700`);
  the type label disambiguates.
- Decorative metric icons (blue/green/purple/orange) → `text-charcoal-600`; purple killed.
- Yellow editable-input highlight → `border-beige-300 bg-beige-100` (warm-neutral; not a
  status hue).

### Deferred (explicit, not silent)
- **net-cash-flow bars → charcoal demote (AC#9):** lives in `CashflowDashboard.tsx`, which
  is owned by the open **#772** (components/dashboard). Deferred to that surface to avoid an
  overlapping edit / merge conflict.
- **a11y non-color cues:** separate pass; existing `// TODO(a11y)` lines left in place.

### Verification
- `npm run check` (baseline:check, client/server/shared compiled separately) — **0 new TS errors**.
- Targeted client vitest — **23/23 pass**: TwoWayPanel (9), StressPanel (10),
  sensitivity-analysis page (4). StressPanel's delta-bar test was reconciled to the new
  `presson.color.negative/positive` rgb values.
- Full diff reviewed line-by-line: scope = exactly 4 source files; no shadcn semantic-token
  over-reach; no residual raw numbered palette; remaining hex/rgb literals are only the
  sanctioned muted-tag palette + the intentional (commented) charcoal heatmap ramp.
- **Live eyeball done** (`ALLOW_MEMORY_STORAGE=1 REQUIRE_AUTH=false npm run dev`, branch off
  main so shadcn `--primary` is still blue — page-level color verified, not primitives):
  - `/cap-tables` → Cap Table Calculator: computed-color probe confirms SAFE badge
    `#efd9bd`/text `#7a4a00` (orange muted-tag), NOTE badge `#F2F2F2`/text `#404040` (neutral),
    highlight inputs bg `#f2f0ed` (beige-100) / border `#ddd6cb` (beige-300). No rainbow/purple
    remains; metric icons charcoal; the beige input highlight reads as visibly distinct from
    plain white fields (the "edit me" cue survives the yellow→beige swap).
  - `/sensitivity-analysis` → form chrome renders clean (charcoal CTAs). The TwoWayPanel heatmap
    ramp and StressPanel delta bars only display after a backend run; their exact token colors
    (charcoal ramp; `rgb(176,0,32)`/`rgb(18,126,61)`) are covered by the 19 passing unit tests
    that render those panels with fixture data.
