### PR TITLE
fix(worker): fall back to Railway PORT for health server

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -59,8 +59,23 @@ COPY --chown=worker:nodejs <<'EOF' /app/healthcheck.js
 const net = require('net');
 const workerType = process.env.WORKER_TYPE || 'reserve';
 
-// Check if worker health server is running (port 9000)
-const healthServerPort = parseInt(process.env.WORKER_HEALTH_PORT || '9000');
+function firstValidPort(...values) {
+  for (const value of values) {
+    const parsed = Number(String(value ?? '').trim());
+    if (Number.isInteger(parsed) && parsed > 0 && parsed <= 65535) {
+      return parsed;
+    }
+  }
+  return 9000;
+}
+
+// Check if worker health server is running.
+const healthServerPort = firstValidPort(
+  process.env.WORKER_HEALTH_PORT,
+  process.env.FUND_SCENARIO_WORKER_HEALTH_PORT,
+  process.env.PORT,
+  '9000'
+);
 
 const socket = new net.Socket();
 socket.setTimeout(2000);
@@ -146,7 +161,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
 RUN mkdir -p /app/logs && chown worker:nodejs /app/logs
 
 # Security: switch to non-root user
-RUN mkdir -p /app/logs && chown worker:nodejs /app/logs
 USER worker
 
 # Use dumb-init for proper signal handling

--- a/tests/unit/workers/fund-scenario-calc-worker.test.ts
+++ b/tests/unit/workers/fund-scenario-calc-worker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   runReserveScenarioCalculationMock,
@@ -124,9 +124,18 @@ describe('fund scenario calc worker handler', () => {
 });
 
 describe('fund scenario calc worker startup', () => {
+  const originalEnv = {
+    FUND_SCENARIO_WORKER_HEALTH_PORT: process.env['FUND_SCENARIO_WORKER_HEALTH_PORT'],
+    PORT: process.env['PORT'],
+    WORKER_HEALTH_PORT: process.env['WORKER_HEALTH_PORT'],
+  };
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    delete process.env['FUND_SCENARIO_WORKER_HEALTH_PORT'];
+    delete process.env['PORT'];
+    delete process.env['WORKER_HEALTH_PORT'];
     getQueueConnectionOptionsMock.mockReturnValue({
       host: 'queue-host',
       port: 6380,
@@ -134,6 +143,16 @@ describe('fund scenario calc worker startup', () => {
       password: 'queue-pass',
       db: 4,
     });
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
   });
 
   it('uses the shared queue connection resolver for production worker startup', async () => {
@@ -158,6 +177,28 @@ describe('fund scenario calc worker startup', () => {
     );
     expect(registerWorkerMock).toHaveBeenCalledWith('fund-scenario-calc', expect.any(Object));
     expect(createHealthServerMock).toHaveBeenCalledWith(0);
+  });
+
+  it('falls back to Railway PORT when WORKER_HEALTH_PORT resolves empty', async () => {
+    process.env['WORKER_HEALTH_PORT'] = '';
+    process.env['PORT'] = '19234';
+    const { startFundScenarioCalcWorker } =
+      await import('../../../workers/fund-scenario-calc-worker');
+
+    startFundScenarioCalcWorker();
+
+    expect(createHealthServerMock).toHaveBeenCalledWith(19234);
+  });
+
+  it('ignores unresolved Railway variable templates when selecting the health port', async () => {
+    process.env['WORKER_HEALTH_PORT'] = '${{PORT}}';
+    process.env['PORT'] = '19235';
+    const { startFundScenarioCalcWorker } =
+      await import('../../../workers/fund-scenario-calc-worker');
+
+    startFundScenarioCalcWorker();
+
+    expect(createHealthServerMock).toHaveBeenCalledWith(19235);
   });
 
   it('fails fast when queue Redis is not configured', async () => {

--- a/workers/fund-scenario-calc-worker.ts
+++ b/workers/fund-scenario-calc-worker.ts
@@ -25,10 +25,22 @@ interface FundScenarioCalcWorkerRuntime {
   close: () => Promise<void>;
 }
 
+function parseHealthPort(value: string | undefined): number | null {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = Number(normalized);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65_535 ? parsed : null;
+}
+
 function getHealthPort(): number {
-  return Number.parseInt(
-    process.env.WORKER_HEALTH_PORT ?? process.env.FUND_SCENARIO_WORKER_HEALTH_PORT ?? '9004',
-    10
+  return (
+    parseHealthPort(process.env['WORKER_HEALTH_PORT']) ??
+    parseHealthPort(process.env['FUND_SCENARIO_WORKER_HEALTH_PORT']) ??
+    parseHealthPort(process.env['PORT']) ??
+    9004
   );
 }
 


### PR DESCRIPTION
## Summary
- validate worker health-port candidates and fall back to Railway's injected `PORT`
- make the Dockerfile worker healthcheck use the same fallback order
- remove the duplicate `/app/logs` ownership layer left by stacked log-dir fixes

## Why
Railway now shows `WORKER_HEALTH_PORT` is configured from the `${{PORT}}` template, but the resolved service-variable value displays as empty. The worker entrypoint used nullish coalescing, so an empty string could be parsed as the selected port and produce `NaN` instead of falling back to the actual Railway `PORT`. That leaves the worker health server unavailable to Railway's `/health` network probe.

## Verification
- `npm exec vitest -- run tests/unit/workers/fund-scenario-calc-worker.test.ts --project=server`
- `npx eslint --no-cache --no-ignore --max-warnings 0 workers/fund-scenario-calc-worker.ts tests/unit/workers/fund-scenario-calc-worker.test.ts`
- `git diff --check`

## Not run
- Local Docker image build: `docker` is not installed in this environment
- Railway deployment verification: pending merge/deploy of this PR