### PR TITLE
fix(security): wire metrics auth on all surfaces and mask prod 500 messages

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -40,6 +40,7 @@ import performanceApiRouter from './routes/performance-api.js';
 import lpReportingImportsRouter from './routes/lp-reporting/imports.js';
 import lpReportingMetricRunsRouter from './routes/lp-reporting/metric-runs.js';
 import metricsRouter from './routes/metrics-endpoint.js';
+import { authenticateMetrics } from './middleware/auth-metrics.js';
 import { installRumIngressGuards } from './routes/metrics-rum-ingress.js';
 import { metricsRumRouter } from './routes/metrics-rum.js';
 import { swaggerSpec } from './config/swagger.js';
@@ -166,9 +167,9 @@ export function makeApp() {
   // Health endpoints (must be before other routes for /healthz)
   app.use(healthRouter);
 
-  // Metrics endpoints (public, no auth required)
-  app.use('/metrics', metricsRouter);
-  app.use('/api', metricsRouter);
+  // Metrics endpoints — auth required (METRICS_KEY or METRICS_ALLOW_FROM)
+  app.use('/metrics', authenticateMetrics, metricsRouter);
+  app.use('/api', authenticateMetrics, metricsRouter);
   installRumIngressGuards(app);
   app.use(metricsRumRouter);
   app.use('/api', metricsRumRouter);

--- a/server/app.ts
+++ b/server/app.ts
@@ -248,12 +248,14 @@ export function makeApp() {
 
   // 404 + error handler
   app.use((_req: Request, res: Response) => res.status(404).json({ error: 'not_found' }));
-  app.use((err: HttpError, _req: Request, res: Response, _next: NextFunction) =>
-    res.status(err.status ?? 500).json({
-      error: 'internal',
-      message: err.message ?? 'unknown',
-    })
-  );
+  app.use((err: HttpError, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.status ?? 500;
+    const message =
+      status < 500 || process.env['NODE_ENV'] !== 'production'
+        ? (err.message ?? 'unknown')
+        : 'internal_error';
+    res.status(status).json({ error: 'internal', message });
+  });
 
   return app;
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -166,7 +166,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   if (FEATURES.metrics) {
     // Prometheus metrics endpoint (/metrics)
     const { metricsRouter } = await import('./routes/metrics-endpoint.js');
-    app.use(metricsRouter);
+    const { authenticateMetrics } = await import('./middleware/auth-metrics.js');
+    app.use(authenticateMetrics, metricsRouter);
 
     // Error budget reporting (/api/error-budget)
     await mountDefaultRoute(app, {

--- a/server/server.ts
+++ b/server/server.ts
@@ -215,9 +215,10 @@ export async function createServer(
     )
   );
 
-  // Metrics endpoints (public, no auth required)
-  app.use('/metrics', metricsRouter);
-  app.use('/api', metricsRouter);
+  // Metrics endpoints — auth required (METRICS_KEY or METRICS_ALLOW_FROM)
+  const { authenticateMetrics } = await import('./middleware/auth-metrics.js');
+  app.use('/metrics', authenticateMetrics, metricsRouter);
+  app.use('/api', authenticateMetrics, metricsRouter);
   installRumIngressGuards(app);
 
   // RUM metrics endpoint (public, for browser telemetry)

--- a/tests/unit/server/route-surface-inventory.test.ts
+++ b/tests/unit/server/route-surface-inventory.test.ts
@@ -619,13 +619,13 @@ describe('route surface inventory', () => {
       readRepoFile('docs/observability/rum.md'),
     ]);
 
-    expect(routesTs).toContain('app.use(metricsRouter)');
+    expect(routesTs).toContain('app.use(authenticateMetrics, metricsRouter)');
     expect(routesTs).not.toContain('metricsRumRouter');
     expect(metricsEndpointTs).toContain("metricsRouter['get']('/metrics'");
 
     for (const source of [appTs, serverTs]) {
-      expect(source).toContain("app.use('/metrics', metricsRouter)");
-      expect(source).toContain("app.use('/api', metricsRouter)");
+      expect(source).toContain("app.use('/metrics', authenticateMetrics, metricsRouter)");
+      expect(source).toContain("app.use('/api', authenticateMetrics, metricsRouter)");
       expect(source).toContain('installRumIngressGuards(app)');
       expect(source).toContain('app.use(metricsRumRouter)');
       expect(source).toContain("app.use('/api', metricsRumRouter)");

--- a/tests/unit/server/route-surface-inventory.test.ts
+++ b/tests/unit/server/route-surface-inventory.test.ts
@@ -658,15 +658,31 @@ describe('route surface inventory', () => {
     const makeAppAuthBoundary = 'const requireApiAuth = requireAuth();';
     expectFragmentBefore(appTs, "app['get']('/api-docs'", makeAppAuthBoundary);
     expectFragmentBefore(appTs, "app['get']('/api-docs.json'", makeAppAuthBoundary);
-    expectFragmentBefore(appTs, "app.use('/metrics', metricsRouter)", makeAppAuthBoundary);
-    expectFragmentBefore(appTs, "app.use('/api', metricsRouter)", makeAppAuthBoundary);
+    expectFragmentBefore(
+      appTs,
+      "app.use('/metrics', authenticateMetrics, metricsRouter)",
+      makeAppAuthBoundary
+    );
+    expectFragmentBefore(
+      appTs,
+      "app.use('/api', authenticateMetrics, metricsRouter)",
+      makeAppAuthBoundary
+    );
     expectFragmentBefore(appTs, 'app.use(metricsRumRouter)', makeAppAuthBoundary);
     expectFragmentBefore(appTs, "app.use('/api', metricsRumRouter)", makeAppAuthBoundary);
 
     const createServerAuthBoundary =
       '// Apply authentication and RLS middleware to protected routes';
-    expectFragmentBefore(serverTs, "app.use('/metrics', metricsRouter)", createServerAuthBoundary);
-    expectFragmentBefore(serverTs, "app.use('/api', metricsRouter)", createServerAuthBoundary);
+    expectFragmentBefore(
+      serverTs,
+      "app.use('/metrics', authenticateMetrics, metricsRouter)",
+      createServerAuthBoundary
+    );
+    expectFragmentBefore(
+      serverTs,
+      "app.use('/api', authenticateMetrics, metricsRouter)",
+      createServerAuthBoundary
+    );
     expectFragmentBefore(serverTs, 'app.use(metricsRumRouter)', createServerAuthBoundary);
     expectFragmentBefore(serverTs, "app.use('/api', metricsRumRouter)", createServerAuthBoundary);
   });


### PR DESCRIPTION
## Summary

- Wire `authenticateMetrics` middleware on all three metrics mount surfaces (`registerRoutes`, `makeApp`, `createServer`) — previously the middleware existed but was never connected, leaving `/metrics` and `/api/metrics` publicly accessible
- Mask raw `err.message` in `makeApp()` 500 responses in production; dev and 4xx responses retain the real message
- Update `route-surface-inventory` contract test assertions to match the new auth-wired mount patterns

## Why these two together

The 500-masking fix was the simpler of the two security findings from the pre-merge review. The metrics auth fix touched all three server bootstrap surfaces and required updating two test blocks that pin mount-order and fragment patterns.

## Test plan

- [x] `npm run check` — 0 TypeScript errors
- [x] `tests/unit/server/route-surface-inventory.test.ts` — 13/13 pass
- [x] Pre-commit hooks pass (lint, format, bigint safety)

## Next

Fix 3 (health endpoint detail stripping) and Fix 4 (RUM `startsWith` origin bypass) are tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)