### PR TITLE
docs: regenerate routing artifacts for forecast drift plan doc

### DIFF
--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-06-09T00:00:00.000Z",
+  "generatedAt": "2026-06-12T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 162,
+      "staleDays": 165,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 74,
+      "staleDays": 77,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 52,
+      "staleDays": 55,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 52,
+      "staleDays": 55,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1176,7 +1176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1192,7 +1192,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1208,7 +1208,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1223,7 +1223,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1305,7 +1305,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 64,
+      "staleDays": 67,
       "status": "UNKNOWN"
     },
     {
@@ -1323,7 +1323,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1340,7 +1340,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1357,7 +1357,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1373,7 +1373,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1403,7 +1403,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1418,7 +1418,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -1434,7 +1434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1449,7 +1449,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1464,7 +1464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1479,7 +1479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1494,7 +1494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1522,7 +1522,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 162,
+      "staleDays": 165,
       "status": "ACTIVE"
     },
     {
@@ -1538,7 +1538,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "UNKNOWN"
     },
     {
@@ -1565,7 +1565,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -1580,7 +1580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -1595,7 +1595,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1610,7 +1610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1625,7 +1625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1678,7 +1678,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 162,
+      "staleDays": 165,
       "status": "ACTIVE"
     },
     {
@@ -1692,7 +1692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1706,7 +1706,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1720,7 +1720,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -1791,7 +1791,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1806,7 +1806,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1821,7 +1821,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -1836,7 +1836,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1851,7 +1851,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1866,7 +1866,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1881,7 +1881,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1896,7 +1896,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1911,7 +1911,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1930,7 +1930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ready"
     },
     {
@@ -1949,7 +1949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ready"
     },
     {
@@ -1968,7 +1968,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ready"
     },
     {
@@ -1983,7 +1983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -1998,7 +1998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2037,7 +2037,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -2052,7 +2052,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -2067,7 +2067,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 19,
+      "staleDays": 22,
       "status": "UNKNOWN"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2135,7 +2135,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2150,7 +2150,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2165,7 +2165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2180,7 +2180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2196,7 +2196,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -2212,7 +2212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2227,7 +2227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2242,7 +2242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2257,7 +2257,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2272,7 +2272,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2288,7 +2288,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -2303,7 +2303,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2318,7 +2318,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2333,7 +2333,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2349,7 +2349,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2364,7 +2364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2379,7 +2379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2394,7 +2394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2408,7 +2408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2423,7 +2423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2439,7 +2439,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2455,7 +2455,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2471,7 +2471,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2566,7 +2566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2582,7 +2582,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2597,7 +2597,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2612,7 +2612,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2627,7 +2627,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2643,7 +2643,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2659,7 +2659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2674,7 +2674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2692,7 +2692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2722,7 +2722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2737,7 +2737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2752,7 +2752,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2768,7 +2768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2783,7 +2783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2798,7 +2798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO-v2.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -2813,7 +2813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -2828,7 +2828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/immediate-actions-summary.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -2843,7 +2843,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2858,7 +2858,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -2873,7 +2873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2888,7 +2888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2903,7 +2903,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2918,7 +2918,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2933,7 +2933,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2948,7 +2948,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -2963,7 +2963,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-baseline-report-2025-12-23.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -2978,7 +2978,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-remediation-summary.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -2993,7 +2993,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/week2-execution-report.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -3008,7 +3008,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -3023,7 +3023,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3038,7 +3038,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3074,7 +3074,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 74,
+      "staleDays": 77,
       "status": "ACTIVE"
     },
     {
@@ -3091,7 +3091,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -3106,7 +3106,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -3121,7 +3121,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3136,7 +3136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3165,7 +3165,7 @@
       "lastUpdated": "2026-05-21",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 19,
+      "staleDays": 22,
       "status": "ACTIVE"
     },
     {
@@ -3180,7 +3180,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 6,
+      "staleDays": 9,
       "status": "ACTIVE"
     },
     {
@@ -3195,7 +3195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3210,7 +3210,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -3237,7 +3237,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3252,7 +3252,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3267,7 +3267,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-QUICK-START.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3282,7 +3282,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3297,7 +3297,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3312,7 +3312,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3327,7 +3327,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3342,7 +3342,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "README.md",
-      "staleDays": 73,
+      "staleDays": 76,
       "status": "ACTIVE"
     },
     {
@@ -3357,7 +3357,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3372,7 +3372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3387,7 +3387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3404,7 +3404,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 74,
+      "staleDays": 77,
       "status": "ACTIVE"
     },
     {
@@ -3419,7 +3419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3434,7 +3434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -3449,7 +3449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3464,7 +3464,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3479,7 +3479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3494,7 +3494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3509,7 +3509,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -3524,7 +3524,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3539,7 +3539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3554,7 +3554,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -3569,7 +3569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3584,7 +3584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3599,7 +3599,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3614,7 +3614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3629,7 +3629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -3644,7 +3644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3659,7 +3659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -3674,7 +3674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3689,7 +3689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3704,7 +3704,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3719,7 +3719,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -3734,7 +3734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3749,7 +3749,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3764,7 +3764,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3779,7 +3779,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3795,7 +3795,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "active"
     },
     {
@@ -3810,7 +3810,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3825,7 +3825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3840,7 +3840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3855,7 +3855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3870,7 +3870,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 64,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -3885,7 +3885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3900,7 +3900,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -3915,7 +3915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3930,7 +3930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -3945,7 +3945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3960,7 +3960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3975,7 +3975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -3990,7 +3990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4005,7 +4005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4020,7 +4020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4035,7 +4035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4050,7 +4050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4065,7 +4065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4080,7 +4080,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 6,
+      "staleDays": 9,
       "status": "ACTIVE"
     },
     {
@@ -4095,7 +4095,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -4110,7 +4110,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 73,
+      "staleDays": 76,
       "status": "ACTIVE"
     },
     {
@@ -4125,7 +4125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4152,7 +4152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4167,7 +4167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4182,7 +4182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4197,7 +4197,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4212,7 +4212,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4227,7 +4227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4242,7 +4242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4281,7 +4281,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 52,
+      "staleDays": 55,
       "status": "ACTIVE"
     },
     {
@@ -4296,7 +4296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4311,7 +4311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4326,7 +4326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4362,7 +4362,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 12,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -4377,7 +4377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4392,7 +4392,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 50,
+      "staleDays": 53,
       "status": "HISTORICAL"
     },
     {
@@ -4407,7 +4407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4422,7 +4422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4437,7 +4437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4452,7 +4452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -4467,7 +4467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4482,7 +4482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4497,7 +4497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4512,7 +4512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4527,7 +4527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4542,7 +4542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4583,7 +4583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -4598,7 +4598,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4613,7 +4613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4628,7 +4628,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 65,
+      "staleDays": 68,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4643,7 +4643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4658,7 +4658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4673,7 +4673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4688,7 +4688,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4702,7 +4702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -4717,7 +4717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4732,7 +4732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4747,7 +4747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4762,7 +4762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4777,7 +4777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -4792,7 +4792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4807,7 +4807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4822,7 +4822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4837,7 +4837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4852,7 +4852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4867,7 +4867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4882,7 +4882,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4897,7 +4897,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4926,7 +4926,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -4941,7 +4941,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4956,7 +4956,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4971,7 +4971,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -4986,7 +4986,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5001,7 +5001,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5016,7 +5016,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5031,7 +5031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -5046,7 +5046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5061,7 +5061,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5076,7 +5076,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5091,7 +5091,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5106,7 +5106,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5121,7 +5121,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -5136,7 +5136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5151,7 +5151,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5166,7 +5166,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5181,7 +5181,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5196,7 +5196,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 32,
+      "staleDays": 35,
       "status": "ACTIVE"
     },
     {
@@ -5211,7 +5211,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 32,
+      "staleDays": 35,
       "status": "ACTIVE"
     },
     {
@@ -5226,7 +5226,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -5241,7 +5241,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 18,
+      "staleDays": 21,
       "status": "ACTIVE"
     },
     {
@@ -5256,7 +5256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5271,7 +5271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5286,7 +5286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5301,7 +5301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5327,7 +5327,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -5342,7 +5342,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "Implemented"
     },
     {
@@ -5357,7 +5357,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 52,
+      "staleDays": 55,
       "status": "ACTIVE"
     },
     {
@@ -5372,7 +5372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5423,7 +5423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5438,7 +5438,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 84,
+      "staleDays": 87,
       "status": "ARCHIVED"
     },
     {
@@ -5453,7 +5453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5468,7 +5468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5483,7 +5483,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -5498,7 +5498,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 13,
+      "staleDays": 16,
       "status": "HISTORICAL"
     },
     {
@@ -5513,7 +5513,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 13,
+      "staleDays": 16,
       "status": "HISTORICAL"
     },
     {
@@ -5528,7 +5528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5543,7 +5543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5558,7 +5558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5573,7 +5573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5588,7 +5588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5603,7 +5603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5618,7 +5618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5633,7 +5633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5648,7 +5648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5663,7 +5663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5678,7 +5678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5693,7 +5693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5708,7 +5708,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5723,7 +5723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5738,7 +5738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5753,7 +5753,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5768,7 +5768,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5783,7 +5783,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 71,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -5798,7 +5798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5813,7 +5813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5827,7 +5827,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -5841,7 +5841,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -5856,7 +5856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -5871,7 +5871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5886,7 +5886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5901,7 +5901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5916,7 +5916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5931,7 +5931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5946,7 +5946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5961,7 +5961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5976,7 +5976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -5991,7 +5991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6006,7 +6006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6021,7 +6021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6036,7 +6036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6051,7 +6051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6066,7 +6066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6081,7 +6081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6096,7 +6096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -6111,7 +6111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6126,7 +6126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6168,7 +6168,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 7,
+      "staleDays": 10,
       "status": "ACTIVE"
     },
     {
@@ -6216,7 +6216,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 7,
+      "staleDays": 10,
       "status": "ACTIVE"
     },
     {
@@ -6261,7 +6261,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 6,
+      "staleDays": 9,
       "status": "ACTIVE"
     },
     {
@@ -6288,7 +6288,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 52,
+      "staleDays": 55,
       "status": "ACTIVE"
     },
     {
@@ -6304,7 +6304,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -6319,7 +6319,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6334,7 +6334,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6349,7 +6349,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6364,7 +6364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6378,7 +6378,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -6393,7 +6393,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6408,7 +6408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6423,7 +6423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6438,7 +6438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6452,7 +6452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -6467,7 +6467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6482,7 +6482,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -6497,7 +6497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6512,7 +6512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6527,7 +6527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6542,7 +6542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6557,7 +6557,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6572,7 +6572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6587,7 +6587,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6602,7 +6602,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6617,7 +6617,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -6632,7 +6632,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6665,7 +6665,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 12,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -6680,7 +6680,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6713,7 +6713,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 12,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -6728,7 +6728,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6743,7 +6743,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6758,7 +6758,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6773,7 +6773,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 50,
+      "staleDays": 53,
       "status": "HISTORICAL"
     },
     {
@@ -6788,7 +6788,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 23,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -6803,7 +6803,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6818,7 +6818,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6833,7 +6833,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6848,7 +6848,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6863,7 +6863,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6878,7 +6878,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6893,7 +6893,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6908,7 +6908,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6923,7 +6923,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6938,7 +6938,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6953,7 +6953,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6968,7 +6968,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -6983,7 +6983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -6998,7 +6998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7013,7 +7013,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7028,7 +7028,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7043,7 +7043,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7058,7 +7058,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7073,7 +7073,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -7088,7 +7088,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7103,7 +7103,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7118,7 +7118,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7139,7 +7139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "active"
     },
     {
@@ -7153,7 +7153,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -7168,7 +7168,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7183,7 +7183,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7198,7 +7198,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7213,7 +7213,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7228,7 +7228,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7243,7 +7243,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7258,7 +7258,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7273,7 +7273,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7288,7 +7288,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7303,7 +7303,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -7318,7 +7318,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -7333,7 +7333,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -7348,7 +7348,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -7363,7 +7363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7378,7 +7378,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7393,7 +7393,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7408,7 +7408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7423,7 +7423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7438,7 +7438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7453,7 +7453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7468,7 +7468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7483,7 +7483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7498,7 +7498,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7513,7 +7513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7528,7 +7528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7543,7 +7543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7558,7 +7558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7573,7 +7573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7588,7 +7588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7603,7 +7603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7618,7 +7618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7633,7 +7633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7648,7 +7648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7663,7 +7663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7678,7 +7678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7694,7 +7694,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 65,
+      "staleDays": 68,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7709,7 +7709,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7724,7 +7724,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7739,7 +7739,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7754,7 +7754,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7769,7 +7769,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7796,7 +7796,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7811,7 +7811,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7826,7 +7826,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 73,
+      "staleDays": 76,
       "status": "ACTIVE"
     },
     {
@@ -7843,7 +7843,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 63,
+      "staleDays": 66,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -7858,7 +7858,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 23,
+      "staleDays": 26,
       "status": "BACKLOG"
     },
     {
@@ -7872,7 +7872,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -7889,7 +7889,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 9,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -7909,7 +7909,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 7,
+      "staleDays": 10,
       "status": "ACTIVE"
     },
     {
@@ -7946,7 +7946,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -7961,7 +7961,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -7976,7 +7976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -7991,7 +7991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -8006,7 +8006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8021,7 +8021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8036,7 +8036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8051,7 +8051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8066,7 +8066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8081,7 +8081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8096,7 +8096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8111,7 +8111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8126,7 +8126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8141,7 +8141,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8156,7 +8156,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8171,7 +8171,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8186,7 +8186,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8201,7 +8201,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8216,7 +8216,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8231,7 +8231,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8246,7 +8246,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 19,
+      "staleDays": 22,
       "status": "ACTIVE"
     },
     {
@@ -8261,7 +8261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8275,7 +8275,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -8302,7 +8302,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8317,7 +8317,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -8332,7 +8332,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8347,7 +8347,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8362,7 +8362,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8377,7 +8377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8392,7 +8392,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8407,7 +8407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8422,7 +8422,7 @@
       "lastUpdated": "2026-06-06",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 3,
+      "staleDays": 6,
       "status": "PROVEN"
     },
     {
@@ -8437,7 +8437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8452,7 +8452,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8467,7 +8467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8482,7 +8482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8497,7 +8497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8512,7 +8512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8527,7 +8527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8542,7 +8542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8557,7 +8557,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8572,7 +8572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8607,7 +8607,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "COMPLETED"
     },
     {
@@ -8638,7 +8638,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "REFERENCE"
     },
     {
@@ -8669,7 +8669,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "REFERENCE"
     },
     {
@@ -8700,7 +8700,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "REFERENCE"
     },
     {
@@ -8733,7 +8733,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "REFERENCE"
     },
     {
@@ -8764,7 +8764,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 18,
+      "staleDays": 21,
       "status": "REFERENCE"
     },
     {
@@ -8796,7 +8796,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "REFERENCE"
     },
     {
@@ -8811,7 +8811,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -8826,7 +8826,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8841,7 +8841,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8856,7 +8856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8871,7 +8871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8886,7 +8886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8914,7 +8914,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 71,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -8929,7 +8929,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8944,7 +8944,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8959,7 +8959,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8974,7 +8974,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -8989,7 +8989,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9004,7 +9004,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9019,7 +9019,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9034,7 +9034,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9049,7 +9049,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9064,7 +9064,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9079,7 +9079,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9094,7 +9094,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9109,7 +9109,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9124,7 +9124,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9139,7 +9139,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9154,7 +9154,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9169,7 +9169,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-01-to-01-07-extraction.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -9184,7 +9184,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-08-to-01-18-extraction.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -9199,7 +9199,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-18-extraction.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -9213,7 +9213,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -9227,7 +9227,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -9241,7 +9241,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -9255,7 +9255,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -9269,7 +9269,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -9283,7 +9283,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -9298,7 +9298,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9313,7 +9313,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9328,7 +9328,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -9369,7 +9369,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "VERIFIED"
     },
     {
@@ -9717,7 +9717,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -9915,7 +9915,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -9997,7 +9997,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "VERIFIED"
     },
     {
@@ -10070,7 +10070,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10114,7 +10114,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10244,7 +10244,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10291,7 +10291,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10333,7 +10333,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 67,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10482,7 +10482,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10508,7 +10508,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10539,7 +10539,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10568,7 +10568,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10597,7 +10597,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10627,7 +10627,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10657,7 +10657,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10687,7 +10687,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 29,
+      "staleDays": 32,
       "status": "DRAFT"
     },
     {
@@ -10720,7 +10720,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 52,
+      "staleDays": 55,
       "status": "DRAFT"
     },
     {
@@ -10785,7 +10785,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -10800,7 +10800,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -10815,7 +10815,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -10842,7 +10842,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -10870,7 +10870,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -10899,7 +10899,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -10927,7 +10927,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -10955,7 +10955,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -10982,8 +10982,20 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 11,
+      "staleDays": 14,
       "status": "COMPLETE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": true,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
     },
     {
       "docType": "doc",
@@ -11011,7 +11023,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 2,
+      "staleDays": 5,
       "status": "ACTIVE"
     },
     {
@@ -11028,7 +11040,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 1,
+      "staleDays": 4,
       "status": "ACTIVE"
     },
     {
@@ -11057,7 +11069,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 1,
+      "staleDays": 4,
       "status": "ACTIVE"
     },
     {
@@ -11086,8 +11098,20 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 0,
+      "staleDays": 3,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-11-worker-prod-ops.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
     },
     {
       "docType": "doc",
@@ -11115,7 +11139,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 1,
+      "staleDays": 4,
       "status": "ACTIVE"
     },
     {
@@ -11144,7 +11168,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 1,
+      "staleDays": 4,
       "status": "ACTIVE"
     },
     {
@@ -11173,8 +11197,20 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 0,
+      "staleDays": 3,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
     },
     {
       "docType": "doc",
@@ -11212,7 +11248,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 20,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -11227,7 +11263,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11242,7 +11278,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11257,7 +11293,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11272,7 +11308,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11299,7 +11335,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11314,7 +11350,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11329,7 +11365,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11344,7 +11380,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11359,7 +11395,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11374,7 +11410,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11389,7 +11425,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "HISTORICAL"
     },
     {
@@ -11404,7 +11440,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11419,7 +11455,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11434,7 +11470,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11449,7 +11485,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11464,7 +11500,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11479,7 +11515,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11494,7 +11530,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11509,7 +11545,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11524,7 +11560,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 12,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -11570,7 +11606,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 162,
+      "staleDays": 165,
       "status": "ACTIVE"
     },
     {
@@ -11585,7 +11621,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     },
     {
@@ -11600,11 +11636,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 141,
+      "staleDays": 144,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-06-09T00:00:00.000Z",
+  "generatedAt": "2026-06-12T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -12784,14 +12820,14 @@
       "REFERENCE": 6,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 110,
+      "UNKNOWN": 113,
       "VERIFIED": 9,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 15,
-    "stale_docs": 97,
-    "total_docs": 648
+    "missing_frontmatter": 18,
+    "stale_docs": 100,
+    "total_docs": 651
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,26 +1,26 @@
 ---
-last_updated: 2026-06-09
+last_updated: 2026-06-12
 ---
 
 # Staleness Report
 
-*Generated: 2026-06-09T00:00:00.000Z*
+*Generated: 2026-06-12T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 648 |
-| Stale Documents | 97 |
-| Missing Frontmatter | 15 |
+| Total Documents | 651 |
+| Stale Documents | 100 |
+| Missing Frontmatter | 18 |
 
 ### By Status
 
 | Status | Count |
 |--------|-------|
 | ACTIVE | 444 |
-| UNKNOWN | 110 |
+| UNKNOWN | 113 |
 | DRAFT | 30 |
 | HISTORICAL | 29 |
 | VERIFIED | 9 |
@@ -78,39 +78,40 @@ Documents that need review (older than their cadence threshold):
 | `docs/skills/WIZARD_INDEX.md` | Never | 999 | No | Unassigned |
 | `docs/skills/template-refl.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/plans/2026-05-19-ca-period-truth-harness-remediation.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md` | Never | 999 | YES - verify! | Unassigned |
+| `docs/superpowers/plans/2026-06-11-worker-prod-ops.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md` | Never | 999 | YES - verify! | Unassigned |
+| `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md` | Never | 999 | No | Unassigned |
 | `docs/tooling-catalog.md` | Never | 999 | No | Unassigned |
-| `cheatsheets/agent-architecture.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/ai-code-review.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/api.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/capability-checklist.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/claude-commands.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/codex-collaboration-protocol.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/coding-pairs-playbook.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/command-summary.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/correct-workflow-example.md` | 2026-01-19 | 141 | No | Unassigned |
-| `cheatsheets/document-review-workflow.md` | 2026-01-19 | 141 | No | Unassigned |
+| `cheatsheets/agent-architecture.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/ai-code-review.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/api.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/capability-checklist.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/claude-commands.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/codex-collaboration-protocol.md` | 2026-01-19 | 144 | No | Unassigned |
+| `cheatsheets/coding-pairs-playbook.md` | 2026-01-19 | 144 | No | Unassigned |
 
-*...and 47 more stale documents.*
+*...and 50 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **CHANGELOG.md** (20 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (141 days old)
-- [ ] **cheatsheets/schema-alignment.md** (141 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (141 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (141 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (141 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (141 days old)
+- [ ] **CHANGELOG.md** (23 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (144 days old)
+- [ ] **cheatsheets/schema-alignment.md** (144 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (144 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (144 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (144 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (144 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)
+- [ ] **docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md** (999 days old)
 - [ ] **docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md** (999 days old)
 
 ## Missing Frontmatter
@@ -130,7 +131,10 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/skills/SKILLS_INDEX.md`
 - [ ] `docs/skills/WIZARD_INDEX.md`
 - [ ] `docs/superpowers/plans/2026-05-19-ca-period-truth-harness-remediation.md`
+- [ ] `docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md`
+- [ ] `docs/superpowers/plans/2026-06-11-worker-prod-ops.md`
 - [ ] `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md`
+- [ ] `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md`
 - [ ] `docs/tooling-catalog.md`
 
 ---


### PR DESCRIPTION
Regenerates docs/_generated/{router-index,router-fast,staleness-report} after PR #831 added the forecast drift plan doc, which left the routing inventory out of sync (Validate Discovery Routing failed non-blocking on #831).

🤖 Generated with [Claude Code](https://claude.com/claude-code)