### PR TITLE
fix(allocations): composite keyset cursor for company list pagination (#744)

### DIFF
--- a/server/routes/allocations.ts
+++ b/server/routes/allocations.ts
@@ -17,7 +17,7 @@ import { logger } from '../lib/logger.js';
 import { applyAllocationUpdates } from '../services/allocation-write-service.js';
 import { funds, portfolioCompanies } from '@shared/schema';
 import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
-import { eq, lt, sql, desc, asc, and } from 'drizzle-orm';
+import { eq, sql, desc, asc, and } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
 // Stage normalization and validation
 import { normalizeStage, CANONICAL_STAGES } from '@shared/schemas/parse-stage-distribution';
@@ -75,6 +75,17 @@ const ALLOCATION_ERROR_MAPPINGS = [
 // Validation Schemas
 // ============================================================================
 
+const COMPANY_LIST_CURSOR_BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const CompanyListSortBySchema = z.enum(['exit_moic_desc', 'planned_reserves_desc', 'name_asc']);
+
+type CompanyListSortBy = z.infer<typeof CompanyListSortBySchema>;
+type CompanyListCursorKey = string | number | null;
+
+interface CompanyListCursor {
+  k: CompanyListCursorKey;
+  id: number;
+}
+
 /**
  * Schema for updating a single company's allocation
  */
@@ -112,22 +123,45 @@ const UpdateAllocationRequestSchema = z
 /**
  * Query parameter schema for company list endpoint
  */
-const CompanyListQuerySchema = z.object({
-  cursor: z.string().regex(/^\d+$/).transform(Number).optional(),
-  limit: z
-    .string()
-    .regex(/^\d+$/)
-    .transform(Number)
-    .default('50')
-    .refine((val) => val >= 1 && val <= 200, {
-      message: 'Limit must be between 1 and 200',
-    }),
-  q: z.string().max(255).optional(), // Search query
-  status: z.enum(['active', 'exited', 'written-off']).optional(),
-  sector: z.string().max(100).optional(),
-  stage: z.string().max(50).optional(), // Investment stage (will be normalized)
-  sortBy: z.enum(['exit_moic_desc', 'planned_reserves_desc', 'name_asc']).default('exit_moic_desc'),
-});
+const CompanyListQuerySchema = z
+  .object({
+    cursor: z
+      .string()
+      .transform((value, context) => {
+        const decoded = decodeCompanyListCursor(value);
+        if (!decoded) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Invalid cursor',
+          });
+          return z.NEVER;
+        }
+        return decoded;
+      })
+      .optional(),
+    limit: z
+      .string()
+      .regex(/^\d+$/)
+      .transform(Number)
+      .default('50')
+      .refine((val) => val >= 1 && val <= 200, {
+        message: 'Limit must be between 1 and 200',
+      }),
+    q: z.string().max(255).optional(), // Search query
+    status: z.enum(['active', 'exited', 'written-off']).optional(),
+    sector: z.string().max(100).optional(),
+    stage: z.string().max(50).optional(), // Investment stage (will be normalized)
+    sortBy: CompanyListSortBySchema.default('exit_moic_desc'),
+  })
+  .superRefine((query, context) => {
+    if (query.cursor && !isCompanyListCursorCompatible(query.cursor, query.sortBy)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['cursor'],
+        message: 'Cursor does not match sort order',
+      });
+    }
+  });
 
 // ============================================================================
 // Type Definitions
@@ -220,6 +254,60 @@ interface CompanyListResponse {
 // Helper Functions
 // ============================================================================
 
+function decodeCompanyListCursor(cursor: string): CompanyListCursor | null {
+  if (!COMPANY_LIST_CURSOR_BASE64URL_PATTERN.test(cursor)) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    const parsed = JSON.parse(decoded) as unknown;
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const payload = parsed as Record<string, unknown>;
+    const id = payload['id'];
+    const key = payload['k'];
+
+    if (!Object.prototype.hasOwnProperty.call(payload, 'k')) {
+      return null;
+    }
+
+    if (typeof id !== 'number' || !Number.isSafeInteger(id) || id <= 0) {
+      return null;
+    }
+
+    if (
+      key !== null &&
+      typeof key !== 'string' &&
+      (typeof key !== 'number' || !Number.isFinite(key))
+    ) {
+      return null;
+    }
+
+    return { k: key as CompanyListCursorKey, id };
+  } catch {
+    return null;
+  }
+}
+
+function isCompanyListCursorCompatible(
+  cursor: CompanyListCursor,
+  sortBy: CompanyListSortBy
+): boolean {
+  if (sortBy === 'name_asc') {
+    return typeof cursor.k === 'string';
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return typeof cursor.k === 'number';
+  }
+
+  return cursor.k === null || typeof cursor.k === 'number';
+}
+
 function allocationErrorText(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
@@ -281,12 +369,135 @@ function plannedReservesSortValue(company: object): number {
   return 0;
 }
 
-function exitMoicSortValue(company: object): number {
+function exitMoicSortKey(company: object): number | null {
   if ('exitMoicBps' in company) {
-    return Number(company.exitMoicBps ?? Number.NEGATIVE_INFINITY);
+    if (company.exitMoicBps == null) {
+      return null;
+    }
+    const value = Number(company.exitMoicBps);
+    return Number.isFinite(value) ? value : null;
   }
 
-  return Number.NEGATIVE_INFINITY;
+  return null;
+}
+
+function companyListSortKey(
+  company: CompanyListSourceRow,
+  sortBy: CompanyListSortBy
+): CompanyListCursorKey {
+  if (sortBy === 'name_asc') {
+    return company.name;
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return plannedReservesSortValue(company);
+  }
+
+  return exitMoicSortKey(company);
+}
+
+function compareNullableNumberDesc(left: number | null, right: number | null): number {
+  if (left === null && right === null) {
+    return 0;
+  }
+  if (left === null) {
+    return 1;
+  }
+  if (right === null) {
+    return -1;
+  }
+  return right - left;
+}
+
+function compareCompanyListRows(
+  left: CompanyListSourceRow,
+  right: CompanyListSourceRow,
+  sortBy: CompanyListSortBy
+): number {
+  if (sortBy === 'name_asc') {
+    return left.name.localeCompare(right.name) || right.id - left.id;
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return plannedReservesSortValue(right) - plannedReservesSortValue(left) || right.id - left.id;
+  }
+
+  return (
+    compareNullableNumberDesc(exitMoicSortKey(left), exitMoicSortKey(right)) || right.id - left.id
+  );
+}
+
+function isAfterCompanyListCursor(
+  company: CompanyListSourceRow,
+  cursor: CompanyListCursor,
+  sortBy: CompanyListSortBy
+): boolean {
+  const key = companyListSortKey(company, sortBy);
+
+  if (sortBy === 'name_asc') {
+    return (
+      typeof key === 'string' &&
+      typeof cursor.k === 'string' &&
+      (key.localeCompare(cursor.k) > 0 || (key === cursor.k && company.id < cursor.id))
+    );
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return (
+      typeof key === 'number' &&
+      typeof cursor.k === 'number' &&
+      (key < cursor.k || (key === cursor.k && company.id < cursor.id))
+    );
+  }
+
+  if (cursor.k === null) {
+    return key === null && company.id < cursor.id;
+  }
+
+  return (
+    typeof cursor.k === 'number' &&
+    (key === null ||
+      (typeof key === 'number' && (key < cursor.k || (key === cursor.k && company.id < cursor.id))))
+  );
+}
+
+function encodeCompanyListCursor(company: CompanyListSourceRow, sortBy: CompanyListSortBy): string {
+  return Buffer.from(
+    JSON.stringify({ k: companyListSortKey(company, sortBy), id: company.id })
+  ).toString('base64url');
+}
+
+function requireCompanyListCursorNumberKey(cursor: CompanyListCursor): number {
+  if (typeof cursor.k !== 'number') {
+    throw new Error('Invalid numeric company-list cursor key');
+  }
+  return cursor.k;
+}
+
+function requireCompanyListCursorStringKey(cursor: CompanyListCursor): string {
+  if (typeof cursor.k !== 'string') {
+    throw new Error('Invalid string company-list cursor key');
+  }
+  return cursor.k;
+}
+
+function companyListCursorPredicate(cursor: CompanyListCursor, sortBy: CompanyListSortBy): SQL {
+  if (sortBy === 'planned_reserves_desc') {
+    const key = requireCompanyListCursorNumberKey(cursor);
+    return sql`(${portfolioCompanies.plannedReservesCents}, ${portfolioCompanies.id}) < (${key}, ${cursor.id})`;
+  }
+
+  if (sortBy === 'name_asc') {
+    const key = requireCompanyListCursorStringKey(cursor);
+    return sql`(${portfolioCompanies.name}, -${portfolioCompanies.id}) > (${key}, ${-cursor.id})`;
+  }
+
+  if (cursor.k === null) {
+    return sql`${portfolioCompanies.exitMoicBps} IS NULL AND ${portfolioCompanies.id} < ${cursor.id}`;
+  }
+
+  const key = requireCompanyListCursorNumberKey(cursor);
+  return sql`((${portfolioCompanies.exitMoicBps}, ${portfolioCompanies.id}) < (${key}, ${cursor.id}) OR ${portfolioCompanies.exitMoicBps} IS NULL)`;
 }
 
 function companyListItemFromRow(row: CompanyListSourceRow, fundId: number): CompanyListItem {
@@ -318,7 +529,7 @@ function companyListItemFromRow(row: CompanyListSourceRow, fundId: number): Comp
  * List portfolio companies with allocation data
  *
  * Query Parameters:
- * - cursor: ID of last company from previous page (for pagination)
+ * - cursor: Opaque cursor from previous page (for pagination)
  * - limit: Number of results (default: 50, max: 200)
  * - q: Search query (company name, case-insensitive)
  * - status: Filter by company status
@@ -406,11 +617,7 @@ router['get'](
 
       const sorted = storedAll
         .filter((company) => {
-          // Id-based cursor (id < cursor), identical to the DB branch above. NOTE:
-          // like the DB path, this only paginates correctly when id order aligns
-          // with the active sort; non-id sorts (exit_moic_desc, planned_reserves_desc,
-          // name_asc) can dup/skip across pages. Shared keyset defect tracked in #744.
-          if (query.cursor !== undefined && company.id >= query.cursor) {
+          if (query.cursor && !isAfterCompanyListCursor(company, query.cursor, query.sortBy)) {
             return false;
           }
           if (query.status && normalizeCompanyListStatus(company.status) !== query.status) {
@@ -427,22 +634,14 @@ router['get'](
           }
           return true;
         })
-        .sort((left, right) => {
-          if (query.sortBy === 'name_asc') {
-            return left.name.localeCompare(right.name) || right.id - left.id;
-          }
-          if (query.sortBy === 'planned_reserves_desc') {
-            return (
-              plannedReservesSortValue(right) - plannedReservesSortValue(left) || right.id - left.id
-            );
-          }
-          return exitMoicSortValue(right) - exitMoicSortValue(left) || right.id - left.id;
-        });
+        .sort((left, right) => compareCompanyListRows(left, right, query.sortBy));
 
       const memHasMore = sorted.length > query.limit;
       const page = memHasMore ? sorted.slice(0, query.limit) : sorted;
       const memNextCursor =
-        memHasMore && page.length > 0 ? String(page[page.length - 1]!.id) : null;
+        memHasMore && page.length > 0
+          ? encodeCompanyListCursor(page[page.length - 1]!, query.sortBy)
+          : null;
       const responseCompanies = page.map((company) => companyListItemFromRow(company, fundId));
 
       const response: CompanyListResponse = {
@@ -472,9 +671,9 @@ router['get'](
     // Build WHERE conditions
     const conditions: SQL[] = [eq(portfolioCompanies.fundId, fundId)];
 
-    // Cursor pagination (id < cursor for DESC ordering)
+    // Cursor pagination follows the active ORDER BY key plus id DESC tiebreaker.
     if (query.cursor !== undefined) {
-      conditions.push(lt(portfolioCompanies.id, query.cursor));
+      conditions.push(companyListCursorPredicate(query.cursor, query.sortBy));
     }
 
     // Status filter
@@ -553,16 +752,18 @@ router['get'](
     const hasMore = results.length > query.limit;
     const companies = hasMore ? results.slice(0, query.limit) : results;
 
-    // Get next cursor (last company ID)
+    // Get next cursor from the last row's active sort key and id.
     const nextCursor =
-      hasMore && companies.length > 0 ? companies[companies.length - 1]!.id.toString() : null;
+      hasMore && companies.length > 0
+        ? encodeCompanyListCursor(companies[companies.length - 1]!, query.sortBy)
+        : null;
 
     // Convert database results to response format
     const responseCompanies: CompanyListItem[] = companies.map((row: (typeof results)[number]) =>
       companyListItemFromRow(row, fundId)
     );
 
-    if (responseCompanies.length === 0 && !query.cursor) {
+    if (responseCompanies.length === 0 && query.cursor === undefined) {
       // Verify fund exists by checking if any companies exist for this fund
       const fundCheck = await db
         .select({ count: sql<number>`count(*)` })

--- a/tests/unit/routes/allocations-keyset-cursor.test.ts
+++ b/tests/unit/routes/allocations-keyset-cursor.test.ts
@@ -1,0 +1,206 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type PortfolioCompanyMock = {
+  id: number;
+  fundId: number;
+  name: string;
+  sector: string;
+  stage: string;
+  status: string;
+  investmentAmount: string;
+  deployedReservesCents: number;
+  plannedReservesCents: number;
+  exitMoicBps: number | null;
+  ownershipCurrentPct: string;
+  allocationCapCents: number | null;
+  allocationReason: string | null;
+  lastAllocationAt: Date | null;
+};
+
+type CompanyListResponseBody = {
+  companies: Array<{ id: number }>;
+  pagination: {
+    next_cursor: string | null;
+    has_more: boolean;
+  };
+};
+
+type CompanyListSortBy = 'exit_moic_desc' | 'planned_reserves_desc' | 'name_asc';
+
+const dbState = vi.hoisted(() => ({
+  db: {
+    select: vi.fn(() => {
+      throw new Error('database branch should not run in memory cursor tests');
+    }),
+  },
+}));
+
+const writeState = vi.hoisted(() => ({
+  applyAllocationUpdates: vi.fn(),
+  transaction: vi.fn(async (fn: (client: unknown) => unknown) => fn({ kind: 'mock-client' })),
+}));
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const storageState = vi.hoisted(() => ({
+  kind: 'memory',
+  getPortfolioCompanies: vi.fn(async (): Promise<PortfolioCompanyMock[]> => []),
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+vi.mock('../../../server/db/pg-circuit', () => ({
+  transaction: writeState.transaction,
+}));
+
+vi.mock('../../../server/services/allocation-write-service.js', () => ({
+  applyAllocationUpdates: writeState.applyAllocationUpdates,
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/lib/stage-validation-mode', () => ({
+  getStageValidationMode: vi.fn(async () => 'warn'),
+}));
+
+vi.mock('../../../server/observability/stage-metrics', () => ({
+  recordValidationDuration: vi.fn(),
+  recordValidationSuccess: vi.fn(),
+  recordUnknownStage: vi.fn(),
+}));
+
+vi.mock('../../../server/middleware/deprecation-headers', () => ({
+  setStageWarningHeaders: vi.fn(),
+}));
+
+vi.mock('../../../server/lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../server/storage', () => ({
+  storage: storageState,
+}));
+
+import allocationsRouter from '../../../server/routes/allocations';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.rid = 'alloc-keyset-rid';
+    req.user = {
+      id: '42',
+      sub: '42',
+      email: 'admin@example.com',
+      role: 'admin',
+      roles: ['admin'],
+      fundIds: [1],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    };
+    next();
+  });
+  app.use('/api', allocationsRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function companyRow(overrides: Partial<PortfolioCompanyMock>): PortfolioCompanyMock {
+  return {
+    id: 1,
+    fundId: 1,
+    name: 'Company',
+    sector: 'SaaS',
+    stage: 'Seed',
+    status: 'active',
+    investmentAmount: '1000000',
+    deployedReservesCents: 0,
+    plannedReservesCents: 0,
+    exitMoicBps: null,
+    ownershipCurrentPct: '0.10',
+    allocationCapCents: null,
+    allocationReason: null,
+    lastAllocationAt: null,
+    ...overrides,
+  };
+}
+
+function responseBody(response: request.Response): CompanyListResponseBody {
+  return response.body as CompanyListResponseBody;
+}
+
+describe('allocations company list keyset cursor', () => {
+  beforeEach(() => {
+    storageState.kind = 'memory';
+    storageState.getPortfolioCompanies.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    dbState.db.select.mockClear();
+  });
+
+  it.each([
+    {
+      sortBy: 'exit_moic_desc',
+      rows: [
+        companyRow({ id: 10, name: 'Alpha', exitMoicBps: 30000 }),
+        companyRow({ id: 30, name: 'Beta', exitMoicBps: 20000 }),
+        companyRow({ id: 20, name: 'Gamma', exitMoicBps: 10000 }),
+      ],
+    },
+    {
+      sortBy: 'planned_reserves_desc',
+      rows: [
+        companyRow({ id: 10, name: 'Alpha', plannedReservesCents: 300_000_00 }),
+        companyRow({ id: 30, name: 'Beta', plannedReservesCents: 200_000_00 }),
+        companyRow({ id: 20, name: 'Gamma', plannedReservesCents: 100_000_00 }),
+      ],
+    },
+    {
+      sortBy: 'name_asc',
+      rows: [
+        companyRow({ id: 10, name: 'Alpha' }),
+        companyRow({ id: 30, name: 'Beta' }),
+        companyRow({ id: 20, name: 'Gamma' }),
+      ],
+    },
+  ] satisfies Array<{ sortBy: CompanyListSortBy; rows: PortfolioCompanyMock[] }>)(
+    'does not duplicate or skip rows across memory pages sorted by $sortBy',
+    async ({ sortBy, rows }) => {
+      storageState.getPortfolioCompanies.mockResolvedValue(rows);
+      const app = makeApp();
+
+      const firstPage = await request(app)
+        .get('/api/funds/1/companies')
+        .query({ limit: '2', sortBy });
+      const firstBody = responseBody(firstPage);
+
+      expect(firstPage.status).toBe(200);
+      expect(firstBody.companies.map((company) => company.id)).toEqual([10, 30]);
+      expect(firstBody.pagination.next_cursor).toEqual(expect.any(String));
+      expect(firstBody.pagination.has_more).toBe(true);
+
+      const secondPage = await request(app)
+        .get('/api/funds/1/companies')
+        .query({ limit: '2', sortBy, cursor: firstBody.pagination.next_cursor });
+      const secondBody = responseBody(secondPage);
+      const combinedIds = [
+        ...firstBody.companies.map((company) => company.id),
+        ...secondBody.companies.map((company) => company.id),
+      ];
+
+      expect(secondPage.status).toBe(200);
+      expect(secondBody.companies.map((company) => company.id)).toEqual([20]);
+      expect(secondBody.pagination).toEqual({ next_cursor: null, has_more: false });
+      expect(combinedIds).toEqual([10, 30, 20]);
+      expect(new Set(combinedIds).size).toBe(combinedIds.length);
+      expect(dbState.db.select).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/tests/unit/routes/allocations.contract.test.ts
+++ b/tests/unit/routes/allocations.contract.test.ts
@@ -147,6 +147,10 @@ function companyRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function cursorFor(payload: Record<string, unknown>) {
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
 describe('allocations route contracts', () => {
   beforeEach(() => resetState());
 
@@ -194,7 +198,10 @@ describe('allocations route contracts', () => {
 
     expect(response.status).toBe(200);
     expect(Object.keys(response.body).sort()).toEqual(['companies', 'pagination']);
-    expect(response.body.pagination).toEqual({ next_cursor: '20', has_more: true });
+    expect(response.body.pagination).toEqual({
+      next_cursor: cursorFor({ k: 35000, id: 20 }),
+      has_more: true,
+    });
     expect(response.body.companies).toHaveLength(2);
     expect(Object.keys(response.body.companies[0]).sort()).toEqual([
       'allocation_cap_cents',
@@ -214,10 +221,7 @@ describe('allocations route contracts', () => {
     ]);
   });
 
-  // Covers the id-aligned ordering case only (fixture ids descend with MOIC), proving
-  // memory-mode pagination reaches page 2 with parity to the DB branch. The shared
-  // id-cursor-under-non-id-sort defect is tracked in #744, not asserted here.
-  it('GET /api/funds/:fundId/companies honors memory-mode cursor pagination for id-aligned ordering', async () => {
+  it('GET /api/funds/:fundId/companies honors memory-mode composite cursor pagination', async () => {
     storageState.kind = 'memory';
     storageState.getPortfolioCompanies.mockResolvedValue([
       companyRow({ id: 30, name: 'Gamma', exitMoicBps: 30000 }),
@@ -229,9 +233,14 @@ describe('allocations route contracts', () => {
 
     expect(firstPage.status).toBe(200);
     expect(firstPage.body.companies.map((company: { id: number }) => company.id)).toEqual([30, 20]);
-    expect(firstPage.body.pagination).toEqual({ next_cursor: '20', has_more: true });
+    expect(firstPage.body.pagination).toEqual({
+      next_cursor: cursorFor({ k: 20000, id: 20 }),
+      has_more: true,
+    });
 
-    const secondPage = await request(makeApp()).get('/api/funds/1/companies?limit=2&cursor=20');
+    const secondPage = await request(makeApp())
+      .get('/api/funds/1/companies')
+      .query({ limit: '2', cursor: firstPage.body.pagination.next_cursor });
 
     expect(secondPage.status).toBe(200);
     expect(secondPage.body.companies.map((company: { id: number }) => company.id)).toEqual([10]);


### PR DESCRIPTION
## Summary

`GET /api/funds/:fundId/companies` paginated with an **id-only cursor** (`id < cursor`)
while supporting **non-id primary sorts** (`exit_moic_desc`, `planned_reserves_desc`,
`name_asc`). When id order diverges from the active sort, pages can **duplicate or skip
rows** (e.g. ids `[10,30,20]` by MOIC desc: page 1 `[10,30]` then page 2 re-emits `10`).

This is a latent defect in the **production (DB) path**; production runs DB mode exclusively.

## What changed (`server/routes/allocations.ts` only)

Replaces the id-only cursor with a composite `(sortKey, id)` keyset cursor:

- **Cursor encoding**: opaque base64url JSON `{k, id}`. Decode validates shape (safe-int
  `id`, key type), and `superRefine` rejects a cursor whose key type does not match the
  active `sortBy` (-> 400 `Cursor does not match sort order`).
- **DB branch**: row-value keyset predicate per sort, preserving the existing
  `exitMoicBps DESC NULLS LAST` semantics (`(moic,id) < (key,cursorId) OR moic IS NULL`,
  plus the `cursor.k === null` tail case) and the secondary `id DESC` tiebreak.
- **Memory branch**: mirrors the identical comparator + keyset filter.
- **`next_cursor`** now encodes the last row's `(sortKey, id)`, not just the id.

## Verification

- `npm run check` -> 0 new TypeScript errors.
- New `tests/unit/routes/allocations-keyset-cursor.test.ts`: parametrized across all three
  sorts, uses the divergent-order scenario the old cursor would duplicate, and asserts no
  dup/skip (`Set(combinedIds).size === length`). Updated the contract test's cursor
  assertions to the opaque format. **11/11 pass**; pre-push `vitest:related` 68/68 pass.

## Correctness notes

- `plannedReservesCents` is `NOT NULL DEFAULT 0` (no null edge); `exitMoicBps` is the only
  nullable sort column and is exactly what the `NULLS LAST` logic handles.
- The cursor's own row evaluates false in every predicate -> no duplicate at page seams.

## Follow-up (recommended, not in this PR)

The new test exercises the **memory** branch; the **DB** keyset SQL (`NULLS LAST` row-value
comparison) is verified by static review only. Recommend a Postgres-backed integration test
(testcontainers/pglite, WSL2 int-gate lane) to execute the SQL predicate before this is
considered fully hardened.

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
