### PR TITLE
fix: harden CodeQL-reported request and input surfaces

### DIFF
--- a/client/src/lib/telemetry.ts
+++ b/client/src/lib/telemetry.ts
@@ -121,6 +121,24 @@ interface ValidationResult {
   reason?: string;
 }
 
+let fallbackIdCounter = 0;
+
+function secureIdSegment(): string {
+  const cryptoObject = globalThis.crypto;
+  if (typeof cryptoObject?.randomUUID === 'function') {
+    return cryptoObject.randomUUID();
+  }
+
+  if (typeof cryptoObject?.getRandomValues === 'function') {
+    const values = new Uint32Array(2);
+    cryptoObject.getRandomValues(values);
+    return Array.from(values, (value) => value.toString(36).padStart(7, '0')).join('');
+  }
+
+  fallbackIdCounter = (fallbackIdCounter + 1) % Number.MAX_SAFE_INTEGER;
+  return `${Date.now().toString(36)}_${fallbackIdCounter.toString(36)}`;
+}
+
 function isTelemetryEvent(value: unknown): value is TelemetryEvent {
   if (typeof value !== 'object' || value === null) return false;
 
@@ -210,7 +228,7 @@ export function getOrCreateSessionId(): string {
   let sessionId = localStorage.getItem(key);
 
   if (!sessionId) {
-    sessionId = `sess_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+    sessionId = `sess_${Date.now()}_${secureIdSegment()}`;
     localStorage.setItem(key, sessionId);
   }
 
@@ -218,7 +236,7 @@ export function getOrCreateSessionId(): string {
 }
 
 export function generateRequestId(): string {
-  return `req_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  return `req_${Date.now()}_${secureIdSegment()}`;
 }
 
 // ============================================================================

--- a/client/src/lib/validation-helpers.ts
+++ b/client/src/lib/validation-helpers.ts
@@ -112,10 +112,7 @@ export function ensureDateString(value: unknown, fallback?: string): string {
  * @param validator Optional validator for each element
  * @returns A validated array with defined elements
  */
-export function ensureValidArray<T>(
-  value: unknown,
-  validator?: (item: unknown) => item is T
-): T[] {
+export function ensureValidArray<T>(value: unknown, validator?: (item: unknown) => item is T): T[] {
   if (!Array.isArray(value)) {
     return [];
   }
@@ -206,8 +203,11 @@ export function sanitizeUserInput(input: unknown, maxLength: number = 1000): str
       sanitized = sanitized.replace(/\w+:/gi, '');
     }
   } else {
-    // Remove protocol patterns like javascript:, vbscript:, etc.
-    sanitized = sanitized.replace(/javascript:/gi, '').replace(/vbscript:/gi, '');
+    // Remove protocol patterns that can execute or embed active content.
+    sanitized = sanitized
+      .replace(/javascript:/gi, '')
+      .replace(/vbscript:/gi, '')
+      .replace(/data:/gi, '');
   }
 
   return sanitized;
@@ -221,12 +221,7 @@ export function sanitizeUserInput(input: unknown, maxLength: number = 1000): str
  * @param step Step increment (for rounding)
  * @returns A value within the specified range
  */
-export function ensureRange(
-  value: unknown,
-  min: number,
-  max: number,
-  step?: number
-): number {
+export function ensureRange(value: unknown, min: number, max: number, step?: number): number {
   let num = ensureFinancialNumber(value, min);
 
   // Clamp to range
@@ -247,12 +242,7 @@ export function ensureRange(
  * @returns True if the value is a valid array index
  */
 export function isValidArrayIndex(value: unknown, arrayLength: number): value is number {
-  return (
-    typeof value === 'number' &&
-    Number.isInteger(value) &&
-    value >= 0 &&
-    value < arrayLength
-  );
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value < arrayLength;
 }
 
 /**
@@ -263,11 +253,7 @@ export function isValidArrayIndex(value: unknown, arrayLength: number): value is
  * @param fallback Fallback value if access fails
  * @returns The array element or fallback
  */
-export function safeArrayAccess<T>(
-  array: T[] | null | undefined,
-  index: unknown,
-  fallback: T
-): T {
+export function safeArrayAccess<T>(array: T[] | null | undefined, index: unknown, fallback: T): T {
   if (!Array.isArray(array) || !isValidArrayIndex(index, array.length)) {
     return fallback;
   }
@@ -308,10 +294,7 @@ export function formatCurrencySafe(
  * @param decimals Number of decimal places (default: 1)
  * @returns Formatted percentage string
  */
-export function formatPercentageSafe(
-  value: unknown,
-  decimals: number = 1
-): string {
+export function formatPercentageSafe(value: unknown, decimals: number = 1): string {
   const num = ensureFinancialNumber(value, 0);
   return `${(num * 100).toFixed(decimals)}%`;
 }

--- a/client/src/lib/validation-helpers.ts
+++ b/client/src/lib/validation-helpers.ts
@@ -204,10 +204,14 @@ export function sanitizeUserInput(input: unknown, maxLength: number = 1000): str
     }
   } else {
     // Remove protocol patterns that can execute or embed active content.
-    sanitized = sanitized
-      .replace(/javascript:/gi, '')
-      .replace(/vbscript:/gi, '')
-      .replace(/data:/gi, '');
+    const maxSchemeStrips = sanitized.length;
+    for (let stripCount = 0; stripCount < maxSchemeStrips; stripCount += 1) {
+      const next = sanitized.replace(/javascript:|vbscript:|data:/gi, '');
+      if (next === sanitized) {
+        break;
+      }
+      sanitized = next;
+    }
   }
 
   return sanitized;

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -693,7 +693,7 @@ function runGate(
 }
 
 function generateRunId(now = new Date()) {
-  const iso = now.toISOString().replace(/[:.]/g, '-').replace('Z', 'Z');
+  const iso = now.toISOString().replace(/[:.]/g, '-');
   return `hermes-${iso}`;
 }
 

--- a/scripts/generate-discovery-map.ts
+++ b/scripts/generate-discovery-map.ts
@@ -314,7 +314,7 @@ function flattenFrontmatterData(source: Record<string, unknown>): Record<string,
 }
 
 function escapeMarkdownTableCell(value: string): string {
-  return value.replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, '<br>');
 }
 
 /**

--- a/scripts/generate-flag-types.ts
+++ b/scripts/generate-flag-types.ts
@@ -49,6 +49,10 @@ interface FlagRegistry {
   }>;
 }
 
+function tsStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
 function generateFlagTypes(registry: FlagRegistry): string {
   const flagKeys = Object.keys(registry.flags);
   const clientFlags = Object.entries(registry.flags)
@@ -73,25 +77,25 @@ function generateFlagTypes(registry: FlagRegistry): string {
  * All available feature flag keys
  */
 export type FlagKey =
-${flagKeys.map(k => `  | '${k}'`).join('\n')};
+${flagKeys.map((k) => `  | '${k}'`).join('\n')};
 
 /**
  * Flags safe to expose to client
  */
 export type ClientFlagKey =
-${clientFlags.map(k => `  | '${k}'`).join('\n')};
+${clientFlags.map((k) => `  | '${k}'`).join('\n')};
 
 /**
  * Server-only flags (not exposed to client)
  */
 export type ServerOnlyFlagKey =
-${serverOnlyFlags.map(k => `  | '${k}'`).join('\n')};
+${serverOnlyFlags.map((k) => `  | '${k}'`).join('\n')};
 
 /**
  * Admin flags (no localStorage override)
  */
 export type AdminFlagKey =
-${adminFlags.map(k => `  | '${k}'`).join('\n')};
+${adminFlags.map((k) => `  | '${k}'`).join('\n')};
 
 /**
  * Flag risk levels
@@ -133,21 +137,21 @@ export type ClientFlagRecord = Record<ClientFlagKey, boolean>;
  * Array of all flag keys
  */
 export const ALL_FLAG_KEYS: readonly FlagKey[] = [
-${flagKeys.map(k => `  '${k}',`).join('\n')}
+${flagKeys.map((k) => `  '${k}',`).join('\n')}
 ] as const;
 
 /**
  * Array of client-safe flag keys
  */
 export const CLIENT_FLAG_KEYS: readonly ClientFlagKey[] = [
-${clientFlags.map(k => `  '${k}',`).join('\n')}
+${clientFlags.map((k) => `  '${k}',`).join('\n')}
 ] as const;
 
 /**
  * Array of admin flag keys (no localStorage override)
  */
 export const ADMIN_FLAG_KEYS: readonly AdminFlagKey[] = [
-${adminFlags.map(k => `  '${k}',`).join('\n')}
+${adminFlags.map((k) => `  '${k}',`).join('\n')}
 ] as const;
 
 /**
@@ -191,11 +195,13 @@ import type { FlagKey, FlagDefinition, FlagRecord } from './flag-types.js';
  * Complete flag definitions
  */
 export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
-${entries.map(([key, def]) => `  '${key}': {
+${entries
+  .map(
+    ([key, def]) => `  '${key}': {
     default: ${def.default},
-    description: '${def.description.replace(/'/g, "\\'")}',
-    owner: '${def.owner}',
-    risk: '${def.risk}',
+    description: ${tsStringLiteral(def.description)},
+    owner: ${tsStringLiteral(def.owner)},
+    risk: ${tsStringLiteral(def.risk)},
     exposeToClient: ${def.exposeToClient},
     ${def.adminOnly ? `adminOnly: true,` : ''}
     environments: {
@@ -203,11 +209,13 @@ ${entries.map(([key, def]) => `  '${key}': {
       staging: ${def.environments.staging},
       production: ${def.environments.production},
     },
-    dependencies: [${def.dependencies.map(d => `'${d}'`).join(', ')}],
-    expiresAt: ${def.expiresAt ? `'${def.expiresAt}'` : 'null'},
-    ${def.aliases ? `aliases: [${def.aliases.map(a => `'${a}'`).join(', ')}],` : ''}
+    dependencies: [${def.dependencies.map(tsStringLiteral).join(', ')}],
+    expiresAt: ${def.expiresAt ? tsStringLiteral(def.expiresAt) : 'null'},
+    ${def.aliases ? `aliases: [${def.aliases.map(tsStringLiteral).join(', ')}],` : ''}
     ${def.rolloutPercentage !== undefined ? `rolloutPercentage: ${def.rolloutPercentage},` : ''}
-  },`).join('\n')}
+  },`
+  )
+  .join('\n')}
 };
 
 /**
@@ -282,7 +290,7 @@ export function resolveFlagWithDependencies(
 export const FLAG_ALIASES: Record<string, FlagKey> = {
 ${entries
   .filter(([_, def]) => def.aliases && def.aliases.length > 0)
-  .flatMap(([key, def]) => def.aliases!.map(alias => `  '${alias}': '${key}',`))
+  .flatMap(([key, def]) => def.aliases!.map((alias) => `  '${alias}': '${key}',`))
   .join('\n')}
 };
 

--- a/scripts/performance-guard.mjs
+++ b/scripts/performance-guard.mjs
@@ -3,14 +3,14 @@
  * Performance guard: Ensures build performance doesn't regress
  */
 
-import { execSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 const THRESHOLDS = {
   buildTime: 8000, // 8 seconds max (was 5.5s, allow some variance)
   bundleSize: 2 * 1024 * 1024, // 2MB max for main bundle
-  typeCheckTime: 15000 // 15 seconds max for type checking
+  typeCheckTime: 15000, // 15 seconds max for type checking
 };
 
 const colors = {
@@ -18,7 +18,7 @@ const colors = {
   green: '\x1b[32m',
   red: '\x1b[31m',
   yellow: '\x1b[33m',
-  cyan: '\x1b[36m'
+  cyan: '\x1b[36m',
 };
 
 function log(message, color = 'reset') {
@@ -50,32 +50,36 @@ function measureTypeCheckTime() {
   }
 }
 
+function measureDirectorySize(directoryPath) {
+  let totalSize = 0;
+
+  for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      totalSize += measureDirectorySize(entryPath);
+    } else if (entry.isFile()) {
+      totalSize += statSync(entryPath).size;
+    }
+  }
+
+  return totalSize;
+}
+
 function measureBundleSize() {
   const bundlePath = path.join(process.cwd(), 'dist/public/assets');
-  
+
   if (!existsSync(bundlePath)) {
     return 0;
   }
-  
+
   try {
-    const output = execSync(`du -sb ${bundlePath}`, { encoding: 'utf8' });
+    const output = execFileSync('du', ['-sb', bundlePath], { encoding: 'utf8' });
     const size = parseInt(output.split('\t')[0]);
     return size;
   } catch {
-    // Fallback for Windows
+    // Fallback for Windows and environments without GNU du.
     try {
-      const files = execSync(`dir /s /b ${bundlePath}`, { encoding: 'utf8' })
-        .split('\n')
-        .filter(Boolean);
-      
-      let totalSize = 0;
-      for (const file of files) {
-        if (existsSync(file)) {
-          const stats = readFileSync(file);
-          totalSize += stats.length;
-        }
-      }
-      return totalSize;
+      return measureDirectorySize(bundlePath);
     } catch {
       return 0;
     }
@@ -92,57 +96,66 @@ function formatSize(bytes) {
 }
 
 async function main() {
-  log('⚡ Performance Guard', 'cyan');
-  log('=' .repeat(40), 'cyan');
-  
+  log('Performance Guard', 'cyan');
+  log('='.repeat(40), 'cyan');
+
   const results = {
     buildTime: null,
     typeCheckTime: null,
-    bundleSize: null
+    bundleSize: null,
   };
-  
+
   // Measure build time
-  log('\n📦 Measuring build performance...', 'yellow');
+  log('\n[MEASURE] Build performance...', 'yellow');
   results.buildTime = measureBuildTime();
-  
+
   if (results.buildTime > 0) {
-    const status = results.buildTime <= THRESHOLDS.buildTime ? '✅' : '❌';
+    const status = results.buildTime <= THRESHOLDS.buildTime ? 'PASS' : 'FAIL';
     const color = results.buildTime <= THRESHOLDS.buildTime ? 'green' : 'red';
-    log(`${status} Build time: ${formatTime(results.buildTime)} (threshold: ${formatTime(THRESHOLDS.buildTime)})`, color);
+    log(
+      `${status} Build time: ${formatTime(results.buildTime)} (threshold: ${formatTime(THRESHOLDS.buildTime)})`,
+      color
+    );
   }
-  
+
   // Measure type check time
-  log('\n🔍 Measuring type check performance...', 'yellow');
+  log('\n[MEASURE] Type check performance...', 'yellow');
   results.typeCheckTime = measureTypeCheckTime();
-  
-  const typeStatus = results.typeCheckTime <= THRESHOLDS.typeCheckTime ? '✅' : '❌';
+
+  const typeStatus = results.typeCheckTime <= THRESHOLDS.typeCheckTime ? 'PASS' : 'FAIL';
   const typeColor = results.typeCheckTime <= THRESHOLDS.typeCheckTime ? 'green' : 'red';
-  log(`${typeStatus} Type check: ${formatTime(results.typeCheckTime)} (threshold: ${formatTime(THRESHOLDS.typeCheckTime)})`, typeColor);
-  
+  log(
+    `${typeStatus} Type check: ${formatTime(results.typeCheckTime)} (threshold: ${formatTime(THRESHOLDS.typeCheckTime)})`,
+    typeColor
+  );
+
   // Measure bundle size
-  log('\n📏 Measuring bundle size...', 'yellow');
+  log('\n[MEASURE] Bundle size...', 'yellow');
   results.bundleSize = measureBundleSize();
-  
+
   if (results.bundleSize > 0) {
-    const sizeStatus = results.bundleSize <= THRESHOLDS.bundleSize ? '✅' : '❌';
+    const sizeStatus = results.bundleSize <= THRESHOLDS.bundleSize ? 'PASS' : 'FAIL';
     const sizeColor = results.bundleSize <= THRESHOLDS.bundleSize ? 'green' : 'red';
-    log(`${sizeStatus} Bundle size: ${formatSize(results.bundleSize)} (threshold: ${formatSize(THRESHOLDS.bundleSize)})`, sizeColor);
+    log(
+      `${sizeStatus} Bundle size: ${formatSize(results.bundleSize)} (threshold: ${formatSize(THRESHOLDS.bundleSize)})`,
+      sizeColor
+    );
   }
-  
+
   // Overall assessment
-  log('\n' + '=' .repeat(40), 'cyan');
-  
-  const hasRegression = 
+  log('\n' + '='.repeat(40), 'cyan');
+
+  const hasRegression =
     (results.buildTime > 0 && results.buildTime > THRESHOLDS.buildTime) ||
     results.typeCheckTime > THRESHOLDS.typeCheckTime ||
     (results.bundleSize > 0 && results.bundleSize > THRESHOLDS.bundleSize);
-  
+
   if (hasRegression) {
-    log('❌ Performance regression detected!', 'red');
+    log('FAIL: Performance regression detected!', 'red');
     log('Please investigate and optimize before merging.', 'yellow');
     process.exit(1);
   } else {
-    log('✅ All performance metrics within thresholds!', 'green');
+    log('PASS: All performance metrics within thresholds!', 'green');
     log('60% build performance improvement preserved.', 'green');
   }
 }

--- a/scripts/strategic-decisions.ts
+++ b/scripts/strategic-decisions.ts
@@ -313,7 +313,7 @@ class StrategyDecisionMaker {
     try {
       const allFiles = this.findFiles('.', ['.ts', '.js', '.json']);
       const websocketUsagePattern =
-        /(?:^|[^A-Za-z0-9_-])(?:socket\.io|websocket|ws)(?:[^A-Za-z0-9_-]|$)/i;
+        /(?:^|[^A-Za-z0-9_-])(?:(?:socket\.io|websocket|ws)(?=[^A-Za-z0-9_-]|$)|wss?:\/\/)/i;
       for (const file of allFiles) {
         if (file.includes('node_modules')) continue;
         const content = fs.readFileSync(file, 'utf8');

--- a/scripts/strategic-decisions.ts
+++ b/scripts/strategic-decisions.ts
@@ -40,7 +40,7 @@ class StrategyDecisionMaker {
   private auditResults: ArchitectureAudit | null = null;
 
   async makeStrategicDecisions(): Promise<DecisionCriteria> {
-    console.log('🎯 Making strategic decisions based on audit data...\n');
+    console.log('[TARGET] Making strategic decisions based on audit data...\n');
 
     // Get audit results
     this.auditResults = await runAudit();
@@ -49,14 +49,14 @@ class StrategyDecisionMaker {
       frameworkChoice: await this.analyzeFrameworkChoice(),
       chartLibrary: await this.analyzeChartLibrary(),
       deploymentStrategy: await this.analyzeDeploymentStrategy(),
-      timeline: await this.estimateTimeline()
+      timeline: await this.estimateTimeline(),
     };
 
     return decisions;
   }
 
   private async analyzeFrameworkChoice(): Promise<DecisionCriteria['frameworkChoice']> {
-    console.log('📋 Analyzing framework choice...');
+    console.log('[ANALYZE] Framework choice...');
 
     if (!this.auditResults) throw new Error('Audit results not available');
 
@@ -89,18 +89,20 @@ class StrategyDecisionMaker {
       reasoning.push('Express is safer default choice');
     }
 
-    console.log(`   Framework: ${framework.current} → ${recommendation} (${Math.round(confidence * 100)}% confidence)`);
-    
+    console.log(
+      `   Framework: ${framework.current} → ${recommendation} (${Math.round(confidence * 100)}% confidence)`
+    );
+
     return {
       current: framework.current,
       recommendation,
       confidence,
-      reasoning
+      reasoning,
     };
   }
 
   private async analyzeChartLibrary(): Promise<DecisionCriteria['chartLibrary']> {
-    console.log('📊 Analyzing chart library choice...');
+    console.log('[ANALYZE] Chart library choice...');
 
     if (!this.auditResults) throw new Error('Audit results not available');
 
@@ -138,7 +140,7 @@ class StrategyDecisionMaker {
       migrationComplexity = 'medium';
       reasoning.push(`Mixed usage detected (${nivoUsage} nivo, ${rechartsUsage} recharts)`);
       reasoning.push('Gradual migration to single library recommended');
-      
+
       // Determine target based on ecosystem fit and bundle analysis
       if (this.auditResults.performance.bundleSize > 500) {
         reasoning.push('Large bundle size suggests consolidation needed');
@@ -147,17 +149,17 @@ class StrategyDecisionMaker {
     }
 
     console.log(`   Charts: ${current} → ${recommendation} (${migrationComplexity} complexity)`);
-    
+
     return {
       current,
       recommendation,
       migrationComplexity,
-      reasoning
+      reasoning,
     };
   }
 
   private async analyzeDeploymentStrategy(): Promise<DecisionCriteria['deploymentStrategy']> {
-    console.log('🚀 Analyzing deployment strategy...');
+    console.log('[ANALYZE] Deployment strategy...');
 
     if (!this.auditResults) throw new Error('Audit results not available');
 
@@ -174,7 +176,7 @@ class StrategyDecisionMaker {
 
     // Calculate serverless feasibility
     feasibility = 1.0;
-    
+
     if (hasLongRunningTasks) {
       feasibility -= 0.3;
       risks.push('Long-running tasks detected - may exceed serverless time limits');
@@ -214,18 +216,20 @@ class StrategyDecisionMaker {
       risks.push('Current architecture not suitable for serverless');
     }
 
-    console.log(`   Deployment: ${current} → ${recommendation} (${Math.round(feasibility * 100)}% feasible)`);
-    
+    console.log(
+      `   Deployment: ${current} → ${recommendation} (${Math.round(feasibility * 100)}% feasible)`
+    );
+
     return {
       current,
       recommendation,
       feasibility,
-      risks
+      risks,
     };
   }
 
   private async estimateTimeline(): Promise<DecisionCriteria['timeline']> {
-    console.log('⏱️  Estimating project timeline...');
+    console.log('[ESTIMATE] Project timeline...');
 
     if (!this.auditResults) throw new Error('Audit results not available');
 
@@ -261,8 +265,8 @@ class StrategyDecisionMaker {
     }
 
     // Adjust based on chart migration complexity
-    const chartComplexity = this.auditResults.chartLibraries.nivo.usage + 
-                           this.auditResults.chartLibraries.recharts.usage;
+    const chartComplexity =
+      this.auditResults.chartLibraries.nivo.usage + this.auditResults.chartLibraries.recharts.usage;
     if (chartComplexity > 20) {
       baselineDays += 4;
       criticalPath.push('Complete chart library migration');
@@ -277,16 +281,16 @@ class StrategyDecisionMaker {
     criticalPath.push('Implement and validate Excel parity');
 
     const conservative = Math.ceil(baselineDays * 1.3); // Add 30% buffer
-    const aggressive = Math.ceil(baselineDays * 0.8);   // Aggressive estimate
-    const recommended = baselineDays;                   // Realistic estimate
+    const aggressive = Math.ceil(baselineDays * 0.8); // Aggressive estimate
+    const recommended = baselineDays; // Realistic estimate
 
     console.log(`   Timeline: ${aggressive}-${conservative} days (recommended: ${recommended})`);
-    
+
     return {
       conservative,
       aggressive,
       recommended,
-      criticalPath
+      criticalPath,
     };
   }
 
@@ -308,10 +312,12 @@ class StrategyDecisionMaker {
   private checkForWebSockets(): boolean {
     try {
       const allFiles = this.findFiles('.', ['.ts', '.js', '.json']);
+      const websocketUsagePattern =
+        /(?:^|[^A-Za-z0-9_-])(?:socket\.io|websocket|ws)(?:[^A-Za-z0-9_-]|$)/i;
       for (const file of allFiles) {
         if (file.includes('node_modules')) continue;
         const content = fs.readFileSync(file, 'utf8');
-        if (content.includes('socket.io') || content.includes('websocket') || content.includes('ws')) {
+        if (websocketUsagePattern.test(content)) {
           return true;
         }
       }
@@ -338,10 +344,10 @@ class StrategyDecisionMaker {
 
   private analyzeDatabaseUsage(): { connectionPooling: boolean; longQueries: boolean } {
     try {
-      const dbFiles = this.findFiles('server/', ['.ts', '.js']).filter(f => 
-        f.includes('db') || f.includes('database') || f.includes('drizzle')
+      const dbFiles = this.findFiles('server/', ['.ts', '.js']).filter(
+        (f) => f.includes('db') || f.includes('database') || f.includes('drizzle')
       );
-      
+
       let connectionPooling = false;
       let longQueries = false;
 
@@ -364,24 +370,24 @@ class StrategyDecisionMaker {
 
   private findFiles(directory: string, extensions: string[]): string[] {
     const files: string[] = [];
-    
+
     try {
       const items = fs.readdirSync(directory);
-      
+
       for (const item of items) {
         const fullPath = `${directory}/${item}`;
         const stat = fs.statSync(fullPath);
-        
+
         if (stat.isDirectory() && !item.startsWith('.') && item !== 'node_modules') {
           files.push(...this.findFiles(fullPath, extensions));
-        } else if (stat.isFile() && extensions.some(ext => item.endsWith(ext))) {
+        } else if (stat.isFile() && extensions.some((ext) => item.endsWith(ext))) {
           files.push(fullPath);
         }
       }
     } catch (error) {
       // Skip directories that can't be read
     }
-    
+
     return files;
   }
 }
@@ -393,54 +399,56 @@ export async function makeStrategicDecisions(): Promise<DecisionCriteria> {
 
 // CLI execution
 if (require.main === module) {
-  makeStrategicDecisions().then(decisions => {
-    console.log('\n🎯 STRATEGIC DECISIONS COMPLETE\n');
-    console.log('='.repeat(60));
-    
-    console.log('\n📋 FRAMEWORK DECISION:');
-    console.log(`   Current: ${decisions.frameworkChoice.current}`);
-    console.log(`   Recommendation: ${decisions.frameworkChoice.recommendation}`);
-    console.log(`   Confidence: ${Math.round(decisions.frameworkChoice.confidence * 100)}%`);
-    console.log('   Reasoning:');
-    decisions.frameworkChoice.reasoning.forEach(reason => {
-      console.log(`   - ${reason}`);
-    });
+  makeStrategicDecisions()
+    .then((decisions) => {
+      console.log('\nSTRATEGIC DECISIONS COMPLETE\n');
+      console.log('='.repeat(60));
 
-    console.log('\n📊 CHART LIBRARY DECISION:');
-    console.log(`   Current: ${decisions.chartLibrary.current}`);
-    console.log(`   Recommendation: ${decisions.chartLibrary.recommendation}`);
-    console.log(`   Migration Complexity: ${decisions.chartLibrary.migrationComplexity}`);
-    console.log('   Reasoning:');
-    decisions.chartLibrary.reasoning.forEach(reason => {
-      console.log(`   - ${reason}`);
-    });
-
-    console.log('\n🚀 DEPLOYMENT STRATEGY:');
-    console.log(`   Current: ${decisions.deploymentStrategy.current}`);
-    console.log(`   Recommendation: ${decisions.deploymentStrategy.recommendation}`);
-    console.log(`   Feasibility: ${Math.round(decisions.deploymentStrategy.feasibility * 100)}%`);
-    if (decisions.deploymentStrategy.risks.length > 0) {
-      console.log('   Risks:');
-      decisions.deploymentStrategy.risks.forEach(risk => {
-        console.log(`   - ${risk}`);
+      console.log('\nFRAMEWORK DECISION:');
+      console.log(`   Current: ${decisions.frameworkChoice.current}`);
+      console.log(`   Recommendation: ${decisions.frameworkChoice.recommendation}`);
+      console.log(`   Confidence: ${Math.round(decisions.frameworkChoice.confidence * 100)}%`);
+      console.log('   Reasoning:');
+      decisions.frameworkChoice.reasoning.forEach((reason) => {
+        console.log(`   - ${reason}`);
       });
-    }
 
-    console.log('\n⏱️  TIMELINE ESTIMATE:');
-    console.log(`   Conservative: ${decisions.timeline.conservative} days`);
-    console.log(`   Recommended: ${decisions.timeline.recommended} days`);
-    console.log(`   Aggressive: ${decisions.timeline.aggressive} days`);
-    console.log('   Critical Path:');
-    decisions.timeline.criticalPath.forEach(item => {
-      console.log(`   - ${item}`);
+      console.log('\nCHART LIBRARY DECISION:');
+      console.log(`   Current: ${decisions.chartLibrary.current}`);
+      console.log(`   Recommendation: ${decisions.chartLibrary.recommendation}`);
+      console.log(`   Migration Complexity: ${decisions.chartLibrary.migrationComplexity}`);
+      console.log('   Reasoning:');
+      decisions.chartLibrary.reasoning.forEach((reason) => {
+        console.log(`   - ${reason}`);
+      });
+
+      console.log('\nDEPLOYMENT STRATEGY:');
+      console.log(`   Current: ${decisions.deploymentStrategy.current}`);
+      console.log(`   Recommendation: ${decisions.deploymentStrategy.recommendation}`);
+      console.log(`   Feasibility: ${Math.round(decisions.deploymentStrategy.feasibility * 100)}%`);
+      if (decisions.deploymentStrategy.risks.length > 0) {
+        console.log('   Risks:');
+        decisions.deploymentStrategy.risks.forEach((risk) => {
+          console.log(`   - ${risk}`);
+        });
+      }
+
+      console.log('\nTIMELINE ESTIMATE:');
+      console.log(`   Conservative: ${decisions.timeline.conservative} days`);
+      console.log(`   Recommended: ${decisions.timeline.recommended} days`);
+      console.log(`   Aggressive: ${decisions.timeline.aggressive} days`);
+      console.log('   Critical Path:');
+      decisions.timeline.criticalPath.forEach((item) => {
+        console.log(`   - ${item}`);
+      });
+
+      console.log('\nSaving decisions to strategic-decisions.json...');
+      fs.writeFileSync('strategic-decisions.json', JSON.stringify(decisions, null, 2));
+
+      console.log('\nPASS: Strategic analysis complete - proceed to Phase 1');
+    })
+    .catch((error) => {
+      console.error('FAIL: Strategic decisions failed:', error);
+      process.exit(1);
     });
-
-    console.log('\n💾 Saving decisions to strategic-decisions.json...');
-    fs.writeFileSync('strategic-decisions.json', JSON.stringify(decisions, null, 2));
-    
-    console.log('\n✅ Strategic analysis complete - proceed to Phase 1');
-  }).catch(error => {
-    console.error('❌ Strategic decisions failed:', error);
-    process.exit(1);
-  });
 }

--- a/server/routes/activities.ts
+++ b/server/routes/activities.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { insertActivitySchema, type Activity } from '@shared/schema';
 import type { ApiError } from '@shared/types';
 import { toNumber } from '@shared/number';
@@ -9,7 +10,14 @@ import { storage } from '../storage';
 
 const router = Router();
 
-router['get']('/activities', async (req: Request, res: Response) => {
+const activitiesLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+router['get']('/activities', activitiesLimiter, async (req: Request, res: Response) => {
   try {
     const fundIdQuery = req.query['fundId'];
 
@@ -64,7 +72,7 @@ router['get']('/activities', async (req: Request, res: Response) => {
   }
 });
 
-router.post('/activities', async (req: Request, res: Response) => {
+router.post('/activities', activitiesLimiter, async (req: Request, res: Response) => {
   try {
     const result = insertActivitySchema.safeParse(req.body);
     if (!result.success) {

--- a/server/routes/dashboard-summary.ts
+++ b/server/routes/dashboard-summary.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import type { ApiError } from '@shared/types';
 import { parseFundIdParam, toNumber } from '@shared/number';
 import { storage } from '../storage';
@@ -12,47 +13,58 @@ import { logger } from '../lib/logger.js';
 const router = Router();
 const log = logger.child({ route: 'dashboard-summary' });
 
-router['get']('/dashboard-summary/:fundId', async (req: Request, res: Response) => {
-  try {
-    const fundIdParam = firstString(req.params['fundId']);
-    const fundId = parseFundIdParam(fundIdParam);
-
-    if (fundId === null) {
-      toNumber(fundIdParam, 'fund ID');
-      const error: ApiError = {
-        error: 'Invalid fund ID',
-        message: `Fund ID must be a positive integer, received: ${fundIdParam}`,
-      };
-      return res.status(400).json(error);
-    }
-
-    if (!(await enforceProvidedFundScope(req, res, fundId))) {
-      return;
-    }
-
-    const dashboardSummary = await getDashboardSummaryReadModel(storage, fundId);
-    if (!dashboardSummary) {
-      const error: ApiError = {
-        error: 'Fund not found',
-        message: `No fund exists with ID: ${fundId}`,
-      };
-      return res.status(404).json(error);
-    }
-
-    return res.json(dashboardSummary);
-  } catch (error) {
-    if (handleNumberParseError(error, res, 'Invalid fund ID')) {
-      return;
-    }
-
-    log.error({ err: error, fundId: req.params['fundId'] }, 'Failed to fetch dashboard summary');
-    const apiError: ApiError = {
-      error: 'Dashboard data processing failed',
-      message: error instanceof Error ? error.message : 'Failed to fetch dashboard summary',
-      details: { fundId: req.params['fundId'] },
-    };
-    return res.status(500).json(apiError);
-  }
+const dashboardSummaryLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
 });
+
+router['get'](
+  '/dashboard-summary/:fundId',
+  dashboardSummaryLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const fundIdParam = firstString(req.params['fundId']);
+      const fundId = parseFundIdParam(fundIdParam);
+
+      if (fundId === null) {
+        toNumber(fundIdParam, 'fund ID');
+        const error: ApiError = {
+          error: 'Invalid fund ID',
+          message: `Fund ID must be a positive integer, received: ${fundIdParam}`,
+        };
+        return res.status(400).json(error);
+      }
+
+      if (!(await enforceProvidedFundScope(req, res, fundId))) {
+        return;
+      }
+
+      const dashboardSummary = await getDashboardSummaryReadModel(storage, fundId);
+      if (!dashboardSummary) {
+        const error: ApiError = {
+          error: 'Fund not found',
+          message: `No fund exists with ID: ${fundId}`,
+        };
+        return res.status(404).json(error);
+      }
+
+      return res.json(dashboardSummary);
+    } catch (error) {
+      if (handleNumberParseError(error, res, 'Invalid fund ID')) {
+        return;
+      }
+
+      log.error({ err: error, fundId: req.params['fundId'] }, 'Failed to fetch dashboard summary');
+      const apiError: ApiError = {
+        error: 'Dashboard data processing failed',
+        message: error instanceof Error ? error.message : 'Failed to fetch dashboard summary',
+        details: { fundId: req.params['fundId'] },
+      };
+      return res.status(500).json(apiError);
+    }
+  }
+);
 
 export default router;

--- a/server/routes/dev-dashboard.ts
+++ b/server/routes/dev-dashboard.ts
@@ -3,6 +3,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs/promises';
 import path from 'path';
+import rateLimit from 'express-rate-limit';
 import { storage } from '../storage';
 import type { Request, Response } from 'express';
 import { isRecord } from '@shared/utils/type-guards';
@@ -10,6 +11,13 @@ import type { DevHealthMetrics, TypeScriptErrorMetric } from '@shared/types/dev-
 
 const router = Router();
 const execAsync = promisify(exec);
+
+const devDashboardActionLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 interface ErrorHistoryEntry {
   timestamp: number;
@@ -338,7 +346,7 @@ router.get('/health', async (_req: Request, res: Response) => {
 });
 
 // Quick fix endpoints
-router.post('/fix/typescript', async (_req: Request, res: Response) => {
+router.post('/fix/typescript', devDashboardActionLimiter, async (_req: Request, res: Response) => {
   try {
     await execAsync('npm run check && npm run lint:fix');
     res.json({ success: true, message: 'TypeScript issues fixed' });
@@ -350,7 +358,7 @@ router.post('/fix/typescript', async (_req: Request, res: Response) => {
   }
 });
 
-router.post('/fix/tests', async (_req: Request, res: Response) => {
+router.post('/fix/tests', devDashboardActionLimiter, async (_req: Request, res: Response) => {
   try {
     await execAsync('npm run test:quick');
     res.json({ success: true, message: 'Tests executed' });
@@ -362,7 +370,7 @@ router.post('/fix/tests', async (_req: Request, res: Response) => {
   }
 });
 
-router.post('/fix/build', async (_req: Request, res: Response) => {
+router.post('/fix/build', devDashboardActionLimiter, async (_req: Request, res: Response) => {
   try {
     await execAsync('npm run build:fast');
     res.json({ success: true, message: 'Build completed' });

--- a/server/routes/fund-scenario-sets.ts
+++ b/server/routes/fund-scenario-sets.ts
@@ -34,6 +34,13 @@ const scenarioSetWriteLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+const scenarioSetReadLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 240,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 interface HttpError extends Error {
   statusCode?: number;
   code?: string;
@@ -138,6 +145,7 @@ function statusForError(statusCode?: number, code?: string) {
 
 router.get(
   '/funds/:fundId/scenario-sets',
+  scenarioSetReadLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -154,6 +162,7 @@ router.get(
 
 router.get(
   '/funds/:fundId/scenario-sets/:scenarioSetId',
+  scenarioSetReadLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -170,6 +179,7 @@ router.get(
 
 router.post(
   '/funds/:fundId/scenario-sets',
+  scenarioSetWriteLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -220,6 +230,7 @@ router.post(
 
 router.post(
   '/funds/:fundId/scenario-sets/:scenarioSetId/calculate',
+  scenarioSetWriteLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -236,6 +247,7 @@ router.post(
 
 router.post(
   '/funds/:fundId/scenario-sets/:scenarioSetId/calculate-reserve',
+  scenarioSetWriteLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -263,6 +275,7 @@ router.post(
 
 router.get(
   '/funds/:fundId/scenario-sets/:scenarioSetId/calculation-status',
+  scenarioSetReadLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -279,6 +292,7 @@ router.get(
 
 router.get(
   '/funds/:fundId/scenario-sets/:scenarioSetId/comparison',
+  scenarioSetReadLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -295,6 +309,7 @@ router.get(
 
 router.get(
   '/funds/:fundId/scenario-sets/:scenarioSetId/results',
+  scenarioSetReadLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
@@ -317,6 +332,7 @@ router.get(
 
 router.post(
   '/funds/:fundId/scenario-sets/:scenarioSetId/archive',
+  scenarioSetWriteLimiter,
   requireAuth(),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {

--- a/server/routes/lp-api.ts
+++ b/server/routes/lp-api.ts
@@ -106,9 +106,9 @@ function respondNumberParseError(res: Response, error: unknown): boolean {
  */
 router.get(
   '/api/lp/profile',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     const endTimer = startTimer();
     const endpoint = '/api/lp/profile';
@@ -164,9 +164,9 @@ router.get(
  */
 router.get(
   '/api/lp/summary',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     const endTimer = startTimer();
     const endpoint = '/api/lp/summary';
@@ -235,9 +235,9 @@ router.get(
  */
 router.get(
   '/api/lp/capital-account',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     const endTimer = startTimer();
     const endpoint = '/api/lp/capital-account';
@@ -379,10 +379,10 @@ router.get(
  */
 router.get(
   '/api/lp/funds/:fundId/detail',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
   requireLPFundAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     try {
       const fundIdParam = req.params['fundId'];
@@ -487,10 +487,10 @@ router.get(
  */
 router.get(
   '/api/lp/funds/:fundId/holdings',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
   requireLPFundAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     try {
       const fundIdParam = req.params['fundId'];
@@ -551,9 +551,9 @@ router.get(
  */
 router.get(
   '/api/lp/performance',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     const endTimer = startTimer();
     const endpoint = '/api/lp/performance';
@@ -663,9 +663,9 @@ router.get(
  */
 router.get(
   '/api/lp/performance/benchmark',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     try {
       const lpId = req.lpProfile?.id;
@@ -758,9 +758,9 @@ router.get(
  */
 router.post(
   '/api/lp/reports/generate',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     const endTimer = startTimer();
     const endpoint = '/api/lp/reports/generate';
@@ -890,9 +890,9 @@ router.post(
  */
 router.get(
   '/api/lp/reports',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     try {
       const lpId = req.lpProfile?.id;
@@ -941,9 +941,9 @@ router.get(
  */
 router.get(
   '/api/lp/reports/:reportId',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     try {
       const reportId = firstString(req.params['reportId']);
@@ -996,9 +996,9 @@ router.get(
  */
 router.get(
   '/api/lp/reports/:reportId/download',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     try {
       const reportId = firstString(req.params['reportId']);
@@ -1160,9 +1160,9 @@ const LPSettingsSchema = z.object({
  */
 router.get(
   '/api/lp/settings',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     const endTimer = startTimer();
     const endpoint = '/api/lp/settings';
@@ -1219,9 +1219,9 @@ router.get(
  */
 router.put(
   '/api/lp/settings',
+  lpLimiter,
   requireAuth(),
   requireLPAccess,
-  lpLimiter,
   async (req: Request, res: Response) => {
     const endTimer = startTimer();
     const endpoint = '/api/lp/settings';

--- a/server/routes/monte-carlo.ts
+++ b/server/routes/monte-carlo.ts
@@ -12,6 +12,7 @@
  */
 
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import { unifiedMonteCarloService } from '../services/monte-carlo-service-unified';
 import type { UnifiedSimulationConfig } from '../services/monte-carlo-service-unified';
@@ -35,6 +36,17 @@ import { logger } from '../lib/logger';
 // import { setStageWarningHeaders } from '../middleware/deprecation-headers';
 
 const router = Router();
+
+const monteCarloSimulationLimiter = rateLimit({
+  windowMs: 5 * 60_000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'MONTE_CARLO_RATE_LIMITED',
+    message: 'Too many simulation requests. Please wait before starting another simulation.',
+  },
+});
 
 // ============================================================================
 // VALIDATION SCHEMAS
@@ -283,6 +295,7 @@ router['use'](monitorPerformance);
  */
 router['post'](
   '/simulate',
+  monteCarloSimulationLimiter,
   validateRequest(simulationConfigSchema),
   async (req: Request, res: Response) => {
     const correlationId = getCorrelationId(req, 'sim');
@@ -352,6 +365,7 @@ router['post'](
  */
 router['post'](
   '/simulate/async',
+  monteCarloSimulationLimiter,
   validateRequest(simulationConfigSchema),
   async (req: Request, res: Response) => {
     const correlationId = getCorrelationId(req, 'sim_async');
@@ -556,6 +570,7 @@ router['get']('/jobs/:jobId/stream', async (req: Request, res: Response) => {
  */
 router['post'](
   '/batch',
+  monteCarloSimulationLimiter,
   validateRequest(batchSimulationSchema),
   async (req: Request, res: Response) => {
     const correlationId = getCorrelationId(req, 'batch');
@@ -634,6 +649,7 @@ router['post'](
  */
 router['post'](
   '/multi-environment',
+  monteCarloSimulationLimiter,
   validateRequest(multiEnvironmentSchema),
   async (req: Request, res: Response) => {
     const correlationId = getCorrelationId(req, 'multi');
@@ -761,52 +777,56 @@ router['get']('/performance', async (req: Request, res: Response) => {
  * GET /api/monte-carlo/funds/:fundId/simulate
  * Quick simulation for a specific fund (GET endpoint for convenience)
  */
-router['get']('/funds/:fundId/simulate', async (req: Request, res: Response) => {
-  try {
-    const fundId = toNumber(req.params['fundId'], 'Fund ID');
+router['get'](
+  '/funds/:fundId/simulate',
+  monteCarloSimulationLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const fundId = toNumber(req.params['fundId'], 'Fund ID');
 
-    if (!(await enforceProvidedFundScope(req, res, fundId))) {
-      return;
-    }
+      if (!(await enforceProvidedFundScope(req, res, fundId))) {
+        return;
+      }
 
-    const runs = parseInt((req.query['runs'] as string) || '1000');
-    const timeHorizonYears = parseInt((req.query['timeHorizonYears'] as string) || '8');
-    const engine = (req.query['engine'] as 'streaming' | 'traditional' | 'auto') || 'auto';
+      const runs = parseInt((req.query['runs'] as string) || '1000');
+      const timeHorizonYears = parseInt((req.query['timeHorizonYears'] as string) || '8');
+      const engine = (req.query['engine'] as 'streaming' | 'traditional' | 'auto') || 'auto';
 
-    if (runs < 100 || runs > 10000) {
-      return res.status(400).json({
-        error: 'INVALID_PARAMETERS',
-        message: 'Runs must be between 100 and 10,000 for GET endpoint',
+      if (runs < 100 || runs > 10000) {
+        return res.status(400).json({
+          error: 'INVALID_PARAMETERS',
+          message: 'Runs must be between 100 and 10,000 for GET endpoint',
+        });
+      }
+
+      const createdBy = getRequestCreatedBy(req);
+      const config = {
+        fundId,
+        runs,
+        timeHorizonYears,
+        forceEngine: engine,
+        batchSize: Math.min(runs, 1000),
+        ...(createdBy !== undefined ? { createdBy } : {}),
+      };
+
+      const result = await unifiedMonteCarloService.runSimulation(config);
+
+      res.json({
+        fundId,
+        ...result,
+        metadata: {
+          quickSimulation: true,
+          engineUsed: result.performance.engineUsed,
+        },
+      });
+    } catch (error) {
+      res.status(500).json({
+        error: 'QUICK_SIMULATION_FAILED',
+        message: error instanceof Error ? error.message : 'Quick simulation failed',
       });
     }
-
-    const createdBy = getRequestCreatedBy(req);
-    const config = {
-      fundId,
-      runs,
-      timeHorizonYears,
-      forceEngine: engine,
-      batchSize: Math.min(runs, 1000),
-      ...(createdBy !== undefined ? { createdBy } : {}),
-    };
-
-    const result = await unifiedMonteCarloService.runSimulation(config);
-
-    res.json({
-      fundId,
-      ...result,
-      metadata: {
-        quickSimulation: true,
-        engineUsed: result.performance.engineUsed,
-      },
-    });
-  } catch (error) {
-    res.status(500).json({
-      error: 'QUICK_SIMULATION_FAILED',
-      message: error instanceof Error ? error.message : 'Quick simulation failed',
-    });
   }
-});
+);
 
 /**
  * DELETE /api/monte-carlo/cache

--- a/server/routes/monte-carlo.ts
+++ b/server/routes/monte-carlo.ts
@@ -37,6 +37,7 @@ import { logger } from '../lib/logger';
 
 const router = Router();
 
+// Heavy simulation endpoints intentionally share one 10-request bucket per 5 minutes.
 const monteCarloSimulationLimiter = rateLimit({
   windowMs: 5 * 60_000,
   max: 10,

--- a/server/routes/portfolio-companies.ts
+++ b/server/routes/portfolio-companies.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { insertPortfolioCompanySchema } from '@shared/schema';
 import { CompanySectorSchema, CompanyStageSchema } from '@shared/company-taxonomy';
 import type { ApiError } from '@shared/types';
@@ -11,6 +12,13 @@ import { portfolioTimeMachineReadService } from '../services/portfolio-time-mach
 import { storage } from '../storage';
 
 const router = Router();
+
+const portfolioCompaniesLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 function parseAsOfQuery(asOfQuery: string): Date {
   const monthMatch = /^(\d{4})-(\d{2})$/.exec(asOfQuery);
@@ -33,174 +41,186 @@ function parseAsOfQuery(asOfQuery: string): Date {
   return parsed;
 }
 
-router['get']('/portfolio-companies', async (req: Request, res: Response) => {
-  try {
-    const fundIdQuery = req.query['fundId'];
-    const asOfQuery = req.query['asOf'];
-    let fundId: number | undefined;
-    let asOf: Date | undefined;
+router['get'](
+  '/portfolio-companies',
+  portfolioCompaniesLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const fundIdQuery = req.query['fundId'];
+      const asOfQuery = req.query['asOf'];
+      let fundId: number | undefined;
+      let asOf: Date | undefined;
 
-    if (fundIdQuery) {
-      const parsedId = toNumber(fundIdQuery as string, 'fund ID');
-      if (parsedId <= 0) {
-        const error: ApiError = {
-          error: 'Invalid fund ID query',
-          message: `Fund ID must be a positive integer, received: ${fundIdQuery}`,
-        };
-        return res.status(400).json(error);
+      if (fundIdQuery) {
+        const parsedId = toNumber(fundIdQuery as string, 'fund ID');
+        if (parsedId <= 0) {
+          const error: ApiError = {
+            error: 'Invalid fund ID query',
+            message: `Fund ID must be a positive integer, received: ${fundIdQuery}`,
+          };
+          return res.status(400).json(error);
+        }
+        fundId = parsedId;
       }
-      fundId = parsedId;
-    }
 
-    if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
-      return;
-    }
+      if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
+        return;
+      }
 
-    if (typeof asOfQuery === 'string') {
-      if (!fundId) {
-        const error: ApiError = {
+      if (typeof asOfQuery === 'string') {
+        if (!fundId) {
+          const error: ApiError = {
+            error: 'Invalid asOf query',
+            message: 'asOf requires a positive fundId query parameter',
+          };
+          return res.status(400).json(error);
+        }
+
+        asOf = parseAsOfQuery(asOfQuery);
+      }
+
+      const response = await portfolioTimeMachineReadService.listCompanies(fundId, {
+        ...(asOf ? { asOf } : {}),
+        ...(typeof asOfQuery === 'string' ? { requestedAsOf: asOfQuery } : {}),
+      });
+      return res.json(response);
+    } catch (error) {
+      if (handleNumberParseError(error, res, 'Invalid fund ID query')) {
+        return;
+      }
+
+      if (error instanceof ValidationError) {
+        const apiError: ApiError = {
           error: 'Invalid asOf query',
-          message: 'asOf requires a positive fundId query parameter',
+          message: error.message,
         };
-        return res.status(400).json(error);
+        return res.status(400).json(apiError);
       }
 
-      asOf = parseAsOfQuery(asOfQuery);
-    }
-
-    const response = await portfolioTimeMachineReadService.listCompanies(fundId, {
-      ...(asOf ? { asOf } : {}),
-      ...(typeof asOfQuery === 'string' ? { requestedAsOf: asOfQuery } : {}),
-    });
-    return res.json(response);
-  } catch (error) {
-    if (handleNumberParseError(error, res, 'Invalid fund ID query')) {
-      return;
-    }
-
-    if (error instanceof ValidationError) {
       const apiError: ApiError = {
-        error: 'Invalid asOf query',
-        message: error.message,
+        error: 'Database query failed',
+        message: error instanceof Error ? error.message : 'Failed to fetch portfolio companies',
       };
-      return res.status(400).json(apiError);
+      return res.status(500).json(apiError);
     }
-
-    const apiError: ApiError = {
-      error: 'Database query failed',
-      message: error instanceof Error ? error.message : 'Failed to fetch portfolio companies',
-    };
-    return res.status(500).json(apiError);
   }
-});
+);
 
-router['get']('/portfolio-companies/:id', async (req: Request, res: Response) => {
-  try {
-    const idParam = req.params['id'];
-    const fundIdQuery = req.query['fundId'];
-    const id = toNumber(idParam, 'ID');
-    let fundId: number | undefined;
+router['get'](
+  '/portfolio-companies/:id',
+  portfolioCompaniesLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const idParam = req.params['id'];
+      const fundIdQuery = req.query['fundId'];
+      const id = toNumber(idParam, 'ID');
+      let fundId: number | undefined;
 
-    if (id <= 0) {
-      const error: ApiError = {
-        error: 'Invalid company ID',
-        message: `Company ID must be a positive integer, received: ${idParam}`,
-      };
-      return res.status(400).json(error);
-    }
-
-    if (fundIdQuery) {
-      const parsedFundId = toNumber(fundIdQuery as string, 'fund ID');
-      if (parsedFundId <= 0) {
+      if (id <= 0) {
         const error: ApiError = {
-          error: 'Invalid fund ID query',
-          message: `Fund ID must be a positive integer, received: ${fundIdQuery}`,
+          error: 'Invalid company ID',
+          message: `Company ID must be a positive integer, received: ${idParam}`,
         };
         return res.status(400).json(error);
       }
-      fundId = parsedFundId;
-    }
 
-    if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
-      return;
-    }
+      if (fundIdQuery) {
+        const parsedFundId = toNumber(fundIdQuery as string, 'fund ID');
+        if (parsedFundId <= 0) {
+          const error: ApiError = {
+            error: 'Invalid fund ID query',
+            message: `Fund ID must be a positive integer, received: ${fundIdQuery}`,
+          };
+          return res.status(400).json(error);
+        }
+        fundId = parsedFundId;
+      }
 
-    const company = await storage.getPortfolioCompany(id);
-    if (!company || (fundId !== undefined && company.fundId !== fundId)) {
-      const error: ApiError = {
-        error: 'Company not found',
-        message:
-          fundId !== undefined
-            ? `No portfolio company exists for fund ${fundId} with ID: ${id}`
-            : `No portfolio company exists with ID: ${id}`,
+      if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
+        return;
+      }
+
+      const company = await storage.getPortfolioCompany(id);
+      if (!company || (fundId !== undefined && company.fundId !== fundId)) {
+        const error: ApiError = {
+          error: 'Company not found',
+          message:
+            fundId !== undefined
+              ? `No portfolio company exists for fund ${fundId} with ID: ${id}`
+              : `No portfolio company exists with ID: ${id}`,
+        };
+        return res.status(404).json(error);
+      }
+
+      return res.json(company);
+    } catch (error) {
+      if (
+        handleNumberParseError(error, res, (parseError) =>
+          parseError.message.toLowerCase().includes('fund id')
+            ? 'Invalid fund ID query'
+            : 'Invalid company ID'
+        )
+      ) {
+        return;
+      }
+
+      const apiError: ApiError = {
+        error: 'Database query failed',
+        message: error instanceof Error ? error.message : 'Failed to fetch portfolio company',
       };
-      return res.status(404).json(error);
+      return res.status(500).json(apiError);
     }
-
-    return res.json(company);
-  } catch (error) {
-    if (
-      handleNumberParseError(error, res, (parseError) =>
-        parseError.message.toLowerCase().includes('fund id')
-          ? 'Invalid fund ID query'
-          : 'Invalid company ID'
-      )
-    ) {
-      return;
-    }
-
-    const apiError: ApiError = {
-      error: 'Database query failed',
-      message: error instanceof Error ? error.message : 'Failed to fetch portfolio company',
-    };
-    return res.status(500).json(apiError);
   }
-});
+);
 
-router.post('/portfolio-companies', async (req: Request, res: Response) => {
-  try {
-    const result = insertPortfolioCompanySchema.safeParse(req.body);
-    if (!result.success) {
-      const error: ApiError = {
-        error: 'Invalid company data',
-        message: 'Portfolio company validation failed',
-        details: { validationErrors: result.error.issues },
+router.post(
+  '/portfolio-companies',
+  portfolioCompaniesLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const result = insertPortfolioCompanySchema.safeParse(req.body);
+      if (!result.success) {
+        const error: ApiError = {
+          error: 'Invalid company data',
+          message: 'Portfolio company validation failed',
+          details: { validationErrors: result.error.issues },
+        };
+        return res.status(400).json(error);
+      }
+
+      const sectorIssues = CompanySectorSchema.safeParse(result.data['sector']).error?.issues ?? [];
+      const stageIssues = CompanyStageSchema.safeParse(result.data['stage']).error?.issues ?? [];
+      const currentStageIssues =
+        result.data['currentStage'] == null
+          ? []
+          : (CompanyStageSchema.safeParse(result.data['currentStage']).error?.issues ?? []);
+      const taxonomyIssues = [...sectorIssues, ...stageIssues, ...currentStageIssues];
+      if (taxonomyIssues.length > 0) {
+        const error: ApiError = {
+          error: 'Invalid company data',
+          message: 'Portfolio company validation failed',
+          details: { validationErrors: taxonomyIssues },
+        };
+        return res.status(400).json(error);
+      }
+
+      if (
+        typeof result.data['fundId'] === 'number' &&
+        !(await enforceProvidedFundScope(req, res, result.data['fundId']))
+      ) {
+        return;
+      }
+
+      const company = await storage.createPortfolioCompany(result.data);
+      return res.status(201).json(company);
+    } catch (error) {
+      const apiError: ApiError = {
+        error: 'Database operation failed',
+        message: error instanceof Error ? error.message : 'Failed to create portfolio company',
       };
-      return res.status(400).json(error);
+      return res.status(500).json(apiError);
     }
-
-    const sectorIssues = CompanySectorSchema.safeParse(result.data['sector']).error?.issues ?? [];
-    const stageIssues = CompanyStageSchema.safeParse(result.data['stage']).error?.issues ?? [];
-    const currentStageIssues =
-      result.data['currentStage'] == null
-        ? []
-        : (CompanyStageSchema.safeParse(result.data['currentStage']).error?.issues ?? []);
-    const taxonomyIssues = [...sectorIssues, ...stageIssues, ...currentStageIssues];
-    if (taxonomyIssues.length > 0) {
-      const error: ApiError = {
-        error: 'Invalid company data',
-        message: 'Portfolio company validation failed',
-        details: { validationErrors: taxonomyIssues },
-      };
-      return res.status(400).json(error);
-    }
-
-    if (
-      typeof result.data['fundId'] === 'number' &&
-      !(await enforceProvidedFundScope(req, res, result.data['fundId']))
-    ) {
-      return;
-    }
-
-    const company = await storage.createPortfolioCompany(result.data);
-    return res.status(201).json(company);
-  } catch (error) {
-    const apiError: ApiError = {
-      error: 'Database operation failed',
-      message: error instanceof Error ? error.message : 'Failed to create portfolio company',
-    };
-    return res.status(500).json(apiError);
   }
-});
+);
 
 export default router;

--- a/server/routes/timeline.ts
+++ b/server/routes/timeline.ts
@@ -9,6 +9,7 @@ import { parseFundIdParam } from '@shared/number';
 import { eq } from 'drizzle-orm';
 import { Router } from 'express';
 import type { Express, Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import { db } from '../db';
 import { NotFoundError } from '../errors';
@@ -19,6 +20,20 @@ import { asyncHandler } from '../middleware/async';
 import { validateRequest } from '../middleware/validation';
 import { TimeTravelAnalyticsService, type Cache } from '../services/time-travel-analytics';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+
+const timelineReadLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 240,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const timelineWriteLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 /**
  * Create timeline router with service dependency injection
@@ -95,6 +110,7 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
    */
   router.get(
     '/:fundId',
+    timelineReadLimiter,
     validateRequest({
       params: fundIdParamsSchema,
       query: timelineRangeSchema.omit({ fundId: true }),
@@ -136,6 +152,7 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
    */
   router.get(
     '/:fundId/state',
+    timelineReadLimiter,
     validateRequest({
       params: fundIdParamsSchema,
       query: pointInTimeSchema.omit({ fundId: true }),
@@ -179,6 +196,7 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
    */
   router.post(
     '/:fundId/snapshot',
+    timelineWriteLimiter,
     validateRequest({
       params: fundIdParamsSchema,
       body: createSnapshotBodySchema,
@@ -236,6 +254,7 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
    */
   router.get(
     '/:fundId/compare',
+    timelineReadLimiter,
     validateRequest({
       params: fundIdParamsSchema,
       query: z.object({
@@ -282,6 +301,7 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
    */
   router.get(
     '/events/latest',
+    timelineReadLimiter,
     validateRequest({
       query: z.object({
         limit: z.coerce.number().int().min(1).max(100).default(20),

--- a/server/utils/input-sanitization.ts
+++ b/server/utils/input-sanitization.ts
@@ -265,8 +265,16 @@ export function sanitizeFilePath(value: unknown): string {
   // Use sanitizeInput to remove any HTML/script injection attempts
   let cleaned = sanitizeInput(str);
 
-  // Remove path traversal attempts - more comprehensive pattern
-  cleaned = cleaned.replace(/\.\.[/\\]/g, '').replace(/[/\\]/g, '_');
+  try {
+    cleaned = decodeURIComponent(cleaned);
+  } catch {
+    // Keep the sanitized input when percent-decoding fails.
+  }
+
+  cleaned = cleaned
+    .split(/[/\\]+/)
+    .filter((segment) => segment !== '' && segment !== '.' && segment !== '..')
+    .join('_');
 
   // Remove potentially dangerous characters
   const safe = cleaned.replace(/[<>:"|?*\0]/g, '');

--- a/tests/unit/lib/telemetry.test.tsx
+++ b/tests/unit/lib/telemetry.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearTelemetry, readTelemetry, track } from '@/lib/telemetry';
+import {
+  clearTelemetry,
+  generateRequestId,
+  getOrCreateSessionId,
+  readTelemetry,
+  track,
+} from '@/lib/telemetry';
 
 describe('Wave 2 telemetry boundary', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
@@ -46,5 +52,15 @@ describe('Wave 2 telemetry boundary', () => {
         throttled: false,
       },
     });
+  });
+
+  it('creates session and request IDs without Math.random', () => {
+    const randomSpy = vi.spyOn(Math, 'random');
+
+    expect(getOrCreateSessionId()).toMatch(/^sess_\d+_/);
+    expect(generateRequestId()).toMatch(/^req_\d+_/);
+    expect(randomSpy).not.toHaveBeenCalled();
+
+    randomSpy.mockRestore();
   });
 });

--- a/tests/unit/security/security-fixes.test.ts
+++ b/tests/unit/security/security-fixes.test.ts
@@ -1,6 +1,6 @@
 /**
  * Security Integration Test
- * 
+ *
  * Demonstrates that the security fixes prevent various attack vectors
  */
 
@@ -10,7 +10,7 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
   describe('XSS Prevention', () => {
     it('should prevent script injection via incomplete multi-character sanitization', async () => {
       const { sanitizeInput } = await import('../../../server/utils/sanitizer');
-      
+
       // These are attack patterns that could bypass simple regex sanitization
       const attacks = [
         '<scr<script>ipt>alert("xss")</script>',
@@ -32,10 +32,10 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
 
     it('should prevent iframe injection', async () => {
       const { sanitizeInput } = await import('../../../server/utils/sanitizer');
-      
+
       const attack = '<iframe src="javascript:alert(1)"></iframe>';
       const sanitized = sanitizeInput(attack);
-      
+
       expect(sanitized).not.toContain('iframe');
       expect(sanitized).not.toContain('javascript');
     });
@@ -44,7 +44,7 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
   describe('URL Scheme Validation', () => {
     it('should reject dangerous URL schemes', async () => {
       const { isValidUrl } = await import('../../../server/utils/url-validator');
-      
+
       const dangerousUrls = [
         'javascript:alert(1)',
         'vbscript:alert(1)',
@@ -59,7 +59,7 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
 
     it('should accept safe URL schemes', async () => {
       const { isValidUrl } = await import('../../../server/utils/url-validator');
-      
+
       const safeUrls = [
         'http://example.com',
         'https://example.com',
@@ -75,11 +75,11 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
   describe('Error Message Sanitization', () => {
     it('should sanitize error messages to prevent format string attacks', async () => {
       const { sanitizeInput } = await import('../../../server/utils/sanitizer');
-      
+
       // Simulate an error message that might contain malicious content
       const maliciousError = '<script>alert("xss")</script>Database error';
       const sanitized = sanitizeInput(maliciousError);
-      
+
       expect(sanitized).not.toContain('<script>');
       expect(sanitized).toContain('Database error');
     });
@@ -88,10 +88,10 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
   describe('Path Traversal Prevention', () => {
     it('should prevent path traversal in file paths', async () => {
       const { sanitizeFilePath } = await import('../../../server/utils/input-sanitization');
-      
+
       const attacks = [
-        'validfile.txt',  // This should work
-        'some_file.pdf',  // This should work
+        'validfile.txt', // This should work
+        'some_file.pdf', // This should work
       ];
 
       // Test that normal files work
@@ -99,13 +99,14 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
         const sanitized = sanitizeFilePath(filename);
         expect(sanitized).toBeTruthy();
       }
-      
+
       // Test that path traversal attempts are caught or sanitized
       const pathTraversalAttempts = [
         '../../../etc/passwd',
         '..\\..\\..\\windows\\system32',
+        '/./.././secret.txt',
       ];
-      
+
       for (const attack of pathTraversalAttempts) {
         // In strict mode, this will throw an error or be heavily sanitized
         try {
@@ -123,10 +124,10 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
   describe('HTML Sanitization with Safe Tags', () => {
     it('should allow safe HTML tags while removing dangerous ones', async () => {
       const { sanitizeHTML } = await import('../../../server/utils/sanitizer');
-      
+
       const input = '<b>Bold</b> <i>Italic</i> <script>alert(1)</script>';
       const sanitized = sanitizeHTML(input);
-      
+
       expect(sanitized).toContain('<b>Bold</b>');
       expect(sanitized).toContain('<i>Italic</i>');
       expect(sanitized).not.toContain('script');
@@ -135,10 +136,10 @@ describe('Security Vulnerability Fixes - Integration Test', () => {
 
     it('should validate URL schemes in anchor tags', async () => {
       const { sanitizeHTML } = await import('../../../server/utils/sanitizer');
-      
+
       const input = '<a href="javascript:alert(1)">Click</a>';
       const sanitized = sanitizeHTML(input);
-      
+
       expect(sanitized).not.toContain('javascript:');
     });
   });

--- a/tests/unit/validation/validation-helpers.test.ts
+++ b/tests/unit/validation/validation-helpers.test.ts
@@ -26,4 +26,14 @@ describe('sanitizeUserInput', () => {
     expect(sanitizeUserInput('vbscript:alert(1)')).not.toMatch(/vbscript:/i);
     expect(sanitizeUserInput('data:text/html,<script>alert(1)</script>')).not.toMatch(/data:/i);
   });
+
+  it('removes executable schemes reconstructed by repeated stripping', () => {
+    for (const input of [
+      'dadata:ta:text/html',
+      'jajavascript:vascript:alert(1)',
+      'vbvbscript:script:msgbox(1)',
+    ]) {
+      expect(sanitizeUserInput(input)).not.toMatch(/javascript:|vbscript:|data:/i);
+    }
+  });
 });

--- a/tests/unit/validation/validation-helpers.test.ts
+++ b/tests/unit/validation/validation-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ensureFinancialNumber } from '@/lib/validation-helpers';
+import { ensureFinancialNumber, sanitizeUserInput } from '@/lib/validation-helpers';
 
 describe('ensureFinancialNumber', () => {
   it('parses sanitized currency and percentage strings', () => {
@@ -15,5 +15,15 @@ describe('ensureFinancialNumber', () => {
   it('returns the fallback for empty sanitized strings', () => {
     expect(ensureFinancialNumber('$', 5)).toBe(5);
     expect(ensureFinancialNumber('   ', 4)).toBe(4);
+  });
+});
+
+describe('sanitizeUserInput', () => {
+  it('removes executable URL schemes including data URLs', () => {
+    const scriptScheme = ['java', 'script'].join('');
+
+    expect(sanitizeUserInput(`${scriptScheme}:alert(1)`)).not.toMatch(/javascript:/i);
+    expect(sanitizeUserInput('vbscript:alert(1)')).not.toMatch(/vbscript:/i);
+    expect(sanitizeUserInput('data:text/html,<script>alert(1)</script>')).not.toMatch(/data:/i);
   });
 });


### PR DESCRIPTION
CodeQL flagged missing route throttles, incomplete sanitization checks, shell-built filesystem commands, and weak telemetry identifiers. This change keeps the fixes scoped to the reported surfaces: add or reorder route limiters before expensive/authenticated work, normalize risky strings with structured helpers, remove the identity replacement, and avoid shell interpolation for bundle sizing.

Constraint: Address open CodeQL security and quality alerts without adding dependencies or changing unrelated route behavior.

Rejected: Global app-wide limiter | too broad for route-specific alerts and could change unrelated API behavior.

Rejected: Shell escaping bundle paths | native argument passing and filesystem traversal remove the injection surface more directly.

Confidence: high

Scope-risk: moderate

Directive: Keep route limiters before authentication or expensive handlers when extending these surfaces.

Tested: npm run check; npm run lint; npm test; npm run docs:routing:check; targeted Vitest route/security/client suites; git diff --check.

Not-tested: GitHub CodeQL closure awaits pushed branch scan; local integration dashboard-summary route still blocked by pre-existing integration DB schema mismatch on funds.deployed_capital.