### PR TITLE
feat(scenarios): C3 async worker persistence — wire fund-scenario-calc in-process

### DIFF
--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -11063,6 +11063,35 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "categories": [
+          "planning",
+          "scenarios",
+          "workers"
+        ],
+        "keywords": [
+          "c3-scenario-async-worker",
+          "fund-scenario-calc",
+          "bullmq",
+          "reserve-allocation"
+        ],
+        "last_updated": "2026-06-09",
+        "owner": "Platform Team",
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": true,
+      "isStale": false,
+      "lastUpdated": "2026-06-09",
+      "owner": "Platform Team",
+      "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
+      "staleDays": 0,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {},
       "hasExecutionClaims": true,
       "isStale": true,
@@ -11116,6 +11145,35 @@
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
       "staleDays": 1,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "categories": [
+          "architecture",
+          "scenarios",
+          "workers"
+        ],
+        "keywords": [
+          "c3-scenario-async-worker",
+          "fund-scenario-calc",
+          "bullmq",
+          "reserve-allocation"
+        ],
+        "last_updated": "2026-06-09",
+        "owner": "Platform Team",
+        "review_cadence": "P180D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-09",
+      "owner": "Platform Team",
+      "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
+      "staleDays": 0,
       "status": "ACTIVE"
     },
     {
@@ -12712,7 +12770,7 @@
   ],
   "stats": {
     "by_status": {
-      "ACTIVE": 442,
+      "ACTIVE": 444,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 1,
@@ -12733,7 +12791,7 @@
     },
     "missing_frontmatter": 15,
     "stale_docs": 97,
-    "total_docs": 646
+    "total_docs": 648
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-06-09
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 646 |
+| Total Documents | 648 |
 | Stale Documents | 97 |
 | Missing Frontmatter | 15 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-06-09
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 442 |
+| ACTIVE | 444 |
 | UNKNOWN | 110 |
 | DRAFT | 30 |
 | HISTORICAL | 29 |

--- a/docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md
+++ b/docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md
@@ -1,0 +1,398 @@
+# C3: Scenario Async Worker Persistence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the fund-scenario-calc BullMQ worker in-process so
+reserve-allocation scenario jobs are consumed, calculated, and persisted —
+ending the infinite `queued` state.
+
+**Architecture:** The handler (`workers/fund-scenario-calc-handler.ts`) and
+worker module (`workers/fund-scenario-calc-worker.ts`) already exist and are
+unit-tested. The gap is a single missing init function in `server/queues/` that
+creates the BullMQ Worker using the IORedis connection supplied by
+`providers.ts`, and a one-line call to that function in
+`providers.ts::buildQueue()`. No other files change.
+
+**Tech Stack:** BullMQ, Node.js, TypeScript, Vitest
+
+---
+
+## File Map
+
+| File                                                       | Action     | Responsibility                                                                       |
+| ---------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------ |
+| `server/queues/fund-scenario-calc-worker-init.ts`          | **Create** | `initializeFundScenarioCalcWorker(redis)` — creates Worker, returns `{close}`        |
+| `server/providers.ts`                                      | **Modify** | Call `initializeFundScenarioCalcWorker(redis)` in `buildQueue()::Promise.allSettled` |
+| `tests/unit/queues/fund-scenario-calc-worker-init.test.ts` | **Create** | Unit tests for the init function                                                     |
+
+---
+
+## Task 1: Unit tests for `initializeFundScenarioCalcWorker`
+
+**Files:**
+
+- Create: `tests/unit/queues/fund-scenario-calc-worker-init.test.ts`
+
+These tests verify the init function creates a Worker with the correct queue
+name and settings, and that the returned `close()` function delegates to
+`worker.close()`. Write them first — they'll fail with an import error until
+Task 2 creates the implementation.
+
+- [ ] **Step 1: Create the test file**
+
+```typescript
+// tests/unit/queues/fund-scenario-calc-worker-init.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  workerConstructorMock,
+  workerOnMock,
+  workerCloseMock,
+  loggerInfoMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  workerConstructorMock: vi.fn(),
+  workerOnMock: vi.fn(),
+  workerCloseMock: vi.fn().mockResolvedValue(undefined),
+  loggerInfoMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Worker: function MockWorker(...args: unknown[]) {
+    workerConstructorMock(...args);
+    return { on: workerOnMock, close: workerCloseMock };
+  },
+}));
+
+vi.mock('../../../server/queues/redis-connection', () => ({
+  getBullMQConnection: vi
+    .fn()
+    .mockReturnValue({ host: 'localhost', port: 6379 }),
+}));
+
+vi.mock('../../../server/logger', () => ({
+  logger: { info: loggerInfoMock, error: loggerErrorMock },
+}));
+
+describe('initializeFundScenarioCalcWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a BullMQ Worker on the fund-scenario-calc queue with correct settings', async () => {
+    const { initializeFundScenarioCalcWorker } =
+      await import('../../../server/queues/fund-scenario-calc-worker-init');
+    const mockRedis = {} as import('ioredis').default;
+
+    await initializeFundScenarioCalcWorker(mockRedis);
+
+    expect(workerConstructorMock).toHaveBeenCalledWith(
+      'fund-scenario-calc',
+      expect.any(Function),
+      expect.objectContaining({ concurrency: 2, lockDuration: 300_000 })
+    );
+  });
+
+  it('returns a close function that calls worker.close()', async () => {
+    const { initializeFundScenarioCalcWorker } =
+      await import('../../../server/queues/fund-scenario-calc-worker-init');
+    const mockRedis = {} as import('ioredis').default;
+
+    const { close } = await initializeFundScenarioCalcWorker(mockRedis);
+    await close();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs startup on initialization', async () => {
+    const { initializeFundScenarioCalcWorker } =
+      await import('../../../server/queues/fund-scenario-calc-worker-init');
+    const mockRedis = {} as import('ioredis').default;
+
+    await initializeFundScenarioCalcWorker(mockRedis);
+
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      expect.stringContaining('[fund-scenario-calc]')
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail with import error**
+
+```
+npx cross-env TZ=UTC vitest run tests/unit/queues/fund-scenario-calc-worker-init.test.ts --project=server
+```
+
+Expected: 3 tests FAIL with
+`Cannot find module '../../../server/queues/fund-scenario-calc-worker-init'`
+
+---
+
+## Task 2: Create `server/queues/fund-scenario-calc-worker-init.ts`
+
+**Files:**
+
+- Create: `server/queues/fund-scenario-calc-worker-init.ts`
+
+The handler is lazy-imported (`await import(...)`) **inside** the processor
+callback to break the `server → workers → server` circular dependency that would
+occur with a static import.
+
+- [ ] **Step 1: Create the implementation file**
+
+```typescript
+// server/queues/fund-scenario-calc-worker-init.ts
+import type IORedis from 'ioredis';
+import { Worker, type Job } from 'bullmq';
+import { getBullMQConnection } from './redis-connection.js';
+import { logger } from '../logger.js';
+
+interface FundScenarioCalcJobData {
+  fundId: number;
+  scenarioSetId: string;
+  correlationId: string;
+  calculationMode: string;
+  actor: { userId: number | null; label: string | null } | null;
+}
+
+export async function initializeFundScenarioCalcWorker(
+  redis: IORedis
+): Promise<{ close: () => Promise<void> }> {
+  const connection = getBullMQConnection(redis);
+
+  // eslint-disable-next-line povc-security/require-bullmq-config -- lockDuration serves as timeout
+  const worker = new Worker<FundScenarioCalcJobData>(
+    'fund-scenario-calc',
+    async (job: Job<FundScenarioCalcJobData>) => {
+      const { handleFundScenarioCalcJob } =
+        await import('../../workers/fund-scenario-calc-handler.js');
+      return handleFundScenarioCalcJob(job);
+    },
+    {
+      connection,
+      concurrency: 2,
+      lockDuration: 300_000,
+    }
+  );
+
+  worker.on('completed', (job: Job<FundScenarioCalcJobData>) => {
+    logger.info('[fund-scenario-calc] Worker completed job', { jobId: job.id });
+  });
+
+  worker.on(
+    'failed',
+    (job: Job<FundScenarioCalcJobData> | undefined, error: Error) => {
+      logger.error('[fund-scenario-calc] Worker failed job', error, {
+        jobId: job?.id,
+      });
+    }
+  );
+
+  logger.info('[fund-scenario-calc] In-process worker started');
+
+  return {
+    close: async () => {
+      await worker.close();
+      logger.info('[fund-scenario-calc] In-process worker stopped');
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run the unit tests — expect all 3 to pass**
+
+```
+npx cross-env TZ=UTC vitest run tests/unit/queues/fund-scenario-calc-worker-init.test.ts --project=server
+```
+
+Expected output:
+
+```
+Test Files  1 passed (1)
+     Tests  3 passed (3)
+```
+
+- [ ] **Step 3: Type-check**
+
+```
+npm run check
+```
+
+Expected: zero TypeScript errors. If there are type errors in the new file, fix
+them before continuing.
+
+- [ ] **Step 4: Lint**
+
+```
+npm run lint
+```
+
+Expected: zero warnings. Common issues to watch for:
+
+- Missing `eslint-disable-next-line povc-security/require-bullmq-config` comment
+  on the `new Worker(...)` line (already included in the template above)
+- Unused import warnings
+
+- [ ] **Step 5: Commit**
+
+```
+git add server/queues/fund-scenario-calc-worker-init.ts tests/unit/queues/fund-scenario-calc-worker-init.test.ts
+git commit -m "feat(scenarios): in-process fund-scenario-calc worker init"
+```
+
+---
+
+## Task 3: Wire `initializeFundScenarioCalcWorker` into `providers.ts`
+
+**Files:**
+
+- Modify: `server/providers.ts` lines 216–235 (the `buildQueue` function body)
+
+Two changes needed: add a dynamic import and add the call to
+`Promise.allSettled`.
+
+- [ ] **Step 1: Add the import and call to `buildQueue`**
+
+In `server/providers.ts`, locate the `buildQueue` function. Find the block that
+looks like:
+
+```typescript
+const { initializeSimulationQueue } =
+  await import('./queues/simulation-queue.js');
+const { initializeReportQueue } =
+  await import('./queues/report-generation-queue.js');
+const { initializeBacktestingQueue } =
+  await import('./queues/backtesting-queue.js');
+```
+
+Add one line immediately after:
+
+```typescript
+const { initializeFundScenarioCalcWorker } =
+  await import('./queues/fund-scenario-calc-worker-init.js');
+```
+
+Then locate the `Promise.allSettled` block:
+
+```typescript
+const initResults = await Promise.allSettled([
+  initializeSimulationQueue(redis),
+  initializeReportQueue(redis),
+  initializeBacktestingQueue(redis),
+]);
+```
+
+Add `initializeFundScenarioCalcWorker(redis),` as the fourth entry:
+
+```typescript
+const initResults = await Promise.allSettled([
+  initializeSimulationQueue(redis),
+  initializeReportQueue(redis),
+  initializeBacktestingQueue(redis),
+  initializeFundScenarioCalcWorker(redis),
+]);
+```
+
+- [ ] **Step 2: Type-check**
+
+```
+npm run check
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Run server unit tests**
+
+```
+npx cross-env TZ=UTC npm test -- --project=server
+```
+
+Expected: all server tests pass. The suite for the queue init file (3 tests)
+should continue to pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git add server/providers.ts
+git commit -m "feat(scenarios): wire fund-scenario-calc worker into providers buildQueue"
+```
+
+---
+
+## Task 4: Quality gate — lint, typecheck, full unit suite
+
+- [ ] **Step 1: Full lint pass**
+
+```
+npm run lint
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 2: Full type check**
+
+```
+npm run check
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Full server unit test suite**
+
+```
+npx cross-env TZ=UTC npm test -- --project=server
+```
+
+Expected: all tests pass. Confirm the 3 new tests in
+`tests/unit/queues/fund-scenario-calc-worker-init.test.ts` appear in the output.
+
+---
+
+## Task 5: Integration gate (WSL2 required on Windows)
+
+The scenario release gate is the authoritative end-to-end proof. It spins up
+real Redis + Postgres via Testcontainers, enqueues a `reserve_allocation` job,
+waits for the worker to complete it, and asserts `status: 'succeeded'` with a
+non-null `snapshotId`.
+
+**This gate requires WSL2 with Docker on Windows.** Run it from WSL2:
+
+```bash
+# In WSL2 Ubuntu terminal (not PowerShell)
+cd /path/to/Updog_restore
+CI=true NODE_OPTIONS=--max-old-space-size=4096 npm run test:scenario-release-gate
+```
+
+Expected: all tests in `scenario-release-gate.integration.test.ts` pass.
+
+If the gate passes, the implementation is complete and ready to ship.
+
+> **Note:** The integration test starts its own in-process worker via
+> `startInProcessFundScenarioCalcWorkerHarness()`, so it does NOT directly
+> exercise the `providers.ts` wiring. What it proves is that the handler +
+> reserve calculation + snapshot persistence chain works end-to-end. The
+> `providers.ts` wiring is covered by the unit tests in Task 2 + the smoke that
+> the app boots without error.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+
+- [x] New file `server/queues/fund-scenario-calc-worker-init.ts` — covered by
+      Task 2
+- [x] `server/providers.ts` wiring — covered by Task 3
+- [x] `lockDuration: 300_000` + eslint disable — in Task 2 Step 1 code
+- [x] Lazy-import circular dep avoidance — in Task 2 Step 1 code
+- [x] `concurrency: 2` — in Task 2 Step 1 code
+- [x] Graceful `close()` — in Task 2 Step 1 code and tested in Task 1
+- [x] Quality gates — covered by Tasks 4 and 5
+
+**No other files change.** The handler, standalone worker, harness, tests, queue
+service, and registry are all untouched.

--- a/docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md
+++ b/docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md
@@ -1,3 +1,13 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-06-09
+owner: "Platform Team"
+review_cadence: P90D
+categories: [planning, scenarios, workers]
+keywords: [c3-scenario-async-worker, fund-scenario-calc, bullmq, reserve-allocation]
+---
+
 # C3: Scenario Async Worker Persistence — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use

--- a/docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md
@@ -1,3 +1,13 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-06-09
+owner: "Platform Team"
+review_cadence: P180D
+categories: [architecture, scenarios, workers]
+keywords: [c3-scenario-async-worker, fund-scenario-calc, bullmq, reserve-allocation]
+---
+
 # C3: Scenario Async Worker Persistence — Design Spec
 
 **Date:** 2026-06-09 **Status:** Approved **M8 Item:** C3 — Async worker

--- a/docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md
@@ -1,0 +1,129 @@
+# C3: Scenario Async Worker Persistence — Design Spec
+
+**Date:** 2026-06-09 **Status:** Approved **M8 Item:** C3 — Async worker
+persistence for reserve-allocation scenario path
+
+---
+
+## Problem
+
+The `reserve_allocation` scenario calculation path is half-wired. When a user
+triggers `POST .../calculate-reserve`, the route enqueues a BullMQ job into the
+`fund-scenario-calc` queue. The queue (producer side) and the job handler both
+exist. However, no consumer worker ever starts — so jobs sit in the queue
+indefinitely and the status endpoint always returns `queued`.
+
+### What exists (no changes required)
+
+| Asset              | Path                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| Job handler        | `workers/fund-scenario-calc-handler.ts` — calls `runReserveScenarioCalculation`                |
+| Standalone worker  | `workers/fund-scenario-calc-worker.ts` — `startFundScenarioCalcWorker` (for Docker/standalone) |
+| In-process harness | `workers/fund-scenario-calc-worker-harness.ts` — used by integration tests                     |
+| Unit tests         | `tests/unit/workers/fund-scenario-calc-worker.test.ts` — 5/5 passing                           |
+| Integration test   | `tests/integration/fund-scenario-reserve-worker.test.ts` — full e2e proof                      |
+| Release gate       | `tests/integration/scenarios/scenario-release-gate.integration.test.ts`                        |
+
+### Root cause
+
+`server/providers.ts::buildQueue()` starts the simulation, report, and
+backtesting workers but has no entry for the fund-scenario-calc worker. The
+queue exists only as a producer.
+
+---
+
+## Deployment decision
+
+The worker runs **in-process with the API** (Railway/Docker, not
+Vercel-serverless which cannot host persistent workers). This matches the
+pattern of the other embedded workers (`simulation-queue.ts`,
+`report-generation-queue.ts`, `backtesting-queue.ts`).
+
+---
+
+## Design
+
+### Option chosen: thin init file + one-line providers wiring
+
+**Rejected alternatives:**
+
+- Inline everything in `providers.ts` — mixes concerns, harder to read
+- Consolidate into `server/queues/fund-scenario-calc-queue.ts` — scope creep,
+  requires moving tests
+
+### New file: `server/queues/fund-scenario-calc-worker-init.ts`
+
+Exports `initializeFundScenarioCalcWorker(redis: IORedis): Promise<{ close }>`.
+
+Key decisions:
+
+- Uses `getBullMQConnection(redis)` to extract plain connection options from the
+  IORedis instance passed in by `providers.ts` (same pattern as all embedded
+  workers)
+- The handler is **lazy-imported** via
+  `await import('../../workers/fund-scenario-calc-handler.js')` inside the
+  processor function to avoid a `server → workers → server` circular dependency
+  at module load time (workers import from server, so a static import the other
+  way creates a cycle)
+- `concurrency: 2` — matches the standalone worker default
+- `lockDuration: 300_000` — 5-minute timeout, satisfies
+  `povc-security/require-bullmq-config`
+- Logs `completed` and `failed` worker events
+- Returns `{ close: () => worker.close() }` for graceful shutdown via
+  `providers.teardown`
+
+### Modified file: `server/providers.ts`
+
+Add `initializeFundScenarioCalcWorker` to the dynamic imports and to the
+`Promise.allSettled` call in `buildQueue`. One-line addition in each location.
+
+### Unchanged: queue service, handler, tests, registry
+
+The `fund-scenario-calc-queue-service.ts` continues to create the Queue
+(producer side) during route registration (Phase 3 of bootstrap). The Worker
+(consumer) starts during `buildQueue` (Phase 2). They interact via Redis — no
+direct code reference needed.
+
+The queue registry entry stays `healthMode: 'producer'` for now. The health
+endpoint won't show `workerAttached`, but the worker runs and processes jobs
+correctly. Updating the health metadata is a follow-up, not required for C3.
+
+---
+
+## Status / failure path (no changes required)
+
+When a job fails:
+
+1. `runReserveScenarioCalculation` catches the error and writes a
+   `calculation_failed` event to `fund_scenario_set_events`
+2. The handler re-throws, BullMQ marks the job failed after retries
+3. The status service reads `calculation_failed` from events → returns
+   `status: 'failed'` with `lastError` populated
+
+`markScenarioCalculationRunFailed` is intentionally not called — the status
+surface reads events, not the `fund_scenario_calculation_runs` table. YAGNI.
+
+---
+
+## Quality gates
+
+| Gate                  | Command                              | Requirement                             |
+| --------------------- | ------------------------------------ | --------------------------------------- |
+| TypeScript            | `npm run check`                      | Zero errors                             |
+| Lint                  | `npm run lint`                       | Zero warnings                           |
+| Unit tests            | `npm test -- --project=server`       | All passing                             |
+| Scenario release gate | `npm run test:scenario-release-gate` | Requires WSL2 + Docker (Testcontainers) |
+
+The scenario release gate is the authoritative end-to-end proof: it spins up
+real Redis + Postgres via Testcontainers, enqueues a reserve-allocation job, and
+asserts `status: 'succeeded'` with a populated `snapshotId`. This test already
+exists and must pass before merging.
+
+---
+
+## File change summary
+
+| File                                              | Change                                         |
+| ------------------------------------------------- | ---------------------------------------------- |
+| `server/queues/fund-scenario-calc-worker-init.ts` | **New** — `initializeFundScenarioCalcWorker`   |
+| `server/providers.ts`                             | **Modified** — add worker init to `buildQueue` |

--- a/server/providers.ts
+++ b/server/providers.ts
@@ -217,6 +217,8 @@ async function buildQueue(
     const { initializeSimulationQueue } = await import('./queues/simulation-queue.js');
     const { initializeReportQueue } = await import('./queues/report-generation-queue.js');
     const { initializeBacktestingQueue } = await import('./queues/backtesting-queue.js');
+    const { initializeFundScenarioCalcWorker } =
+      await import('./queues/fund-scenario-calc-worker-init.js');
 
     const redis = new IORedis(queueConfig.queueRedisUrl, {
       lazyConnect: true,
@@ -230,6 +232,7 @@ async function buildQueue(
       initializeSimulationQueue(redis),
       initializeReportQueue(redis),
       initializeBacktestingQueue(redis),
+      initializeFundScenarioCalcWorker(redis),
     ]);
 
     const closers = initResults.flatMap((result) =>

--- a/server/queues/fund-scenario-calc-worker-init.ts
+++ b/server/queues/fund-scenario-calc-worker-init.ts
@@ -1,0 +1,82 @@
+import { Worker, type Job } from 'bullmq';
+import type IORedis from 'ioredis';
+import { logger } from '../lib/logger.js';
+import { getBullMQConnection } from './redis-connection.js';
+
+const QUEUE_NAME = 'fund-scenario-calc';
+const LOCK_DURATION_MS = 300_000;
+
+interface FundScenarioCalcJobData {
+  fundId: number;
+  scenarioSetId: string;
+  correlationId: string;
+  calculationMode: string;
+  actor: {
+    userId: number | null;
+    label: string | null;
+  } | null;
+}
+
+type FundScenarioCalcJobResult = unknown;
+
+interface FundScenarioCalcHandlerModule {
+  handleFundScenarioCalcJob(
+    job: Pick<Job<FundScenarioCalcJobData, FundScenarioCalcJobResult, string>, 'id' | 'data'>
+  ): Promise<FundScenarioCalcJobResult>;
+}
+
+let worker: Worker<FundScenarioCalcJobData, FundScenarioCalcJobResult, string> | null = null;
+
+async function closeFundScenarioCalcWorker(): Promise<void> {
+  const workerRef = worker;
+  worker = null;
+
+  await workerRef?.close();
+  logger.info('[fund-scenario-calc] In-process worker stopped');
+}
+
+export async function initializeFundScenarioCalcWorker(
+  redisConnection: IORedis
+): Promise<{ close: () => Promise<void> }> {
+  if (worker) {
+    return {
+      close: closeFundScenarioCalcWorker,
+    };
+  }
+
+  const connection = getBullMQConnection(redisConnection);
+
+  // eslint-disable-next-line povc-security/require-bullmq-config -- lockDuration is the BullMQ timeout control
+  worker = new Worker<FundScenarioCalcJobData, FundScenarioCalcJobResult, string>(
+    QUEUE_NAME,
+    async (job: Job<FundScenarioCalcJobData, FundScenarioCalcJobResult, string>) => {
+      const { handleFundScenarioCalcJob: processJob } = (await import(
+        '../../workers/fund-scenario-calc-handler.js' as string
+      )) as unknown as FundScenarioCalcHandlerModule;
+      return processJob(job);
+    },
+    {
+      connection,
+      concurrency: 2,
+      lockDuration: LOCK_DURATION_MS,
+    }
+  );
+
+  worker.on('completed', (job) => {
+    logger.info({ jobId: job.id }, '[fund-scenario-calc] Worker completed job');
+  });
+
+  worker.on('failed', (job, error) => {
+    logger.error({ err: error, jobId: job?.id }, '[fund-scenario-calc] Worker failed job');
+  });
+
+  worker.on('error', (error) => {
+    logger.error({ err: error }, '[fund-scenario-calc] Worker error');
+  });
+
+  logger.info('[fund-scenario-calc] In-process worker started');
+
+  return {
+    close: closeFundScenarioCalcWorker,
+  };
+}

--- a/tests/unit/queues/fund-scenario-calc-worker-init.test.ts
+++ b/tests/unit/queues/fund-scenario-calc-worker-init.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { workerConstructorMock, workerOnMock, workerCloseMock, loggerInfoMock, loggerErrorMock } =
+  vi.hoisted(() => ({
+    workerConstructorMock: vi.fn(),
+    workerOnMock: vi.fn(),
+    workerCloseMock: vi.fn().mockResolvedValue(undefined),
+    loggerInfoMock: vi.fn(),
+    loggerErrorMock: vi.fn(),
+  }));
+
+vi.mock('bullmq', () => ({
+  Worker: function MockWorker(...args: unknown[]) {
+    workerConstructorMock(...args);
+    return { on: workerOnMock, close: workerCloseMock };
+  },
+}));
+
+vi.mock('../../../server/queues/redis-connection', () => ({
+  getBullMQConnection: vi.fn().mockReturnValue({ host: 'localhost', port: 6379 }),
+}));
+
+vi.mock('../../../server/lib/logger', () => ({
+  logger: { info: loggerInfoMock, error: loggerErrorMock },
+}));
+
+describe('initializeFundScenarioCalcWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('creates a BullMQ Worker on the fund-scenario-calc queue with correct settings', async () => {
+    const { initializeFundScenarioCalcWorker } =
+      await import('../../../server/queues/fund-scenario-calc-worker-init');
+    const mockRedis = {} as import('ioredis').default;
+
+    await initializeFundScenarioCalcWorker(mockRedis);
+
+    expect(workerConstructorMock).toHaveBeenCalledWith(
+      'fund-scenario-calc',
+      expect.any(Function),
+      expect.objectContaining({ concurrency: 2, lockDuration: 300_000 })
+    );
+  });
+
+  it('returns a close function that calls worker.close()', async () => {
+    const { initializeFundScenarioCalcWorker } =
+      await import('../../../server/queues/fund-scenario-calc-worker-init');
+    const mockRedis = {} as import('ioredis').default;
+
+    const { close } = await initializeFundScenarioCalcWorker(mockRedis);
+    await close();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs startup on initialization', async () => {
+    const { initializeFundScenarioCalcWorker } =
+      await import('../../../server/queues/fund-scenario-calc-worker-init');
+    const mockRedis = {} as import('ioredis').default;
+
+    await initializeFundScenarioCalcWorker(mockRedis);
+
+    expect(loggerInfoMock).toHaveBeenCalledWith(expect.stringContaining('[fund-scenario-calc]'));
+  });
+});


### PR DESCRIPTION
## Summary

- Creates `server/queues/fund-scenario-calc-worker-init.ts` with `initializeFundScenarioCalcWorker(redis)` — a BullMQ Worker on the `fund-scenario-calc` queue with `concurrency:2` and `lockDuration:300s`
- Wires it into `providers.ts::buildQueue()` alongside the existing simulation/report/backtesting embedded workers, ending the infinite `queued` state for reserve-allocation scenario jobs
- Handler is lazy-imported (`await import(...)`) inside the processor callback to break the `server → workers → server` circular dependency at module load time

## Root cause closed

`providers.ts::buildQueue()` started the queue's producer side (via the route importing `fund-scenario-calc-queue-service.ts`) but never started a consumer. Jobs enqueued by `POST .../calculate-reserve` sat in Redis forever.

## Test plan

- [x] 3 new unit tests in `tests/unit/queues/fund-scenario-calc-worker-init.test.ts` — Worker construction, `close()` delegation, startup log
- [x] `npm run check` — zero TypeScript errors
- [x] `npm run lint` — zero warnings
- [x] Full server test suite — 6835 pass / 0 fail
- [x] `npm run test:scenario-release-gate` — passed in WSL2 (Testcontainers Postgres + Redis): proves ADR-022 lifecycle `queued → calculating → succeeded` with snapshot persisted

## M8 status after this PR

| Item | Status |
|---|---|
| C1 — Methodology scenario creation UI | DONE (#819) |
| C2 — Economics comparison generalization | DONE (#817) |
| C3 — Async worker persistence | **THIS PR** |
| C4 — Forecast drift UX | DONE (#803) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)