### PR TITLE
fix(routes): mount reallocation on makeApp production surface

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -25,6 +25,7 @@ import dualForecastRouter from './routes/dual-forecast.js';
 import allocationsRouter from './routes/allocations.js';
 import allocationScenariosRouter from './routes/allocation-scenarios.js';
 import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
+import reallocationRouter from './routes/reallocation.js';
 import backtestingRouter from './routes/backtesting.js';
 import fundsRouter from './routes/funds.js';
 import fundMetricsRouter from './routes/fund-metrics.js';
@@ -217,6 +218,10 @@ export function makeApp() {
   app.use('/api', allocationsRouter);
   app.use('/api', allocationScenariosRouter);
   app.use('/api', fundScenarioSetsRouter);
+
+  // Reallocation API (Phase 1b) - mounted at root; the router self-defines its
+  // full /api/funds/:fundId/reallocation/* paths (mirrors the registerRoutes mount).
+  app.use(reallocationRouter);
 
   // Deal Pipeline API (Sprint 1 - Deal tracking, DD, scoring)
   app.use('/api/deals', dealPipelineRouter);

--- a/tests/unit/server/route-surface-inventory.test.ts
+++ b/tests/unit/server/route-surface-inventory.test.ts
@@ -101,19 +101,26 @@ const routeSurfaceInventory = {
     intent: 'Core API route available through both active app bootstrap surfaces.',
   },
   reallocation: {
-    surfaceStatus: 'registerRoutes-only-defect',
+    surfaceStatus: 'both',
     registerRoutesMount: '/api/funds/:fundId/reallocation/*',
+    makeAppMount: '/api/funds/:fundId/reallocation/*',
     exposure: 'protected',
     endpoints: [
       {
         method: 'POST',
         path: '/api/funds/:fundId/reallocation/preview',
-        mountSurfaces: ['registerRoutes'],
+        mountSurfaces: ['registerRoutes', 'makeApp'],
+        authPosture: 'protected',
+      },
+      {
+        method: 'POST',
+        path: '/api/funds/:fundId/reallocation/commit',
+        mountSurfaces: ['registerRoutes', 'makeApp'],
         authPosture: 'protected',
       },
     ],
     intent:
-      'Current route gap: full-path router is registerRoutes-only and must not be silently blessed before extraction.',
+      'Fund-scoped reallocation router (preview + commit) mounted on both active bootstrap surfaces; guarded by parseFundIdParam + enforceProvidedFundScope.',
   },
   'api-docs': {
     surfaceStatus: 'makeApp-only-intentional',
@@ -486,8 +493,9 @@ describe('route surface inventory', () => {
     );
 
     expect(routeSurfaceInventory.reallocation).toMatchObject({
-      surfaceStatus: 'registerRoutes-only-defect',
+      surfaceStatus: 'both',
       registerRoutesMount: '/api/funds/:fundId/reallocation/*',
+      makeAppMount: '/api/funds/:fundId/reallocation/*',
       exposure: 'protected',
     });
 
@@ -581,7 +589,7 @@ describe('route surface inventory', () => {
     expect(appTs).toContain("app.use('/api/deals', dealPipelineRouter)");
 
     expect(routesTs).toContain('app.use(reallocationRoutes.default)');
-    expect(appTs).not.toContain('reallocationRoutes');
+    expect(appTs).toContain('app.use(reallocationRouter)');
 
     expect(appTs).toContain("app['get']('/api-docs'");
     expect(routesTs).not.toContain('/api-docs');
@@ -685,7 +693,7 @@ describe('route surface inventory', () => {
     });
   }, 30_000);
 
-  it('keeps reallocation on registerRoutes only', async () => {
+  it('exposes reallocation through both registerRoutes and makeApp', async () => {
     const { app: registerRoutesApp, server } = await makeRegisterRoutesApp();
     servers.push(server);
 
@@ -697,14 +705,17 @@ describe('route surface inventory', () => {
       error: 'Invalid fund ID',
     });
 
+    // After mounting on makeApp, a non-numeric fundId reaches the reallocation
+    // handler and returns its own 400 (NOT the makeApp catch-all 404). This
+    // 400-vs-404 distinction is a DB-free proof that the router is mounted.
     const makeApp = await makeAppWithTestAuth();
     const makeAppResponse = await request(makeApp)
       .post('/api/funds/not-a-number/reallocation/preview')
       .set('Authorization', await authorizationHeader())
       .send({});
-    expect(makeAppResponse.status).toBe(404);
-    expect(makeAppResponse.body).toEqual({
-      error: 'not_found',
+    expect(makeAppResponse.status).toBe(400);
+    expect(makeAppResponse.body).toMatchObject({
+      error: 'Invalid fund ID',
     });
   }, 30_000);
 
@@ -757,6 +768,21 @@ describe('route surface inventory', () => {
       .get('/api/funds/2/allocation-scenarios')
       .set('Authorization', await authorizationHeader());
     expect(unrestricted.status).not.toBe(403);
+  }, 30_000);
+
+  it('denies a scoped token cross-fund on reallocation (makeApp surface)', async () => {
+    const makeApp = await makeAppWithTestAuth();
+
+    // Scoped to fund 1, POSTing to fund 2 -> fund-scope denial before body parse.
+    const crossFund = await request(makeApp)
+      .post('/api/funds/2/reallocation/preview')
+      .set('Authorization', await scopedAuthorizationHeader([1]))
+      .send({
+        current_version: 1,
+        proposed_allocations: [{ company_id: 1, planned_reserves_cents: 0 }],
+      });
+    expect(crossFund.status).toBe(403);
+    expect(crossFund.body).toMatchObject({ code: 'FUND_ACCESS_DENIED' });
   }, 30_000);
 
   it('denies a scoped token cross-fund on the registerRoutes surface', async () => {


### PR DESCRIPTION
## Summary

The reallocation router (`POST /api/funds/:fundId/reallocation/preview` and `/commit`) was mounted **only** on `registerRoutes` (server/routes.ts:97-99) and absent from `makeApp` (server/app.ts) — the canonical production surface (Docker `dist/index.js`, Vercel). So both endpoints **404'd in production**. Same class of prod gap as the #787 scenario-sets fix.

This PR mounts the router at root on `makeApp` (it self-defines full `/api/funds/...` paths, mirroring the registerRoutes mount).

## Prod-readiness verification

Both endpoints are fund-scoped and guarded (`parseFundIdParam` + `enforceProvidedFundScope`) — the same guards the already-live allocations siblings use. DB dependencies:

- **`preview`** reads only `portfoliocompanies` + `funds` — the exact tables/columns the already-mounted allocations router uses, so they are definitely prod-live.
- **`commit`** additionally writes the **net-new** `reallocation_audit` table (not used by the live allocations router). It is defined in `shared/schema.ts` (`reallocationAudit`) and journaled migration `0001` — i.e. it is in the schema prod is built from via `db:push`. **I have not directly queried the prod DB to confirm the table exists there** (inference from schema, not verified against prod). Risk is bounded: reallocation was a hard 404 in prod before this PR, so a missing-table 500 on `commit` would be no regression over feature-absent, and `preview` is unaffected. **Follow-up:** confirm `to_regclass('public.reallocation_audit')` in prod (or run `db:push`) before relying on `commit`.

No behavior change for already-reachable paths: this only exposes an existing guarded route on the second surface.

## Intent-note override (on the record)

The inventory previously classified this as `registerRoutes-only-defect` with the note *"must not be silently blessed before extraction."* This PR **intentionally retires that gate** — the prod-readiness review it asked for is the verification above (with the `reallocation_audit` caveat called out explicitly). The router is mounted as-is (no extraction); status is now `both`.

## Test changes (tests/unit/server/route-surface-inventory.test.ts)

- Inventory entry: `surfaceStatus: 'both'`, added `makeAppMount`, added the missing `/commit` endpoint, both endpoints now `mountSurfaces: ['registerRoutes','makeApp']`.
- Rewrote the boot test to assert `makeApp` returns the **router-owned 400** (non-numeric fundId) instead of the catch-all 404 — a DB-free proof of the mount.
- Added a **wrong-fund-403** boot assertion on `makeApp` (`scopedAuthorizationHeader([1])` POSTing to fund 2 -> 403 `FUND_ACCESS_DENIED`), matching the Slice-7 fund-scoped coverage policy.

## Verification

- `npm run check`: 0 new TS errors (gate).
- `npx vitest run --project=server tests/unit/server tests/unit/routes`: **540/540 pass** (63 files), incl. the rewritten parity test and new 403 test. No collateral from the mount.
- CI: all checks green incl. required `CI Gate Status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)