### PR TITLE
feat(forecasting): drift callouts, labeled tooltips, mobile KPI fix

### DIFF
--- a/client/src/components/dashboard/dual-forecast-dashboard.tsx
+++ b/client/src/components/dashboard/dual-forecast-dashboard.tsx
@@ -17,6 +17,16 @@ import type { DashboardSummary } from '@/types/fund';
 import { useFundContext } from '@/contexts/FundContext';
 import { useDualForecast } from '@/hooks/useDualForecast';
 import { presson } from '@/theme/presson.tokens';
+import {
+  buildForecastChartPoints,
+  formatForecastSeriesName,
+  formatMillionValue,
+  formatSignedMillion,
+  formatSignedPercent,
+  getLatestForecastDrift,
+  type ForecastChartPoint,
+  type ForecastMetricDrift,
+} from '@/lib/dual-forecast-display';
 
 const MILLION = 1_000_000;
 const FORECAST_SERIES_COLORS = [
@@ -33,16 +43,6 @@ interface PortfolioChartPoint {
   stage: string;
 }
 
-interface ForecastChartPoint {
-  label: string;
-  constructionNav: number;
-  actualNav: number | null;
-  currentForecastNav: number | null;
-  constructionCalledCapital: number;
-  actualCalledCapital: number | null;
-  currentForecastCalledCapital: number | null;
-}
-
 function parseNumericValue(value: string | number | null | undefined): number {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : 0;
@@ -56,25 +56,96 @@ function parseNumericValue(value: string | number | null | undefined): number {
   return 0;
 }
 
-function formatMillionValue(value: ValueType | undefined): string {
-  if (Array.isArray(value)) {
-    return value.join(', ');
-  }
-
-  if (typeof value === 'number' || typeof value === 'string') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? `$${parsed}M` : `${value}`;
-  }
-
-  return '';
-}
-
 function formatSeriesName(name: NameType | undefined): string {
   return name === 'value' ? 'Current Value' : 'Investment';
 }
 
-function toMillions(value: number): number {
-  return Math.round(value / MILLION);
+function formatRechartsMillionValue(value: ValueType | undefined): string {
+  if (value == null) {
+    return formatMillionValue(undefined);
+  }
+
+  if (typeof value === 'number' || typeof value === 'string') {
+    return formatMillionValue(value);
+  }
+
+  return formatMillionValue([...value]);
+}
+
+function DriftCallout({
+  metricLabel,
+  drift,
+}: {
+  metricLabel: string;
+  drift: ForecastMetricDrift | null;
+}) {
+  if (!drift) return null;
+
+  const percentPhrase = formatSignedPercent(drift.deltaPct);
+
+  return (
+    <div className="rounded-md border border-beige-200 bg-white px-3 py-2 text-sm">
+      <p className="font-medium text-pov-charcoal">
+        {drift.label} {metricLabel} drift
+      </p>
+      <p className="mt-1 text-lg font-semibold tabular-nums text-pov-charcoal">
+        {formatSignedMillion(drift.delta)}
+      </p>
+      {percentPhrase ? (
+        <p className="text-xs text-charcoal-600">
+          Current forecast is {percentPhrase} construction plan.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface ForecastTooltipPayloadItem {
+  name?: NameType;
+  value?: ValueType;
+  color?: string;
+  payload?: ForecastChartPoint;
+}
+
+function ForecastTooltip({
+  active,
+  label,
+  payload,
+  metric,
+}: {
+  active?: boolean;
+  label?: string;
+  payload?: ForecastTooltipPayloadItem[];
+  metric: 'nav' | 'calledCapital';
+}) {
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0]?.payload;
+  const delta = metric === 'nav' ? point?.navDelta : point?.calledCapitalDelta;
+  const deltaPct = metric === 'nav' ? point?.navDeltaPct : point?.calledCapitalDeltaPct;
+  const percentPhrase = formatSignedPercent(deltaPct ?? null);
+
+  return (
+    <div className="rounded-md border border-beige-200 bg-white p-3 text-xs shadow-md">
+      <p className="mb-2 font-medium text-pov-charcoal">{label}</p>
+      <div className="space-y-1">
+        {payload.map((item) => (
+          <div key={String(item.name)} className="flex items-center justify-between gap-4">
+            <span className="text-charcoal-600">{formatForecastSeriesName(item.name)}</span>
+            <span className="font-medium tabular-nums text-pov-charcoal">
+              {formatRechartsMillionValue(item.value)}
+            </span>
+          </div>
+        ))}
+      </div>
+      {delta != null ? (
+        <p className="mt-2 border-t border-beige-200 pt-2 font-medium text-pov-charcoal">
+          Delta vs construction: {formatSignedMillion(delta)}
+          {percentPhrase ? ` (${percentPhrase})` : ''}
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 export default function DualForecastDashboard() {
@@ -182,16 +253,8 @@ export default function DualForecastDashboard() {
   const currentMetrics = dashboardData.metrics;
   const baseValue = parseNumericValue(currentMetrics?.totalValue);
   const currentIRR = parseNumericValue(currentMetrics?.irr);
-  const forecastData: ForecastChartPoint[] = dualForecast.series.map((point) => ({
-    label: point.label,
-    constructionNav: toMillions(point.construction.nav),
-    actualNav: point.actual ? toMillions(point.actual.nav) : null,
-    currentForecastNav: point.currentMode === 'forecast' ? toMillions(point.current.nav) : null,
-    constructionCalledCapital: toMillions(point.construction.calledCapital),
-    actualCalledCapital: point.actual ? toMillions(point.actual.calledCapital) : null,
-    currentForecastCalledCapital:
-      point.currentMode === 'forecast' ? toMillions(point.current.calledCapital) : null,
-  }));
+  const forecastData: ForecastChartPoint[] = buildForecastChartPoints(dualForecast.series);
+  const latestDrift = getLatestForecastDrift(forecastData);
 
   // Portfolio allocation data from real API
   const portfolioData: PortfolioChartPoint[] = dashboardData.portfolioCompanies.map((company) => ({
@@ -284,9 +347,7 @@ export default function DualForecastDashboard() {
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="label" />
                 <YAxis label={{ value: 'NAV ($M)', angle: -90, position: 'insideLeft' }} />
-                <Tooltip
-                  formatter={(value: ValueType | undefined) => [formatMillionValue(value), '']}
-                />
+                <Tooltip content={<ForecastTooltip metric="nav" />} />
                 <Legend />
                 <Line
                   type="monotone"
@@ -314,6 +375,9 @@ export default function DualForecastDashboard() {
                 />
               </LineChart>
             </ResponsiveContainer>
+            <div className="mt-3" aria-label="Forecast drift summary">
+              <DriftCallout metricLabel="NAV" drift={latestDrift?.nav ?? null} />
+            </div>
           </CardContent>
         </Card>
 
@@ -336,7 +400,7 @@ export default function DualForecastDashboard() {
                 <YAxis label={{ value: 'Value ($M)', angle: -90, position: 'insideLeft' }} />
                 <Tooltip
                   formatter={(value: ValueType | undefined, name: NameType | undefined) => [
-                    formatMillionValue(value),
+                    formatRechartsMillionValue(value),
                     formatSeriesName(name),
                   ]}
                 />
@@ -361,12 +425,8 @@ export default function DualForecastDashboard() {
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="label" />
               <YAxis label={{ value: 'Called ($M)', angle: -90, position: 'insideLeft' }} />
-              <Tooltip
-                formatter={(value: ValueType | undefined) => [
-                  formatMillionValue(value),
-                  'Called Capital',
-                ]}
-              />
+              <Tooltip content={<ForecastTooltip metric="calledCapital" />} />
+              <Legend />
               <Line
                 type="monotone"
                 dataKey="constructionCalledCapital"
@@ -393,6 +453,9 @@ export default function DualForecastDashboard() {
               />
             </LineChart>
           </ResponsiveContainer>
+          <div className="mt-3" aria-label="Called capital drift summary">
+            <DriftCallout metricLabel="called capital" drift={latestDrift?.calledCapital ?? null} />
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/client/src/components/layout/HeaderKpis.tsx
+++ b/client/src/components/layout/HeaderKpis.tsx
@@ -51,7 +51,7 @@ export default function HeaderKpis() {
       data-testid="header-kpis"
     >
       <div
-        className="grid max-w-full grid-cols-6 gap-3 overflow-x-auto pb-1 sm:overflow-visible sm:pb-0"
+        className="grid max-w-full grid-flow-col auto-cols-[7rem] gap-3 overflow-x-auto pb-1 sm:grid-flow-row sm:grid-cols-6 sm:overflow-visible sm:pb-0"
         aria-label="Selected fund KPI summary"
       >
         {viewModel.items.map((item) => (

--- a/client/src/lib/dual-forecast-display.ts
+++ b/client/src/lib/dual-forecast-display.ts
@@ -1,0 +1,194 @@
+import type { DualForecastPoint } from '@shared/types/dual-forecast';
+
+type NameType = string | number;
+type ValueType = string | number | Array<string | number>;
+
+export type ForecastMetricKey = 'nav' | 'calledCapital';
+
+export interface ForecastChartPoint {
+  label: string;
+  constructionNav: number;
+  actualNav: number | null;
+  currentForecastNav: number | null;
+  constructionCalledCapital: number;
+  actualCalledCapital: number | null;
+  currentForecastCalledCapital: number | null;
+  navDelta: number | null;
+  navDeltaPct: number | null;
+  calledCapitalDelta: number | null;
+  calledCapitalDeltaPct: number | null;
+}
+
+export interface ForecastMetricDrift {
+  label: string;
+  delta: number;
+  deltaPct: number | null;
+  constructionValue: number;
+  currentValue: number;
+}
+
+export interface ForecastDriftSummary {
+  label: string;
+  nav: ForecastMetricDrift | null;
+  calledCapital: ForecastMetricDrift | null;
+}
+
+const MILLION = 1_000_000;
+
+const FORECAST_SERIES_LABELS: Record<string, string> = {
+  constructionNav: 'Construction Plan NAV',
+  actualNav: 'Actual NAV',
+  currentForecastNav: 'Current Forecast NAV',
+  constructionCalledCapital: 'Construction Plan Called Capital',
+  actualCalledCapital: 'Actual Called Capital',
+  currentForecastCalledCapital: 'Current Forecast Called Capital',
+};
+
+function toRoundedMillions(value: number): number {
+  return Math.round(value / MILLION);
+}
+
+function toRoundedDisplayNumber(value: number): number {
+  return Math.round(value);
+}
+
+function toPercentDelta(currentValue: number, constructionValue: number): number | null {
+  if (constructionValue === 0) {
+    return null;
+  }
+
+  return (currentValue - constructionValue) / constructionValue;
+}
+
+function buildMetricDrift(
+  point: ForecastChartPoint,
+  metric: ForecastMetricKey
+): ForecastMetricDrift | null {
+  if (metric === 'nav') {
+    if (point.currentForecastNav == null || point.navDelta == null) {
+      return null;
+    }
+
+    return {
+      label: point.label,
+      delta: point.navDelta,
+      deltaPct: point.navDeltaPct,
+      constructionValue: point.constructionNav,
+      currentValue: point.currentForecastNav,
+    };
+  }
+
+  if (point.currentForecastCalledCapital == null || point.calledCapitalDelta == null) {
+    return null;
+  }
+
+  return {
+    label: point.label,
+    delta: point.calledCapitalDelta,
+    deltaPct: point.calledCapitalDeltaPct,
+    constructionValue: point.constructionCalledCapital,
+    currentValue: point.currentForecastCalledCapital,
+  };
+}
+
+export function buildForecastChartPoints(series: DualForecastPoint[]): ForecastChartPoint[] {
+  return series.map((point) => {
+    const isForecast = point.currentMode === 'forecast';
+    const navRawDelta = point.current.nav - point.construction.nav;
+    const calledCapitalRawDelta = point.current.calledCapital - point.construction.calledCapital;
+
+    return {
+      label: point.label,
+      constructionNav: toRoundedMillions(point.construction.nav),
+      actualNav: point.actual ? toRoundedMillions(point.actual.nav) : null,
+      currentForecastNav: isForecast ? toRoundedMillions(point.current.nav) : null,
+      constructionCalledCapital: toRoundedMillions(point.construction.calledCapital),
+      actualCalledCapital: point.actual ? toRoundedMillions(point.actual.calledCapital) : null,
+      currentForecastCalledCapital: isForecast
+        ? toRoundedMillions(point.current.calledCapital)
+        : null,
+      navDelta: isForecast ? toRoundedMillions(navRawDelta) : null,
+      navDeltaPct: isForecast ? toPercentDelta(point.current.nav, point.construction.nav) : null,
+      calledCapitalDelta: isForecast ? toRoundedMillions(calledCapitalRawDelta) : null,
+      calledCapitalDeltaPct: isForecast
+        ? toPercentDelta(point.current.calledCapital, point.construction.calledCapital)
+        : null,
+    };
+  });
+}
+
+export function getLatestForecastDrift(points: ForecastChartPoint[]): ForecastDriftSummary | null {
+  for (let index = points.length - 1; index >= 0; index -= 1) {
+    const point = points[index];
+    if (!point) {
+      continue;
+    }
+
+    const nav = buildMetricDrift(point, 'nav');
+    const calledCapital = buildMetricDrift(point, 'calledCapital');
+
+    if (nav || calledCapital) {
+      return {
+        label: point.label,
+        nav,
+        calledCapital,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function formatMillionValue(value: ValueType | undefined): string {
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+
+  if (typeof value === 'number' || typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? `$${toRoundedDisplayNumber(parsed)}M` : `${value}`;
+  }
+
+  return '';
+}
+
+export function formatSignedMillion(value: number): string {
+  const rounded = toRoundedDisplayNumber(value);
+
+  if (rounded === 0) {
+    return '$0M';
+  }
+
+  const prefix = rounded > 0 ? '+' : '-';
+  return `${prefix}$${Math.abs(rounded)}M`;
+}
+
+export function formatSignedPercent(value: number | null): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  const magnitude = Math.abs(value * 100).toFixed(1);
+  return `${magnitude}% ${describeDriftDirection(value)}`;
+}
+
+export function formatForecastSeriesName(name: NameType | undefined): string {
+  if (name == null) {
+    return '';
+  }
+
+  const key = String(name);
+  return FORECAST_SERIES_LABELS[key] ?? key;
+}
+
+export function describeDriftDirection(value: number): 'above' | 'below' | 'in line with' {
+  if (value > 0) {
+    return 'above';
+  }
+
+  if (value < 0) {
+    return 'below';
+  }
+
+  return 'in line with';
+}

--- a/tests/e2e/qa-audit-latest-route-publish.spec.ts
+++ b/tests/e2e/qa-audit-latest-route-publish.spec.ts
@@ -158,6 +158,56 @@ const ROUTE_DUAL_FORECAST = {
         irr: 0.185,
       },
     },
+    {
+      quarterIndex: 2,
+      label: 'Q3 2026',
+      date: '2026-09-30',
+      construction: {
+        nav: 52_000_000,
+        calledCapital: 28_000_000,
+        distributions: 2_000_000,
+        tvpi: null,
+        dpi: null,
+        rvpi: null,
+        irr: null,
+      },
+      actual: null,
+      currentMode: 'forecast',
+      current: {
+        nav: 50_000_000,
+        calledCapital: 29_000_000,
+        distributions: 1_800_000,
+        tvpi: null,
+        dpi: null,
+        rvpi: null,
+        irr: null,
+      },
+    },
+    {
+      quarterIndex: 3,
+      label: 'Q4 2026',
+      date: '2026-12-31',
+      construction: {
+        nav: 59_000_000,
+        calledCapital: 34_000_000,
+        distributions: 3_000_000,
+        tvpi: null,
+        dpi: null,
+        rvpi: null,
+        irr: null,
+      },
+      actual: null,
+      currentMode: 'forecast',
+      current: {
+        nav: 51_000_000,
+        calledCapital: 39_000_000,
+        distributions: 2_500_000,
+        tvpi: null,
+        dpi: null,
+        rvpi: null,
+        irr: null,
+      },
+    },
   ],
   sources: {
     construction: 'construction_forecast_jcurve',
@@ -465,10 +515,14 @@ test.describe('latest QA route/nav/publish closeout matrix', () => {
           page.getByText(/select or create a fund to view forecasting data/i)
         ).not.toBeVisible();
       } else {
+        // /forecasting?fundId=1 — full forecast surface with drift callouts
         await expect(
           page.getByRole('heading', { name: /financial modeling & forecasting/i })
         ).toBeVisible();
         await expect(page.getByText(/fund value forecast/i)).toBeVisible();
+        await expect(page.getByLabel('Forecast drift summary')).toContainText('Q4 2026 NAV drift');
+        await expect(page.getByLabel('Forecast drift summary')).toContainText('-$8M');
+        await expect(page.getByLabel('Called capital drift summary')).toContainText('+$5M');
       }
     }
 

--- a/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
+++ b/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
@@ -127,7 +127,7 @@ function makeDualForecast() {
       },
       {
         quarterIndex: 1,
-        label: 'Q+1',
+        label: 'Q2 2026',
         date: '2026-07-01T00:00:00.000Z',
         construction: {
           nav: 8_000_000,
@@ -148,6 +148,56 @@ function makeDualForecast() {
           dpi: 0.07,
           rvpi: 1.2,
           irr: 0.18,
+        },
+      },
+      {
+        quarterIndex: 2,
+        label: 'Q3 2026',
+        date: '2026-10-01T00:00:00.000Z',
+        construction: {
+          nav: 40_000_000,
+          calledCapital: 25_000_000,
+          distributions: 0,
+          tvpi: null,
+          dpi: null,
+          rvpi: null,
+          irr: null,
+        },
+        actual: null,
+        currentMode: 'forecast',
+        current: {
+          nav: 38_000_000,
+          calledCapital: 26_000_000,
+          distributions: 0,
+          tvpi: null,
+          dpi: null,
+          rvpi: null,
+          irr: null,
+        },
+      },
+      {
+        quarterIndex: 3,
+        label: 'Q4 2026',
+        date: '2027-01-01T00:00:00.000Z',
+        construction: {
+          nav: 59_000_000,
+          calledCapital: 34_000_000,
+          distributions: 0,
+          tvpi: null,
+          dpi: null,
+          rvpi: null,
+          irr: null,
+        },
+        actual: null,
+        currentMode: 'forecast',
+        current: {
+          nav: 51_000_000,
+          calledCapital: 39_000_000,
+          distributions: 0,
+          tvpi: null,
+          dpi: null,
+          rvpi: null,
+          irr: null,
         },
       },
     ],
@@ -270,5 +320,16 @@ describe('DualForecastDashboard', () => {
     expect(screen.getByText(/cumulative called capital by quarter/i)).toBeInTheDocument();
     expect(screen.queryByText('Live Data')).toBeNull();
     expect(screen.queryByText('Real-time')).toBeNull();
+
+    // Drift callouts: Q4 2026 is the latest forecast point with meaningful variance
+    const navSummary = await screen.findByLabelText('Forecast drift summary');
+    expect(navSummary).toHaveTextContent('Q4 2026 NAV drift');
+    expect(navSummary).toHaveTextContent('-$8M');
+    expect(navSummary).toHaveTextContent('Current forecast is 13.6% below construction plan.');
+
+    const calledSummary = screen.getByLabelText('Called capital drift summary');
+    expect(calledSummary).toHaveTextContent('Q4 2026 called capital drift');
+    expect(calledSummary).toHaveTextContent('+$5M');
+    expect(calledSummary).toHaveTextContent('Current forecast is 14.7% above construction plan.');
   });
 });

--- a/tests/unit/components/layout/dynamic-fund-header.test.tsx
+++ b/tests/unit/components/layout/dynamic-fund-header.test.tsx
@@ -409,6 +409,11 @@ describe('DynamicFundHeader', () => {
 
     render(<DynamicFundHeader />);
 
+    const summary = screen.getByLabelText('Selected fund KPI summary');
+    expect(summary).toHaveClass('grid-flow-col');
+    expect(summary).toHaveClass('auto-cols-[7rem]');
+    expect(summary).toHaveClass('sm:grid-cols-6');
+
     const panel = screen.getByTestId('header-kpis');
     const cards = within(panel).getAllByTestId(/^compact-kpi-/);
     expect(cards.map((card) => card.textContent)).toEqual([

--- a/tests/unit/lib/dual-forecast-display.test.ts
+++ b/tests/unit/lib/dual-forecast-display.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from 'vitest';
+import type { DualForecastPoint } from '@shared/types/dual-forecast';
+import {
+  buildForecastChartPoints,
+  describeDriftDirection,
+  formatForecastSeriesName,
+  formatMillionValue,
+  formatSignedMillion,
+  formatSignedPercent,
+  getLatestForecastDrift,
+} from '@/lib/dual-forecast-display';
+
+// All fixtures are inline -- not shared with dual-forecast-dashboard.test.tsx
+
+const M = 1_000_000;
+
+function metrics(nav: number, calledCapital: number) {
+  return { nav, calledCapital, distributions: 0, tvpi: null, dpi: null, rvpi: null, irr: null };
+}
+
+function actualPoint(
+  label: string,
+  qi: number,
+  constructionNav: number,
+  constructionCalled: number,
+  actualNav: number,
+  actualCalled: number
+): DualForecastPoint {
+  return {
+    quarterIndex: qi,
+    label,
+    date: '2026-01-01T00:00:00.000Z',
+    construction: metrics(constructionNav, constructionCalled),
+    actual: metrics(actualNav, actualCalled),
+    currentMode: 'actual',
+    current: metrics(actualNav, actualCalled),
+  };
+}
+
+function forecastPoint(
+  label: string,
+  qi: number,
+  constructionNav: number,
+  constructionCalled: number,
+  currentNav: number,
+  currentCalled: number
+): DualForecastPoint {
+  return {
+    quarterIndex: qi,
+    label,
+    date: '2026-01-01T00:00:00.000Z',
+    construction: metrics(constructionNav, constructionCalled),
+    actual: null,
+    currentMode: 'forecast',
+    current: metrics(currentNav, currentCalled),
+  };
+}
+
+// Q4 fixture: construction NAV $59M, current NAV $51M, construction called $34M, current called $39M
+const Q4 = forecastPoint('Q4 2026', 3, 59 * M, 34 * M, 51 * M, 39 * M);
+
+// ---------------------------------------------------------------------------
+// buildForecastChartPoints
+// ---------------------------------------------------------------------------
+
+describe('buildForecastChartPoints', () => {
+  it('maps actual points to actualNav and null currentForecastNav', () => {
+    const [point] = buildForecastChartPoints([
+      actualPoint('Q1 2026', 0, 20 * M, 15 * M, 21 * M, 15 * M),
+    ]);
+    expect(point.label).toBe('Q1 2026');
+    expect(point.actualNav).toBe(21);
+    expect(point.currentForecastNav).toBeNull();
+    expect(point.constructionNav).toBe(20);
+  });
+
+  it('maps forecast points to currentForecastNav and null actualNav', () => {
+    const [point] = buildForecastChartPoints([
+      forecastPoint('Q2 2026', 1, 30 * M, 20 * M, 28 * M, 21 * M),
+    ]);
+    expect(point.actualNav).toBeNull();
+    expect(point.currentForecastNav).toBe(28);
+    expect(point.constructionNav).toBe(30);
+  });
+
+  it('sets delta fields to null for actual points', () => {
+    const [point] = buildForecastChartPoints([
+      actualPoint('Q1 2026', 0, 20 * M, 15 * M, 21 * M, 15 * M),
+    ]);
+    expect(point.navDelta).toBeNull();
+    expect(point.navDeltaPct).toBeNull();
+    expect(point.calledCapitalDelta).toBeNull();
+    expect(point.calledCapitalDeltaPct).toBeNull();
+  });
+
+  it('computes navDelta in millions for forecast points', () => {
+    const [point] = buildForecastChartPoints([Q4]);
+    // 51_000_000 - 59_000_000 = -8_000_000 → -8 millions
+    expect(point.navDelta).toBe(-8);
+    // 39_000_000 - 34_000_000 = 5_000_000 → +5 millions
+    expect(point.calledCapitalDelta).toBe(5);
+  });
+
+  it('computes navDeltaPct as a fraction using raw dollar values', () => {
+    const [point] = buildForecastChartPoints([Q4]);
+    // (-8_000_000) / 59_000_000 ≈ -0.13559
+    expect(point.navDeltaPct).toBeCloseTo(-8 / 59, 4);
+    // 5_000_000 / 34_000_000 ≈ 0.14706
+    expect(point.calledCapitalDeltaPct).toBeCloseTo(5 / 34, 4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLatestForecastDrift
+// ---------------------------------------------------------------------------
+
+describe('getLatestForecastDrift', () => {
+  it('returns Q4 label when Q4 is the latest comparable forecast point', () => {
+    const series = [
+      actualPoint('Q1 2026', 0, 20 * M, 15 * M, 21 * M, 15 * M),
+      forecastPoint('Q2 2026', 1, 30 * M, 20 * M, 28 * M, 21 * M),
+      forecastPoint('Q3 2026', 2, 45 * M, 27 * M, 43 * M, 28 * M),
+      Q4,
+    ];
+    const drift = getLatestForecastDrift(buildForecastChartPoints(series));
+    expect(drift?.label).toBe('Q4 2026');
+  });
+
+  it('returns null when there are no forecast points', () => {
+    const drift = getLatestForecastDrift(
+      buildForecastChartPoints([actualPoint('Q1 2026', 0, 20 * M, 15 * M, 21 * M, 15 * M)])
+    );
+    expect(drift).toBeNull();
+  });
+
+  it('computes NAV delta of -8 for construction $59M vs current $51M', () => {
+    const drift = getLatestForecastDrift(buildForecastChartPoints([Q4]));
+    expect(drift?.nav?.delta).toBe(-8);
+  });
+
+  it('computes called-capital delta of +5 for construction $34M vs current $39M', () => {
+    const drift = getLatestForecastDrift(buildForecastChartPoints([Q4]));
+    expect(drift?.calledCapital?.delta).toBe(5);
+  });
+
+  it('formats NAV drift percent as 13.6% below', () => {
+    const drift = getLatestForecastDrift(buildForecastChartPoints([Q4]));
+    expect(formatSignedPercent(drift!.nav!.deltaPct)).toBe('13.6% below');
+  });
+
+  it('formats called-capital drift percent as 14.7% above', () => {
+    const drift = getLatestForecastDrift(buildForecastChartPoints([Q4]));
+    expect(formatSignedPercent(drift!.calledCapital!.deltaPct)).toBe('14.7% above');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zero construction denominator
+// ---------------------------------------------------------------------------
+
+describe('zero construction denominator', () => {
+  const ZERO_CONST = forecastPoint('Q0', 0, 0, 0, 5 * M, 3 * M);
+
+  it('returns null navDeltaPct when construction nav is zero', () => {
+    const [point] = buildForecastChartPoints([ZERO_CONST]);
+    expect(point.navDeltaPct).toBeNull();
+  });
+
+  it('still returns the money delta when construction is zero', () => {
+    const [point] = buildForecastChartPoints([ZERO_CONST]);
+    expect(point.navDelta).toBe(5);
+  });
+
+  it('formatSignedPercent returns null for null input', () => {
+    expect(formatSignedPercent(null)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zero delta
+// ---------------------------------------------------------------------------
+
+describe('zero delta', () => {
+  const FLAT = forecastPoint('Q0', 0, 10 * M, 8 * M, 10 * M, 8 * M);
+
+  it('returns 0 navDelta for identical construction and current', () => {
+    const [point] = buildForecastChartPoints([FLAT]);
+    expect(point.navDelta).toBe(0);
+  });
+
+  it('formatSignedMillion returns $0M without sign prefix', () => {
+    expect(formatSignedMillion(0)).toBe('$0M');
+  });
+
+  it('describeDriftDirection returns in line with for zero', () => {
+    expect(describeDriftDirection(0)).toBe('in line with');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSignedMillion
+// ---------------------------------------------------------------------------
+
+describe('formatSignedMillion', () => {
+  it('formats -8 as -$8M', () => {
+    expect(formatSignedMillion(-8)).toBe('-$8M');
+  });
+
+  it('formats 5 as +$5M', () => {
+    expect(formatSignedMillion(5)).toBe('+$5M');
+  });
+
+  it('formats 0 as $0M without sign prefix', () => {
+    expect(formatSignedMillion(0)).toBe('$0M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSignedPercent
+// ---------------------------------------------------------------------------
+
+describe('formatSignedPercent', () => {
+  it('formats -0.136 as 13.6% below', () => {
+    expect(formatSignedPercent(-0.136)).toBe('13.6% below');
+  });
+
+  it('formats 0.071 as 7.1% above', () => {
+    expect(formatSignedPercent(0.071)).toBe('7.1% above');
+  });
+
+  it('returns null for null input', () => {
+    expect(formatSignedPercent(null)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatForecastSeriesName
+// ---------------------------------------------------------------------------
+
+describe('formatForecastSeriesName', () => {
+  it.each([
+    ['constructionNav', 'Construction Plan NAV'],
+    ['actualNav', 'Actual NAV'],
+    ['currentForecastNav', 'Current Forecast NAV'],
+    ['constructionCalledCapital', 'Construction Plan Called Capital'],
+    ['actualCalledCapital', 'Actual Called Capital'],
+    ['currentForecastCalledCapital', 'Current Forecast Called Capital'],
+  ])('labels %s as %s', (key, label) => {
+    expect(formatForecastSeriesName(key)).toBe(label);
+  });
+
+  it('falls back to String(name) for unknown string keys', () => {
+    expect(formatForecastSeriesName('unknownKey')).toBe('unknownKey');
+  });
+
+  it('falls back to String(name) for numeric Recharts names', () => {
+    expect(formatForecastSeriesName(42)).toBe('42');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(formatForecastSeriesName(undefined)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeDriftDirection
+// ---------------------------------------------------------------------------
+
+describe('describeDriftDirection', () => {
+  it('returns above for positive values', () => {
+    expect(describeDriftDirection(5)).toBe('above');
+  });
+
+  it('returns below for negative values', () => {
+    expect(describeDriftDirection(-3)).toBe('below');
+  });
+
+  it('returns in line with for zero', () => {
+    expect(describeDriftDirection(0)).toBe('in line with');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatMillionValue
+// ---------------------------------------------------------------------------
+
+describe('formatMillionValue', () => {
+  it('formats a plain number as $NM', () => {
+    expect(formatMillionValue(59)).toBe('$59M');
+  });
+
+  it('formats a string number as $NM', () => {
+    expect(formatMillionValue('51')).toBe('$51M');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(formatMillionValue(undefined)).toBe('');
+  });
+});

--- a/tests/unit/lib/dual-forecast-display.test.tsx
+++ b/tests/unit/lib/dual-forecast-display.test.tsx
@@ -1,3 +1,0 @@
-// Tests are in dual-forecast-display.test.ts (server project, pure TS, no DOM).
-// This file exists only to satisfy client-project globs without conflicts.
-export {};

--- a/tests/unit/lib/dual-forecast-display.test.tsx
+++ b/tests/unit/lib/dual-forecast-display.test.tsx
@@ -1,0 +1,3 @@
+// Tests are in dual-forecast-display.test.ts (server project, pure TS, no DOM).
+// This file exists only to satisfy client-project globs without conflicts.
+export {};

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -15,5 +15,6 @@
     "ai-utils/**/*.ts",
     "tailwind.config.ts"
   ],
-  "exclude": ["dist", "node_modules", "build", "coverage"]
+  "exclude": ["dist", "node_modules", "build", "coverage"],
+  "files": ["tests/unit/lib/dual-forecast-display.test.tsx"]
 }


### PR DESCRIPTION
## Summary

- Add : pure TS helper for chart point construction, drift summary extraction, signed money/percent formatters, and series label lookup. Computes deltas from raw dollar values (not rounded millions).
- Refactor  to consume the helper — removes duplicated local  interface, wires  and  local components.
- : persistent NAV and called-capital variance callouts visible without hover ( targeted by tests).
- : labeled series rows + delta vs construction plan on Recharts hover.
- Fix  mobile grid:  replaces fixed  so the KPI rail scrolls horizontally on narrow viewports instead of cramming all cards.
- Extend Playwright smoke fixture to Q4 2026 and assert drift copy (, ).
- Fix : add stub  to  to work around same-stem TypeScript glob exclusion on Windows.

## Test plan

- [x] 38 unit tests in  lock display math, formatters, and zero-denominator edge cases
- [x] 4 dashboard tests extended with Q1-Q4 fixture, drift copy assertions (, , )
- [x] 15 header tests assert  class contract
- [x] Playwright smoke test : 1/1 pass with drift label assertions
- [x] TypeScript baseline: 0 new errors
- [x] ESLint on touched files: clean
- [x] Visual QA screenshots: drift callouts visible on desktop 1280x720 and mobile 390x844, no body overflow

Generated with [Claude Code](https://claude.ai/claude-code)