### PR TITLE
docs(scenarios): record green scenario-release-gate run for C1 closeout

### DIFF
--- a/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
+++ b/docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md
@@ -1569,5 +1569,8 @@ Expected: 0 errors.
   specialist because it is a shared contract value, not a cosmetic label.
 - Deferred for separate routing: React duplicate-key warning in a sibling
   comparison view.
-- Final sign-off still requires a NON-skipped
-  `npm run test:scenario-release-gate` result from CI or a provisioned DB.
+- Release gate VERIFIED on 2026-06-13: `npm run test:scenario-release-gate`
+  passed non-skipped on `e7fe43f9` against real Postgres + Redis + worker via
+  WSL2 testcontainers (`CI=true`), exercising the full ADR-022 scenario
+  lifecycle (create, calculate, async reserve, results read, archive, and the
+  archived-recalculate 409 guard). 1 passed / 0 skipped.

--- a/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
+++ b/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
@@ -632,5 +632,8 @@ npm run lint                         # zero lint errors
   specialist because it is a shared contract value, not a cosmetic label.
 - Deferred for separate routing: React duplicate-key warning in a sibling
   comparison view.
-- Final sign-off still requires a NON-skipped
-  `npm run test:scenario-release-gate` result from CI or a provisioned DB.
+- Release gate VERIFIED on 2026-06-13: `npm run test:scenario-release-gate`
+  passed non-skipped on `e7fe43f9` against real Postgres + Redis + worker via
+  WSL2 testcontainers (`CI=true`), exercising the full ADR-022 scenario
+  lifecycle (create, calculate, async reserve, results read, archive, and the
+  archived-recalculate 409 guard). 1 passed / 0 skipped.


### PR DESCRIPTION
## Summary

Records the final C1 closeout evidence. The closeout note in both the plan and spec framed `npm run test:scenario-release-gate` as a pending sign-off step; it has now passed.

## Evidence

Ran on the WSL2 disposable clone, reset to current main (`e7fe43f9`), `npm ci` clean, `CI=true`:

- `test:scenario-release-gate`: **1 passed / 0 skipped** — the ADR-022 scenario lifecycle against real Postgres + Redis + in-process worker (create fee_profile & reserve_allocation sets, calculate, async reserve to `succeeded`, results read, archive, archived-recalculate 409 guard).
- Confirmed genuinely non-skipped: live `pg-circuit` connections, worker job processing, and the `CI=true` container-leave path — none of the local "infrastructure unavailable" skip branch.

Docs-only change (plan + spec closeout sections). No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)