### PR TITLE
fix(scenarios): stabilize idempotency key and guard re-entrant submit in methodology modal

### DIFF
--- a/client/src/components/scenarios/CreateMethodologyScenarioModal.tsx
+++ b/client/src/components/scenarios/CreateMethodologyScenarioModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -114,6 +114,8 @@ export function CreateMethodologyScenarioModal({
 }: CreateMethodologyScenarioModalProps) {
   const queryClient = useQueryClient();
   const [serverError, setServerError] = useState<string | null>(null);
+  const idempotencyRef = useRef<{ signature: string; key: string } | null>(null);
+  const submitInFlightRef = useRef(false);
 
   const form = useForm<
     CreateMethodologyScenarioFormInput,
@@ -129,10 +131,26 @@ export function CreateMethodologyScenarioModal({
     },
   });
 
+  function resolveIdempotencyKey(payload: CreateFundScenarioSetV1): string {
+    const signature = JSON.stringify(payload);
+    if (idempotencyRef.current?.signature === signature) {
+      return idempotencyRef.current.key;
+    }
+    const key = createIdempotencyKey();
+    idempotencyRef.current = { signature, key };
+    return key;
+  }
+
   const createMutation = useMutation({
-    mutationFn: (payload: CreateFundScenarioSetV1) =>
+    mutationFn: ({
+      payload,
+      idempotencyKey,
+    }: {
+      payload: CreateFundScenarioSetV1;
+      idempotencyKey: string;
+    }) =>
       apiRequest('POST', scenarioApiPath(fundId, '/scenario-sets'), payload, {
-        headers: { 'Idempotency-Key': createIdempotencyKey() },
+        headers: { 'Idempotency-Key': idempotencyKey },
       }).then((raw) => FundScenarioSetDetailV1Schema.parse(raw)),
     onMutate: () => {
       setServerError(null);
@@ -141,6 +159,7 @@ export function CreateMethodologyScenarioModal({
       queryClient.setQueryData(scenarioSetDetailQueryKey(fundId, created.id), created);
       await queryClient.invalidateQueries({ queryKey: workspaceQueryKey(fundId) });
       form.reset();
+      idempotencyRef.current = null;
       setServerError(null);
       onOpenChange(false);
       onSuccess(created);
@@ -165,13 +184,25 @@ export function CreateMethodologyScenarioModal({
     if (!nextOpen && createMutation.isPending) return;
     if (!nextOpen) {
       form.reset();
+      idempotencyRef.current = null;
       setServerError(null);
     }
     onOpenChange(nextOpen);
   }
 
   function onSubmit(values: CreateMethodologyScenarioFormValues) {
-    createMutation.mutate(buildCreateMethodologyScenarioPayload(values));
+    if (submitInFlightRef.current) return;
+    const payload = buildCreateMethodologyScenarioPayload(values);
+    const idempotencyKey = resolveIdempotencyKey(payload);
+    submitInFlightRef.current = true;
+    createMutation.mutate(
+      { payload, idempotencyKey },
+      {
+        onSettled: () => {
+          submitInFlightRef.current = false;
+        },
+      }
+    );
   }
 
   const {

--- a/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
+++ b/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
@@ -1,7 +1,7 @@
 ---
-status: ACTIVE
+status: COMPLETE
 audience: agents
-last_updated: 2026-06-08
+last_updated: 2026-06-13
 owner: 'Platform Team'
 ---
 
@@ -1556,3 +1556,18 @@ Expected: 0 errors.
 ```
 
 Expected: 0 errors.
+
+## Closeout hardening (2026-06-13)
+
+- Feature implemented and merged on main.
+- Modal now uses a payload-scoped idempotency key plus a synchronous re-entrancy
+  guard.
+- Regression tests added for re-entrant single-POST behavior, same-payload retry
+  key reuse, changed-payload key rotation, and the Radix Select override POST
+  path.
+- Deferred for separate routing: waterfall enum terminology to a domain
+  specialist because it is a shared contract value, not a cosmetic label.
+- Deferred for separate routing: React duplicate-key warning in a sibling
+  comparison view.
+- Final sign-off still requires a NON-skipped
+  `npm run test:scenario-release-gate` result from CI or a provisioned DB.

--- a/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
+++ b/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
@@ -1,7 +1,7 @@
 ---
-status: ACTIVE
+status: COMPLETE
 audience: agents
-last_updated: 2026-06-08
+last_updated: 2026-06-13
 owner: 'Platform Team'
 ---
 
@@ -619,3 +619,18 @@ npm run lint                         # zero lint errors
 | `tests/unit/lib/queryClient.test.ts`                                      | Create — `apiRequest` error code preservation (blocker)                             |
 | `tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx` | Create — 19 modal cases + payload builder cases                                     |
 | `tests/unit/pages/fund-scenario-workspace.test.tsx`                       | Modify — thin integration: button renders + opens modal                             |
+
+## Closeout hardening (2026-06-13)
+
+- Feature implemented and merged on main.
+- Modal now uses a payload-scoped idempotency key plus a synchronous re-entrancy
+  guard.
+- Regression tests added for re-entrant single-POST behavior, same-payload retry
+  key reuse, changed-payload key rotation, and the Radix Select override POST
+  path.
+- Deferred for separate routing: waterfall enum terminology to a domain
+  specialist because it is a shared contract value, not a cosmetic label.
+- Deferred for separate routing: React duplicate-key warning in a sibling
+  comparison view.
+- Final sign-off still requires a NON-skipped
+  `npm run test:scenario-release-gate` result from CI or a provisioned DB.

--- a/tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
+++ b/tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   CreateMethodologyScenarioModal,
   buildCreateMethodologyScenarioPayload,
 } from '../../../../client/src/components/scenarios/CreateMethodologyScenarioModal';
 import type { FundScenarioSetDetailV1 } from '../../../../shared/contracts/fund-scenario-sets-v1.contract';
+import { installRadixSelectShim } from '../../../helpers/radix-select-shim';
 
 function makeQueryClient() {
   return new QueryClient({
@@ -161,6 +163,8 @@ describe('buildCreateMethodologyScenarioPayload', () => {
 describe('CreateMethodologyScenarioModal', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
 
+  beforeAll(installRadixSelectShim);
+
   beforeEach(() => {
     fetchSpy = vi.fn();
     globalThis.fetch = fetchSpy;
@@ -251,6 +255,101 @@ describe('CreateMethodologyScenarioModal', () => {
         'Idempotency-Key': expect.any(String),
       })
     );
+  });
+
+  it('guards against re-entrant submit (one POST)', async () => {
+    fetchSpy.mockReturnValueOnce(new Promise(() => {}));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+
+    const form = document.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('reuses the same Idempotency-Key on same-payload retry after a transient failure', async () => {
+    fetchSpy.mockResolvedValueOnce(errorResponse(500, 'server_error', 'boom'));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const firstInit = fetchSpy.mock.calls[0][1] as RequestInit;
+    const key1 = (firstInit.headers as Record<string, string>)['Idempotency-Key'];
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to create scenario/i)).toBeInTheDocument();
+    });
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeCreatedDetail()));
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    const secondInit = fetchSpy.mock.calls[1][1] as RequestInit;
+    const key2 = (secondInit.headers as Record<string, string>)['Idempotency-Key'];
+
+    expect(key2).toBe(key1);
+  });
+
+  it('mints a new Idempotency-Key when the payload changes after a failure', async () => {
+    fetchSpy.mockResolvedValueOnce(errorResponse(500, 'server_error', 'boom'));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'S' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText(/management fee rate/i), {
+      target: { value: '2', valueAsNumber: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const firstInit = fetchSpy.mock.calls[0][1] as RequestInit;
+    const key1 = (firstInit.headers as Record<string, string>)['Idempotency-Key'];
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to create scenario/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'V2' } });
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeCreatedDetail()));
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    const secondInit = fetchSpy.mock.calls[1][1] as RequestInit;
+    const key2 = (secondInit.headers as Record<string, string>)['Idempotency-Key'];
+
+    expect(key2).not.toBe(key1);
+  });
+
+  it('POSTs waterfallType when chosen via the Select dropdown', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeCreatedDetail()));
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/scenario set name/i), {
+      target: { value: 'Wf set' },
+    });
+    fireEvent.change(screen.getByLabelText(/variant name/i), { target: { value: 'Wf v' } });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByLabelText(/waterfall type/i));
+    await user.click(screen.getByRole('option', { name: /american \(deal-by-deal\)/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /create scenario/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.variants[0].override.payload).toEqual({ waterfallType: 'american' });
+    expect('managementFeeRate' in body.variants[0].override.payload).toBe(false);
   });
 
   it('shows duplicate_scenario_set_name error under name field', async () => {


### PR DESCRIPTION
## Summary

Closeout hardening for the C1 methodology scenario creation modal. The modal minted a fresh `Idempotency-Key` inside `mutationFn` on every request, defeating the server's `(fund_id, idempotency_key)` dedup, and `onSubmit` had no synchronous re-entrancy guard.

## Changes

- **Payload-scoped idempotency key**: a `{ signature, key }` ref — reuse on identical retry, rotate on payload change, reset on success/close. A same-payload retry replays cleanly server-side; an edited resubmit never triggers `422 idempotency_key_reused`.
- **Synchronous re-entrancy guard**: `submitInFlightRef` set in `onSubmit`, cleared via `mutate(..., { onSettled })`.
- **Regression tests (+4, 26/26 in the file)**: re-entrant submit issues one POST; same-payload retry reuses the key; changed-payload retry rotates it; the Radix Select override path POSTs `waterfallType` (via the existing `installRadixSelectShim` + `userEvent`).
- **Docs**: C1 plan/spec flipped `ACTIVE` to `COMPLETE` with a short closeout note (no new files).

## Why payload-scoped (not modal-session)

The server stores the key only on a successful insert and returns `422 idempotency_key_reused` on same-key + different-payload. A modal-session key would risk a spurious 422 if a user edits the form and resubmits after an ambiguous failure. Payload-scoping rotates the key on change, avoiding both duplicate creates and the 422.

## Process

Plan was steelmanned via a Hermes `--workflow debate` (codex + kimi comparators), which corrected the original "modal-session key" to payload-scoped and replaced an incorrect "identical-header" test that contradicted the new guard. Implemented via Hermes production (codex), reviewed line-by-line.

## Verification

- `npm run check`: 0 TypeScript errors.
- Modal suite: 26/26. Pre-push targeted run: 121/121 across 9 files.
- Scope: only the 4 intended files changed.

## Remaining before final C1 sign-off

- A **non-skipped** `npm run test:scenario-release-gate` (needs CI or a provisioned DB; it skips locally without infra).

## Deferred (separate routing)

- `waterfall` enum terminology to `waterfall-specialist` (shared contract value, not a cosmetic label).
- React duplicate-key warning in `ScenarioComparisonWorkspace` (`fund-scenario-workspace.tsx:518`) — re-surfaced in this run; non-blocking, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
