### PR TITLE
docs: re-probe docs-only CI fast-path after #656 fix

### DIFF
--- a/ci-656-reprobe.md
+++ b/ci-656-reprobe.md
@@ -1,0 +1,5 @@
+# CI #656 Re-Probe
+
+Throwaway docs-only change to confirm that, after the path-filter fix
+(`c19d3056`), heavyweight CI jobs skip on docs-only PRs while the required
+`CI Gate Status` stays green. Delete after verification.


### PR DESCRIPTION
Throwaway docs-only PR to confirm heavy CI jobs now skip after the #656 path-filter fix (merged c19d3056). Expected: check/test-affected/build SKIP; CI Gate Status green. Do not merge; will close after verification.