### PR TITLE
fix(cashflow): color stress scenarios by impact vs baseline + align chart axis units

### DIFF
--- a/client/src/components/dashboard/CashflowDashboard.tsx
+++ b/client/src/components/dashboard/CashflowDashboard.tsx
@@ -49,6 +49,8 @@ import { useFundContext } from '@/contexts/FundContext';
 import { isDemoMode } from '@/core/demo/persona';
 import { presson } from '@/theme/presson.tokens';
 import { colors as brandColors, getChartColor } from '@/lib/brand-tokens';
+import { getImpactBadgeClass, getImpactTextClass } from '@/lib/display/impact-semantics';
+import { toStressScenarioViewModel } from './stress-test-view-model';
 
 const STATUS_SUCCESS = brandColors.success;
 const CASHFLOW_CHART_COLORS = {
@@ -159,6 +161,16 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
 
     return data;
   }, [analytics.liquidityForecast, timeframe]);
+
+  const forecastMax = useMemo(() => {
+    const values = liquidityForecastData
+      .flatMap((d) => [d.cash, d.committed])
+      .filter((n) => Number.isFinite(n));
+    const max = Math.max(0, ...values);
+    return max === 0 ? 1 : Math.ceil(max * 1.1);
+  }, [liquidityForecastData]);
+
+  const stressBaselineCash = analytics.stressTestResult?.currentPosition.totalCash ?? 0;
 
   const expenseBreakdownData = useMemo(() => {
     if (!analytics.cashFlowAnalysis) return [];
@@ -354,34 +366,40 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                 <CardDescription>Monthly inflows vs outflows over time</CardDescription>
               </CardHeader>
               <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <AreaChart data={cashFlowChartData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="month" />
-                    <YAxis />
-                    <Tooltip
-                      formatter={(value) =>
-                        value !== undefined ? formatCurrencyShort(Number(value)) : ''
-                      }
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="inflows"
-                      stackId="1"
-                      stroke={CASHFLOW_CHART_COLORS.positive}
-                      fill={CASHFLOW_CHART_COLORS.positive}
-                      fillOpacity={0.6}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="outflows"
-                      stackId="2"
-                      stroke={CASHFLOW_CHART_COLORS.negative}
-                      fill={CASHFLOW_CHART_COLORS.negative}
-                      fillOpacity={0.6}
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
+                {cashFlowChartData.length === 0 ? (
+                  <div className="flex h-[300px] items-center justify-center text-sm text-charcoal-500">
+                    No cash flow data available.
+                  </div>
+                ) : (
+                  <ResponsiveContainer width="100%" height={300}>
+                    <AreaChart data={cashFlowChartData}>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="month" />
+                      <YAxis tickFormatter={(value) => formatCurrencyShort(Number(value))} />
+                      <Tooltip
+                        formatter={(value) =>
+                          value !== undefined ? formatCurrencyShort(Number(value)) : ''
+                        }
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey="inflows"
+                        stackId="1"
+                        stroke={CASHFLOW_CHART_COLORS.positive}
+                        fill={CASHFLOW_CHART_COLORS.positive}
+                        fillOpacity={0.6}
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey="outflows"
+                        stackId="2"
+                        stroke={CASHFLOW_CHART_COLORS.negative}
+                        fill={CASHFLOW_CHART_COLORS.negative}
+                        fillOpacity={0.6}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                )}
               </CardContent>
             </Card>
 
@@ -391,20 +409,26 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                 <CardDescription>Monthly net cash position</CardDescription>
               </CardHeader>
               <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={cashFlowChartData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="month" />
-                    <YAxis />
-                    <Tooltip
-                      formatter={(value) =>
-                        value !== undefined ? formatCurrencyShort(Number(value)) : ''
-                      }
-                    />
-                    {/* charcoal accent per DESIGN.md (net-flow is non-semantic; no blue) */}
-                    <Bar dataKey="netFlow" fill={CASHFLOW_CHART_COLORS.text} />
-                  </BarChart>
-                </ResponsiveContainer>
+                {cashFlowChartData.length === 0 ? (
+                  <div className="flex h-[300px] items-center justify-center text-sm text-charcoal-500">
+                    No cash flow data available.
+                  </div>
+                ) : (
+                  <ResponsiveContainer width="100%" height={300}>
+                    <BarChart data={cashFlowChartData}>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="month" />
+                      <YAxis tickFormatter={(value) => formatCurrencyShort(Number(value))} />
+                      <Tooltip
+                        formatter={(value) =>
+                          value !== undefined ? formatCurrencyShort(Number(value)) : ''
+                        }
+                      />
+                      {/* charcoal accent per DESIGN.md (net-flow is non-semantic; no blue) */}
+                      <Bar dataKey="netFlow" fill={CASHFLOW_CHART_COLORS.text} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                )}
               </CardContent>
             </Card>
           </div>
@@ -420,33 +444,42 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <ResponsiveContainer width="100%" height={400}>
-                <LineChart data={liquidityForecastData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <Tooltip
-                    formatter={(value) =>
-                      value !== undefined ? formatCurrencyShort(Number(value)) : ''
-                    }
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="cash"
-                    stroke={CASHFLOW_CHART_COLORS.info}
-                    strokeWidth={3}
-                    name="Available Cash"
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="committed"
-                    stroke={CASHFLOW_CHART_COLORS.text}
-                    strokeWidth={2}
-                    strokeDasharray="5 5"
-                    name="Undrawn Commitments"
-                  />
-                </LineChart>
-              </ResponsiveContainer>
+              {liquidityForecastData.length === 0 ? (
+                <div className="flex h-[400px] items-center justify-center text-sm text-charcoal-500">
+                  No forecast data available.
+                </div>
+              ) : (
+                <ResponsiveContainer width="100%" height={400}>
+                  <LineChart data={liquidityForecastData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="month" />
+                    <YAxis
+                      domain={[0, forecastMax]}
+                      tickFormatter={(value) => formatCurrencyShort(Number(value))}
+                    />
+                    <Tooltip
+                      formatter={(value) =>
+                        value !== undefined ? formatCurrencyShort(Number(value)) : ''
+                      }
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="cash"
+                      stroke={CASHFLOW_CHART_COLORS.info}
+                      strokeWidth={3}
+                      name="Available Cash"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="committed"
+                      stroke={CASHFLOW_CHART_COLORS.text}
+                      strokeWidth={2}
+                      strokeDasharray="5 5"
+                      name="Undrawn Commitments"
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
             </CardContent>
           </Card>
 
@@ -607,35 +640,43 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
 
                   <div className="space-y-3">
                     <h4 className="font-medium">Stress Test Scenarios</h4>
-                    {analytics.stressTestResult.scenarios.map((scenario, index) => (
-                      <div
-                        key={index}
-                        className="flex items-center justify-between p-4 border rounded-lg"
-                      >
-                        <div className="flex-1">
-                          <h5 className="font-medium">{scenario.name}</h5>
-                          <p className="text-sm text-muted-foreground">{scenario.description}</p>
-                        </div>
-                        <div className="text-right">
-                          <div
-                            className={`font-medium ${scenario.endingCash > 0 ? 'text-presson-positive' : 'text-presson-negative'}`}
-                          >
-                            {formatCurrencyShort(scenario.endingCash / 1000000)}
+                    {analytics.stressTestResult.scenarios.map((scenario, index) => {
+                      const vm = toStressScenarioViewModel(scenario, stressBaselineCash);
+                      const DirectionIcon =
+                        vm.impactDirection === 'unfavorable'
+                          ? TrendingDown
+                          : vm.impactDirection === 'favorable'
+                            ? TrendingUp
+                            : Activity;
+                      const signedImpact = `${vm.liquidityImpact >= 0 ? '+' : '-'}${formatCurrencyShort(
+                        Math.abs(vm.liquidityImpact) / 1000000
+                      )}`;
+                      return (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between p-4 border rounded-lg"
+                        >
+                          <div className="flex-1">
+                            <h5 className="font-medium">{vm.name}</h5>
+                            <p className="text-sm text-muted-foreground">{vm.description}</p>
                           </div>
-                          <Badge
-                            variant={
-                              scenario.impactRating === 'high'
-                                ? 'destructive'
-                                : scenario.impactRating === 'medium'
-                                  ? 'default'
-                                  : 'secondary'
-                            }
-                          >
-                            {scenario.impactRating} impact
-                          </Badge>
+                          <div className="text-right">
+                            <div
+                              className={`font-medium ${getImpactTextClass({ direction: vm.impactDirection, severity: vm.impactSeverity })}`}
+                            >
+                              {formatCurrencyShort(vm.endingCash / 1000000)}
+                            </div>
+                            <div className="flex items-center justify-end gap-1 text-xs text-charcoal-600">
+                              <DirectionIcon className="h-3 w-3" aria-hidden="true" />
+                              <span>{signedImpact} vs current</span>
+                            </div>
+                            <Badge className={getImpactBadgeClass(vm.impactSeverity)}>
+                              {vm.impactSeverity} impact
+                            </Badge>
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
 
                   {analytics.stressTestResult.recommendations.length > 0 && (

--- a/client/src/components/dashboard/stress-test-view-model.ts
+++ b/client/src/components/dashboard/stress-test-view-model.ts
@@ -1,0 +1,38 @@
+import type { StressTestScenario } from '@/core/LiquidityEngine';
+import type { ImpactDirection, ImpactSeverity } from '@/lib/display/impact-semantics';
+
+export type StressScenarioViewModel = {
+  name: string;
+  description: string;
+  /** Ending cash in dollars. */
+  endingCash: number;
+  /** Signed change vs the current position, in dollars. */
+  liquidityImpact: number;
+  impactDirection: ImpactDirection;
+  impactSeverity: ImpactSeverity;
+  probability: number;
+};
+
+/**
+ * Derive display semantics for a stress scenario. Impact direction is computed
+ * from the change vs the baseline (current) cash position, not from whether
+ * ending cash is positive.
+ */
+export function toStressScenarioViewModel(
+  scenario: StressTestScenario,
+  baselineCash: number
+): StressScenarioViewModel {
+  const liquidityImpact = scenario.endingCash - baselineCash;
+  const impactDirection: ImpactDirection =
+    liquidityImpact < 0 ? 'unfavorable' : liquidityImpact > 0 ? 'favorable' : 'neutral';
+
+  return {
+    name: scenario.name,
+    description: scenario.description,
+    endingCash: scenario.endingCash,
+    liquidityImpact,
+    impactDirection,
+    impactSeverity: scenario.impactRating,
+    probability: scenario.probability,
+  };
+}

--- a/tests/unit/components/dashboard/stress-test-view-model.test.tsx
+++ b/tests/unit/components/dashboard/stress-test-view-model.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { toStressScenarioViewModel } from '@/components/dashboard/stress-test-view-model';
+import type { StressTestScenario } from '@/core/LiquidityEngine';
+import { getImpactTextClass } from '@/lib/display/impact-semantics';
+
+function makeScenario(overrides: Partial<StressTestScenario> = {}): StressTestScenario {
+  return {
+    name: 'Distribution delay',
+    description: 'LP distributions arrive later than expected',
+    endingCash: 3_000_000,
+    impactRating: 'medium',
+    probability: 0.35,
+    ...overrides,
+  } as StressTestScenario;
+}
+
+describe('toStressScenarioViewModel', () => {
+  it('maps ending cash below baseline to unfavorable impact', () => {
+    const vm = toStressScenarioViewModel(makeScenario({ endingCash: 3_000_000 }), 5_000_000);
+
+    expect(vm.impactDirection).toBe('unfavorable');
+    expect(vm.liquidityImpact).toBe(-2_000_000);
+  });
+
+  it('maps ending cash above baseline to favorable impact', () => {
+    const vm = toStressScenarioViewModel(makeScenario({ endingCash: 7_000_000 }), 5_000_000);
+
+    expect(vm.impactDirection).toBe('favorable');
+  });
+
+  it('maps ending cash equal to baseline to neutral impact', () => {
+    const vm = toStressScenarioViewModel(makeScenario({ endingCash: 5_000_000 }), 5_000_000);
+
+    expect(vm.impactDirection).toBe('neutral');
+  });
+
+  it('copies impact severity from the scenario impact rating', () => {
+    const vm = toStressScenarioViewModel(makeScenario({ impactRating: 'high' }), 5_000_000);
+
+    expect(vm.impactSeverity).toBe('high');
+  });
+
+  it('keeps cash-positive but below-baseline scenarios unfavorable', () => {
+    const vm = toStressScenarioViewModel(
+      makeScenario({ endingCash: 1_000_000, impactRating: 'high' }),
+      5_000_000
+    );
+
+    expect(vm.impactDirection).toBe('unfavorable');
+    expect(getImpactTextClass({ direction: vm.impactDirection, severity: vm.impactSeverity })).toBe(
+      'text-presson-negative'
+    );
+    expect(
+      getImpactTextClass({ direction: vm.impactDirection, severity: vm.impactSeverity })
+    ).not.toBe('text-presson-positive');
+  });
+});


### PR DESCRIPTION
## What & why

Two verified P0 trust defects in the cashflow surface.

**Stress scenarios colored by cash-positivity, not impact.** The stress tab
colored each scenario `endingCash > 0 ? green : red`, so a scenario ending
**cash-positive but below the current position** — an adverse liquidity impact —
displayed as favorable (green). Color now derives from impact **direction**
(`endingCash` vs `currentPosition.totalCash`) **+ severity** via the
`impact-semantics` primitive (#840), paired with a trend icon and a signed
"vs current" delta so impact is never conveyed by color alone (WCAG 1.4.1). A new
pure `stress-test-view-model.ts` performs the mapping.

**Chart axes lacked unit formatting.** The forecast line chart and the overview
area/bar charts build data in millions and format the tooltip with
`formatCurrencyShort`, but every `<YAxis />` had no `tickFormatter` — ticks showed
bare numbers (`5`) while tooltips showed `$5.0M`. Axes now reuse the same
formatter; the forecast Y domain derives from visible data; and all three charts
render explicit empty states (relevant since #839 makes prod charts empty until a
real data source is wired).

## Deliberately untouched

- Cash-velocity section — already structured rows with an empty state (the v1
  audit's "raw markdown leak" did not match current code).
- Forecast-tab scenario list.
- No new formatter added — reuses the existing `formatCurrencyShort`.

## Tests

- `stress-test-view-model.test.tsx` (5) including the trust regression: a
  **cash-positive but below-baseline** scenario maps to `unfavorable` ->
  `text-presson-negative`, asserted **not** `text-presson-positive`.
- `npm run check`: 0 new errors. `dashboard-modern` page test: 5/5, no regression.

Stacked on #840 (now merged); first consumer of the `impact-semantics` primitive.
PR 3 of the trust-first sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
