### PR TITLE
fix(worker): make Railway log directory writable

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -142,6 +142,9 @@ EOF
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD node /app/healthcheck.js
 
+# Winston file transports create this directory before the health server starts.
+RUN mkdir -p /app/logs && chown worker:nodejs /app/logs
+
 # Security: switch to non-root user
 USER worker
 


### PR DESCRIPTION
## Summary
- pre-create `/app/logs` in `Dockerfile.worker`
- chown the directory to `worker:nodejs` before switching to the non-root `worker` user

## Why
Railway healthchecks fail because the worker crashes during production startup with `EACCES: permission denied, mkdir 'logs'`. Winston file transports initialize before the worker health server binds `/health`, so the process exits before Railway can observe a healthy service.

## Verification
- `git diff --check`
- Dockerfile order check: log directory setup precedes `USER worker`

## Not run
- Local Docker image build: `docker` is not installed in this environment