### PR TITLE
fix(header): render stable placeholders for unavailable metric values

### DIFF
--- a/client/src/lib/fund-header-metric-formatters.ts
+++ b/client/src/lib/fund-header-metric-formatters.ts
@@ -16,10 +16,8 @@ export function unavailableMetric(
 }
 
 export function formatUnavailableMetric(availability: MetricAvailabilityDetail | undefined) {
-  if (!availability) return 'N/A';
-  if (availability.reason === 'no_distributions_recorded') return 'No distributions';
-  if (availability.reason === 'insufficient_dated_cashflows') return 'Needs history';
-  return availability.message ?? 'Unavailable';
+  // The value slot must stay a stable placeholder so numeric rhythm is preserved.
+  return availability ? '—' : 'N/A';
 }
 
 export function formatCurrency(value: number | null | undefined) {

--- a/tests/unit/components/layout/dynamic-fund-header.test.tsx
+++ b/tests/unit/components/layout/dynamic-fund-header.test.tsx
@@ -202,9 +202,9 @@ describe('DynamicFundHeader', () => {
     expect(metricLabel('Current Value').parentElement).toHaveTextContent('$46M');
     expect(screen.getByText('$46M')).toHaveClass('tabular-nums');
     expect(metricLabel('Remaining').parentElement).toHaveTextContent('$38M');
-    expect(metricLabel('Net IRR').parentElement).toHaveTextContent('Needs history');
+    expect(metricLabel('Net IRR').parentElement).toHaveTextContent('—');
     expect(metricLabel('TVPI').parentElement).toHaveTextContent('2.30x');
-    expect(metricLabel('DPI').parentElement).toHaveTextContent('No distributions');
+    expect(metricLabel('DPI').parentElement).toHaveTextContent('—');
     expect(metricLabel('Active').parentElement).toHaveTextContent('3');
     expect(screen.queryByText('Avg Check')).not.toBeInTheDocument();
     expect(screen.getByText('24% Deployed')).toBeInTheDocument();
@@ -280,7 +280,7 @@ describe('DynamicFundHeader', () => {
 
     expect(screen.getByText('Awaiting deployment')).toBeInTheDocument();
     expect(metricLabel('Total Invested').parentElement).toHaveTextContent('$0');
-    expect(metricLabel('Current Value').parentElement).toHaveTextContent('Needs investment facts');
+    expect(metricLabel('Current Value').parentElement).toHaveTextContent('—');
     expect(metricLabel('Current Value').parentElement).not.toHaveTextContent('$46M');
     expect(screen.queryByText('$46M')).not.toBeInTheDocument();
   });
@@ -352,7 +352,7 @@ describe('DynamicFundHeader', () => {
     render(<DynamicFundHeader />);
 
     const panel = screen.getByTestId('compact-kpi-dpi');
-    expect(panel).toHaveTextContent('No distributions');
+    expect(panel).toHaveTextContent('—');
     expect(panel).toHaveAttribute(
       'title',
       'DPI is unavailable because no distributions have been recorded.'
@@ -391,7 +391,7 @@ describe('DynamicFundHeader', () => {
 
     const navCard = screen.getByTestId('compact-kpi-nav');
     expect(navCard).toHaveTextContent('NAV');
-    expect(navCard).toHaveTextContent('Needs investment facts');
+    expect(navCard).toHaveTextContent('—');
     expect(navCard).toHaveAttribute(
       'title',
       'NAV is unavailable until investment facts are recorded for valued portfolio companies.'
@@ -442,7 +442,7 @@ describe('DynamicFundHeader', () => {
     render(<DynamicFundHeader />);
 
     const panel = screen.getByTestId('compact-kpi-dpi');
-    expect(panel).toHaveTextContent('Metrics unavailable');
+    expect(panel).toHaveTextContent('—');
     expect(panel).toHaveAttribute(
       'title',
       'Metrics unavailable because the live metrics source is unavailable.'

--- a/tests/unit/lib/fund-header-metric-formatters.test.ts
+++ b/tests/unit/lib/fund-header-metric-formatters.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { MetricAvailabilityDetail } from '@shared/types/metrics';
+import {
+  formatCompactKpiDisplayValue,
+  formatPerformanceMetric,
+  formatUnavailableMetric,
+} from '@/lib/fund-header-metric-formatters';
+
+const availableCashflows: MetricAvailabilityDetail = {
+  status: 'available',
+  source: 'cashflows',
+};
+
+const unavailableDistributions: MetricAvailabilityDetail = {
+  status: 'unavailable',
+  source: 'distributions',
+  reason: 'no_distributions_recorded',
+  message: 'No distributions recorded',
+};
+
+const unavailableCashflows: MetricAvailabilityDetail = {
+  status: 'unavailable',
+  source: 'cashflows',
+  reason: 'insufficient_dated_cashflows',
+  message: 'Needs history',
+};
+
+describe('fund header metric formatters', () => {
+  describe('formatUnavailableMetric', () => {
+    it('uses N/A when no availability detail exists', () => {
+      expect(formatUnavailableMetric(undefined)).toBe('N/A');
+    });
+
+    it('uses a stable dash for unavailable distribution metrics', () => {
+      expect(formatUnavailableMetric(unavailableDistributions)).toBe('—');
+    });
+
+    it('uses a stable dash for unavailable cash-flow metrics', () => {
+      expect(formatUnavailableMetric(unavailableCashflows)).toBe('—');
+    });
+  });
+
+  describe('formatPerformanceMetric', () => {
+    it('formats available values with the provided formatter', () => {
+      expect(
+        formatPerformanceMetric(1.5, availableCashflows, (value) => `${value.toFixed(2)}x`, false)
+      ).toBe('1.50x');
+    });
+
+    it('uses a stable dash for per-metric unavailable values', () => {
+      expect(
+        formatPerformanceMetric(null, unavailableDistributions, (value) => String(value), false)
+      ).toBe('—');
+    });
+
+    it('uses N/A when the whole header is unavailable', () => {
+      expect(formatPerformanceMetric(1.5, availableCashflows, (value) => String(value), true)).toBe(
+        'N/A'
+      );
+    });
+  });
+
+  describe('formatCompactKpiDisplayValue', () => {
+    it('uses a stable dash when a compact KPI has availability detail but no value', () => {
+      expect(formatCompactKpiDisplayValue(null, 'multiple', unavailableDistributions, false)).toBe(
+        '—'
+      );
+    });
+
+    it('formats zero multiple values instead of replacing them with a placeholder', () => {
+      expect(formatCompactKpiDisplayValue(0, 'multiple', undefined, false)).toBe('0.00x');
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Unavailable header metrics rendered short sentences in the **value** slot —
"No distributions", "Needs history", "Needs investment facts", "Metrics
unavailable" — which breaks numeric rhythm against the other tabular values and
truncates in the compact card.

`formatUnavailableMetric` now returns a stable **`—`** when a reason exists (or
**`N/A`** when there is no availability detail, e.g. TVPI). The value slot is
therefore always a number, `—`, or `N/A`. The human-readable reason is unchanged
and stays accessible via the existing `titleText` / `explanation` tooltip (the
compact cards already assert that `title` attribute).

DPI still shows `0.00x` only for a true zero, never for an unavailable metric.

## Scope

One production function (`formatUnavailableMetric`); `formatPerformanceMetric` and
`formatCompactKpiDisplayValue` delegate to it and were not touched. The calculation
layer (titleText/explanation) was already wired and is unchanged.

## Tests

- New `tests/unit/lib/fund-header-metric-formatters.test.ts` (8) — dash vs N/A vs
  formatted value across `formatUnavailableMetric` / `formatPerformanceMetric` /
  `formatCompactKpiDisplayValue`, incl. the DPI-zero rule (`0 -> "0.00x"`).
- `dynamic-fund-header.test.tsx` — 6 assertions updated from the old sentence value
  to `—`; the `N/A`, status-text, and `title`-attribute assertions stayed valid.
- Full header suite green (dynamic-fund-header, calculations, compact wizard
  header, kpi edge-cases): 35 passing. `npm run check`: 0 new errors.

PR 4 of the trust-first sequence (header metric empty states). Note: this used the
header's native value/detail view-model, so PR 2's `metric-state`/`MetricValue`
remains available for a future focusable-tooltip a11y pass rather than being forced
in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
