### PR TITLE
refactor(dashboard): remove dead top-bar controls and scope action labels

### DIFF
--- a/client/src/components/dashboard/CashflowDashboard.tsx
+++ b/client/src/components/dashboard/CashflowDashboard.tsx
@@ -241,7 +241,7 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
             }}
           >
             <Download className="h-4 w-4 mr-2" />
-            Export
+            Export cashflow
           </Button>
         </div>
       </div>

--- a/client/src/pages/dashboard-modern.tsx
+++ b/client/src/pages/dashboard-modern.tsx
@@ -4,14 +4,7 @@ import { PremiumCard } from '@/components/ui/PremiumCard';
 import { POVBrandHeader } from '@/components/ui/POVLogo';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Filter, Download, Activity, Share2 } from 'lucide-react';
+import { Activity, Share2 } from 'lucide-react';
 import CashflowDashboard from '@/components/dashboard/CashflowDashboard';
 import ShareConfigModal from '@/components/sharing/ShareConfigModal';
 import type { CreateShareLinkRequest } from '@shared/sharing-schema';
@@ -150,7 +143,6 @@ function PerformanceMetricsPanel({
 
 export default function ModernDashboard() {
   const { currentFund, isLoading } = useFundContext();
-  const [timeframe, setTimeframe] = useState('12m');
   const [activeView, setActiveView] = useState('overview');
   const metricsQuery = useFundMetrics({ enabled: Boolean(currentFund) });
 
@@ -243,36 +235,6 @@ export default function ModernDashboard() {
           </div>
 
           <div className="flex items-center space-x-3">
-            <Select value={timeframe} onValueChange={setTimeframe}>
-              <SelectTrigger className="w-32 bg-pov-white border-pov-gray">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="3m">3 Months</SelectItem>
-                <SelectItem value="6m">6 Months</SelectItem>
-                <SelectItem value="12m">12 Months</SelectItem>
-                <SelectItem value="all">All Time</SelectItem>
-              </SelectContent>
-            </Select>
-
-            <Button
-              variant="outline"
-              size="sm"
-              className="border-pov-gray hover:bg-pov-charcoal hover:text-pov-white"
-            >
-              <Filter className="h-4 w-4 mr-2" />
-              Filter
-            </Button>
-
-            <Button
-              variant="outline"
-              size="sm"
-              className="border-pov-gray hover:bg-pov-charcoal hover:text-pov-white"
-            >
-              <Download className="h-4 w-4 mr-2" />
-              Export
-            </Button>
-
             <ShareConfigModal
               fundId={String(currentFund.id || 'demo-fund')}
               fundName={currentFund.name || 'Demo Fund'}

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -6303,6 +6303,18 @@
       "isStale": true,
       "lastUpdated": null,
       "owner": null,
+      "path": "docs/design/implementation/action-scope-grammar.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
       "path": "docs/design/updog-design-philosophy-v3.1.1-implementation-notes.md",
       "staleDays": 999,
       "status": "UNKNOWN"
@@ -12927,14 +12939,14 @@
       "REFERENCE": 6,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 114,
+      "UNKNOWN": 115,
       "VERIFIED": 9,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 19,
-    "stale_docs": 101,
-    "total_docs": 655
+    "missing_frontmatter": 20,
+    "stale_docs": 102,
+    "total_docs": 656
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,16 +11,16 @@ last_updated: 2026-06-15
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 655 |
-| Stale Documents | 101 |
-| Missing Frontmatter | 19 |
+| Total Documents | 656 |
+| Stale Documents | 102 |
+| Missing Frontmatter | 20 |
 
 ### By Status
 
 | Status | Count |
 |--------|-------|
 | ACTIVE | 445 |
-| UNKNOWN | 114 |
+| UNKNOWN | 115 |
 | DRAFT | 30 |
 | HISTORICAL | 29 |
 | VERIFIED | 9 |
@@ -51,6 +51,7 @@ Documents that need review (older than their cadence threshold):
 | `docs/agents/domain.md` | Never | 999 | No | Unassigned |
 | `docs/agents/issue-tracker.md` | Never | 999 | No | Unassigned |
 | `docs/agents/triage-labels.md` | Never | 999 | No | Unassigned |
+| `docs/design/implementation/action-scope-grammar.md` | Never | 999 | No | Unassigned |
 | `docs/design/updog-design-philosophy-v3.1.1-implementation-notes.md` | Never | 999 | No | Unassigned |
 | `docs/phase2-calibration-benchmarks.md` | Never | 999 | No | Unassigned |
 | `docs/quarantine/2026-05-28-stabilization-triage.md` | Never | 999 | No | Unassigned |
@@ -93,9 +94,8 @@ Documents that need review (older than their cadence threshold):
 | `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 147 | No | Unassigned |
 | `cheatsheets/claude-commands.md` | 2026-01-19 | 147 | No | Unassigned |
 | `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/codex-collaboration-protocol.md` | 2026-01-19 | 147 | No | Unassigned |
 
-*...and 51 more stale documents.*
+*...and 52 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
@@ -125,6 +125,7 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/agents/domain.md`
 - [ ] `docs/agents/issue-tracker.md`
 - [ ] `docs/agents/triage-labels.md`
+- [ ] `docs/design/implementation/action-scope-grammar.md`
 - [ ] `docs/design/updog-design-philosophy-v3.1.1-implementation-notes.md`
 - [ ] `docs/phase2-calibration-benchmarks.md`
 - [ ] `docs/quarantine/2026-05-28-stabilization-triage.md`

--- a/docs/design/implementation/action-scope-grammar.md
+++ b/docs/design/implementation/action-scope-grammar.md
@@ -1,0 +1,45 @@
+# Action Scope Grammar
+
+Every action belongs to exactly one scope. The scope must be unambiguous from
+the label and placement. No two controls on a screen may share a visible label
+with a different scope.
+
+## Global / workspace actions
+
+Affect the current workspace or selected fund. Live in the command header.
+Examples: Search, Share with LPs, Create LP snapshot, Export dashboard, command
+palette.
+
+## Module actions
+
+Affect only the active tab/module. Live in that module's header. Examples:
+Refresh cashflow, Export cashflow, Filter performance, change cashflow forecast
+horizon.
+
+## Object actions
+
+Affect one card, row, chart point, scenario, company, or task. Examples: View
+proof, Create task, Assign owner, Open work panel.
+
+## WorkPanel footer actions
+
+Affect only the currently opened object. Examples: Save, Cancel, Approve,
+Archive.
+
+## Rules
+
+- A control with no behavior is not an action. Do not render non-functional
+  affordances (truth-first): wire it, disable it with an explicit unavailable
+  state, or remove it.
+- Every Export states what it exports (Export dashboard vs Export cashflow).
+- Module state (e.g. cashflow forecast horizon) stays module-scoped unless
+  explicitly lifted to global state with a single source of truth.
+
+## Current state (2026-06-15)
+
+- Global: Share with LPs (real). The former dashboard-level timeframe / Filter /
+  Export were non-functional placeholders and were removed (PR 5).
+- Cashflow module: timeframe (forecast horizon), Refresh cashflow, Export
+  cashflow.
+- A reusable ModuleToolbar primitive will be extracted when a second module
+  needs one (deferred; YAGNI).

--- a/tests/unit/pages/dashboard-modern.test.tsx
+++ b/tests/unit/pages/dashboard-modern.test.tsx
@@ -88,6 +88,14 @@ describe('ModernDashboard', () => {
     expect(screen.queryByText(/Portfolio Value Trend/i)).not.toBeInTheDocument();
   });
 
+  it('keeps only the real global action in the top bar (no dead placeholder controls)', () => {
+    render(<ModernDashboard />);
+
+    expect(screen.getByText('Share with LPs')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^filter$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /export/i })).not.toBeInTheDocument();
+  });
+
   it('renders supported performance metrics while keeping unsupported claims unavailable', async () => {
     const user = userEvent.setup();
     render(<ModernDashboard />);


### PR DESCRIPTION
## What & why

The dashboard top bar had three **non-functional placeholder** controls — a
`timeframe` Select (state never read), a `Filter` button, and an `Export` button
(both with no `onClick`) — sitting next to the cashflow tab's **real** Export.
That's a dead-but-clickable affordance and a duplicate "Export" label.

Per the same truth-first doctrine as the demo-data fix (#839): don't render
affordances that lie. This PR:

- **Removes** the dead `timeframe` / `Filter` / `Export` controls (and their
  now-unused imports + state). The only global action that remains is the real
  **Share with LPs**.
- **Scopes** the cashflow module's Export label to **"Export cashflow"** (its
  timeframe/refresh are wired and unchanged).
- Adds `docs/design/implementation/action-scope-grammar.md` codifying
  global / module / object / work-panel action scope, with the rule that a
  control with no behavior is not an action.

## Deliberately NOT done

No feature flag and no `ModuleToolbar` component. The fix is *removal*, not a new
toolbar primitive — a reusable `ModuleToolbar` should be extracted when a second
module actually needs one (YAGNI). "Share with LPs" keeps its label.

## Tests

- `dashboard-modern.test.tsx` — new test asserts the top bar keeps only the real
  Share action (no `Filter`/`Export` buttons); the existing 5 tests stay green
  (6/6).
- `npm run check`: 0 new errors; `npm run lint` clean (no unused symbols after the
  removals).

PR 5 of the plan (action-scope cleanup / screen-grammar tier), right-sized after
verifying the controls were dead placeholders rather than functional duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
