### PR TITLE
feat(scenarios): M7 methodology override for waterfall parity

### DIFF
--- a/client/src/pages/fund-scenario-workspace.tsx
+++ b/client/src/pages/fund-scenario-workspace.tsx
@@ -55,6 +55,7 @@ const OVERRIDE_TYPE_LABELS: Record<FundScenarioOverrideTypeV1, string> = {
   reserve_allocation: 'Reserve allocation',
   allocation: 'Allocation',
   sector_profile: 'Sector profile',
+  methodology: 'Methodology',
 };
 const EMPTY_SCENARIO_SETS: FundScenarioSetSummaryV1[] = [];
 const RESERVE_STATUS_POLL_INTERVAL_MS = 4000;
@@ -218,6 +219,8 @@ function syncCalculationModeForOverrideType(
       return 'sync_allocation';
     case 'sector_profile':
       return 'sync_sector_profile';
+    case 'methodology':
+      return 'sync_methodology';
   }
 }
 

--- a/server/services/fund-scenario-calculation-run-service.ts
+++ b/server/services/fund-scenario-calculation-run-service.ts
@@ -11,8 +11,14 @@ export interface ScenarioCalculationRunIdentity {
     | 'sync_fee_profile'
     | 'sync_allocation'
     | 'sync_sector_profile'
+    | 'sync_methodology'
     | 'async_reserve_allocation';
-  overrideType: 'fee_profile' | 'allocation' | 'sector_profile' | 'reserve_allocation';
+  overrideType:
+    | 'fee_profile'
+    | 'allocation'
+    | 'sector_profile'
+    | 'methodology'
+    | 'reserve_allocation';
   inputHash: string;
   correlationId: string;
   jobId?: string | null;

--- a/server/services/fund-scenario-calculation-service.ts
+++ b/server/services/fund-scenario-calculation-service.ts
@@ -392,6 +392,7 @@ function syncCalculationModeForOverrideType(
 ): FundScenarioCalculationModeV1 {
   if (overrideType === 'fee_profile') return 'sync_fee_profile';
   if (overrideType === 'allocation') return 'sync_allocation';
+  if (overrideType === 'methodology') return 'sync_methodology';
   return 'sync_sector_profile';
 }
 
@@ -412,6 +413,21 @@ function applySyncScenarioOverride(
       ...(override.payload.capitalPlanAllocations != null
         ? { capitalPlanAllocations: override.payload.capitalPlanAllocations }
         : {}),
+    };
+  }
+
+  if (override.overrideType === 'methodology') {
+    return {
+      ...sourceConfig,
+      ...(override.payload.waterfallType !== undefined && {
+        waterfallType: override.payload.waterfallType,
+      }),
+      ...(override.payload.waterfallTiers !== undefined && {
+        waterfallTiers: override.payload.waterfallTiers,
+      }),
+      ...(override.payload.managementFeeRate !== undefined && {
+        managementFeeRate: override.payload.managementFeeRate,
+      }),
     };
   }
 

--- a/shared/contracts/fund-scenario-sets-v1.contract.ts
+++ b/shared/contracts/fund-scenario-sets-v1.contract.ts
@@ -17,6 +17,7 @@ export const FundScenarioOverrideTypeV1Schema = z.enum([
   'reserve_allocation',
   'allocation',
   'sector_profile',
+  'methodology',
 ]);
 
 const FeeProfileOverridePayloadV1Schema = FundDraftWriteV1Schema.pick({
@@ -91,11 +92,34 @@ export const FundScenarioReserveAllocationOverrideV1Schema = z
   })
   .strict();
 
+export const MethodologyOverridePayloadV1Schema = z
+  .object({
+    waterfallType: FundDraftWriteV1Schema.shape.waterfallType,
+    waterfallTiers: FundDraftWriteV1Schema.shape.waterfallTiers,
+    managementFeeRate: FundDraftWriteV1Schema.shape.managementFeeRate,
+  })
+  .strict()
+  .refine(
+    (p) =>
+      p.waterfallType !== undefined ||
+      p.waterfallTiers !== undefined ||
+      p.managementFeeRate !== undefined,
+    { message: 'Methodology override must specify at least one field' }
+  );
+
+export const FundScenarioMethodologyOverrideV1Schema = z
+  .object({
+    overrideType: z.literal('methodology'),
+    payload: MethodologyOverridePayloadV1Schema,
+  })
+  .strict();
+
 export const FundScenarioVariantOverrideV1Schema = z.discriminatedUnion('overrideType', [
   FundScenarioFeeProfileOverrideV1Schema,
   FundScenarioReserveAllocationOverrideV1Schema,
   FundScenarioAllocationOverrideV1Schema,
   FundScenarioSectorProfileOverrideV1Schema,
+  FundScenarioMethodologyOverrideV1Schema,
 ]);
 
 export const CreateFundScenarioVariantV1Schema = z
@@ -296,17 +320,28 @@ export const ScenarioSetReserveVariantResultSummaryV1Schema = z
   })
   .strict();
 
+export const ScenarioSetMethodologyVariantResultSummaryV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('methodology'),
+    economicsSummary: EconomicsSummaryV1Schema,
+  })
+  .strict();
+
 export const ScenarioSetVariantResultSummaryV1Schema = z.discriminatedUnion('overrideType', [
   ScenarioSetFeeProfileVariantResultSummaryV1Schema,
   ScenarioSetAllocationVariantResultSummaryV1Schema,
   ScenarioSetSectorProfileVariantResultSummaryV1Schema,
   ScenarioSetReserveVariantResultSummaryV1Schema,
+  ScenarioSetMethodologyVariantResultSummaryV1Schema,
 ]);
 
 export const FundScenarioCalculationModeV1Schema = z.enum([
   'sync_fee_profile',
   'sync_allocation',
   'sync_sector_profile',
+  'sync_methodology',
   'async_reserve_allocation',
 ]);
 
@@ -320,6 +355,8 @@ function overrideTypeForCalculationMode(
       return 'allocation';
     case 'sync_sector_profile':
       return 'sector_profile';
+    case 'sync_methodology':
+      return 'methodology';
     case 'async_reserve_allocation':
       return 'reserve_allocation';
   }
@@ -409,11 +446,22 @@ export const FundScenarioReserveCalculationVariantV1Schema = z
   })
   .strict();
 
+export const FundScenarioMethodologyCalculationVariantV1Schema = z
+  .object({
+    variantId: z.string().uuid(),
+    scenarioSetId: z.string().uuid(),
+    name: z.string(),
+    overrideType: z.literal('methodology'),
+    economics: EconomicsResultV1Schema,
+  })
+  .strict();
+
 export const FundScenarioCalculationVariantV1Schema = z.discriminatedUnion('overrideType', [
   FundScenarioFeeProfileCalculationVariantV1Schema,
   FundScenarioAllocationCalculationVariantV1Schema,
   FundScenarioSectorProfileCalculationVariantV1Schema,
   FundScenarioReserveCalculationVariantV1Schema,
+  FundScenarioMethodologyCalculationVariantV1Schema,
 ]);
 
 export const FundScenarioCalculationPayloadV1Schema = z
@@ -525,3 +573,4 @@ export type FundScenarioReserveCalculationQueuedV1 = z.infer<
   typeof FundScenarioReserveCalculationQueuedV1Schema
 >;
 export type FundScenarioCalculationStatusV1 = z.infer<typeof FundScenarioCalculationStatusV1Schema>;
+export type MethodologyOverridePayloadV1 = z.infer<typeof MethodologyOverridePayloadV1Schema>;

--- a/shared/lib/scenarios/scenario-input-envelope.ts
+++ b/shared/lib/scenarios/scenario-input-envelope.ts
@@ -7,11 +7,13 @@ export type ScenarioInputCalculationMode =
   | 'sync_fee_profile'
   | 'sync_allocation'
   | 'sync_sector_profile'
+  | 'sync_methodology'
   | 'async_reserve_allocation';
 export type ScenarioInputOverrideType =
   | 'fee_profile'
   | 'allocation'
   | 'sector_profile'
+  | 'methodology'
   | 'reserve_allocation';
 
 export interface ScenarioInputHashEnvelopeV1 {

--- a/tests/unit/contract/fund-scenario-sets.test.ts
+++ b/tests/unit/contract/fund-scenario-sets.test.ts
@@ -643,6 +643,55 @@ describe('FundScenarioSetsV1 contract', () => {
       'SCENARIOS_LOAD_FAILED',
     ]);
   });
+
+  it('accepts a methodology override with waterfallType only', () => {
+    const result = FundScenarioVariantOverrideV1Schema.safeParse({
+      overrideType: 'methodology',
+      payload: { waterfallType: 'hybrid' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.overrideType).toBe('methodology');
+    }
+  });
+
+  it('accepts a methodology override specifying managementFeeRate', () => {
+    const result = FundScenarioVariantOverrideV1Schema.safeParse({
+      overrideType: 'methodology',
+      payload: { waterfallType: 'american', managementFeeRate: 0.025 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a methodology override with no fields set', () => {
+    const result = FundScenarioVariantOverrideV1Schema.safeParse({
+      overrideType: 'methodology',
+      payload: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a methodology override with an unknown key', () => {
+    const result = FundScenarioVariantOverrideV1Schema.safeParse({
+      overrideType: 'methodology',
+      payload: { waterfallType: 'hybrid', unknownKey: true },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a full scenario set create payload with a methodology override', () => {
+    const result = CreateFundScenarioSetV1Schema.safeParse({
+      name: 'Waterfall comparison',
+      variants: [
+        {
+          name: 'Hybrid waterfall',
+          override: { overrideType: 'methodology', payload: { waterfallType: 'hybrid' } },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.variants[0]?.override.overrideType).toBe('methodology');
+  });
 });
 
 function economicsResult() {

--- a/tests/unit/pages/fund-scenario-workspace.test.tsx
+++ b/tests/unit/pages/fund-scenario-workspace.test.tsx
@@ -92,6 +92,34 @@ describe('FundScenarioWorkspacePage', () => {
         return Promise.resolve(jsonResponse(sectorProfileScenarioSetDetail()));
       }
 
+      if (
+        method === 'GET' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000511'
+      ) {
+        return Promise.resolve(jsonResponse(methodologyScenarioSetDetail()));
+      }
+
+      if (
+        method === 'POST' &&
+        url === '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000511/calculate'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            snapshotId: 45,
+            correlationId: '00000000-0000-0000-0000-000000000995',
+            source: 'fund_snapshots',
+            payload: syncCalculationPayload({
+              calculationMode: 'sync_methodology',
+              scenarioSetId: '00000000-0000-0000-0000-000000000511',
+              variantId: '00000000-0000-0000-0000-000000000512',
+              overrideType: 'methodology',
+              sourceConfigId: 16,
+              name: 'Hybrid waterfall',
+            }),
+          })
+        );
+      }
+
       if (method === 'GET' && url === '/api/funds/123/results') {
         return Promise.resolve(jsonResponse(fundResultsResponse()));
       }
@@ -458,6 +486,33 @@ describe('FundScenarioWorkspacePage', () => {
     });
   });
 
+  it('shows the Methodology badge and Calculate button for methodology scenario sets', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    const methodologyCard = await screen.findByTestId(
+      'scenario-workspace-set-00000000-0000-0000-0000-000000000511'
+    );
+    expect(within(methodologyCard).getByText('Methodology')).toBeInTheDocument();
+    expect(
+      within(methodologyCard).getByRole('button', { name: /calculate waterfall comparison/i })
+    ).toBeInTheDocument();
+  });
+
+  it('uses the sync calculation endpoint for methodology scenario sets', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    fireEvent.click(await screen.findByRole('button', { name: /calculate waterfall comparison/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/funds/123/scenario-sets/00000000-0000-0000-0000-000000000511/calculate',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
   it('creates an optimized reserve scenario set from the workspace', async () => {
     mockWorkspaceFetches();
     renderWorkspace();
@@ -493,6 +548,7 @@ function scenarioSetSummaries(): FundScenarioSetSummaryV1[] {
     scenarioSetSummary('00000000-0000-0000-0000-000000000211', 'Reserve plan', 13, 4),
     scenarioSetSummary('00000000-0000-0000-0000-000000000311', 'Allocation mix', 14, 4),
     scenarioSetSummary('00000000-0000-0000-0000-000000000411', 'Sector mix', 15, 4),
+    scenarioSetSummary('00000000-0000-0000-0000-000000000511', 'Waterfall comparison', 16, 4),
   ];
 }
 
@@ -609,6 +665,27 @@ function sectorProfileScenarioSetDetail(): FundScenarioSetDetailV1 {
           payload: {
             sectorProfiles: [{ id: 'ai-infra', name: 'AI infrastructure', targetPercentage: 40 }],
           },
+        },
+        createdAt: '2026-05-29T12:00:00.000Z',
+        updatedAt: '2026-05-29T12:00:00.000Z',
+      },
+    ],
+  };
+}
+
+function methodologyScenarioSetDetail(): FundScenarioSetDetailV1 {
+  return {
+    ...scenarioSetSummary('00000000-0000-0000-0000-000000000511', 'Waterfall comparison', 16, 4),
+    variants: [
+      {
+        id: '00000000-0000-0000-0000-000000000512',
+        scenarioSetId: '00000000-0000-0000-0000-000000000511',
+        name: 'Hybrid waterfall',
+        description: null,
+        sortOrder: 0,
+        override: {
+          overrideType: 'methodology',
+          payload: { waterfallType: 'hybrid' },
         },
         createdAt: '2026-05-29T12:00:00.000Z',
         updatedAt: '2026-05-29T12:00:00.000Z',
@@ -884,10 +961,14 @@ function syncCalculationPayload({
   sourceConfigId,
   name,
 }: {
-  calculationMode: 'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile';
+  calculationMode:
+    | 'sync_fee_profile'
+    | 'sync_allocation'
+    | 'sync_sector_profile'
+    | 'sync_methodology';
   scenarioSetId: string;
   variantId: string;
-  overrideType: 'fee_profile' | 'allocation' | 'sector_profile';
+  overrideType: 'fee_profile' | 'allocation' | 'sector_profile' | 'methodology';
   sourceConfigId: number;
   name: string;
 }) {

--- a/tests/unit/services/fund-scenario-set-service.test.ts
+++ b/tests/unit/services/fund-scenario-set-service.test.ts
@@ -124,6 +124,46 @@ describe('fund scenario set persistence shell', () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
+  it('accepts a valid methodology override at the service boundary', async () => {
+    const methodologyVariantRow = {
+      id: variantId,
+      scenario_set_id: scenarioSetId,
+      name: 'Hybrid waterfall',
+      description: null,
+      sort_order: 0,
+      override_type: 'methodology',
+      override_payload: { waterfallType: 'hybrid' },
+      created_at: new Date('2026-05-26T12:00:00.000Z'),
+      updated_at: new Date('2026-05-26T12:00:00.000Z'),
+    };
+
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4 }] })
+      .mockResolvedValueOnce({ rows: [{ active_count: '0' }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [methodologyVariantRow] })
+      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000113' }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+      .mockResolvedValueOnce({ rows: [methodologyVariantRow] });
+
+    const result = await createFundScenarioSet(
+      1,
+      {
+        name: 'Waterfall comparison',
+        variants: [
+          {
+            name: 'Hybrid waterfall',
+            override: { overrideType: 'methodology', payload: { waterfallType: 'hybrid' } },
+          },
+        ],
+      },
+      { userId: 17, label: 'analyst@example.com' }
+    );
+
+    expect(result).toBeDefined();
+  });
+
   it('creates a scenario set against the current published config and records an audit event', async () => {
     queryMock
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })


### PR DESCRIPTION
## Summary

- Adds a fifth scenario override type (`methodology`) so GPs can model "what if we switched from American to Hybrid waterfall?" through the existing scenario workspace with the same validation rigor as fee/allocation overrides
- No DB migration needed — `override_type` and `calculation_mode` are already `varchar(48)` columns
- Full sync path: `sync_methodology` calculation mode, `applySyncScenarioOverride` spreads `waterfallType`/`waterfallTiers`/`managementFeeRate` onto the source config

## Changes

| File | What changed |
|---|---|
| `shared/contracts/fund-scenario-sets-v1.contract.ts` | `MethodologyOverridePayloadV1Schema` (picks `waterfallType`/`waterfallTiers`/`managementFeeRate` from `FundDraftWriteV1Schema`); methodology added to all 3 discriminated unions; `sync_methodology` calc mode; `overrideTypeForCalculationMode` case |
| `server/services/fund-scenario-calculation-service.ts` | `syncCalculationModeForOverrideType` + `applySyncScenarioOverride` methodology branches |
| `server/services/fund-scenario-calculation-run-service.ts` | `ScenarioCalculationRunIdentity` types extended |
| `shared/lib/scenarios/scenario-input-envelope.ts` | `ScenarioInput*` types extended |
| `client/src/pages/fund-scenario-workspace.tsx` | `Methodology` label + `sync_methodology` switch case |

## Test plan

- [x] 5 contract tests: accept with `waterfallType`, accept with `managementFeeRate`, reject empty payload, reject unknown keys, accept full `CreateFundScenarioSet` payload
- [x] 1 service-boundary test: valid methodology override passes `createFundScenarioSet` without `400 invalid_scenario_set_payload`
- [x] 2 workspace tests: Methodology badge renders; `/calculate` endpoint called for methodology sets
- [x] `npm run check` — 0 new TS errors
- [x] `npm run lint` — clean
- [x] `npm run test:scenario-release-gate` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)