### PR TITLE
fix(a11y): non-color direction cue for StressPanel delta bar (rollout follow-up #4)

### DIFF
--- a/client/src/components/sensitivity/StressPanel.tsx
+++ b/client/src/components/sensitivity/StressPanel.tsx
@@ -58,8 +58,9 @@ interface DeltaBarStyle {
 
 function deltaBarStyle(delta: number, maxAbsDelta: number): DeltaBarStyle {
   const widthPct = maxAbsDelta === 0 ? 0 : (Math.abs(delta) / maxAbsDelta) * 100;
-  // Loss (negative) vs gain (positive) via PoV financial tokens.
-  // TODO(a11y): baseline delta bar needs a non-color direction cue.
+  // Loss (negative) vs gain (positive) via PoV financial tokens. Direction is also
+  // conveyed non-visually by the signed delta value rendered beside the bar (WCAG 1.4.1),
+  // so the bar itself is decorative (aria-hidden at the call site).
   const backgroundColor = delta < 0 ? presson.color.negative : presson.color.positive;
   return { width: `${widthPct}%`, backgroundColor };
 }
@@ -236,12 +237,23 @@ function ResultsSection({ result }: { result: StressAnalysisResultV1 }) {
                   {scenario && (
                     <div className="text-xs text-charcoal-500">{scenario.description}</div>
                   )}
-                  <div className="h-2 w-full overflow-hidden rounded bg-pov-gray">
-                    <div
-                      className="h-2 rounded"
-                      style={deltaBarStyle(dp.baselineDelta, maxAbsDelta)}
-                      data-testid={`stress-delta-bar-${dp.scenarioId}`}
-                    />
+                  <div className="flex items-center gap-2">
+                    <div className="h-2 flex-1 overflow-hidden rounded bg-pov-gray">
+                      <div
+                        className="h-2 rounded"
+                        style={deltaBarStyle(dp.baselineDelta, maxAbsDelta)}
+                        data-testid={`stress-delta-bar-${dp.scenarioId}`}
+                        aria-hidden="true"
+                      />
+                    </div>
+                    <span
+                      className="w-20 shrink-0 text-right tabular-nums text-xs text-charcoal-600"
+                      data-testid={`stress-delta-value-${dp.scenarioId}`}
+                      aria-label={`Baseline delta ${dp.baselineDelta >= 0 ? '+' : '-'}${formatMetricValue(Math.abs(dp.baselineDelta), metric)}`}
+                    >
+                      {dp.baselineDelta >= 0 ? '+' : '-'}
+                      {formatMetricValue(Math.abs(dp.baselineDelta), metric)}
+                    </span>
                   </div>
                 </div>
               );

--- a/tests/unit/components/sensitivity/StressPanel.test.tsx
+++ b/tests/unit/components/sensitivity/StressPanel.test.tsx
@@ -263,4 +263,24 @@ describe('StressPanel', () => {
     // presson.color.positive (#127E3D) for positive baselineDelta; DOM normalizes to rgb.
     expect(posBar.style.backgroundColor).toBe('rgb(18, 126, 61)');
   });
+
+  it('conveys delta direction with a non-color signed-delta cue and hides the decorative bar from assistive tech (WCAG 1.4.1)', () => {
+    installMutationState({
+      isSuccess: true,
+      data: { result: makeFixtureResult() },
+    });
+    renderPanel(7);
+
+    // Direction is legible without relying on color: negative -> minus, positive -> plus.
+    const negDelta = screen.getByTestId('stress-delta-value-mild_downside');
+    const posDelta = screen.getByTestId('stress-delta-value-best_case');
+    expect(negDelta.textContent).toMatch(/^-/);
+    expect(posDelta.textContent).toMatch(/^\+/);
+
+    // The color-coded bar is decorative; direction lives in the signed text cue.
+    expect(screen.getByTestId('stress-delta-bar-mild_downside')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

The final Theme-2 rollout follow-up: **follow-up #4 — the deferred WCAG 1.4.1
(use-of-color) item.** During the token migration, gain/loss encoded by hue alone
was flagged with `// TODO(a11y)` rather than fixed inline. This resolves the one
such case on a **live** surface.

`sensitivity/StressPanel.tsx` rendered each stress-scenario's baseline delta as a
bar whose **color alone** carried direction (`presson-positive`/`negative`); the
visible number was the absolute metric, not the signed delta. Direction was lost
for color-blind users and absent for screen readers.

## Fix (live surface only)

- Render the **signed baseline delta** beside the bar — `+`/`-` + magnitude in
  `tabular-nums`, with an `aria-label` for context. Sign + magnitude convey
  direction without relying on color and are screen-reader legible.
- Mark the now-decorative color bar `aria-hidden` so direction isn't announced
  twice. Bar color is unchanged.
- No semantic re-interpretation: the cue mirrors the existing
  `delta < 0 ? negative : positive` branch exactly — it makes the current meaning
  perceivable, it does not re-decide it.
- `formatMetricValue(Math.abs(delta), metric)` avoids double-signs / the `$-`
  currency glitch (formatters render their own sign).

## Verification

- 11 `StressPanel` tests pass. Added an assertion that negative rows show a
  leading `-`, positive a leading `+`, and the bar is `aria-hidden`. **axe /
  axe-playwright cannot detect 1.4.1** (use-of-color is not machine-checkable), so
  this unit assertion — not the a11y lane — is the durable regression guard. The
  pre-existing bar-color assertions stay green (color unchanged).
- `npm run check` 0 TypeScript errors; `eslint --max-warnings 0` clean.

## Scope note

The one remaining `// TODO(a11y)` lives in `charts/MobileOptimizedCharts.tsx`
(`Sparkline`) — **dead code**: BFS-unreachable from `main.tsx` and the export has
no importers, so it has no live exposure. Left dormant per the rollout dead-code
policy (the same policy that kept the 42-file transitively-dead set + 17 dead
pages untouched); a11y will be handled if/when that component is revived.

With this merged, the Theme-2 design-token rollout and its follow-ups are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
