### PR TITLE
design(rollout): demote net-cash-flow bar to charcoal accent

### DIFF
--- a/client/src/components/dashboard/CashflowDashboard.tsx
+++ b/client/src/components/dashboard/CashflowDashboard.tsx
@@ -396,7 +396,8 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                         value !== undefined ? formatCurrencyShort(Number(value)) : ''
                       }
                     />
-                    <Bar dataKey="netFlow" fill={CASHFLOW_CHART_COLORS.info} />
+                    {/* charcoal accent per DESIGN.md (net-flow is non-semantic; no blue) */}
+                    <Bar dataKey="netFlow" fill={CASHFLOW_CHART_COLORS.text} />
                   </BarChart>
                 </ResponsiveContainer>
               </CardContent>


### PR DESCRIPTION
## Summary

Theme-2 rollout follow-up (AC#9). Demote the **Net Cash Flow** overview bar from
sanctioned info-blue (`presson.color.info`, `#2563EB`) to charcoal
(`presson.color.text`, `#292929`) per `DESIGN.md` doctrine: accent is charcoal,
never blue.

Net-flow magnitude is non-semantic (the value can be positive or negative), so
the blue carried no meaning — demoting loses zero information while aligning the
chart with the brand accent. This matches the existing `.text` chart-fill
precedent already in this file (the expense pie, `~line 500`).

## Scope

- One line changed: `CashflowDashboard.tsx` netFlow `<Bar>` `fill` → `.text`.
- The unrelated **Liquidity Forecast** "Available Cash" line keeps `.info` (a
  different chart on a different tab) — intentionally untouched.
- Bi-color-by-sign (green/red) was consciously set aside: it is a redesign plus a
  color-alone a11y concern, tracked separately under the a11y follow-up, not this
  doctrine demote.

## Verification

- `npm run check` — 0 new TypeScript errors.
- No test asserts the bar color (the only reference is a `vi.mock` stub of the
  component in `dashboard-modern.test.tsx`).
- Reachability confirmed live: routed `pages/dashboard` -> `dashboard-modern` ->
  `CashflowDashboard`, Net Cash Flow card is on the default `overview` tab.
- Taste call reviewed via the advisor before editing.
