### PR TITLE
design(rollout): wave 3 B1+B3+B4 - long-tail token migration

### DIFF
--- a/client/src/app/app-layout.tsx
+++ b/client/src/app/app-layout.tsx
@@ -65,7 +65,9 @@ function EnabledMobileNavigationItem({
       aria-label={item.label}
       aria-current={isActive ? 'page' : undefined}
       className={`flex min-w-0 items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-beige focus-visible:ring-offset-2 ${
-        isActive ? 'bg-slate-900 text-white' : 'text-charcoal/70 hover:bg-slate-100 hover:text-charcoal'
+        isActive
+          ? 'bg-pov-charcoal text-pov-white'
+          : 'text-charcoal/70 hover:bg-pov-gray hover:text-charcoal'
       }`}
     >
       <Icon className="h-4 w-4 flex-shrink-0" />
@@ -123,7 +125,7 @@ export function MobileNavigation({
   const items = [...getNavigationItems(), ...getFooterNavigationItems()];
 
   return (
-    <nav className="md:hidden border-b border-slate-200 bg-white px-3 py-2" aria-label="Mobile">
+    <nav className="md:hidden border-b border-beige-200 bg-pov-white px-3 py-2" aria-label="Mobile">
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {items.map((item) => (
           <MobileNavigationItem
@@ -143,13 +145,13 @@ function MobileNavigationToggle({ isOpen, onToggle }: { isOpen: boolean; onToggl
   const Icon = isOpen ? X : Menu;
 
   return (
-    <div className="md:hidden border-b border-slate-200 bg-white px-3 py-2">
+    <div className="md:hidden border-b border-beige-200 bg-pov-white px-3 py-2">
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
         aria-controls="mobile-app-navigation"
-        className="inline-flex min-h-10 items-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-charcoal shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-beige focus-visible:ring-offset-2"
+        className="inline-flex min-h-10 items-center gap-2 rounded-md border border-beige-200 px-3 py-2 text-sm font-medium text-charcoal shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-beige focus-visible:ring-offset-2"
       >
         <Icon className="h-4 w-4" />
         Navigation
@@ -165,7 +167,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const isFundSetupRoute = location.startsWith('/fund-setup');
 
   return (
-    <div className="flex min-h-screen flex-col overflow-x-hidden bg-slate-50 font-poppins text-charcoal">
+    <div className="flex min-h-screen flex-col overflow-x-hidden bg-pov-gray font-poppins text-charcoal">
       {isFundSetupRoute ? <FundConstructionKpiHeader /> : <DynamicFundHeader />}
       <MobileNavigationToggle
         isOpen={isMobileNavigationOpen}
@@ -181,7 +183,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
       )}
       <div className="flex min-w-0 flex-1">
         <Sidebar activeModule={activeModule} className="hidden md:flex" />
-        <main className="min-w-0 flex-1 overflow-auto bg-slate-50">{children}</main>
+        <main className="min-w-0 flex-1 overflow-auto bg-pov-gray">{children}</main>
       </div>
     </div>
   );

--- a/client/src/app/app-router.tsx
+++ b/client/src/app/app-router.tsx
@@ -40,7 +40,7 @@ function HomeRoute() {
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600"></div>
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-pov-charcoal"></div>
       </div>
     );
   }
@@ -60,7 +60,7 @@ function ProtectedRoute({ component: Component, ...props }: ProtectedRouteProps)
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600"></div>
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-pov-charcoal"></div>
       </div>
     );
   }
@@ -68,20 +68,20 @@ function ProtectedRoute({ component: Component, ...props }: ProtectedRouteProps)
   if (fundLoadError && requiresFundContextRecovery(location)) {
     return (
       <main className="flex-1 overflow-y-auto p-6 custom-scrollbar">
-        <div className="max-w-2xl rounded-lg border border-red-200 bg-red-50 p-6 text-red-950">
+        <div className="max-w-2xl rounded-lg border border-error/50 bg-error/10 p-6 text-error-dark">
           <h1 className="text-2xl font-semibold">Unable to load fund context</h1>
-          <p className="mt-2 text-sm text-red-900">
+          <p className="mt-2 text-sm text-error-dark">
             The fund list could not be loaded, so this workspace cannot determine whether setup is
             required. Retry once the API is reachable.
           </p>
           {fundLoadErrorMessage && (
-            <p className="mt-3 rounded-md bg-white/70 px-3 py-2 font-mono text-xs text-red-900">
+            <p className="mt-3 rounded-md bg-pov-white/70 px-3 py-2 font-mono text-xs text-error-dark">
               {fundLoadErrorMessage}
             </p>
           )}
           <button
             type="button"
-            className="mt-4 rounded-md bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800"
+            className="mt-4 rounded-md bg-pov-charcoal px-4 py-2 text-sm font-medium text-pov-white hover:bg-charcoal-700"
             onClick={() => queryClient.invalidateQueries({ queryKey: ['/api/funds'] })}
           >
             Retry loading funds

--- a/client/src/app/app-routes.tsx
+++ b/client/src/app/app-routes.tsx
@@ -163,8 +163,8 @@ export function PageLoadingFallback() {
   return (
     <div className="flex-1 flex items-center justify-center min-h-screen">
       <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-        <p className="text-gray-600">Loading page...</p>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pov-charcoal mx-auto mb-4"></div>
+        <p className="text-charcoal-600">Loading page...</p>
       </div>
     </div>
   );

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -54,23 +54,23 @@ export class ErrorBoundary extends Component<Props, State> {
 
       // Default error UI
       return (
-        <Card className="border-red-200 bg-red-50">
+        <Card className="border-error/50 bg-error/10">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-red-800">
+            <CardTitle className="flex items-center gap-2 text-error-dark">
               <AlertCircle className="h-5 w-5" />
               Something went wrong
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <p className="text-red-700">
+            <p className="text-error-dark">
               An unexpected error occurred while rendering this component.
             </p>
 
             {import.meta.env.DEV && this.state.error && (
-              <div className="bg-red-100 border border-red-300 rounded p-3">
-                <p className="text-sm font-mono text-red-800">{this.state.error.toString()}</p>
+              <div className="bg-error/10 border border-error/50 rounded p-3">
+                <p className="text-sm font-mono text-error-dark">{this.state.error.toString()}</p>
                 {this.state.errorInfo?.componentStack && (
-                  <pre className="text-xs text-red-700 mt-2 overflow-x-auto">
+                  <pre className="text-xs text-error-dark mt-2 overflow-x-auto">
                     {this.state.errorInfo.componentStack}
                   </pre>
                 )}
@@ -120,11 +120,11 @@ export function ChartErrorBoundary({
   return (
     <ErrorBoundary
       fallback={
-        <div className="h-64 flex items-center justify-center border border-gray-200 rounded-lg bg-gray-50">
+        <div className="h-64 flex items-center justify-center border border-beige-200 rounded-lg bg-pov-gray">
           <div className="text-center">
-            <AlertCircle className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-            <p className="text-sm text-gray-600">Chart temporarily unavailable</p>
-            <p className="text-xs text-gray-500 mt-1">
+            <AlertCircle className="h-8 w-8 text-charcoal-400 mx-auto mb-2" />
+            <p className="text-sm text-charcoal-600">Chart temporarily unavailable</p>
+            <p className="text-xs text-charcoal-500 mt-1">
               {chartName ? `${chartName} data is being processed` : 'Data is being processed'}
             </p>
           </div>
@@ -154,11 +154,11 @@ export function FormErrorBoundary({
   return (
     <ErrorBoundary
       fallback={
-        <Card className="border-amber-200 bg-amber-50">
+        <Card className="border-warning/50 bg-warning/10">
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <AlertCircle className="h-4 w-4 text-amber-600" />
-              <p className="text-sm text-amber-800">
+              <AlertCircle className="h-4 w-4 text-warning-dark" />
+              <p className="text-sm text-warning-dark">
                 {formName ? `${formName} form` : 'Form'} encountered an error. Your data has been
                 preserved.
               </p>
@@ -167,7 +167,7 @@ export function FormErrorBoundary({
               onClick={() => window.location.reload()}
               variant="outline"
               size="sm"
-              className="mt-2 text-amber-700 border-amber-300 hover:bg-amber-100"
+              className="mt-2 text-warning-dark border-warning/50 hover:bg-warning/10"
             >
               Refresh to continue
             </Button>
@@ -207,15 +207,15 @@ export function CalculationErrorBoundary({
     <ErrorBoundary
       fallback={
         fallbackValue || (
-          <div className="p-3 border border-blue-200 bg-blue-50 rounded">
+          <div className="p-3 border border-presson-info/30 bg-presson-info/10 rounded">
             <div className="flex items-center space-x-2">
-              <AlertCircle className="h-4 w-4 text-blue-600" />
-              <p className="text-sm text-blue-800">
+              <AlertCircle className="h-4 w-4 text-presson-info" />
+              <p className="text-sm text-presson-info">
                 {calculationType ? `${calculationType} calculation` : 'Calculation'} temporarily
                 unavailable
               </p>
             </div>
-            <p className="text-xs text-blue-600 mt-1">Using cached results or default values</p>
+            <p className="text-xs text-presson-info mt-1">Using cached results or default values</p>
           </div>
         )
       }

--- a/client/src/components/StagingRibbon.tsx
+++ b/client/src/components/StagingRibbon.tsx
@@ -31,14 +31,14 @@ export function StagingRibbon() {
   };
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 bg-amber-500 text-amber-950 px-4 py-2 flex items-center justify-center gap-3 shadow-md">
+    <div className="fixed top-0 left-0 right-0 z-50 bg-warning text-pov-white px-4 py-2 flex items-center justify-center gap-3 shadow-md">
       <AlertTriangle className="h-4 w-4 flex-shrink-0" />
       <span className="text-sm font-medium">
         STAGING ENVIRONMENT - For testing purposes only
       </span>
       <button
         onClick={handleDismiss}
-        className="ml-auto p-1 hover:bg-amber-600/20 rounded-md transition-colors"
+        className="ml-auto p-1 hover:bg-pov-white/20 rounded-md transition-colors"
         aria-label="Dismiss staging banner"
       >
         <X className="h-4 w-4" />

--- a/client/src/components/analytics/AnalyticsErrorBoundary.tsx
+++ b/client/src/components/analytics/AnalyticsErrorBoundary.tsx
@@ -118,20 +118,20 @@ function AnalyticsErrorFallback({ error, onRetry }: AnalyticsErrorFallbackProps)
     <div className="min-h-[400px] flex items-center justify-center p-6">
       <Card className="max-w-2xl w-full">
         <CardHeader className="text-center">
-          <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
-            <AlertTriangle className="w-8 h-8 text-red-600" />
+          <div className="mx-auto w-16 h-16 bg-error/10 rounded-full flex items-center justify-center mb-4">
+            <AlertTriangle className="w-8 h-8 text-error" />
           </div>
-          <CardTitle className="text-xl font-semibold text-gray-900">{title}</CardTitle>
+          <CardTitle className="text-xl font-semibold text-pov-charcoal">{title}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          <p className="text-center text-gray-600">{message}</p>
+          <p className="text-center text-charcoal-600">{message}</p>
 
           {error && (
-            <details className="bg-gray-50 p-4 rounded-lg">
-              <summary className="cursor-pointer text-sm font-medium text-gray-700 mb-2">
+            <details className="bg-pov-gray p-4 rounded-lg">
+              <summary className="cursor-pointer text-sm font-medium text-charcoal-700 mb-2">
                 Technical Details
               </summary>
-              <pre className="text-xs text-gray-600 bg-white p-3 rounded border overflow-auto">
+              <pre className="text-xs text-charcoal-600 bg-pov-white p-3 rounded border overflow-auto">
                 {error.message}
                 {error.stack && <div className="mt-2 pt-2 border-t">{error.stack}</div>}
               </pre>
@@ -139,12 +139,12 @@ function AnalyticsErrorFallback({ error, onRetry }: AnalyticsErrorFallbackProps)
           )}
 
           {suggestions.length > 0 && (
-            <div className="bg-blue-50 p-4 rounded-lg">
-              <h4 className="font-medium text-blue-900 mb-2">Try these solutions:</h4>
-              <ul className="space-y-1 text-sm text-blue-800">
+            <div className="bg-presson-info/10 p-4 rounded-lg">
+              <h4 className="font-medium text-presson-info mb-2">Try these solutions:</h4>
+              <ul className="space-y-1 text-sm text-presson-info">
                 {suggestions.map((suggestion: string, index: number) => (
                   <li key={index} className="flex items-start">
-                    <span className="w-2 h-2 bg-blue-400 rounded-full mt-2 mr-2 flex-shrink-0" />
+                    <span className="w-2 h-2 bg-presson-info rounded-full mt-2 mr-2 flex-shrink-0" />
                     {suggestion}
                   </li>
                 ))}

--- a/client/src/components/analytics/ErrorState.tsx
+++ b/client/src/components/analytics/ErrorState.tsx
@@ -27,13 +27,13 @@ export function ErrorState({
   return (
     <Card className={className}>
       <CardHeader className="text-center">
-        <div className="mx-auto w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mb-4">
-          <AlertTriangle className="w-6 h-6 text-red-600" />
+        <div className="mx-auto w-12 h-12 bg-error/10 rounded-full flex items-center justify-center mb-4">
+          <AlertTriangle className="w-6 h-6 text-error" />
         </div>
-        <CardTitle className="text-lg font-semibold text-gray-900">{title}</CardTitle>
+        <CardTitle className="text-lg font-semibold text-pov-charcoal">{title}</CardTitle>
       </CardHeader>
       <CardContent className="text-center space-y-4">
-        <p className="text-gray-600">{message}</p>
+        <p className="text-charcoal-600">{message}</p>
 
         {showDetails && errorMessage && (
           <Alert variant="destructive" className="text-left">
@@ -121,11 +121,11 @@ export function EmptyState({
   return (
     <Card className={className}>
       <CardContent className="text-center py-12">
-        <div className="mx-auto w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mb-4">
-          <AlertTriangle className="w-6 h-6 text-gray-400" />
+        <div className="mx-auto w-12 h-12 bg-pov-gray rounded-full flex items-center justify-center mb-4">
+          <AlertTriangle className="w-6 h-6 text-charcoal-400" />
         </div>
-        <h3 className="text-lg font-semibold text-gray-900 mb-2">{title}</h3>
-        <p className="text-gray-600 mb-6">{message}</p>
+        <h3 className="text-lg font-semibold text-pov-charcoal mb-2">{title}</h3>
+        <p className="text-charcoal-600 mb-6">{message}</p>
 
         {actionLabel && onAction && (
           <Button onClick={onAction} variant="default">

--- a/client/src/components/analytics/StatCard.tsx
+++ b/client/src/components/analytics/StatCard.tsx
@@ -38,10 +38,10 @@ export function StatCard({
       <Card className={className}>
         <CardContent className="p-6">
           <div className="flex items-center space-x-4">
-            <div className="w-10 h-10 bg-gray-200 rounded-full animate-pulse" />
+            <div className="w-10 h-10 bg-pov-gray rounded-full animate-pulse" />
             <div className="space-y-2 flex-1">
-              <div className="h-4 w-16 bg-gray-200 rounded animate-pulse" />
-              <div className="h-6 w-24 bg-gray-200 rounded animate-pulse" />
+              <div className="h-4 w-16 bg-pov-gray rounded animate-pulse" />
+              <div className="h-6 w-24 bg-pov-gray rounded animate-pulse" />
             </div>
           </div>
         </CardContent>
@@ -65,29 +65,29 @@ export function StatCard({
   const getTrendColor = () => {
     switch (trend?.direction) {
       case 'up':
-        return 'text-green-600';
+        return 'text-presson-positive';
       case 'down':
-        return 'text-red-600';
+        return 'text-presson-negative';
       case 'neutral':
-        return 'text-gray-600';
+        return 'text-charcoal-600';
       default:
-        return 'text-gray-600';
+        return 'text-charcoal-600';
     }
   };
 
   return (
     <Card className={cn("hover:shadow-md transition-shadow", className)}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium text-gray-600">{title}</CardTitle>
+        <CardTitle className="text-sm font-medium text-charcoal-600">{title}</CardTitle>
         {Icon && (
-          <div className="w-4 h-4 text-gray-400">
+          <div className="w-4 h-4 text-charcoal-400">
             <Icon className="w-4 h-4" />
           </div>
         )}
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-baseline justify-between">
-          <div className="text-2xl font-bold text-gray-900">
+          <div className="text-2xl font-bold text-pov-charcoal">
             {typeof value === 'number' && value > 1000000
               ? `$${(value / 1000000).toFixed(1)}M`
               : typeof value === 'number' && value > 1000
@@ -106,12 +106,12 @@ export function StatCard({
           <div className={cn("flex items-center space-x-1 text-sm", getTrendColor())}>
             {getTrendIcon()}
             <span className="font-medium">{trend.value > 0 ? '+' : ''}{trend.value}%</span>
-            <span className="text-gray-500">{trend.label}</span>
+            <span className="text-charcoal-500">{trend.label}</span>
           </div>
         )}
 
         {description && (
-          <p className="text-xs text-gray-500">{description}</p>
+          <p className="text-xs text-charcoal-500">{description}</p>
         )}
       </CardContent>
     </Card>

--- a/client/src/components/analytics/TimelineChart.tsx
+++ b/client/src/components/analytics/TimelineChart.tsx
@@ -4,6 +4,12 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { format, parseISO, isValid } from 'date-fns';
 
+const CHART_GRID_COLOR = '#E0D8D1';
+const CHART_AXIS_COLOR = '#5A5A5A';
+const CHART_DATA_COLOR = '#2563EB';
+const CHART_REFERENCE_COLOR = '#9C6F19';
+const CHART_BACKGROUND_COLOR = '#FFFFFF';
+
 interface TimelineDataPoint {
   timestamp: string;
   value: number;
@@ -55,13 +61,13 @@ export function TimelineChart({
     if (active && payload && payload.length) {
       const data = payload[0]!.payload;
       return (
-        <div className="bg-white p-3 border border-gray-200 rounded-lg shadow-lg">
-          <p className="font-medium text-gray-900">{data.formattedDate}</p>
-          <p className="text-sm text-gray-600">
+        <div className="bg-pov-white p-3 border border-beige-200 rounded-lg shadow-lg">
+          <p className="font-medium text-pov-charcoal">{data.formattedDate}</p>
+          <p className="text-sm text-charcoal-600">
             Value: <span className="font-medium">{valueFormatter(payload[0]!.value)}</span>
           </p>
           {data.label && (
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-charcoal-600">
               Event: <span className="font-medium">{data.label}</span>
             </p>
           )}
@@ -80,11 +86,11 @@ export function TimelineChart({
     return (
       <Card className={className}>
         <CardHeader>
-          <div className="h-6 w-48 bg-gray-200 rounded animate-pulse" />
-          {description && <div className="h-4 w-72 bg-gray-200 rounded animate-pulse mt-2" />}
+          <div className="h-6 w-48 bg-pov-gray rounded animate-pulse" />
+          {description && <div className="h-4 w-72 bg-pov-gray rounded animate-pulse mt-2" />}
         </CardHeader>
         <CardContent>
-          <div style={{ height }} className="w-full bg-gray-100 rounded animate-pulse" />
+          <div style={{ height }} className="w-full bg-pov-gray rounded animate-pulse" />
         </CardContent>
       </Card>
     );
@@ -98,7 +104,7 @@ export function TimelineChart({
           {description && <CardDescription>{description}</CardDescription>}
         </CardHeader>
         <CardContent>
-          <div style={{ height }} className="w-full flex items-center justify-center text-gray-500">
+          <div style={{ height }} className="w-full flex items-center justify-center text-charcoal-500">
             No timeline data available
           </div>
         </CardContent>
@@ -116,19 +122,19 @@ export function TimelineChart({
         <div style={{ height }} className="w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={processedData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
               <XAxis
                 dataKey="timestamp"
                 domain={['dataMin', 'dataMax']}
                 scale="time"
                 type="number"
                 tickFormatter={(timestamp: number) => format(new Date(timestamp), 'MMM dd')}
-                stroke="#6b7280"
+                stroke={CHART_AXIS_COLOR}
                 fontSize={12}
               />
               <YAxis
                 tickFormatter={valueFormatter as (value: number) => string}
-                stroke="#6b7280"
+                stroke={CHART_AXIS_COLOR}
                 fontSize={12}
               />
               <Tooltip content={<CustomTooltip />} />
@@ -136,7 +142,7 @@ export function TimelineChart({
               {showBaseline && baselineValue && (
                 <ReferenceLine
                   y={baselineValue}
-                  stroke="#dc2626"
+                  stroke={CHART_REFERENCE_COLOR}
                   strokeDasharray="5 5"
                   label={{ value: baselineLabel, position: "top" }}
                 />
@@ -145,10 +151,10 @@ export function TimelineChart({
               <Line
                 type="monotone"
                 dataKey="value"
-                stroke="#2563eb"
+                stroke={CHART_DATA_COLOR}
                 strokeWidth={2}
-                dot={{ fill: '#2563eb', strokeWidth: 2, r: 4 }}
-                activeDot={{ r: 6, stroke: '#2563eb', strokeWidth: 2, fill: '#ffffff' }}
+                dot={{ fill: CHART_DATA_COLOR, strokeWidth: 2, r: 4 }}
+                activeDot={{ r: 6, stroke: CHART_DATA_COLOR, strokeWidth: 2, fill: CHART_BACKGROUND_COLOR }}
               />
             </LineChart>
           </ResponsiveContainer>
@@ -195,9 +201,9 @@ export function EventTimelineChart({
     if (active && payload && payload.length) {
       const event = payload[0]!.payload;
       return (
-        <div className="bg-white p-3 border border-gray-200 rounded-lg shadow-lg">
-          <p className="font-medium text-gray-900">{event.label}</p>
-          <p className="text-sm text-gray-600">{event.formattedDate}</p>
+        <div className="bg-pov-white p-3 border border-beige-200 rounded-lg shadow-lg">
+          <p className="font-medium text-pov-charcoal">{event.label}</p>
+          <p className="text-sm text-charcoal-600">{event.formattedDate}</p>
           <Badge variant="outline" className="mt-1">
             {event.type}
           </Badge>
@@ -217,14 +223,14 @@ export function EventTimelineChart({
         <div style={{ height }} className="w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={processedEvents} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
               <XAxis
                 dataKey="timestamp"
                 domain={['dataMin', 'dataMax']}
                 scale="time"
                 type="number"
                 tickFormatter={(timestamp: number) => format(new Date(timestamp), 'MMM dd')}
-                stroke="#6b7280"
+                stroke={CHART_AXIS_COLOR}
                 fontSize={12}
               />
               <YAxis hide />
@@ -234,7 +240,7 @@ export function EventTimelineChart({
                 type="monotone"
                 dataKey="y"
                 stroke="none"
-                dot={{ fill: '#2563eb', strokeWidth: 2, r: 6 }}
+                dot={{ fill: CHART_DATA_COLOR, strokeWidth: 2, r: 6 }}
               />
             </LineChart>
           </ResponsiveContainer>

--- a/client/src/components/analytics/VarianceChart.tsx
+++ b/client/src/components/analytics/VarianceChart.tsx
@@ -35,6 +35,16 @@ type ProcessedVarianceDataPoint = VarianceDataPoint & {
   severityColor: string;
 };
 
+const UI_SUCCESS_COLOR = '#10b981';
+const UI_ERROR_COLOR = '#ef4444';
+const CHART_GRID_COLOR = '#E0D8D1';
+const CHART_AXIS_COLOR = '#5A5A5A';
+const CHART_BASELINE_COLOR = CHART_GRID_COLOR;
+const CHART_ACTUAL_COLOR = '#2563EB';
+const CHART_REFERENCE_COLOR = '#9C6F19';
+const CHART_VARIANCE_COLOR = '#B00020';
+const CHART_BACKGROUND_COLOR = '#FFFFFF';
+
 interface VarianceChartProps {
   data: VarianceDataPoint[];
   title: string;
@@ -50,11 +60,11 @@ interface VarianceChartProps {
 
 function getSeverityColor(severity?: string) {
   switch (severity) {
-    case 'critical': return '#dc2626';
-    case 'high': return '#ea580c';
-    case 'medium': return '#d97706';
-    case 'low': return '#16a34a';
-    default: return '#6b7280';
+    case 'critical': return UI_ERROR_COLOR;
+    case 'high': return CHART_REFERENCE_COLOR;
+    case 'medium': return CHART_REFERENCE_COLOR;
+    case 'low': return UI_SUCCESS_COLOR;
+    default: return CHART_AXIS_COLOR;
   }
 }
 
@@ -90,22 +100,22 @@ export function VarianceChart({
     if (active && payload && payload.length && payload[0]) {
       const data = payload[0].payload;
       return (
-        <div className="bg-white p-4 border border-gray-200 rounded-lg shadow-lg">
-          <p className="font-medium text-gray-900 mb-2">{data.metric}</p>
+        <div className="bg-pov-white p-4 border border-beige-200 rounded-lg shadow-lg">
+          <p className="font-medium text-pov-charcoal mb-2">{data.metric}</p>
           <div className="space-y-1 text-sm">
             <div className="flex justify-between">
-              <span className="text-gray-600">Baseline:</span>
+              <span className="text-charcoal-600">Baseline:</span>
               <span className="font-medium">{valueFormatter(data.baseline)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Actual:</span>
+              <span className="text-charcoal-600">Actual:</span>
               <span className="font-medium">{valueFormatter(data.actual)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Variance:</span>
+              <span className="text-charcoal-600">Variance:</span>
               <span className={cn(
                 "font-medium",
-                data.variance > 0 ? "text-green-600" : "text-red-600"
+                data.variance > 0 ? "text-presson-positive" : "text-presson-negative"
               )}>
                 {data.variance > 0 ? '+' : ''}{data.variancePercent.toFixed(1)}%
               </span>
@@ -116,10 +126,10 @@ export function VarianceChart({
               variant="outline"
               className={cn(
                 "mt-2",
-                data.severity === 'critical' && "border-red-500 text-red-700",
-                data.severity === 'high' && "border-orange-500 text-orange-700",
-                data.severity === 'medium' && "border-yellow-500 text-yellow-700",
-                data.severity === 'low' && "border-green-500 text-green-700"
+                data.severity === 'critical' && "border-error/50 text-error-dark",
+                data.severity === 'high' && "border-warning/50 text-warning-dark",
+                data.severity === 'medium' && "border-warning/50 text-warning-dark",
+                data.severity === 'low' && "border-success/50 text-success-dark"
               )}
             >
               {data.severity}
@@ -135,11 +145,11 @@ export function VarianceChart({
     return (
       <Card className={className}>
         <CardHeader>
-          <div className="h-6 w-48 bg-gray-200 rounded animate-pulse" />
-          {description && <div className="h-4 w-72 bg-gray-200 rounded animate-pulse mt-2" />}
+          <div className="h-6 w-48 bg-pov-gray rounded animate-pulse" />
+          {description && <div className="h-4 w-72 bg-pov-gray rounded animate-pulse mt-2" />}
         </CardHeader>
         <CardContent>
-          <div style={{ height }} className="w-full bg-gray-100 rounded animate-pulse" />
+          <div style={{ height }} className="w-full bg-pov-gray rounded animate-pulse" />
         </CardContent>
       </Card>
     );
@@ -153,7 +163,7 @@ export function VarianceChart({
           {description && <CardDescription>{description}</CardDescription>}
         </CardHeader>
         <CardContent>
-          <div style={{ height }} className="w-full flex items-center justify-center text-gray-500">
+          <div style={{ height }} className="w-full flex items-center justify-center text-charcoal-500">
             No variance data available
           </div>
         </CardContent>
@@ -165,18 +175,18 @@ export function VarianceChart({
     if (chartType === 'scatter') {
       return (
         <ScatterChart data={processedData} margin={{ top: 20, right: 30, bottom: 60, left: 20 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
           <XAxis
             dataKey="baseline"
             tickFormatter={valueFormatter}
-            stroke="#6b7280"
+            stroke={CHART_AXIS_COLOR}
             fontSize={12}
             label={{ value: 'Baseline', position: 'bottom', offset: -5 }}
           />
           <YAxis
             dataKey="actual"
             tickFormatter={valueFormatter}
-            stroke="#6b7280"
+            stroke={CHART_AXIS_COLOR}
             fontSize={12}
             label={{ value: 'Actual', angle: -90, position: 'insideLeft' }}
           />
@@ -185,7 +195,7 @@ export function VarianceChart({
           {showVarianceBands && (
             <>
               <ReferenceLine
-                stroke="#dc2626"
+                stroke={CHART_AXIS_COLOR}
                 strokeDasharray="5 5"
                 segment={[
                   { x: Math.min(...processedData.map(d => d.baseline)), y: Math.min(...processedData.map(d => d.baseline)) },
@@ -197,7 +207,7 @@ export function VarianceChart({
 
           <Scatter
             dataKey="actual"
-            fill="#2563eb"
+            fill={CHART_ACTUAL_COLOR}
           />
         </ScatterChart>
       );
@@ -205,26 +215,26 @@ export function VarianceChart({
 
     return (
       <ComposedChart data={processedData} margin={{ top: 20, right: 30, bottom: 60, left: 20 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+        <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="formattedMetric"
           angle={-45}
           textAnchor="end"
           height={80}
-          stroke="#6b7280"
+          stroke={CHART_AXIS_COLOR}
           fontSize={12}
         />
         <YAxis
           yAxisId="left"
           tickFormatter={valueFormatter}
-          stroke="#6b7280"
+          stroke={CHART_AXIS_COLOR}
           fontSize={12}
         />
         <YAxis
           yAxisId="right"
           orientation="right"
           tickFormatter={(value) => `${value}%`}
-          stroke="#6b7280"
+          stroke={CHART_AXIS_COLOR}
           fontSize={12}
         />
         <Tooltip content={<CustomTooltip />} />
@@ -234,14 +244,14 @@ export function VarianceChart({
             <ReferenceLine
               yAxisId="right"
               y={acceptableVariance}
-              stroke="#f59e0b"
+              stroke={CHART_REFERENCE_COLOR}
               strokeDasharray="5 5"
               label={{ value: `+${acceptableVariance}%`, position: "top" }}
             />
             <ReferenceLine
               yAxisId="right"
               y={-acceptableVariance}
-              stroke="#f59e0b"
+              stroke={CHART_REFERENCE_COLOR}
               strokeDasharray="5 5"
               label={{ value: `-${acceptableVariance}%`, position: "bottom" }}
             />
@@ -251,14 +261,14 @@ export function VarianceChart({
         <Bar
           yAxisId="left"
           dataKey="baseline"
-          fill="#e5e7eb"
+          fill={CHART_BASELINE_COLOR}
           name="Baseline"
           radius={[2, 2, 0, 0]}
         />
         <Bar
           yAxisId="left"
           dataKey="actual"
-          fill="#3b82f6"
+          fill={CHART_ACTUAL_COLOR}
           name="Actual"
           radius={[2, 2, 0, 0]}
         />
@@ -268,9 +278,9 @@ export function VarianceChart({
             yAxisId="right"
             type="monotone"
             dataKey="variancePercent"
-            stroke="#dc2626"
+            stroke={CHART_VARIANCE_COLOR}
             strokeWidth={2}
-            dot={{ fill: '#dc2626', strokeWidth: 2, r: 4 }}
+            dot={{ fill: CHART_VARIANCE_COLOR, strokeWidth: 2, r: 4 }}
             name="Variance %"
           />
         )}
@@ -345,15 +355,15 @@ export function VarianceTrendChart({
     if (active && payload && payload.length && payload[0]) {
       const data = payload[0].payload;
       return (
-        <div className="bg-white p-3 border border-gray-200 rounded-lg shadow-lg">
-          <p className="font-medium text-gray-900">{data.formattedDate}</p>
-          <p className="text-sm text-gray-600">
+        <div className="bg-pov-white p-3 border border-beige-200 rounded-lg shadow-lg">
+          <p className="font-medium text-pov-charcoal">{data.formattedDate}</p>
+          <p className="text-sm text-charcoal-600">
             Metric: <span className="font-medium">{data.metric}</span>
           </p>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-charcoal-600">
             Variance: <span className={cn(
               "font-medium",
-              data.variance > 0 ? "text-green-600" : "text-red-600"
+              data.variance > 0 ? "text-presson-positive" : "text-presson-negative"
             )}>
               {data.variance > 0 ? '+' : ''}{data.variance.toFixed(1)}%
             </span>
@@ -374,7 +384,7 @@ export function VarianceTrendChart({
         <div style={{ height }} className="w-full">
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={processedData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
               <XAxis
                 dataKey="timestamp"
                 domain={['dataMin', 'dataMax']}
@@ -383,25 +393,25 @@ export function VarianceTrendChart({
                 tickFormatter={(timestamp: ValueType | NameType) =>
                   format(new Date(Number(timestamp)), 'MMM dd')
                 }
-                stroke="#6b7280"
+                stroke={CHART_AXIS_COLOR}
                 fontSize={12}
               />
               <YAxis
                 tickFormatter={(value) => `${value}%`}
-                stroke="#6b7280"
+                stroke={CHART_AXIS_COLOR}
                 fontSize={12}
               />
               <Tooltip content={<TrendTooltip />} />
 
-              <ReferenceLine y={0} stroke="#6b7280" strokeDasharray="2 2" />
+              <ReferenceLine y={0} stroke={CHART_AXIS_COLOR} strokeDasharray="2 2" />
 
               <Line
                 type="monotone"
                 dataKey="variance"
-                stroke="#dc2626"
+                stroke={CHART_VARIANCE_COLOR}
                 strokeWidth={2}
-                dot={{ fill: '#dc2626', strokeWidth: 2, r: 4 }}
-                activeDot={{ r: 6, stroke: '#dc2626', strokeWidth: 2, fill: '#ffffff' }}
+                dot={{ fill: CHART_VARIANCE_COLOR, strokeWidth: 2, r: 4 }}
+                activeDot={{ r: 6, stroke: CHART_VARIANCE_COLOR, strokeWidth: 2, fill: CHART_BACKGROUND_COLOR }}
               />
             </ComposedChart>
           </ResponsiveContainer>

--- a/client/src/components/demo/DemoBanner.tsx
+++ b/client/src/components/demo/DemoBanner.tsx
@@ -18,13 +18,13 @@ export default function DemoBanner() {
   }
 
   return (
-    <div className="bg-gradient-to-r from-blue-600 to-purple-600 text-white px-6 py-2 flex items-center justify-center gap-2 text-sm font-medium shadow-md">
+    <div className="bg-pov-charcoal text-pov-white px-6 py-2 flex items-center justify-center gap-2 text-sm font-medium shadow-md">
       <Eye className="h-4 w-4" />
       <span>
-        🎯 <strong>DEMO MODE</strong> - Showing sample data
+        <strong>DEMO MODE</strong> - Showing sample data
         {currentFund ? ` for ${currentFund.name}` : ''}
       </span>
-      <span className="ml-2 px-2 py-0.5 bg-white/20 rounded text-xs">
+      <span className="ml-2 px-2 py-0.5 bg-pov-white/20 rounded text-xs">
         Press Escape to exit
       </span>
     </div>

--- a/client/src/components/fund-results/FundModelScorecard.tsx
+++ b/client/src/components/fund-results/FundModelScorecard.tsx
@@ -71,9 +71,9 @@ function formatCurrency(value: number): string {
 }
 
 const RISK_STYLES: Record<string, string> = {
-  LOW: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/30',
-  MEDIUM: 'bg-amber-500/20 text-amber-300 border-amber-500/30',
-  HIGH: 'bg-red-500/20 text-red-300 border-red-500/30',
+  LOW: 'bg-success/20 text-pov-white border-success/50',
+  MEDIUM: 'bg-warning/20 text-pov-white border-warning/50',
+  HIGH: 'bg-error/20 text-pov-white border-error/50',
 };
 
 // ============================================================================
@@ -102,36 +102,36 @@ export function FundModelScorecard({
     >
       {/* Header row: fund identity */}
       <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2 mb-8">
-        <h1 className="font-inter font-bold text-2xl text-white tracking-tight">{fundName}</h1>
-        <span className="font-poppins text-sm text-white/60">Vintage {vintageYear}</span>
-        <span className="font-poppins text-sm text-white/60">{formatCurrency(fundSize)}</span>
+        <h1 className="font-inter font-bold text-2xl text-pov-white tracking-tight">{fundName}</h1>
+        <span className="font-poppins text-sm text-pov-white/60">Vintage {vintageYear}</span>
+        <span className="font-poppins text-sm text-pov-white/60">{formatCurrency(fundSize)}</span>
       </div>
 
       {/* Metrics grid */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
         {/* Expected MOIC */}
         <div className="space-y-1">
-          <p className="font-poppins text-xs uppercase tracking-wider text-white/50">
+          <p className="font-poppins text-xs uppercase tracking-wider text-pov-white/50">
             Expected MOIC
           </p>
-          <p className="font-inter font-bold text-3xl text-white tabular-nums">
+          <p className="font-inter font-bold text-3xl text-pov-white tabular-nums">
             {animatedMOIC.toFixed(1)}x
           </p>
         </div>
 
         {/* Reserve Ratio */}
         <div className="space-y-1">
-          <p className="font-poppins text-xs uppercase tracking-wider text-white/50">
+          <p className="font-poppins text-xs uppercase tracking-wider text-pov-white/50">
             Reserve Ratio
           </p>
-          <p className="font-inter font-bold text-3xl text-white tabular-nums">
+          <p className="font-inter font-bold text-3xl text-pov-white tabular-nums">
             {animatedReserve.toFixed(0)}%
           </p>
         </div>
 
         {/* Concentration Risk */}
         <div className="space-y-1">
-          <p className="font-poppins text-xs uppercase tracking-wider text-white/50">
+          <p className="font-poppins text-xs uppercase tracking-wider text-pov-white/50">
             Concentration Risk
           </p>
           <div className="pt-1">
@@ -148,8 +148,8 @@ export function FundModelScorecard({
 
         {/* Net IRR */}
         <div className="space-y-1">
-          <p className="font-poppins text-xs uppercase tracking-wider text-white/50">Net IRR</p>
-          <p className="font-inter font-bold text-3xl text-white tabular-nums">
+          <p className="font-poppins text-xs uppercase tracking-wider text-pov-white/50">Net IRR</p>
+          <p className="font-inter font-bold text-3xl text-pov-white tabular-nums">
             {netIRR != null ? `${animatedIRR.toFixed(1)}%` : 'N/A'}
           </p>
         </div>

--- a/client/src/components/fund-results/ReserveAllocationBreakdown.tsx
+++ b/client/src/components/fund-results/ReserveAllocationBreakdown.tsx
@@ -41,9 +41,9 @@ function getDivergence(engine: number, user: number): number {
 }
 
 function getDeltaStyle(divergence: number): string {
-  if (divergence < 5) return 'text-emerald-600';
-  if (divergence <= 15) return 'text-amber-600';
-  return 'text-red-600';
+  if (divergence < 5) return 'text-success-dark';
+  if (divergence <= 15) return 'text-warning-dark';
+  return 'text-error-dark';
 }
 
 function getDeltaLabel(divergence: number): string {

--- a/client/src/components/lp-reporting/MetricsCards.tsx
+++ b/client/src/components/lp-reporting/MetricsCards.tsx
@@ -34,9 +34,9 @@ export interface MetricCardProps {
 }
 
 const TONE_CLASS: Record<MetricCardTone, string> = {
-  neutral: 'text-charcoal',
-  positive: 'text-emerald-700',
-  warning: 'text-amber-700',
+  neutral: 'text-pov-charcoal',
+  positive: 'text-presson-positive',
+  warning: 'text-presson-warning',
 };
 
 export function MetricCard({

--- a/client/src/components/lp-reporting/XirrDiagnosticPanel.tsx
+++ b/client/src/components/lp-reporting/XirrDiagnosticPanel.tsx
@@ -88,12 +88,12 @@ export function XirrDiagnosticBlock({ title, diagnostic, testId }: XirrDiagnosti
             <TooltipTrigger asChild>
               <div
                 data-testid={`${testId}-bound-hit`}
-                className="inline-flex items-center gap-2 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 cursor-help"
+                className="inline-flex items-center gap-2 rounded-md bg-warning/10 px-3 py-2 text-xs text-warning-dark cursor-help"
               >
                 <span className="font-semibold">
                   {diagnostic.boundHit === 'max' ? 'Hit upper bound' : 'Hit lower bound'}
                 </span>
-                <span className="text-amber-700/80">
+                <span className="text-warning-dark/80">
                   ({diagnostic.boundHit === 'max' ? '200' : '-0.999999'})
                 </span>
               </div>
@@ -110,7 +110,7 @@ export function XirrDiagnosticBlock({ title, diagnostic, testId }: XirrDiagnosti
               <div
                 data-testid={`${testId}-failure-reason`}
                 data-failure-code={diagnostic.failureReason}
-                className="inline-flex items-center gap-2 rounded-md bg-red-50 px-3 py-2 text-xs text-red-800 cursor-help"
+                className="inline-flex items-center gap-2 rounded-md bg-error/10 px-3 py-2 text-xs text-error-dark cursor-help"
               >
                 <span className="font-semibold">{diagnostic.failureReason}</span>
               </div>

--- a/client/src/components/lp/CapitalAccountTable.tsx
+++ b/client/src/components/lp/CapitalAccountTable.tsx
@@ -8,10 +8,23 @@
 
 import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { ArrowUpDown, ArrowDown, ArrowUp, Download, Filter } from 'lucide-react';
 import type { CapitalAccountTransaction, TransactionType } from '@shared/types/lp-api';
 
@@ -55,7 +68,9 @@ function getTransactionTypeLabel(type: TransactionType): string {
   return labels[type] || type;
 }
 
-function getTransactionTypeVariant(type: TransactionType): 'default' | 'secondary' | 'outline' | 'destructive' {
+function getTransactionTypeVariant(
+  type: TransactionType
+): 'default' | 'secondary' | 'outline' | 'destructive' {
   if (type.includes('distribution')) return 'default';
   if (type.includes('call')) return 'destructive';
   if (type.includes('fee')) return 'outline';
@@ -101,7 +116,8 @@ export default function CapitalAccountTable({
 
       switch (sortField) {
         case 'transactionDate':
-          comparison = new Date(a.transactionDate).getTime() - new Date(b.transactionDate).getTime();
+          comparison =
+            new Date(a.transactionDate).getTime() - new Date(b.transactionDate).getTime();
           break;
         case 'amount':
           comparison = a.amount - b.amount;
@@ -134,19 +150,22 @@ export default function CapitalAccountTable({
   };
 
   return (
-    <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+    <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
       <CardHeader>
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <CardTitle className="font-inter text-[#292929]">Capital Account</CardTitle>
-            <CardDescription className="font-poppins text-[#292929]/70">
+            <CardTitle className="font-inter text-pov-charcoal">Capital Account</CardTitle>
+            <CardDescription className="font-poppins text-pov-charcoal/70">
               Transaction history and capital flows
             </CardDescription>
           </div>
 
           <div className="flex items-center gap-3">
             {/* Filter */}
-            <Select value={filterType} onValueChange={(v) => setFilterType(v as TransactionType | 'all')}>
+            <Select
+              value={filterType}
+              onValueChange={(v) => setFilterType(v as TransactionType | 'all')}
+            >
               <SelectTrigger className="w-[180px]">
                 <Filter className="h-4 w-4 mr-2" />
                 <SelectValue />
@@ -175,7 +194,7 @@ export default function CapitalAccountTable({
             <TableHeader>
               <TableRow>
                 <TableHead
-                  className="cursor-pointer hover:bg-gray-50"
+                  className="cursor-pointer hover:bg-pov-gray"
                   onClick={() => handleSort('transactionDate')}
                 >
                   <div className="flex items-center">
@@ -185,7 +204,7 @@ export default function CapitalAccountTable({
                 </TableHead>
                 <TableHead>Fund</TableHead>
                 <TableHead
-                  className="cursor-pointer hover:bg-gray-50"
+                  className="cursor-pointer hover:bg-pov-gray"
                   onClick={() => handleSort('type')}
                 >
                   <div className="flex items-center">
@@ -195,7 +214,7 @@ export default function CapitalAccountTable({
                 </TableHead>
                 <TableHead>Description</TableHead>
                 <TableHead
-                  className="text-right cursor-pointer hover:bg-gray-50"
+                  className="text-right cursor-pointer hover:bg-pov-gray"
                   onClick={() => handleSort('amount')}
                 >
                   <div className="flex items-center justify-end">
@@ -211,7 +230,7 @@ export default function CapitalAccountTable({
 
             <TableBody>
               {sortedTransactions.map((txn) => (
-                <TableRow key={txn.id} className="hover:bg-[#E0D8D1]/20">
+                <TableRow key={txn.id} className="hover:bg-beige/20">
                   <TableCell className="font-mono text-sm">
                     {formatDate(txn.transactionDate)}
                   </TableCell>
@@ -221,11 +240,11 @@ export default function CapitalAccountTable({
                       {getTransactionTypeLabel(txn.type)}
                     </Badge>
                   </TableCell>
-                  <TableCell className="font-poppins text-sm text-[#292929]/70 max-w-xs truncate">
+                  <TableCell className="font-poppins text-sm text-pov-charcoal/70 max-w-xs truncate">
                     {txn.description}
                   </TableCell>
                   <TableCell
-                    className={`text-right font-mono text-sm ${txn.amount < 0 ? 'text-red-600' : 'text-green-600'}`}
+                    className={`text-right font-mono text-sm ${txn.amount < 0 ? 'text-presson-negative' : 'text-presson-positive'}`}
                   >
                     {formatCurrency(txn.amount)}
                   </TableCell>
@@ -243,7 +262,7 @@ export default function CapitalAccountTable({
 
               {sortedTransactions.length === 0 && !isLoading && (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-center py-8 text-[#292929]/50">
+                  <TableCell colSpan={8} className="text-center py-8 text-pov-charcoal/50">
                     No transactions found
                   </TableCell>
                 </TableRow>

--- a/client/src/components/lp/CapitalCallsWidget.tsx
+++ b/client/src/components/lp/CapitalCallsWidget.tsx
@@ -50,7 +50,7 @@ export function CapitalCallsWidget() {
         );
       case 'due':
         return (
-          <Badge variant="default" className="ml-2 bg-orange-500">
+          <Badge variant="default" className="ml-2 bg-warning text-pov-white">
             Due
           </Badge>
         );
@@ -73,7 +73,7 @@ export function CapitalCallsWidget() {
 
   if (isLoading) {
     return (
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
           <Skeleton className="h-6 w-40" />
           <Skeleton className="h-4 w-60" />
@@ -94,14 +94,14 @@ export function CapitalCallsWidget() {
     BigInt(summary?.totalOverdueAmount || '0');
 
   return (
-    <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+    <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 font-inter text-[#292929]">
-          <DollarSign className="h-5 w-5 text-blue-600" />
+        <CardTitle className="flex items-center gap-2 font-inter text-pov-charcoal">
+          <DollarSign className="h-5 w-5 text-presson-info" />
           Capital Calls
-          {hasUrgentCalls && <AlertTriangle className="h-4 w-4 text-orange-500" />}
+          {hasUrgentCalls && <AlertTriangle className="h-4 w-4 text-warning" />}
         </CardTitle>
-        <CardDescription className="font-poppins text-[#292929]/70">
+        <CardDescription className="font-poppins text-pov-charcoal/70">
           {totalPendingAmount > 0n
             ? `${formatCurrency(totalPendingAmount.toString())} total outstanding`
             : 'No outstanding capital calls'}
@@ -115,21 +115,23 @@ export function CapitalCallsWidget() {
           <>
             <div className="grid grid-cols-3 gap-4 mb-4">
               {(summary?.totalOverdue ?? 0) > 0 && (
-                <div className="text-center p-3 bg-red-50 rounded-lg">
-                  <div className="text-2xl font-bold text-red-600">{summary?.totalOverdue}</div>
-                  <div className="text-xs text-red-600/70 font-poppins">Overdue</div>
+                <div className="text-center p-3 bg-error/10 rounded-lg">
+                  <div className="text-2xl font-bold text-error-dark">{summary?.totalOverdue}</div>
+                  <div className="text-xs text-error-dark/70 font-poppins">Overdue</div>
                 </div>
               )}
               {(summary?.totalDue ?? 0) > 0 && (
-                <div className="text-center p-3 bg-orange-50 rounded-lg">
-                  <div className="text-2xl font-bold text-orange-600">{summary?.totalDue}</div>
-                  <div className="text-xs text-orange-600/70 font-poppins">Due Now</div>
+                <div className="text-center p-3 bg-warning/10 rounded-lg">
+                  <div className="text-2xl font-bold text-warning-dark">{summary?.totalDue}</div>
+                  <div className="text-xs text-warning-dark/70 font-poppins">Due Now</div>
                 </div>
               )}
               {(summary?.totalPending ?? 0) > 0 && (
-                <div className="text-center p-3 bg-blue-50 rounded-lg">
-                  <div className="text-2xl font-bold text-blue-600">{summary?.totalPending}</div>
-                  <div className="text-xs text-blue-600/70 font-poppins">Upcoming</div>
+                <div className="text-center p-3 bg-presson-info/10 rounded-lg">
+                  <div className="text-2xl font-bold text-presson-info">
+                    {summary?.totalPending}
+                  </div>
+                  <div className="text-xs text-presson-info/70 font-poppins">Upcoming</div>
                 </div>
               )}
             </div>
@@ -139,7 +141,7 @@ export function CapitalCallsWidget() {
               {calls?.calls.slice(0, 3).map((call) => (
                 <div
                   key={call.id}
-                  className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-lg hover:bg-gray-50 cursor-pointer"
+                  className="flex items-center justify-between p-3 border border-beige-200 rounded-lg hover:bg-pov-gray cursor-pointer"
                   onClick={() => navigate(`/lp/capital-calls/${call.id}`)}
                 >
                   <div>
@@ -147,7 +149,7 @@ export function CapitalCallsWidget() {
                       <span className="font-medium font-inter text-sm">{call.fundName}</span>
                       {getStatusBadge(call.status)}
                     </div>
-                    <div className="flex items-center gap-2 text-xs text-[#292929]/60 font-poppins mt-1">
+                    <div className="flex items-center gap-2 text-xs text-pov-charcoal/60 font-poppins mt-1">
                       <Clock className="h-3 w-3" />
                       <span>Due: {formatDate(call.dueDate)}</span>
                     </div>
@@ -160,8 +162,8 @@ export function CapitalCallsWidget() {
             </div>
           </>
         ) : (
-          <div className="text-center py-6 text-[#292929]/60 font-poppins">
-            <DollarSign className="h-10 w-10 mx-auto mb-2 text-[#292929]/30" />
+          <div className="text-center py-6 text-pov-charcoal/60 font-poppins">
+            <DollarSign className="h-10 w-10 mx-auto mb-2 text-pov-charcoal/30" />
             <p>No pending capital calls</p>
           </div>
         )}

--- a/client/src/components/lp/DashboardSummary.tsx
+++ b/client/src/components/lp/DashboardSummary.tsx
@@ -12,7 +12,14 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { TrendingUp, TrendingDown, DollarSign, Wallet, ArrowDownToLine, PiggyBank } from 'lucide-react';
+import {
+  TrendingUp,
+  TrendingDown,
+  DollarSign,
+  Wallet,
+  ArrowDownToLine,
+  PiggyBank,
+} from 'lucide-react';
 import type { LPSummaryMetrics } from '@shared/types/lp-api';
 
 // ============================================================================
@@ -50,7 +57,7 @@ export default function DashboardSummary({ metrics, isLoading }: DashboardSummar
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         {[1, 2, 3, 4].map((i) => (
-          <Card key={i} className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card key={i} className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
             <CardHeader className="pb-3">
               <Skeleton className="h-4 w-24" />
             </CardHeader>
@@ -64,91 +71,92 @@ export default function DashboardSummary({ metrics, isLoading }: DashboardSummar
     );
   }
 
-  const calledPercent = metrics.totalCommitted > 0
-    ? metrics.totalCalled / metrics.totalCommitted
-    : 0;
+  const calledPercent =
+    metrics.totalCommitted > 0 ? metrics.totalCalled / metrics.totalCommitted : 0;
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       {/* Total Committed */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md hover:shadow-lg transition-shadow">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md hover:shadow-lg transition-shadow">
         <CardHeader className="pb-3">
-          <CardTitle className="flex items-center justify-between text-sm font-medium text-[#292929]/70 font-poppins">
+          <CardTitle className="flex items-center justify-between text-sm font-medium text-pov-charcoal/70 font-poppins">
             <span>Total Committed</span>
-            <DollarSign className="h-4 w-4 text-blue-600" />
+            <DollarSign className="h-4 w-4 text-presson-info" />
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold font-inter text-[#292929]">
+          <div className="text-2xl font-bold font-inter text-pov-charcoal">
             {formatCurrency(metrics.totalCommitted)}
           </div>
-          <div className="text-xs text-[#292929]/50 font-poppins mt-1">
+          <div className="text-xs text-pov-charcoal/50 font-poppins mt-1">
             Across {metrics.totalCommitted > 0 ? 'all funds' : 'no funds'}
           </div>
         </CardContent>
       </Card>
 
       {/* Total Called */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md hover:shadow-lg transition-shadow">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md hover:shadow-lg transition-shadow">
         <CardHeader className="pb-3">
-          <CardTitle className="flex items-center justify-between text-sm font-medium text-[#292929]/70 font-poppins">
+          <CardTitle className="flex items-center justify-between text-sm font-medium text-pov-charcoal/70 font-poppins">
             <span>Total Called</span>
-            <Wallet className="h-4 w-4 text-amber-600" />
+            <Wallet className="h-4 w-4 text-presson-warning" />
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold font-inter text-[#292929]">
+          <div className="text-2xl font-bold font-inter text-pov-charcoal">
             {formatCurrency(metrics.totalCalled)}
           </div>
-          <div className="flex items-center gap-2 text-xs text-[#292929]/50 font-poppins mt-1">
+          <div className="flex items-center gap-2 text-xs text-pov-charcoal/50 font-poppins mt-1">
             <span>{formatPercent(calledPercent)} of commitment</span>
-            {calledPercent >= 0.8 && <TrendingUp className="h-3 w-3 text-amber-600" />}
+            {calledPercent >= 0.8 && <TrendingUp className="h-3 w-3 text-presson-warning" />}
           </div>
         </CardContent>
       </Card>
 
       {/* Total Distributed */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md hover:shadow-lg transition-shadow">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md hover:shadow-lg transition-shadow">
         <CardHeader className="pb-3">
-          <CardTitle className="flex items-center justify-between text-sm font-medium text-[#292929]/70 font-poppins">
+          <CardTitle className="flex items-center justify-between text-sm font-medium text-pov-charcoal/70 font-poppins">
             <span>Total Distributed</span>
-            <ArrowDownToLine className="h-4 w-4 text-green-600" />
+            <ArrowDownToLine className="h-4 w-4 text-presson-positive" />
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold font-inter text-[#292929]">
+          <div className="text-2xl font-bold font-inter text-pov-charcoal">
             {formatCurrency(metrics.totalDistributed)}
           </div>
           <div className="flex items-center gap-2 text-xs font-poppins mt-1">
-            <span className="text-[#292929]/50">
-              DPI: {metrics.dpi.toFixed(2)}x
-            </span>
-            {metrics.dpi >= 1 && <TrendingUp className="h-3 w-3 text-green-600" />}
+            <span className="text-pov-charcoal/50">DPI: {metrics.dpi.toFixed(2)}x</span>
+            {metrics.dpi >= 1 && <TrendingUp className="h-3 w-3 text-presson-positive" />}
           </div>
         </CardContent>
       </Card>
 
       {/* Current NAV */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md hover:shadow-lg transition-shadow">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md hover:shadow-lg transition-shadow">
         <CardHeader className="pb-3">
-          <CardTitle className="flex items-center justify-between text-sm font-medium text-[#292929]/70 font-poppins">
+          <CardTitle className="flex items-center justify-between text-sm font-medium text-pov-charcoal/70 font-poppins">
             <span>Current NAV</span>
-            <PiggyBank className="h-4 w-4 text-purple-600" />
+            <PiggyBank className="h-4 w-4 text-presson-info" />
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold font-inter text-[#292929]">
+          <div className="text-2xl font-bold font-inter text-pov-charcoal">
             {formatCurrency(metrics.currentNAV)}
           </div>
           <div className="flex items-center gap-2 text-xs font-poppins mt-1">
-            <span className={metrics.unrealizedGain >= 0 ? 'text-green-600' : 'text-red-600'}>
+            <span
+              className={
+                metrics.unrealizedGain >= 0 ? 'text-presson-positive' : 'text-presson-negative'
+              }
+            >
               {metrics.unrealizedGain >= 0 ? '+' : ''}
               {formatCurrency(metrics.unrealizedGain)} unrealized
             </span>
             {metrics.unrealizedGain >= 0 ? (
-              <TrendingUp className="h-3 w-3 text-green-600" />
+              <TrendingUp className="h-3 w-3 text-presson-positive" />
             ) : (
-              <TrendingDown className="h-3 w-3 text-red-600" />
+              <TrendingDown className="h-3 w-3 text-presson-negative" />
             )}
           </div>
         </CardContent>

--- a/client/src/components/lp/DistributionsWidget.tsx
+++ b/client/src/components/lp/DistributionsWidget.tsx
@@ -41,7 +41,7 @@ export function DistributionsWidget() {
     switch (type) {
       case 'special':
         return (
-          <Badge variant="default" className="bg-purple-500">
+          <Badge variant="default" className="bg-presson-info text-pov-white">
             Special
           </Badge>
         );
@@ -56,7 +56,7 @@ export function DistributionsWidget() {
 
   if (isLoading) {
     return (
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
           <Skeleton className="h-6 w-40" />
           <Skeleton className="h-4 w-60" />
@@ -78,13 +78,13 @@ export function DistributionsWidget() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+    <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 font-inter text-[#292929]">
-          <Banknote className="h-5 w-5 text-green-600" />
+        <CardTitle className="flex items-center gap-2 font-inter text-pov-charcoal">
+          <Banknote className="h-5 w-5 text-presson-positive" />
           Distributions
         </CardTitle>
-        <CardDescription className="font-poppins text-[#292929]/70">
+        <CardDescription className="font-poppins text-pov-charcoal/70">
           {summary?.pendingDistributions
             ? `${summary.pendingDistributions} pending distribution${summary.pendingDistributions > 1 ? 's' : ''}`
             : 'Recent and upcoming distributions'}
@@ -93,21 +93,23 @@ export function DistributionsWidget() {
       <CardContent>
         {/* YTD Summary */}
         <div className="grid grid-cols-2 gap-4 mb-4">
-          <div className="p-4 bg-green-50 rounded-lg text-center">
+          <div className="p-4 bg-presson-positive/10 rounded-lg text-center">
             <div className="flex items-center justify-center gap-1 mb-1">
-              <TrendingUp className="h-4 w-4 text-green-600" />
-              <span className="text-xs text-green-600/70 font-poppins">YTD {currentYear}</span>
+              <TrendingUp className="h-4 w-4 text-presson-positive" />
+              <span className="text-xs text-presson-positive/70 font-poppins">
+                YTD {currentYear}
+              </span>
             </div>
-            <div className="text-xl font-bold text-green-700 font-inter">
+            <div className="text-xl font-bold text-presson-positive font-inter">
               {ytdAmount > 0n ? formatCurrency(summary?.ytdDistributed || '0') : '$0'}
             </div>
           </div>
-          <div className="p-4 bg-blue-50 rounded-lg text-center">
+          <div className="p-4 bg-presson-positive/10 rounded-lg text-center">
             <div className="flex items-center justify-center gap-1 mb-1">
-              <Banknote className="h-4 w-4 text-blue-600" />
-              <span className="text-xs text-blue-600/70 font-poppins">Total Received</span>
+              <Banknote className="h-4 w-4 text-presson-positive" />
+              <span className="text-xs text-presson-positive/70 font-poppins">Total Received</span>
             </div>
-            <div className="text-xl font-bold text-blue-700 font-inter">
+            <div className="text-xl font-bold text-presson-positive font-inter">
               {summary?.totalDistributed ? formatCurrency(summary.totalDistributed) : '$0'}
             </div>
           </div>
@@ -116,13 +118,13 @@ export function DistributionsWidget() {
         {/* Recent Distributions */}
         {summary?.recentDistributions && summary.recentDistributions.length > 0 ? (
           <div className="space-y-3">
-            <div className="text-sm font-medium text-[#292929]/70 font-poppins">
+            <div className="text-sm font-medium text-pov-charcoal/70 font-poppins">
               Recent Distributions
             </div>
             {summary.recentDistributions.map((dist) => (
               <div
                 key={dist.id}
-                className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-lg hover:bg-gray-50 cursor-pointer"
+                className="flex items-center justify-between p-3 border border-beige-200 rounded-lg hover:bg-pov-gray cursor-pointer"
                 onClick={() => navigate(`/lp/distributions/${dist.id}`)}
               >
                 <div>
@@ -130,13 +132,13 @@ export function DistributionsWidget() {
                     <span className="font-medium font-inter text-sm">{dist.fundName}</span>
                     {getDistributionTypeBadge(dist.distributionType)}
                   </div>
-                  <div className="flex items-center gap-2 text-xs text-[#292929]/60 font-poppins mt-1">
+                  <div className="flex items-center gap-2 text-xs text-pov-charcoal/60 font-poppins mt-1">
                     <Calendar className="h-3 w-3" />
                     <span>{formatDate(dist.distributionDate)}</span>
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="font-bold font-inter text-green-600">
+                  <div className="font-bold font-inter text-presson-positive">
                     {formatCurrency(dist.netAmount)}
                   </div>
                 </div>
@@ -144,8 +146,8 @@ export function DistributionsWidget() {
             ))}
           </div>
         ) : (
-          <div className="text-center py-6 text-[#292929]/60 font-poppins">
-            <Banknote className="h-10 w-10 mx-auto mb-2 text-[#292929]/30" />
+          <div className="text-center py-6 text-pov-charcoal/60 font-poppins">
+            <Banknote className="h-10 w-10 mx-auto mb-2 text-pov-charcoal/30" />
             <p>No distributions yet</p>
           </div>
         )}

--- a/client/src/components/lp/DocumentsWidget.tsx
+++ b/client/src/components/lp/DocumentsWidget.tsx
@@ -34,18 +34,19 @@ const getDocumentTypeLabel = (type: DocumentType): string => {
 };
 
 const getDocumentTypeColor = (type: DocumentType): string => {
+  // TODO(design): document types exceed six categorical colors; define an extended token palette before assigning unique hues to every type.
   const colors: Record<DocumentType, string> = {
-    k1: 'bg-purple-500',
-    capital_statement: 'bg-blue-500',
-    quarterly_report: 'bg-green-500',
-    annual_report: 'bg-indigo-500',
-    subscription_agreement: 'bg-orange-500',
-    side_letter: 'bg-pink-500',
-    legal: 'bg-gray-500',
-    tax: 'bg-red-500',
-    other: 'bg-gray-400',
+    k1: 'bg-pov-charcoal',
+    capital_statement: 'bg-presson-positive',
+    quarterly_report: 'bg-presson-info',
+    annual_report: 'bg-success',
+    subscription_agreement: 'bg-presson-warning',
+    side_letter: 'bg-presson-negative',
+    legal: 'bg-charcoal-700',
+    tax: 'bg-error',
+    other: 'bg-charcoal-500',
   };
-  return colors[type] || 'bg-gray-500';
+  return colors[type] || 'bg-charcoal-500';
 };
 
 const formatFileSize = (bytes: number): string => {
@@ -76,7 +77,7 @@ export function DocumentsWidget() {
 
   if (isLoading) {
     return (
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
           <Skeleton className="h-6 w-40" />
           <Skeleton className="h-4 w-60" />
@@ -91,14 +92,14 @@ export function DocumentsWidget() {
   }
 
   return (
-    <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+    <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 font-inter text-[#292929]">
-          <FileText className="h-5 w-5 text-indigo-600" />
+        <CardTitle className="flex items-center gap-2 font-inter text-pov-charcoal">
+          <FileText className="h-5 w-5 text-presson-info" />
           Documents
-          {data?.hasNewDocuments && <Sparkles className="h-4 w-4 text-yellow-500" />}
+          {data?.hasNewDocuments && <Sparkles className="h-4 w-4 text-presson-info" />}
         </CardTitle>
-        <CardDescription className="font-poppins text-[#292929]/70">
+        <CardDescription className="font-poppins text-pov-charcoal/70">
           {data?.totalDocuments
             ? `${data.totalDocuments} document${data.totalDocuments !== 1 ? 's' : ''} available`
             : 'Fund documents and reports'}
@@ -110,25 +111,25 @@ export function DocumentsWidget() {
             {data.recentDocuments.map((doc) => (
               <div
                 key={doc.id}
-                className="flex items-center justify-between p-3 border border-[#E0D8D1] rounded-lg hover:bg-gray-50 cursor-pointer group"
+                className="flex items-center justify-between p-3 border border-beige-200 rounded-lg hover:bg-pov-gray cursor-pointer group"
                 onClick={() => navigate(`/lp/documents/${doc.id}`)}
               >
                 <div className="flex items-center gap-3 min-w-0">
                   <div
                     className={`w-10 h-10 rounded-lg ${getDocumentTypeColor(doc.documentType)} flex items-center justify-center`}
                   >
-                    <FileText className="h-5 w-5 text-white" />
+                    <FileText className="h-5 w-5 text-pov-white" />
                   </div>
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
                       <span className="font-medium font-inter text-sm truncate">{doc.title}</span>
                       {isNewDocument(doc.createdAt) && (
-                        <Badge variant="default" className="bg-yellow-500 text-xs">
+                        <Badge variant="default" className="bg-presson-info text-pov-white text-xs">
                           New
                         </Badge>
                       )}
                     </div>
-                    <div className="flex items-center gap-2 text-xs text-[#292929]/60 font-poppins">
+                    <div className="flex items-center gap-2 text-xs text-pov-charcoal/60 font-poppins">
                       <Badge variant="outline" className="text-xs">
                         {getDocumentTypeLabel(doc.documentType)}
                       </Badge>
@@ -148,8 +149,8 @@ export function DocumentsWidget() {
             ))}
           </div>
         ) : (
-          <div className="text-center py-6 text-[#292929]/60 font-poppins">
-            <FileText className="h-10 w-10 mx-auto mb-2 text-[#292929]/30" />
+          <div className="text-center py-6 text-pov-charcoal/60 font-poppins">
+            <FileText className="h-10 w-10 mx-auto mb-2 text-pov-charcoal/30" />
             <p>No documents available</p>
           </div>
         )}

--- a/client/src/components/lp/NotificationsWidget.tsx
+++ b/client/src/components/lp/NotificationsWidget.tsx
@@ -57,17 +57,17 @@ const getNotificationIcon = (type: NotificationType) => {
 const getNotificationIconColor = (type: NotificationType): string => {
   switch (type) {
     case 'capital_call':
-      return 'text-blue-600 bg-blue-100';
+      return 'text-pov-charcoal bg-pov-gray';
     case 'distribution':
-      return 'text-green-600 bg-green-100';
+      return 'text-presson-positive bg-presson-positive/10';
     case 'document':
-      return 'text-indigo-600 bg-indigo-100';
+      return 'text-presson-info bg-presson-info/10';
     case 'report':
-      return 'text-purple-600 bg-purple-100';
+      return 'text-success-dark bg-success/10';
     case 'fund_update':
-      return 'text-orange-600 bg-orange-100';
+      return 'text-presson-warning bg-presson-warning/10';
     default:
-      return 'text-gray-600 bg-gray-100';
+      return 'text-charcoal-600 bg-pov-gray';
   }
 };
 
@@ -82,7 +82,7 @@ const getPriorityBadge = (priority: NotificationPriority) => {
       );
     case 'high':
       return (
-        <Badge variant="default" className="bg-orange-500 text-xs">
+        <Badge variant="default" className="bg-warning text-pov-white text-xs">
           High
         </Badge>
       );
@@ -125,7 +125,7 @@ export function NotificationsWidget() {
 
   if (isLoading) {
     return (
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
           <Skeleton className="h-6 w-40" />
           <Skeleton className="h-4 w-60" />
@@ -140,11 +140,11 @@ export function NotificationsWidget() {
   }
 
   return (
-    <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+    <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 font-inter text-[#292929]">
-            <Bell className="h-5 w-5 text-amber-600" />
+          <CardTitle className="flex items-center gap-2 font-inter text-pov-charcoal">
+            <Bell className="h-5 w-5 text-presson-warning" />
             Notifications
             {unreadCount > 0 && (
               <Badge variant="destructive" className="ml-1">
@@ -165,7 +165,7 @@ export function NotificationsWidget() {
             </Button>
           )}
         </div>
-        <CardDescription className="font-poppins text-[#292929]/70">
+        <CardDescription className="font-poppins text-pov-charcoal/70">
           {unreadCount > 0
             ? `${unreadCount} unread notification${unreadCount > 1 ? 's' : ''}`
             : "You're all caught up"}
@@ -179,8 +179,8 @@ export function NotificationsWidget() {
                 key={notification.id}
                 className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors ${
                   notification.isRead
-                    ? 'bg-gray-50 hover:bg-gray-100'
-                    : 'bg-blue-50 hover:bg-blue-100 border-l-4 border-blue-500'
+                    ? 'bg-pov-gray hover:bg-beige/20'
+                    : 'bg-pov-gray hover:bg-beige/20 border-l-4 border-pov-charcoal'
                 }`}
                 onClick={() => handleNotificationClick(notification)}
               >
@@ -192,18 +192,18 @@ export function NotificationsWidget() {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
                     <span
-                      className={`font-medium text-sm ${notification.isRead ? 'text-[#292929]/70' : 'text-[#292929]'}`}
+                      className={`font-medium text-sm ${notification.isRead ? 'text-pov-charcoal/70' : 'text-pov-charcoal'}`}
                     >
                       {notification.title}
                     </span>
                     {getPriorityBadge(notification.priority)}
                   </div>
                   <p
-                    className={`text-xs mt-1 line-clamp-2 ${notification.isRead ? 'text-[#292929]/50' : 'text-[#292929]/70'}`}
+                    className={`text-xs mt-1 line-clamp-2 ${notification.isRead ? 'text-pov-charcoal/50' : 'text-pov-charcoal/70'}`}
                   >
                     {notification.message}
                   </p>
-                  <span className="text-xs text-[#292929]/40 mt-1 block">
+                  <span className="text-xs text-pov-charcoal/40 mt-1 block">
                     {formatDistanceToNow(new Date(notification.createdAt), { addSuffix: true })}
                   </span>
                 </div>
@@ -211,8 +211,8 @@ export function NotificationsWidget() {
             ))}
           </div>
         ) : (
-          <div className="text-center py-6 text-[#292929]/60 font-poppins">
-            <Bell className="h-10 w-10 mx-auto mb-2 text-[#292929]/30" />
+          <div className="text-center py-6 text-pov-charcoal/60 font-poppins">
+            <Bell className="h-10 w-10 mx-auto mb-2 text-pov-charcoal/30" />
             <p>No notifications</p>
           </div>
         )}

--- a/client/src/components/lp/PerformanceMetricsCard.tsx
+++ b/client/src/components/lp/PerformanceMetricsCard.tsx
@@ -38,54 +38,62 @@ export default function PerformanceMetricsCard({
   const tvpiVariant = tvpi >= 2 ? 'default' : tvpi >= 1 ? 'secondary' : 'outline';
 
   return (
-    <Card className={`bg-white rounded-xl border border-[#E0D8D1] shadow-md ${className}`}>
+    <Card className={`bg-pov-white rounded-xl border border-beige-200 shadow-md ${className}`}>
       <CardHeader>
-        <CardTitle className="font-inter text-lg text-[#292929]">Performance Metrics</CardTitle>
+        <CardTitle className="font-inter text-lg text-pov-charcoal">Performance Metrics</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
           {/* IRR */}
           <div className="text-center">
-            <div className="text-xs font-poppins text-[#292929]/50 mb-2">IRR</div>
+            <div className="text-xs font-poppins text-pov-charcoal/50 mb-2">IRR</div>
             <Badge variant={irrVariant} className="text-lg px-3 py-1">
               {formatPercent(irr)}
             </Badge>
             <div className="mt-2">
               {irr >= 0 ? (
-                <TrendingUp className="h-4 w-4 text-green-600 mx-auto" />
+                <TrendingUp className="h-4 w-4 text-presson-positive mx-auto" />
               ) : (
-                <TrendingDown className="h-4 w-4 text-red-600 mx-auto" />
+                <TrendingDown className="h-4 w-4 text-presson-negative mx-auto" />
               )}
             </div>
           </div>
 
           {/* TVPI */}
           <div className="text-center">
-            <div className="text-xs font-poppins text-[#292929]/50 mb-2">TVPI</div>
+            <div className="text-xs font-poppins text-pov-charcoal/50 mb-2">TVPI</div>
             <Badge variant={tvpiVariant} className="text-lg px-3 py-1">
               {formatMultiple(tvpi)}
             </Badge>
-            <div className="text-xs font-poppins text-[#292929]/70 mt-2">Total Value / Paid-In</div>
+            <div className="text-xs font-poppins text-pov-charcoal/70 mt-2">
+              Total Value / Paid-In
+            </div>
           </div>
 
           {/* DPI */}
           <div className="text-center">
-            <div className="text-xs font-poppins text-[#292929]/50 mb-2">DPI</div>
-            <div className="text-2xl font-bold font-inter text-[#292929]">
+            <div className="text-xs font-poppins text-pov-charcoal/50 mb-2">DPI</div>
+            <div className="text-2xl font-bold font-inter text-pov-charcoal">
               {formatMultiple(dpi)}
             </div>
-            <div className="text-xs font-poppins text-[#292929]/70 mt-2">Distributions / Paid-In</div>
+            <div className="text-xs font-poppins text-pov-charcoal/70 mt-2">
+              Distributions / Paid-In
+            </div>
           </div>
 
           {/* RVPI or MOIC */}
           <div className="text-center">
-            <div className="text-xs font-poppins text-[#292929]/50 mb-2">
+            <div className="text-xs font-poppins text-pov-charcoal/50 mb-2">
               {rvpi !== undefined ? 'RVPI' : 'MOIC'}
             </div>
-            <div className="text-2xl font-bold font-inter text-[#292929]">
-              {rvpi !== undefined ? formatMultiple(rvpi) : moic !== undefined ? formatMultiple(moic) : 'N/A'}
+            <div className="text-2xl font-bold font-inter text-pov-charcoal">
+              {rvpi !== undefined
+                ? formatMultiple(rvpi)
+                : moic !== undefined
+                  ? formatMultiple(moic)
+                  : 'N/A'}
             </div>
-            <div className="text-xs font-poppins text-[#292929]/70 mt-2">
+            <div className="text-xs font-poppins text-pov-charcoal/70 mt-2">
               {rvpi !== undefined ? 'Residual Value / Paid-In' : 'Multiple on Invested Capital'}
             </div>
           </div>

--- a/client/src/components/monte-carlo/CalibrationStatusCard.tsx
+++ b/client/src/components/monte-carlo/CalibrationStatusCard.tsx
@@ -41,9 +41,19 @@ const STATUS_CONFIG: Record<
   },
 };
 
+const UI_SUCCESS_COLOR = '#10b981';
+const UI_ERROR_COLOR = '#ef4444';
+const UI_WARNING_COLOR = '#9C6F19';
+const GAUGE_TRACK_COLOR = '#E0D8D1';
+
 function QualityGauge({ score }: { score: number }) {
   const clampedScore = Math.max(0, Math.min(100, score));
-  const color = clampedScore >= 70 ? '#10b981' : clampedScore >= 40 ? '#f59e0b' : '#ef4444';
+  const color =
+    clampedScore >= 70
+      ? UI_SUCCESS_COLOR
+      : clampedScore >= 40
+        ? UI_WARNING_COLOR
+        : UI_ERROR_COLOR;
 
   return (
     <div className="flex flex-col items-center gap-1">
@@ -52,7 +62,7 @@ function QualityGauge({ score }: { score: number }) {
           <path
             d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
             fill="none"
-            stroke="#e5e7eb"
+            stroke={GAUGE_TRACK_COLOR}
             strokeWidth="3"
           />
           <path

--- a/client/src/components/monte-carlo/MetricDistributionChart.tsx
+++ b/client/src/components/monte-carlo/MetricDistributionChart.tsx
@@ -19,6 +19,11 @@ import {
 } from 'recharts';
 import type { RenderableDistribution } from '@/types/backtesting-ui';
 
+const CHART_GRID_COLOR = '#E0D8D1';
+const CHART_AXIS_COLOR = '#5A5A5A';
+const CHART_BAR_COLOR = '#292929';
+const CHART_ACTUAL_COLOR = '#2563EB';
+
 interface Props {
   distributions: RenderableDistribution[];
 }
@@ -71,16 +76,22 @@ export function MetricDistributionChart({ distributions }: Props) {
           layout="vertical"
           margin={{ top: 10, right: 30, left: 60, bottom: 10 }}
         >
-          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-          <XAxis type="number" fontSize={11} stroke="#6b7280" />
-          <YAxis type="category" dataKey="label" fontSize={12} stroke="#6b7280" width={60} />
-          <Tooltip contentStyle={{ fontSize: 12, borderRadius: 6, border: '1px solid #e5e7eb' }} />
+          <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
+          <XAxis type="number" fontSize={11} stroke={CHART_AXIS_COLOR} />
+          <YAxis type="category" dataKey="label" fontSize={12} stroke={CHART_AXIS_COLOR} width={60} />
+          <Tooltip
+            contentStyle={{
+              fontSize: 12,
+              borderRadius: 6,
+              border: `1px solid ${CHART_GRID_COLOR}`,
+            }}
+          />
 
           {/* IQR bar (p25-p75) */}
-          <Bar dataKey="median" fill="#292929" barSize={20} radius={[2, 2, 2, 2]}>
-            <ErrorBar dataKey="iqr" width={8} stroke="#292929" strokeWidth={2} direction="x" />
+          <Bar dataKey="median" fill={CHART_BAR_COLOR} barSize={20} radius={[2, 2, 2, 2]}>
+            <ErrorBar dataKey="iqr" width={8} stroke={CHART_BAR_COLOR} strokeWidth={2} direction="x" />
             {data.map((entry, index) => (
-              <Cell key={index} fill="#292929" opacity={0.7} />
+              <Cell key={index} fill={CHART_BAR_COLOR} opacity={0.7} />
             ))}
           </Bar>
 
@@ -91,10 +102,10 @@ export function MetricDistributionChart({ distributions }: Props) {
                 <ReferenceLine
                   key={`actual-${entry.metric}`}
                   x={entry.actual}
-                  stroke="#2563EB"
+                  stroke={CHART_ACTUAL_COLOR}
                   strokeDasharray="4 4"
                   strokeWidth={2}
-                  label={{ value: 'Actual', fill: '#2563EB', fontSize: 10, position: 'top' }}
+                  label={{ value: 'Actual', fill: CHART_ACTUAL_COLOR, fontSize: 10, position: 'top' }}
                 />
               )
           )}

--- a/client/src/components/performance/PerformanceDashboard.tsx
+++ b/client/src/components/performance/PerformanceDashboard.tsx
@@ -33,6 +33,8 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, RefreshCw, Calendar } from 'lucide-react';
 import { usePerformanceTimeseries, usePerformanceBreakdown } from '@/hooks/usePerformanceDashboard';
+import { colors as brandColors } from '@/lib/brand-tokens';
+import { presson } from '@/theme/presson.tokens';
 import type { DataSource, Granularity, GroupByDimension } from '@shared/types/performance-api';
 
 // ============================================================================
@@ -71,11 +73,11 @@ function hasFiniteMetric(points: Array<Record<string, unknown>>, keys: string[])
 function EmptyChartState({ title, description }: { title: string; description: string }) {
   return (
     <div
-      className="flex min-h-80 flex-col items-center justify-center rounded-lg border border-dashed border-[#E0D8D1] bg-slate-50 px-6 text-center"
+      className="flex min-h-80 flex-col items-center justify-center rounded-lg border border-dashed border-beige-200 bg-pov-gray px-6 text-center"
       data-testid="performance-chart-empty-state"
     >
-      <p className="font-inter text-base font-semibold text-[#292929]">{title}</p>
-      <p className="mt-2 max-w-md font-poppins text-sm text-[#292929]/70">{description}</p>
+      <p className="font-inter text-base font-semibold text-pov-charcoal">{title}</p>
+      <p className="mt-2 max-w-md font-poppins text-sm text-pov-charcoal/70">{description}</p>
     </div>
   );
 }
@@ -117,21 +119,20 @@ function getDateRange(timeframe: string): { startDate: string; endDate: string }
 // ============================================================================
 
 const CHART_COLORS = {
-  irr: '#2563eb', // Blue
-  tvpi: '#059669', // Green
-  dpi: '#d97706', // Amber
-  totalValue: '#7c3aed', // Purple
+  irr: presson.color.text,
+  tvpi: presson.color.positive,
+  dpi: presson.color.info,
+  totalValue: brandColors.success,
 };
 
+// TODO(design): performance breakdown can exceed six categorical hues; define an extended Press On palette before assigning unique colors beyond this fixed order.
 const BREAKDOWN_COLORS = [
-  '#292929', // Charcoal
-  '#E0D8D1', // Beige
-  '#10B981', // Emerald
-  '#F59E0B', // Amber
-  '#6366F1', // Indigo
-  '#EC4899', // Pink
-  '#8B5CF6', // Purple
-  '#06B6D4', // Cyan
+  presson.color.text,
+  presson.color.positive,
+  presson.color.info,
+  brandColors.success,
+  presson.color.warning,
+  presson.color.negative,
 ];
 
 // ============================================================================
@@ -215,11 +216,11 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
   if (isLoading && !timeseriesData && !breakdownData) {
     return (
       <div className={`space-y-6 ${className}`}>
-        <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+        <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
           <CardContent className="pt-6">
             <div className="animate-pulse space-y-4">
-              <div className="h-8 bg-gray-200 rounded w-1/3" />
-              <div className="h-64 bg-gray-200 rounded" />
+              <div className="h-8 bg-pov-gray rounded w-1/3" />
+              <div className="h-64 bg-pov-gray rounded" />
             </div>
           </CardContent>
         </Card>
@@ -230,15 +231,15 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
   return (
     <div className={`space-y-6 ${className}`}>
       {/* Header Controls */}
-      <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+      <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
         <CardHeader>
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
             <div>
-              <CardTitle className="flex items-center space-x-2 font-inter text-[#292929]">
-                <TrendingUp className="h-5 w-5 text-blue-600" />
+              <CardTitle className="flex items-center space-x-2 font-inter text-pov-charcoal">
+                <TrendingUp className="h-5 w-5 text-presson-info" />
                 <span>Portfolio Performance</span>
               </CardTitle>
-              <CardDescription className="font-poppins text-[#292929]/70">
+              <CardDescription className="font-poppins text-pov-charcoal/70">
                 Track persisted IRR, TVPI, and DPI metrics over time
               </CardDescription>
             </div>
@@ -284,7 +285,7 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
 
       {/* Main Content Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="bg-white border border-[#E0D8D1]">
+        <TabsList className="bg-pov-white border border-beige-200">
           <TabsTrigger value="timeseries">Time Series</TabsTrigger>
           <TabsTrigger value="breakdown">Breakdown</TabsTrigger>
         </TabsList>
@@ -293,11 +294,11 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
         <TabsContent value="timeseries" className="space-y-6">
           {hasDerivedPoints && (
             <Card
-              className="bg-amber-50 border border-amber-200 shadow-sm"
+              className="bg-warning/10 border border-warning/50 shadow-sm"
               data-testid="timeseries-source-note"
             >
               <CardContent className="pt-4">
-                <div className="flex flex-wrap items-center gap-2 text-sm text-amber-950">
+                <div className="flex flex-wrap items-center gap-2 text-sm text-warning-dark">
                   <Badge variant="secondary">Data quality note</Badge>
                   {sourceSummary.interpolated > 0 && (
                     <span>
@@ -322,12 +323,12 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
           )}
 
           {/* IRR Chart */}
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
             <CardHeader>
-              <CardTitle className="font-inter text-lg text-[#292929]">
+              <CardTitle className="font-inter text-lg text-pov-charcoal">
                 Internal Rate of Return (IRR)
               </CardTitle>
-              <CardDescription className="font-poppins text-sm text-[#292929]/70">
+              <CardDescription className="font-poppins text-sm text-pov-charcoal/70">
                 Annualized return over persisted metric snapshots
               </CardDescription>
             </CardHeader>
@@ -373,12 +374,12 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
           </Card>
 
           {/* TVPI & DPI Chart */}
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
             <CardHeader>
-              <CardTitle className="font-inter text-lg text-[#292929]">
+              <CardTitle className="font-inter text-lg text-pov-charcoal">
                 Fund Multiples (TVPI & DPI)
               </CardTitle>
-              <CardDescription className="font-poppins text-sm text-[#292929]/70">
+              <CardDescription className="font-poppins text-sm text-pov-charcoal/70">
                 Total Value and Distributions to Paid-In Capital over persisted metric snapshots
               </CardDescription>
             </CardHeader>
@@ -436,14 +437,14 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
         {/* Breakdown Tab */}
         <TabsContent value="breakdown" className="space-y-6">
           {/* Group By Selector */}
-          <Card className="bg-white rounded-xl border border-[#E0D8D1] shadow-md">
+          <Card className="bg-pov-white rounded-xl border border-beige-200 shadow-md">
             <CardHeader>
               <div className="flex justify-between items-center">
                 <div>
-                  <CardTitle className="font-inter text-lg text-[#292929]">
+                  <CardTitle className="font-inter text-lg text-pov-charcoal">
                     Performance Breakdown
                   </CardTitle>
-                  <CardDescription className="font-poppins text-sm text-[#292929]/70">
+                  <CardDescription className="font-poppins text-sm text-pov-charcoal/70">
                     Analyze current-state returns by portfolio dimension
                   </CardDescription>
                 </div>
@@ -464,29 +465,29 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
                 <>
                   {/* Summary Stats */}
                   <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {breakdownData.totals.companyCount}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Companies</div>
+                      <div className="text-sm font-poppins text-pov-charcoal/70">Companies</div>
                     </div>
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {formatCurrency(breakdownData.totals.totalDeployed)}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Deployed</div>
+                      <div className="text-sm font-poppins text-pov-charcoal/70">Deployed</div>
                     </div>
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {formatMultiple(breakdownData.totals.averageMOIC)}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Avg MOIC</div>
+                      <div className="text-sm font-poppins text-pov-charcoal/70">Avg MOIC</div>
                     </div>
-                    <div className="text-center p-4 bg-gray-50 rounded-lg">
-                      <div className="text-2xl font-bold font-inter text-[#292929]">
+                    <div className="text-center p-4 bg-pov-gray rounded-lg">
+                      <div className="text-2xl font-bold font-inter text-pov-charcoal">
                         {formatPercent(breakdownData.totals.portfolioIRR)}
                       </div>
-                      <div className="text-sm font-poppins text-[#292929]/70">Portfolio IRR</div>
+                      <div className="text-sm font-poppins text-pov-charcoal/70">Portfolio IRR</div>
                     </div>
                   </div>
 
@@ -511,7 +512,10 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
                           {breakdownData.breakdown.slice(0, 10).map((_, index) => (
                             <Cell
                               key={`cell-${index}`}
-                              fill={BREAKDOWN_COLORS[index % BREAKDOWN_COLORS.length] ?? '#8884d8'}
+                              fill={
+                                BREAKDOWN_COLORS[index % BREAKDOWN_COLORS.length] ??
+                                presson.color.text
+                              }
                             />
                           ))}
                         </Bar>
@@ -523,30 +527,30 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
                   <div className="overflow-x-auto">
                     <table className="w-full border-collapse">
                       <thead>
-                        <tr className="border-b border-[#E0D8D1]">
-                          <th className="text-left p-3 font-inter font-bold text-[#292929]">
+                        <tr className="border-b border-beige-200">
+                          <th className="text-left p-3 font-inter font-bold text-pov-charcoal">
                             {groupBy === 'sector'
                               ? 'Sector'
                               : groupBy === 'stage'
                                 ? 'Stage'
                                 : 'Company'}
                           </th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
                             Companies
                           </th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
                             Deployed
                           </th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
                             Current Value
                           </th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
                             MOIC
                           </th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
                             IRR
                           </th>
-                          <th className="text-right p-3 font-inter font-bold text-[#292929]">
+                          <th className="text-right p-3 font-inter font-bold text-pov-charcoal">
                             % of Portfolio
                           </th>
                         </tr>
@@ -555,9 +559,9 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
                         {breakdownData.breakdown.map((row, index) => (
                           <tr
                             key={row.group}
-                            className="border-b border-[#E0D8D1] hover:bg-[#E0D8D1]/20 transition-colors"
+                            className="border-b border-beige-200 hover:bg-beige/20 transition-colors"
                           >
-                            <td className="p-3 font-poppins font-medium text-[#292929]">
+                            <td className="p-3 font-poppins font-medium text-pov-charcoal">
                               <div className="flex items-center gap-2">
                                 <div
                                   className="w-3 h-3 rounded-full"
@@ -569,13 +573,13 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
                                 {row.group}
                               </div>
                             </td>
-                            <td className="p-3 text-right font-mono text-[#292929]">
+                            <td className="p-3 text-right font-mono text-pov-charcoal">
                               {row.companyCount}
                             </td>
-                            <td className="p-3 text-right font-mono text-[#292929]">
+                            <td className="p-3 text-right font-mono text-pov-charcoal">
                               {formatCurrency(row.totalDeployed)}
                             </td>
-                            <td className="p-3 text-right font-mono text-[#292929]">
+                            <td className="p-3 text-right font-mono text-pov-charcoal">
                               {formatCurrency(row.currentValue)}
                             </td>
                             <td className="p-3 text-right">
@@ -591,10 +595,10 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
                                 {formatMultiple(row.moic)}
                               </Badge>
                             </td>
-                            <td className="p-3 text-right font-mono text-[#292929]">
+                            <td className="p-3 text-right font-mono text-pov-charcoal">
                               {formatPercent(row.irr)}
                             </td>
-                            <td className="p-3 text-right font-mono text-[#292929]">
+                            <td className="p-3 text-right font-mono text-pov-charcoal">
                               {row.percentOfPortfolio.toFixed(1)}%
                             </td>
                           </tr>
@@ -617,7 +621,7 @@ export default function PerformanceDashboard({ className }: PerformanceDashboard
 
       {/* Metadata */}
       {timeseriesData?.meta && (
-        <div className="text-xs text-[#292929]/50 font-poppins flex justify-between">
+        <div className="text-xs text-pov-charcoal/50 font-poppins flex justify-between">
           <span>
             Data range: {timeseriesData.meta.startDate} to {timeseriesData.meta.endDate}
           </span>

--- a/client/src/components/portfolio/benchmarking-dashboard.tsx
+++ b/client/src/components/portfolio/benchmarking-dashboard.tsx
@@ -33,6 +33,21 @@ import {
 import { Search, Settings, Info } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 
+const UI_SUCCESS_COLOR = '#10b981';
+const BENCHMARK_SERIES_COLORS = [
+  '#292929',
+  '#127E3D',
+  '#2563EB',
+  UI_SUCCESS_COLOR,
+  '#9C6F19',
+  '#B00020',
+] as const;
+const RADAR_SERIES_COLOR = '#2563EB';
+
+function getBenchmarkSeriesColor(index: number): string {
+  return BENCHMARK_SERIES_COLORS[index % BENCHMARK_SERIES_COLORS.length] ?? '#292929';
+}
+
 // Mock data - in real app, this would come from API
 const PORTFOLIO_COMPANIES = [
   {
@@ -146,8 +161,8 @@ export default function BenchmarkingDashboard() {
           <YAxis />
           <Tooltip />
           <Legend />
-          <Bar dataKey="portfolioMedian" fill="#3b82f6" name="Portfolio Benchmarks" />
-          <Bar dataKey="globalMedian" fill="#10b981" name="Global Benchmarks" />
+          <Bar dataKey="portfolioMedian" fill={getBenchmarkSeriesColor(0)} name="Portfolio Benchmarks" />
+          <Bar dataKey="globalMedian" fill={getBenchmarkSeriesColor(1)} name="Global Benchmarks" />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -173,8 +188,8 @@ export default function BenchmarkingDashboard() {
           <Radar
             name="Company Percentile"
             dataKey="value"
-            stroke="#3b82f6"
-            fill="#3b82f6"
+            stroke={RADAR_SERIES_COLOR}
+            fill={RADAR_SERIES_COLOR}
             fillOpacity={0.3}
             strokeWidth={2}
           />
@@ -328,7 +343,7 @@ export default function BenchmarkingDashboard() {
               </Badge>
               <span className="text-sm">Global Benchmarks</span>
               <div className="w-6 h-4 bg-presson-positive rounded-full relative">
-                <div className="absolute right-1 top-0.5 w-3 h-3 bg-white rounded-full"></div>
+                <div className="absolute right-1 top-0.5 w-3 h-3 bg-pov-white rounded-full"></div>
               </div>
             </div>
           </div>
@@ -470,7 +485,7 @@ export default function BenchmarkingDashboard() {
                     onClick={() => setSelectedCompany(company)}
                   >
                     <div className="flex items-center space-x-3">
-                      <div className="w-8 h-8 bg-pov-charcoal text-white rounded flex items-center justify-center text-sm font-medium">
+                      <div className="w-8 h-8 bg-pov-charcoal text-pov-white rounded flex items-center justify-center text-sm font-medium">
                         {company.name.charAt(0)}
                       </div>
                       <span className="font-medium">{company.name}</span>
@@ -510,7 +525,7 @@ export default function BenchmarkingDashboard() {
                   <div className="relative">
                     <div className="w-full h-6 bg-gradient-to-r from-presson-negative/20 via-presson-warning/20 to-presson-positive/20 rounded"></div>
                     <div className="absolute top-0 right-8 transform -translate-y-1">
-                      <Badge variant="default" className="bg-pov-charcoal text-white text-xs">
+                      <Badge variant="default" className="bg-pov-charcoal text-pov-white text-xs">
                         Instaspace 30.66%
                       </Badge>
                       <div className="w-0.5 h-8 bg-pov-charcoal mx-auto"></div>

--- a/client/src/components/portfolio/portfolio-analytics-dashboard.tsx
+++ b/client/src/components/portfolio/portfolio-analytics-dashboard.tsx
@@ -118,6 +118,22 @@ const DIMENSIONS = [
   { value: 'year', label: 'Year' },
 ];
 
+const UI_SUCCESS_COLOR = '#10b981';
+const CATEGORICAL_SERIES_COLORS = [
+  '#292929',
+  '#127E3D',
+  '#2563EB',
+  UI_SUCCESS_COLOR,
+  '#9C6F19',
+  '#B00020',
+] as const;
+const CHART_PRIMARY_COLOR = '#2563EB';
+
+function getCategoricalChartColor(index: number): string {
+  // TODO(design): Define an extended categorical palette before showing more than six slices.
+  return CATEGORICAL_SERIES_COLORS[index % CATEGORICAL_SERIES_COLORS.length] ?? '#292929';
+}
+
 const SAMPLE_COMPANIES: PortfolioCompany[] = [
   {
     id: 1,
@@ -268,7 +284,7 @@ export default function PortfolioAnalyticsDashboard() {
                   yMetric?.label,
                 ]}
               />
-              <Bar dataKey={currentChart.yAxis} fill="#3B82F6" />
+              <Bar dataKey={currentChart.yAxis} fill={CHART_PRIMARY_COLOR} />
             </BarChart>
           </ResponsiveContainer>
         );
@@ -288,7 +304,12 @@ export default function PortfolioAnalyticsDashboard() {
                   yMetric?.label,
                 ]}
               />
-              <Line type="monotone" dataKey={currentChart.yAxis} stroke="#3B82F6" strokeWidth={2} />
+              <Line
+                type="monotone"
+                dataKey={currentChart.yAxis}
+                stroke={CHART_PRIMARY_COLOR}
+                strokeWidth={2}
+              />
             </LineChart>
           </ResponsiveContainer>
         );
@@ -311,8 +332,8 @@ export default function PortfolioAnalyticsDashboard() {
               <Area
                 type="monotone"
                 dataKey={currentChart.yAxis}
-                stroke="#3B82F6"
-                fill="#3B82F6"
+                stroke={CHART_PRIMARY_COLOR}
+                fill={CHART_PRIMARY_COLOR}
                 fillOpacity={0.3}
               />
             </AreaChart>
@@ -330,7 +351,7 @@ export default function PortfolioAnalyticsDashboard() {
                 cx="50%"
                 cy="50%"
                 outerRadius={120}
-                fill="#3B82F6"
+                fill={CHART_PRIMARY_COLOR}
                 label={(props: { name?: string; value?: number }) => {
                   // Handle the case where props might have undefined properties
                   const name = props.name ?? '';
@@ -339,7 +360,7 @@ export default function PortfolioAnalyticsDashboard() {
                 }}
               >
                 {data.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={`hsl(${210 + index * 30}, 70%, 50%)`} />
+                  <Cell key={`cell-${index}`} fill={getCategoricalChartColor(index)} />
                 ))}
               </Pie>
               <Tooltip
@@ -389,7 +410,7 @@ export default function PortfolioAnalyticsDashboard() {
   return (
     <div className="min-h-screen bg-pov-gray">
       {/* Header */}
-      <div className="bg-white border-b border-beige-200 p-6">
+      <div className="bg-pov-white border-b border-beige-200 p-6">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold text-pov-charcoal">Portfolio Analytics</h1>
@@ -449,7 +470,7 @@ export default function PortfolioAnalyticsDashboard() {
 
       <div className="flex h-[calc(100vh-120px)]">
         {/* Left Sidebar - Data Sources & Saved Views */}
-        <div className="w-80 bg-white border-r border-beige-200 p-4 overflow-y-auto">
+        <div className="w-80 bg-pov-white border-r border-beige-200 p-4 overflow-y-auto">
           <div className="space-y-6">
             {/* Search */}
             <div className="relative">

--- a/client/src/components/portfolio/tag-performance-analysis.tsx
+++ b/client/src/components/portfolio/tag-performance-analysis.tsx
@@ -26,8 +26,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tag, TrendingUp, DollarSign, Target } from 'lucide-react';
-import { getChartColor } from '@/lib/chart-theme';
 import { createTupleFormatter } from '@/lib/chart-formatters';
+import { getChartColor } from '@/lib/chart-theme';
 
 interface TagPerformance {
   tag: string;
@@ -274,7 +274,7 @@ export default function TagPerformanceAnalysis({ className = '' }: TagPerformanc
                   <XAxis dataKey="name" angle={-45} textAnchor="end" height={80} fontSize={12} />
                   <YAxis fontSize={12} />
                   <Tooltip formatter={formatTooltip} />
-                  <Bar dataKey="value" fill="#3b82f6" />
+                  <Bar dataKey="value" fill={getChartColor(0)} />
                 </BarChart>
               ) : (
                 <PieChart>
@@ -285,7 +285,7 @@ export default function TagPerformanceAnalysis({ className = '' }: TagPerformanc
                     labelLine={false}
                     label={({ name, display }) => `${name}: ${display}`}
                     outerRadius={100}
-                    fill="#8884d8"
+                    fill={getChartColor(0)}
                     dataKey="value"
                   >
                     {chartData.map((_entry: unknown, index: number) => (

--- a/client/src/components/reports/reports.tsx
+++ b/client/src/components/reports/reports.tsx
@@ -176,13 +176,13 @@ export default function Reports() {
   if (isLoading || !currentFund) {
     return (
       <div className="space-y-6">
-        <div className="h-36 animate-pulse rounded-xl bg-gray-200" />
+        <div className="h-36 animate-pulse rounded-xl bg-pov-gray" />
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           {Array.from({ length: 4 }).map((_, index) => (
-            <div key={index} className="h-28 animate-pulse rounded-xl bg-gray-200" />
+            <div key={index} className="h-28 animate-pulse rounded-xl bg-pov-gray" />
           ))}
         </div>
-        <div className="h-80 animate-pulse rounded-xl bg-gray-200" />
+        <div className="h-80 animate-pulse rounded-xl bg-pov-gray" />
       </div>
     );
   }
@@ -239,23 +239,23 @@ export default function Reports() {
 
   return (
     <div className="space-y-6">
-      <Card className="border-slate-200">
+      <Card className="border-beige-200">
         <CardContent className="flex flex-col gap-6 p-6 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <Badge variant="outline" className="border-blue-200 bg-blue-50 text-blue-700">
+              <Badge variant="outline" className="border-presson-info/30 bg-presson-info/10 text-presson-info">
                 Live Reporting
               </Badge>
               <Badge
                 variant={defaultBaseline ? 'secondary' : 'destructive'}
-                className={defaultBaseline ? 'bg-emerald-50 text-emerald-700' : ''}
+                className={defaultBaseline ? 'bg-success/10 text-success-dark' : ''}
               >
                 {defaultBaseline ? 'Default Baseline Ready' : 'Baseline Required'}
               </Badge>
             </div>
             <div>
-              <h2 className="text-xl font-semibold text-slate-900">Fund reporting hub</h2>
-              <p className="mt-1 max-w-2xl text-sm text-slate-600">
+              <h2 className="text-xl font-semibold text-pov-charcoal">Fund reporting hub</h2>
+              <p className="mt-1 max-w-2xl text-sm text-charcoal-600">
                 Variance reports use the current fund baseline. Planned reporting surfaces stay
                 clearly labeled until they are backed by fund data and export rules.
               </p>
@@ -283,21 +283,21 @@ export default function Reports() {
       </Card>
 
       {!defaultBaseline && !dashboardLoading && (
-        <Card className="border-amber-200 bg-amber-50">
+        <Card className="border-warning/50 bg-warning/10">
           <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
             <div className="space-y-1">
-              <div className="flex items-center gap-2 text-amber-900">
+              <div className="flex items-center gap-2 text-warning-dark">
                 <AlertTriangle className="h-4 w-4" />
                 <span className="font-medium">Variance report generation is blocked</span>
               </div>
-              <p className="text-sm text-amber-800">
+              <p className="text-sm text-warning-dark">
                 Create or assign a default baseline in Variance Tracking before generating reports
                 from this page.
               </p>
             </div>
             <Button
               variant="outline"
-              className="border-amber-300 bg-white text-amber-900 hover:bg-amber-100"
+              className="border-pov-charcoal bg-pov-white text-pov-charcoal hover:bg-pov-gray"
               onClick={() => openVarianceWorkspace()}
             >
               Set Up Baseline
@@ -373,7 +373,7 @@ export default function Reports() {
                 {Array.from({ length: 3 }).map((_, index) => (
                   <div
                     key={index}
-                    className="h-28 animate-pulse rounded-lg border border-slate-200 bg-slate-100"
+                    className="h-28 animate-pulse rounded-lg border border-beige-200 bg-pov-gray"
                   />
                 ))}
               </div>
@@ -395,27 +395,27 @@ export default function Reports() {
                 {reports.map((report) => (
                   <div
                     key={report.id}
-                    className="rounded-xl border border-slate-200 p-4 transition-colors hover:border-slate-300 hover:bg-slate-50"
+                    className="rounded-xl border border-beige-200 p-4 transition-colors hover:border-charcoal-300 hover:bg-pov-gray"
                   >
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
-                          <h3 className="font-medium text-slate-900">{report.reportName}</h3>
+                          <h3 className="font-medium text-pov-charcoal">{report.reportName}</h3>
                           <Badge variant="outline">{report.reportType}</Badge>
                           {report.reportPeriod && (
-                            <Badge variant="secondary" className="bg-slate-100 text-slate-700">
+                            <Badge variant="secondary" className="bg-pov-gray text-charcoal-700">
                               {report.reportPeriod}
                             </Badge>
                           )}
                         </div>
-                        <p className="text-sm text-slate-600">
+                        <p className="text-sm text-charcoal-600">
                           Generated {formatTimestamp(report.generatedAt)}
                         </p>
-                        <div className="flex flex-wrap gap-2 text-xs text-slate-600">
-                          <Badge variant="secondary" className="bg-slate-100 text-slate-700">
+                        <div className="flex flex-wrap gap-2 text-xs text-charcoal-600">
+                          <Badge variant="secondary" className="bg-pov-gray text-charcoal-700">
                             {report.summary.totalVariances} total variances
                           </Badge>
-                          <Badge variant="secondary" className="bg-amber-50 text-amber-700">
+                          <Badge variant="secondary" className="bg-warning/10 text-warning-dark">
                             {report.summary.significantVariances} significant
                           </Badge>
                           <Badge
@@ -427,15 +427,15 @@ export default function Reports() {
                           </Badge>
                         </div>
                         {report.variances.length > 0 && (
-                          <div className="flex flex-wrap gap-3 text-sm text-slate-600">
+                          <div className="flex flex-wrap gap-3 text-sm text-charcoal-600">
                             {report.variances.slice(0, 3).map((variance) => (
                               <span key={`${report.id}-${variance.metric}`}>
-                                <span className="font-medium text-slate-900">
+                                <span className="font-medium text-pov-charcoal">
                                   {formatMetricLabel(variance.metric)}:
                                 </span>{' '}
                                 {formatMetricValue(variance.metric, variance.value)}
                                 {formatMetricPercent(variance.pct) && (
-                                  <span className="ml-1 text-slate-500">
+                                  <span className="ml-1 text-charcoal-500">
                                     ({formatMetricPercent(variance.pct)})
                                   </span>
                                 )}
@@ -490,16 +490,16 @@ export default function Reports() {
               return (
                 <div key={surface.id} className="space-y-4">
                   <div className="flex gap-3">
-                    <div className="rounded-lg bg-slate-100 p-2">
-                      <Icon className="h-5 w-5 text-slate-700" />
+                    <div className="rounded-lg bg-pov-gray p-2">
+                      <Icon className="h-5 w-5 text-charcoal-700" />
                     </div>
                     <div className="min-w-0 flex-1 space-y-2">
                       <div className="flex flex-wrap items-center gap-2">
-                        <h3 className="font-medium text-slate-900">{surface.title}</h3>
+                        <h3 className="font-medium text-pov-charcoal">{surface.title}</h3>
                         <Badge variant={statusVariant}>{statusLabel}</Badge>
                       </div>
-                      <p className="text-sm text-slate-600">{surface.description}</p>
-                      <p className="text-xs text-slate-500">{surface.helperText}</p>
+                      <p className="text-sm text-charcoal-600">{surface.description}</p>
+                      <p className="text-xs text-charcoal-500">{surface.helperText}</p>
 
                       {surface.id === 'variance-analysis' && (
                         <div className="flex flex-wrap gap-2 pt-1">
@@ -559,21 +559,21 @@ export default function Reports() {
 
           {reportDetailLoading ? (
             <div className="flex items-center justify-center py-16">
-              <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+              <Loader2 className="h-8 w-8 animate-spin text-charcoal-400" />
             </div>
           ) : reportDetail ? (
             <div className="mt-6 space-y-6">
               <div className="space-y-2">
                 <div className="flex flex-wrap items-center gap-2">
-                  <h3 className="text-xl font-semibold text-slate-900">{reportDetail.reportName}</h3>
+                  <h3 className="text-xl font-semibold text-pov-charcoal">{reportDetail.reportName}</h3>
                   <Badge variant="outline">{reportDetail.reportType}</Badge>
                   {reportDetail.reportPeriod && (
-                    <Badge variant="secondary" className="bg-slate-100 text-slate-700">
+                    <Badge variant="secondary" className="bg-pov-gray text-charcoal-700">
                       {reportDetail.reportPeriod}
                     </Badge>
                   )}
                 </div>
-                <p className="text-sm text-slate-600">
+                <p className="text-sm text-charcoal-600">
                   Generated {formatTimestamp(reportDetail.generatedAt)} for as-of{' '}
                   {format(parseISO(reportDetail.asOfDate), 'MMM dd, yyyy')}
                 </p>
@@ -610,24 +610,24 @@ export default function Reports() {
                 </CardHeader>
                 <CardContent className="space-y-3">
                   {reportDetail.variances.length === 0 ? (
-                    <p className="text-sm text-slate-600">No variance metrics were emitted.</p>
+                    <p className="text-sm text-charcoal-600">No variance metrics were emitted.</p>
                   ) : (
                     reportDetail.variances.map((variance) => (
                       <div
                         key={variance.metric}
-                        className="flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2"
+                        className="flex items-center justify-between rounded-lg border border-beige-200 px-3 py-2"
                       >
                         <div>
-                          <div className="font-medium text-slate-900">
+                          <div className="font-medium text-pov-charcoal">
                             {formatMetricLabel(variance.metric)}
                           </div>
                           {formatMetricPercent(variance.pct) && (
-                            <div className="text-sm text-slate-500">
+                            <div className="text-sm text-charcoal-500">
                               {formatMetricPercent(variance.pct)}
                             </div>
                           )}
                         </div>
-                        <div className="text-right font-medium text-slate-900">
+                        <div className="text-right font-medium text-pov-charcoal">
                           {formatMetricValue(variance.metric, variance.value)}
                         </div>
                       </div>
@@ -644,27 +644,27 @@ export default function Reports() {
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  <div className="rounded-lg border border-slate-200 p-3">
-                    <div className="text-sm text-slate-500">Company Rows</div>
-                    <div className="mt-1 text-lg font-semibold text-slate-900">
+                  <div className="rounded-lg border border-beige-200 p-3">
+                    <div className="text-sm text-charcoal-500">Company Rows</div>
+                    <div className="mt-1 text-lg font-semibold text-pov-charcoal">
                       {reportDetail.portfolioVariances?.companyVariances.length ?? 0}
                     </div>
                   </div>
-                  <div className="rounded-lg border border-slate-200 p-3">
-                    <div className="text-sm text-slate-500">Sector Buckets</div>
-                    <div className="mt-1 text-lg font-semibold text-slate-900">
+                  <div className="rounded-lg border border-beige-200 p-3">
+                    <div className="text-sm text-charcoal-500">Sector Buckets</div>
+                    <div className="mt-1 text-lg font-semibold text-pov-charcoal">
                       {Object.keys(reportDetail.sectorVariances ?? {}).length}
                     </div>
                   </div>
-                  <div className="rounded-lg border border-slate-200 p-3">
-                    <div className="text-sm text-slate-500">Stage Buckets</div>
-                    <div className="mt-1 text-lg font-semibold text-slate-900">
+                  <div className="rounded-lg border border-beige-200 p-3">
+                    <div className="text-sm text-charcoal-500">Stage Buckets</div>
+                    <div className="mt-1 text-lg font-semibold text-pov-charcoal">
                       {Object.keys(reportDetail.stageVariances ?? {}).length}
                     </div>
                   </div>
-                  <div className="rounded-lg border border-slate-200 p-3">
-                    <div className="text-sm text-slate-500">Reserve / Pacing Signals</div>
-                    <div className="mt-1 text-lg font-semibold text-slate-900">
+                  <div className="rounded-lg border border-beige-200 p-3">
+                    <div className="text-sm text-charcoal-500">Reserve / Pacing Signals</div>
+                    <div className="mt-1 text-lg font-semibold text-pov-charcoal">
                       {(reportDetail.reserveVariances?.hasData ? 1 : 0) +
                         (reportDetail.pacingVariances?.hasData ? 1 : 0)}
                     </div>

--- a/client/src/components/reports/tear-sheet-dashboard.tsx
+++ b/client/src/components/reports/tear-sheet-dashboard.tsx
@@ -167,9 +167,9 @@ const MOCK_TEAR_SHEETS: TearSheet[] = [
       previousAnswer: 'Great - Really think the CEO is doing a great job with hiring SWEs.'
     },
     contacts: [
-      { name: 'Ethan Finkel', role: 'Solutions Architect', initial: 'E', color: 'bg-blue-600' },
-      { name: 'Xiaozhou Wang', role: '', initial: 'X', color: 'bg-teal-600' },
-      { name: 'Ann Demirtjis', role: 'CEO', initial: 'A', color: 'bg-green-600' }
+      { name: 'Ethan Finkel', role: 'Solutions Architect', initial: 'E', color: 'bg-pov-charcoal' },
+      { name: 'Xiaozhou Wang', role: '', initial: 'X', color: 'bg-presson-positive' },
+      { name: 'Ann Demirtjis', role: 'CEO', initial: 'A', color: 'bg-presson-info' }
     ]
   },
   {
@@ -210,8 +210,8 @@ const MOCK_TEAR_SHEETS: TearSheet[] = [
       version: 1
     },
     contacts: [
-      { name: 'Sarah Chen', role: 'Partner', initial: 'S', color: 'bg-purple-600' },
-      { name: 'Mike Rodriguez', role: 'CTO', initial: 'M', color: 'bg-orange-600' }
+      { name: 'Sarah Chen', role: 'Partner', initial: 'S', color: 'bg-pov-charcoal' },
+      { name: 'Mike Rodriguez', role: 'CTO', initial: 'M', color: 'bg-presson-positive' }
     ]
   }
 ];
@@ -376,17 +376,17 @@ export default function TearSheetDashboard() {
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between">
           <div className="flex items-center space-x-3">
-            <div className="w-8 h-8 bg-orange-500 rounded flex items-center justify-center">
-              <span className="text-white font-bold text-sm">
+            <div className="w-8 h-8 bg-pov-charcoal rounded flex items-center justify-center">
+              <span className="text-pov-white font-bold text-sm">
                 {tearSheet.companyName.charAt(0)}
               </span>
             </div>
             <div>
               <CardTitle className="text-lg flex items-center gap-2">
                 {tearSheet.companyName}
-                <ExternalLink className="h-4 w-4 text-gray-400" />
+                <ExternalLink className="h-4 w-4 text-charcoal-400" />
               </CardTitle>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-charcoal-600">
                 as of March 31, 2025
               </p>
             </div>
@@ -406,34 +406,34 @@ export default function TearSheetDashboard() {
         {/* Company Info Grid */}
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
           <div>
-            <div className="text-gray-500 text-xs uppercase">Fiscal Year</div>
+            <div className="text-charcoal-500 text-xs uppercase">Fiscal Year</div>
             <div className="font-medium">{tearSheet.data.fiscalYear}</div>
           </div>
           <div>
-            <div className="text-gray-500 text-xs uppercase">Location</div>
+            <div className="text-charcoal-500 text-xs uppercase">Location</div>
             <div className="font-medium">{tearSheet.data.location}</div>
           </div>
           <div>
-            <div className="text-gray-500 text-xs uppercase">Investment Lead</div>
+            <div className="text-charcoal-500 text-xs uppercase">Investment Lead</div>
             <div className="font-medium">{tearSheet.data.investmentLead}</div>
           </div>
           <div>
-            <div className="text-gray-500 text-xs uppercase">% of Fund</div>
+            <div className="text-charcoal-500 text-xs uppercase">% of Fund</div>
             <div className="font-medium">{tearSheet.data.percentOfFund}</div>
           </div>
           <div>
-            <div className="text-gray-500 text-xs uppercase">Classification</div>
+            <div className="text-charcoal-500 text-xs uppercase">Classification</div>
             <Badge variant="outline">{tearSheet.data.classification}</Badge>
           </div>
           <div>
-            <div className="text-gray-500 text-xs uppercase">Expected Exit Value</div>
+            <div className="text-charcoal-500 text-xs uppercase">Expected Exit Value</div>
             <div className="font-medium">{tearSheet.data.expectedExitValue}</div>
           </div>
         </div>
 
         {/* Board Composition */}
         <div>
-          <div className="text-gray-500 text-xs uppercase mb-2">Board Composition</div>
+          <div className="text-charcoal-500 text-xs uppercase mb-2">Board Composition</div>
           <div className="flex flex-wrap gap-1">
             {tearSheet.data.boardComposition.map((member, idx) => (
               <Badge key={idx} variant="secondary" className="text-xs">
@@ -445,7 +445,7 @@ export default function TearSheetDashboard() {
 
         {/* Co-Investors */}
         <div>
-          <div className="text-gray-500 text-xs uppercase mb-2">Co-Investors</div>
+          <div className="text-charcoal-500 text-xs uppercase mb-2">Co-Investors</div>
           <div className="flex flex-wrap gap-1">
             {tearSheet.data.coInvestors.map((investor, idx) => (
               <Badge key={idx} variant="outline" className="text-xs">
@@ -457,16 +457,16 @@ export default function TearSheetDashboard() {
 
         {/* Contacts */}
         <div className="flex items-center justify-between">
-          <div className="text-gray-500 text-xs uppercase">Contact</div>
+          <div className="text-charcoal-500 text-xs uppercase">Contact</div>
           <div className="flex items-center space-x-2">
             {tearSheet.contacts.map((contact, idx) => (
               <div key={idx} className="flex items-center space-x-1">
-                <div className={`w-6 h-6 rounded-full ${contact.color} text-white text-xs flex items-center justify-center`}>
+                <div className={`w-6 h-6 rounded-full ${contact.color} text-pov-white text-xs flex items-center justify-center`}>
                   {contact.initial}
                 </div>
                 <div className="text-sm">
                   <div className="font-medium">{contact.name}</div>
-                  {contact.role && <div className="text-gray-500 text-xs">{contact.role}</div>}
+                  {contact.role && <div className="text-charcoal-500 text-xs">{contact.role}</div>}
                 </div>
               </div>
             ))}
@@ -487,20 +487,20 @@ export default function TearSheetDashboard() {
           </div>
           
           {tearSheet.commentary.previousAnswer && (
-            <div className="mb-2 p-2 bg-gray-50 rounded text-sm">
-              <div className="text-gray-500 text-xs mb-1">Previous answer (as of Q4 2024)</div>
+            <div className="mb-2 p-2 bg-pov-gray rounded text-sm">
+              <div className="text-charcoal-500 text-xs mb-1">Previous answer (as of Q4 2024)</div>
               <div className="italic">{tearSheet.commentary.previousAnswer}</div>
             </div>
           )}
           
-          <div className="p-3 bg-blue-50 rounded">
+          <div className="p-3 bg-presson-info/10 rounded">
             <p className="text-sm">{tearSheet.commentary.content}</p>
           </div>
         </div>
 
         {/* Actions */}
         <div className="flex items-center justify-between pt-4 border-t">
-          <div className="flex items-center space-x-2 text-xs text-gray-500">
+          <div className="flex items-center space-x-2 text-xs text-charcoal-500">
             <User className="h-3 w-3" />
             <span>Modified by {tearSheet.modifiedBy}</span>
             <Clock className="h-3 w-3 ml-2" />
@@ -533,7 +533,7 @@ export default function TearSheetDashboard() {
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Tear Sheets</h1>
-          <p className="text-gray-600">Portfolio company tear sheets with LP commentary and audit trails</p>
+          <p className="text-charcoal-600">Portfolio company tear sheets with LP commentary and audit trails</p>
         </div>
         <div className="flex items-center space-x-2">
           <Button variant="outline">
@@ -557,7 +557,7 @@ export default function TearSheetDashboard() {
       {/* Search and Filters */}
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex-1 relative">
-          <Search className="h-4 w-4 absolute left-3 top-3 text-gray-400" />
+          <Search className="h-4 w-4 absolute left-3 top-3 text-charcoal-400" />
           <Input
             placeholder="Search companies, sectors, or team members..."
             value={searchTerm}
@@ -596,7 +596,7 @@ export default function TearSheetDashboard() {
 
       {/* Results Summary */}
       <div className="flex items-center justify-between">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-charcoal-600">
           Showing {filteredTearSheets.length} of {tearSheets.length} tear sheets
         </p>
         <div className="flex items-center space-x-2">
@@ -621,7 +621,7 @@ export default function TearSheetDashboard() {
           
           <div className="space-y-4">
             {selectedTearSheet?.commentary.previousAnswer && (
-              <div className="p-3 bg-gray-50 rounded">
+              <div className="p-3 bg-pov-gray rounded">
                 <div className="text-sm font-medium mb-2">Previous Answer</div>
                 <p className="text-sm italic">{selectedTearSheet.commentary.previousAnswer}</p>
               </div>
@@ -638,7 +638,7 @@ export default function TearSheetDashboard() {
             </div>
             
             <div className="flex items-center justify-between">
-              <div className="text-xs text-gray-500">
+              <div className="text-xs text-charcoal-500">
                 Version {selectedTearSheet?.commentary.version || 1} • 
                 Last updated {selectedTearSheet?.commentary.createdAt ? new Date(selectedTearSheet.commentary.createdAt).toLocaleDateString() : 'Never'}
               </div>
@@ -667,7 +667,7 @@ export default function TearSheetDashboard() {
           
           <div className="space-y-4">
             {auditLog.map((entry) => (
-              <div key={entry.id} className="border-l-4 border-blue-500 pl-4 py-2">
+              <div key={entry.id} className="border-l-4 border-l-presson-info pl-4 py-2">
                 <div className="flex items-center justify-between mb-2">
                   <div className="font-medium">
                     {entry.companyName} - {entry.action}
@@ -675,18 +675,18 @@ export default function TearSheetDashboard() {
                   <Badge variant="outline">v{entry.version}</Badge>
                 </div>
                 
-                <div className="text-sm text-gray-600 mb-2">
+                <div className="text-sm text-charcoal-600 mb-2">
                   {entry.field} updated by {entry.author} on {new Date(entry.timestamp).toLocaleString()}
                 </div>
                 
                 {entry.oldValue && entry.newValue && (
                   <div className="space-y-2">
-                    <div className="p-2 bg-red-50 rounded border-l-2 border-red-300">
-                      <div className="text-xs text-red-600 font-medium">Previous Value:</div>
+                    <div className="p-2 bg-error/10 rounded border-l-2 border-error/30">
+                      <div className="text-xs text-error-dark font-medium">Previous Value:</div>
                       <div className="text-sm">{entry.oldValue}</div>
                     </div>
-                    <div className="p-2 bg-green-50 rounded border-l-2 border-green-300">
-                      <div className="text-xs text-green-600 font-medium">New Value:</div>
+                    <div className="p-2 bg-success/10 rounded border-l-2 border-success/30">
+                      <div className="text-xs text-success-dark font-medium">New Value:</div>
                       <div className="text-sm">{entry.newValue}</div>
                     </div>
                   </div>

--- a/client/src/components/results/EvidenceHeader.tsx
+++ b/client/src/components/results/EvidenceHeader.tsx
@@ -42,7 +42,7 @@ interface EvidenceHeaderProps {
 type EvidenceState = 'READY' | 'CALCULATING' | 'FAILED' | 'STALE' | 'UNAVAILABLE';
 
 const DEFAULT_SOURCE = '/api/funds/:id/results';
-const NEUTRAL_BADGE = 'border-beige-200 bg-beige-50 text-charcoal-500';
+const NEUTRAL_BADGE = 'border-beige-200 bg-pov-gray text-charcoal-500';
 
 function deriveEvidenceState(lifecycle: EvidenceHeaderLifecycle): EvidenceState {
   if (lifecycle.status === 'failed') return 'FAILED';
@@ -63,15 +63,15 @@ function deriveEvidenceState(lifecycle: EvidenceHeaderLifecycle): EvidenceState 
 function statusClasses(state: EvidenceState) {
   switch (state) {
     case 'READY':
-      return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+      return 'border-success/50 bg-success/10 text-success-dark';
     case 'CALCULATING':
-      return 'border-amber-200 bg-amber-50 text-amber-800';
+      return 'border-warning/50 bg-warning/10 text-warning-dark';
     case 'FAILED':
-      return 'border-rose-200 bg-rose-50 text-rose-800';
+      return 'border-error/50 bg-error/10 text-error-dark';
     case 'STALE':
-      return 'border-amber-200 bg-amber-50 text-amber-800';
+      return 'border-warning/50 bg-warning/10 text-warning-dark';
     default:
-      return 'border-beige-200 bg-beige-50 text-charcoal-500';
+      return 'border-beige-200 bg-pov-gray text-charcoal-500';
   }
 }
 

--- a/client/src/components/results/scenario-evidence.ts
+++ b/client/src/components/results/scenario-evidence.ts
@@ -19,15 +19,15 @@ export interface ScenarioEvidenceSourceV1 {
 export function scenarioStateClasses(state: ScenarioEvidenceStateV1): string {
   switch (state) {
     case 'CURRENT':
-      return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+      return 'border-success/50 bg-success/10 text-success-dark';
     case 'STALE_PUBLISH':
     case 'CALCULATING':
-      return 'border-amber-200 bg-amber-50 text-amber-800';
+      return 'border-warning/50 bg-warning/10 text-warning-dark';
     case 'STALE_CONFIG':
     case 'FAILED':
-      return 'border-rose-200 bg-rose-50 text-rose-800';
+      return 'border-error/50 bg-error/10 text-error-dark';
     case 'UNAVAILABLE':
-      return 'border-beige-200 bg-beige-50 text-charcoal-500';
+      return 'border-beige-200 bg-pov-gray text-charcoal-500';
   }
 }
 

--- a/client/src/components/sensitivity/OneWayPanel.tsx
+++ b/client/src/components/sensitivity/OneWayPanel.tsx
@@ -51,6 +51,10 @@ import {
 import { formatMetricValue, formatVariableValue, useElapsedSeconds, SummaryCard } from './_shared';
 import { SensitivityRunErrorCard } from './SensitivityRunErrorCard';
 
+const CHART_GRID_COLOR = '#E0D8D1';
+const CHART_AXIS_COLOR = '#5A5A5A';
+const CHART_LINE_COLOR = '#292929';
+
 // =====================
 // VALIDATION
 // =====================
@@ -203,18 +207,18 @@ function ResultsSection({ result }: { result: OneWayAnalysisResultV1 }) {
           <div className="h-72" data-testid="one-way-chart">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={chartData} margin={{ top: 10, right: 24, bottom: 10, left: 12 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
                 <XAxis
                   dataKey="variableValue"
                   tickFormatter={(v: number) => formatVariableValue(v, variable)}
                   fontSize={11}
-                  stroke="#6b7280"
+                  stroke={CHART_AXIS_COLOR}
                 />
                 <YAxis
                   dataKey="metricValue"
                   tickFormatter={(v: number) => formatMetricValue(v, metric)}
                   fontSize={11}
-                  stroke="#6b7280"
+                  stroke={CHART_AXIS_COLOR}
                 />
                 <Tooltip
                   formatter={
@@ -226,18 +230,22 @@ function ResultsSection({ result }: { result: OneWayAnalysisResultV1 }) {
                   labelFormatter={
                     ((label: number) => formatVariableValue(label, variable)) as never
                   }
-                  contentStyle={{ fontSize: 12, borderRadius: 6, border: '1px solid #e5e7eb' }}
+                  contentStyle={{
+                    fontSize: 12,
+                    borderRadius: 6,
+                    border: `1px solid ${CHART_GRID_COLOR}`,
+                  }}
                 />
                 <ReferenceLine
                   y={result.baselineValue}
-                  stroke="#94a3b8"
+                  stroke={CHART_AXIS_COLOR}
                   strokeDasharray="4 4"
-                  label={{ value: 'Baseline', fill: '#64748b', fontSize: 10, position: 'right' }}
+                  label={{ value: 'Baseline', fill: CHART_AXIS_COLOR, fontSize: 10, position: 'right' }}
                 />
                 <Line
                   type="monotone"
                   dataKey="metricValue"
-                  stroke="#1e293b"
+                  stroke={CHART_LINE_COLOR}
                   strokeWidth={2}
                   dot={{ r: 3 }}
                 />

--- a/client/src/components/sharing/ShareConfigModal.tsx
+++ b/client/src/components/sharing/ShareConfigModal.tsx
@@ -126,8 +126,8 @@ export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
 
         {createdLink ? (
           <div className="space-y-4">
-            <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-              <h3 className="font-medium text-green-900 mb-2 flex items-center gap-2">
+            <div className="bg-success/10 border border-success/50 rounded-lg p-4">
+              <h3 className="font-medium text-success-dark mb-2 flex items-center gap-2">
                 <Eye className="h-4 w-4" />
                 Share Link Created Successfully
               </h3>
@@ -194,7 +194,7 @@ export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
               <div className="flex items-center justify-between">
                 <div>
                   <Label>Require Passkey</Label>
-                  <p className="text-sm text-gray-600">Protect access with a password</p>
+                  <p className="text-sm text-charcoal-600">Protect access with a password</p>
                 </div>
                 <Switch
                   checked={config.requirePasskey}
@@ -266,7 +266,7 @@ export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
             {/* Hidden Metrics */}
             <div className="space-y-4">
               <h3 className="font-medium">Hidden Metrics (LP Protection)</h3>
-              <p className="text-sm text-gray-600">Select metrics to hide from LP view</p>
+              <p className="text-sm text-charcoal-600">Select metrics to hide from LP view</p>
 
               <div className="grid grid-cols-2 gap-3">
                 {LP_HIDDEN_METRICS.map((metric) => (

--- a/client/src/features/analytics-parity/QuarterlyReviewTrace.tsx
+++ b/client/src/features/analytics-parity/QuarterlyReviewTrace.tsx
@@ -20,11 +20,11 @@ const STATUS_LABELS: Record<AnalyticsTraceStatus, string> = {
 };
 
 const STATUS_CLASSES: Record<AnalyticsTraceStatus, string> = {
-  available: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  pending: 'border-amber-200 bg-amber-50 text-amber-700',
-  unavailable: 'border-slate-200 bg-slate-50 text-slate-600',
-  linked: 'border-blue-200 bg-blue-50 text-blue-700',
-  deferred: 'border-beige-200 bg-lightGray text-charcoal-500',
+  available: 'border-success/50 bg-success/10 text-success-dark',
+  pending: 'border-warning/50 bg-warning/10 text-warning-dark',
+  unavailable: 'border-beige-200 bg-pov-gray text-charcoal-600',
+  linked: 'border-presson-info/30 bg-presson-info/10 text-presson-info',
+  deferred: 'border-beige-200 bg-pov-gray text-charcoal-500',
 };
 
 interface QuarterlyReviewTraceProps {
@@ -61,7 +61,7 @@ export function QuarterlyReviewTrace({ results, comparison, fundId }: QuarterlyR
 
   return (
     <section
-      className="bg-white rounded-lg border border-beige-200 p-6 space-y-5"
+      className="bg-pov-white rounded-lg border border-beige-200 p-6 space-y-5"
       aria-labelledby="quarterly-review-trace-title"
       data-testid="quarterly-review-trace"
     >
@@ -104,7 +104,7 @@ export function QuarterlyReviewTrace({ results, comparison, fundId }: QuarterlyR
         ))}
       </div>
 
-      <div className="rounded-md border border-beige-200 bg-lightGray p-4">
+      <div className="rounded-md border border-beige-200 bg-pov-gray p-4">
         <h3 className="text-sm font-semibold text-charcoal">Deferred Parity Ledger</h3>
         <dl className="mt-3 grid gap-3 md:grid-cols-2">
           {trace.deferred.map((item) => (

--- a/client/src/lib/fund-header-metric-calculations.ts
+++ b/client/src/lib/fund-header-metric-calculations.ts
@@ -36,7 +36,7 @@ const COMPACT_KPI_DEFINITIONS: Record<CompactKpiKey, CompactKpiDefinition> = {
     key: 'deployed',
     label: 'Deployed',
     icon: 'activity',
-    colorClassName: 'text-slate-700',
+    colorClassName: 'text-charcoal-700',
     description: 'Capital deployed as a percentage of fund size',
     valueType: 'percentage',
   },
@@ -44,7 +44,7 @@ const COMPACT_KPI_DEFINITIONS: Record<CompactKpiKey, CompactKpiDefinition> = {
     key: 'remaining',
     label: 'Remaining',
     icon: 'calendar',
-    colorClassName: 'text-slate-700',
+    colorClassName: 'text-charcoal-700',
     description: 'Remaining deployable capital',
     valueType: 'currency',
   },
@@ -52,7 +52,7 @@ const COMPACT_KPI_DEFINITIONS: Record<CompactKpiKey, CompactKpiDefinition> = {
     key: 'nav',
     label: 'NAV',
     icon: 'target',
-    colorClassName: 'text-slate-700',
+    colorClassName: 'text-charcoal-700',
     description: 'Net Asset Value',
     valueType: 'currency',
   },
@@ -60,7 +60,7 @@ const COMPACT_KPI_DEFINITIONS: Record<CompactKpiKey, CompactKpiDefinition> = {
     key: 'tvpi',
     label: 'TVPI',
     icon: 'trending-up',
-    colorClassName: 'text-slate-700',
+    colorClassName: 'text-charcoal-700',
     description: 'Total Value to Paid-In',
     valueType: 'multiple',
   },
@@ -68,7 +68,7 @@ const COMPACT_KPI_DEFINITIONS: Record<CompactKpiKey, CompactKpiDefinition> = {
     key: 'dpi',
     label: 'DPI',
     icon: 'dollar',
-    colorClassName: 'text-slate-700',
+    colorClassName: 'text-charcoal-700',
     description: 'Distributions to Paid-In',
     valueType: 'multiple',
   },
@@ -76,7 +76,7 @@ const COMPACT_KPI_DEFINITIONS: Record<CompactKpiKey, CompactKpiDefinition> = {
     key: 'netIrr',
     label: 'Net IRR',
     icon: 'bar-chart',
-    colorClassName: 'text-slate-700',
+    colorClassName: 'text-charcoal-700',
     description: 'Net internal rate of return',
     valueType: 'percentage',
   },
@@ -397,8 +397,8 @@ function getLastUpdatedText(
 }
 
 function getStatusIndicatorClassName(metricUnavailable: boolean) {
-  if (metricUnavailable) return 'bg-red-500';
-  return 'bg-green-500 animate-pulse';
+  if (metricUnavailable) return 'bg-error';
+  return 'bg-success animate-pulse';
 }
 
 function getStatusIndicatorText(metricsLoading: boolean, metricUnavailable: boolean) {

--- a/client/src/lib/reallocation-utils.ts
+++ b/client/src/lib/reallocation-utils.ts
@@ -94,9 +94,9 @@ export function formatDelta(
  * @returns Tailwind color class
  */
 export function getDeltaColorClass(deltaCents: number): string {
-  if (deltaCents > 0) return 'text-green-600';
-  if (deltaCents < 0) return 'text-red-600';
-  return 'text-gray-500';
+  if (deltaCents > 0) return 'text-presson-positive';
+  if (deltaCents < 0) return 'text-presson-negative';
+  return 'text-charcoal-500';
 }
 
 /**

--- a/client/src/lib/toast.ts
+++ b/client/src/lib/toast.ts
@@ -8,11 +8,10 @@ export function toast(message: string, type: 'success' | 'error' | 'info' = 'suc
   const existingToasts = document.querySelectorAll('.simple-toast').length;
   const div = document.createElement('div');
   
-  const bgColor = type === 'success' ? 'bg-green-500' : 
-                  type === 'error' ? 'bg-red-500' : 
-                  'bg-blue-500';
+  const bgColor =
+    type === 'success' ? 'bg-success' : type === 'error' ? 'bg-error' : 'bg-presson-info';
   
-  div.className = `simple-toast fixed top-4 right-4 px-4 py-2 rounded shadow-lg z-50 ${bgColor} text-white transition-transform duration-300`;
+  div.className = `simple-toast fixed top-4 right-4 px-4 py-2 rounded shadow-lg z-50 ${bgColor} text-pov-white transition-transform duration-300`;
   
   // Offset new toasts from existing ones
   div.style.transform = `translateY(${existingToasts * 60}px)`;
@@ -62,4 +61,3 @@ export async function withToast<T>(
     throw err;
   }
 }
-

--- a/client/src/pages/FundBasicsStep.tsx
+++ b/client/src/pages/FundBasicsStep.tsx
@@ -182,7 +182,7 @@ export default function FundBasicsStep() {
         {/* Fund Structure Section */}
         <div className="space-y-6">
           <div className="space-y-3">
-            <Label htmlFor="fund-name" className="text-sm font-poppins font-medium text-[#292929]">
+            <Label htmlFor="fund-name" className="text-sm font-poppins font-medium text-pov-charcoal">
               Fund Name *
             </Label>
             <Input
@@ -195,7 +195,7 @@ export default function FundBasicsStep() {
               data-testid="fund-name"
               required
               aria-required="true"
-              className="h-12 max-w-2xl text-base font-poppins border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929]"
+              className="h-12 max-w-2xl text-base font-poppins border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40"
             />
           </div>
 
@@ -210,7 +210,7 @@ export default function FundBasicsStep() {
             required
           />
 
-          <div className="flex items-center space-x-3 pt-6 border-t border-[#E0D8D1]">
+          <div className="flex items-center space-x-3 pt-6 border-t border-beige-200">
             <Switch
               id="evergreen"
               checked={isEvergreen || false}
@@ -219,7 +219,7 @@ export default function FundBasicsStep() {
             />
             <Label
               htmlFor="evergreen"
-              className="cursor-pointer text-sm font-poppins font-medium text-[#292929]"
+              className="cursor-pointer text-sm font-poppins font-medium text-pov-charcoal"
             >
               Evergreen Fund Structure
             </Label>
@@ -230,7 +230,7 @@ export default function FundBasicsStep() {
               <div className="space-y-3">
                 <Label
                   htmlFor="fund-life"
-                  className="text-sm font-poppins font-medium text-[#292929]"
+                  className="text-sm font-poppins font-medium text-pov-charcoal"
                 >
                   Fund Life (years)
                 </Label>
@@ -245,14 +245,14 @@ export default function FundBasicsStep() {
                   }
                   placeholder="e.g., 10"
                   data-testid="fund-life"
-                  className="h-12 font-poppins border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929]"
+                  className="h-12 font-poppins border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40"
                 />
               </div>
 
               <div className="space-y-3">
                 <Label
                   htmlFor="investment-period"
-                  className="text-sm font-poppins font-medium text-[#292929]"
+                  className="text-sm font-poppins font-medium text-pov-charcoal"
                 >
                   Investment Period (years)
                 </Label>
@@ -267,7 +267,7 @@ export default function FundBasicsStep() {
                   }
                   placeholder="e.g., 3"
                   data-testid="investment-period"
-                  className="h-12 font-poppins border-[#E0D8D1] focus:border-[#292929] focus:ring-[#292929]"
+                  className="h-12 font-poppins border-beige-200 focus:border-pov-charcoal focus:ring-charcoal/40"
                 />
               </div>
             </div>
@@ -304,9 +304,9 @@ export default function FundBasicsStep() {
         </WizardCard>
 
         {/* Navigation */}
-        <div className="space-y-3 pt-8 border-t border-[#E0D8D1] mt-8">
+        <div className="space-y-3 pt-8 border-t border-beige-200 mt-8">
           {bootstrapError && (
-            <p role="alert" className="text-sm font-poppins text-red-600">
+            <p role="alert" className="text-sm font-poppins text-error-dark">
               {bootstrapError}
             </p>
           )}
@@ -318,7 +318,7 @@ export default function FundBasicsStep() {
                 void handleNext();
               }}
               disabled={isBootstrapping}
-              className="flex items-center gap-2 bg-[#292929] hover:bg-[#292929]/90 text-white px-8 py-3 h-auto font-poppins font-medium transition-all duration-200"
+              className="flex items-center gap-2 bg-pov-charcoal hover:bg-charcoal-700 text-pov-white px-8 py-3 h-auto font-poppins font-medium transition-all duration-200"
             >
               {bootstrapStage === 'creating'
                 ? 'Creating Draft...'

--- a/client/src/pages/InvestmentRoundsStepV2.tsx
+++ b/client/src/pages/InvestmentRoundsStepV2.tsx
@@ -209,12 +209,12 @@ export default function InvestmentRoundsStepV2() {
             </div>
 
             {/* Navigation */}
-            <div className="flex justify-between pt-6 mt-8 border-t border-[#E0D8D1]">
+            <div className="flex justify-between pt-6 mt-8 border-t border-beige-200">
               <Button
                 data-testid="previous-step"
                 variant="outline"
                 onClick={() => navigate('/fund-setup?step=1')}
-                className="flex items-center gap-2 px-8 py-3 h-auto border-[#E0D8D1] hover:bg-[#E0D8D1]/20 hover:border-[#292929] font-poppins font-medium"
+                className="flex items-center gap-2 px-8 py-3 h-auto border-beige-200 hover:bg-beige/20 hover:border-pov-charcoal font-poppins font-medium"
               >
                 <ArrowLeft className="h-4 w-4" />
                 Previous
@@ -223,7 +223,7 @@ export default function InvestmentRoundsStepV2() {
                 data-testid="next-step"
                 onClick={() => navigate('/fund-setup?step=3')}
                 disabled={hasErrors}
-                className="flex items-center gap-2 bg-[#292929] hover:bg-[#292929]/90 text-white px-8 py-3 h-auto font-poppins font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 bg-pov-charcoal hover:bg-charcoal-700 text-pov-white px-8 py-3 h-auto font-poppins font-medium disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Next Step
                 <ArrowRight className="h-4 w-4" />

--- a/client/src/pages/help.tsx
+++ b/client/src/pages/help.tsx
@@ -19,7 +19,7 @@ import {
 
 export default function HelpPage() {
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className="min-h-screen bg-pov-gray">
       <POVBrandHeader
         title="Help & Support"
         subtitle="Documentation, tutorials, and contact support"
@@ -39,7 +39,7 @@ export default function HelpPage() {
                   <h3 className="font-inter font-semibold text-sm text-pov-charcoal mb-1">
                     Documentation
                   </h3>
-                  <p className="font-poppins text-xs text-gray-500 mb-3">
+                  <p className="font-poppins text-xs text-charcoal-500 mb-3">
                     Comprehensive guides for all features
                   </p>
                   <Button variant="link" className="p-0 h-auto text-pov-charcoal">
@@ -60,7 +60,7 @@ export default function HelpPage() {
                   <h3 className="font-inter font-semibold text-sm text-pov-charcoal mb-1">
                     Video Tutorials
                   </h3>
-                  <p className="font-poppins text-xs text-gray-500 mb-3">
+                  <p className="font-poppins text-xs text-charcoal-500 mb-3">
                     Step-by-step walkthrough videos
                   </p>
                   <Button variant="link" className="p-0 h-auto text-pov-charcoal">
@@ -86,20 +86,20 @@ export default function HelpPage() {
             </div>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="border-b border-gray-100 pb-4">
+            <div className="border-b border-beige-200 pb-4">
               <h4 className="font-inter font-medium text-sm text-pov-charcoal mb-2">
                 How do I add a new portfolio company?
               </h4>
-              <p className="font-poppins text-xs text-gray-500">
+              <p className="font-poppins text-xs text-charcoal-500">
                 Navigate to Portfolio, then click "Add Company" in the Companies tab.
                 Fill in the company details and investment information.
               </p>
             </div>
-            <div className="border-b border-gray-100 pb-4">
+            <div className="border-b border-beige-200 pb-4">
               <h4 className="font-inter font-medium text-sm text-pov-charcoal mb-2">
                 What is Reserve Planning?
               </h4>
-              <p className="font-poppins text-xs text-gray-500">
+              <p className="font-poppins text-xs text-charcoal-500">
                 Reserve Planning helps you allocate follow-on capital across your portfolio.
                 Use the Reallocation Tools to optimize reserve distribution.
               </p>
@@ -108,7 +108,7 @@ export default function HelpPage() {
               <h4 className="font-inter font-medium text-sm text-pov-charcoal mb-2">
                 How do I create scenarios for a company?
               </h4>
-              <p className="font-poppins text-xs text-gray-500">
+              <p className="font-poppins text-xs text-charcoal-500">
                 Open any company from Portfolio, then select the Scenarios tab.
                 Create scenarios to model different exit outcomes and valuations.
               </p>
@@ -130,14 +130,14 @@ export default function HelpPage() {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="flex items-center justify-between p-4 rounded-lg bg-gray-50">
+            <div className="flex items-center justify-between p-4 rounded-lg bg-pov-gray">
               <div className="flex items-center gap-3">
                 <Mail className="h-5 w-5 text-pov-charcoal/60" />
                 <div>
                   <p className="font-inter text-sm font-medium text-pov-charcoal">
                     Email Support
                   </p>
-                  <p className="font-poppins text-xs text-gray-500">
+                  <p className="font-poppins text-xs text-charcoal-500">
                     support@pressonfund.com
                   </p>
                 </div>
@@ -167,13 +167,13 @@ export default function HelpPage() {
             <div className="space-y-3">
               <div className="flex items-start gap-3">
                 <span className="font-mono text-xs text-pov-charcoal/60 mt-0.5">v2.4.0</span>
-                <p className="font-poppins text-sm text-gray-600">
+                <p className="font-poppins text-sm text-charcoal-600">
                   Simplified navigation with 4 primary nav items, merged Reserve Planning tab
                 </p>
               </div>
               <div className="flex items-start gap-3">
                 <span className="font-mono text-xs text-pov-charcoal/60 mt-0.5">v2.3.0</span>
-                <p className="font-poppins text-sm text-gray-600">
+                <p className="font-poppins text-sm text-charcoal-600">
                   Added company-level Scenarios tab with scenario comparison charts
                 </p>
               </div>

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -8,15 +8,15 @@ import { AlertCircle } from "lucide-react";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen w-full flex items-center justify-center bg-pov-gray">
       <Card className="w-full max-w-md mx-4">
         <CardContent className="pt-6">
           <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+            <AlertCircle className="h-8 w-8 text-error" />
+            <h1 className="text-2xl font-bold text-pov-charcoal">404 Page Not Found</h1>
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
+          <p className="mt-4 text-sm text-charcoal-600">
             Did you forget to add the page to the router?
           </p>
         </CardContent>
@@ -24,4 +24,3 @@ export default function NotFound() {
     </div>
   );
 }
-

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -20,7 +20,7 @@ import {
 
 export default function SettingsPage() {
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className="min-h-screen bg-pov-gray">
       <POVBrandHeader
         title="Settings"
         subtitle="Configure your fund preferences and integrations"
@@ -45,14 +45,14 @@ export default function SettingsPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="font-inter text-sm font-medium text-pov-charcoal">Display Name</p>
-                <p className="font-poppins text-xs text-gray-500">Fund Manager</p>
+                <p className="font-poppins text-xs text-charcoal-500">Fund Manager</p>
               </div>
               <Button variant="outline" size="sm">Edit</Button>
             </div>
             <div className="flex items-center justify-between">
               <div>
                 <p className="font-inter text-sm font-medium text-pov-charcoal">Email</p>
-                <p className="font-poppins text-xs text-gray-500">manager@pressonfund.com</p>
+                <p className="font-poppins text-xs text-charcoal-500">manager@pressonfund.com</p>
               </div>
               <Button variant="outline" size="sm">Change</Button>
             </div>
@@ -76,14 +76,14 @@ export default function SettingsPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="font-inter text-sm font-medium text-pov-charcoal">Email Digests</p>
-                <p className="font-poppins text-xs text-gray-500">Weekly portfolio summary</p>
+                <p className="font-poppins text-xs text-charcoal-500">Weekly portfolio summary</p>
               </div>
               <Switch />
             </div>
             <div className="flex items-center justify-between">
               <div>
                 <p className="font-inter text-sm font-medium text-pov-charcoal">KPI Reminders</p>
-                <p className="font-poppins text-xs text-gray-500">Notify when company updates are due</p>
+                <p className="font-poppins text-xs text-charcoal-500">Notify when company updates are due</p>
               </div>
               <Switch defaultChecked />
             </div>
@@ -107,7 +107,7 @@ export default function SettingsPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="font-inter text-sm font-medium text-pov-charcoal">Export Data</p>
-                <p className="font-poppins text-xs text-gray-500">Download all fund data as CSV</p>
+                <p className="font-poppins text-xs text-charcoal-500">Download all fund data as CSV</p>
               </div>
               <Button variant="outline" size="sm">
                 <Database className="h-4 w-4 mr-2" />
@@ -131,12 +131,12 @@ export default function SettingsPage() {
             </div>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="flex items-center justify-between p-3 rounded-lg bg-gray-50">
+            <div className="flex items-center justify-between p-3 rounded-lg bg-pov-gray">
               <div className="flex items-center gap-3">
                 <Activity className="h-5 w-5 text-pov-charcoal/60" />
                 <div>
                   <p className="font-inter text-sm font-medium text-pov-charcoal">Secondary Market</p>
-                  <p className="font-poppins text-xs text-gray-500">
+                  <p className="font-poppins text-xs text-charcoal-500">
                     Deferred until the core internal workflow perimeter is stabilized
                   </p>
                 </div>
@@ -145,12 +145,12 @@ export default function SettingsPage() {
                 Deferred
               </Button>
             </div>
-            <div className="flex items-center justify-between p-3 rounded-lg bg-gray-50">
+            <div className="flex items-center justify-between p-3 rounded-lg bg-pov-gray">
               <div className="flex items-center gap-3">
                 <Database className="h-5 w-5 text-pov-charcoal/60" />
                 <div>
                   <p className="font-inter text-sm font-medium text-pov-charcoal">Notion Integration</p>
-                  <p className="font-poppins text-xs text-gray-500">
+                  <p className="font-poppins text-xs text-charcoal-500">
                     Deferred until the default runtime perimeter is reduced and hardened
                   </p>
                 </div>

--- a/client/src/pages/steps/StepNotFound.tsx
+++ b/client/src/pages/steps/StepNotFound.tsx
@@ -3,18 +3,18 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function StepNotFound() {
   return (
-    <Card className="border-yellow-200 bg-yellow-50">
+    <Card className="border-warning/50 bg-warning/10">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-yellow-800">
+        <CardTitle className="flex items-center gap-2 text-warning-dark">
           <AlertCircle className="h-5 w-5" />
           Step Not Found
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="text-yellow-700">
+        <p className="text-warning-dark">
           The requested wizard step could not be loaded. This may be due to a navigation error or missing component.
         </p>
-        <p className="text-sm text-yellow-600 mt-2">
+        <p className="text-sm text-warning-dark mt-2">
           Please try refreshing the page or contact support if the problem persists.
         </p>
       </CardContent>

--- a/client/src/pages/v2/cash.tsx
+++ b/client/src/pages/v2/cash.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react';
 import { AppShell } from '@/components/presson-v2/AppShell';
 import { Btn } from '@/components/presson-v2/primitives';
 import { cashCalls, cashBreakdown } from '@/components/presson-v2/mock';
+import { presson } from '@/theme/presson.tokens';
 
 /**
  * Cash & forecast · Press On v2 ledger.
@@ -136,7 +137,7 @@ const TABLE_STYLE: CSSProperties = {
 };
 
 function barColor(tone: 'warm' | 'tint' | 'ink'): string {
-  if (tone === 'warm') return 'var(--pv2-warm-deep, #C9BFB4)';
+  if (tone === 'warm') return presson.color.highlight;
   if (tone === 'tint') return 'var(--pv2-rule)';
   return 'var(--pv2-ink)';
 }
@@ -269,21 +270,21 @@ function CashRibbon() {
     >
       <defs>
         <linearGradient id="pv2-ribbon-grad" x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0%" stopColor="#E0D8D1" stopOpacity="0.5" />
-          <stop offset="100%" stopColor="#E0D8D1" stopOpacity="0" />
+          <stop offset="0%" stopColor={presson.color.highlight} stopOpacity="0.5" />
+          <stop offset="100%" stopColor={presson.color.highlight} stopOpacity="0" />
         </linearGradient>
         <pattern id="pv2-ribbon-grain" width="3" height="3" patternUnits="userSpaceOnUse">
           <circle cx="0.5" cy="0.5" r="0.3" fill="rgba(41,41,41,0.05)" />
         </pattern>
       </defs>
 
-      <g stroke="#EEE9E3">
+      <g stroke={presson.color.borderSubtle}>
         <line x1="32" y1="70" x2="1300" y2="70" />
         <line x1="32" y1="140" x2="1300" y2="140" />
         <line x1="32" y1="210" x2="1300" y2="210" />
       </g>
 
-      <g fontFamily="JetBrains Mono" fontSize="9.5" fill="#A8A8A8" letterSpacing="0.1em">
+      <g fontFamily="JetBrains Mono" fontSize="9.5" fill={presson.color.textMuted} letterSpacing="0.1em">
         <text x="6" y="74">
           $18M
         </text>
@@ -297,7 +298,7 @@ function CashRibbon() {
 
       <path
         d="M32,96 L120,100 L208,90 L296,106 L384,112 L472,120 L560,128 L600,132"
-        stroke="#292929"
+        stroke={presson.color.text}
         strokeWidth="2.5"
         fill="none"
       />
@@ -308,32 +309,32 @@ function CashRibbon() {
       />
       <path
         d="M600,132 L740,148 L880,156 L1020,180 L1160,196 L1300,218"
-        stroke="#C9BFB4"
+        stroke={presson.color.highlight}
         strokeWidth="1"
         fill="none"
       />
       <path
         d="M600,132 L740,104 L880,82 L1020,60 L1160,70 L1300,96"
-        stroke="#C9BFB4"
+        stroke={presson.color.highlight}
         strokeWidth="1"
         fill="none"
       />
 
       <path
         d="M600,132 L740,126 L880,118 L1020,128 L1160,138 L1300,148"
-        stroke="#292929"
+        stroke={presson.color.text}
         strokeWidth="1.5"
         strokeDasharray="5 4"
         fill="none"
       />
 
-      <line x1="600" y1="20" x2="600" y2="248" stroke="#292929" strokeWidth="1" />
+      <line x1="600" y1="20" x2="600" y2="248" stroke={presson.color.text} strokeWidth="1" />
       <text
         x="608"
         y="34"
         fontFamily="JetBrains Mono"
         fontSize="10"
-        fill="#292929"
+        fill={presson.color.text}
         letterSpacing="0.1em"
       >
         TODAY · MAY 12
@@ -346,7 +347,7 @@ function CashRibbon() {
 
       <rect width="1320" height="280" fill="url(#pv2-ribbon-grain)" />
 
-      <g fontFamily="JetBrains Mono" fontSize="10" fill="#A8A8A8" letterSpacing="0.1em">
+      <g fontFamily="JetBrains Mono" fontSize="10" fill={presson.color.textMuted} letterSpacing="0.1em">
         <text x="32" y="266">
           JAN
         </text>
@@ -381,18 +382,18 @@ function Pin({ x, y, label, dashed }: { x: number; y: number; label: string; das
         y1={y}
         x2={x}
         y2={y + 18}
-        stroke="#292929"
+        stroke={presson.color.text}
         strokeWidth="1"
         strokeDasharray={dashed ? '2 2' : undefined}
       />
-      <circle cx={x} cy={y} r="3.5" fill="#292929" />
+      <circle cx={x} cy={y} r="3.5" fill={presson.color.text} />
       <text
         x={x + 8}
         y={y + 2}
         fontFamily="Inter"
         fontSize="11.5"
         fontWeight="600"
-        fill="#292929"
+        fill={presson.color.text}
         letterSpacing="-0.01em"
       >
         {label}

--- a/client/src/pages/v2/company.tsx
+++ b/client/src/pages/v2/company.tsx
@@ -2,6 +2,7 @@ import { useParams, useLocation } from 'wouter';
 import { AppShell } from '@/components/presson-v2/AppShell';
 import { Btn } from '@/components/presson-v2/primitives';
 import { companies, kpiSparklines } from '@/components/presson-v2/mock';
+import { presson } from '@/theme/presson.tokens';
 
 /**
  * Company file · Press On v2.
@@ -46,10 +47,10 @@ export default function CompanyV2() {
             <div className="pv2-dossier-watchers-row">
               <span className="pv2-avatar">PJ</span>
               <span className="pv2-avatar">FC</span>
-              <span className="pv2-avatar" style={{ background: '#5A5A5A' }}>
+              <span className="pv2-avatar" style={{ background: presson.color.textMuted }}>
                 KS
               </span>
-              <span className="pv2-avatar" style={{ background: '#9A9A9A' }}>
+              <span className="pv2-avatar" style={{ background: presson.color.textMuted }}>
                 +2
               </span>
             </div>
@@ -163,9 +164,9 @@ function TrajectoryRibbon() {
         </pattern>
       </defs>
       {/* Spine */}
-      <line x1="40" y1="120" x2="1140" y2="120" stroke="#E0D8D1" strokeWidth="2" />
-      <rect x="40" y="118" width="460" height="4" fill="#292929" />
-      <rect x="500" y="118" width="640" height="4" fill="#E0D8D1" />
+      <line x1="40" y1="120" x2="1140" y2="120" stroke={presson.color.highlight} strokeWidth="2" />
+      <rect x="40" y="118" width="460" height="4" fill={presson.color.text} />
+      <rect x="500" y="118" width="640" height="4" fill={presson.color.highlight} />
 
       {/* SEED */}
       <Node x={80} r={6} label="SEED" date="JAN ’19" amount="$250K" pre="$3M pre" />
@@ -226,25 +227,25 @@ function Node({
   projected?: boolean;
 }) {
   return (
-    <g fontFamily="JetBrains Mono" fontSize="10" fill="#7A7A7A" letterSpacing="0.06em">
+    <g fontFamily="JetBrains Mono" fontSize="10" fill={presson.color.textMuted} letterSpacing="0.06em">
       {projected ? (
         <circle
           cx={x}
           cy="120"
           r={r}
           fill="none"
-          stroke="#292929"
+          stroke={presson.color.text}
           strokeWidth="1"
           strokeDasharray="2 2"
         />
       ) : (
-        <circle cx={x} cy="120" r={r} fill="#292929" />
+        <circle cx={x} cy="120" r={r} fill={presson.color.text} />
       )}
       <text
         x={x}
         y="146"
         textAnchor="middle"
-        fill="#292929"
+        fill={presson.color.text}
         fontWeight={big ? 700 : 500}
         letterSpacing="0.08em"
       >
@@ -257,7 +258,7 @@ function Node({
         x={x}
         y="100"
         textAnchor="middle"
-        fill="#292929"
+        fill={presson.color.text}
         fontFamily="Inter"
         fontSize="12"
         fontWeight="600"

--- a/client/src/pages/v2/exits.tsx
+++ b/client/src/pages/v2/exits.tsx
@@ -1,6 +1,7 @@
 import { AppShell } from '@/components/presson-v2/AppShell';
 import { Btn } from '@/components/presson-v2/primitives';
 import { exitCases } from '@/components/presson-v2/mock';
+import { presson } from '@/theme/presson.tokens';
 
 /**
  * Exits · Press On v2 cinema.
@@ -35,7 +36,7 @@ function CinemaMast() {
         </h1>
         <p className="pv2-cinema-sub">
           Probability-weighted 25 / 50 / 25 →{' '}
-          <span style={{ color: '#fff' }}>3.42× TVPI · $599M</span>
+          <span style={{ color: presson.color.accentOn }}>3.42× TVPI · $599M</span>
         </p>
       </div>
       <div className="pv2-cinema-fig">
@@ -108,7 +109,7 @@ const FUND_RETURNS = [
 const WEIGHTED_LINE_STYLE = {
   fontFamily: 'var(--pv2-font-mono)',
   fontSize: 10,
-  color: '#888',
+  color: presson.color.highlight,
   letterSpacing: '0.1em',
   textTransform: 'uppercase',
   marginTop: 20,
@@ -142,7 +143,7 @@ function CinemaBottom() {
         ))}
         <div style={WEIGHTED_LINE_STYLE}>
           Probability-weighted · 25% / 50% / 25% →{' '}
-          <span style={{ color: '#fff' }}>3.42× TVPI · $599M</span>
+          <span style={{ color: presson.color.accentOn }}>3.42× TVPI · $599M</span>
         </div>
       </div>
     </div>
@@ -182,7 +183,7 @@ function Distribution() {
   const colW = 84;
   return (
     <svg viewBox="0 0 720 220" style={{ width: '100%', height: 220 }}>
-      <g stroke="#1F1F1F">
+      <g stroke={presson.color.text}>
         <line x1="0" y1="60" x2="720" y2="60" />
         <line x1="0" y1="120" x2="720" y2="120" />
         <line x1="0" y1="180" x2="720" y2="180" />
@@ -203,7 +204,7 @@ function Distribution() {
             fontFamily="Inter"
             fontSize="12"
             fontWeight="600"
-            fill={b.pct === 0 ? '#666' : '#fff'}
+            fill={b.pct === 0 ? presson.color.textMuted : presson.color.accentOn}
             letterSpacing="-0.01em"
           >
             {b.pct}%
@@ -214,7 +215,7 @@ function Distribution() {
             textAnchor="middle"
             fontFamily="JetBrains Mono"
             fontSize="10"
-            fill="#888"
+            fill={presson.color.highlight}
             letterSpacing="0.06em"
           >
             {b.label}

--- a/client/src/pages/v2/insights.tsx
+++ b/client/src/pages/v2/insights.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { AppShell } from '@/components/presson-v2/AppShell';
 import { Btn } from '@/components/presson-v2/primitives';
 import { insights } from '@/components/presson-v2/mock';
+import { presson } from '@/theme/presson.tokens';
 
 const LENSES = [
   {
@@ -122,7 +123,7 @@ export default function InsightsV2() {
                     display: 'inline-block',
                     width: 10,
                     height: 10,
-                    background: 'var(--pv2-warm-deep, #C9BFB4)',
+                    background: presson.color.highlight,
                     verticalAlign: 'middle',
                   }}
                 />{' '}
@@ -180,7 +181,7 @@ function DeploymentChart() {
   ];
   return (
     <svg viewBox="0 0 1100 260" style={{ width: '100%', height: 280 }}>
-      <g stroke="#EEE9E3">
+      <g stroke={presson.color.borderSubtle}>
         <line x1="0" y1="60" x2="1100" y2="60" />
         <line x1="0" y1="120" x2="1100" y2="120" />
         <line x1="0" y1="180" x2="1100" y2="180" />
@@ -196,9 +197,9 @@ function DeploymentChart() {
         const label = r[1] >= 1 ? `$${r[1].toFixed(1)}M` : `$${(r[1] * 1000).toFixed(0)}K`;
         return (
           <g key={r[0]}>
-            <rect x={x} y={y1} width="40" height={initH} fill="#292929" />
-            <rect x={x} y={y2} width="40" height={resH} fill="#C9BFB4" />
-            <rect x={x} y={y3} width="40" height={remH} fill="#E0D8D1" />
+            <rect x={x} y={y1} width="40" height={initH} fill={presson.color.text} />
+            <rect x={x} y={y2} width="40" height={resH} fill={presson.color.highlight} />
+            <rect x={x} y={y3} width="40" height={remH} fill={presson.color.surfaceSubtle} />
             <text
               x={x + 20}
               y={y3 - 6}
@@ -206,7 +207,7 @@ function DeploymentChart() {
               fontFamily="Inter"
               fontSize="10"
               fontWeight="600"
-              fill="#292929"
+              fill={presson.color.text}
               letterSpacing="-0.01em"
             >
               {label}
@@ -217,7 +218,7 @@ function DeploymentChart() {
               textAnchor="middle"
               fontFamily="JetBrains Mono"
               fontSize="9"
-              fill="#7A7A7A"
+              fill={presson.color.textMuted}
               letterSpacing="0.06em"
               transform={`rotate(35 ${x + 20} 220)`}
             >

--- a/client/src/pages/v2/portfolio.tsx
+++ b/client/src/pages/v2/portfolio.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter';
 import { AppShell } from '@/components/presson-v2/AppShell';
 import { Btn } from '@/components/presson-v2/primitives';
 import { companies, sectorGroups, type Company } from '@/components/presson-v2/mock';
+import { presson } from '@/theme/presson.tokens';
 
 /**
  * Portfolio · Press On v2 blotter.
@@ -327,8 +328,8 @@ function Inspector({ company, onOpen }: { company: Company; onOpen: () => void }
           <svg viewBox="0 0 320 64" style={{ width: '100%', height: 60 }}>
             <defs>
               <linearGradient id="pv2-spark-fade" x1="0" x2="0" y1="0" y2="1">
-                <stop offset="0%" stopColor="#E0D8D1" stopOpacity="0.6" />
-                <stop offset="100%" stopColor="#E0D8D1" stopOpacity="0" />
+                <stop offset="0%" stopColor={presson.color.highlight} stopOpacity="0.6" />
+                <stop offset="100%" stopColor={presson.color.highlight} stopOpacity="0" />
               </linearGradient>
             </defs>
             <path
@@ -338,10 +339,10 @@ function Inspector({ company, onOpen }: { company: Company; onOpen: () => void }
             <path
               d="M0,52 L53,48 L106,38 L160,40 L213,22 L266,32 L320,16"
               fill="none"
-              stroke="#292929"
+              stroke={presson.color.text}
               strokeWidth="1.5"
             />
-            <circle cx="320" cy="16" r="3" fill="#292929" />
+            <circle cx="320" cy="16" r="3" fill={presson.color.text} />
           </svg>
           <div
             style={{
@@ -418,12 +419,17 @@ function SectorSpark({ name }: { name: string }) {
   };
   return (
     <svg viewBox="0 0 100 24" preserveAspectRatio="none" style={{ width: '100%', height: '100%' }}>
-      <path d={paths[name] ?? 'M0,12 L100,12'} fill="none" stroke="#292929" strokeWidth="1.5" />
+      <path
+        d={paths[name] ?? 'M0,12 L100,12'}
+        fill="none"
+        stroke={presson.color.text}
+        strokeWidth="1.5"
+      />
       <circle
         cx="100"
         cy={Number((paths[name] ?? 'M0,12 L100,12').match(/L\s*100\s*,\s*([\d.]+)/)?.[1] ?? 12)}
         r="2.2"
-        fill="#292929"
+        fill={presson.color.text}
       />
     </svg>
   );

--- a/client/src/pages/v2/today.tsx
+++ b/client/src/pages/v2/today.tsx
@@ -1,6 +1,7 @@
 import { AppShell } from '@/components/presson-v2/AppShell';
 import { Btn } from '@/components/presson-v2/primitives';
 import { decisions, watchList } from '@/components/presson-v2/mock';
+import { presson } from '@/theme/presson.tokens';
 
 /**
  * Today · Press On v2 dashboard.
@@ -193,7 +194,7 @@ function PacingChart() {
       </defs>
 
       {/* gridlines */}
-      <g stroke="#EEE9E3" strokeWidth="1">
+      <g stroke={presson.color.borderSubtle} strokeWidth="1">
         <line x1="0" y1="70" x2="1200" y2="70" />
         <line x1="0" y1="140" x2="1200" y2="140" />
         <line x1="0" y1="210" x2="1200" y2="210" />
@@ -201,7 +202,7 @@ function PacingChart() {
       </g>
 
       {/* y-axis labels */}
-      <g fontFamily="JetBrains Mono" fontSize="9.5" fill="#A8A8A8" letterSpacing="0.1em">
+      <g fontFamily="JetBrains Mono" fontSize="9.5" fill={presson.color.textMuted} letterSpacing="0.1em">
         <text x="6" y="66">
           $120M
         </text>
@@ -219,7 +220,7 @@ function PacingChart() {
       {/* Plan band (the construction plan envelope) */}
       <path
         d="M0,260 L200,220 L400,180 L600,140 L800,100 L1000,68 L1200,40 L1200,55 L1000,82 L800,118 L600,158 L400,200 L200,238 L0,275 Z"
-        fill="#E0D8D1"
+        fill={presson.color.highlight}
         opacity="0.85"
       />
       {/* Grain overlay */}
@@ -228,7 +229,7 @@ function PacingChart() {
       {/* Plan line (dashed) */}
       <path
         d="M0,267 L200,229 L400,190 L600,149 L800,109 L1000,75 L1200,47"
-        stroke="#292929"
+        stroke={presson.color.text}
         strokeWidth="1"
         strokeDasharray="4 4"
         fill="none"
@@ -237,7 +238,7 @@ function PacingChart() {
       {/* Actual (solid) */}
       <path
         d="M0,294 L100,290 L200,272 L300,255 L400,242 L500,226 L600,210"
-        stroke="#292929"
+        stroke={presson.color.text}
         strokeWidth="2.5"
         fill="none"
         strokeLinecap="round"
@@ -246,7 +247,7 @@ function PacingChart() {
       {/* Forecast (dashed continuation) */}
       <path
         d="M600,210 L720,194 L840,174 L960,150 L1080,118 L1200,82"
-        stroke="#292929"
+        stroke={presson.color.text}
         strokeWidth="1.6"
         strokeDasharray="6 5"
         fill="none"
@@ -254,28 +255,28 @@ function PacingChart() {
       />
 
       {/* NOW vertical rule */}
-      <line x1="600" y1="20" x2="600" y2="300" stroke="#292929" strokeWidth="1" />
+      <line x1="600" y1="20" x2="600" y2="300" stroke={presson.color.text} strokeWidth="1" />
       <text
         x="606"
         y="32"
         fontFamily="JetBrains Mono"
         fontSize="10"
-        fill="#292929"
+        fill={presson.color.text}
         letterSpacing="0.1em"
       >
         NOW · Q2&rsquo;26
       </text>
 
       {/* Callout */}
-      <circle cx="600" cy="210" r="5" fill="#292929" />
-      <line x1="612" y1="204" x2="660" y2="178" stroke="#292929" strokeWidth="1" />
+      <circle cx="600" cy="210" r="5" fill={presson.color.text} />
+      <line x1="612" y1="204" x2="660" y2="178" stroke={presson.color.text} strokeWidth="1" />
       <text
         x="668"
         y="174"
         fontFamily="Inter"
         fontSize="14"
         fontWeight="700"
-        fill="#292929"
+        fill={presson.color.text}
         letterSpacing="-0.01em"
       >
         $42.6M actual
@@ -285,14 +286,14 @@ function PacingChart() {
         y="190"
         fontFamily="JetBrains Mono"
         fontSize="10"
-        fill="#7A7A7A"
+        fill={presson.color.textMuted}
         letterSpacing="0.06em"
       >
         vs $48.6M plan · −6.7%
       </text>
 
       {/* x-axis */}
-      <g fontFamily="JetBrains Mono" fontSize="10" fill="#A8A8A8" letterSpacing="0.1em">
+      <g fontFamily="JetBrains Mono" fontSize="10" fill={presson.color.textMuted} letterSpacing="0.1em">
         <text x="0" y="316">
           &rsquo;21
         </text>
@@ -317,8 +318,8 @@ function PacingChart() {
       </g>
 
       {/* legend */}
-      <g fontFamily="JetBrains Mono" fontSize="10" fill="#7A7A7A" letterSpacing="0.08em">
-        <line x1="900" y1="304" x2="922" y2="304" stroke="#292929" strokeWidth="2.5" />
+      <g fontFamily="JetBrains Mono" fontSize="10" fill={presson.color.textMuted} letterSpacing="0.08em">
+        <line x1="900" y1="304" x2="922" y2="304" stroke={presson.color.text} strokeWidth="2.5" />
         <text x="930" y="308">
           ACTUAL
         </text>
@@ -327,7 +328,7 @@ function PacingChart() {
           y1="304"
           x2="1012"
           y2="304"
-          stroke="#292929"
+          stroke={presson.color.text}
           strokeWidth="1"
           strokeDasharray="4 4"
         />
@@ -339,7 +340,7 @@ function PacingChart() {
           y1="304"
           x2="1092"
           y2="304"
-          stroke="#292929"
+          stroke={presson.color.text}
           strokeWidth="1.6"
           strokeDasharray="6 5"
         />

--- a/client/src/utils/pdf/chart-export.ts
+++ b/client/src/utils/pdf/chart-export.ts
@@ -277,9 +277,9 @@ export function createChartPlaceholder(
 ): ChartExportResult {
   const svgString = `
     <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
-      <rect width="100%" height="100%" fill="#F5F5F5" stroke="#E0E0E0" stroke-width="1"/>
+      <rect width="100%" height="100%" fill="#F2F2F2" stroke="#E0D8D1" stroke-width="1"/>
       <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle"
-            font-family="Inter, sans-serif" font-size="14" fill="#666666">
+            font-family="Inter, sans-serif" font-size="14" fill="#5A5A5A">
         ${message}
       </text>
     </svg>

--- a/client/src/utils/pdf/components/PdfMetricCard.tsx
+++ b/client/src/utils/pdf/components/PdfMetricCard.tsx
@@ -50,10 +50,10 @@ const styles = StyleSheet.create({
     color: pdfTheme.colors.textMuted,
   },
   trendUp: {
-    color: '#10b981', // Success green
+    color: '#127E3D',
   },
   trendDown: {
-    color: '#ef4444', // Error red
+    color: '#B00020',
   },
 });
 

--- a/tests/unit/components/monte-carlo/monte-carlo-components.test.tsx
+++ b/tests/unit/components/monte-carlo/monte-carlo-components.test.tsx
@@ -68,12 +68,12 @@ describe('CalibrationStatusCard', () => {
     expect(scorePath.getAttribute('stroke-dasharray')).toBe('75, 100');
   });
 
-  it('uses amber stroke (#f59e0b) when score is in 40-69 range', () => {
+  it('uses warning stroke (#9C6F19) when score is in 40-69 range', () => {
     const { container } = render(
       <CalibrationStatusCard calibrationStatus="under-predicting" modelQualityScore={50} />
     );
     const scorePath = container.querySelectorAll('path')[1]!;
-    expect(scorePath.getAttribute('stroke')).toBe('#f59e0b');
+    expect(scorePath.getAttribute('stroke')).toBe('#9C6F19');
     expect(scorePath.getAttribute('stroke-dasharray')).toBe('50, 100');
   });
 

--- a/tests/unit/lib/reallocation-utils.test.ts
+++ b/tests/unit/lib/reallocation-utils.test.ts
@@ -172,16 +172,16 @@ describe('reallocation-utils', () => {
   });
 
   describe('getDeltaColorClass', () => {
-    it('should return green for positive delta', () => {
-      expect(getDeltaColorClass(100)).toBe('text-green-600');
+    it('should return positive token for positive delta', () => {
+      expect(getDeltaColorClass(100)).toBe('text-presson-positive');
     });
 
-    it('should return red for negative delta', () => {
-      expect(getDeltaColorClass(-100)).toBe('text-red-600');
+    it('should return negative token for negative delta', () => {
+      expect(getDeltaColorClass(-100)).toBe('text-presson-negative');
     });
 
-    it('should return gray for zero delta', () => {
-      expect(getDeltaColorClass(0)).toBe('text-gray-500');
+    it('should return neutral charcoal for zero delta', () => {
+      expect(getDeltaColorClass(0)).toBe('text-charcoal-500');
     });
   });
 


### PR DESCRIPTION
## Summary

Theme-2 design-token rollout, wave-3 long-tail. Migrates the remaining live
raw-Tailwind/hex color surfaces (3 disjoint batches, 55 files) to canonical
Press On Ventures tokens. **Color-only migration; no logic changes.** Mechanical
bulk dispatched to Codex via Hermes; every diff line reviewed by hand against the
DESIGN.md doctrine (charcoal accent never blue; muted status; no purple) and the
8-step wave-3 decision procedure.

Branches off `f7114906` (B2 / #777 merged). Three batch commits:

| Batch | Theme | Files | Commit |
| --- | --- | --- | --- |
| B1 | Reporting + LP | 14 | `a44b961e` |
| B3 | Analytics + misc | 18 (+1 test) | `9cac5f78` |
| B4 | Pages + app shell | 20 (+1 test) | `bc334408` |

## What the migration does (by rule)

- **Financial direction (rule 4a):** unrealized gain/loss, distributions, capital
  flows, IRR/TVPI trends, variance, reallocation deltas, PDF trend up/down ->
  `presson-positive` / `presson-negative` / `presson-warning`, always paired with
  an existing +/- sign (no color-only encoding introduced).
- **Status (rule 3):** overdue/due/blocked/failed/stale/baseline/staging/404 ->
  `error` / `warning` / `success` (`/10` bg, `-dark` text).
- **Action (rule 2):** "Set Up Baseline", fund-load retry, wizard Next buttons,
  active mobile-nav, loading spinners -> charcoal (were red/blue/slate).
- **Kills:** purple/violet (NAV icon, Special badge, doc/notification types,
  DemoBanner blue->purple gradient, hsl() rainbow generator) and indigo/blue
  (numerous) re-resolved by intent; charcoal-dominant.
- **Neutral ramp:** slate/gray -> `charcoal-{300..700}` / `pov-charcoal`; warm
  borders `border-beige-200`; `bg-white`/`text-white` -> `pov-white`;
  `bg-lightGray` -> `bg-pov-gray` (pixel-identical); legacy `#7A7A7A` -> textMuted
  (aligns the resolved pv2-mute drift in DESIGN.md).
- **Charts (Recharts/SVG):** stroke/fill hexes moved to named constants holding
  canonical token values; categorical series use the rule-4b fixed-order palette
  (<=6 hues, `// TODO(design)` where slices can exceed six); v2 inline SVG colors
  -> `presson.color.*`.
- **PDF/canvas:** hex literals remapped to nearest token VALUES and kept literal
  (Tailwind classes do not apply to canvas/PDF; no theme import into the
  server-compiled `utils/pdf` layer).

## Verification

- Per batch: scope-diff (owned files only), residual off-token grep (clean except
  4 `// TODO(design)` escalations + sanctioned muted-tag chips), every diff line
  read, **every emitted token/hex verified to resolve** in `tailwind.config.ts` /
  `presson.tokens.ts` (the silent failure `tsc` cannot catch).
- Full `npm run check` (client + server + shared): **0 TypeScript errors.**
- 136 targeted component/unit tests pass (B1 33, B3 63, B4 40), including the
  **StressPanel canary** confirming the TwoWayPanel heatmap residue was not churned.
- 3 residue files intentionally left unchanged (TwoWayPanel charcoal interpolation
  hexes; cap-table-calculator + safe-note-editor sanctioned muted-tag chips).
- No shadcn primitives rewritten.

### Reviewer fixes applied during review
- `tag-performance-analysis`: Codex over-migrated the sanctioned monochrome
  `getChartColor()` helper to a chromatic palette; reverted to `getChartColor()`,
  migrating only its 2 genuine strays (per the "do not touch getChartColor()" rule).
- Test contracts updated to match changed tokens (logic unchanged):
  `monte-carlo-components` calibration gauge `#f59e0b` -> `#9C6F19`;
  `reallocation-utils` `getDeltaColorClass` green/red/gray -> presson tokens.

## For the Vercel preview eyeball (all legal tokens; none block)

- **Categorical-identity-via-financial-tokens** (the recurring rollout call, same
  as B2): document/notification type swatches and `portfolio-analytics` /
  `benchmarking` pie/bar series use the chromatic rule-4b palette. Confirm
  green/red on non-directional categories reads acceptably.
- `DistributionsWidget`: "Special" badge -> `presson-info`; YTD + Total Received
  cards both -> `presson-positive` (both are positive financial; lost the old
  blue/green split).
- `CalibrationStatusCard` gauge caution band amber -> canonical warning `#9C6F19`.
- v2 SVG charts: axis labels `#A8A8A8` -> textMuted `#5A5A5A` (slight darkening);
  dark **exits** "cinema" screen grays remapped to nearest legal tokens.
- `charts.visual` is a Playwright screenshot lane (not vitest); B4 only touches the
  PDF placeholder fallback (not captured) — confirm no baseline drift in CI.

## Out of scope (per scope doc)
Residue batch R (9 hand-migrate files: `wizard/*`, swept-surface leftovers) and
follow-up a11y pass. The 42-file transitively-dead set was excluded (verified: zero
intersection with these 55 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
