### PR TITLE
fix(ci): stop docs-only PRs from triggering heavy CI (#656)

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -12,9 +12,12 @@
 #                   HARD boundary -- a single non-allowlisted change disqualifies
 #                   the fast path.
 # code:             Source-bearing changes that warrant the full ci-unified
-#                   pipeline. NOTE: excludes scripts/validation/** because those
-#                   are doc-validation scripts treated as docs by ci-unified.
-# docs:             Documentation changes (mirror of code's exclusions).
+#                   pipeline. Includes all of scripts/**; scripts/validation/**
+#                   is intentionally NOT excluded. A bare '!glob' negation under
+#                   dorny/paths-filter any-match semantics matches nearly every
+#                   path (everything except the negated glob), which made `code`
+#                   true for docs-only PRs and broke fast-path detection (#656).
+# docs:             Documentation changes.
 # docs_links:       Active documentation link-check inputs. Kept separate from
 #                   docs because docs intentionally excludes CHANGELOG.md.
 # code_with_validation:
@@ -95,7 +98,6 @@ code:
   - 'client/**'
   - 'shared/**'
   - 'scripts/**'
-  - '!scripts/validation/**'
   - 'tests/**'
   - 'tools/**'
   - 'eslint-rules/**'


### PR DESCRIPTION
## Root cause (#656)

Docs-only PRs were running the heavy CI path (`check` lint/typecheck/unit-fast,
`test-affected`, `build`). The cause is a single line in `.github/path-filters.yml`:

```yaml
code:
  ...
  - 'scripts/**'
  - '!scripts/validation/**'   # <- removed
```

`dorny/paths-filter` uses **any-match** semantics: a path matches a filter if it
matches **any** rule. A bare `!glob` rule therefore matches *every path except*
the negated glob — i.e. nearly everything, including `*.md`. So `code` was `true`
for essentially all PRs, making `heavy_ci_relevant = true` even for docs.

## Evidence (reproduced)

A throwaway docs-only PR (#792, single `.md`) logged in the `changes` job:

```
Filter code = true
Matching files: docs/notes/ci-656-fastpath-probe.md [added]
```

A `.md` matched `code` — only the negation can do that (no positive `code`
pattern matches a markdown file). The heavy jobs ran (`Check lint` 2m18s,
`typecheck` 2m21s, `unit-fast` 3m12s, `Test (Affected)` 2m11s, `Build` 1m24s),
while the security filters (which have no negations) correctly skipped.

## Fix

Remove the negation. `scripts/validation/**` now matches `scripts/**` and triggers
heavy CI — the **safe** direction, consistent with this file's own "fail toward the
heavy path rather than silently fast-pathing" contract. The header comment is
updated to document the dorny gotcha so the negation is not re-introduced.

## Verification

- `npm run check` (Hermes postflight): 0 new TypeScript errors.
- Full empirical proof requires merge: this PR edits `path-filters.yml` (a
  `dependency`-classified file), so it legitimately runs heavy CI itself. After
  merge, a fresh docs-only PR will read the corrected filter and skip the heavy
  jobs (the required `CI Gate Status` stays green via its existing expected-skip
  logic). I'll re-run the docs-only probe post-merge to confirm.

Closes #656