### PR TITLE
feat(scenarios): methodology scenario creation UI (C1)

### DIFF
--- a/client/src/components/scenarios/CreateMethodologyScenarioModal.tsx
+++ b/client/src/components/scenarios/CreateMethodologyScenarioModal.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -88,6 +89,13 @@ function extractErrorCode(error: unknown): string | null {
   return error instanceof ApiError ? (error.errorCode ?? null) : null;
 }
 
+function createIdempotencyKey(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `methodology-scenario-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export interface CreateMethodologyScenarioModalProps {
@@ -118,9 +126,9 @@ export function CreateMethodologyScenarioModal({
 
   const createMutation = useMutation({
     mutationFn: (payload: CreateFundScenarioSetV1) =>
-      apiRequest('POST', scenarioApiPath(fundId, '/scenario-sets'), payload).then((raw) =>
-        FundScenarioSetDetailV1Schema.parse(raw)
-      ),
+      apiRequest('POST', scenarioApiPath(fundId, '/scenario-sets'), payload, {
+        headers: { 'Idempotency-Key': createIdempotencyKey() },
+      }).then((raw) => FundScenarioSetDetailV1Schema.parse(raw)),
     onMutate: () => {
       setServerError(null);
     },
@@ -176,6 +184,9 @@ export function CreateMethodologyScenarioModal({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="font-inter text-charcoal">New methodology scenario</DialogTitle>
+          <DialogDescription className="sr-only">
+            Create one scenario variant by changing waterfall type, management fee rate, or both.
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/client/src/components/scenarios/CreateMethodologyScenarioModal.tsx
+++ b/client/src/components/scenarios/CreateMethodologyScenarioModal.tsx
@@ -1,0 +1,307 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { apiRequest, ApiError } from '@/lib/queryClient';
+import { scenarioApiPath } from '@/lib/fund-scenario-workspace-api';
+import {
+  scenarioSetDetailQueryKey,
+  workspaceQueryKey,
+} from '@/lib/fund-scenario-workspace-query-keys';
+import {
+  FundScenarioSetDetailV1Schema,
+  type FundScenarioSetDetailV1,
+  type CreateFundScenarioSetV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const OptionalPercentageNumberSchema = z.preprocess((value) => {
+  if (value === '' || value === null || value === undefined) return undefined;
+  if (typeof value === 'string' && value.trim() === '') return undefined;
+  if (typeof value === 'number' && Number.isNaN(value)) return undefined;
+  return Number(value);
+}, z.number().finite().min(0).max(100).optional());
+
+const CreateMethodologyScenarioFormSchema = z
+  .object({
+    scenarioSetName: z.string().trim().min(1, 'Required').max(120),
+    variantName: z.string().trim().min(1, 'Required').max(120),
+    waterfallType: z.enum(['american', 'hybrid']).optional(),
+    managementFeeRate: OptionalPercentageNumberSchema,
+  })
+  .refine((data) => data.waterfallType !== undefined || data.managementFeeRate !== undefined, {
+    message: 'Specify at least one override: waterfall type or management fee rate.',
+    path: ['waterfallType'],
+  });
+
+type CreateMethodologyScenarioFormValues = z.infer<typeof CreateMethodologyScenarioFormSchema>;
+
+const WATERFALL_UNSET_VALUE = '__unset__';
+
+// ─── Payload builder ─────────────────────────────────────────────────────────
+
+export function buildCreateMethodologyScenarioPayload(
+  values: CreateMethodologyScenarioFormValues
+): CreateFundScenarioSetV1 {
+  return {
+    name: values.scenarioSetName,
+    variants: [
+      {
+        name: values.variantName,
+        override: {
+          overrideType: 'methodology',
+          payload: {
+            ...(values.waterfallType ? { waterfallType: values.waterfallType } : {}),
+            ...(values.managementFeeRate !== undefined
+              ? { managementFeeRate: values.managementFeeRate }
+              : {}),
+          },
+        },
+      },
+    ],
+  };
+}
+
+// ─── Error helper ─────────────────────────────────────────────────────────────
+
+function extractErrorCode(error: unknown): string | null {
+  return error instanceof ApiError ? (error.errorCode ?? null) : null;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export interface CreateMethodologyScenarioModalProps {
+  fundId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: (created: FundScenarioSetDetailV1) => void;
+}
+
+export function CreateMethodologyScenarioModal({
+  fundId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: CreateMethodologyScenarioModalProps) {
+  const queryClient = useQueryClient();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm<CreateMethodologyScenarioFormValues>({
+    resolver: zodResolver(CreateMethodologyScenarioFormSchema),
+    defaultValues: {
+      scenarioSetName: '',
+      variantName: '',
+      waterfallType: undefined,
+      managementFeeRate: undefined,
+    },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateFundScenarioSetV1) =>
+      apiRequest('POST', scenarioApiPath(fundId, '/scenario-sets'), payload).then((raw) =>
+        FundScenarioSetDetailV1Schema.parse(raw)
+      ),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: async (created) => {
+      queryClient.setQueryData(scenarioSetDetailQueryKey(fundId, created.id), created);
+      await queryClient.invalidateQueries({ queryKey: workspaceQueryKey(fundId) });
+      form.reset();
+      setServerError(null);
+      onOpenChange(false);
+      onSuccess(created);
+    },
+    onError: (error) => {
+      const code = extractErrorCode(error);
+      if (code === 'duplicate_scenario_set_name') {
+        form.setError('scenarioSetName', {
+          message: 'A scenario set with this name already exists.',
+        });
+      } else if (code === 'max_scenario_sets') {
+        setServerError('This fund has reached the maximum of 10 active scenario sets.');
+      } else if (code === 'no_published_config') {
+        setServerError('Publish a fund configuration before creating scenarios.');
+      } else {
+        setServerError('Failed to create scenario. Please try again.');
+      }
+    },
+  });
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && createMutation.isPending) return;
+    if (!nextOpen) {
+      form.reset();
+      setServerError(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  function onSubmit(values: CreateMethodologyScenarioFormValues) {
+    createMutation.mutate(buildCreateMethodologyScenarioPayload(values));
+  }
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+  } = form;
+
+  const waterfallTypeValue = watch('waterfallType');
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-inter text-charcoal">New methodology scenario</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="scenarioSetName" className="font-poppins text-sm text-charcoal">
+              Scenario set name
+            </Label>
+            <Input
+              id="scenarioSetName"
+              aria-label="Scenario set name"
+              {...register('scenarioSetName')}
+              placeholder="e.g. Waterfall comparison"
+            />
+            {errors.scenarioSetName && (
+              <p className="text-xs text-error-dark font-poppins">
+                {errors.scenarioSetName.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="variantName" className="font-poppins text-sm text-charcoal">
+              Variant name
+            </Label>
+            <Input
+              id="variantName"
+              aria-label="Variant name"
+              {...register('variantName')}
+              placeholder="e.g. American waterfall"
+            />
+            {errors.variantName && (
+              <p className="text-xs text-error-dark font-poppins">{errors.variantName.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-3 rounded-md border border-beige-200 p-3">
+            <p className="font-poppins text-xs uppercase text-charcoal-400">
+              At least one override required
+            </p>
+
+            <div className="space-y-1">
+              <Label htmlFor="waterfallType" className="font-poppins text-sm text-charcoal">
+                Waterfall type
+              </Label>
+              <Select
+                value={waterfallTypeValue ?? WATERFALL_UNSET_VALUE}
+                onValueChange={(value) =>
+                  setValue(
+                    'waterfallType',
+                    value === WATERFALL_UNSET_VALUE ? undefined : (value as 'american' | 'hybrid'),
+                    { shouldValidate: true }
+                  )
+                }
+              >
+                <SelectTrigger id="waterfallType" aria-label="Waterfall type">
+                  <SelectValue placeholder="No change" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={WATERFALL_UNSET_VALUE}>No change</SelectItem>
+                  <SelectItem value="american">American (deal-by-deal)</SelectItem>
+                  <SelectItem value="hybrid">Hybrid (fund-level)</SelectItem>
+                </SelectContent>
+              </Select>
+              {errors.waterfallType && (
+                <p className="text-xs text-error-dark font-poppins">
+                  {errors.waterfallType.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="managementFeeRate" className="font-poppins text-sm text-charcoal">
+                Management fee rate
+              </Label>
+              <div className="relative">
+                <Input
+                  id="managementFeeRate"
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  inputMode="decimal"
+                  placeholder="e.g. 2"
+                  className="pr-7"
+                  aria-label="Management fee rate"
+                  {...register('managementFeeRate', { valueAsNumber: true })}
+                />
+                <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-charcoal-400">
+                  %
+                </span>
+              </div>
+              {errors.managementFeeRate && (
+                <p className="text-xs text-error-dark font-poppins">
+                  {errors.managementFeeRate.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {serverError && (
+            <Alert className="border-error/20 bg-error/5">
+              <AlertDescription className="font-poppins text-sm text-error-dark">
+                {serverError}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={createMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={createMutation.isPending}
+              className="bg-charcoal text-white hover:bg-charcoal/90"
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create scenario'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/fund-scenario-workspace-api.ts
+++ b/client/src/lib/fund-scenario-workspace-api.ts
@@ -1,0 +1,24 @@
+const FUND_ID_PATTERN = /^\d+$/;
+const SCENARIO_SET_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function assertFundId(fundId: string): void {
+  if (!FUND_ID_PATTERN.test(fundId)) {
+    throw new Error(`Invalid fund ID: ${fundId}`);
+  }
+}
+
+export function assertScenarioSetId(scenarioSetId: string): void {
+  if (!SCENARIO_SET_ID_PATTERN.test(scenarioSetId)) {
+    throw new Error(`Invalid scenario set ID: ${scenarioSetId}`);
+  }
+}
+
+export function scenarioApiPath(fundId: string, suffix: string): string {
+  assertFundId(fundId);
+  return `/api/funds/${encodeURIComponent(fundId)}${suffix}`;
+}
+
+export function scenarioSetApiPath(fundId: string, scenarioSetId: string, suffix = ''): string {
+  assertScenarioSetId(scenarioSetId);
+  return scenarioApiPath(fundId, `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`);
+}

--- a/client/src/lib/fund-scenario-workspace-query-keys.ts
+++ b/client/src/lib/fund-scenario-workspace-query-keys.ts
@@ -1,0 +1,23 @@
+export function workspaceQueryKey(fundId: string) {
+  return ['fund-scenario-workspace', fundId] as const;
+}
+
+export function scenarioSetListQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets'] as const;
+}
+
+export function scenarioSetDetailQueryKey(fundId: string, scenarioSetId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'detail'] as const;
+}
+
+export function scenarioSetStatusQueryKey(fundId: string, scenarioSetId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'status'] as const;
+}
+
+export function fundResultsQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'results'] as const;
+}
+
+export function scenarioComparisonQueryKey(fundId: string, scenarioSetId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'comparison'] as const;
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -37,6 +37,10 @@ export class ApiError extends Error {
   }
 }
 
+interface ApiRequestOptions {
+  headers?: Record<string, string>;
+}
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
@@ -55,12 +59,14 @@ async function throwIfResNotOk(res: Response) {
 export async function apiRequest<TResponse = unknown>(
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
   url: string,
-  body?: unknown
+  body?: unknown,
+  requestOptions: ApiRequestOptions = {}
 ): Promise<TResponse> {
   const options: RequestInit = {
     method,
     headers: {
       'Content-Type': 'application/json',
+      ...requestOptions.headers,
     },
     credentials: 'include',
   };

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -75,12 +75,15 @@ export async function apiRequest<TResponse = unknown>(
     type ErrorBody = {
       message?: string;
       error?: string;
+      code?: string;
       issues?: Array<{ path: (string | number)[]; message: string }>;
+      details?: unknown;
     };
     const errorData = (await response.json().catch(() => ({}) as ErrorBody)) as ErrorBody;
     const errorMessage =
       errorData.message || errorData.error || `API request failed: ${response.statusText}`;
-    throw new ApiError(response.status, errorMessage, errorData.error, errorData.issues);
+    const errorCode = errorData.code ?? errorData.error;
+    throw new ApiError(response.status, errorMessage, errorCode, errorData.issues);
   }
 
   return response.json() as Promise<TResponse>;

--- a/client/src/pages/fund-scenario-workspace.tsx
+++ b/client/src/pages/fund-scenario-workspace.tsx
@@ -45,11 +45,17 @@ import {
   FundScenarioComparisonV1Schema,
   type FundScenarioComparisonV1,
 } from '@shared/contracts/fund-scenario-comparison-v1.contract';
+import {
+  fundResultsQueryKey,
+  scenarioComparisonQueryKey,
+  scenarioSetDetailQueryKey,
+  scenarioSetListQueryKey,
+  scenarioSetStatusQueryKey,
+  workspaceQueryKey,
+} from '@/lib/fund-scenario-workspace-query-keys';
+import { scenarioApiPath, scenarioSetApiPath } from '@/lib/fund-scenario-workspace-api';
 
 const FUND_SCENARIO_WORKSPACE_ROUTE = '/fund-model-results/:fundId/scenarios';
-const FUND_ID_PATH_SEGMENT_PATTERN = /^\d+$/;
-const SCENARIO_SET_ID_PATH_SEGMENT_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const OVERRIDE_TYPE_LABELS: Record<FundScenarioOverrideTypeV1, string> = {
   fee_profile: 'Fee profile',
   reserve_allocation: 'Reserve allocation',
@@ -67,52 +73,6 @@ export function reserveStatusPollIntervalMs(
   status: FundScenarioCalculationStatusV1['status'] | undefined
 ): number | false {
   return status === 'queued' || status === 'calculating' ? RESERVE_STATUS_POLL_INTERVAL_MS : false;
-}
-
-function workspaceQueryKey(fundId: string) {
-  return ['fund-scenario-workspace', fundId] as const;
-}
-
-function scenarioSetListQueryKey(fundId: string) {
-  return [...workspaceQueryKey(fundId), 'scenario-sets'] as const;
-}
-
-function scenarioSetDetailQueryKey(fundId: string, scenarioSetId: string) {
-  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'detail'] as const;
-}
-
-function scenarioSetStatusQueryKey(fundId: string, scenarioSetId: string) {
-  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'status'] as const;
-}
-
-function fundResultsQueryKey(fundId: string) {
-  return [...workspaceQueryKey(fundId), 'results'] as const;
-}
-
-function scenarioComparisonQueryKey(fundId: string, scenarioSetId: string) {
-  return [...workspaceQueryKey(fundId), 'scenario-sets', scenarioSetId, 'comparison'] as const;
-}
-
-function assertFundId(fundId: string): void {
-  if (!FUND_ID_PATH_SEGMENT_PATTERN.test(fundId)) {
-    throw new Error('Invalid fund ID');
-  }
-}
-
-function assertScenarioSetId(scenarioSetId: string): void {
-  if (!SCENARIO_SET_ID_PATH_SEGMENT_PATTERN.test(scenarioSetId)) {
-    throw new Error('Invalid scenario set ID');
-  }
-}
-
-function scenarioApiPath(fundId: string, suffix: string): string {
-  assertFundId(fundId);
-  return `/api/funds/${encodeURIComponent(fundId)}${suffix}`;
-}
-
-function scenarioSetApiPath(fundId: string, scenarioSetId: string, suffix = ''): string {
-  assertScenarioSetId(scenarioSetId);
-  return scenarioApiPath(fundId, `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`);
 }
 
 async function fetchScenarioSetList(fundId: string) {
@@ -176,7 +136,7 @@ async function createReserveOptimizationScenarioSet(fundId: string) {
 function useWorkspaceFundId() {
   const [, params] = useRoute(FUND_SCENARIO_WORKSPACE_ROUTE);
   const fundId = params?.fundId ?? null;
-  return fundId && FUND_ID_PATH_SEGMENT_PATTERN.test(fundId) ? fundId : null;
+  return fundId && /^\d+$/.test(fundId) ? fundId : null;
 }
 
 function scenarioPayloadFromResults(results: FundResultsReadV1 | undefined) {

--- a/client/src/pages/fund-scenario-workspace.tsx
+++ b/client/src/pages/fund-scenario-workspace.tsx
@@ -12,6 +12,8 @@
 import React, { useMemo, useState } from 'react';
 import { Link, useRoute } from 'wouter';
 import { ArrowLeft, RefreshCw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { CreateMethodologyScenarioModal } from '@/components/scenarios/CreateMethodologyScenarioModal';
 import {
   type Query,
   useMutation,
@@ -348,12 +350,14 @@ function ScenarioSetActionCard({
   detail,
   status,
   pendingScenarioSetId,
+  isHighlighted,
   onCalculate,
 }: {
   summary: FundScenarioSetSummaryV1;
   detail: FundScenarioSetDetailV1 | null;
   status: FundScenarioCalculationStatusV1 | null;
   pendingScenarioSetId: string | null;
+  isHighlighted?: boolean;
   onCalculate: (detail: FundScenarioSetDetailV1) => void;
 }) {
   const isPending = pendingScenarioSetId === summary.id;
@@ -363,7 +367,10 @@ function ScenarioSetActionCard({
 
   return (
     <article
-      className="rounded-md border border-beige-200 bg-white p-4"
+      className={cn(
+        'rounded-md border border-beige-200 bg-white p-4',
+        isHighlighted && 'ring-2 ring-charcoal'
+      )}
       data-testid={`scenario-workspace-set-${summary.id}`}
     >
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
@@ -411,12 +418,14 @@ function ScenarioActionList({
   detailById,
   statusById,
   pendingScenarioSetId,
+  highlightedScenarioSetId,
   onCalculate,
 }: {
   scenarioSets: FundScenarioSetSummaryV1[];
   detailById: Map<string, FundScenarioSetDetailV1>;
   statusById: Map<string, FundScenarioCalculationStatusV1>;
   pendingScenarioSetId: string | null;
+  highlightedScenarioSetId?: string | null;
   onCalculate: (detail: FundScenarioSetDetailV1) => void;
 }) {
   return (
@@ -435,6 +444,7 @@ function ScenarioActionList({
             detail={detailById.get(summary.id) ?? null}
             status={statusById.get(summary.id) ?? null}
             pendingScenarioSetId={pendingScenarioSetId}
+            isHighlighted={summary.id === highlightedScenarioSetId}
             onCalculate={onCalculate}
           />
         ))}
@@ -482,6 +492,8 @@ function FundScenarioWorkspacePage() {
   const fundId = useWorkspaceFundId();
   const queryClient = useQueryClient();
   const [pendingScenarioSetId, setPendingScenarioSetId] = useState<string | null>(null);
+  const [isCreateMethodologyOpen, setIsCreateMethodologyOpen] = useState(false);
+  const [highlightedScenarioSetId, setHighlightedScenarioSetId] = useState<string | null>(null);
 
   const scenarioSetsQuery = useQuery({
     queryKey: fundId ? scenarioSetListQueryKey(fundId) : ['fund-scenario-workspace', 'invalid'],
@@ -609,20 +621,25 @@ function FundScenarioWorkspacePage() {
               Back to Results
             </Link>
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={createReserveOptimizationMutation.isPending}
-            onClick={() => createReserveOptimizationMutation.mutate()}
-          >
-            {createReserveOptimizationMutation.isPending && (
-              <RefreshCw className="h-4 w-4 animate-spin" />
-            )}
-            {createReserveOptimizationMutation.isPending
-              ? 'Creating'
-              : 'Create optimized reserve plan'}
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" size="sm" onClick={() => setIsCreateMethodologyOpen(true)}>
+              New methodology scenario
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={createReserveOptimizationMutation.isPending}
+              onClick={() => createReserveOptimizationMutation.mutate()}
+            >
+              {createReserveOptimizationMutation.isPending && (
+                <RefreshCw className="h-4 w-4 animate-spin" />
+              )}
+              {createReserveOptimizationMutation.isPending
+                ? 'Creating'
+                : 'Create optimized reserve plan'}
+            </Button>
+          </div>
         </div>
         <div>
           <h1 className="text-2xl font-semibold text-charcoal">Scenario Workspace</h1>
@@ -655,6 +672,7 @@ function FundScenarioWorkspacePage() {
         detailById={detailById}
         statusById={statusById}
         pendingScenarioSetId={pendingScenarioSetId}
+        highlightedScenarioSetId={highlightedScenarioSetId}
         onCalculate={(detail) => {
           setPendingScenarioSetId(detail.id);
           calculateMutation.mutate(detail);
@@ -678,6 +696,12 @@ function FundScenarioWorkspacePage() {
       <ScenarioComparisonWorkspace
         comparisons={comparisons}
         isLoading={comparisonQueries.some((query) => query.isLoading)}
+      />
+      <CreateMethodologyScenarioModal
+        fundId={fundId}
+        open={isCreateMethodologyOpen}
+        onOpenChange={setIsCreateMethodologyOpen}
+        onSuccess={(created) => setHighlightedScenarioSetId(created.id)}
       />
     </div>
   );

--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-06-08T00:00:00.000Z",
+  "generatedAt": "2026-06-09T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 161,
+      "staleDays": 162,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 51,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 51,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1176,7 +1176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1192,7 +1192,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1208,7 +1208,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1223,7 +1223,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1305,7 +1305,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 63,
+      "staleDays": 64,
       "status": "UNKNOWN"
     },
     {
@@ -1323,7 +1323,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1340,7 +1340,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1357,7 +1357,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1373,7 +1373,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1403,7 +1403,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1418,7 +1418,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -1434,7 +1434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1449,7 +1449,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1464,7 +1464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1479,7 +1479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1494,7 +1494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1522,7 +1522,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 161,
+      "staleDays": 162,
       "status": "ACTIVE"
     },
     {
@@ -1538,7 +1538,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "UNKNOWN"
     },
     {
@@ -1565,7 +1565,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -1580,7 +1580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -1595,7 +1595,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1610,7 +1610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1625,7 +1625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1678,7 +1678,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 161,
+      "staleDays": 162,
       "status": "ACTIVE"
     },
     {
@@ -1692,7 +1692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1706,7 +1706,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1720,7 +1720,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1791,7 +1791,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1806,7 +1806,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1821,7 +1821,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -1836,7 +1836,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1851,7 +1851,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1866,7 +1866,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1881,7 +1881,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1896,7 +1896,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1911,7 +1911,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1930,7 +1930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ready"
     },
     {
@@ -1949,7 +1949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ready"
     },
     {
@@ -1968,7 +1968,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ready"
     },
     {
@@ -1983,7 +1983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -1998,7 +1998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2037,7 +2037,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -2052,7 +2052,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -2067,7 +2067,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 18,
+      "staleDays": 19,
       "status": "UNKNOWN"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2135,7 +2135,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2150,7 +2150,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2165,7 +2165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2180,7 +2180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2196,7 +2196,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -2212,7 +2212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2227,7 +2227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2242,7 +2242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2257,7 +2257,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2272,7 +2272,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2288,7 +2288,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -2303,7 +2303,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2318,7 +2318,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2333,7 +2333,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2349,7 +2349,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2364,7 +2364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2379,7 +2379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2394,7 +2394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2408,7 +2408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2423,7 +2423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2439,7 +2439,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2455,7 +2455,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2471,7 +2471,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2566,7 +2566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2582,7 +2582,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2597,7 +2597,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2612,7 +2612,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2627,7 +2627,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2643,7 +2643,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2659,7 +2659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2674,7 +2674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2692,7 +2692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2722,7 +2722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2737,7 +2737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2752,7 +2752,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2768,7 +2768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -2783,7 +2783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2798,7 +2798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO-v2.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -2813,7 +2813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -2828,7 +2828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/immediate-actions-summary.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -2843,7 +2843,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2858,7 +2858,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -2873,7 +2873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2888,7 +2888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2903,7 +2903,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2918,7 +2918,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2933,7 +2933,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2948,7 +2948,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -2963,7 +2963,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-baseline-report-2025-12-23.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -2978,7 +2978,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-remediation-summary.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -2993,7 +2993,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/week2-execution-report.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -3008,7 +3008,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -3023,7 +3023,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3038,7 +3038,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3074,7 +3074,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -3091,7 +3091,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -3106,7 +3106,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -3121,7 +3121,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3136,7 +3136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3165,7 +3165,7 @@
       "lastUpdated": "2026-05-21",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 18,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -3180,7 +3180,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -3195,7 +3195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3210,7 +3210,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -3237,7 +3237,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3252,7 +3252,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3267,7 +3267,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-QUICK-START.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3282,7 +3282,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3297,7 +3297,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3312,7 +3312,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3327,7 +3327,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3342,7 +3342,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "README.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -3357,7 +3357,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3372,7 +3372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3387,7 +3387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3404,7 +3404,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -3419,7 +3419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3434,7 +3434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -3449,7 +3449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3464,7 +3464,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3479,7 +3479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3494,7 +3494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3509,7 +3509,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -3524,7 +3524,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3539,7 +3539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3554,7 +3554,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -3569,7 +3569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3584,7 +3584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3599,7 +3599,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3614,7 +3614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3629,7 +3629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -3644,7 +3644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3659,7 +3659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -3674,7 +3674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3689,7 +3689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3704,7 +3704,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3719,7 +3719,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -3734,7 +3734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3749,7 +3749,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3764,7 +3764,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3779,7 +3779,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3795,7 +3795,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "active"
     },
     {
@@ -3810,7 +3810,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3825,7 +3825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3840,7 +3840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3855,7 +3855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3870,7 +3870,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 63,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -3885,7 +3885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3900,7 +3900,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -3915,7 +3915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3930,7 +3930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -3945,7 +3945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3960,7 +3960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3975,7 +3975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -3990,7 +3990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4005,7 +4005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4020,7 +4020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4035,7 +4035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4050,7 +4050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4065,7 +4065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4080,7 +4080,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -4095,7 +4095,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -4110,7 +4110,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -4125,7 +4125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4152,7 +4152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4167,7 +4167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4182,7 +4182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4197,7 +4197,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4212,7 +4212,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4227,7 +4227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4242,7 +4242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4281,7 +4281,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 51,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -4296,7 +4296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4311,7 +4311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4326,7 +4326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4362,7 +4362,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 11,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -4377,7 +4377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4392,7 +4392,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 49,
+      "staleDays": 50,
       "status": "HISTORICAL"
     },
     {
@@ -4407,7 +4407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4422,7 +4422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4437,7 +4437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4452,7 +4452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -4467,7 +4467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4482,7 +4482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4497,7 +4497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4512,7 +4512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4527,7 +4527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4542,7 +4542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4583,7 +4583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -4598,7 +4598,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4613,7 +4613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4628,7 +4628,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 64,
+      "staleDays": 65,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4643,7 +4643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4658,7 +4658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4673,7 +4673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4688,7 +4688,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4702,7 +4702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -4717,7 +4717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4732,7 +4732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4747,7 +4747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4762,7 +4762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4777,7 +4777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -4792,7 +4792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4807,7 +4807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4822,7 +4822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4837,7 +4837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4852,7 +4852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4867,7 +4867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4882,7 +4882,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4897,7 +4897,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4926,7 +4926,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -4941,7 +4941,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4956,7 +4956,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4971,7 +4971,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -4986,7 +4986,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5001,7 +5001,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5016,7 +5016,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5031,7 +5031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -5046,7 +5046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5061,7 +5061,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5076,7 +5076,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5091,7 +5091,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5106,7 +5106,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5121,7 +5121,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -5136,7 +5136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5151,7 +5151,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5166,7 +5166,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5181,7 +5181,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5196,7 +5196,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 31,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -5211,7 +5211,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 31,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -5226,7 +5226,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -5241,7 +5241,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -5256,7 +5256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5271,7 +5271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5286,7 +5286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5301,7 +5301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5327,7 +5327,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -5342,7 +5342,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "Implemented"
     },
     {
@@ -5357,7 +5357,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 51,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -5372,7 +5372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5423,7 +5423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5438,7 +5438,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 83,
+      "staleDays": 84,
       "status": "ARCHIVED"
     },
     {
@@ -5453,7 +5453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5468,7 +5468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5483,7 +5483,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -5498,7 +5498,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "HISTORICAL"
     },
     {
@@ -5513,7 +5513,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "HISTORICAL"
     },
     {
@@ -5528,7 +5528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5543,7 +5543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5558,7 +5558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5573,7 +5573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5588,7 +5588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5603,7 +5603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5618,7 +5618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5633,7 +5633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5648,7 +5648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5663,7 +5663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5678,7 +5678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5693,7 +5693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5708,7 +5708,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5723,7 +5723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5738,7 +5738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5753,7 +5753,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5768,7 +5768,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5783,7 +5783,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 70,
+      "staleDays": 71,
       "status": "ACTIVE"
     },
     {
@@ -5798,7 +5798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5813,7 +5813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5827,7 +5827,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -5841,7 +5841,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -5856,7 +5856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -5871,7 +5871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5886,7 +5886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5901,7 +5901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5916,7 +5916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5931,7 +5931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5946,7 +5946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5961,7 +5961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5976,7 +5976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -5991,7 +5991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6006,7 +6006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6021,7 +6021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6036,7 +6036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6051,7 +6051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6066,7 +6066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6081,7 +6081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6096,7 +6096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -6111,7 +6111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6126,7 +6126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6168,7 +6168,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -6216,7 +6216,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -6261,7 +6261,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -6288,7 +6288,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 51,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -6304,7 +6304,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -6319,7 +6319,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6334,7 +6334,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6349,7 +6349,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6364,7 +6364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6378,7 +6378,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -6393,7 +6393,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6408,7 +6408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6423,7 +6423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6438,7 +6438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6452,7 +6452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -6467,7 +6467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6482,7 +6482,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -6497,7 +6497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6512,7 +6512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6527,7 +6527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6542,7 +6542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6557,7 +6557,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6572,7 +6572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6587,7 +6587,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6602,7 +6602,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6617,7 +6617,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -6632,7 +6632,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6665,7 +6665,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 11,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -6680,7 +6680,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6713,7 +6713,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 11,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -6728,7 +6728,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6743,7 +6743,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6758,7 +6758,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6773,7 +6773,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 49,
+      "staleDays": 50,
       "status": "HISTORICAL"
     },
     {
@@ -6788,7 +6788,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 22,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -6803,7 +6803,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6818,7 +6818,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6833,7 +6833,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6848,7 +6848,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6863,7 +6863,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6878,7 +6878,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6893,7 +6893,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6908,7 +6908,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6923,7 +6923,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6938,7 +6938,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6953,7 +6953,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6968,7 +6968,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -6983,7 +6983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -6998,7 +6998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7013,7 +7013,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7028,7 +7028,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7043,7 +7043,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7058,7 +7058,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7073,7 +7073,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -7088,7 +7088,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7103,7 +7103,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7118,7 +7118,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7139,7 +7139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "active"
     },
     {
@@ -7153,7 +7153,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -7168,7 +7168,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7183,7 +7183,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7198,7 +7198,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7213,7 +7213,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7228,7 +7228,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7243,7 +7243,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7258,7 +7258,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7273,7 +7273,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7288,7 +7288,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7303,7 +7303,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -7318,7 +7318,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -7333,7 +7333,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -7348,7 +7348,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -7363,7 +7363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7378,7 +7378,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7393,7 +7393,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7408,7 +7408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7423,7 +7423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7438,7 +7438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7453,7 +7453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7468,7 +7468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7483,7 +7483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7498,7 +7498,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7513,7 +7513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7528,7 +7528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7543,7 +7543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7558,7 +7558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7573,7 +7573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7588,7 +7588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7603,7 +7603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7618,7 +7618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7633,7 +7633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7648,7 +7648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7663,7 +7663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7678,7 +7678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7694,7 +7694,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 64,
+      "staleDays": 65,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7709,7 +7709,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7724,7 +7724,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7739,7 +7739,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7754,7 +7754,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7769,7 +7769,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7796,7 +7796,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7811,7 +7811,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7826,7 +7826,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -7843,7 +7843,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 62,
+      "staleDays": 63,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -7858,7 +7858,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 22,
+      "staleDays": 23,
       "status": "BACKLOG"
     },
     {
@@ -7872,7 +7872,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -7889,7 +7889,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 8,
+      "staleDays": 9,
       "status": "ACTIVE"
     },
     {
@@ -7909,7 +7909,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -7946,7 +7946,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -7961,7 +7961,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -7976,7 +7976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -7991,7 +7991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -8006,7 +8006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8021,7 +8021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8036,7 +8036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8051,7 +8051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8066,7 +8066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8081,7 +8081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8096,7 +8096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8111,7 +8111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8126,7 +8126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8141,7 +8141,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8156,7 +8156,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8171,7 +8171,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8186,7 +8186,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8201,7 +8201,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8216,7 +8216,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8231,7 +8231,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8246,7 +8246,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 18,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -8261,7 +8261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8275,7 +8275,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -8302,7 +8302,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8317,7 +8317,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -8332,7 +8332,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8347,7 +8347,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8362,7 +8362,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8377,7 +8377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8392,7 +8392,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8407,7 +8407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8422,7 +8422,7 @@
       "lastUpdated": "2026-06-06",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 2,
+      "staleDays": 3,
       "status": "PROVEN"
     },
     {
@@ -8437,7 +8437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8452,7 +8452,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8467,7 +8467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8482,7 +8482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8497,7 +8497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8512,7 +8512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8527,7 +8527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8542,7 +8542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8557,7 +8557,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8572,7 +8572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8607,7 +8607,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "COMPLETED"
     },
     {
@@ -8638,7 +8638,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "REFERENCE"
     },
     {
@@ -8669,7 +8669,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "REFERENCE"
     },
     {
@@ -8700,7 +8700,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "REFERENCE"
     },
     {
@@ -8733,7 +8733,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "REFERENCE"
     },
     {
@@ -8764,7 +8764,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "REFERENCE"
     },
     {
@@ -8796,7 +8796,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "REFERENCE"
     },
     {
@@ -8811,7 +8811,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -8826,7 +8826,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8841,7 +8841,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8856,7 +8856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8871,7 +8871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8886,7 +8886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8914,7 +8914,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 70,
+      "staleDays": 71,
       "status": "ACTIVE"
     },
     {
@@ -8929,7 +8929,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8944,7 +8944,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8959,7 +8959,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8974,7 +8974,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -8989,7 +8989,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9004,7 +9004,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9019,7 +9019,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9034,7 +9034,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9049,7 +9049,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9064,7 +9064,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9079,7 +9079,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9094,7 +9094,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9109,7 +9109,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9124,7 +9124,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9139,7 +9139,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9154,7 +9154,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9169,7 +9169,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-01-to-01-07-extraction.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -9184,7 +9184,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-08-to-01-18-extraction.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -9199,7 +9199,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-18-extraction.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -9213,7 +9213,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -9227,7 +9227,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -9241,7 +9241,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -9255,7 +9255,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -9269,7 +9269,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -9283,7 +9283,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "UNKNOWN"
     },
     {
@@ -9298,7 +9298,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9313,7 +9313,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9328,7 +9328,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -9369,7 +9369,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "VERIFIED"
     },
     {
@@ -9717,7 +9717,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "DRAFT"
     },
     {
@@ -9915,7 +9915,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -9997,7 +9997,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "VERIFIED"
     },
     {
@@ -10070,7 +10070,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "DRAFT"
     },
     {
@@ -10114,7 +10114,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "DRAFT"
     },
     {
@@ -10244,7 +10244,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "DRAFT"
     },
     {
@@ -10291,7 +10291,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "DRAFT"
     },
     {
@@ -10333,7 +10333,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 66,
+      "staleDays": 67,
       "status": "DRAFT"
     },
     {
@@ -10482,7 +10482,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10508,7 +10508,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10539,7 +10539,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10568,7 +10568,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10597,7 +10597,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10627,7 +10627,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10657,7 +10657,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10687,7 +10687,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -10720,7 +10720,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 51,
+      "staleDays": 52,
       "status": "DRAFT"
     },
     {
@@ -10785,7 +10785,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -10800,7 +10800,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -10815,7 +10815,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -10842,7 +10842,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -10870,7 +10870,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -10899,7 +10899,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -10927,7 +10927,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -10955,7 +10955,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -10982,7 +10982,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "COMPLETE"
     },
     {
@@ -11011,6 +11011,23 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
+      "staleDays": 2,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "last_updated": "2026-06-08",
+        "owner": "Platform Team",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": true,
+      "isStale": false,
+      "lastUpdated": "2026-06-08",
+      "owner": "Platform Team",
+      "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
       "staleDays": 1,
       "status": "ACTIVE"
     },
@@ -11040,7 +11057,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 0,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -11054,6 +11071,23 @@
       "path": "docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md",
       "staleDays": 999,
       "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "last_updated": "2026-06-08",
+        "owner": "Platform Team",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-08",
+      "owner": "Platform Team",
+      "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
+      "staleDays": 1,
+      "status": "ACTIVE"
     },
     {
       "docType": "doc",
@@ -11081,7 +11115,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 0,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -11120,7 +11154,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -11135,7 +11169,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11150,7 +11184,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11165,7 +11199,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11180,7 +11214,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11207,7 +11241,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11222,7 +11256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11237,7 +11271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11252,7 +11286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11267,7 +11301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11282,7 +11316,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11297,7 +11331,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "HISTORICAL"
     },
     {
@@ -11312,7 +11346,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11327,7 +11361,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11342,7 +11376,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11357,7 +11391,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11372,7 +11406,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11387,7 +11421,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11402,7 +11436,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11417,7 +11451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11432,7 +11466,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 11,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -11478,7 +11512,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 161,
+      "staleDays": 162,
       "status": "ACTIVE"
     },
     {
@@ -11493,7 +11527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     },
     {
@@ -11508,11 +11542,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 140,
+      "staleDays": 141,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-06-08T00:00:00.000Z",
+  "generatedAt": "2026-06-09T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -12678,7 +12712,7 @@
   ],
   "stats": {
     "by_status": {
-      "ACTIVE": 440,
+      "ACTIVE": 442,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 1,
@@ -12699,7 +12733,7 @@
     },
     "missing_frontmatter": 15,
     "stale_docs": 97,
-    "total_docs": 644
+    "total_docs": 646
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,17 +1,17 @@
 ---
-last_updated: 2026-06-08
+last_updated: 2026-06-09
 ---
 
 # Staleness Report
 
-*Generated: 2026-06-08T00:00:00.000Z*
+*Generated: 2026-06-09T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 644 |
+| Total Documents | 646 |
 | Stale Documents | 97 |
 | Missing Frontmatter | 15 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-06-08
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 440 |
+| ACTIVE | 442 |
 | UNKNOWN | 110 |
 | DRAFT | 30 |
 | HISTORICAL | 29 |
@@ -80,20 +80,20 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/plans/2026-05-19-ca-period-truth-harness-remediation.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md` | Never | 999 | YES - verify! | Unassigned |
 | `docs/tooling-catalog.md` | Never | 999 | No | Unassigned |
-| `cheatsheets/agent-architecture.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/ai-code-review.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/api.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/capability-checklist.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/claude-commands.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/codex-collaboration-protocol.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/coding-pairs-playbook.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/command-summary.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/correct-workflow-example.md` | 2026-01-19 | 140 | No | Unassigned |
-| `cheatsheets/document-review-workflow.md` | 2026-01-19 | 140 | No | Unassigned |
+| `cheatsheets/agent-architecture.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/ai-code-review.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/api.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/capability-checklist.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/claude-commands.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/codex-collaboration-protocol.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/coding-pairs-playbook.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/command-summary.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/correct-workflow-example.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/document-review-workflow.md` | 2026-01-19 | 141 | No | Unassigned |
 
 *...and 47 more stale documents.*
 
@@ -101,13 +101,13 @@ Documents that need review (older than their cadence threshold):
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **CHANGELOG.md** (19 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (140 days old)
-- [ ] **cheatsheets/schema-alignment.md** (140 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (140 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (140 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (140 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (140 days old)
+- [ ] **CHANGELOG.md** (20 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (141 days old)
+- [ ] **cheatsheets/schema-alignment.md** (141 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (141 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (141 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (141 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (141 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)

--- a/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
+++ b/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
@@ -1,0 +1,1551 @@
+# C1: Methodology Scenario Creation UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "New methodology scenario" modal to the workspace so GPs can
+create a methodology scenario set with one variant (waterfallType +
+managementFeeRate) directly from the UI.
+
+**Architecture:** `apiRequest` fix is the blocker (Task 1). Shared helpers
+extracted first (Task 2). Modal built TDD (Tasks 3–4). Workspace wired last
+(Task 5). All test commands use `.\scripts\windows-node-env.ps1` on Windows.
+
+**Tech Stack:** React 18, TypeScript, Zod, React Hook Form, shadcn/ui Dialog +
+Select + Input, TanStack Query useMutation, Vitest, React Testing Library.
+
+---
+
+## File Map
+
+| File                                                                      | Action                                                    |
+| ------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `client/src/lib/queryClient.ts`                                           | Modify — preserve server `code` in `ApiError.errorCode`   |
+| `client/src/lib/fund-scenario-workspace-query-keys.ts`                    | Create — cache key helpers                                |
+| `client/src/lib/fund-scenario-workspace-api.ts`                           | Create — path + validation helpers                        |
+| `client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`      | Create — modal component                                  |
+| `client/src/pages/fund-scenario-workspace.tsx`                            | Modify — imports, state, button cluster, modal, highlight |
+| `tests/unit/lib/queryClient.test.ts`                                      | Create — apiRequest error code test                       |
+| `tests/unit/lib/fund-scenario-workspace-api.test.ts`                      | Create — path helper validation tests                     |
+| `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx` | Create — 19 modal cases + payload builder                 |
+| `tests/unit/pages/fund-scenario-workspace.test.tsx`                       | Modify — thin integration: button + modal open            |
+
+---
+
+## Task 1: Fix apiRequest error code preservation (BLOCKER)
+
+**Files:**
+
+- Modify: `client/src/lib/queryClient.ts:74-83`
+- Create: `tests/unit/lib/queryClient.test.ts`
+
+- [ ] **Step 1.1: Write failing tests**
+
+Create `tests/unit/lib/queryClient.test.ts`:
+
+```ts
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest, ApiError } from '../../../client/src/lib/queryClient';
+
+describe('apiRequest', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves specific server error code over generic error field', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'conflict',
+          code: 'duplicate_scenario_set_name',
+          message: 'Already exists',
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const err = await apiRequest('POST', '/api/test', {}).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).errorCode).toBe('duplicate_scenario_set_name');
+  });
+
+  it('falls back to generic error field when no specific code', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: 'not_found', message: 'Not found' }),
+        {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+    const err = await apiRequest('GET', '/api/test').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).errorCode).toBe('not_found');
+  });
+
+  it('does not crash when response includes a details field', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'invalid_request',
+          message: 'Bad input',
+          details: { issues: [{ path: ['name'], message: 'Required' }] },
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const err = await apiRequest('POST', '/api/test', {}).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).errorCode).toBe('invalid_request');
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests to confirm failure**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/lib/queryClient.test.ts
+```
+
+Expected: First test fails — `errorCode` is `'conflict'` not
+`'duplicate_scenario_set_name'`.
+
+- [ ] **Step 1.3: Fix `queryClient.ts`**
+
+In `client/src/lib/queryClient.ts`, replace lines 74–83 (the `if (!response.ok)`
+block):
+
+```ts
+if (!response.ok) {
+  type ErrorBody = {
+    message?: string;
+    error?: string;
+    code?: string;
+    issues?: Array<{ path: (string | number)[]; message: string }>;
+    details?: unknown;
+  };
+  const errorData = (await response
+    .json()
+    .catch(() => ({}) as ErrorBody)) as ErrorBody;
+  const errorMessage =
+    errorData.message ||
+    errorData.error ||
+    `API request failed: ${response.statusText}`;
+  const errorCode = errorData.code ?? errorData.error;
+  throw new ApiError(
+    response.status,
+    errorMessage,
+    errorCode,
+    errorData.issues
+  );
+}
+```
+
+- [ ] **Step 1.4: Verify tests pass**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/lib/queryClient.test.ts
+```
+
+Expected: 3/3 pass, exit 0.
+
+```powershell
+& .\scripts\windows-node-env.ps1 npm.cmd run check
+```
+
+Expected: 0 TypeScript errors.
+
+- [ ] **Step 1.5: Commit**
+
+```
+git add client/src/lib/queryClient.ts tests/unit/lib/queryClient.test.ts
+git commit -m "fix(api): preserve specific server error code in ApiError.errorCode"
+```
+
+---
+
+## Task 2: Extract shared helpers + refactor workspace page
+
+**Files:**
+
+- Create: `client/src/lib/fund-scenario-workspace-query-keys.ts`
+- Create: `client/src/lib/fund-scenario-workspace-api.ts`
+- Create: `tests/unit/lib/fund-scenario-workspace-api.test.ts`
+- Modify: `client/src/pages/fund-scenario-workspace.tsx`
+
+- [ ] **Step 2.1: Create query key helpers**
+
+Create `client/src/lib/fund-scenario-workspace-query-keys.ts`:
+
+```ts
+export function workspaceQueryKey(fundId: string) {
+  return ['fund-scenario-workspace', fundId] as const;
+}
+
+export function scenarioSetListQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets'] as const;
+}
+
+export function scenarioSetDetailQueryKey(
+  fundId: string,
+  scenarioSetId: string
+) {
+  return [
+    ...workspaceQueryKey(fundId),
+    'scenario-sets',
+    scenarioSetId,
+    'detail',
+  ] as const;
+}
+
+export function scenarioSetStatusQueryKey(
+  fundId: string,
+  scenarioSetId: string
+) {
+  return [
+    ...workspaceQueryKey(fundId),
+    'scenario-sets',
+    scenarioSetId,
+    'status',
+  ] as const;
+}
+
+export function fundResultsQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'results'] as const;
+}
+
+export function scenarioComparisonQueryKey(
+  fundId: string,
+  scenarioSetId: string
+) {
+  return [
+    ...workspaceQueryKey(fundId),
+    'scenario-sets',
+    scenarioSetId,
+    'comparison',
+  ] as const;
+}
+```
+
+- [ ] **Step 2.2: Create API path helpers**
+
+Create `client/src/lib/fund-scenario-workspace-api.ts`:
+
+```ts
+const FUND_ID_PATTERN = /^\d+$/;
+const SCENARIO_SET_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function assertFundId(fundId: string): void {
+  if (!FUND_ID_PATTERN.test(fundId)) {
+    throw new Error(`Invalid fund ID: ${fundId}`);
+  }
+}
+
+export function assertScenarioSetId(scenarioSetId: string): void {
+  if (!SCENARIO_SET_ID_PATTERN.test(scenarioSetId)) {
+    throw new Error(`Invalid scenario set ID: ${scenarioSetId}`);
+  }
+}
+
+export function scenarioApiPath(fundId: string, suffix: string): string {
+  assertFundId(fundId);
+  return `/api/funds/${encodeURIComponent(fundId)}${suffix}`;
+}
+
+export function scenarioSetApiPath(
+  fundId: string,
+  scenarioSetId: string,
+  suffix = ''
+): string {
+  assertScenarioSetId(scenarioSetId);
+  return scenarioApiPath(
+    fundId,
+    `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`
+  );
+}
+```
+
+- [ ] **Step 2.3: Write API path helper tests**
+
+Create `tests/unit/lib/fund-scenario-workspace-api.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  assertFundId,
+  assertScenarioSetId,
+  scenarioApiPath,
+  scenarioSetApiPath,
+} from '../../../client/src/lib/fund-scenario-workspace-api';
+
+const VALID_UUID = '00000000-0000-0000-0000-000000000111';
+
+describe('assertFundId', () => {
+  it('accepts numeric strings', () => {
+    expect(() => assertFundId('123')).not.toThrow();
+  });
+  it('rejects non-numeric strings', () => {
+    expect(() => assertFundId('abc')).toThrow('Invalid fund ID');
+  });
+  it('rejects empty string', () => {
+    expect(() => assertFundId('')).toThrow('Invalid fund ID');
+  });
+  it('rejects strings with leading non-digits', () => {
+    expect(() => assertFundId('1e1')).toThrow('Invalid fund ID');
+  });
+});
+
+describe('assertScenarioSetId', () => {
+  it('accepts valid UUID', () => {
+    expect(() => assertScenarioSetId(VALID_UUID)).not.toThrow();
+  });
+  it('rejects non-UUID strings', () => {
+    expect(() => assertScenarioSetId('not-a-uuid')).toThrow(
+      'Invalid scenario set ID'
+    );
+  });
+});
+
+describe('scenarioApiPath', () => {
+  it('builds correct path for valid fundId', () => {
+    expect(scenarioApiPath('123', '/scenario-sets')).toBe(
+      '/api/funds/123/scenario-sets'
+    );
+  });
+  it('throws for invalid fundId', () => {
+    expect(() => scenarioApiPath('abc', '/scenario-sets')).toThrow(
+      'Invalid fund ID'
+    );
+  });
+});
+
+describe('scenarioSetApiPath', () => {
+  it('builds correct path for valid ids', () => {
+    expect(scenarioSetApiPath('123', VALID_UUID)).toBe(
+      `/api/funds/123/scenario-sets/${VALID_UUID}`
+    );
+  });
+  it('appends suffix when provided', () => {
+    expect(scenarioSetApiPath('123', VALID_UUID, '/calculate')).toBe(
+      `/api/funds/123/scenario-sets/${VALID_UUID}/calculate`
+    );
+  });
+});
+```
+
+- [ ] **Step 2.4: Run helper tests**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/lib/fund-scenario-workspace-api.test.ts
+```
+
+Expected: All pass, exit 0.
+
+- [ ] **Step 2.5: Update workspace page to use imported helpers**
+
+In `client/src/pages/fund-scenario-workspace.tsx`:
+
+**Add two import lines** at the top (after existing imports):
+
+```ts
+import {
+  fundResultsQueryKey,
+  scenarioComparisonQueryKey,
+  scenarioSetDetailQueryKey,
+  scenarioSetListQueryKey,
+  scenarioSetStatusQueryKey,
+  workspaceQueryKey,
+} from '@/lib/fund-scenario-workspace-query-keys';
+import {
+  scenarioApiPath,
+  scenarioSetApiPath,
+} from '@/lib/fund-scenario-workspace-api';
+```
+
+**Remove** the following local definitions (they are replaced by the imports
+above):
+
+- The constants `FUND_ID_PATH_SEGMENT_PATTERN` and
+  `SCENARIO_SET_ID_PATH_SEGMENT_PATTERN`
+- The functions `workspaceQueryKey`, `scenarioSetListQueryKey`,
+  `scenarioSetDetailQueryKey`, `scenarioSetStatusQueryKey`,
+  `fundResultsQueryKey`, `scenarioComparisonQueryKey`
+- The functions `assertFundId`, `assertScenarioSetId`, `scenarioApiPath`,
+  `scenarioSetApiPath`
+
+**Keep** `useWorkspaceFundId` but inline its pattern check. Replace:
+
+```ts
+// Before (uses the removed constant)
+return fundId && FUND_ID_PATH_SEGMENT_PATTERN.test(fundId) ? fundId : null;
+
+// After (inline — no external dependency needed for this one-liner)
+return fundId && /^\d+$/.test(fundId) ? fundId : null;
+```
+
+- [ ] **Step 2.6: Verify existing workspace tests still pass**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/pages/fund-scenario-workspace.test.tsx
+```
+
+Expected: All existing tests pass.
+
+```powershell
+& .\scripts\windows-node-env.ps1 npm.cmd run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 2.7: Commit**
+
+```
+git add client/src/lib/fund-scenario-workspace-query-keys.ts \
+  client/src/lib/fund-scenario-workspace-api.ts \
+  client/src/pages/fund-scenario-workspace.tsx \
+  tests/unit/lib/fund-scenario-workspace-api.test.ts
+git commit -m "refactor(scenarios): extract workspace query key and API path helpers"
+```
+
+---
+
+## Task 3: Write failing modal tests
+
+**Files:**
+
+- Create:
+  `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx`
+
+All tests in this task will fail (the modal component does not exist yet). That
+is the expected TDD state.
+
+- [ ] **Step 3.1: Create test file**
+
+Create
+`tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx`:
+
+```tsx
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CreateMethodologyScenarioModal,
+  buildCreateMethodologyScenarioPayload,
+} from '../../../../client/src/components/scenarios/CreateMethodologyScenarioModal';
+import type { FundScenarioSetDetailV1 } from '../../../../shared/contracts/fund-scenario-sets-v1.contract';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+interface ModalProps {
+  fundId?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onSuccess?: (created: FundScenarioSetDetailV1) => void;
+}
+
+function renderModal(props: ModalProps = {}) {
+  const queryClient = makeQueryClient();
+  const onOpenChange = props.onOpenChange ?? vi.fn();
+  const onSuccess = props.onSuccess ?? vi.fn();
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <CreateMethodologyScenarioModal
+        fundId={props.fundId ?? '123'}
+        open={props.open ?? true}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+      />
+    </QueryClientProvider>
+  );
+  return { ...result, queryClient, onOpenChange, onSuccess };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function errorResponse(status: number, code: string, message: string) {
+  return jsonResponse({ error: 'error', code, message }, status);
+}
+
+function makeCreatedDetail(): FundScenarioSetDetailV1 {
+  return {
+    id: '00000000-0000-0000-0000-000000000711',
+    fundId: 123,
+    name: 'American waterfall test',
+    description: null,
+    sourceConfigId: 12,
+    sourceConfigVersion: 4,
+    variantCount: 1,
+    archivedAt: null,
+    archivedByUserId: null,
+    archivedByLabel: null,
+    createdByUserId: 17,
+    createdByLabel: 'analyst@example.com',
+    updatedByUserId: 17,
+    updatedByLabel: 'analyst@example.com',
+    createdAt: '2026-06-08T12:00:00.000Z',
+    updatedAt: '2026-06-08T12:00:00.000Z',
+    variants: [
+      {
+        id: '00000000-0000-0000-0000-000000000712',
+        scenarioSetId: '00000000-0000-0000-0000-000000000711',
+        name: 'American variant',
+        description: null,
+        sortOrder: 0,
+        override: {
+          overrideType: 'methodology',
+          payload: { waterfallType: 'american' },
+        },
+        createdAt: '2026-06-08T12:00:00.000Z',
+        updatedAt: '2026-06-08T12:00:00.000Z',
+      },
+    ],
+  };
+}
+
+// ─── payload builder ─────────────────────────────────────────────────────────
+
+describe('buildCreateMethodologyScenarioPayload', () => {
+  it('builds payload with waterfallType only', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'My set',
+      variantName: 'My variant',
+      waterfallType: 'american',
+      managementFeeRate: undefined,
+    });
+    expect(result.name).toBe('My set');
+    expect(result.variants[0]?.name).toBe('My variant');
+    expect(result.variants[0]?.override.overrideType).toBe('methodology');
+    expect(result.variants[0]?.override.payload).toEqual({
+      waterfallType: 'american',
+    });
+    expect(
+      'managementFeeRate' in (result.variants[0]?.override.payload ?? {})
+    ).toBe(false);
+  });
+
+  it('builds payload with managementFeeRate only', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Fee test',
+      variantName: 'Fee variant',
+      waterfallType: undefined,
+      managementFeeRate: 2,
+    });
+    expect(result.variants[0]?.override.payload).toEqual({
+      managementFeeRate: 2,
+    });
+    expect(
+      'waterfallType' in (result.variants[0]?.override.payload ?? {})
+    ).toBe(false);
+  });
+
+  it('builds payload with both fields', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Both',
+      variantName: 'Both variant',
+      waterfallType: 'hybrid',
+      managementFeeRate: 2.5,
+    });
+    expect(result.variants[0]?.override.payload).toEqual({
+      waterfallType: 'hybrid',
+      managementFeeRate: 2.5,
+    });
+  });
+
+  it('submits decimal fee as percentage, not divided by 100', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Decimal',
+      variantName: 'v',
+      waterfallType: undefined,
+      managementFeeRate: 2.5,
+    });
+    expect(
+      (result.variants[0]?.override.payload as { managementFeeRate: number })
+        .managementFeeRate
+    ).toBe(2.5);
+  });
+
+  it('submits zero fee as a real override value', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Zero',
+      variantName: 'v',
+      waterfallType: undefined,
+      managementFeeRate: 0,
+    });
+    expect(result.variants[0]?.override.payload).toEqual({
+      managementFeeRate: 0,
+    });
+  });
+
+  it('maps scenarioSetName to name and variantName to variants[0].name', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Set name',
+      variantName: 'Variant name',
+      waterfallType: 'american',
+      managementFeeRate: undefined,
+    });
+    expect(result.name).toBe('Set name');
+    expect(result.variants[0]?.name).toBe('Variant name');
+  });
+});
+
+// ─── modal component ─────────────────────────────────────────────────────────
+
+describe('CreateMethodologyScenarioModal', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders all four form fields when open', () => {
+    renderModal();
+    expect(screen.getByLabelText(/scenario set name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/variant name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/waterfall type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/management fee rate/i)).toBeInTheDocument();
+  });
+
+  it('does not render dialog content when closed', () => {
+    renderModal({ open: false });
+    expect(
+      screen.queryByLabelText(/scenario set name/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows required errors under name fields on empty submit', async () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(await screen.findAllByText('Required')).toHaveLength(2);
+  });
+
+  it('shows cross-field error when names filled but no override specified', async () => {
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'My set' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'My variant' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(
+      await screen.findByText(/specify at least one override/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows field error for negative management fee', async () => {
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'V' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '-1', valueAsNumber: -1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('shows field error for fee above 100', async () => {
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'V' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '101', valueAsNumber: 101 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('POSTs correct body with managementFeeRate only', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeCreatedDetail()));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'Fee set' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'Fee v' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.variants[0].override.overrideType).toBe('methodology');
+    expect(body.variants[0].override.payload).toEqual({ managementFeeRate: 2 });
+    expect('waterfallType' in body.variants[0].override.payload).toBe(false);
+  });
+
+  it('shows duplicate_scenario_set_name error under name field', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      errorResponse(409, 'duplicate_scenario_set_name', 'Already exists')
+    );
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'V' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(
+      await screen.findByText(/a scenario set with this name already exists/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows max_scenario_sets banner', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      errorResponse(409, 'max_scenario_sets', 'Max reached')
+    );
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'V' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(
+      await screen.findByText(/maximum of 10 active scenario sets/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows no_published_config banner', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      errorResponse(409, 'no_published_config', 'No config')
+    );
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'V' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(
+      await screen.findByText(/publish a fund configuration/i)
+    ).toBeInTheDocument();
+  });
+
+  it('disables Create button while mutation is pending', async () => {
+    // Never resolves — keeps mutation in pending state
+    fetchSpy.mockReturnValueOnce(new Promise(() => {}));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'V' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /create scenario/i })
+      ).toBeDisabled();
+    });
+  });
+
+  it('blocks close while mutation is pending (Cancel click is a no-op)', async () => {
+    fetchSpy.mockReturnValueOnce(new Promise(() => {}));
+    const onOpenChange = vi.fn();
+    renderModal({ onOpenChange });
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'V' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it('resets form on close and re-open', async () => {
+    function Harness() {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <button onClick={() => setOpen((o) => !o)}>Toggle</button>
+          <QueryClientProvider client={makeQueryClient()}>
+            <CreateMethodologyScenarioModal
+              fundId="123"
+              open={open}
+              onOpenChange={setOpen}
+              onSuccess={vi.fn()}
+            />
+          </QueryClientProvider>
+        </>
+      );
+    }
+    render(<Harness />);
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'Filled' },
+    });
+    expect(screen.getByLabelText(/scenario set name/i)).toHaveValue('Filled');
+    // Close
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    // Re-open
+    fireEvent.click(screen.getByRole('button', { name: /toggle/i }));
+    expect(await screen.findByLabelText(/scenario set name/i)).toHaveValue('');
+  });
+
+  it('calls onSuccess with the created detail on successful submit', async () => {
+    const detail = makeCreatedDetail();
+    fetchSpy.mockResolvedValueOnce(jsonResponse(detail));
+    const onSuccess = vi.fn();
+    renderModal({ onSuccess });
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'American waterfall test' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'American variant' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() =>
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ id: detail.id })
+      )
+    );
+  });
+
+  it('invalidates workspace query on success', async () => {
+    const detail = makeCreatedDetail();
+    fetchSpy.mockResolvedValueOnce(jsonResponse(detail));
+    const { queryClient } = renderModal();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'American waterfall test' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'American variant' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ['fund-scenario-workspace', '123'],
+        })
+      );
+    });
+  });
+
+  it('seeds detail query cache on success', async () => {
+    const detail = makeCreatedDetail();
+    fetchSpy.mockResolvedValueOnce(jsonResponse(detail));
+    const { queryClient } = renderModal();
+    const setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData');
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'American waterfall test' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'American variant' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(setQueryDataSpy).toHaveBeenCalledWith(
+        [
+          'fund-scenario-workspace',
+          '123',
+          'scenario-sets',
+          detail.id,
+          'detail',
+        ],
+        expect.objectContaining({ id: detail.id })
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 3.2: Run tests to confirm RED state**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
+```
+
+Expected: Tests fail with "Cannot find module" or similar — the component file
+does not exist yet.
+
+---
+
+## Task 4: Implement the modal component
+
+**Files:**
+
+- Create: `client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`
+
+- [ ] **Step 4.1: Create the modal component**
+
+Create `client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`:
+
+```tsx
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { apiRequest, ApiError } from '@/lib/queryClient';
+import { scenarioApiPath } from '@/lib/fund-scenario-workspace-api';
+import {
+  scenarioSetDetailQueryKey,
+  workspaceQueryKey,
+} from '@/lib/fund-scenario-workspace-query-keys';
+import {
+  FundScenarioSetDetailV1Schema,
+  type FundScenarioSetDetailV1,
+} from '@shared/contracts/fund-scenario-sets-v1.contract';
+import type { CreateFundScenarioSetV1 } from '@shared/contracts/fund-scenario-sets-v1.contract';
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const OptionalPercentageNumberSchema = z.preprocess((value) => {
+  if (value === '' || value === null || value === undefined) return undefined;
+  if (typeof value === 'string' && value.trim() === '') return undefined;
+  if (typeof value === 'number' && Number.isNaN(value)) return undefined;
+  return Number(value);
+}, z.number().finite().min(0).max(100).optional());
+
+const CreateMethodologyScenarioFormSchema = z
+  .object({
+    scenarioSetName: z.string().trim().min(1, 'Required').max(120),
+    variantName: z.string().trim().min(1, 'Required').max(120),
+    waterfallType: z.enum(['american', 'hybrid']).optional(),
+    managementFeeRate: OptionalPercentageNumberSchema,
+  })
+  .refine(
+    (data) =>
+      data.waterfallType !== undefined || data.managementFeeRate !== undefined,
+    {
+      message:
+        'Specify at least one override: waterfall type or management fee rate.',
+      path: ['waterfallType'],
+    }
+  );
+
+type CreateMethodologyScenarioFormValues = z.infer<
+  typeof CreateMethodologyScenarioFormSchema
+>;
+
+const WATERFALL_UNSET_VALUE = '__unset__';
+
+// ─── Payload builder (exported for direct testing) ────────────────────────────
+
+export function buildCreateMethodologyScenarioPayload(
+  values: CreateMethodologyScenarioFormValues
+): CreateFundScenarioSetV1 {
+  return {
+    name: values.scenarioSetName,
+    variants: [
+      {
+        name: values.variantName,
+        override: {
+          overrideType: 'methodology',
+          payload: {
+            ...(values.waterfallType
+              ? { waterfallType: values.waterfallType }
+              : {}),
+            ...(values.managementFeeRate !== undefined
+              ? { managementFeeRate: values.managementFeeRate }
+              : {}),
+          },
+        },
+      },
+    ],
+  };
+}
+
+// ─── Error helper ─────────────────────────────────────────────────────────────
+
+function extractErrorCode(error: unknown): string | null {
+  return error instanceof ApiError ? (error.errorCode ?? null) : null;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export interface CreateMethodologyScenarioModalProps {
+  fundId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: (created: FundScenarioSetDetailV1) => void;
+}
+
+export function CreateMethodologyScenarioModal({
+  fundId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: CreateMethodologyScenarioModalProps) {
+  const queryClient = useQueryClient();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm<CreateMethodologyScenarioFormValues>({
+    resolver: zodResolver(CreateMethodologyScenarioFormSchema),
+    defaultValues: {
+      scenarioSetName: '',
+      variantName: '',
+      waterfallType: undefined,
+      managementFeeRate: undefined,
+    },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateFundScenarioSetV1) =>
+      apiRequest(
+        'POST',
+        scenarioApiPath(fundId, '/scenario-sets'),
+        payload
+      ).then((raw) => FundScenarioSetDetailV1Schema.parse(raw)),
+    onMutate: () => {
+      setServerError(null);
+    },
+    onSuccess: async (created) => {
+      queryClient.setQueryData(
+        scenarioSetDetailQueryKey(fundId, created.id),
+        created
+      );
+      await queryClient.invalidateQueries({
+        queryKey: workspaceQueryKey(fundId),
+      });
+      form.reset();
+      setServerError(null);
+      onOpenChange(false);
+      onSuccess(created);
+    },
+    onError: (error) => {
+      const code = extractErrorCode(error);
+      if (code === 'duplicate_scenario_set_name') {
+        form.setError('scenarioSetName', {
+          message: 'A scenario set with this name already exists.',
+        });
+      } else if (code === 'max_scenario_sets') {
+        setServerError(
+          'This fund has reached the maximum of 10 active scenario sets.'
+        );
+      } else if (code === 'no_published_config') {
+        setServerError(
+          'Publish a fund configuration before creating scenarios.'
+        );
+      } else {
+        setServerError('Failed to create scenario. Please try again.');
+      }
+    },
+  });
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && createMutation.isPending) return;
+    if (!nextOpen) {
+      form.reset();
+      setServerError(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  function onSubmit(values: CreateMethodologyScenarioFormValues) {
+    createMutation.mutate(buildCreateMethodologyScenarioPayload(values));
+  }
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+  } = form;
+
+  const waterfallTypeValue = watch('waterfallType');
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-inter text-charcoal">
+            New methodology scenario
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Scenario set name */}
+          <div className="space-y-1">
+            <Label
+              htmlFor="scenarioSetName"
+              className="font-poppins text-sm text-charcoal"
+            >
+              Scenario set name
+            </Label>
+            <Input
+              id="scenarioSetName"
+              {...register('scenarioSetName')}
+              placeholder="e.g. Waterfall comparison"
+              aria-label="Scenario set name"
+            />
+            {errors.scenarioSetName && (
+              <p className="text-xs text-error-dark font-poppins">
+                {errors.scenarioSetName.message}
+              </p>
+            )}
+          </div>
+
+          {/* Variant name */}
+          <div className="space-y-1">
+            <Label
+              htmlFor="variantName"
+              className="font-poppins text-sm text-charcoal"
+            >
+              Variant name
+            </Label>
+            <Input
+              id="variantName"
+              {...register('variantName')}
+              placeholder="e.g. American waterfall"
+              aria-label="Variant name"
+            />
+            {errors.variantName && (
+              <p className="text-xs text-error-dark font-poppins">
+                {errors.variantName.message}
+              </p>
+            )}
+          </div>
+
+          {/* Override fields */}
+          <div className="space-y-3 rounded-md border border-beige-200 p-3">
+            <p className="font-poppins text-xs uppercase text-charcoal-400">
+              At least one override required
+            </p>
+
+            {/* Waterfall type */}
+            <div className="space-y-1">
+              <Label
+                htmlFor="waterfallType"
+                className="font-poppins text-sm text-charcoal"
+              >
+                Waterfall type
+              </Label>
+              <Select
+                value={waterfallTypeValue ?? WATERFALL_UNSET_VALUE}
+                onValueChange={(value) =>
+                  setValue(
+                    'waterfallType',
+                    value === WATERFALL_UNSET_VALUE
+                      ? undefined
+                      : (value as 'american' | 'hybrid'),
+                    { shouldValidate: true }
+                  )
+                }
+              >
+                <SelectTrigger id="waterfallType" aria-label="Waterfall type">
+                  <SelectValue placeholder="No change" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={WATERFALL_UNSET_VALUE}>
+                    No change
+                  </SelectItem>
+                  <SelectItem value="american">
+                    American (deal-by-deal)
+                  </SelectItem>
+                  <SelectItem value="hybrid">Hybrid (fund-level)</SelectItem>
+                </SelectContent>
+              </Select>
+              {errors.waterfallType && (
+                <p className="text-xs text-error-dark font-poppins">
+                  {errors.waterfallType.message}
+                </p>
+              )}
+            </div>
+
+            {/* Management fee rate */}
+            <div className="space-y-1">
+              <Label
+                htmlFor="managementFeeRate"
+                className="font-poppins text-sm text-charcoal"
+              >
+                Management fee rate
+              </Label>
+              <div className="relative">
+                <Input
+                  id="managementFeeRate"
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  inputMode="decimal"
+                  placeholder="e.g. 2"
+                  className="pr-7"
+                  aria-label="Management fee rate"
+                  {...register('managementFeeRate', { valueAsNumber: true })}
+                />
+                <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-charcoal-400">
+                  %
+                </span>
+              </div>
+              {errors.managementFeeRate && (
+                <p className="text-xs text-error-dark font-poppins">
+                  {errors.managementFeeRate.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Server error banner */}
+          {serverError && (
+            <Alert className="border-error/20 bg-error/5">
+              <AlertDescription className="font-poppins text-sm text-error-dark">
+                {serverError}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={createMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={createMutation.isPending}
+              className="bg-charcoal text-white hover:bg-charcoal/90"
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create scenario'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4.2: Run modal tests**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
+```
+
+Expected: Most tests pass. If Radix Select interactions fail, the
+`waterfallType` tests may need adjustment. The managementFeeRate tests should
+pass since they use `fireEvent.change` with `valueAsNumber`.
+
+- [ ] **Step 4.3: Verify Radix Select tests pass in jsdom**
+
+The modal uses `setValue` + `watch` for the waterfall select (not a
+`<Controller>`). In jsdom, Radix Select renders a trigger button with role
+`combobox`. If the waterfallType tests fail because the Select portal does not
+render in jsdom, add `data-testid="waterfall-select-trigger"` to the
+`<SelectTrigger>` and use
+`fireEvent.click(screen.getByTestId('waterfall-select-trigger'))` followed by
+`fireEvent.click(screen.getByRole('option', { name: /american/i }))`. The tests
+that use the fee-rate field only (no waterfallType) are not affected by this.
+
+- [ ] **Step 4.4: Run typecheck**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npm.cmd run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4.5: Commit**
+
+```
+git add client/src/components/scenarios/CreateMethodologyScenarioModal.tsx \
+  tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
+git commit -m "feat(scenarios): add CreateMethodologyScenarioModal with Zod form + mutation"
+```
+
+---
+
+## Task 5: Wire modal into workspace page
+
+**Files:**
+
+- Modify: `client/src/pages/fund-scenario-workspace.tsx`
+- Modify: `tests/unit/pages/fund-scenario-workspace.test.tsx`
+
+- [ ] **Step 5.1: Add highlight prop to ScenarioSetActionCard**
+
+In `client/src/pages/fund-scenario-workspace.tsx`, find `ScenarioSetActionCard`
+(around line 386). Add `isHighlighted?: boolean` to its props interface and
+apply a ring class to the article element:
+
+```tsx
+// Props interface addition
+isHighlighted?: boolean;
+
+// Article element — replace existing className
+className={cn(
+  'rounded-md border border-beige-200 bg-white p-4',
+  isHighlighted && 'ring-2 ring-charcoal'
+)}
+```
+
+Add `cn` import if not already present: `import { cn } from '@/lib/utils';`
+
+- [ ] **Step 5.2: Pass highlight through ScenarioActionList**
+
+In `ScenarioActionList`, add `highlightedScenarioSetId?: string | null` to props
+and pass `isHighlighted={summary.id === highlightedScenarioSetId}` to each
+`ScenarioSetActionCard`.
+
+- [ ] **Step 5.3: Add state, button cluster, and modal mount to
+      FundScenarioWorkspacePage**
+
+In `FundScenarioWorkspacePage`, add:
+
+```tsx
+// After existing useState declarations
+const [isCreateMethodologyOpen, setIsCreateMethodologyOpen] = useState(false);
+const [highlightedScenarioSetId, setHighlightedScenarioSetId] = useState<
+  string | null
+>(null);
+```
+
+Add the modal import at the top of the file:
+
+```ts
+import { CreateMethodologyScenarioModal } from '@/components/scenarios/CreateMethodologyScenarioModal';
+```
+
+Replace the header
+`<div className="flex flex-wrap items-center justify-between gap-3">` content.
+Currently it has one button on the right. Wrap the right side in a group:
+
+```tsx
+<div className="flex flex-wrap items-center justify-between gap-3">
+  <Button asChild variant="outline" size="sm">
+    <Link href={`/fund-model-results/${fundId}`}>
+      <ArrowLeft className="h-4 w-4" />
+      Back to Results
+    </Link>
+  </Button>
+  <div className="flex flex-wrap items-center gap-2">
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => setIsCreateMethodologyOpen(true)}
+    >
+      New methodology scenario
+    </Button>
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={createReserveOptimizationMutation.isPending}
+      onClick={() => createReserveOptimizationMutation.mutate()}
+    >
+      {createReserveOptimizationMutation.isPending && (
+        <RefreshCw className="h-4 w-4 animate-spin" />
+      )}
+      {createReserveOptimizationMutation.isPending
+        ? 'Creating'
+        : 'Create optimized reserve plan'}
+    </Button>
+  </div>
+</div>
+```
+
+Add the modal mount just before the closing `</div>` of the page root:
+
+```tsx
+<CreateMethodologyScenarioModal
+  fundId={fundId}
+  open={isCreateMethodologyOpen}
+  onOpenChange={setIsCreateMethodologyOpen}
+  onSuccess={(created) => setHighlightedScenarioSetId(created.id)}
+/>
+```
+
+Pass `highlightedScenarioSetId` to `ScenarioActionList`:
+
+```tsx
+<ScenarioActionList
+  scenarioSets={scenarioSets}
+  detailById={detailById}
+  statusById={statusById}
+  pendingScenarioSetId={pendingScenarioSetId}
+  highlightedScenarioSetId={highlightedScenarioSetId}
+  onCalculate={(detail) => {
+    setPendingScenarioSetId(detail.id);
+    calculateMutation.mutate(detail);
+  }}
+/>
+```
+
+- [ ] **Step 5.4: Add thin workspace integration test**
+
+In `tests/unit/pages/fund-scenario-workspace.test.tsx`, add a new `it` block
+inside the main `describe('FundScenarioWorkspacePage', ...)` block:
+
+```ts
+it('renders New methodology scenario button and opens modal on click', async () => {
+  mockWorkspaceFetches();
+  renderWorkspace();
+
+  const newScenarioBtn = await screen.findByRole('button', {
+    name: /new methodology scenario/i,
+  });
+  expect(newScenarioBtn).toBeInTheDocument();
+
+  fireEvent.click(newScenarioBtn);
+  expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+  // No create POST issued merely by opening
+  const createPosts = fetchSpy.mock.calls.filter(
+    ([url, init]: [string, RequestInit]) =>
+      url.includes('/scenario-sets') &&
+      (init?.method ?? 'GET') === 'POST' &&
+      !url.includes('/reserve-optimization') &&
+      !url.includes('/calculate')
+  );
+  expect(createPosts).toHaveLength(0);
+});
+```
+
+- [ ] **Step 5.5: Run all workspace and modal tests**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/pages/fund-scenario-workspace.test.tsx tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
+```
+
+Expected: All pass, exit 0.
+
+```powershell
+& .\scripts\windows-node-env.ps1 npm.cmd run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5.6: Commit**
+
+```
+git add client/src/pages/fund-scenario-workspace.tsx \
+  tests/unit/pages/fund-scenario-workspace.test.tsx
+git commit -m "feat(scenarios): wire CreateMethodologyScenarioModal into workspace page"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 6.1: Run all focused tests**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/lib/queryClient.test.ts tests/unit/lib/fund-scenario-workspace-api.test.ts
+```
+
+Expected: All pass.
+
+```powershell
+& .\scripts\windows-node-env.ps1 npx.cmd vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx tests/unit/pages/fund-scenario-workspace.test.tsx
+```
+
+Expected: All pass.
+
+- [ ] **Step 6.2: Run scenario release gate**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npm.cmd run test:scenario-release-gate
+```
+
+Expected: Passes, exit 0.
+
+- [ ] **Step 6.3: Typecheck**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npm.cmd run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 6.4: Lint**
+
+```powershell
+& .\scripts\windows-node-env.ps1 npm.cmd run lint
+```
+
+Expected: 0 errors.

--- a/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
+++ b/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
@@ -1,3 +1,10 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-06-08
+owner: 'Platform Team'
+---
+
 # C1: Methodology Scenario Creation UI — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use

--- a/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
+++ b/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
@@ -9,9 +9,9 @@ direct API call.
 
 ## Scope
 
-Methodology-only, one variant per creation. `waterfallTiers` excluded — tier
-editing is a separate workflow. `waterfallType` and `managementFeeRate` are the
-only exposed override fields.
+Methodology-only, one variant per creation. `waterfallTiers` is intentionally
+excluded because tier editing needs a dedicated workflow. `waterfallType` and
+`managementFeeRate` are the only C1 override fields.
 
 ---
 
@@ -39,8 +39,13 @@ implemented and tested.
 
 ## Section 1: Architecture + Component Interface
 
-**New file:**
-`client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`
+**New files:**
+
+- `client/src/components/scenarios/CreateMethodologyScenarioModal.tsx` — modal
+  component
+- `client/src/lib/fund-scenario-workspace-query-keys.ts` — shared cache key
+  helpers
+- `client/src/lib/fund-scenario-workspace-api.ts` — shared API path helpers
 
 The modal is a self-contained feature component. Public interface:
 
@@ -54,22 +59,18 @@ interface CreateMethodologyScenarioModalProps {
 ```
 
 `fundId` is the validated numeric string from the workspace route. `onSuccess`
-receives the created detail so the workspace can optionally highlight it.
+receives the created detail so the workspace can highlight the new card.
 `onOpenChange` follows shadcn Dialog convention — workspace passes
 `setIsCreateMethodologyOpen`.
 
-The mutation (`useMutation`) and cache invalidation
-(`queryClient.invalidateQueries`) live inside the modal. The workspace
-`onSuccess` callback is a downstream hook for selection, scroll, or toast — not
-responsible for cache invalidation.
+The mutation (`useMutation`) and cache invalidation live inside the modal. The
+workspace `onSuccess` is a downstream hook for highlight/scroll behavior.
 
-**Query key extraction:**
+### Query key extraction
 
 New file: `client/src/lib/fund-scenario-workspace-query-keys.ts`
 
-Extracts the cache key helpers currently private to
-`fund-scenario-workspace.tsx` so both the workspace page and modal share the
-same cache root without duplicating literals:
+Extracts cache key helpers currently private to `fund-scenario-workspace.tsx`:
 
 ```ts
 export function workspaceQueryKey(fundId: string) {
@@ -119,11 +120,55 @@ export function scenarioComparisonQueryKey(
 `fund-scenario-workspace.tsx` replaces its local definitions with imports from
 this module.
 
-**Workspace integration:**
+### API path helpers
+
+New file: `client/src/lib/fund-scenario-workspace-api.ts`
+
+Centralizes the path validation and construction currently local to
+`fund-scenario-workspace.tsx`:
+
+```ts
+const FUND_ID_PATTERN = /^\d+$/;
+const SCENARIO_SET_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function assertFundId(fundId: string): void {
+  if (!FUND_ID_PATTERN.test(fundId)) throw new Error('Invalid fund ID');
+}
+
+export function assertScenarioSetId(scenarioSetId: string): void {
+  if (!SCENARIO_SET_ID_PATTERN.test(scenarioSetId))
+    throw new Error('Invalid scenario set ID');
+}
+
+export function scenarioApiPath(fundId: string, suffix: string): string {
+  assertFundId(fundId);
+  return `/api/funds/${encodeURIComponent(fundId)}${suffix}`;
+}
+
+export function scenarioSetApiPath(
+  fundId: string,
+  scenarioSetId: string,
+  suffix = ''
+): string {
+  assertScenarioSetId(scenarioSetId);
+  return scenarioApiPath(
+    fundId,
+    `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`
+  );
+}
+```
+
+`fund-scenario-workspace.tsx` replaces its local definitions with imports from
+this module. The modal uses `scenarioApiPath(fundId, '/scenario-sets')` for the
+POST path.
+
+### Workspace integration
 
 ```tsx
 // State
 const [isCreateMethodologyOpen, setIsCreateMethodologyOpen] = useState(false);
+const [highlightedScenarioSetId, setHighlightedScenarioSetId] = useState<string | null>(null);
 
 // Header (right-side button cluster)
 <div className="flex flex-wrap items-center justify-between gap-3">
@@ -161,9 +206,15 @@ const [isCreateMethodologyOpen, setIsCreateMethodologyOpen] = useState(false);
   fundId={fundId}
   open={isCreateMethodologyOpen}
   onOpenChange={setIsCreateMethodologyOpen}
-  onSuccess={() => {}}
+  onSuccess={(created) => setHighlightedScenarioSetId(created.id)}
 />
 ```
+
+`highlightedScenarioSetId` is passed to `ScenarioActionList` /
+`ScenarioSetActionCard` to visually indicate the newly created card (e.g. a
+`ring` border or "New" badge). It is cleared when the user first interacts with
+the card or after a short timeout. This separates creation UX from calculation
+UX — users see the new card appear and then click Calculate themselves.
 
 ---
 
@@ -174,9 +225,10 @@ const [isCreateMethodologyOpen, setIsCreateMethodologyOpen] = useState(false);
 ```ts
 const OptionalPercentageNumberSchema = z.preprocess((value) => {
   if (value === '' || value === null || value === undefined) return undefined;
+  if (typeof value === 'string' && value.trim() === '') return undefined;
   if (typeof value === 'number' && Number.isNaN(value)) return undefined;
   return Number(value);
-}, z.number().min(0).max(100).optional());
+}, z.number().finite().min(0).max(100).optional());
 
 const CreateMethodologyScenarioFormSchema = z
   .object({
@@ -203,7 +255,13 @@ type CreateMethodologyScenarioFormValues = z.infer<
 The `.refine` error is placed on `waterfallType` so it surfaces near the first
 override field.
 
-**Payload transform (exported, independently testable):**
+**`managementFeeRate` range note:** The backend
+`MethodologyOverridePayloadV1Schema` accepts `z.number().optional()` with no
+range constraint. The 0–100 range and `finite()` guard are client-side product
+rules, not server-derived. Test coverage for 0, 2.5, negative, and out-of-range
+values is required (see Section 4).
+
+**Payload transform (exported):**
 
 ```ts
 export function buildCreateMethodologyScenarioPayload(
@@ -231,26 +289,42 @@ export function buildCreateMethodologyScenarioPayload(
 }
 ```
 
-`managementFeeRate` is submitted as the percentage value (e.g., `2` for 2%) —
-matching `FundDraftWriteV1Schema` convention. Do not divide by 100 in the modal.
+`managementFeeRate` is submitted as the percentage value (e.g., `2` for 2%,
+`2.5` for 2.5%) — matching `FundDraftWriteV1Schema` convention. Do not divide by
+100 in the modal.
 
 ---
 
 ## Section 3: Component Internals
 
-### apiRequest update (prerequisite)
+### Prerequisite: `apiRequest` error body fix
 
-The current `apiRequest` reads `errorData.error` into `ApiError.errorCode` but
-not `errorData.code`. The server route emits both `error` (generic HTTP reason)
-and `code` (specific, e.g., `duplicate_scenario_set_name`). Update `apiRequest`
-once, backward-compatibly:
+**This is a required blocker before the modal error handling will work.**
+
+Current `client/src/lib/queryClient.ts` line ~83:
 
 ```ts
+// Before
+throw new ApiError(
+  response.status,
+  errorMessage,
+  errorData.error,
+  errorData.issues
+);
+```
+
+The server emits both `error` (generic HTTP reason like `'conflict'`) and `code`
+(specific, like `'duplicate_scenario_set_name'`). Update `apiRequest` to capture
+`code`:
+
+```ts
+// Updated ErrorBody type (add code + details)
 type ErrorBody = {
   message?: string;
   error?: string;
   code?: string;
   issues?: Array<{ path: (string | number)[]; message: string }>;
+  details?: unknown;
 };
 const errorData = (await response
   .json()
@@ -263,7 +337,9 @@ const errorCode = errorData.code ?? errorData.error;
 throw new ApiError(response.status, errorMessage, errorCode, errorData.issues);
 ```
 
-The modal then uses:
+The `details` field is captured in the type but not threaded into `ApiError` in
+this pass — it is preserved so a future normalization pass can expose it without
+another type widening. The modal helper then becomes:
 
 ```ts
 import { ApiError } from '@/lib/queryClient';
@@ -294,15 +370,19 @@ const [serverError, setServerError] = useState<string | null>(null);
 
 const createMutation = useMutation({
   mutationFn: (payload: CreateFundScenarioSetV1) =>
-    apiRequest(
-      'POST',
-      `/api/funds/${encodeURIComponent(fundId)}/scenario-sets`,
-      payload
-    ).then((raw) => FundScenarioSetDetailV1Schema.parse(raw)),
+    apiRequest('POST', scenarioApiPath(fundId, '/scenario-sets'), payload).then(
+      (raw) => FundScenarioSetDetailV1Schema.parse(raw)
+    ),
   onMutate: () => {
     setServerError(null);
   },
   onSuccess: async (created) => {
+    // Seed detail cache immediately so the card loads without a second fetch.
+    queryClient.setQueryData(
+      scenarioSetDetailQueryKey(fundId, created.id),
+      created
+    );
+    // Then invalidate the list/root to refresh the scenario set list and results.
     await queryClient.invalidateQueries({
       queryKey: workspaceQueryKey(fundId),
     });
@@ -330,6 +410,20 @@ const createMutation = useMutation({
 });
 ```
 
+### Idempotency
+
+C1 defers idempotency key support. The submit button is disabled while the
+mutation is pending, which is the only duplicate-protection mechanism in this
+pass. A follow-on pass should add:
+
+```ts
+// In mutationFn options
+headers: { 'Idempotency-Key': crypto.randomUUID() },
+```
+
+The backend already supports this via `x-idempotency-key` — the create service
+resolves, hashes, and replays existing scenario sets on key reuse.
+
 ### Close guard
 
 ```ts
@@ -345,6 +439,9 @@ function handleOpenChange(nextOpen: boolean) {
 // <Dialog open={open} onOpenChange={handleOpenChange}>
 ```
 
+This guards all `onOpenChange(false)` sources — Cancel button, Escape key, and
+overlay click — via Radix's single `onOpenChange` callback.
+
 ### Waterfall select sentinel
 
 ```ts
@@ -358,10 +455,29 @@ const WATERFALL_UNSET_VALUE = '__unset__';
   }
 >
   <SelectItem value={WATERFALL_UNSET_VALUE}>No change</SelectItem>
-  <SelectItem value="american">American</SelectItem>
-  <SelectItem value="hybrid">Hybrid</SelectItem>
+  <SelectItem value="american">American (deal-by-deal)</SelectItem>
+  <SelectItem value="hybrid">Hybrid (fund-level)</SelectItem>
 </Select>
 ```
+
+Display labels clarify the waterfall styles without changing the payload enum.
+
+### Management fee rate input
+
+```tsx
+<Input
+  type="number"
+  min={0}
+  max={100}
+  step="0.01"
+  inputMode="decimal"
+  placeholder="e.g. 2"
+  {...form.register('managementFeeRate', { valueAsNumber: true })}
+/>
+```
+
+The `z.preprocess` handles `NaN` from an empty number input. `step="0.01"` and
+`inputMode="decimal"` enable decimal entry on mobile.
 
 ### Field layout
 
@@ -373,94 +489,97 @@ Label: Variant name         [Input]            ← required, error below
 ──────────────────────────────────────────────
 At least one override required:
 Label: Waterfall type       [Select]           ← cross-field error appears here
-Label: Management fee rate  [Input type=number, "%" suffix]
+Label: Management fee rate  [Input, "%" suffix]
 ──────────────────────────────────────────────
 [server error alert banner if present]
 ──────────────────────────────────────────────
 DialogFooter:  [Cancel]  [Create scenario]     ← Create disabled while isPending
 ```
 
-`managementFeeRate` uses
-`{...form.register('managementFeeRate', { valueAsNumber: true })}`. The
-`z.preprocess` handles `NaN` from an empty number input.
-
 ---
 
 ## Section 4: Tests
 
-### 4a. `tests/unit/lib/queryClient.test.ts` (new file)
+### 4a. `tests/unit/lib/queryClient.test.ts` (new file) — REQUIRED BLOCKER
 
-**Case: `apiRequest` preserves specific server error code**
-
-Mock a 409 response body
+**Case: `apiRequest` preserves specific server error code** Mock a 409 response
+body
 `{ error: 'conflict', code: 'duplicate_scenario_set_name', message: '...' }`.
-Assert that the thrown `ApiError.errorCode === 'duplicate_scenario_set_name'`
-(not `'conflict'`).
+Assert `ApiError.errorCode === 'duplicate_scenario_set_name'` (not
+`'conflict'`).
 
-This is a required blocker — without the `apiRequest` fix, the modal cannot
-distinguish specific server errors.
+**Case: `apiRequest` handles response with `details` field without crashing**
+Mock a 400 response body
+`{ error: 'invalid_request', message: '...', details: { issues: [...] } }`.
+Assert no crash and `ApiError.errorCode === 'invalid_request'`.
 
 ### 4b. `buildCreateMethodologyScenarioPayload` unit tests
-
-Four cases (inline in the modal test file or a separate util test):
 
 - **waterfallType only** — payload contains `{ waterfallType: 'american' }`, no
   `managementFeeRate` key
 - **managementFeeRate only** — payload contains `{ managementFeeRate: 2 }`, no
   `waterfallType` key
 - **both fields** — payload contains both keys
-- **name mapping** — `scenarioSetName` maps to `payload.name`; `variantName`
-  maps to `payload.variants[0].name`
+- **name mapping** — `scenarioSetName` → `payload.name`; `variantName` →
+  `payload.variants[0].name`
+- **decimal fee** — `managementFeeRate: 2.5` → `{ managementFeeRate: 2.5 }` (not
+  divided by 100)
+- **zero fee** — `managementFeeRate: 0` is a valid override, payload contains
+  `{ managementFeeRate: 0 }`
 
 ### 4c. `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx` (new file)
 
-| Case                                  | Setup                                                                | Assert                                                                                                                    |
-| ------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Renders fields when open              | `open=true`                                                          | Name, variant name, waterfall type, fee rate fields present                                                               |
-| Hidden when closed                    | `open=false`                                                         | Dialog content not in DOM                                                                                                 |
-| Empty submit shows required errors    | Submit without filling                                               | "Required" under name + variant name                                                                                      |
-| Cross-field refine                    | Fill both name fields, leave both override fields unset, submit      | Cross-field error near waterfall select                                                                                   |
-| Valid submit (waterfallType only)     | Fill names + select 'american', submit                               | `fetch` called with `{ overrideType: 'methodology', payload: { waterfallType: 'american' } }`, no `managementFeeRate` key |
-| Valid submit (managementFeeRate only) | Fill names + type fee rate, submit                                   | `fetch` called with `{ managementFeeRate: 2 }`, no `waterfallType` key                                                    |
-| Duplicate name error                  | Mock 409 `duplicate_scenario_set_name`                               | Field error under scenario set name field                                                                                 |
-| Max sets error                        | Mock 409 `max_scenario_sets`                                         | Alert banner with max-sets message                                                                                        |
-| No published config error             | Mock 409 `no_published_config`                                       | Alert banner with publish-config message                                                                                  |
-| Submit disabled while pending         | Mock fetch with deferred promise                                     | Create button is disabled                                                                                                 |
-| Close blocked while pending           | Mock fetch with deferred promise, click Cancel                       | `onOpenChange` not called                                                                                                 |
-| Reset on close                        | Parent harness: open → fill fields → close → reopen                  | Fields show default values                                                                                                |
-| onSuccess called with detail          | Mock successful response with full `FundScenarioSetDetailV1` fixture | `onSuccess` called with the parsed detail                                                                                 |
-| Cache invalidated on success          | Spy on `queryClient.invalidateQueries`                               | Called with `{ queryKey: workspaceQueryKey(fundId) }`                                                                     |
+| Case                                        | Setup                                                                | Assert                                                                                     |
+| ------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Renders fields when open                    | `open=true`                                                          | Name, variant name, waterfall type, fee rate inputs present                                |
+| Hidden when closed                          | `open=false`                                                         | Dialog content not in DOM                                                                  |
+| Empty submit shows required errors          | Submit without filling                                               | "Required" under name + variant name                                                       |
+| Cross-field refine                          | Fill both name fields, leave both override fields unset, submit      | Cross-field error near waterfall select                                                    |
+| Valid submit (waterfallType only)           | Fill names + select 'american'                                       | `fetch` POST body has `payload: { waterfallType: 'american' }`, no `managementFeeRate` key |
+| Valid submit (managementFeeRate only)       | Fill names + type `2` in fee field                                   | `fetch` POST body has `payload: { managementFeeRate: 2 }`, no `waterfallType` key          |
+| Decimal fee submits correctly               | Type `2.5`                                                           | POST body has `{ managementFeeRate: 2.5 }`                                                 |
+| Zero fee is valid                           | Type `0`, select no waterfall                                        | POST body has `{ managementFeeRate: 0 }`                                                   |
+| Negative fee shows error                    | Type `-1`                                                            | Field error shown, no POST issued                                                          |
+| Out-of-range fee shows error                | Type `101`                                                           | Field error shown, no POST issued                                                          |
+| `duplicate_scenario_set_name` → field error | Mock 409 `duplicate_scenario_set_name`                               | Error message under scenario set name field                                                |
+| `max_scenario_sets` → banner                | Mock 409 `max_scenario_sets`                                         | Alert banner with max-sets message                                                         |
+| `no_published_config` → banner              | Mock 409 `no_published_config`                                       | Alert banner with publish-config message                                                   |
+| Submit disabled while pending               | Mock fetch with deferred promise                                     | Create button is `disabled`                                                                |
+| Close blocked while pending                 | Mock fetch with deferred promise, trigger close                      | `onOpenChange` not called                                                                  |
+| Reset on close                              | Parent harness: open → fill → close → reopen                         | Fields show default values                                                                 |
+| `onSuccess` called with detail              | Mock successful response with full `FundScenarioSetDetailV1` fixture | Callback receives the parsed detail                                                        |
+| Cache invalidated on success                | Spy on `queryClient.invalidateQueries`                               | Called with `{ queryKey: workspaceQueryKey(fundId) }`                                      |
+| Detail seeded in cache on success           | Spy on `queryClient.setQueryData`                                    | Called with `scenarioSetDetailQueryKey(fundId, created.id)` and the created detail         |
 
-**Notes on specific cases:**
+**Notes:**
 
-- Pending-state tests need a manually controlled deferred promise (resolve never
-  called during assertion).
-- Close-blocked test: prefer clicking Cancel button (which should be
-  disabled/guarded while pending) or use the `handleOpenChange` guard directly.
+- Pending-state tests need a deferred promise (never resolves during assertion
+  window).
+- Close-blocked: test Cancel button click and/or verify
+  `handleOpenChange(false)` is a no-op while pending. Radix routes Escape and
+  overlay through the same `onOpenChange`.
 - Reset-on-close: requires a small wrapper component owning `open` state.
-- Success fixture: must be a complete `FundScenarioSetDetailV1` including all
-  required summary fields + `variants` array; partial fixtures fail schema
-  parsing.
+- Success fixture must be a complete `FundScenarioSetDetailV1` (schema-valid,
+  including all required summary fields + `variants` array).
 
-### 4d. `tests/unit/pages/fund-scenario-workspace.test.tsx` — thin integration addition
+### 4d. `tests/unit/pages/fund-scenario-workspace.test.tsx` — thin integration
 
-Add to the primary workspace test ("loads scenario sets without polling reserve
-status for sync sets"):
+Add to the primary workspace test:
 
 ```ts
-// "New methodology scenario" button renders
+// Button renders
 expect(
   screen.getByRole('button', { name: /new methodology scenario/i })
 ).toBeInTheDocument();
 
-// Clicking it opens the modal (no POST issued)
+// Click opens modal
 fireEvent.click(
   screen.getByRole('button', { name: /new methodology scenario/i })
 );
-// Modal dialog appears
 expect(await screen.findByRole('dialog')).toBeInTheDocument();
-// No create POST issued merely by opening the modal
-const createCalls = fetchSpy.mock.calls.filter(
+
+// No create POST issued merely by opening
+const createPosts = fetchSpy.mock.calls.filter(
   ([url, init]) =>
     typeof url === 'string' &&
     url.includes('/scenario-sets') &&
@@ -468,7 +587,7 @@ const createCalls = fetchSpy.mock.calls.filter(
     !url.includes('/reserve-optimization') &&
     !url.includes('/calculate')
 );
-expect(createCalls).toHaveLength(0);
+expect(createPosts).toHaveLength(0);
 ```
 
 ### Gates
@@ -483,12 +602,13 @@ npm run lint                         # zero lint errors
 
 ## File Summary
 
-| File                                                                      | Action                                                                            |
-| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `client/src/lib/fund-scenario-workspace-query-keys.ts`                    | Create — query key helpers extracted from workspace page                          |
-| `client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`      | Create — modal component                                                          |
-| `client/src/lib/queryClient.ts`                                           | Modify — preserve `code` field from server error response in `ApiError.errorCode` |
-| `client/src/pages/fund-scenario-workspace.tsx`                            | Modify — import query keys, add state + button + modal mount                      |
-| `tests/unit/lib/queryClient.test.ts`                                      | Create — `apiRequest` error code preservation                                     |
-| `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx` | Create — modal unit tests (14 cases)                                              |
-| `tests/unit/pages/fund-scenario-workspace.test.tsx`                       | Modify — thin integration: button renders + opens modal                           |
+| File                                                                      | Action                                                                              |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `client/src/lib/fund-scenario-workspace-query-keys.ts`                    | Create — cache key helpers                                                          |
+| `client/src/lib/fund-scenario-workspace-api.ts`                           | Create — path/validation helpers                                                    |
+| `client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`      | Create — modal component                                                            |
+| `client/src/lib/queryClient.ts`                                           | Modify — preserve server `code` field in `ApiError.errorCode`                       |
+| `client/src/pages/fund-scenario-workspace.tsx`                            | Modify — import helpers, add state + button cluster + modal mount + highlight state |
+| `tests/unit/lib/queryClient.test.ts`                                      | Create — `apiRequest` error code preservation (blocker)                             |
+| `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx` | Create — 19 modal cases + payload builder cases                                     |
+| `tests/unit/pages/fund-scenario-workspace.test.tsx`                       | Modify — thin integration: button renders + opens modal                             |

--- a/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
+++ b/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
@@ -1,0 +1,494 @@
+# C1: Methodology Scenario Creation UI — Design Spec
+
+**Date:** 2026-06-08 **Branch:** main (off `46373b70`, #817) **Goal:** Add a
+"New methodology scenario" modal to the workspace so GPs can create a
+`methodology` scenario set with one variant directly from the UI, without a
+direct API call.
+
+---
+
+## Scope
+
+Methodology-only, one variant per creation. `waterfallTiers` excluded — tier
+editing is a separate workflow. `waterfallType` and `managementFeeRate` are the
+only exposed override fields.
+
+---
+
+## Problem
+
+The scenario workspace (`/fund-model-results/:fundId/scenarios`) is
+read/calculate-only. The only creation action today is "Create optimized reserve
+plan" (a specialized reserve path). Creating a `methodology`, `fee_profile`,
+`allocation`, or `sector_profile` scenario set requires a direct API call. The
+backend create path (`POST /api/funds/:fundId/scenario-sets`,
+`createFundScenarioSet` service, `CreateFundScenarioSetV1Schema`) is fully
+implemented and tested.
+
+---
+
+## Non-Goals
+
+- No `waterfallTiers` field in this modal.
+- No multi-variant form (one variant only in this pass).
+- No `fee_profile`, `allocation`, or `sector_profile` creation forms.
+- No new API routes or schema changes.
+- No changes to the comparison or calculation surfaces.
+
+---
+
+## Section 1: Architecture + Component Interface
+
+**New file:**
+`client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`
+
+The modal is a self-contained feature component. Public interface:
+
+```ts
+interface CreateMethodologyScenarioModalProps {
+  fundId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: (created: FundScenarioSetDetailV1) => void;
+}
+```
+
+`fundId` is the validated numeric string from the workspace route. `onSuccess`
+receives the created detail so the workspace can optionally highlight it.
+`onOpenChange` follows shadcn Dialog convention — workspace passes
+`setIsCreateMethodologyOpen`.
+
+The mutation (`useMutation`) and cache invalidation
+(`queryClient.invalidateQueries`) live inside the modal. The workspace
+`onSuccess` callback is a downstream hook for selection, scroll, or toast — not
+responsible for cache invalidation.
+
+**Query key extraction:**
+
+New file: `client/src/lib/fund-scenario-workspace-query-keys.ts`
+
+Extracts the cache key helpers currently private to
+`fund-scenario-workspace.tsx` so both the workspace page and modal share the
+same cache root without duplicating literals:
+
+```ts
+export function workspaceQueryKey(fundId: string) {
+  return ['fund-scenario-workspace', fundId] as const;
+}
+export function scenarioSetListQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'scenario-sets'] as const;
+}
+export function scenarioSetDetailQueryKey(
+  fundId: string,
+  scenarioSetId: string
+) {
+  return [
+    ...workspaceQueryKey(fundId),
+    'scenario-sets',
+    scenarioSetId,
+    'detail',
+  ] as const;
+}
+export function scenarioSetStatusQueryKey(
+  fundId: string,
+  scenarioSetId: string
+) {
+  return [
+    ...workspaceQueryKey(fundId),
+    'scenario-sets',
+    scenarioSetId,
+    'status',
+  ] as const;
+}
+export function fundResultsQueryKey(fundId: string) {
+  return [...workspaceQueryKey(fundId), 'results'] as const;
+}
+export function scenarioComparisonQueryKey(
+  fundId: string,
+  scenarioSetId: string
+) {
+  return [
+    ...workspaceQueryKey(fundId),
+    'scenario-sets',
+    scenarioSetId,
+    'comparison',
+  ] as const;
+}
+```
+
+`fund-scenario-workspace.tsx` replaces its local definitions with imports from
+this module.
+
+**Workspace integration:**
+
+```tsx
+// State
+const [isCreateMethodologyOpen, setIsCreateMethodologyOpen] = useState(false);
+
+// Header (right-side button cluster)
+<div className="flex flex-wrap items-center justify-between gap-3">
+  <Button asChild variant="outline" size="sm">
+    <Link href={`/fund-model-results/${fundId}`}>
+      <ArrowLeft className="h-4 w-4" />
+      Back to Results
+    </Link>
+  </Button>
+  <div className="flex flex-wrap items-center gap-2">
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => setIsCreateMethodologyOpen(true)}
+    >
+      New methodology scenario
+    </Button>
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={createReserveOptimizationMutation.isPending}
+      onClick={() => createReserveOptimizationMutation.mutate()}
+    >
+      {createReserveOptimizationMutation.isPending && (
+        <RefreshCw className="h-4 w-4 animate-spin" />
+      )}
+      {createReserveOptimizationMutation.isPending ? 'Creating' : 'Create optimized reserve plan'}
+    </Button>
+  </div>
+</div>
+
+// Modal mount
+<CreateMethodologyScenarioModal
+  fundId={fundId}
+  open={isCreateMethodologyOpen}
+  onOpenChange={setIsCreateMethodologyOpen}
+  onSuccess={() => {}}
+/>
+```
+
+---
+
+## Section 2: Form Schema + Submission Shape
+
+**Client-side form schema:**
+
+```ts
+const OptionalPercentageNumberSchema = z.preprocess((value) => {
+  if (value === '' || value === null || value === undefined) return undefined;
+  if (typeof value === 'number' && Number.isNaN(value)) return undefined;
+  return Number(value);
+}, z.number().min(0).max(100).optional());
+
+const CreateMethodologyScenarioFormSchema = z
+  .object({
+    scenarioSetName: z.string().trim().min(1, 'Required').max(120),
+    variantName: z.string().trim().min(1, 'Required').max(120),
+    waterfallType: z.enum(['american', 'hybrid']).optional(),
+    managementFeeRate: OptionalPercentageNumberSchema,
+  })
+  .refine(
+    (data) =>
+      data.waterfallType !== undefined || data.managementFeeRate !== undefined,
+    {
+      message:
+        'Specify at least one override: waterfall type or management fee rate.',
+      path: ['waterfallType'],
+    }
+  );
+
+type CreateMethodologyScenarioFormValues = z.infer<
+  typeof CreateMethodologyScenarioFormSchema
+>;
+```
+
+The `.refine` error is placed on `waterfallType` so it surfaces near the first
+override field.
+
+**Payload transform (exported, independently testable):**
+
+```ts
+export function buildCreateMethodologyScenarioPayload(
+  values: CreateMethodologyScenarioFormValues
+): CreateFundScenarioSetV1 {
+  return {
+    name: values.scenarioSetName,
+    variants: [
+      {
+        name: values.variantName,
+        override: {
+          overrideType: 'methodology',
+          payload: {
+            ...(values.waterfallType
+              ? { waterfallType: values.waterfallType }
+              : {}),
+            ...(values.managementFeeRate !== undefined
+              ? { managementFeeRate: values.managementFeeRate }
+              : {}),
+          },
+        },
+      },
+    ],
+  };
+}
+```
+
+`managementFeeRate` is submitted as the percentage value (e.g., `2` for 2%) —
+matching `FundDraftWriteV1Schema` convention. Do not divide by 100 in the modal.
+
+---
+
+## Section 3: Component Internals
+
+### apiRequest update (prerequisite)
+
+The current `apiRequest` reads `errorData.error` into `ApiError.errorCode` but
+not `errorData.code`. The server route emits both `error` (generic HTTP reason)
+and `code` (specific, e.g., `duplicate_scenario_set_name`). Update `apiRequest`
+once, backward-compatibly:
+
+```ts
+type ErrorBody = {
+  message?: string;
+  error?: string;
+  code?: string;
+  issues?: Array<{ path: (string | number)[]; message: string }>;
+};
+const errorData = (await response
+  .json()
+  .catch(() => ({}) as ErrorBody)) as ErrorBody;
+const errorMessage =
+  errorData.message ||
+  errorData.error ||
+  `API request failed: ${response.statusText}`;
+const errorCode = errorData.code ?? errorData.error;
+throw new ApiError(response.status, errorMessage, errorCode, errorData.issues);
+```
+
+The modal then uses:
+
+```ts
+import { ApiError } from '@/lib/queryClient';
+function extractErrorCode(error: unknown): string | null {
+  return error instanceof ApiError ? (error.errorCode ?? null) : null;
+}
+```
+
+### Form setup
+
+```ts
+const form = useForm<CreateMethodologyScenarioFormValues>({
+  resolver: zodResolver(CreateMethodologyScenarioFormSchema),
+  defaultValues: {
+    scenarioSetName: '',
+    variantName: '',
+    waterfallType: undefined,
+    managementFeeRate: undefined,
+  },
+});
+```
+
+### Mutation
+
+```ts
+const queryClient = useQueryClient();
+const [serverError, setServerError] = useState<string | null>(null);
+
+const createMutation = useMutation({
+  mutationFn: (payload: CreateFundScenarioSetV1) =>
+    apiRequest(
+      'POST',
+      `/api/funds/${encodeURIComponent(fundId)}/scenario-sets`,
+      payload
+    ).then((raw) => FundScenarioSetDetailV1Schema.parse(raw)),
+  onMutate: () => {
+    setServerError(null);
+  },
+  onSuccess: async (created) => {
+    await queryClient.invalidateQueries({
+      queryKey: workspaceQueryKey(fundId),
+    });
+    form.reset();
+    setServerError(null);
+    onOpenChange(false);
+    onSuccess(created);
+  },
+  onError: (error) => {
+    const code = extractErrorCode(error);
+    if (code === 'duplicate_scenario_set_name') {
+      form.setError('scenarioSetName', {
+        message: 'A scenario set with this name already exists.',
+      });
+    } else if (code === 'max_scenario_sets') {
+      setServerError(
+        'This fund has reached the maximum of 10 active scenario sets.'
+      );
+    } else if (code === 'no_published_config') {
+      setServerError('Publish a fund configuration before creating scenarios.');
+    } else {
+      setServerError('Failed to create scenario. Please try again.');
+    }
+  },
+});
+```
+
+### Close guard
+
+```ts
+function handleOpenChange(nextOpen: boolean) {
+  if (!nextOpen && createMutation.isPending) return;
+  if (!nextOpen) {
+    form.reset();
+    setServerError(null);
+  }
+  onOpenChange(nextOpen);
+}
+
+// <Dialog open={open} onOpenChange={handleOpenChange}>
+```
+
+### Waterfall select sentinel
+
+```ts
+const WATERFALL_UNSET_VALUE = '__unset__';
+
+// In the Controller render:
+<Select
+  value={field.value ?? WATERFALL_UNSET_VALUE}
+  onValueChange={(value) =>
+    field.onChange(value === WATERFALL_UNSET_VALUE ? undefined : value)
+  }
+>
+  <SelectItem value={WATERFALL_UNSET_VALUE}>No change</SelectItem>
+  <SelectItem value="american">American</SelectItem>
+  <SelectItem value="hybrid">Hybrid</SelectItem>
+</Select>
+```
+
+### Field layout
+
+```
+DialogHeader → "New methodology scenario"
+──────────────────────────────────────────────
+Label: Scenario set name    [Input]            ← required, error below
+Label: Variant name         [Input]            ← required, error below
+──────────────────────────────────────────────
+At least one override required:
+Label: Waterfall type       [Select]           ← cross-field error appears here
+Label: Management fee rate  [Input type=number, "%" suffix]
+──────────────────────────────────────────────
+[server error alert banner if present]
+──────────────────────────────────────────────
+DialogFooter:  [Cancel]  [Create scenario]     ← Create disabled while isPending
+```
+
+`managementFeeRate` uses
+`{...form.register('managementFeeRate', { valueAsNumber: true })}`. The
+`z.preprocess` handles `NaN` from an empty number input.
+
+---
+
+## Section 4: Tests
+
+### 4a. `tests/unit/lib/queryClient.test.ts` (new file)
+
+**Case: `apiRequest` preserves specific server error code**
+
+Mock a 409 response body
+`{ error: 'conflict', code: 'duplicate_scenario_set_name', message: '...' }`.
+Assert that the thrown `ApiError.errorCode === 'duplicate_scenario_set_name'`
+(not `'conflict'`).
+
+This is a required blocker — without the `apiRequest` fix, the modal cannot
+distinguish specific server errors.
+
+### 4b. `buildCreateMethodologyScenarioPayload` unit tests
+
+Four cases (inline in the modal test file or a separate util test):
+
+- **waterfallType only** — payload contains `{ waterfallType: 'american' }`, no
+  `managementFeeRate` key
+- **managementFeeRate only** — payload contains `{ managementFeeRate: 2 }`, no
+  `waterfallType` key
+- **both fields** — payload contains both keys
+- **name mapping** — `scenarioSetName` maps to `payload.name`; `variantName`
+  maps to `payload.variants[0].name`
+
+### 4c. `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx` (new file)
+
+| Case                                  | Setup                                                                | Assert                                                                                                                    |
+| ------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Renders fields when open              | `open=true`                                                          | Name, variant name, waterfall type, fee rate fields present                                                               |
+| Hidden when closed                    | `open=false`                                                         | Dialog content not in DOM                                                                                                 |
+| Empty submit shows required errors    | Submit without filling                                               | "Required" under name + variant name                                                                                      |
+| Cross-field refine                    | Fill both name fields, leave both override fields unset, submit      | Cross-field error near waterfall select                                                                                   |
+| Valid submit (waterfallType only)     | Fill names + select 'american', submit                               | `fetch` called with `{ overrideType: 'methodology', payload: { waterfallType: 'american' } }`, no `managementFeeRate` key |
+| Valid submit (managementFeeRate only) | Fill names + type fee rate, submit                                   | `fetch` called with `{ managementFeeRate: 2 }`, no `waterfallType` key                                                    |
+| Duplicate name error                  | Mock 409 `duplicate_scenario_set_name`                               | Field error under scenario set name field                                                                                 |
+| Max sets error                        | Mock 409 `max_scenario_sets`                                         | Alert banner with max-sets message                                                                                        |
+| No published config error             | Mock 409 `no_published_config`                                       | Alert banner with publish-config message                                                                                  |
+| Submit disabled while pending         | Mock fetch with deferred promise                                     | Create button is disabled                                                                                                 |
+| Close blocked while pending           | Mock fetch with deferred promise, click Cancel                       | `onOpenChange` not called                                                                                                 |
+| Reset on close                        | Parent harness: open → fill fields → close → reopen                  | Fields show default values                                                                                                |
+| onSuccess called with detail          | Mock successful response with full `FundScenarioSetDetailV1` fixture | `onSuccess` called with the parsed detail                                                                                 |
+| Cache invalidated on success          | Spy on `queryClient.invalidateQueries`                               | Called with `{ queryKey: workspaceQueryKey(fundId) }`                                                                     |
+
+**Notes on specific cases:**
+
+- Pending-state tests need a manually controlled deferred promise (resolve never
+  called during assertion).
+- Close-blocked test: prefer clicking Cancel button (which should be
+  disabled/guarded while pending) or use the `handleOpenChange` guard directly.
+- Reset-on-close: requires a small wrapper component owning `open` state.
+- Success fixture: must be a complete `FundScenarioSetDetailV1` including all
+  required summary fields + `variants` array; partial fixtures fail schema
+  parsing.
+
+### 4d. `tests/unit/pages/fund-scenario-workspace.test.tsx` — thin integration addition
+
+Add to the primary workspace test ("loads scenario sets without polling reserve
+status for sync sets"):
+
+```ts
+// "New methodology scenario" button renders
+expect(
+  screen.getByRole('button', { name: /new methodology scenario/i })
+).toBeInTheDocument();
+
+// Clicking it opens the modal (no POST issued)
+fireEvent.click(
+  screen.getByRole('button', { name: /new methodology scenario/i })
+);
+// Modal dialog appears
+expect(await screen.findByRole('dialog')).toBeInTheDocument();
+// No create POST issued merely by opening the modal
+const createCalls = fetchSpy.mock.calls.filter(
+  ([url, init]) =>
+    typeof url === 'string' &&
+    url.includes('/scenario-sets') &&
+    (init?.method ?? 'GET') === 'POST' &&
+    !url.includes('/reserve-optimization') &&
+    !url.includes('/calculate')
+);
+expect(createCalls).toHaveLength(0);
+```
+
+### Gates
+
+```
+npm run test:scenario-release-gate   # must pass before PR
+npm run check                        # zero TypeScript errors
+npm run lint                         # zero lint errors
+```
+
+---
+
+## File Summary
+
+| File                                                                      | Action                                                                            |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `client/src/lib/fund-scenario-workspace-query-keys.ts`                    | Create — query key helpers extracted from workspace page                          |
+| `client/src/components/scenarios/CreateMethodologyScenarioModal.tsx`      | Create — modal component                                                          |
+| `client/src/lib/queryClient.ts`                                           | Modify — preserve `code` field from server error response in `ApiError.errorCode` |
+| `client/src/pages/fund-scenario-workspace.tsx`                            | Modify — import query keys, add state + button + modal mount                      |
+| `tests/unit/lib/queryClient.test.ts`                                      | Create — `apiRequest` error code preservation                                     |
+| `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx` | Create — modal unit tests (14 cases)                                              |
+| `tests/unit/pages/fund-scenario-workspace.test.tsx`                       | Modify — thin integration: button renders + opens modal                           |

--- a/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
+++ b/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
@@ -1,3 +1,10 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-06-08
+owner: 'Platform Team'
+---
+
 # C1: Methodology Scenario Creation UI — Design Spec
 
 **Date:** 2026-06-08 **Branch:** main (off `46373b70`, #817) **Goal:** Add a

--- a/server/services/fund-scenario-calculation-service.ts
+++ b/server/services/fund-scenario-calculation-service.ts
@@ -381,6 +381,60 @@ function applyFeeProfileOverride(
   };
 }
 
+function percentToRatio(percent: number): number {
+  return percent / 100;
+}
+
+function applyMethodologyOverride(
+  sourceConfig: FundDraftWriteV1,
+  override: Extract<FundScenarioVariantOverrideV1, { overrideType: 'methodology' }>
+): FundDraftWriteV1 {
+  const { payload } = override;
+  let variantConfig: FundDraftWriteV1 = {
+    ...sourceConfig,
+    ...(payload.waterfallType !== undefined && {
+      waterfallType: payload.waterfallType,
+    }),
+    ...(payload.waterfallTiers !== undefined && {
+      waterfallTiers: payload.waterfallTiers,
+    }),
+  };
+
+  if (payload.managementFeeRate !== undefined) {
+    variantConfig = {
+      ...variantConfig,
+      managementFeeRate: payload.managementFeeRate,
+      feeProfiles: undefined,
+    };
+  }
+
+  const economicsAssumptions = sourceConfig.economicsAssumptions;
+  if (economicsAssumptions == null) {
+    return variantConfig;
+  }
+
+  const nextEconomicsAssumptions = { ...economicsAssumptions };
+
+  if (payload.managementFeeRate !== undefined) {
+    nextEconomicsAssumptions.feeModel = {
+      source: 'economics_override',
+      defaultRate: percentToRatio(payload.managementFeeRate),
+      ...(economicsAssumptions.feeModel?.defaultBasis !== undefined && {
+        defaultBasis: economicsAssumptions.feeModel.defaultBasis,
+      }),
+    };
+  }
+
+  if (payload.waterfallType !== undefined || payload.waterfallTiers !== undefined) {
+    delete nextEconomicsAssumptions.waterfallModel;
+  }
+
+  return {
+    ...variantConfig,
+    economicsAssumptions: nextEconomicsAssumptions,
+  };
+}
+
 function isSyncScenarioOverride(
   override: FundScenarioVariantOverrideV1
 ): override is SyncScenarioVariantOverride {
@@ -417,18 +471,7 @@ function applySyncScenarioOverride(
   }
 
   if (override.overrideType === 'methodology') {
-    return {
-      ...sourceConfig,
-      ...(override.payload.waterfallType !== undefined && {
-        waterfallType: override.payload.waterfallType,
-      }),
-      ...(override.payload.waterfallTiers !== undefined && {
-        waterfallTiers: override.payload.waterfallTiers,
-      }),
-      ...(override.payload.managementFeeRate !== undefined && {
-        managementFeeRate: override.payload.managementFeeRate,
-      }),
-    };
+    return applyMethodologyOverride(sourceConfig, override);
   }
 
   return {

--- a/tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
+++ b/tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
@@ -176,6 +176,7 @@ describe('CreateMethodologyScenarioModal', () => {
     expect(screen.getByLabelText(/variant name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/waterfall type/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/management fee rate/i)).toBeInTheDocument();
+    expect(screen.getByText(/create one scenario variant/i)).toBeInTheDocument();
   });
 
   it('does not render dialog content when closed', () => {
@@ -244,6 +245,12 @@ describe('CreateMethodologyScenarioModal', () => {
     expect(body.variants[0].override.overrideType).toBe('methodology');
     expect(body.variants[0].override.payload).toEqual({ managementFeeRate: 2 });
     expect('waterfallType' in body.variants[0].override.payload).toBe(false);
+    expect(init.headers).toEqual(
+      expect.objectContaining({
+        'Content-Type': 'application/json',
+        'Idempotency-Key': expect.any(String),
+      })
+    );
   });
 
   it('shows duplicate_scenario_set_name error under name field', async () => {

--- a/tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
+++ b/tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
@@ -1,0 +1,409 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CreateMethodologyScenarioModal,
+  buildCreateMethodologyScenarioPayload,
+} from '../../../../client/src/components/scenarios/CreateMethodologyScenarioModal';
+import type { FundScenarioSetDetailV1 } from '../../../../shared/contracts/fund-scenario-sets-v1.contract';
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+interface ModalProps {
+  fundId?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onSuccess?: (created: FundScenarioSetDetailV1) => void;
+}
+
+function renderModal(props: ModalProps = {}) {
+  const queryClient = makeQueryClient();
+  const onOpenChange = props.onOpenChange ?? vi.fn();
+  const onSuccess = props.onSuccess ?? vi.fn();
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <CreateMethodologyScenarioModal
+        fundId={props.fundId ?? '123'}
+        open={props.open ?? true}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+      />
+    </QueryClientProvider>
+  );
+  return { ...result, queryClient, onOpenChange, onSuccess };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function errorResponse(status: number, code: string, message: string) {
+  return jsonResponse({ error: 'error', code, message }, status);
+}
+
+function makeCreatedDetail(): FundScenarioSetDetailV1 {
+  return {
+    id: '00000000-0000-0000-0000-000000000711',
+    fundId: 123,
+    name: 'American waterfall test',
+    description: null,
+    sourceConfigId: 12,
+    sourceConfigVersion: 4,
+    variantCount: 1,
+    archivedAt: null,
+    archivedByUserId: null,
+    archivedByLabel: null,
+    createdByUserId: 17,
+    createdByLabel: 'analyst@example.com',
+    updatedByUserId: 17,
+    updatedByLabel: 'analyst@example.com',
+    createdAt: '2026-06-08T12:00:00.000Z',
+    updatedAt: '2026-06-08T12:00:00.000Z',
+    variants: [
+      {
+        id: '00000000-0000-0000-0000-000000000712',
+        scenarioSetId: '00000000-0000-0000-0000-000000000711',
+        name: 'American variant',
+        description: null,
+        sortOrder: 0,
+        override: { overrideType: 'methodology', payload: { waterfallType: 'american' } },
+        createdAt: '2026-06-08T12:00:00.000Z',
+        updatedAt: '2026-06-08T12:00:00.000Z',
+      },
+    ],
+  };
+}
+
+// ─── payload builder ─────────────────────────────────────────────────────────
+
+describe('buildCreateMethodologyScenarioPayload', () => {
+  it('builds payload with waterfallType only', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'My set',
+      variantName: 'My variant',
+      waterfallType: 'american',
+      managementFeeRate: undefined,
+    });
+    expect(result.name).toBe('My set');
+    expect(result.variants[0]?.name).toBe('My variant');
+    expect(result.variants[0]?.override.overrideType).toBe('methodology');
+    expect(result.variants[0]?.override.payload).toEqual({ waterfallType: 'american' });
+    expect('managementFeeRate' in (result.variants[0]?.override.payload ?? {})).toBe(false);
+  });
+
+  it('builds payload with managementFeeRate only', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Fee test',
+      variantName: 'Fee variant',
+      waterfallType: undefined,
+      managementFeeRate: 2,
+    });
+    expect(result.variants[0]?.override.payload).toEqual({ managementFeeRate: 2 });
+    expect('waterfallType' in (result.variants[0]?.override.payload ?? {})).toBe(false);
+  });
+
+  it('builds payload with both fields', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Both',
+      variantName: 'Both variant',
+      waterfallType: 'hybrid',
+      managementFeeRate: 2.5,
+    });
+    expect(result.variants[0]?.override.payload).toEqual({
+      waterfallType: 'hybrid',
+      managementFeeRate: 2.5,
+    });
+  });
+
+  it('submits decimal fee as percentage, not divided by 100', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Decimal',
+      variantName: 'v',
+      waterfallType: undefined,
+      managementFeeRate: 2.5,
+    });
+    const payload = result.variants[0]?.override.payload as { managementFeeRate: number };
+    expect(payload.managementFeeRate).toBe(2.5);
+  });
+
+  it('submits zero fee as a real override value', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Zero',
+      variantName: 'v',
+      waterfallType: undefined,
+      managementFeeRate: 0,
+    });
+    expect(result.variants[0]?.override.payload).toEqual({ managementFeeRate: 0 });
+  });
+
+  it('maps scenarioSetName to name and variantName to variants[0].name', () => {
+    const result = buildCreateMethodologyScenarioPayload({
+      scenarioSetName: 'Set name',
+      variantName: 'Variant name',
+      waterfallType: 'american',
+      managementFeeRate: undefined,
+    });
+    expect(result.name).toBe('Set name');
+    expect(result.variants[0]?.name).toBe('Variant name');
+  });
+});
+
+// ─── modal component ─────────────────────────────────────────────────────────
+
+describe('CreateMethodologyScenarioModal', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders all four form fields when open', () => {
+    renderModal();
+    expect(screen.getByLabelText(/scenario set name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/variant name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/waterfall type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/management fee rate/i)).toBeInTheDocument();
+  });
+
+  it('does not render dialog content when closed', () => {
+    renderModal({ open: false });
+    expect(screen.queryByLabelText(/scenario set name/i)).not.toBeInTheDocument();
+  });
+
+  it('shows required errors under name fields on empty submit', async () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(await screen.findAllByText('Required')).toHaveLength(2);
+  });
+
+  it('shows cross-field error when names filled but no override specified', async () => {
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'My set' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'My variant' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(await screen.findByText(/specify at least one override/i)).toBeInTheDocument();
+  });
+
+  it('does not POST when fee rate is negative', async () => {
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), { target: { value: 'S' } });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '-1', valueAsNumber: -1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not POST when fee rate is above 100', async () => {
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), { target: { value: 'S' } });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '101', valueAsNumber: 101 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('POSTs correct body with managementFeeRate only', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeCreatedDetail()));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'Fee set' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'Fee v' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.variants[0].override.overrideType).toBe('methodology');
+    expect(body.variants[0].override.payload).toEqual({ managementFeeRate: 2 });
+    expect('waterfallType' in body.variants[0].override.payload).toBe(false);
+  });
+
+  it('shows duplicate_scenario_set_name error under name field', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      errorResponse(409, 'duplicate_scenario_set_name', 'Already exists')
+    );
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), { target: { value: 'S' } });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(
+      await screen.findByText(/a scenario set with this name already exists/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows max_scenario_sets banner', async () => {
+    fetchSpy.mockResolvedValueOnce(errorResponse(409, 'max_scenario_sets', 'Max reached'));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), { target: { value: 'S' } });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(await screen.findByText(/maximum of 10 active scenario sets/i)).toBeInTheDocument();
+  });
+
+  it('shows no_published_config banner', async () => {
+    fetchSpy.mockResolvedValueOnce(errorResponse(409, 'no_published_config', 'No config'));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), { target: { value: 'S' } });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    expect(await screen.findByText(/publish a fund configuration/i)).toBeInTheDocument();
+  });
+
+  it('disables Create button while mutation is pending', async () => {
+    fetchSpy.mockReturnValueOnce(new Promise(() => {}));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), { target: { value: 'S' } });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /creating/i })).toBeDisabled();
+    });
+  });
+
+  it('blocks close while mutation is pending', async () => {
+    fetchSpy.mockReturnValueOnce(new Promise(() => {}));
+    const onOpenChange = vi.fn();
+    renderModal({ onOpenChange });
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), { target: { value: 'S' } });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it('resets form on close and re-open', async () => {
+    function Harness() {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <button onClick={() => setOpen((o) => !o)}>Toggle</button>
+          <QueryClientProvider client={makeQueryClient()}>
+            <CreateMethodologyScenarioModal
+              fundId="123"
+              open={open}
+              onOpenChange={setOpen}
+              onSuccess={vi.fn()}
+            />
+          </QueryClientProvider>
+        </>
+      );
+    }
+    render(<Harness />);
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'Filled' },
+    });
+    expect(screen.getByLabelText(/scenario set name/i)).toHaveValue('Filled');
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    fireEvent.click(screen.getByRole('button', { name: /toggle/i }));
+    expect(await screen.findByLabelText(/scenario set name/i)).toHaveValue('');
+  });
+
+  it('calls onSuccess with the created detail', async () => {
+    const detail = makeCreatedDetail();
+    fetchSpy.mockResolvedValueOnce(jsonResponse(detail));
+    const onSuccess = vi.fn();
+    renderModal({ onSuccess });
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'American waterfall test' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'American variant' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() =>
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ id: detail.id }))
+    );
+  });
+
+  it('invalidates workspace query on success', async () => {
+    const detail = makeCreatedDetail();
+    fetchSpy.mockResolvedValueOnce(jsonResponse(detail));
+    const { queryClient } = renderModal();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'American waterfall test' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'American variant' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['fund-scenario-workspace', '123'] })
+      );
+    });
+  });
+
+  it('seeds detail query cache on success', async () => {
+    const detail = makeCreatedDetail();
+    fetchSpy.mockResolvedValueOnce(jsonResponse(detail));
+    const { queryClient } = renderModal();
+    const setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData');
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'American waterfall test' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), {
+      target: { value: 'American variant' },
+    });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => {
+      expect(setQueryDataSpy).toHaveBeenCalledWith(
+        ['fund-scenario-workspace', '123', 'scenario-sets', detail.id, 'detail'],
+        expect.objectContaining({ id: detail.id })
+      );
+    });
+  });
+});

--- a/tests/unit/lib/fund-scenario-workspace-api.test.ts
+++ b/tests/unit/lib/fund-scenario-workspace-api.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertFundId,
+  assertScenarioSetId,
+  scenarioApiPath,
+  scenarioSetApiPath,
+} from '../../../client/src/lib/fund-scenario-workspace-api';
+
+const VALID_UUID = '00000000-0000-0000-0000-000000000111';
+
+describe('assertFundId', () => {
+  it('accepts numeric strings', () => {
+    expect(() => assertFundId('123')).not.toThrow();
+  });
+  it('rejects non-numeric strings', () => {
+    expect(() => assertFundId('abc')).toThrow('Invalid fund ID');
+  });
+  it('rejects empty string', () => {
+    expect(() => assertFundId('')).toThrow('Invalid fund ID');
+  });
+  it('rejects strings with non-digit characters', () => {
+    expect(() => assertFundId('1e1')).toThrow('Invalid fund ID');
+  });
+});
+
+describe('assertScenarioSetId', () => {
+  it('accepts valid UUID', () => {
+    expect(() => assertScenarioSetId(VALID_UUID)).not.toThrow();
+  });
+  it('rejects non-UUID strings', () => {
+    expect(() => assertScenarioSetId('not-a-uuid')).toThrow('Invalid scenario set ID');
+  });
+});
+
+describe('scenarioApiPath', () => {
+  it('builds correct path for valid fundId', () => {
+    expect(scenarioApiPath('123', '/scenario-sets')).toBe('/api/funds/123/scenario-sets');
+  });
+  it('throws for invalid fundId', () => {
+    expect(() => scenarioApiPath('abc', '/scenario-sets')).toThrow('Invalid fund ID');
+  });
+});
+
+describe('scenarioSetApiPath', () => {
+  it('builds correct path for valid ids', () => {
+    expect(scenarioSetApiPath('123', VALID_UUID)).toBe(
+      `/api/funds/123/scenario-sets/${VALID_UUID}`
+    );
+  });
+  it('appends suffix when provided', () => {
+    expect(scenarioSetApiPath('123', VALID_UUID, '/calculate')).toBe(
+      `/api/funds/123/scenario-sets/${VALID_UUID}/calculate`
+    );
+  });
+});

--- a/tests/unit/lib/queryClient.test.ts
+++ b/tests/unit/lib/queryClient.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest, ApiError } from '../../../client/src/lib/queryClient';
+
+describe('apiRequest', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves specific server error code over generic error field', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'conflict',
+          code: 'duplicate_scenario_set_name',
+          message: 'Already exists',
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const err = await apiRequest('POST', '/api/test', {}).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).errorCode).toBe('duplicate_scenario_set_name');
+  });
+
+  it('falls back to generic error field when no specific code', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'not_found', message: 'Not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const err = await apiRequest('GET', '/api/test').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).errorCode).toBe('not_found');
+  });
+
+  it('does not crash when response includes a details field', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'invalid_request',
+          message: 'Bad input',
+          details: { issues: [{ path: ['name'], message: 'Required' }] },
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const err = await apiRequest('POST', '/api/test', {}).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).errorCode).toBe('invalid_request');
+  });
+});

--- a/tests/unit/lib/queryClient.test.ts
+++ b/tests/unit/lib/queryClient.test.ts
@@ -52,4 +52,33 @@ describe('apiRequest', () => {
     expect(err).toBeInstanceOf(ApiError);
     expect((err as ApiError).errorCode).toBe('invalid_request');
   });
+
+  it('merges caller-provided headers into the request', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await apiRequest(
+      'POST',
+      '/api/test',
+      { name: 'Scenario' },
+      {
+        headers: { 'Idempotency-Key': 'scenario-create-1' },
+      }
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/test',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'scenario-create-1',
+        }),
+      })
+    );
+  });
 });

--- a/tests/unit/pages/fund-scenario-workspace.test.tsx
+++ b/tests/unit/pages/fund-scenario-workspace.test.tsx
@@ -540,6 +540,29 @@ describe('FundScenarioWorkspacePage', () => {
     expect(screen.getByText('Invalid scenario workspace route')).toBeInTheDocument();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it('renders New methodology scenario button and opens modal on click', async () => {
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    const newScenarioBtn = await screen.findByRole('button', {
+      name: /new methodology scenario/i,
+    });
+    expect(newScenarioBtn).toBeInTheDocument();
+
+    fireEvent.click(newScenarioBtn);
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+    // No create POST issued merely by opening the modal
+    const createPosts = (fetchSpy.mock.calls as [string, RequestInit][]).filter(
+      ([url, init]) =>
+        url.includes('/scenario-sets') &&
+        (init?.method ?? 'GET') === 'POST' &&
+        !url.includes('/reserve-optimization') &&
+        !url.includes('/calculate')
+    );
+    expect(createPosts).toHaveLength(0);
+  });
 });
 
 function jsonResponse(body: unknown) {

--- a/tests/unit/services/fund-scenario-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-calculation-service.test.ts
@@ -92,6 +92,14 @@ const sectorProfileOverride = {
   },
 } as const;
 
+const methodologyOverride = {
+  overrideType: 'methodology',
+  payload: {
+    waterfallType: 'hybrid',
+    managementFeeRate: 3,
+  },
+} as const;
+
 const baseConfig = {
   fundName: 'Test Fund',
   fundSize: 100_000_000,
@@ -292,8 +300,12 @@ function calculationRunRow(
   status: 'queued' | 'running' | 'completed',
   snapshotId: number | null = null,
   options: {
-    calculationMode?: 'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile';
-    overrideType?: 'fee_profile' | 'allocation' | 'sector_profile';
+    calculationMode?:
+      | 'sync_fee_profile'
+      | 'sync_allocation'
+      | 'sync_sector_profile'
+      | 'sync_methodology';
+    overrideType?: 'fee_profile' | 'allocation' | 'sector_profile' | 'methodology';
     inputHash?: string;
   } = {}
 ) {
@@ -320,9 +332,17 @@ function expectedInputHash(): string {
 }
 
 function expectedInputHashFor(
-  override: typeof feeProfileOverride | typeof allocationOverride | typeof sectorProfileOverride,
-  calculationMode: 'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile',
-  overrideType: 'fee_profile' | 'allocation' | 'sector_profile'
+  override:
+    | typeof feeProfileOverride
+    | typeof allocationOverride
+    | typeof sectorProfileOverride
+    | typeof methodologyOverride,
+  calculationMode:
+    | 'sync_fee_profile'
+    | 'sync_allocation'
+    | 'sync_sector_profile'
+    | 'sync_methodology',
+  overrideType: 'fee_profile' | 'allocation' | 'sector_profile' | 'methodology'
 ): string {
   return createScenarioInputHash({
     version: SCENARIO_INPUT_HASH_VERSION,
@@ -440,6 +460,79 @@ describe('fund scenario calculation service', () => {
         variant_count: 1,
       }),
     ]);
+  });
+
+  it('applies methodology overrides to nested economics assumptions before calculation', async () => {
+    const methodologyHash = expectedInputHashFor(
+      methodologyOverride,
+      'sync_methodology',
+      'methodology'
+    );
+    const methodologyRunOptions = {
+      calculationMode: 'sync_methodology' as const,
+      overrideType: 'methodology' as const,
+      inputHash: methodologyHash,
+    };
+
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [scenarioSetRow({ name: 'Methodology sensitivity' })] })
+      .mockResolvedValueOnce({ rows: [variantRow(methodologyOverride)] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 12,
+            version: 4,
+            config: {
+              ...baseConfig,
+              economicsAssumptions: explicitFeeTierEconomicsAssumptions,
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ version: 4 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [calculationRunRow('queued', null, methodologyRunOptions)] })
+      .mockResolvedValueOnce({ rows: [calculationRunRow('running', null, methodologyRunOptions)] })
+      .mockImplementationOnce((_sql: string, params: unknown[]) => ({
+        rows: [
+          {
+            id: 43,
+            payload: params[1],
+            correlation_id: params[3],
+            created_at: new Date('2026-05-26T12:05:00.000Z'),
+            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+          },
+        ],
+      }))
+      .mockResolvedValueOnce({ rows: [calculationRunRow('completed', 43, methodologyRunOptions)] })
+      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000127' }] });
+
+    const result = await calculateFundScenarioSet(1, scenarioSetId, {
+      userId: 17,
+      label: 'analyst@example.com',
+    });
+
+    expect(result.payload.calculationMode).toBe('sync_methodology');
+    expect(runEconomicsModelMock).toHaveBeenCalledTimes(1);
+
+    const calledConfig = runEconomicsModelMock.mock.calls[0]?.[0] as {
+      managementFeeRate?: number;
+      waterfallType?: string;
+      feeProfiles?: unknown;
+      economicsAssumptions?: {
+        feeModel?: unknown;
+        waterfallModel?: unknown;
+      };
+    };
+    expect(calledConfig.managementFeeRate).toBe(3);
+    expect(calledConfig.waterfallType).toBe('hybrid');
+    expect(calledConfig.feeProfiles).toBeUndefined();
+    expect(calledConfig.economicsAssumptions?.feeModel).toEqual({
+      source: 'economics_override',
+      defaultRate: 0.03,
+    });
+    expect(calledConfig.economicsAssumptions).not.toHaveProperty('waterfallModel');
   });
 
   it('applies allocation overrides through the sync scenario calculation path', async () => {


### PR DESCRIPTION
## Summary

- Fixes `apiRequest` to preserve the server's specific `code` field in `ApiError.errorCode` (was previously overwritten by the generic `error` field — `duplicate_scenario_set_name` became `conflict`)
- Extracts workspace cache-key helpers (`fund-scenario-workspace-query-keys.ts`) and API path helpers (`fund-scenario-workspace-api.ts`) from the workspace page into shared lib modules
- Adds `CreateMethodologyScenarioModal` — a shadcn Dialog with React Hook Form + Zod, supporting `waterfallType` (American/Hybrid select) and `managementFeeRate` (% input), with cross-field validation requiring at least one override field, structured server error handling (duplicate name → field error, max sets / no config → banner), pending-guard on close, and cache seeding on success
- Wires the modal into the workspace page with a two-button header cluster, `highlightedScenarioSetId` state to visually mark newly created cards, and a `ring-2 ring-charcoal` highlight on `ScenarioSetActionCard`

## Test plan

- [x] `fix(api)` regression test: `ApiError.errorCode === 'duplicate_scenario_set_name'` on a 409 with both `error` + `code` fields
- [x] Path helper unit tests: `assertFundId`, `assertScenarioSetId`, `scenarioApiPath`, `scenarioSetApiPath`
- [x] 22 modal tests: payload builder (6), form validation, cross-field refine, server error codes, pending state, close guard, reset on re-open, cache invalidation, cache seeding
- [x] Workspace integration: button renders, click opens modal, no premature POST
- [x] `npm run test:scenario-release-gate` — exit 0
- [x] `npm run check` — 0 TypeScript errors
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)