### PR TITLE
docs: CI fast-path probe for docs-only gating (#656)

### DIFF
--- a/docs/notes/ci-656-fastpath-probe.md
+++ b/docs/notes/ci-656-fastpath-probe.md
@@ -1,0 +1,6 @@
+# CI #656 Fast-Path Probe
+
+Temporary docs-only change used to verify that heavyweight CI jobs skip on
+docs-only PRs while the required `CI Gate Status` check stays green.
+
+Safe to delete once issue #656 is closed.


### PR DESCRIPTION
Throwaway docs-only PR to empirically verify that heavyweight CI jobs skip on docs-only changes while the required `CI Gate Status` stays green. Will be closed after evidence is captured on #656. Do not merge.