### PR TITLE
design(rollout): wave 3 B2 - portfolio-construction token migration + sweep scope

### DIFF
--- a/client/src/components/allocation/allocation-ui.tsx
+++ b/client/src/components/allocation/allocation-ui.tsx
@@ -253,13 +253,16 @@ export default function AllocationUI() {
           <div className="flex items-center justify-between">
             <div>
               <CardTitle className="text-xl font-bold">{allocation.name}</CardTitle>
-              <div className="flex items-center gap-6 text-sm text-gray-600 mt-2">
+              <div className="flex items-center gap-6 text-sm text-charcoal-600 mt-2">
                 <span>Capital Allocated: {formatCurrency(summary.capitalAllocated)}</span>
                 <span>Expected MOIC: {summary.expectedMOIC.toFixed(2)}x</span>
                 <span>Reserve Ratio: {formatPercentage(summary.reserveRatio)}</span>
               </div>
             </div>
-            <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
+            <Badge
+              variant="outline"
+              className="bg-presson-info/10 text-presson-info border-presson-info/20"
+            >
               <Calculator className="w-3 h-3 mr-1" />
               Auto-Calculated
             </Badge>
@@ -281,14 +284,14 @@ export default function AllocationUI() {
                 id="allocationName"
                 value={allocation.name}
                 onChange={(e) => updateInitialParameters('name', e.target.value)}
-                className="bg-yellow-50 border-yellow-200"
+                className="bg-warning/10 border-warning/50"
               />
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="sectorProfile">
                 Linked Sector Profile
-                <Info className="w-4 h-4 inline ml-1 text-gray-400" />
+                <Info className="w-4 h-4 inline ml-1 text-charcoal-400" />
               </Label>
               <Select
                 value={allocation.linkedSectorProfile}
@@ -332,7 +335,7 @@ export default function AllocationUI() {
           <CardHeader>
             <CardTitle className="text-lg">
               Initial Check Size
-              <Info className="w-4 h-4 inline ml-1 text-gray-400" />
+              <Info className="w-4 h-4 inline ml-1 text-charcoal-400" />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -355,12 +358,12 @@ export default function AllocationUI() {
                   onChange={(e) =>
                     updateInitialParameters('initialCheckSize', parseFloat(e.target.value))
                   }
-                  className="bg-yellow-50 border-yellow-200"
+                  className="bg-warning/10 border-warning/50"
                 />
               </div>
             </div>
 
-            <div className="space-y-2 text-sm text-gray-600">
+            <div className="space-y-2 text-sm text-charcoal-600">
               <div className="flex justify-between">
                 <span>Implied Entry Ownership</span>
                 <span>{formatPercentage(allocation.impliedEntryOwnership)}</span>
@@ -381,17 +384,17 @@ export default function AllocationUI() {
         <Card>
           <CardHeader>
             <CardTitle className="text-lg flex items-center">
-              <Target className="w-5 h-5 mr-2 text-green-600" />
+              <Target className="w-5 h-5 mr-2 text-presson-positive" />
               Performance Target
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-center">
-              <div className="text-3xl font-bold text-green-600">
+              <div className="text-3xl font-bold text-presson-positive">
                 {summary.expectedMOIC.toFixed(2)}x
               </div>
-              <div className="text-sm text-gray-600 mt-1">Expected MOIC</div>
-              <div className="text-xs text-gray-500 mt-2">
+              <div className="text-sm text-charcoal-600 mt-1">Expected MOIC</div>
+              <div className="text-xs text-charcoal-500 mt-2">
                 Based on sector profile and graduation rates
               </div>
             </div>
@@ -404,7 +407,7 @@ export default function AllocationUI() {
         <CardHeader>
           <CardTitle className="text-lg">
             Follow-On Strategy
-            <Info className="w-4 h-4 inline ml-1 text-gray-400" />
+            <Info className="w-4 h-4 inline ml-1 text-charcoal-400" />
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -412,18 +415,18 @@ export default function AllocationUI() {
             <table className="w-full">
               <thead>
                 <tr className="border-b">
-                  <th className="text-left py-3 px-2 font-medium text-gray-600"></th>
-                  <th className="text-center py-3 px-2 font-medium text-gray-600">Pre-Seed</th>
-                  <th className="text-center py-3 px-2 font-medium text-gray-600">Seed</th>
-                  <th className="text-center py-3 px-2 font-medium text-gray-600">Series A</th>
-                  <th className="text-center py-3 px-2 font-medium text-gray-600">Series B</th>
+                  <th className="text-left py-3 px-2 font-medium text-charcoal-600"></th>
+                  <th className="text-center py-3 px-2 font-medium text-charcoal-600">Pre-Seed</th>
+                  <th className="text-center py-3 px-2 font-medium text-charcoal-600">Seed</th>
+                  <th className="text-center py-3 px-2 font-medium text-charcoal-600">Series A</th>
+                  <th className="text-center py-3 px-2 font-medium text-charcoal-600">Series B</th>
                 </tr>
               </thead>
               <tbody className="space-y-2">
-                <tr className="border-b border-gray-100">
+                <tr className="border-b border-charcoal/7">
                   <td className="py-3 px-2 font-medium">
                     Maintain Ownership (%) of
-                    <Info className="w-3 h-3 inline ml-1 text-gray-400" />
+                    <Info className="w-3 h-3 inline ml-1 text-charcoal-400" />
                   </td>
                   <td className="py-3 px-2 text-center">
                     <Input
@@ -452,7 +455,7 @@ export default function AllocationUI() {
                           parseFloat(e.target.value) || 0
                         )
                       }
-                      className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                      className="w-16 h-8 text-center bg-warning/10 border-warning/50"
                     />
                     <span className="text-xs ml-1">%</span>
                   </td>
@@ -467,7 +470,7 @@ export default function AllocationUI() {
                           parseFloat(e.target.value) || 0
                         )
                       }
-                      className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                      className="w-16 h-8 text-center bg-warning/10 border-warning/50"
                     />
                     <span className="text-xs ml-1">%</span>
                   </td>
@@ -489,10 +492,10 @@ export default function AllocationUI() {
                   </td>
                 </tr>
 
-                <tr className="border-b border-gray-100">
+                <tr className="border-b border-charcoal/7">
                   <td className="py-3 px-2 font-medium">
                     Follow-on Participation (%)
-                    <Info className="w-3 h-3 inline ml-1 text-gray-400" />
+                    <Info className="w-3 h-3 inline ml-1 text-charcoal-400" />
                   </td>
                   <td className="py-3 px-2 text-center">
                     <Input
@@ -514,7 +517,7 @@ export default function AllocationUI() {
                           parseFloat(e.target.value) || 0
                         )
                       }
-                      className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                      className="w-16 h-8 text-center bg-warning/10 border-warning/50"
                     />
                     <span className="text-xs ml-1">%</span>
                   </td>
@@ -529,7 +532,7 @@ export default function AllocationUI() {
                           parseFloat(e.target.value) || 0
                         )
                       }
-                      className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                      className="w-16 h-8 text-center bg-warning/10 border-warning/50"
                     />
                     <span className="text-xs ml-1">%</span>
                   </td>
@@ -547,82 +550,84 @@ export default function AllocationUI() {
                 <Separator />
 
                 {/* Read-only calculated fields */}
-                <tr className="bg-gray-50">
-                  <td className="py-3 px-2 font-medium text-gray-600">Implied Follow-On Check</td>
-                  <td className="py-3 px-2 text-center text-gray-600">-</td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                <tr className="bg-pov-gray">
+                  <td className="py-3 px-2 font-medium text-charcoal-600">
+                    Implied Follow-On Check
+                  </td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">-</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {formatCurrency(allocation.followOnStrategy.seed.impliedCheck)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {formatCurrency(allocation.followOnStrategy.seriesA.impliedCheck)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">-</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">-</td>
                 </tr>
 
-                <tr className="bg-gray-50">
-                  <td className="py-3 px-2 font-medium text-gray-600">Graduation Rate</td>
-                  <td className="py-3 px-2 text-center text-gray-600">-</td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                <tr className="bg-pov-gray">
+                  <td className="py-3 px-2 font-medium text-charcoal-600">Graduation Rate</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">-</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {formatPercentage(allocation.followOnStrategy.seed.graduationRate)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {formatPercentage(allocation.followOnStrategy.seriesA.graduationRate)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {formatPercentage(allocation.followOnStrategy.seriesB.graduationRate)}
                   </td>
                 </tr>
 
-                <tr className="bg-gray-50">
-                  <td className="py-3 px-2 font-medium text-gray-600">Number of Graduations</td>
-                  <td className="py-3 px-2 text-center text-gray-600">-</td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                <tr className="bg-pov-gray">
+                  <td className="py-3 px-2 font-medium text-charcoal-600">Number of Graduations</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">-</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {allocation.followOnStrategy.seed.graduations.toFixed(2)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {allocation.followOnStrategy.seriesA.graduations.toFixed(2)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {allocation.followOnStrategy.seriesB.graduations.toFixed(2)}
                   </td>
                 </tr>
 
-                <tr className="bg-gray-50">
-                  <td className="py-3 px-2 font-medium text-gray-600">Number of Follow-ons</td>
-                  <td className="py-3 px-2 text-center text-gray-600">-</td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                <tr className="bg-pov-gray">
+                  <td className="py-3 px-2 font-medium text-charcoal-600">Number of Follow-ons</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">-</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {allocation.followOnStrategy.seed.followOns.toFixed(2)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">
+                  <td className="py-3 px-2 text-center text-charcoal-600">
                     {allocation.followOnStrategy.seriesA.followOns.toFixed(2)}
                   </td>
-                  <td className="py-3 px-2 text-center text-gray-600">-</td>
+                  <td className="py-3 px-2 text-center text-charcoal-600">-</td>
                 </tr>
 
-                <tr className="bg-blue-50 border-2 border-blue-200">
-                  <td className="py-3 px-2 font-bold text-blue-800">Capital Allocated</td>
-                  <td className="py-3 px-2 text-center font-bold text-blue-800">-</td>
-                  <td className="py-3 px-2 text-center font-bold text-blue-800">
+                <tr className="bg-presson-info/10 border-2 border-presson-info/20">
+                  <td className="py-3 px-2 font-bold text-presson-info">Capital Allocated</td>
+                  <td className="py-3 px-2 text-center font-bold text-presson-info">-</td>
+                  <td className="py-3 px-2 text-center font-bold text-presson-info">
                     {formatCurrency(allocation.followOnStrategy.seed.capitalAllocated)}
                   </td>
-                  <td className="py-3 px-2 text-center font-bold text-blue-800">
+                  <td className="py-3 px-2 text-center font-bold text-presson-info">
                     {formatCurrency(allocation.followOnStrategy.seriesA.capitalAllocated)}
                   </td>
-                  <td className="py-3 px-2 text-center font-bold text-blue-800">-</td>
+                  <td className="py-3 px-2 text-center font-bold text-presson-info">-</td>
                 </tr>
               </tbody>
             </table>
           </div>
 
-          <div className="mt-6 p-4 bg-blue-50 rounded-lg border border-blue-200">
+          <div className="mt-6 p-4 bg-presson-info/10 rounded-lg border border-presson-info/20">
             <div className="flex items-center mb-2">
-              <Info className="w-4 h-4 text-blue-600 mr-2" />
-              <span className="font-medium text-blue-800">Capital Deployment Methodology</span>
+              <Info className="w-4 h-4 text-presson-info mr-2" />
+              <span className="font-medium text-presson-info">Capital Deployment Methodology</span>
             </div>
-            <p className="text-sm text-blue-700 mb-2">
+            <p className="text-sm text-presson-info mb-2">
               <strong>All available capital is deployed</strong> - no unused capital allowed:
             </p>
-            <ul className="text-sm text-blue-700 mt-2 ml-4 space-y-1">
+            <ul className="text-sm text-presson-info mt-2 ml-4 space-y-1">
               <li>• Precise number of deals calculated to deploy 100% of available capital</li>
               <li>• Reserves auto-calculated from graduation rates and follow-on strategy</li>
               <li>• Expected MOIC built up from market data, not fixed exit multiples</li>
@@ -632,14 +637,14 @@ export default function AllocationUI() {
             </ul>
             <div className="mt-3 grid grid-cols-2 gap-4 text-sm">
               <div>
-                <span className="text-blue-600">Reserve Ratio:</span>
-                <span className="font-medium text-blue-800 ml-1">
+                <span className="text-presson-info">Reserve Ratio:</span>
+                <span className="font-medium text-presson-info ml-1">
                   {formatPercentage(summary.reserveRatio)}
                 </span>
               </div>
               <div>
-                <span className="text-blue-600">Capital Utilization:</span>
-                <span className="font-medium text-green-800 ml-1">100.00%</span>
+                <span className="text-presson-info">Capital Utilization:</span>
+                <span className="font-medium text-presson-positive ml-1">100.00%</span>
               </div>
             </div>
           </div>
@@ -650,61 +655,65 @@ export default function AllocationUI() {
       <Card>
         <CardHeader>
           <CardTitle className="text-lg flex items-center">
-            <Calendar className="w-5 h-5 mr-2 text-blue-600" />
+            <Calendar className="w-5 h-5 mr-2 text-presson-info" />
             Initial Investment Horizon
-            <Info className="w-4 h-4 ml-2 text-gray-400" />
+            <Info className="w-4 h-4 ml-2 text-charcoal-400" />
           </CardTitle>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-charcoal-600">
             Control the pacing of capital deployment for this allocation
           </p>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-4">
-            <div className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg">
-              <span className="text-sm font-medium text-gray-700 min-w-0 flex-shrink-0">
+            <div className="flex items-center gap-4 p-4 bg-pov-gray rounded-lg">
+              <span className="text-sm font-medium text-charcoal-700 min-w-0 flex-shrink-0">
                 Fund will invest
               </span>
               <Input
                 type="number"
                 defaultValue={50.0}
-                className="w-20 h-8 text-center bg-yellow-50 border-yellow-200"
+                className="w-20 h-8 text-center bg-warning/10 border-warning/50"
               />
-              <span className="text-sm text-gray-600">%</span>
-              <span className="text-sm text-gray-600">of total allocated capital, from month</span>
+              <span className="text-sm text-charcoal-600">%</span>
+              <span className="text-sm text-charcoal-600">
+                of total allocated capital, from month
+              </span>
               <Input
                 type="number"
                 defaultValue={1}
-                className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                className="w-16 h-8 text-center bg-warning/10 border-warning/50"
               />
-              <span className="text-sm text-gray-600">to</span>
+              <span className="text-sm text-charcoal-600">to</span>
               <Input
                 type="number"
                 defaultValue={12}
-                className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                className="w-16 h-8 text-center bg-warning/10 border-warning/50"
               />
             </div>
 
-            <div className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg">
-              <span className="text-sm font-medium text-gray-700 min-w-0 flex-shrink-0">
+            <div className="flex items-center gap-4 p-4 bg-pov-gray rounded-lg">
+              <span className="text-sm font-medium text-charcoal-700 min-w-0 flex-shrink-0">
                 Fund will invest
               </span>
               <Input
                 type="number"
                 defaultValue={50.0}
-                className="w-20 h-8 text-center bg-yellow-50 border-yellow-200"
+                className="w-20 h-8 text-center bg-warning/10 border-warning/50"
               />
-              <span className="text-sm text-gray-600">%</span>
-              <span className="text-sm text-gray-600">of total allocated capital, from month</span>
+              <span className="text-sm text-charcoal-600">%</span>
+              <span className="text-sm text-charcoal-600">
+                of total allocated capital, from month
+              </span>
               <Input
                 type="number"
                 defaultValue={13}
-                className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                className="w-16 h-8 text-center bg-warning/10 border-warning/50"
               />
-              <span className="text-sm text-gray-600">to</span>
+              <span className="text-sm text-charcoal-600">to</span>
               <Input
                 type="number"
                 defaultValue={36}
-                className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                className="w-16 h-8 text-center bg-warning/10 border-warning/50"
               />
             </div>
           </div>

--- a/client/src/components/allocation/sector-profile-builder.tsx
+++ b/client/src/components/allocation/sector-profile-builder.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Info, TrendingUp } from "lucide-react";
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Info, TrendingUp } from 'lucide-react';
 
 interface RoundData {
   round: string;
@@ -24,96 +24,94 @@ interface SectorProfileData {
 
 export default function SectorProfileBuilder() {
   const [sectorProfile, setSectorProfile] = useState<SectorProfileData>({
-    name: "Default",
+    name: 'Default',
     rounds: [
       {
-        round: "Pre-Seed",
+        round: 'Pre-Seed',
         roundSize: 625000,
         valuation: 6750000,
-        esop: 10.00,
-        graduationRate: 70.00,
-        exitRate: 0.00,
-        failureRate: 30.00,
+        esop: 10.0,
+        graduationRate: 70.0,
+        exitRate: 0.0,
+        failureRate: 30.0,
         exitValuation: 15000000,
-        timeToGraduate: 18
+        timeToGraduate: 18,
       },
       {
-        round: "Seed",
+        round: 'Seed',
         roundSize: 3700000,
         valuation: 15000000,
-        esop: 10.00,
-        graduationRate: 50.00,
-        exitRate: 0.00,
-        failureRate: 50.00,
+        esop: 10.0,
+        graduationRate: 50.0,
+        exitRate: 0.0,
+        failureRate: 50.0,
         exitValuation: 48000000,
-        timeToGraduate: 24
+        timeToGraduate: 24,
       },
       {
-        round: "Series A",
+        round: 'Series A',
         roundSize: 10000000,
         valuation: 48000000,
-        esop: 7.50,
-        graduationRate: 50.00,
-        exitRate: 10.00,
-        failureRate: 40.00,
+        esop: 7.5,
+        graduationRate: 50.0,
+        exitRate: 10.0,
+        failureRate: 40.0,
         exitValuation: 125000000,
-        timeToGraduate: 30
+        timeToGraduate: 30,
       },
       {
-        round: "Series B",
+        round: 'Series B',
         roundSize: 22500000,
         valuation: 125000000,
-        esop: 6.50,
-        graduationRate: 65.00,
-        exitRate: 15.00,
-        failureRate: 20.00,
+        esop: 6.5,
+        graduationRate: 65.0,
+        exitRate: 15.0,
+        failureRate: 20.0,
         exitValuation: 277000000,
-        timeToGraduate: 36
+        timeToGraduate: 36,
       },
       {
-        round: "Series C",
+        round: 'Series C',
         roundSize: 35000000,
         valuation: 277000000,
-        esop: 5.40,
-        graduationRate: 70.00,
-        exitRate: 20.00,
-        failureRate: 10.00,
+        esop: 5.4,
+        graduationRate: 70.0,
+        exitRate: 20.0,
+        failureRate: 10.0,
         exitValuation: 474000000,
-        timeToGraduate: 42
+        timeToGraduate: 42,
       },
       {
-        round: "Series D",
+        round: 'Series D',
         roundSize: 57500000,
         valuation: 474000000,
-        esop: 4.80,
-        graduationRate: 75.00,
-        exitRate: 20.00,
-        failureRate: 5.00,
+        esop: 4.8,
+        graduationRate: 75.0,
+        exitRate: 20.0,
+        failureRate: 5.0,
         exitValuation: 1654000000,
-        timeToGraduate: 48
+        timeToGraduate: 48,
       },
       {
-        round: "Series E+",
+        round: 'Series E+',
         roundSize: 60000000,
         valuation: 1654000000,
-        esop: 2.50,
-        graduationRate: 0.00,
-        exitRate: 100.00,
-        failureRate: 0.00,
+        esop: 2.5,
+        graduationRate: 0.0,
+        exitRate: 100.0,
+        failureRate: 0.0,
         exitValuation: 2000000000,
-        timeToGraduate: 60
-      }
-    ]
+        timeToGraduate: 60,
+      },
+    ],
   });
 
   const updateRoundData = (roundIndex: number, field: keyof RoundData, value: number) => {
-    setSectorProfile(prev => ({
+    setSectorProfile((prev) => ({
       ...prev,
       rounds: prev.rounds.map((round, index) =>
-        index === roundIndex
-          ? { ...round, [field]: value }
-          : round
-      )
+        index === roundIndex ? { ...round, [field]: value } : round
+      ),
     }));
   };
 
@@ -123,15 +121,15 @@ export default function SectorProfileBuilder() {
 
   const getRoundColor = (round: string) => {
     const colors: Record<string, string> = {
-      "Pre-Seed": "bg-green-100 text-green-800",
-      "Seed": "bg-blue-100 text-blue-800",
-      "Series A": "bg-purple-100 text-purple-800",
-      "Series B": "bg-orange-100 text-orange-800",
-      "Series C": "bg-red-100 text-red-800",
-      "Series D": "bg-indigo-100 text-indigo-800",
-      "Series E+": "bg-gray-100 text-gray-800"
+      'Pre-Seed': 'bg-[#cfe7df] text-pov-charcoal border-[#cfe7df]',
+      Seed: 'bg-[#ddd6f5] text-pov-charcoal border-[#ddd6f5]',
+      'Series A': 'bg-[#efd9bd] text-pov-charcoal border-[#efd9bd]',
+      'Series B': 'bg-[#f2d7dc] text-pov-charcoal border-[#f2d7dc]',
+      'Series C': 'bg-[#cfe7df] text-pov-charcoal border-[#cfe7df]',
+      'Series D': 'bg-[#ddd6f5] text-pov-charcoal border-[#ddd6f5]',
+      'Series E+': 'bg-pov-gray text-charcoal-700 border-beige-200',
     };
-    return colors[round] || "bg-gray-100 text-gray-800";
+    return colors[round] || 'bg-pov-gray text-charcoal-700 border-beige-200';
   };
 
   return (
@@ -142,11 +140,15 @@ export default function SectorProfileBuilder() {
           <div className="flex items-center justify-between">
             <div>
               <CardTitle className="text-xl font-bold">Sector Profile Builder</CardTitle>
-              <p className="text-gray-600 mt-1">
-                Configure market-driven assumptions for valuations, graduation rates, and exit patterns
+              <p className="text-charcoal-600 mt-1">
+                Configure market-driven assumptions for valuations, graduation rates, and exit
+                patterns
               </p>
             </div>
-            <Badge variant="outline" className="bg-blue-50 text-blue-700">
+            <Badge
+              variant="outline"
+              className="bg-presson-info/10 text-presson-info border-presson-info/20"
+            >
               <TrendingUp className="w-3 h-3 mr-1" />
               Market Data Driven
             </Badge>
@@ -158,13 +160,14 @@ export default function SectorProfileBuilder() {
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start">
-            <Info className="w-5 h-5 text-blue-600 mt-0.5 mr-3 flex-shrink-0" />
+            <Info className="w-5 h-5 text-presson-info mt-0.5 mr-3 flex-shrink-0" />
             <div>
-              <h3 className="font-semibold text-gray-900 mb-2">Market-Driven Methodology</h3>
-              <p className="text-sm text-gray-600 mb-3">
-                Instead of setting fixed exit multiples, this approach builds up performance expectations from granular market assumptions:
+              <h3 className="font-semibold text-pov-charcoal mb-2">Market-Driven Methodology</h3>
+              <p className="text-sm text-charcoal-600 mb-3">
+                Instead of setting fixed exit multiples, this approach builds up performance
+                expectations from granular market assumptions:
               </p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-charcoal-600">
                 <div>
                   <strong>Market Dynamics:</strong>
                   <ul className="list-disc ml-6 mt-1 space-y-1">
@@ -191,46 +194,60 @@ export default function SectorProfileBuilder() {
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Valuations and Round Size Expectations</CardTitle>
-          <p className="text-sm text-gray-600">Configure market expectations for each funding round</p>
+          <p className="text-sm text-charcoal-600">
+            Configure market expectations for each funding round
+          </p>
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
-                <tr className="border-b bg-gray-50">
-                  <th className="text-left py-3 px-4 font-medium text-gray-600">Round</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">Round Size</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">Valuation</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">ESOP (%)</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">Graduation (%)</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">Exit (%)</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">Failure (%)</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">Exit Valuation</th>
-                  <th className="text-center py-3 px-4 font-medium text-gray-600">Time to Graduate (mo)</th>
+                <tr className="border-b bg-pov-gray">
+                  <th className="text-left py-3 px-4 font-medium text-charcoal-600">Round</th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">
+                    Round Size
+                  </th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">Valuation</th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">ESOP (%)</th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">
+                    Graduation (%)
+                  </th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">Exit (%)</th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">
+                    Failure (%)
+                  </th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">
+                    Exit Valuation
+                  </th>
+                  <th className="text-center py-3 px-4 font-medium text-charcoal-600">
+                    Time to Graduate (mo)
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {sectorProfile.rounds.map((round, index) => (
-                  <tr key={round.round} className="border-b hover:bg-gray-50">
+                  <tr key={round.round} className="border-b hover:bg-pov-gray">
                     <td className="py-3 px-4">
-                      <Badge className={getRoundColor(round.round)}>
-                        {round.round}
-                      </Badge>
+                      <Badge className={getRoundColor(round.round)}>{round.round}</Badge>
                     </td>
                     <td className="py-3 px-4 text-center">
                       <Input
                         type="number"
                         value={round.roundSize}
-                        onChange={(e) => updateRoundData(index, 'roundSize', parseFloat(e.target.value) || 0)}
-                        className="w-24 h-8 text-center bg-yellow-50 border-yellow-200"
+                        onChange={(e) =>
+                          updateRoundData(index, 'roundSize', parseFloat(e.target.value) || 0)
+                        }
+                        className="w-24 h-8 text-center bg-warning/10 border-warning/50"
                       />
                     </td>
                     <td className="py-3 px-4 text-center">
                       <Input
                         type="number"
                         value={round.valuation}
-                        onChange={(e) => updateRoundData(index, 'valuation', parseFloat(e.target.value) || 0)}
-                        className="w-32 h-8 text-center bg-yellow-50 border-yellow-200"
+                        onChange={(e) =>
+                          updateRoundData(index, 'valuation', parseFloat(e.target.value) || 0)
+                        }
+                        className="w-32 h-8 text-center bg-warning/10 border-warning/50"
                       />
                     </td>
                     <td className="py-3 px-4 text-center">
@@ -239,8 +256,10 @@ export default function SectorProfileBuilder() {
                           type="number"
                           step="0.1"
                           value={round.esop}
-                          onChange={(e) => updateRoundData(index, 'esop', parseFloat(e.target.value) || 0)}
-                          className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                          onChange={(e) =>
+                            updateRoundData(index, 'esop', parseFloat(e.target.value) || 0)
+                          }
+                          className="w-16 h-8 text-center bg-warning/10 border-warning/50"
                         />
                         <span className="text-xs ml-1">%</span>
                       </div>
@@ -251,8 +270,14 @@ export default function SectorProfileBuilder() {
                           type="number"
                           step="0.1"
                           value={round.graduationRate}
-                          onChange={(e) => updateRoundData(index, 'graduationRate', parseFloat(e.target.value) || 0)}
-                          className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                          onChange={(e) =>
+                            updateRoundData(
+                              index,
+                              'graduationRate',
+                              parseFloat(e.target.value) || 0
+                            )
+                          }
+                          className="w-16 h-8 text-center bg-warning/10 border-warning/50"
                         />
                         <span className="text-xs ml-1">%</span>
                       </div>
@@ -263,15 +288,17 @@ export default function SectorProfileBuilder() {
                           type="number"
                           step="0.1"
                           value={round.exitRate}
-                          onChange={(e) => updateRoundData(index, 'exitRate', parseFloat(e.target.value) || 0)}
-                          className="w-16 h-8 text-center bg-yellow-50 border-yellow-200"
+                          onChange={(e) =>
+                            updateRoundData(index, 'exitRate', parseFloat(e.target.value) || 0)
+                          }
+                          className="w-16 h-8 text-center bg-warning/10 border-warning/50"
                         />
                         <span className="text-xs ml-1">%</span>
                       </div>
                     </td>
                     <td className="py-3 px-4 text-center">
                       <div className="flex items-center justify-center">
-                        <span className="text-sm text-red-600 font-medium">
+                        <span className="text-sm text-error font-medium">
                           {formatPercentage(round.failureRate)}
                         </span>
                       </div>
@@ -280,16 +307,20 @@ export default function SectorProfileBuilder() {
                       <Input
                         type="number"
                         value={round.exitValuation}
-                        onChange={(e) => updateRoundData(index, 'exitValuation', parseFloat(e.target.value) || 0)}
-                        className="w-32 h-8 text-center bg-yellow-50 border-yellow-200"
+                        onChange={(e) =>
+                          updateRoundData(index, 'exitValuation', parseFloat(e.target.value) || 0)
+                        }
+                        className="w-32 h-8 text-center bg-warning/10 border-warning/50"
                       />
                     </td>
                     <td className="py-3 px-4 text-center">
                       <Input
                         type="number"
                         value={round.timeToGraduate}
-                        onChange={(e) => updateRoundData(index, 'timeToGraduate', parseFloat(e.target.value) || 0)}
-                        className="w-20 h-8 text-center bg-yellow-50 border-yellow-200"
+                        onChange={(e) =>
+                          updateRoundData(index, 'timeToGraduate', parseFloat(e.target.value) || 0)
+                        }
+                        className="w-20 h-8 text-center bg-warning/10 border-warning/50"
                       />
                     </td>
                   </tr>
@@ -304,32 +335,32 @@ export default function SectorProfileBuilder() {
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Performance Expectations</CardTitle>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-charcoal-600">
             Based on graduation rates, exit rates, and market valuations
           </p>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="text-center p-4 bg-green-50 rounded-lg">
-              <div className="text-2xl font-bold text-green-600">5.40x</div>
-              <div className="text-sm text-green-700 mt-1">Expected MOIC</div>
-              <div className="text-xs text-gray-600 mt-2">
+            <div className="text-center p-4 bg-presson-positive/10 rounded-lg">
+              <div className="text-2xl font-bold text-presson-positive">5.40x</div>
+              <div className="text-sm text-presson-positive mt-1">Expected MOIC</div>
+              <div className="text-xs text-charcoal-600 mt-2">
                 Probability-weighted across all exit scenarios
               </div>
             </div>
-            
-            <div className="text-center p-4 bg-blue-50 rounded-lg">
-              <div className="text-2xl font-bold text-blue-600">33.33%</div>
-              <div className="text-sm text-blue-700 mt-1">Reserve Ratio</div>
-              <div className="text-xs text-gray-600 mt-2">
+
+            <div className="text-center p-4 bg-presson-info/10 rounded-lg">
+              <div className="text-2xl font-bold text-presson-info">33.33%</div>
+              <div className="text-sm text-presson-info mt-1">Reserve Ratio</div>
+              <div className="text-xs text-charcoal-600 mt-2">
                 Auto-calculated from follow-on strategy
               </div>
             </div>
-            
-            <div className="text-center p-4 bg-purple-50 rounded-lg">
-              <div className="text-2xl font-bold text-purple-600">18.5%</div>
-              <div className="text-sm text-purple-700 mt-1">Overall Success Rate</div>
-              <div className="text-xs text-gray-600 mt-2">
+
+            <div className="text-center p-4 bg-presson-positive/10 rounded-lg">
+              <div className="text-2xl font-bold text-presson-positive">18.5%</div>
+              <div className="text-sm text-presson-positive mt-1">Overall Success Rate</div>
+              <div className="text-xs text-charcoal-600 mt-2">
                 Companies achieving meaningful exits
               </div>
             </div>
@@ -339,16 +370,10 @@ export default function SectorProfileBuilder() {
 
       {/* Action Buttons */}
       <div className="flex justify-between">
-        <Button variant="outline">
-          Import Market Data
-        </Button>
+        <Button variant="outline">Import Market Data</Button>
         <div className="space-x-2">
-          <Button variant="outline">
-            Save as Template
-          </Button>
-          <Button>
-            Apply to Allocations
-          </Button>
+          <Button variant="outline">Save as Template</Button>
+          <Button>Apply to Allocations</Button>
         </div>
       </div>
     </div>

--- a/client/src/components/backtesting/BacktestingWorkspace.tsx
+++ b/client/src/components/backtesting/BacktestingWorkspace.tsx
@@ -53,9 +53,9 @@ function useElapsedSeconds(isActive: boolean): number {
 }
 
 function getRunnerBorderColor(phase: string): string {
-  if (phase === 'failed') return 'border-red-200';
-  if (phase === 'queued' || phase === 'running') return 'border-blue-200';
-  return 'border-emerald-200';
+  if (phase === 'failed') return 'border-error/50';
+  if (phase === 'queued' || phase === 'running') return 'border-presson-info/30';
+  return 'border-success/50';
 }
 
 function getRunnerStatusText(phase: string, stage: string | null, message: string): string {
@@ -76,10 +76,10 @@ function RunnerHeader({
   return (
     <div className="mb-2 flex items-center justify-between">
       <div className="flex items-center gap-2">
-        {isActive && <div className="h-2 w-2 animate-pulse rounded-full bg-blue-500" />}
-        <span className="text-sm font-medium text-gray-700">{statusText}</span>
+        {isActive && <div className="h-2 w-2 animate-pulse rounded-full bg-presson-info" />}
+        <span className="text-sm font-medium text-charcoal-700">{statusText}</span>
       </div>
-      {isActive && <span className="tabular-nums text-xs text-gray-500">{elapsed}s</span>}
+      {isActive && <span className="tabular-nums text-xs text-charcoal-500">{elapsed}s</span>}
     </div>
   );
 }
@@ -93,9 +93,9 @@ function RunnerProgressBar({
 }) {
   if (!isActive) return null;
   return (
-    <div className="h-1.5 w-full rounded-full bg-gray-200">
+    <div className="h-1.5 w-full rounded-full bg-pov-gray">
       <div
-        className="h-1.5 rounded-full bg-blue-500 transition-all duration-500"
+        className="h-1.5 rounded-full bg-presson-info transition-all duration-500"
         style={{ width: `${Math.max(progressPercent, 2)}%` }}
       />
     </div>
@@ -113,9 +113,9 @@ function ErrorDisplay({
   const config = ERROR_TIER_MESSAGES[tier];
   return (
     <div className="text-sm">
-      <p className="font-medium text-red-700">{config.title}</p>
-      <p className="mt-0.5 text-xs text-gray-600">{errorMessage}</p>
-      <p className="mt-1 text-xs text-gray-500">{config.guidance}</p>
+      <p className="font-medium text-error-dark">{config.title}</p>
+      <p className="mt-0.5 text-xs text-charcoal-600">{errorMessage}</p>
+      <p className="mt-1 text-xs text-charcoal-500">{config.guidance}</p>
     </div>
   );
 }
@@ -182,7 +182,7 @@ function RunnerPanel(props: RunnerPanelProps) {
           {...(props.onRetry ? { onRetry: props.onRetry } : {})}
         />
         {correlationId && (
-          <p className="mt-1 font-mono text-[10px] text-gray-400">{correlationId}</p>
+          <p className="mt-1 font-mono text-[10px] text-charcoal-400">{correlationId}</p>
         )}
       </CardContent>
     </Card>
@@ -199,11 +199,11 @@ function SubmitErrorPanel({
   if (!error) return null;
 
   return (
-    <Card className="border-red-200">
+    <Card className="border-error/50">
       <CardContent className="px-4 py-3">
         <ErrorDisplay errorCode={error.errorCode} errorMessage={error.errorMessage} />
         {error.status && (
-          <p className="mt-1 font-mono text-[10px] text-gray-400">HTTP {error.status}</p>
+          <p className="mt-1 font-mono text-[10px] text-charcoal-400">HTTP {error.status}</p>
         )}
         {error.isRetryable && onRetry && (
           <Button variant="outline" size="sm" onClick={onRetry} className="mt-2">
@@ -225,9 +225,9 @@ function SummaryCard({
   highlight?: boolean;
 }) {
   return (
-    <div className="rounded-lg border border-gray-200 p-3">
-      <p className="text-xs text-gray-500">{label}</p>
-      <p className={cn('text-lg font-semibold text-gray-800', highlight && 'text-amber-600')}>
+    <div className="rounded-lg border border-beige-200 p-3">
+      <p className="text-xs text-charcoal-500">{label}</p>
+      <p className={cn('text-lg font-semibold text-pov-charcoal', highlight && 'text-warning')}>
         {value}
       </p>
     </div>
@@ -277,12 +277,12 @@ function ScenarioComparisonWarning({ result }: { result: BacktestResultViewModel
   }
 
   return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+    <div className="rounded-lg border border-warning/50 bg-warning/10 px-4 py-3 text-sm text-warning-dark">
       <p className="font-medium">
         Scenario comparison incomplete: {summary.scenariosCompared} of {summary.requestedScenarios}{' '}
         requested historical scenarios succeeded.
       </p>
-      <p className="mt-1 text-xs text-amber-800">
+      <p className="mt-1 text-xs text-warning">
         Failed scenarios: {summary.failedScenarios.map(formatScenarioLabel).join(', ')}
       </p>
     </div>
@@ -302,15 +302,15 @@ function ScenarioComparisons({
       <CardContent>
         <div className="space-y-3">
           {comparisons.map((comparison) => (
-            <div key={comparison.scenario} className="border-l-2 border-gray-300 pl-3">
-              <p className="text-sm font-medium text-gray-800">
+            <div key={comparison.scenario} className="border-l-2 border-charcoal-300 pl-3">
+              <p className="text-sm font-medium text-pov-charcoal">
                 {formatScenarioLabel(comparison.scenario)}
               </p>
-              <p className="text-xs text-gray-500">{comparison.description}</p>
+              <p className="text-xs text-charcoal-500">{comparison.description}</p>
               {comparison.keyInsights.length > 0 && (
                 <ul className="mt-1 space-y-0.5">
                   {comparison.keyInsights.map((insight, index) => (
-                    <li key={index} className="text-xs text-gray-600">
+                    <li key={index} className="text-xs text-charcoal-600">
                       - {insight}
                     </li>
                   ))}
@@ -360,24 +360,26 @@ function HistoryPanel({
   const { data, isLoading } = useBacktestHistory(fundId);
 
   if (isLoading) {
-    return <p className="text-xs text-gray-500">Loading history...</p>;
+    return <p className="text-xs text-charcoal-500">Loading history...</p>;
   }
 
   if (!data?.history?.length) {
-    return <p className="text-xs text-gray-500">No previous backtests</p>;
+    return <p className="text-xs text-charcoal-500">No previous backtests</p>;
   }
 
   return (
     <div className="space-y-1">
-      <h3 className="mb-2 text-xs font-medium text-gray-600">Recent Backtests</h3>
+      <h3 className="mb-2 text-xs font-medium text-charcoal-600">Recent Backtests</h3>
       {data.history.slice(0, 5).map((result) => (
         <button
           key={result.backtestId}
           onClick={() => onSelect(toResultViewModel(result))}
-          className="w-full rounded px-2 py-1.5 text-left text-xs transition-colors hover:bg-gray-100"
+          className="w-full rounded px-2 py-1.5 text-left text-xs transition-colors hover:bg-pov-gray"
         >
-          <span className="text-gray-800">{new Date(result.timestamp).toLocaleDateString()}</span>
-          <span className="ml-2 text-gray-500">
+          <span className="text-pov-charcoal">
+            {new Date(result.timestamp).toLocaleDateString()}
+          </span>
+          <span className="ml-2 text-charcoal-500">
             {result.simulationSummary.runs.toLocaleString()} runs
           </span>
         </button>
@@ -483,7 +485,7 @@ function BacktestingMainPanel({
   return (
     <div className="space-y-4 lg:col-span-2">
       {state.resumeMismatch && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+        <div className="rounded-lg border border-warning/50 bg-warning/10 px-4 py-3 text-sm text-warning-dark">
           Ignored resumed backtest job from fund {state.resumeMismatch.actualFundId} while viewing
           the currently selected fund.
         </div>
@@ -502,8 +504,8 @@ function BacktestingMainPanel({
       />
       {state.displayedResult && <ResultsSection result={state.displayedResult} />}
       {!state.displayedResult && !state.submitError && state.jobStatus.phase === 'idle' && (
-        <div className="flex h-48 items-center justify-center rounded-lg border border-dashed border-gray-300">
-          <p className="text-sm text-gray-400">Configure and run a backtest to see results</p>
+        <div className="flex h-48 items-center justify-center rounded-lg border border-dashed border-beige-200">
+          <p className="text-sm text-charcoal-400">Configure and run a backtest to see results</p>
         </div>
       )}
     </div>
@@ -532,11 +534,11 @@ export function BacktestingWorkspace({
       <div className={cn('max-w-6xl mx-auto p-6', containerClassName)}>
         {showHeader && (
           <>
-            <h1 className="mb-1 text-xl font-semibold text-gray-800">{title}</h1>
-            <p className="mb-6 text-sm text-gray-500">{description}</p>
+            <h1 className="mb-1 text-xl font-semibold text-pov-charcoal">{title}</h1>
+            <p className="mb-6 text-sm text-charcoal-500">{description}</p>
           </>
         )}
-        <p className="text-sm text-gray-500">Please select a fund to begin backtesting.</p>
+        <p className="text-sm text-charcoal-500">Please select a fund to begin backtesting.</p>
       </div>
     );
   }
@@ -545,8 +547,8 @@ export function BacktestingWorkspace({
     <div className={cn('max-w-6xl mx-auto p-6', containerClassName)}>
       {showHeader && (
         <>
-          <h1 className="mb-1 text-xl font-semibold text-gray-800">{title}</h1>
-          <p className="mb-6 text-sm text-gray-500">{description}</p>
+          <h1 className="mb-1 text-xl font-semibold text-pov-charcoal">{title}</h1>
+          <p className="mb-6 text-sm text-charcoal-500">{description}</p>
         </>
       )}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/client/src/components/cash-management/cash-management-dashboard.tsx
+++ b/client/src/components/cash-management/cash-management-dashboard.tsx
@@ -3,11 +3,28 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Calendar, Plus, Download, Filter, Search, Trash2, Edit3, DollarSign, TrendingUp, TrendingDown } from 'lucide-react';
+import {
+  Calendar,
+  Plus,
+  Download,
+  Filter,
+  Search,
+  Trash2,
+  Edit3,
+  DollarSign,
+  TrendingUp,
+  TrendingDown,
+} from 'lucide-react';
 
 interface CashCategory {
   category: string;
@@ -31,32 +48,32 @@ const CASH_CATEGORIES: CashCategory[] = [
     category: 'Fund Capital Reserves',
     previousBalance: 37795000,
     weightedRequirements: 42450000,
-    currentBalance: 45710000
+    currentBalance: 45710000,
   },
   {
     category: 'Management Fees',
     previousBalance: 2450000,
     weightedRequirements: 2680000,
-    currentBalance: 2890000
+    currentBalance: 2890000,
   },
   {
     category: 'Follow-On Commitments',
     previousBalance: 15840000,
     weightedRequirements: 18200000,
-    currentBalance: 19560000
+    currentBalance: 19560000,
   },
   {
     category: 'Operating Expenses',
     previousBalance: 1250000,
     weightedRequirements: 1350000,
-    currentBalance: 1180000
+    currentBalance: 1180000,
   },
   {
     category: 'Distributions',
     previousBalance: 850000,
     weightedRequirements: 920000,
-    currentBalance: 1250000
-  }
+    currentBalance: 1250000,
+  },
 ];
 
 const SAMPLE_TRANSACTIONS: CashTransaction[] = [
@@ -67,7 +84,7 @@ const SAMPLE_TRANSACTIONS: CashTransaction[] = [
     description: 'LP Capital Call - Q1 2024',
     amount: 5000000,
     type: 'inflow',
-    status: 'completed'
+    status: 'completed',
   },
   {
     id: '2',
@@ -76,7 +93,7 @@ const SAMPLE_TRANSACTIONS: CashTransaction[] = [
     description: 'TechCorp Series B Follow-On',
     amount: 2500000,
     type: 'outflow',
-    status: 'completed'
+    status: 'completed',
   },
   {
     id: '3',
@@ -85,7 +102,7 @@ const SAMPLE_TRANSACTIONS: CashTransaction[] = [
     description: 'Q1 Management Fee Payment',
     amount: 450000,
     type: 'outflow',
-    status: 'completed'
+    status: 'completed',
   },
   {
     id: '4',
@@ -94,7 +111,7 @@ const SAMPLE_TRANSACTIONS: CashTransaction[] = [
     description: 'Legal and Administrative Costs',
     amount: 75000,
     type: 'outflow',
-    status: 'pending'
+    status: 'pending',
   },
   {
     id: '5',
@@ -103,8 +120,8 @@ const SAMPLE_TRANSACTIONS: CashTransaction[] = [
     description: 'LP Distribution - DataFlow Exit',
     amount: 1200000,
     type: 'outflow',
-    status: 'scheduled'
-  }
+    status: 'scheduled',
+  },
 ];
 
 const formatCurrency = (amount: number) => {
@@ -131,16 +148,20 @@ export default function CashManagementDashboard() {
   const [showAddTransaction, setShowAddTransaction] = useState(false);
 
   const totalCurrentBalance = CASH_CATEGORIES.reduce((sum, cat) => sum + cat.currentBalance, 0);
-  const totalWeightedRequirements = CASH_CATEGORIES.reduce((sum, cat) => sum + cat.weightedRequirements, 0);
+  const totalWeightedRequirements = CASH_CATEGORIES.reduce(
+    (sum, cat) => sum + cat.weightedRequirements,
+    0
+  );
   const totalPreviousBalance = CASH_CATEGORIES.reduce((sum, cat) => sum + cat.previousBalance, 0);
-  
-  const balanceChange = totalCurrentBalance - totalPreviousBalance;
-  const balanceChangePercent = ((balanceChange / totalPreviousBalance) * 100);
 
-  const filteredTransactions = transactions.filter(transaction => {
+  const balanceChange = totalCurrentBalance - totalPreviousBalance;
+  const balanceChangePercent = (balanceChange / totalPreviousBalance) * 100;
+
+  const filteredTransactions = transactions.filter((transaction) => {
     const matchesCategory = filterCategory === 'all' || transaction.category === filterCategory;
-    const matchesSearch = transaction.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         transaction.category.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesSearch =
+      transaction.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      transaction.category.toLowerCase().includes(searchTerm.toLowerCase());
     return matchesCategory && matchesSearch;
   });
 
@@ -150,7 +171,7 @@ export default function CashManagementDashboard() {
       description: '',
       amount: '',
       type: 'outflow' as 'inflow' | 'outflow',
-      date: new Date().toISOString().split('T')[0]
+      date: new Date().toISOString().split('T')[0],
     });
 
     const handleSubmit = () => {
@@ -159,7 +180,7 @@ export default function CashManagementDashboard() {
         ...newTransaction,
         amount: parseFloat(newTransaction.amount),
         status: 'pending',
-        date: newTransaction.date || new Date().toISOString().split('T')[0] || ''
+        date: newTransaction.date || new Date().toISOString().split('T')[0] || '',
       };
       setTransactions([transaction, ...transactions]);
       setShowAddTransaction(false);
@@ -168,7 +189,7 @@ export default function CashManagementDashboard() {
         description: '',
         amount: '',
         type: 'outflow',
-        date: new Date().toISOString().split('T')[0]
+        date: new Date().toISOString().split('T')[0],
       });
     };
 
@@ -182,8 +203,12 @@ export default function CashManagementDashboard() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="type">Transaction Type</Label>
-                <Select value={newTransaction.type} onValueChange={(value: 'inflow' | 'outflow') => 
-                  setNewTransaction({...newTransaction, type: value})}>
+                <Select
+                  value={newTransaction.type}
+                  onValueChange={(value: 'inflow' | 'outflow') =>
+                    setNewTransaction({ ...newTransaction, type: value })
+                  }
+                >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
@@ -198,14 +223,16 @@ export default function CashManagementDashboard() {
                 <Input
                   type="date"
                   value={newTransaction.date}
-                  onChange={(e) => setNewTransaction({...newTransaction, date: e.target.value})}
+                  onChange={(e) => setNewTransaction({ ...newTransaction, date: e.target.value })}
                 />
               </div>
             </div>
             <div>
               <Label htmlFor="category">Category</Label>
-              <Select value={newTransaction.category} onValueChange={(value) => 
-                setNewTransaction({...newTransaction, category: value})}>
+              <Select
+                value={newTransaction.category}
+                onValueChange={(value) => setNewTransaction({ ...newTransaction, category: value })}
+              >
                 <SelectTrigger>
                   <SelectValue placeholder="Select category" />
                 </SelectTrigger>
@@ -223,7 +250,9 @@ export default function CashManagementDashboard() {
               <Input
                 placeholder="Transaction description"
                 value={newTransaction.description}
-                onChange={(e) => setNewTransaction({...newTransaction, description: e.target.value})}
+                onChange={(e) =>
+                  setNewTransaction({ ...newTransaction, description: e.target.value })
+                }
               />
             </div>
             <div>
@@ -232,14 +261,19 @@ export default function CashManagementDashboard() {
                 type="number"
                 placeholder="0.00"
                 value={newTransaction.amount}
-                onChange={(e) => setNewTransaction({...newTransaction, amount: e.target.value})}
+                onChange={(e) => setNewTransaction({ ...newTransaction, amount: e.target.value })}
               />
             </div>
             <div className="flex justify-end space-x-2">
               <Button variant="outline" onClick={() => setShowAddTransaction(false)}>
                 Cancel
               </Button>
-              <Button onClick={handleSubmit} disabled={!newTransaction.category || !newTransaction.description || !newTransaction.amount}>
+              <Button
+                onClick={handleSubmit}
+                disabled={
+                  !newTransaction.category || !newTransaction.description || !newTransaction.amount
+                }
+              >
                 Add Transaction
               </Button>
             </div>
@@ -254,8 +288,10 @@ export default function CashManagementDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Cash Management</h1>
-          <p className="text-gray-600 mt-1">Monitor fund cash flows, track balances, and manage liquidity requirements</p>
+          <h1 className="text-3xl font-bold text-pov-charcoal">Cash Management</h1>
+          <p className="text-charcoal-600 mt-1">
+            Monitor fund cash flows, track balances, and manage liquidity requirements
+          </p>
         </div>
         <div className="flex items-center space-x-3">
           <Select value={selectedPeriod} onValueChange={setSelectedPeriod}>
@@ -286,21 +322,26 @@ export default function CashManagementDashboard() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Total Cash Balance</p>
-                <p className="text-2xl font-bold text-gray-900">{formatCurrencyShort(totalCurrentBalance)}</p>
+                <p className="text-sm font-medium text-charcoal-600">Total Cash Balance</p>
+                <p className="text-2xl font-bold text-pov-charcoal">
+                  {formatCurrencyShort(totalCurrentBalance)}
+                </p>
                 <div className="flex items-center mt-1">
                   {balanceChange >= 0 ? (
-                    <TrendingUp className="h-4 w-4 text-green-500 mr-1" />
+                    <TrendingUp className="h-4 w-4 text-presson-positive mr-1" />
                   ) : (
-                    <TrendingDown className="h-4 w-4 text-red-500 mr-1" />
+                    <TrendingDown className="h-4 w-4 text-presson-negative mr-1" />
                   )}
-                  <span className={`text-sm ${balanceChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                    {balanceChangePercent >= 0 ? '+' : ''}{balanceChangePercent.toFixed(1)}% from last period
+                  <span
+                    className={`text-sm ${balanceChange >= 0 ? 'text-presson-positive' : 'text-presson-negative'}`}
+                  >
+                    {balanceChangePercent >= 0 ? '+' : ''}
+                    {balanceChangePercent.toFixed(1)}% from last period
                   </span>
                 </div>
               </div>
-              <div className="w-12 h-12 bg-blue-50 rounded-lg flex items-center justify-center">
-                <DollarSign className="h-6 w-6 text-blue-500" />
+              <div className="w-12 h-12 bg-presson-info/10 rounded-lg flex items-center justify-center">
+                <DollarSign className="h-6 w-6 text-presson-info" />
               </div>
             </div>
           </CardContent>
@@ -310,12 +351,14 @@ export default function CashManagementDashboard() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Weighted Requirements</p>
-                <p className="text-2xl font-bold text-gray-900">{formatCurrencyShort(totalWeightedRequirements)}</p>
-                <p className="text-sm text-gray-500 mt-1">Target liquidity needs</p>
+                <p className="text-sm font-medium text-charcoal-600">Weighted Requirements</p>
+                <p className="text-2xl font-bold text-pov-charcoal">
+                  {formatCurrencyShort(totalWeightedRequirements)}
+                </p>
+                <p className="text-sm text-charcoal-500 mt-1">Target liquidity needs</p>
               </div>
-              <div className="w-12 h-12 bg-orange-50 rounded-lg flex items-center justify-center">
-                <TrendingUp className="h-6 w-6 text-orange-500" />
+              <div className="w-12 h-12 bg-presson-warning/10 rounded-lg flex items-center justify-center">
+                <TrendingUp className="h-6 w-6 text-presson-warning" />
               </div>
             </div>
           </CardContent>
@@ -325,14 +368,14 @@ export default function CashManagementDashboard() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Excess/(Deficit)</p>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-sm font-medium text-charcoal-600">Excess/(Deficit)</p>
+                <p className="text-2xl font-bold text-pov-charcoal">
                   {formatCurrencyShort(totalCurrentBalance - totalWeightedRequirements)}
                 </p>
-                <p className="text-sm text-gray-500 mt-1">vs. requirements</p>
+                <p className="text-sm text-charcoal-500 mt-1">vs. requirements</p>
               </div>
-              <div className="w-12 h-12 bg-green-50 rounded-lg flex items-center justify-center">
-                <TrendingUp className="h-6 w-6 text-green-500" />
+              <div className="w-12 h-12 bg-presson-positive/10 rounded-lg flex items-center justify-center">
+                <TrendingUp className="h-6 w-6 text-presson-positive" />
               </div>
             </div>
           </CardContent>
@@ -342,12 +385,12 @@ export default function CashManagementDashboard() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Active Categories</p>
-                <p className="text-2xl font-bold text-gray-900">{CASH_CATEGORIES.length}</p>
-                <p className="text-sm text-gray-500 mt-1">Cash categories</p>
+                <p className="text-sm font-medium text-charcoal-600">Active Categories</p>
+                <p className="text-2xl font-bold text-pov-charcoal">{CASH_CATEGORIES.length}</p>
+                <p className="text-sm text-charcoal-500 mt-1">Cash categories</p>
               </div>
-              <div className="w-12 h-12 bg-purple-50 rounded-lg flex items-center justify-center">
-                <Calendar className="h-6 w-6 text-purple-500" />
+              <div className="w-12 h-12 bg-pov-gray rounded-lg flex items-center justify-center">
+                <Calendar className="h-6 w-6 text-charcoal-600" />
               </div>
             </div>
           </CardContent>
@@ -373,31 +416,44 @@ export default function CashManagementDashboard() {
                 <table className="w-full">
                   <thead>
                     <tr className="border-b">
-                      <th className="text-left py-3 px-4 font-medium text-gray-600">Category</th>
-                      <th className="text-right py-3 px-4 font-medium text-gray-600">Previous Balance</th>
-                      <th className="text-right py-3 px-4 font-medium text-gray-600">Weighted Requirements</th>
-                      <th className="text-right py-3 px-4 font-medium text-gray-600">Current Balance</th>
-                      <th className="text-right py-3 px-4 font-medium text-gray-600">Variance</th>
+                      <th className="text-left py-3 px-4 font-medium text-charcoal-600">
+                        Category
+                      </th>
+                      <th className="text-right py-3 px-4 font-medium text-charcoal-600">
+                        Previous Balance
+                      </th>
+                      <th className="text-right py-3 px-4 font-medium text-charcoal-600">
+                        Weighted Requirements
+                      </th>
+                      <th className="text-right py-3 px-4 font-medium text-charcoal-600">
+                        Current Balance
+                      </th>
+                      <th className="text-right py-3 px-4 font-medium text-charcoal-600">
+                        Variance
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
                     {CASH_CATEGORIES.map((category, index) => {
                       const variance = category.currentBalance - category.weightedRequirements;
                       return (
-                        <tr key={index} className="border-b hover:bg-gray-50">
+                        <tr key={index} className="border-b hover:bg-pov-gray">
                           <td className="py-3 px-4 font-medium">{category.category}</td>
-                          <td className="py-3 px-4 text-right text-gray-600">
+                          <td className="py-3 px-4 text-right text-charcoal-600">
                             {formatCurrency(category.previousBalance)}
                           </td>
-                          <td className="py-3 px-4 text-right text-gray-600">
+                          <td className="py-3 px-4 text-right text-charcoal-600">
                             {formatCurrency(category.weightedRequirements)}
                           </td>
                           <td className="py-3 px-4 text-right font-medium">
                             {formatCurrency(category.currentBalance)}
                           </td>
                           <td className="py-3 px-4 text-right">
-                            <span className={`${variance >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                              {variance >= 0 ? '+' : ''}{formatCurrency(variance)}
+                            <span
+                              className={`${variance >= 0 ? 'text-presson-positive' : 'text-presson-negative'}`}
+                            >
+                              {variance >= 0 ? '+' : ''}
+                              {formatCurrency(variance)}
                             </span>
                           </td>
                         </tr>
@@ -407,12 +463,20 @@ export default function CashManagementDashboard() {
                   <tfoot>
                     <tr className="border-t-2 font-semibold">
                       <td className="py-3 px-4">Total</td>
-                      <td className="py-3 px-4 text-right">{formatCurrency(totalPreviousBalance)}</td>
-                      <td className="py-3 px-4 text-right">{formatCurrency(totalWeightedRequirements)}</td>
-                      <td className="py-3 px-4 text-right">{formatCurrency(totalCurrentBalance)}</td>
                       <td className="py-3 px-4 text-right">
-                        <span className={`${(totalCurrentBalance - totalWeightedRequirements) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                          {(totalCurrentBalance - totalWeightedRequirements) >= 0 ? '+' : ''}
+                        {formatCurrency(totalPreviousBalance)}
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        {formatCurrency(totalWeightedRequirements)}
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        {formatCurrency(totalCurrentBalance)}
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        <span
+                          className={`${totalCurrentBalance - totalWeightedRequirements >= 0 ? 'text-presson-positive' : 'text-presson-negative'}`}
+                        >
+                          {totalCurrentBalance - totalWeightedRequirements >= 0 ? '+' : ''}
                           {formatCurrency(totalCurrentBalance - totalWeightedRequirements)}
                         </span>
                       </td>
@@ -430,7 +494,7 @@ export default function CashManagementDashboard() {
             <CardContent className="pt-6">
               <div className="flex items-center space-x-4">
                 <div className="flex items-center space-x-2">
-                  <Search className="h-4 w-4 text-gray-400" />
+                  <Search className="h-4 w-4 text-charcoal-400" />
                   <Input
                     placeholder="Search transactions..."
                     value={searchTerm}
@@ -464,27 +528,46 @@ export default function CashManagementDashboard() {
             <CardContent>
               <div className="space-y-3">
                 {filteredTransactions.map((transaction) => (
-                  <div key={transaction.id} className="flex items-center justify-between p-3 border rounded-lg hover:bg-gray-50">
+                  <div
+                    key={transaction.id}
+                    className="flex items-center justify-between p-3 border rounded-lg hover:bg-pov-gray"
+                  >
                     <div className="flex items-center space-x-3">
-                      <div className={`w-3 h-3 rounded-full ${
-                        transaction.type === 'inflow' ? 'bg-green-500' : 'bg-red-500'
-                      }`}></div>
+                      <div
+                        className={`w-3 h-3 rounded-full ${
+                          transaction.type === 'inflow'
+                            ? 'bg-presson-positive'
+                            : 'bg-presson-negative'
+                        }`}
+                      ></div>
                       <div>
                         <p className="font-medium">{transaction.description}</p>
-                        <p className="text-sm text-gray-600">{transaction.category} • {transaction.date}</p>
+                        <p className="text-sm text-charcoal-600">
+                          {transaction.category} • {transaction.date}
+                        </p>
                       </div>
                     </div>
                     <div className="flex items-center space-x-3">
-                      <Badge 
-                        variant={transaction.status === 'completed' ? 'default' : 
-                                transaction.status === 'pending' ? 'secondary' : 'outline'}
+                      <Badge
+                        variant={
+                          transaction.status === 'completed'
+                            ? 'default'
+                            : transaction.status === 'pending'
+                              ? 'secondary'
+                              : 'outline'
+                        }
                       >
                         {transaction.status}
                       </Badge>
-                      <span className={`font-medium ${
-                        transaction.type === 'inflow' ? 'text-green-600' : 'text-red-600'
-                      }`}>
-                        {transaction.type === 'inflow' ? '+' : '-'}{formatCurrency(transaction.amount)}
+                      <span
+                        className={`font-medium ${
+                          transaction.type === 'inflow'
+                            ? 'text-presson-positive'
+                            : 'text-presson-negative'
+                        }`}
+                      >
+                        {transaction.type === 'inflow' ? '+' : '-'}
+                        {formatCurrency(transaction.amount)}
                       </span>
                       <div className="flex items-center space-x-1">
                         <Button variant="ghost" size="sm">
@@ -508,7 +591,9 @@ export default function CashManagementDashboard() {
               <CardTitle>Cash Flow Projections</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-500">Cash flow projection modeling and scenario analysis coming soon...</p>
+              <p className="text-charcoal-500">
+                Cash flow projection modeling and scenario analysis coming soon...
+              </p>
             </CardContent>
           </Card>
         </TabsContent>

--- a/client/src/components/pipeline/DealCard.tsx
+++ b/client/src/components/pipeline/DealCard.tsx
@@ -17,21 +17,21 @@ interface DealCardProps {
 
 // Status color mapping
 const statusColors: Record<string, string> = {
-  lead: 'bg-gray-100 text-gray-700 border-gray-200',
-  qualified: 'bg-blue-50 text-blue-700 border-blue-200',
-  pitch: 'bg-purple-50 text-purple-700 border-purple-200',
-  dd: 'bg-amber-50 text-amber-700 border-amber-200',
-  committee: 'bg-indigo-50 text-indigo-700 border-indigo-200',
-  term_sheet: 'bg-pink-50 text-pink-700 border-pink-200',
-  closed: 'bg-green-50 text-green-700 border-green-200',
-  passed: 'bg-red-50 text-red-700 border-red-200',
+  lead: 'bg-pov-gray text-charcoal-700 border-beige-200',
+  qualified: 'bg-[#cfe7df] text-pov-charcoal border-[#cfe7df]',
+  pitch: 'bg-[#ddd6f5] text-pov-charcoal border-[#ddd6f5]',
+  dd: 'bg-[#efd9bd] text-pov-charcoal border-[#efd9bd]',
+  committee: 'bg-[#f2d7dc] text-pov-charcoal border-[#f2d7dc]',
+  term_sheet: 'bg-[#ddd6f5] text-pov-charcoal border-[#ddd6f5]',
+  closed: 'bg-success/10 text-success-dark border-success/50',
+  passed: 'bg-error/10 text-error-dark border-error/50',
 };
 
 // Priority color mapping
 const priorityColors: Record<string, string> = {
-  high: 'bg-red-100 text-red-700',
-  medium: 'bg-yellow-100 text-yellow-700',
-  low: 'bg-green-100 text-green-700',
+  high: 'bg-error/10 text-error-dark border-error/50',
+  medium: 'bg-warning/10 text-warning-dark border-warning/50',
+  low: 'bg-success/10 text-success-dark border-success/50',
 };
 
 // Status display labels
@@ -75,7 +75,7 @@ export function DealCard({ deal, onClick }: DealCardProps) {
             <h4 className="font-inter font-semibold text-pov-charcoal truncate">
               {deal.companyName}
             </h4>
-            <p className="font-poppins text-xs text-gray-500 truncate">{deal.sector}</p>
+            <p className="font-poppins text-xs text-charcoal-500 truncate">{deal.sector}</p>
           </div>
           <Badge
             variant="outline"
@@ -91,45 +91,49 @@ export function DealCard({ deal, onClick }: DealCardProps) {
           <Badge variant="outline" className={statusColors[deal.status] || statusColors['lead']}>
             {statusLabels[deal.status] || deal.status}
           </Badge>
-          <span className="font-poppins text-xs text-gray-400">{deal.stage}</span>
+          <span className="font-poppins text-xs text-charcoal-400">{deal.stage}</span>
         </div>
 
         {/* Key Metrics */}
-        <div className="grid grid-cols-2 gap-2 pt-2 border-t border-gray-100">
+        <div className="grid grid-cols-2 gap-2 pt-2 border-t border-charcoal/7">
           {dealSize !== null && (
             <div className="flex items-center gap-1.5">
-              <DollarSign className="h-3.5 w-3.5 text-gray-400" />
-              <span className="font-poppins text-xs text-gray-600">
+              <DollarSign className="h-3.5 w-3.5 text-charcoal-400" />
+              <span className="font-poppins text-xs text-charcoal-600">
                 ${(dealSize / 1000000).toFixed(1)}M
               </span>
             </div>
           )}
           {deal.employeeCount && (
             <div className="flex items-center gap-1.5">
-              <Users className="h-3.5 w-3.5 text-gray-400" />
-              <span className="font-poppins text-xs text-gray-600">
+              <Users className="h-3.5 w-3.5 text-charcoal-400" />
+              <span className="font-poppins text-xs text-charcoal-600">
                 {deal.employeeCount} employees
               </span>
             </div>
           )}
           {deal.foundedYear && (
             <div className="flex items-center gap-1.5">
-              <Building2 className="h-3.5 w-3.5 text-gray-400" />
-              <span className="font-poppins text-xs text-gray-600">Founded {deal.foundedYear}</span>
+              <Building2 className="h-3.5 w-3.5 text-charcoal-400" />
+              <span className="font-poppins text-xs text-charcoal-600">
+                Founded {deal.foundedYear}
+              </span>
             </div>
           )}
           {deal.sourceType && (
             <div className="flex items-center gap-1.5">
-              <TrendingUp className="h-3.5 w-3.5 text-gray-400" />
-              <span className="font-poppins text-xs text-gray-600 truncate">{deal.sourceType}</span>
+              <TrendingUp className="h-3.5 w-3.5 text-charcoal-400" />
+              <span className="font-poppins text-xs text-charcoal-600 truncate">
+                {deal.sourceType}
+              </span>
             </div>
           )}
         </div>
 
         {/* Next Action */}
         {deal.nextAction && (
-          <div className="pt-2 border-t border-gray-100">
-            <p className="font-poppins text-xs text-gray-500 truncate">
+          <div className="pt-2 border-t border-charcoal/7">
+            <p className="font-poppins text-xs text-charcoal-500 truncate">
               <span className="font-medium">Next:</span> {deal.nextAction}
             </p>
           </div>

--- a/client/src/components/pipeline/DroppableColumn.tsx
+++ b/client/src/components/pipeline/DroppableColumn.tsx
@@ -50,13 +50,13 @@ export function DroppableColumn({
         ref={setNodeRef}
         className={cn(
           'space-y-3 min-h-[100px] rounded-lg transition-colors',
-          highlighted && 'ring-2 ring-blue-200 bg-blue-50/20'
+          highlighted && 'ring-2 ring-pov-charcoal/20 bg-pov-charcoal/5'
         )}
       >
         {children}
         {dealCount === 0 && (
-          <div className="border-2 border-dashed border-gray-200 rounded-lg p-4 text-center">
-            <p className="font-poppins text-xs text-gray-400">No deals</p>
+          <div className="border-2 border-dashed border-beige-200 rounded-lg p-4 text-center">
+            <p className="font-poppins text-xs text-charcoal-400">No deals</p>
           </div>
         )}
       </div>

--- a/client/src/components/pipeline/ImportDealsModal.tsx
+++ b/client/src/components/pipeline/ImportDealsModal.tsx
@@ -312,10 +312,12 @@ export function ImportDealsModal({ open, onOpenChange, fundId }: ImportDealsModa
           {/* Template Download */}
           {phase === 'upload' && (
             <>
-              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-200">
+              <div className="flex items-center justify-between p-3 bg-pov-gray rounded-lg border border-beige-200">
                 <div className="flex items-center gap-2">
-                  <FileSpreadsheet className="h-5 w-5 text-green-600" />
-                  <span className="font-poppins text-sm text-gray-600">Download template CSV</span>
+                  <FileSpreadsheet className="h-5 w-5 text-success" />
+                  <span className="font-poppins text-sm text-charcoal-600">
+                    Download template CSV
+                  </span>
                 </div>
                 <Button
                   type="button"
@@ -351,11 +353,11 @@ export function ImportDealsModal({ open, onOpenChange, fundId }: ImportDealsModa
                       : 'border-pov-beige hover:border-pov-charcoal/50'
                   )}
                 >
-                  <Upload className="h-10 w-10 text-gray-400 mx-auto mb-3" />
+                  <Upload className="h-10 w-10 text-charcoal-400 mx-auto mb-3" />
                   <p className="font-inter font-medium text-pov-charcoal mb-1">
                     Drop your CSV file here
                   </p>
-                  <p className="font-poppins text-sm text-gray-500 mb-3">or click to browse</p>
+                  <p className="font-poppins text-sm text-charcoal-500 mb-3">or click to browse</p>
                   <input
                     type="file"
                     accept=".csv"
@@ -376,9 +378,9 @@ export function ImportDealsModal({ open, onOpenChange, fundId }: ImportDealsModa
                 <div className="border rounded-lg p-4">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <FileSpreadsheet className="h-5 w-5 text-green-600" />
+                      <FileSpreadsheet className="h-5 w-5 text-success" />
                       <span className="font-poppins font-medium text-sm">{file.name}</span>
-                      <span className="font-poppins text-xs text-gray-400">
+                      <span className="font-poppins text-xs text-charcoal-400">
                         ({(file.size / 1024).toFixed(1)} KB)
                       </span>
                     </div>
@@ -389,7 +391,7 @@ export function ImportDealsModal({ open, onOpenChange, fundId }: ImportDealsModa
                 </div>
               )}
 
-              <div className="text-xs text-gray-500 font-poppins space-y-1">
+              <div className="text-xs text-charcoal-500 font-poppins space-y-1">
                 <p>Required columns: companyName, sector, stage, sourceType</p>
                 <p>
                   Stage values: Pre-seed, Seed, Series A, Series B, Series C, Growth, Late Stage
@@ -403,19 +405,21 @@ export function ImportDealsModal({ open, onOpenChange, fundId }: ImportDealsModa
             <div className="space-y-3">
               {/* Summary Cards */}
               <div className="grid grid-cols-3 gap-2">
-                <div className="p-3 bg-gray-50 rounded-lg text-center">
+                <div className="p-3 bg-pov-gray rounded-lg text-center">
                   <p className="font-inter font-bold text-lg text-pov-charcoal">{preview.total}</p>
-                  <p className="font-poppins text-xs text-gray-500">Total rows</p>
+                  <p className="font-poppins text-xs text-charcoal-500">Total rows</p>
                 </div>
-                <div className="p-3 bg-green-50 rounded-lg text-center">
-                  <p className="font-inter font-bold text-lg text-green-700">{preview.toImport}</p>
-                  <p className="font-poppins text-xs text-green-600">Ready to import</p>
+                <div className="p-3 bg-success/10 rounded-lg text-center">
+                  <p className="font-inter font-bold text-lg text-success-dark">
+                    {preview.toImport}
+                  </p>
+                  <p className="font-poppins text-xs text-success">Ready to import</p>
                 </div>
-                <div className="p-3 bg-amber-50 rounded-lg text-center">
-                  <p className="font-inter font-bold text-lg text-amber-700">
+                <div className="p-3 bg-warning/10 rounded-lg text-center">
+                  <p className="font-inter font-bold text-lg text-warning-dark">
                     {preview.duplicates}
                   </p>
-                  <p className="font-poppins text-xs text-amber-600">Duplicates</p>
+                  <p className="font-poppins text-xs text-warning">Duplicates</p>
                 </div>
               </div>
 
@@ -470,21 +474,19 @@ export function ImportDealsModal({ open, onOpenChange, fundId }: ImportDealsModa
           {/* Done Phase */}
           {phase === 'done' && importResult && (
             <div className="space-y-3">
-              <div className="flex items-center gap-2 p-4 bg-green-50 rounded-lg">
-                <CheckCircle2 className="h-5 w-5 text-green-600" />
+              <div className="flex items-center gap-2 p-4 bg-success/10 rounded-lg">
+                <CheckCircle2 className="h-5 w-5 text-success" />
                 <div>
-                  <p className="font-inter font-semibold text-green-800">
+                  <p className="font-inter font-semibold text-success-dark">
                     {importResult.imported} deal{importResult.imported !== 1 ? 's' : ''} imported
                   </p>
                   {importResult.skipped > 0 && (
-                    <p className="font-poppins text-xs text-green-600">
+                    <p className="font-poppins text-xs text-success">
                       {importResult.skipped} duplicates skipped
                     </p>
                   )}
                   {importResult.failed > 0 && (
-                    <p className="font-poppins text-xs text-red-600">
-                      {importResult.failed} failed
-                    </p>
+                    <p className="font-poppins text-xs text-error">{importResult.failed} failed</p>
                   )}
                 </div>
               </div>

--- a/client/src/components/reserves/graduation-reserves-demo.tsx
+++ b/client/src/components/reserves/graduation-reserves-demo.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/core/reserves/computeReservesFromGraduation';
 import { Calculator, TrendingUp, Target, AlertTriangle } from 'lucide-react';
 import { createDynamicFormatter } from '@/lib/chart-formatters';
+import { presson } from '@/theme/presson.tokens';
 
 type GraduationRates = FundDataForReserves['graduationRates'];
 type GraduationStage = keyof GraduationRates;
@@ -42,7 +43,7 @@ export default function GraduationReservesDemo() {
     {
       name: 'Conservative VC',
       description: 'Lower graduation rates, higher follow-on checks',
-      color: '#ef4444',
+      color: presson.color.negative,
       fundData: {
         totalCommitment: 50000000,
         targetCompanies: 25,
@@ -59,7 +60,7 @@ export default function GraduationReservesDemo() {
     {
       name: 'Aggressive Growth',
       description: 'Higher graduation rates, moderate follow-ons',
-      color: '#10b981',
+      color: presson.color.positive,
       fundData: {
         totalCommitment: 50000000,
         targetCompanies: 35,
@@ -76,7 +77,7 @@ export default function GraduationReservesDemo() {
     {
       name: 'Balanced Portfolio',
       description: 'Market-average rates and check sizes',
-      color: '#3b82f6',
+      color: presson.color.info,
       fundData: {
         totalCommitment: 50000000,
         targetCompanies: 30,
@@ -132,15 +133,18 @@ export default function GraduationReservesDemo() {
           <div className="flex items-center justify-between">
             <div>
               <CardTitle className="text-2xl font-bold flex items-center">
-                <Calculator className="w-6 h-6 mr-2 text-blue-600" />
+                <Calculator className="w-6 h-6 mr-2 text-presson-info" />
                 Graduation-Driven Reserves Engine
               </CardTitle>
-              <p className="text-gray-600 mt-2">
+              <p className="text-charcoal-600 mt-2">
                 Compare how different graduation rates and follow-on strategies impact your reserve
                 requirements
               </p>
             </div>
-            <Badge variant="outline" className="bg-blue-50 text-blue-700">
+            <Badge
+              variant="outline"
+              className="bg-presson-info/10 text-presson-info border-presson-info/20"
+            >
               Expected Value v1
             </Badge>
           </div>
@@ -159,13 +163,13 @@ export default function GraduationReservesDemo() {
                 key={index}
                 variant={selectedScenario === index ? 'default' : 'outline'}
                 className={`h-auto p-4 text-left justify-start ${
-                  selectedScenario === index ? '' : 'hover:bg-gray-50'
+                  selectedScenario === index ? '' : 'hover:bg-pov-gray'
                 }`}
                 onClick={() => setSelectedScenario(index)}
               >
                 <div>
                   <div className="font-semibold">{scenario.name}</div>
-                  <div className="text-sm text-gray-600 mt-1">{scenario.description}</div>
+                  <div className="text-sm text-charcoal-600 mt-1">{scenario.description}</div>
                 </div>
               </Button>
             ))}
@@ -179,22 +183,22 @@ export default function GraduationReservesDemo() {
         <Card>
           <CardHeader>
             <CardTitle className="text-lg flex items-center">
-              <Target className="w-5 h-5 mr-2 text-green-600" />
+              <Target className="w-5 h-5 mr-2 text-presson-positive" />
               {currentScenario.name} Results
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
-                <div className="bg-blue-50 p-4 rounded-lg">
-                  <div className="text-sm font-medium text-blue-600">Total Reserves</div>
-                  <div className="text-2xl font-bold text-blue-900">
+                <div className="bg-presson-info/10 p-4 rounded-lg">
+                  <div className="text-sm font-medium text-presson-info">Total Reserves</div>
+                  <div className="text-2xl font-bold text-presson-info">
                     {formatCurrency(result?.totalReserves ?? 0)}
                   </div>
                 </div>
-                <div className="bg-green-50 p-4 rounded-lg">
-                  <div className="text-sm font-medium text-green-600">Reserve Ratio</div>
-                  <div className="text-2xl font-bold text-green-900" data-testid="demo-ratio">
+                <div className="bg-presson-info/10 p-4 rounded-lg">
+                  <div className="text-sm font-medium text-presson-info">Reserve Ratio</div>
+                  <div className="text-2xl font-bold text-presson-info" data-testid="demo-ratio">
                     {formatPercent(result?.reserveRatioPct ?? 0)}
                   </div>
                 </div>
@@ -202,19 +206,19 @@ export default function GraduationReservesDemo() {
 
               <div className="space-y-2">
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Series A Follow-ons:</span>
+                  <span className="text-charcoal-600">Series A Follow-ons:</span>
                   <span className="font-medium">
                     {formatCurrency(result?.aggregateByStage.A ?? 0)}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Series B Follow-ons:</span>
+                  <span className="text-charcoal-600">Series B Follow-ons:</span>
                   <span className="font-medium">
                     {formatCurrency(result?.aggregateByStage.B ?? 0)}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Series C Follow-ons:</span>
+                  <span className="text-charcoal-600">Series C Follow-ons:</span>
                   <span className="font-medium">
                     {formatCurrency(result?.aggregateByStage.C ?? 0)}
                   </span>
@@ -222,7 +226,7 @@ export default function GraduationReservesDemo() {
               </div>
 
               <div className="pt-4 border-t">
-                <div className="text-sm text-gray-600 space-y-1">
+                <div className="text-sm text-charcoal-600 space-y-1">
                   <div>
                     <strong>Companies per Quarter:</strong> {result?.assumptions.perQuarter ?? 0}
                   </div>
@@ -248,8 +252,8 @@ export default function GraduationReservesDemo() {
           <CardContent>
             <div className="space-y-4">
               {graduationRateEntries.map(([stage, rates]) => (
-                <div key={stage} className="bg-gray-50 p-4 rounded-lg">
-                  <div className="text-sm font-semibold text-gray-700 mb-2">
+                <div key={stage} className="bg-pov-gray p-4 rounded-lg">
+                  <div className="text-sm font-semibold text-charcoal-700 mb-2">
                     {stage === 'seedToA'
                       ? 'Seed -> Series A'
                       : stage === 'aToB'
@@ -258,16 +262,18 @@ export default function GraduationReservesDemo() {
                   </div>
                   <div className="grid grid-cols-3 gap-2 text-xs">
                     <div>
-                      <div className="text-green-600 font-medium">Graduate: {rates.graduate}%</div>
+                      <div className="text-success font-medium">Graduate: {rates.graduate}%</div>
                     </div>
                     <div>
-                      <div className="text-red-600 font-medium">Fail: {rates.fail}%</div>
+                      <div className="text-error font-medium">Fail: {rates.fail}%</div>
                     </div>
                     <div>
-                      <div className="text-yellow-600 font-medium">Remain: {rates.remain}%</div>
+                      <div className="text-warning font-medium">Remain: {rates.remain}%</div>
                     </div>
                   </div>
-                  <div className="text-xs text-gray-500 mt-1">Avg time: {rates.months} months</div>
+                  <div className="text-xs text-charcoal-500 mt-1">
+                    Avg time: {rates.months} months
+                  </div>
                 </div>
               ))}
             </div>
@@ -279,7 +285,7 @@ export default function GraduationReservesDemo() {
       <Card>
         <CardHeader>
           <CardTitle className="text-lg flex items-center">
-            <BarChart className="w-5 h-5 mr-2 text-purple-600" />
+            <BarChart className="w-5 h-5 mr-2 text-presson-info" />
             Strategy Comparison
           </CardTitle>
         </CardHeader>
@@ -304,27 +310,27 @@ export default function GraduationReservesDemo() {
                   yAxisId="left"
                   dataKey="seriesA"
                   stackId="reserves"
-                  fill="#3b82f6"
+                  fill={presson.color.text}
                   name="Series A"
                 />
                 <Bar
                   yAxisId="left"
                   dataKey="seriesB"
                   stackId="reserves"
-                  fill="#10b981"
+                  fill={presson.color.positive}
                   name="Series B"
                 />
                 <Bar
                   yAxisId="left"
                   dataKey="seriesC"
                   stackId="reserves"
-                  fill="#f59e0b"
+                  fill={presson.color.info}
                   name="Series C"
                 />
                 <Bar
                   yAxisId="right"
                   dataKey="reserveRatio"
-                  fill="#ef4444"
+                  fill={presson.color.warning}
                   name="Reserve Ratio (%)"
                 />
               </BarChart>
@@ -337,41 +343,41 @@ export default function GraduationReservesDemo() {
       <Card>
         <CardHeader>
           <CardTitle className="text-lg flex items-center">
-            <TrendingUp className="w-5 h-5 mr-2 text-orange-600" />
+            <TrendingUp className="w-5 h-5 mr-2 text-presson-warning" />
             Key Insights
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="bg-blue-50 p-4 rounded-lg border border-blue-200">
+            <div className="bg-warning/10 p-4 rounded-lg border border-warning/50">
               <div className="flex items-center mb-2">
-                <AlertTriangle className="w-4 h-4 text-blue-600 mr-2" />
-                <span className="text-sm font-medium text-blue-800">Conservative Strategy</span>
+                <AlertTriangle className="w-4 h-4 text-warning mr-2" />
+                <span className="text-sm font-medium text-warning-dark">Conservative Strategy</span>
               </div>
-              <p className="text-sm text-blue-700">
+              <p className="text-sm text-warning-dark">
                 Lower graduation rates require higher reserve ratios (
                 {formatPercent(comparisonData[0]?.reserveRatio ?? 0)}) due to fewer companies
                 reaching follow-on stages.
               </p>
             </div>
 
-            <div className="bg-green-50 p-4 rounded-lg border border-green-200">
+            <div className="bg-success/10 p-4 rounded-lg border border-success/50">
               <div className="flex items-center mb-2">
-                <TrendingUp className="w-4 h-4 text-green-600 mr-2" />
-                <span className="text-sm font-medium text-green-800">Aggressive Growth</span>
+                <TrendingUp className="w-4 h-4 text-success mr-2" />
+                <span className="text-sm font-medium text-success-dark">Aggressive Growth</span>
               </div>
-              <p className="text-sm text-green-700">
+              <p className="text-sm text-success-dark">
                 High graduation rates with smaller checks create the most capital-efficient reserves
                 ({formatPercent(comparisonData[1]?.reserveRatio ?? 0)}).
               </p>
             </div>
 
-            <div className="bg-purple-50 p-4 rounded-lg border border-purple-200">
+            <div className="bg-presson-info/10 p-4 rounded-lg border border-presson-info/20">
               <div className="flex items-center mb-2">
-                <Target className="w-4 h-4 text-purple-600 mr-2" />
-                <span className="text-sm font-medium text-purple-800">Dynamic Calculation</span>
+                <Target className="w-4 h-4 text-presson-info mr-2" />
+                <span className="text-sm font-medium text-presson-info">Dynamic Calculation</span>
               </div>
-              <p className="text-sm text-purple-700">
+              <p className="text-sm text-presson-info">
                 Reserve ratios automatically adjust based on your portfolio graduation assumptions
                 instead of using fixed percentages.
               </p>

--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-06-03T00:00:00.000Z",
+  "generatedAt": "2026-06-04T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 156,
+      "staleDays": 157,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 68,
+      "staleDays": 69,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 46,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 46,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1176,7 +1176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1192,7 +1192,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1208,7 +1208,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1223,7 +1223,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1305,7 +1305,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "UNKNOWN"
     },
     {
@@ -1323,7 +1323,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1340,7 +1340,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1357,7 +1357,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1373,7 +1373,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1403,7 +1403,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1418,7 +1418,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -1434,7 +1434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1449,7 +1449,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1464,7 +1464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1479,7 +1479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1494,7 +1494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1522,7 +1522,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 156,
+      "staleDays": 157,
       "status": "ACTIVE"
     },
     {
@@ -1538,7 +1538,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "UNKNOWN"
     },
     {
@@ -1565,7 +1565,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -1580,7 +1580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -1595,7 +1595,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1610,7 +1610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1625,7 +1625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1678,7 +1678,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 156,
+      "staleDays": 157,
       "status": "ACTIVE"
     },
     {
@@ -1692,7 +1692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1706,7 +1706,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1720,7 +1720,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -1791,7 +1791,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1806,7 +1806,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1821,7 +1821,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -1836,7 +1836,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1851,7 +1851,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1866,7 +1866,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1881,7 +1881,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1896,7 +1896,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1911,7 +1911,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1930,7 +1930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ready"
     },
     {
@@ -1949,7 +1949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ready"
     },
     {
@@ -1968,7 +1968,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ready"
     },
     {
@@ -1983,7 +1983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -1998,7 +1998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2037,7 +2037,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -2052,7 +2052,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -2067,7 +2067,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "UNKNOWN"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2135,7 +2135,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2150,7 +2150,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2165,7 +2165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2180,7 +2180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2196,7 +2196,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -2212,7 +2212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2227,7 +2227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2242,7 +2242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2257,7 +2257,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2272,7 +2272,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2288,7 +2288,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -2303,7 +2303,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2318,7 +2318,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2333,7 +2333,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2349,7 +2349,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2364,7 +2364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2379,7 +2379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2394,7 +2394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2408,7 +2408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2423,7 +2423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2439,7 +2439,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2455,7 +2455,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2471,7 +2471,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2566,7 +2566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2582,7 +2582,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2597,7 +2597,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2612,7 +2612,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2627,7 +2627,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2643,7 +2643,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2659,7 +2659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2674,7 +2674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2692,7 +2692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2722,7 +2722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2737,7 +2737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2752,7 +2752,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2768,7 +2768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -2783,7 +2783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2798,7 +2798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO-v2.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -2813,7 +2813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -2828,7 +2828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/immediate-actions-summary.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -2843,7 +2843,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2858,7 +2858,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -2873,7 +2873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2888,7 +2888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2903,7 +2903,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2918,7 +2918,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2933,7 +2933,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2948,7 +2948,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -2963,7 +2963,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-baseline-report-2025-12-23.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -2978,7 +2978,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-remediation-summary.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -2993,7 +2993,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/week2-execution-report.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -3008,7 +3008,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -3023,7 +3023,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3038,7 +3038,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3074,7 +3074,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 68,
+      "staleDays": 69,
       "status": "ACTIVE"
     },
     {
@@ -3091,7 +3091,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -3106,7 +3106,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -3121,7 +3121,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3136,7 +3136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3165,7 +3165,7 @@
       "lastUpdated": "2026-05-21",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -3180,7 +3180,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 0,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -3195,7 +3195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3210,7 +3210,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -3237,7 +3237,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3252,7 +3252,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3267,7 +3267,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-QUICK-START.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3282,7 +3282,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3297,7 +3297,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3312,7 +3312,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3327,7 +3327,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3342,7 +3342,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "README.md",
-      "staleDays": 67,
+      "staleDays": 68,
       "status": "ACTIVE"
     },
     {
@@ -3357,7 +3357,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3372,7 +3372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3387,7 +3387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3404,7 +3404,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 68,
+      "staleDays": 69,
       "status": "ACTIVE"
     },
     {
@@ -3419,7 +3419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3434,7 +3434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -3449,7 +3449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3464,7 +3464,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3479,7 +3479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3494,7 +3494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3509,7 +3509,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -3524,7 +3524,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3539,7 +3539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3554,7 +3554,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -3569,7 +3569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3584,7 +3584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3599,7 +3599,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3614,7 +3614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3629,7 +3629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -3644,7 +3644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3659,7 +3659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -3674,7 +3674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3689,7 +3689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3704,7 +3704,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3719,7 +3719,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -3734,7 +3734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3749,7 +3749,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3764,7 +3764,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3779,7 +3779,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3795,7 +3795,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "active"
     },
     {
@@ -3810,7 +3810,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3825,7 +3825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3840,7 +3840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3855,7 +3855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3870,7 +3870,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "ACTIVE"
     },
     {
@@ -3885,7 +3885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3900,7 +3900,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -3915,7 +3915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3930,7 +3930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -3945,7 +3945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3960,7 +3960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3975,7 +3975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3990,7 +3990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4005,7 +4005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4020,7 +4020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4035,7 +4035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4050,7 +4050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4065,7 +4065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4080,7 +4080,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 0,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -4095,7 +4095,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -4110,7 +4110,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 67,
+      "staleDays": 68,
       "status": "ACTIVE"
     },
     {
@@ -4125,7 +4125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4152,7 +4152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4167,7 +4167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4182,7 +4182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4197,7 +4197,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4212,7 +4212,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4227,7 +4227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4242,7 +4242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4281,7 +4281,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 46,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -4296,7 +4296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4311,7 +4311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4326,7 +4326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4362,7 +4362,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -4377,7 +4377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4392,7 +4392,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 44,
+      "staleDays": 45,
       "status": "HISTORICAL"
     },
     {
@@ -4407,7 +4407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4422,7 +4422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4437,7 +4437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4452,7 +4452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -4467,7 +4467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4482,7 +4482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4497,7 +4497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4512,7 +4512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4527,7 +4527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4542,7 +4542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4583,7 +4583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -4598,7 +4598,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4613,7 +4613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4628,7 +4628,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 59,
+      "staleDays": 60,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4643,7 +4643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4658,7 +4658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4673,7 +4673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4688,7 +4688,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4702,7 +4702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -4717,7 +4717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4732,7 +4732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4747,7 +4747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4762,7 +4762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4777,7 +4777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -4792,7 +4792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4807,7 +4807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4822,7 +4822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4837,7 +4837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4852,7 +4852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4867,7 +4867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4882,7 +4882,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4897,7 +4897,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4926,7 +4926,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -4941,7 +4941,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4956,7 +4956,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4971,7 +4971,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -4986,7 +4986,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5001,7 +5001,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5016,7 +5016,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5031,7 +5031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -5046,7 +5046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5061,7 +5061,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5076,7 +5076,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5091,7 +5091,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5106,7 +5106,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5121,7 +5121,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -5136,7 +5136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5151,7 +5151,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5166,7 +5166,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5181,7 +5181,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5196,7 +5196,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -5211,7 +5211,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -5226,7 +5226,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -5241,7 +5241,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -5256,7 +5256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5271,7 +5271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5286,7 +5286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5301,7 +5301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5327,7 +5327,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -5342,7 +5342,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "Implemented"
     },
     {
@@ -5357,7 +5357,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 46,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -5372,7 +5372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5423,7 +5423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5438,7 +5438,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 78,
+      "staleDays": 79,
       "status": "ARCHIVED"
     },
     {
@@ -5453,7 +5453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5468,7 +5468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5483,7 +5483,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -5498,7 +5498,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 7,
+      "staleDays": 8,
       "status": "HISTORICAL"
     },
     {
@@ -5513,7 +5513,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 7,
+      "staleDays": 8,
       "status": "HISTORICAL"
     },
     {
@@ -5528,7 +5528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5543,7 +5543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5558,7 +5558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5573,7 +5573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5588,7 +5588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5603,7 +5603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5618,7 +5618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5633,7 +5633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5648,7 +5648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5663,7 +5663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5678,7 +5678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5693,7 +5693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5708,7 +5708,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5723,7 +5723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5738,7 +5738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5753,7 +5753,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5768,7 +5768,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5783,7 +5783,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "ACTIVE"
     },
     {
@@ -5798,7 +5798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5813,7 +5813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5827,7 +5827,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -5841,7 +5841,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -5856,7 +5856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -5871,7 +5871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5886,7 +5886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5901,7 +5901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5916,7 +5916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5931,7 +5931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5946,7 +5946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5961,7 +5961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5976,7 +5976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -5991,7 +5991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6006,7 +6006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6021,7 +6021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6036,7 +6036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6051,7 +6051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6066,7 +6066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6081,7 +6081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6096,7 +6096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -6111,7 +6111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6126,7 +6126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6168,7 +6168,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -6216,7 +6216,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -6261,7 +6261,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 0,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -6288,7 +6288,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 46,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -6304,7 +6304,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -6319,7 +6319,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6334,7 +6334,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6349,7 +6349,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6364,7 +6364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6378,7 +6378,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -6393,7 +6393,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6408,7 +6408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6423,7 +6423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6438,7 +6438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6452,7 +6452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -6467,7 +6467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6482,7 +6482,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -6497,7 +6497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6512,7 +6512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6527,7 +6527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6542,7 +6542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6557,7 +6557,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6572,7 +6572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6587,7 +6587,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6602,7 +6602,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6617,7 +6617,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -6632,7 +6632,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6665,7 +6665,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -6680,7 +6680,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6713,7 +6713,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -6728,7 +6728,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6743,7 +6743,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6758,7 +6758,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6773,7 +6773,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 44,
+      "staleDays": 45,
       "status": "HISTORICAL"
     },
     {
@@ -6788,7 +6788,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -6803,7 +6803,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6818,7 +6818,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6833,7 +6833,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6848,7 +6848,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6863,7 +6863,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6878,7 +6878,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6893,7 +6893,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6908,7 +6908,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6923,7 +6923,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6938,7 +6938,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6953,7 +6953,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6968,7 +6968,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -6983,7 +6983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -6998,7 +6998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7013,7 +7013,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7028,7 +7028,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7043,7 +7043,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7058,7 +7058,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7073,7 +7073,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -7088,7 +7088,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7103,7 +7103,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7118,7 +7118,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7139,7 +7139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "active"
     },
     {
@@ -7153,7 +7153,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -7168,7 +7168,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7183,7 +7183,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7198,7 +7198,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7213,7 +7213,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7228,7 +7228,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7243,7 +7243,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7258,7 +7258,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7273,7 +7273,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7288,7 +7288,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7303,7 +7303,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -7318,7 +7318,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -7333,7 +7333,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -7348,7 +7348,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -7363,7 +7363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7378,7 +7378,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7393,7 +7393,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7408,7 +7408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7423,7 +7423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7438,7 +7438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7453,7 +7453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7468,7 +7468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7483,7 +7483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7498,7 +7498,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7513,7 +7513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7528,7 +7528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7543,7 +7543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7558,7 +7558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7573,7 +7573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7588,7 +7588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7603,7 +7603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7618,7 +7618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7633,7 +7633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7648,7 +7648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7663,7 +7663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7678,7 +7678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7694,7 +7694,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 59,
+      "staleDays": 60,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7709,7 +7709,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7724,7 +7724,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7739,7 +7739,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7754,7 +7754,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7769,7 +7769,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7796,7 +7796,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7811,7 +7811,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -7834,7 +7834,7 @@
       "lastUpdated": "2026-03-20",
       "owner": null,
       "path": "docs/plans/2026-03-20-contract-integrity-final-counterproposal.md",
-      "staleDays": 75,
+      "staleDays": 76,
       "status": "ACCEPTED"
     },
     {
@@ -7848,7 +7848,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-03-21-phase-2b-execution-spec.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -7862,7 +7862,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-03-22-phase-3-results-execution-spec.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -7876,7 +7876,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-03-22-phase-3c-implementation-plan.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -7890,7 +7890,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-03-22-phase-4-implementation-spec.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -7911,7 +7911,7 @@
       "lastUpdated": "2026-03-26",
       "owner": null,
       "path": "docs/plans/2026-03-26-development-spec-set.md",
-      "staleDays": 69,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -7926,7 +7926,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 67,
+      "staleDays": 68,
       "status": "ACTIVE"
     },
     {
@@ -7959,7 +7959,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/plans/2026-03-31-variance-roadmap-revision.md",
-      "staleDays": 59,
+      "staleDays": 60,
       "status": "HISTORICAL-FRAMEWORK"
     },
     {
@@ -7982,7 +7982,7 @@
       "lastUpdated": "2026-04-02",
       "owner": null,
       "path": "docs/plans/2026-04-01-variance-phase1a1c-implementation-plan.md",
-      "staleDays": 62,
+      "staleDays": 63,
       "status": "IMPLEMENTED"
     },
     {
@@ -7996,7 +7996,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-04-02-phase-1c1-alert-evaluation-implementation-strategy.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -8010,7 +8010,7 @@
       "lastUpdated": "2026-04-07",
       "owner": null,
       "path": "docs/plans/2026-04-02-phase-1c2-alert-scheduling-and-remaining-capital-plan.md",
-      "staleDays": 57,
+      "staleDays": 58,
       "status": "UNKNOWN"
     },
     {
@@ -8024,7 +8024,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-04-02-phase-2-scenario-comparison-consolidation-plan.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -8038,7 +8038,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-04-03-phase-1a2-baseline-automation-hardening-validated.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -8052,7 +8052,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-04-03-phase-1b-single-owner-pr-queue.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -8066,7 +8066,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-04-03-phase-2-slice-3-saved-comparison-retirement-plan.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -8080,7 +8080,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/plans/2026-04-03-phase-2-slice-4-backtesting-integration-rewrite-plan.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -8094,7 +8094,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-04-06-phase-4-closeout.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -8111,7 +8111,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 57,
+      "staleDays": 58,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -8126,7 +8126,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "BACKLOG"
     },
     {
@@ -8140,7 +8140,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-04-08-backtesting-scenario-comparison-rewrite.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -8154,7 +8154,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -8171,7 +8171,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 3,
+      "staleDays": 4,
       "status": "ACTIVE"
     },
     {
@@ -8191,7 +8191,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -8228,7 +8228,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -8243,7 +8243,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -8258,7 +8258,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8273,7 +8273,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -8288,7 +8288,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8303,7 +8303,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8318,7 +8318,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8333,7 +8333,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8348,7 +8348,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8363,7 +8363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8378,7 +8378,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8393,7 +8393,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8408,7 +8408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8423,7 +8423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8438,7 +8438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8453,7 +8453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8468,7 +8468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8483,7 +8483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8498,7 +8498,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8513,7 +8513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8528,7 +8528,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -8543,7 +8543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8557,7 +8557,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -8584,7 +8584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8599,7 +8599,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -8614,7 +8614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8629,7 +8629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8644,7 +8644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8659,7 +8659,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8674,7 +8674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8689,7 +8689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8704,7 +8704,7 @@
       "lastUpdated": "2026-06-02",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "DRAFT"
     },
     {
@@ -8719,7 +8719,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8734,7 +8734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8749,7 +8749,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8764,7 +8764,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8779,7 +8779,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8794,7 +8794,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8809,7 +8809,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8824,7 +8824,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8839,7 +8839,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8854,7 +8854,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -8889,7 +8889,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "COMPLETED"
     },
     {
@@ -8920,7 +8920,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "REFERENCE"
     },
     {
@@ -8951,7 +8951,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "REFERENCE"
     },
     {
@@ -8982,7 +8982,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "REFERENCE"
     },
     {
@@ -9015,7 +9015,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "REFERENCE"
     },
     {
@@ -9046,7 +9046,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "REFERENCE"
     },
     {
@@ -9078,7 +9078,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "REFERENCE"
     },
     {
@@ -9093,7 +9093,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -9108,7 +9108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9123,7 +9123,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9138,7 +9138,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9153,7 +9153,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9168,7 +9168,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9196,7 +9196,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "ACTIVE"
     },
     {
@@ -9211,7 +9211,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9226,7 +9226,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9241,7 +9241,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9256,7 +9256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9271,7 +9271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9286,7 +9286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9301,7 +9301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9316,7 +9316,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9331,7 +9331,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9346,7 +9346,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9361,7 +9361,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9376,7 +9376,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9391,7 +9391,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9406,7 +9406,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9421,7 +9421,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9436,7 +9436,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9451,7 +9451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-01-to-01-07-extraction.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -9466,7 +9466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-08-to-01-18-extraction.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -9481,7 +9481,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-18-extraction.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -9495,7 +9495,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -9509,7 +9509,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -9523,7 +9523,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -9537,7 +9537,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "UNKNOWN"
     },
     {
@@ -9551,7 +9551,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -9565,7 +9565,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "UNKNOWN"
     },
     {
@@ -9580,7 +9580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9595,7 +9595,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9610,7 +9610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -9651,7 +9651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "VERIFIED"
     },
     {
@@ -9999,7 +9999,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "DRAFT"
     },
     {
@@ -10197,7 +10197,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10279,7 +10279,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "VERIFIED"
     },
     {
@@ -10352,7 +10352,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "DRAFT"
     },
     {
@@ -10396,7 +10396,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "DRAFT"
     },
     {
@@ -10526,7 +10526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "DRAFT"
     },
     {
@@ -10573,7 +10573,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "DRAFT"
     },
     {
@@ -10615,7 +10615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "DRAFT"
     },
     {
@@ -10764,7 +10764,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10790,7 +10790,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10821,7 +10821,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10850,7 +10850,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10879,7 +10879,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10909,7 +10909,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10939,7 +10939,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -10969,7 +10969,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 23,
+      "staleDays": 24,
       "status": "DRAFT"
     },
     {
@@ -11002,7 +11002,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 46,
+      "staleDays": 47,
       "status": "DRAFT"
     },
     {
@@ -11067,7 +11067,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11082,7 +11082,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11097,7 +11097,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11154,7 +11154,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-20-hermes-integration.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -11169,7 +11169,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -11197,7 +11197,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -11226,7 +11226,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -11254,7 +11254,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -11294,7 +11294,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -11321,7 +11321,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -11389,6 +11389,32 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
+        "authors": [
+          "claude",
+          "nikhil"
+        ],
+        "created": "2026-06-04",
+        "related": [
+          "DESIGN.md",
+          "client/src/theme/presson.tokens.ts",
+          "docs/superpowers/specs/2026-06-03-theme2-parallel-hermes-partition-design.md (wave 2 — Sec 2 mapping reused verbatim)",
+          "PR"
+        ],
+        "status": "DRAFT (scope only — NOT approved for execution)",
+        "topic": "Theme 2 — long-tail census sweep (wave 3) to declare token rollout 100% done"
+      },
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/specs/2026-06-04-theme2-longtail-census-sweep.md",
+      "staleDays": 999,
+      "status": "DRAFT (scope only — NOT approved for execution)"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
         "categories": [
           "tech-debt",
           "type-safety"
@@ -11421,7 +11447,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -11436,7 +11462,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11451,7 +11477,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11466,7 +11492,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11481,7 +11507,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11508,7 +11534,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11523,7 +11549,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11538,7 +11564,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11553,7 +11579,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11568,7 +11594,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11583,7 +11609,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11598,7 +11624,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "HISTORICAL"
     },
     {
@@ -11613,7 +11639,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11628,7 +11654,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11643,7 +11669,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11658,7 +11684,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11673,7 +11699,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11688,7 +11714,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11703,7 +11729,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11718,7 +11744,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11733,7 +11759,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -11779,7 +11805,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 156,
+      "staleDays": 157,
       "status": "ACTIVE"
     },
     {
@@ -11794,7 +11820,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -11809,11 +11835,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-06-03T00:00:00.000Z",
+  "generatedAt": "2026-06-04T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -12985,6 +13011,7 @@
       "BACKLOG": 1,
       "COMPLETED": 1,
       "DRAFT": 33,
+      "DRAFT (scope only — NOT approved for execution)": 1,
       "HISTORICAL": 29,
       "HISTORICAL-FRAMEWORK": 1,
       "HISTORICAL-SNAPSHOT": 1,
@@ -13000,8 +13027,8 @@
       "ready": 3
     },
     "missing_frontmatter": 20,
-    "stale_docs": 103,
-    "total_docs": 665
+    "stale_docs": 104,
+    "total_docs": 666
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,18 +1,18 @@
 ---
-last_updated: 2026-06-03
+last_updated: 2026-06-04
 ---
 
 # Staleness Report
 
-*Generated: 2026-06-03T00:00:00.000Z*
+*Generated: 2026-06-04T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 665 |
-| Stale Documents | 103 |
+| Total Documents | 666 |
+| Stale Documents | 104 |
 | Missing Frontmatter | 20 |
 
 ### By Status
@@ -38,6 +38,7 @@ last_updated: 2026-06-03
 | TRACKED (not scheduled) | 1 |
 | BACKLOG | 1 |
 | COMPLETED | 1 |
+| DRAFT (scope only — NOT approved for execution) | 1 |
 
 ## Stale Documents
 
@@ -86,29 +87,29 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md` | Never | 999 | YES - verify! | Unassigned |
 | `docs/superpowers/specs/2026-06-02-prove-and-ship-the-spine-lean-release-design.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/specs/2026-06-03-theme2-parallel-hermes-partition-design.md` | Never | 999 | YES - verify! | Unassigned |
+| `docs/superpowers/specs/2026-06-04-theme2-longtail-census-sweep.md` | Never | 999 | No | Unassigned |
 | `docs/tooling-catalog.md` | Never | 999 | No | Unassigned |
-| `cheatsheets/agent-architecture.md` | 2026-01-19 | 135 | No | Unassigned |
-| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 135 | No | Unassigned |
-| `cheatsheets/ai-code-review.md` | 2026-01-19 | 135 | No | Unassigned |
-| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 135 | No | Unassigned |
-| `cheatsheets/api.md` | 2026-01-19 | 135 | No | Unassigned |
-| `cheatsheets/capability-checklist.md` | 2026-01-19 | 135 | No | Unassigned |
-| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 135 | No | Unassigned |
-| `cheatsheets/claude-commands.md` | 2026-01-19 | 135 | No | Unassigned |
+| `cheatsheets/agent-architecture.md` | 2026-01-19 | 136 | No | Unassigned |
+| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 136 | No | Unassigned |
+| `cheatsheets/ai-code-review.md` | 2026-01-19 | 136 | No | Unassigned |
+| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 136 | No | Unassigned |
+| `cheatsheets/api.md` | 2026-01-19 | 136 | No | Unassigned |
+| `cheatsheets/capability-checklist.md` | 2026-01-19 | 136 | No | Unassigned |
+| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 136 | No | Unassigned |
 
-*...and 53 more stale documents.*
+*...and 54 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **CHANGELOG.md** (14 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (135 days old)
-- [ ] **cheatsheets/schema-alignment.md** (135 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (135 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (135 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (135 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (135 days old)
+- [ ] **CHANGELOG.md** (15 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (136 days old)
+- [ ] **cheatsheets/schema-alignment.md** (136 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (136 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (136 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (136 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (136 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)

--- a/docs/superpowers/specs/2026-06-04-theme2-longtail-census-sweep.md
+++ b/docs/superpowers/specs/2026-06-04-theme2-longtail-census-sweep.md
@@ -1,0 +1,288 @@
+---
+status: DRAFT (scope only — NOT approved for execution)
+created: 2026-06-04
+topic:
+  Theme 2 — long-tail census sweep (wave 3) to declare token rollout 100% done
+authors: [claude, nikhil]
+related:
+  - DESIGN.md
+  - client/src/theme/presson.tokens.ts
+  - docs/superpowers/specs/2026-06-03-theme2-parallel-hermes-partition-design.md
+    (wave 2 — Sec 2 mapping reused verbatim)
+  - PR #769 #771 #772 #773 #774 (rollout waves, all merged to main @ 73640dd6)
+---
+
+# Theme 2 — Long-Tail Census Sweep (Wave 3)
+
+## Status
+
+**SCOPE ONLY.** This document sizes and partitions the remaining work. It is NOT
+an execution plan and nothing here has been dispatched. Execution (writing-plans
+
+- Hermes) is a separate, explicit go.
+
+## Problem
+
+The token rollout migrated its named high-value surfaces across waves 1–2
+(#769/#771), the shared layer (#772), the page long-tail (#773), and cap-table +
+sensitivity (#774). The **unnamed long tail** — feature components and pages no
+wave claimed — still carries raw Tailwind/hex color. This sweep censuses what
+remains on **live** surfaces, excludes dead code, and partitions the migration
+so the rollout can be formally declared 100% complete.
+
+## Headline numbers (reproducible — see Methodology)
+
+| Bucket                                 | Files  | Occ      | Notes                                |
+| -------------------------------------- | ------ | -------- | ------------------------------------ |
+| **LIVE migration target**              | **71** | **1096** | the work                             |
+| — fresh (untouched files)              | 63     | 1055     | auto-dispatchable                    |
+| — residue (already-swept globs / TODO) | 9      | 41       | hand-migrate, hard cases             |
+| Transitively DEAD (excluded)           | 42     | 797      | imported only by the 17 dead pages   |
+| Token-definition files (excluded)      | 6      | 163      | their hexes ARE the tokens           |
+| Shared layer (#772, excluded)          | 1      | 18       | `ui/BrandShowcase.tsx` — verify-only |
+
+Off-token sub-types within the live target:
+
+- **KILL (purple / violet / fuchsia): 23** — hard doctrine violation (rule 7).
+  Highest priority. Concentrated in **B2** (16 of 23).
+- **indigo: 9** — blue-family, NOT a kill; resolves to charcoal (action) or info
+  (static) per rules 2/5.
+- **black `#000`: 0** — none (charcoal is `#292929`, not black).
+- **white: 68** — `bg-white`/`text-white`, pixel-identical to `pov-white`.
+  Cosmetic token-naming only; lowest priority, batch with whatever file owns it.
+
+## Methodology (so this is reproducible without the temp scripts)
+
+**Off-token regexes** (applied to `client/src/**/*.{ts,tsx}`):
+
+```
+numbered  \b(bg|text|border|ring|fill|stroke|from|to|via|divide|outline|placeholder|caret|accent|decoration|shadow)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(50|100|200|300|400|500|600|700|800|900|950)\b
+arbitrary \[#[0-9a-fA-F]{3,8}\]                         (e.g. text-[#292929])
+hex-lit   ['"`]#[0-9a-fA-F]{6}\b                         (e.g. fill="#3b82f6")
+kill      \b(bg|text|border|ring|fill|stroke|from|to|via)-(violet|purple|fuchsia)-
+black     \b(bg|text|border|fill|stroke|ring|divide)-black\b
+white     \b(bg|text|border|fill|stroke|ring|divide)-white\b   (cosmetic)
+```
+
+**Three exclusion sets** (applied before counting):
+
+1. **Tests / stories**: `*.test.{ts,tsx}`, `__tests__/`, `*.stories.*`.
+2. **Token-definition files** (hexes are canonical, not strays):
+   `client/src/theme/**`, `lib/brand-tokens.ts`, `lib/press-on-theme.ts`,
+   `lib/chart-theme/**`.
+3. **Dead code**:
+   - 17 dead pages (see `project_dead_page_audit` memory) + dead trees
+     (`components/investments/**`, `components/portfolio-constructor/**`,
+     `components/cap-table/scenario-manager.tsx`).
+   - **Transitively-dead** modules: a static import-graph BFS rooted at the Vite
+     entry `client/src/main.tsx` (resolving `@/` and relative specs, static +
+     `React.lazy` dynamic imports). Any target file NOT in the reachable set is
+     imported only by dead pages → excluded. 332 modules are reachable.
+
+**Reachability was spot-validated**: `CohortHeatMap`, `irr-summary`, and the
+capital-allocation `AllocationsTable` have zero importers;
+`exit-proceeds-recycling` and `optimal-reserves-ranking` are imported only by
+`pages/planning.tsx` (dead). The analyzer is sound — false-DEAD risk is low, but
+**re-run the reachability check at execution time** (the import graph drifts).
+
+## Transitively-DEAD exclusion list (42 files — DO NOT migrate)
+
+Load-bearing artifact: this is the expensive insight that prevents repeating the
+#771 waste (migrating dead pages). Keep dormant per team policy; do not delete.
+
+```
+components/recycling/exit-proceeds-recycling.tsx                         (K4)
+components/planning/graduation-rate-strategy.tsx                          (K6)
+components/planning/exit-analysis.tsx                                     (K5)
+components/performance/irr-summary.tsx
+components/cohorts/CohortHeatMap.tsx
+components/planning/portfolio-construction.tsx                           (K6)
+components/custom-fields/custom-fields-manager.tsx                       (K2)
+components/reports/mobile-tear-sheet.tsx
+components/reserves/optimal-reserves-ranking.tsx
+components/budget/budget-creator.tsx
+components/cohorts/CohortDefinitionSelector.tsx
+components/integrations/NotionIntegrationHub.tsx                         (K1)
+components/investment/fund-liquidation-warnings.tsx                      (K1)
+components/insights/data-driven-insights.tsx
+components/custom-fields/custom-fields-editor.tsx
+components/examples/KpiDashboardExample.tsx
+components/reports/tearsheet-customization.tsx                           (K3)
+components/reserves/ApprovalPanel.tsx
+components/cohorts/CoverageIndicator.tsx
+components/cohorts/SectorMappingUI.tsx
+components/ComingSoonPage.tsx
+components/modeling-wizard/steps/capital-allocation/AllocationsTable.tsx
+components/metrics/TargetMetricsSnapshot.tsx
+hooks/useFlags.tsx
+components/metrics/MetricsCard.tsx
+components/forecasting/portfolio-insights.tsx
+components/timeline/TimelineSlider.tsx
+components/modeling-wizard/steps/capital-allocation/PortfolioTable.tsx
+components/forecasting/investable-capital-summary.tsx
+components/metrics/VarianceBadge.tsx
+components/portfolio/SecondaryMarketAnalysis.tsx
+features/scenario/ScenarioCompareChart.tsx
+components/admin/AIUsageWidget.tsx
+components/DemoToolbar.tsx
+components/insights/OptimalReservesCard.tsx
+components/reserves/ReserveOpportunityTable.tsx
+utils/pdf/templates/QuarterlyTemplate.tsx
+components/modeling-wizard/steps/capital-allocation/CapitalHeader.tsx
+components/modeling-wizard/steps/capital-allocation/PortfolioConfigForm.tsx
+components/modeling-wizard/steps/capital-allocation/PortfolioSummary.tsx
+components/portfolio/moic-analysis.tsx
+utils/pdf/templates/K1Template.tsx
+```
+
+> Note: several areas are SPLIT (live + dead). E.g. `reports/reports.tsx` is
+> live but `reports/mobile-tear-sheet.tsx` is dead;
+> `performance/PerformanceDashboard` live, `performance/irr-summary` dead.
+> **Batches are area globs MINUS this dead list** — agents must operate on the
+> explicit per-batch manifest below, NOT a blanket `components/<area>/**` glob.
+
+## Canonical mapping
+
+Reuse the wave-2 spec Section 2 **verbatim** (legal vocabulary, hard
+constraints, the 8-step decision procedure, the affordance test, colorblind
+rule). Do not re-derive. Two clarifications surfaced by this census:
+
+- **indigo** is blue-family → rule 2 (charcoal, if it has an interactive
+  affordance) or rule 5 (presson-info, if static). It is NOT a rule-7 kill.
+- **`bg-white`/`text-white`** → `bg-pov-white`/`text-pov-white` (mechanical,
+  pixel identical). Migrate opportunistically; never a blocker.
+
+## Proposed partition (4 disjoint batches + residue)
+
+Disjoint file sets → can run as parallel Hermes agents on one branch (wave-2
+pattern). Each agent owns the explicit manifest, excludes shared layer
+(`components/{ui,layout,charts,dashboard,common}`), and flags
+shared-layer-blocked surfaces with `// TODO(design)` rather than touching them.
+
+| Batch  | Theme                                                                                                    | Files | Occ | KILL   | indigo |
+| ------ | -------------------------------------------------------------------------------------------------------- | ----- | --- | ------ | ------ |
+| **B2** | Portfolio construction (allocation/reserves/pipeline/cash/backtesting)                                   | 8     | 365 | **16** | 5      |
+| **B1** | Reporting + LP (lp/reports/performance/fund-results/lp-reporting)                                        | 14    | 326 | 6      | 4      |
+| **B3** | Analytics + misc components (analytics/results/sensitivity/monte-carlo/portfolio/cap-table/features/...) | 21    | 216 | 1      | 0      |
+| **B4** | Pages + app shell (pages/_, pages/v2/_, app/, lib/, utils/)                                              | 20    | 148 | 0      | 0      |
+| **R**  | Residue (hand-migrate, NOT auto-dispatch)                                                                | 9     | 41  | —      | —      |
+
+**B2 is the doctrine hotspot** (16 of 23 kills) — run/review it first.
+
+### B2 — Portfolio construction (8f / 365)
+
+```
+99      allocation/allocation-ui.tsx
+63  K5  allocation/sector-profile-builder.tsx
+47  K6  reserves/graduation-reserves-demo.tsx
+45  K2  cash-management/cash-management-dashboard.tsx
+43  K3  pipeline/DealCard.tsx
+42      backtesting/BacktestingWorkspace.tsx
+22      pipeline/ImportDealsModal.tsx
+4       pipeline/DroppableColumn.tsx
+```
+
+### B1 — Reporting + LP (14f / 326)
+
+```
+66      performance/PerformanceDashboard.tsx
+62      reports/reports.tsx
+35  K1  reports/tear-sheet-dashboard.tsx
+30  K2  lp/NotificationsWidget.tsx
+26  K1  lp/DashboardSummary.tsx
+22  K1  lp/DocumentsWidget.tsx
+21      lp/CapitalCallsWidget.tsx
+21  K1  lp/DistributionsWidget.tsx
+13      lp/PerformanceMetricsCard.tsx
+11      lp/CapitalAccountTable.tsx
+9       fund-results/FundModelScorecard.tsx
+5       lp-reporting/XirrDiagnosticPanel.tsx
+3       fund-results/ReserveAllocationBreakdown.tsx
+2       lp-reporting/MetricsCards.tsx
+```
+
+### B3 — Analytics + misc (21f / 216)
+
+```
+53  analytics/VarianceChart.tsx          25  ErrorBoundary.tsx
+22  analytics/TimelineChart.tsx          12  analytics/StatCard.tsx
+12  results/EvidenceHeader.tsx           12  features/analytics-parity/QuarterlyReviewTrace.tsx
+11  analytics/AnalyticsErrorBoundary.tsx  9  results/scenario-evidence.ts
+8   analytics/ErrorState.tsx              8  cap-table/cap-table-calculator.tsx
+8   monte-carlo/MetricDistributionChart.tsx  6  sensitivity/OneWayPanel.tsx
+5   portfolio/portfolio-analytics-dashboard.tsx  5  sharing/ShareConfigModal.tsx
+4   monte-carlo/CalibrationStatusCard.tsx  4  portfolio/benchmarking-dashboard.tsx
+3   sensitivity/TwoWayPanel.tsx           3  StagingRibbon.tsx
+2   cap-table/safe-note-editor.tsx        2  demo/DemoBanner.tsx (K1)
+2   portfolio/tag-performance-analysis.tsx
+```
+
+### B4 — Pages + shell (20f / 148)
+
+```
+18  pages/FundBasicsStep.tsx     17  pages/v2/today.tsx     14  pages/v2/cash.tsx
+12  pages/help.tsx               10  pages/settings.tsx     10  pages/v2/company.tsx
+9   app/app-router.tsx           8   lib/fund-header-metric-calculations.ts
+7   app/app-layout.tsx           6   pages/InvestmentRoundsStepV2.tsx
+6   pages/v2/insights.tsx        6   pages/v2/portfolio.tsx  5  pages/steps/StepNotFound.tsx
+5   utils/pdf/chart-export.ts    4   pages/not-found.tsx     3  lib/reallocation-utils.ts
+3   lib/toast.ts                 2   app/app-routes.tsx
+2   utils/pdf/components/PdfMetricCard.tsx   1  pages/v2/exits.tsx
+```
+
+### R — Residue (9f / 41 — hand-migrate)
+
+Files inside already-swept globs (wave-2 Agent W / #773) or carrying TODO
+markers. These are the hard/adjudicated cases; auto-migration is poor at them.
+Review by hand, do not dispatch to Codex.
+
+```
+13  wizard/StageAccordionRow.tsx      5  pages/reports.tsx (residual)
+4   wizard/ModernStepContainer.tsx    4  wizard/ProfileHeader.tsx
+4   wizard/SectorProfileSwitcher.tsx  4  pages/fund-setup.tsx (residual)
+4   pages/performance.tsx (residual)  3  wizard/WizardCard.tsx
+0   sensitivity/StressPanel.tsx       (TODO(a11y) only — belongs to follow-up #4, not here)
+```
+
+## Special cases & guardrails
+
+- **Charts**: categorical series → `getChartColor()` / `presson.color.*`,
+  fixed-order palette, **≤6 hues** (rule 4b). Existing `// TODO(design)` >6-hue
+  deferrals (`charts/fund-expense-charts`, `dashboard/portfolio-concentration`)
+  are shared-layer — out of scope.
+- **a11y**: sole-color gain/loss → `// TODO(a11y)` only (defer to follow-up #4,
+  its own PR). StressPanel already carries this marker.
+- **shadcn semantic tokens** (`bg-muted`, `border-input`, `*-foreground`,
+  `ring-ring`) are NOT numbered-palette and are correctly excluded — do not
+  rewrite primitives (the #772 lesson; see
+  `feedback_token_migration_shadcn_exclusion`).
+- **Sanctioned arbitrary-hex tags** (muted teal/lavender/orange/pink
+  classification chips) are the TARGET vocabulary — leave them; do not
+  neutralize.
+- **white** (`bg-white`/`text-white`) is cosmetic — migrate opportunistically
+  only.
+
+## Risks
+
+| ID  | Risk                                                     | Mitigation                                                                                                         |
+| --- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| R1  | False-DEAD (live file misread as dead → under-migration) | Re-run `main.tsx` reachability + grep importers at execution; analyzer spot-validated                              |
+| R2  | Auto-migration churns the hard residue                   | Residue (batch R) is hand-migrated, never dispatched                                                               |
+| R3  | Cross-batch token inconsistency                          | Shared wave-2 Sec 2 mapping + reviewer cross-surface cohesion diff                                                 |
+| R4  | Test asserts an old raw color                            | Grep touched files' tests for old values before push (the StressPanel #774 lesson)                                 |
+| R5  | Blanket `area/**` glob sweeps a dead sibling             | Agents use the explicit per-batch manifest, not area globs                                                         |
+| R6  | Self-promotion to the calc gate                          | Keep the `--task` string finance-keyword-free; detail in `.hermes-*.md`; dry-run must show `risk:standard score:0` |
+
+## Acceptance
+
+Reuse wave-2 spec Section 5 acceptance criteria (AC#1–10) per batch. Plus: a
+final re-census (this methodology) over live surfaces returns **0** off-token
+classes except explicit `// TODO(design)`/`// TODO(a11y)` escalations → rollout
+100% done.
+
+## Next step (requires explicit approval — NOT taken)
+
+On approval: re-verify reachability, then `writing-plans` to produce the
+executable plan (per-batch `.hermes-*.md` + branch/PR checklist). B2 first
+(doctrine hotspot). Do not launch Hermes or writing-plans from this scope doc
+alone.

--- a/tests/unit/components/pipeline/DroppableColumn.test.tsx
+++ b/tests/unit/components/pipeline/DroppableColumn.test.tsx
@@ -71,7 +71,7 @@ describe('DroppableColumn', () => {
     // The droppable area (second child div) gets ring-2 when highlighted
     const droppableArea = container.querySelector('.ring-2');
     expect(droppableArea).not.toBeNull();
-    expect(droppableArea?.className).toContain('ring-blue-200');
+    expect(droppableArea?.className).toContain('ring-pov-charcoal');
   });
 
   it('shows empty state when dealCount is 0', () => {


### PR DESCRIPTION
## Summary

Wave-3 of the Theme-2 token rollout: the **scope** for the remaining long tail,
plus execution of its first batch (**B2 — portfolio-construction surfaces**).

Two commits:
1. `docs(rollout): wave-3 long-tail census sweep scope` — reproducible census of
   the remaining live raw-color surfaces (71 files / 1096 occ), the verbatim
   42-file transitively-dead exclusion list, methodology, and a 4-batch partition.
2. `design(rollout): wave 3 B2 ...` — migrates the 8 live portfolio-construction
   component files to canonical Press On Ventures tokens.

## B2 files migrated (8)

`allocation/allocation-ui`, `allocation/sector-profile-builder`,
`reserves/graduation-reserves-demo`, `cash-management/cash-management-dashboard`,
`pipeline/DealCard`, `pipeline/ImportDealsModal`, `pipeline/DroppableColumn`,
`backtesting/BacktestingWorkspace`.

## What the migration does

- **Kills purple/violet/indigo** and re-resolves by intent (cash "Active
  Categories" → neutral charcoal; deal/round badges → muted-tag palette; reserves
  "Dynamic Calculation" → presson-info).
- **Preserves financial direction** (rule 4a): MOIC / capital utilization →
  `presson-positive`; balance deltas, variances, inflow/outflow →
  `presson-positive`/`presson-negative` (each paired with a `+`/`-` sign — no
  color-only encoding introduced).
- **Status** → success/warning/error (run phases, import results, deal
  closed/passed). Informational accents → presson-info.
- **Neutral ramp** gray → `charcoal-{400..700}`/`pov-charcoal` (hierarchy
  preserved); warm borders (`border-beige-200`, `border-charcoal/7`);
  `tabular-nums` kept.
- **Charts** → categorical series via `presson.color` fixed-order palette, ≤6 hues.
- Sanctioned muted-tag classification chips preserved; **shadcn primitives
  untouched**.

## Verification

- Every emitted token class verified to resolve in `tailwind.config.ts` (catches
  silent nonexistent-class renders that `tsc` cannot).
- `npm run check` — 0 new TS errors.
- 14 targeted tests pass (DroppableColumn, DraggableDealCard, sensitivity-analysis).
- Reviewer fixes: DroppableColumn test stale `ring-blue-200` → `ring-pov-charcoal`;
  sector-profile "Success Rate" `success` → `presson-positive` (rule 4a + resolves
  the two-green collision).

## Eyeball on the Vercel preview (judgment calls left for visual confirm)

- `bg-yellow-50` editable inputs → `bg-warning/10` (~16 fields in allocation-ui +
  sector-profile): editable-field highlight reframed as warning token (faint amber).
- Reserve scenario identity colors use financial tokens for categorical identity.
- Both reserve KPI cards collapsed to `presson-info`.

All legal tokens; none block. Flagged for the preview eyeball.
