### PR TITLE
fix(test): authenticate /health/detailed in storage-health-mode int test

### DIFF
--- a/tests/integration/storage-health-mode.test.ts
+++ b/tests/integration/storage-health-mode.test.ts
@@ -1,15 +1,29 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { registerRoutes } from '../../server/routes';
 
+// /health/detailed requires X-Health-Key or bearer auth since PR #801.
+const HEALTH_KEY = 'storage-health-mode-secret-32-chars-min';
+
 describe('storage health mode exposure', () => {
   let app: express.Express;
+  let previousHealthKey: string | undefined;
 
   beforeAll(async () => {
+    previousHealthKey = process.env['HEALTH_KEY'];
+    process.env['HEALTH_KEY'] = HEALTH_KEY;
     app = express();
     app.use(express.json({ limit: '1mb' }));
     await registerRoutes(app);
+  });
+
+  afterAll(() => {
+    if (previousHealthKey === undefined) {
+      delete process.env['HEALTH_KEY'];
+    } else {
+      process.env['HEALTH_KEY'] = previousHealthKey;
+    }
   });
 
   it('surfaces storage mode through readiness checks', async () => {
@@ -22,7 +36,10 @@ describe('storage health mode exposure', () => {
   });
 
   it('surfaces storage runtime details in detailed health output', async () => {
-    const response = await request(app).get('/health/detailed').expect(200);
+    const response = await request(app)
+      .get('/health/detailed')
+      .set('X-Health-Key', HEALTH_KEY)
+      .expect(200);
 
     expect(response.body).toHaveProperty('storage.kind');
     expect(response.body).toHaveProperty('metrics.mockDatabase');


### PR DESCRIPTION
## Root cause
PR #801 (`7eb20a37`) put `requireHealthKeyOrAuth` on `/health/detailed` (server/routes/health.ts:310). `tests/integration/storage-health-mode.test.ts` still probed it anonymously, so it 401s deterministically.

**Every full `CI Unified` run on main has failed on this single test since #801 merged (2026-06-06)** — verified identical failure on runs 27243198438 (06-09), 27393791456 (06-12 04:06), and 27447553556 (06-12 22:49). The intervening green runs were docs-only pushes (~1m) that skip integration, which masked the breakage. Integration tests do not run on PRs (test-smart -> smoke only), which is why #801 merged green.

## Fix
Follow the #801-era pattern from `tests/unit/server/route-surface-inventory.test.ts:740-756`: set `HEALTH_KEY` for the suite, send `X-Health-Key`, restore the prior env value in `afterAll` (int suite shares one process; no leakage).

The deployed boundary behavior itself is correct and separately proven by `tests/smoke/production-boundaries.spec.ts` against live production (401 unauthenticated / 200 with key).

## Verification
`TZ=UTC npx vitest run tests/integration/storage-health-mode.test.ts --config vitest.config.int.ts --configLoader native` — 2 passed.

Note for reviewer: this PR's own CI will not exercise the fixed test (integration is main-push gated); the proof lands on the post-merge main run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)