### PR TITLE
fix(routes): mount fund-scenario-sets on makeApp production surface

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -24,6 +24,7 @@ import scenarioAnalysisRouter from './routes/scenario-analysis.js';
 import dualForecastRouter from './routes/dual-forecast.js';
 import allocationsRouter from './routes/allocations.js';
 import allocationScenariosRouter from './routes/allocation-scenarios.js';
+import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
 import backtestingRouter from './routes/backtesting.js';
 import fundsRouter from './routes/funds.js';
 import fundMetricsRouter from './routes/fund-metrics.js';
@@ -215,6 +216,7 @@ export function makeApp() {
   // Fund Allocation Management API (Phase 1b - Reserve allocations with optimistic locking)
   app.use('/api', allocationsRouter);
   app.use('/api', allocationScenariosRouter);
+  app.use('/api', fundScenarioSetsRouter);
 
   // Deal Pipeline API (Sprint 1 - Deal tracking, DD, scoring)
   app.use('/api/deals', dealPipelineRouter);

--- a/tests/unit/routes/fund-scenario-sets-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/fund-scenario-sets-makeapp-surface.contract.test.ts
@@ -1,0 +1,122 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function authorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '1',
+    email: 'route-surface-test@example.com',
+    role: 'admin',
+    fundIds: [],
+  })}`;
+}
+
+describe('fund scenario sets makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('mounts the fund scenario sets router on the production makeApp API surface', async () => {
+    const app = await makeAppWithTestAuth();
+
+    // A non-numeric fundId reaches the mounted router's fund-access guard, which
+    // rejects it with 400 "Invalid fund ID" before any DB access. When the
+    // router is NOT mounted (the production mount-parity defect this test guards
+    // against), the identical request falls through to the makeApp catch-all
+    // 404 {error:'not_found'}. 400-vs-404 is therefore a fast, DB-free proof of
+    // the mount. (Mirrors the reallocation idiom in route-surface-inventory.)
+    const res = await request(app)
+      .get('/api/funds/abc/scenario-sets')
+      .set('Authorization', await authorizationHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Bad Request', message: 'Invalid fund ID' });
+  }, 30_000);
+});


### PR DESCRIPTION
## What

Mounts the `fund-scenario-sets` router on the **makeApp** production surface (`server/app.ts`). It was registered only in `registerRoutes()` (`server/routes.ts:69`), never in `makeApp()`.

## Why (live production blocker)

Production boots via `makeApp()` (`server/index.ts:9`). Because the router was absent there, **every** scenario-workspace call — `GET /api/funds/:fundId/scenario-sets` plus the create / calculate / calculation-status / comparison / results / archive sub-routes (all defined in the single `fund-scenario-sets.ts` router) — returned `404 {error:'not_found'}` in production, surfacing as "workspace unavailable" in the GP loop. The routes passed on dev/test surfaces that boot via `registerRoutes`, so the gap was invisible to existing tests.

The existing `fund-scenario-sets-route-contract.test.ts` is a **static source-text** test (`readRepoFile` + string assertions); it never boots makeApp, which is why the mount gap went undetected.

## Change (smallest safe diff — 2 files)

- `server/app.ts`: `import fundScenarioSetsRouter` + `app.use('/api', fundScenarioSetsRouter)` (mirrors `routes.ts:69`).
- New `tests/unit/routes/fund-scenario-sets-makeapp-surface.contract.test.ts`: boots the real makeApp surface (reusing the `route-surface-inventory` auth/env helpers) and proves reachability.

## Audit

Audited `app.ts` vs `routes.ts` for other GP-loop routers on the results/scenario path. The other leg — `GET /api/funds/:id/results` — is already on makeApp via `registerFundConfigRoutes(app)` (`fund-config.ts:471`). The full scenario surface lives in this one router, so this single mount fixes the entire `/scenarios` path. No other GP-loop router needed mounting. (Out-of-scope: many non-GP-loop routers — moic, graduation, capital-allocation, liquidity, etc. — remain registerRoutes-only; not addressed here per KISS/YAGNI.)

## Test design (DB-free, deterministic)

A non-numeric `fundId` hits the mounted router's fund-access guard, which returns `400 "Invalid fund ID"` **before any DB access**; an unmounted route falls through to the makeApp catch-all `404`. `400`-vs-`404` is a fast, deterministic mount proof — the same idiom `route-surface-inventory` uses for `reallocation`. (A numeric `fundId` was rejected as the discriminator: in no-DB test mode the handler returns its own `404 {code:'fund_not_found'}`, which collides with the catch-all 404.)

## Verification

- `npm run check`: 0 new TypeScript errors.
- New test **GREEN** with mount; **RED** (`expected 404 to be 400`) on negative-control revert of the `app.use` line; **GREEN** again on restore — proves the test binds to the mount.
- Related suite green: `route-surface-inventory` (12), `fund-scenario-sets-route-contract` (2), new test (1); pre-push related batch 28/28.
- Lint clean (`eslint --max-warnings 0`) on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
