### PR TITLE
fix(worker): create /app/logs writable by worker user

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -143,6 +143,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD node /app/healthcheck.js
 
 # Security: switch to non-root user
+RUN mkdir -p /app/logs && chown worker:nodejs /app/logs
 USER worker
 
 # Use dumb-init for proper signal handling


### PR DESCRIPTION
Railway worker deploy crashed at startup: winston File transports (`lib/logger.ts:30-42`, production-only) try to create `logs/` under root-owned `/app`; the non-root `worker` user lacks write permission, so the process died before the health server bound and every healthcheck failed.

One line: `RUN mkdir -p /app/logs && chown worker:nodejs /app/logs` before `USER worker`. `Dockerfile.railway` is unaffected (it does a blanket `chown -R`).

Follow-up to #826 (worker prod ops plan, Task 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)