### PR TITLE
feat(dashboard): context rail shell + collapse affordance (enable_context_rail)

### DIFF
--- a/client/src/components/context-rail/ContextRail.tsx
+++ b/client/src/components/context-rail/ContextRail.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils';
+import type { ContextRailSection } from './context-rail-types';
+
+export function ContextRail({
+  sections,
+  className,
+}: {
+  sections: ContextRailSection[];
+  className?: string;
+}) {
+  return (
+    <aside aria-label="Context rail" className={cn('space-y-6', className)}>
+      {sections.map((section) => (
+        <section key={section.id} aria-label={section.title}>
+          <h3 className="text-sm font-semibold text-charcoal-900">{section.title}</h3>
+          {section.items.length === 0 ? (
+            <p className="mt-2 text-xs text-charcoal-500">{section.emptyText}</p>
+          ) : (
+            <ul className="mt-2 space-y-2">
+              {section.items.map((item) => (
+                <li key={item.id} className="rounded-md border border-beige-200 bg-white p-3">
+                  <p className="text-xs font-medium text-charcoal-700">{item.label}</p>
+                  {item.detail ? (
+                    <p className="mt-1 text-xs text-charcoal-500">{item.detail}</p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
+    </aside>
+  );
+}

--- a/client/src/components/context-rail/ContextRailTrigger.tsx
+++ b/client/src/components/context-rail/ContextRailTrigger.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { PanelRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+import { ContextRail } from './ContextRail';
+import type { ContextRailSection } from './context-rail-types';
+
+export function ContextRailTrigger({
+  sections,
+  className,
+}: {
+  sections: ContextRailSection[];
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm" className={cn('text-charcoal-700', className)}>
+          <PanelRight className="mr-2 h-4 w-4" />
+          Context
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-sm">
+        <SheetHeader>
+          <SheetTitle className="text-charcoal-900">Context</SheetTitle>
+          <SheetDescription className="text-charcoal-600">
+            Freshness, attention, and recent activity for this fund.
+          </SheetDescription>
+        </SheetHeader>
+        <ContextRail sections={sections} className="mt-6" />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/client/src/components/context-rail/context-rail-types.ts
+++ b/client/src/components/context-rail/context-rail-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Context rail (dashboard fourth zone) contracts.
+ * Shell-stage: enumerates all item kinds for future use; only `freshness`
+ * is populated today (no operating-object backend yet - see PR 0-S audit).
+ */
+
+export type ContextRailItemKind =
+  | 'freshness'
+  | 'due'
+  | 'blocker'
+  | 'owner'
+  | 'artifact'
+  | 'activity';
+
+/** Lets a rail item deep-link to an operating object (WorkPanel, PR 7+). */
+export interface ContextRailObjectLink {
+  objectType: string;
+  objectId: string;
+}
+
+export interface ContextRailItem {
+  id: string;
+  kind: ContextRailItemKind;
+  label: string;
+  detail?: string;
+  objectLink?: ContextRailObjectLink;
+}
+
+export interface ContextRailSection {
+  id: string;
+  title: string;
+  items: ContextRailItem[];
+  /** Shown when `items` is empty - never leave a section blank. */
+  emptyText: string;
+}

--- a/client/src/components/context-rail/context-rail-view-model.ts
+++ b/client/src/components/context-rail/context-rail-view-model.ts
@@ -1,0 +1,60 @@
+import type { ContextRailItem, ContextRailSection } from './context-rail-types';
+
+export interface ContextRailInput {
+  /** ISO timestamp from the unified metrics layer (`metrics.actual.asOfDate`). */
+  asOfDate?: string | null;
+}
+
+/** "As of Apr 24, 2026" in UTC; null when the timestamp is missing/invalid. */
+function formatFreshness(asOfDate: string): string | null {
+  const date = new Date(asOfDate);
+  if (Number.isNaN(date.getTime())) return null;
+  const formatted = date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+  return `As of ${formatted}`;
+}
+
+/**
+ * Build the canonical rail sections from the data available today. Only
+ * freshness can be honestly populated; attention/activity stay explicit empty
+ * states until their backends land (do not fabricate items).
+ */
+export function buildContextRailSections(input: ContextRailInput): ContextRailSection[] {
+  const freshnessItems: ContextRailItem[] = [];
+  if (input.asOfDate) {
+    const detail = formatFreshness(input.asOfDate);
+    if (detail) {
+      freshnessItems.push({
+        id: 'freshness-metrics',
+        kind: 'freshness',
+        label: 'Fund metrics',
+        detail,
+      });
+    }
+  }
+
+  return [
+    {
+      id: 'freshness',
+      title: 'Freshness',
+      items: freshnessItems,
+      emptyText: 'No freshness signal yet.',
+    },
+    {
+      id: 'attention',
+      title: 'Needs attention',
+      items: [],
+      emptyText: 'No blockers or due items surfaced yet.',
+    },
+    {
+      id: 'activity',
+      title: 'Recent activity',
+      items: [],
+      emptyText: 'No recent activity yet.',
+    },
+  ];
+}

--- a/client/src/pages/dashboard-modern.tsx
+++ b/client/src/pages/dashboard-modern.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useFundContext } from '@/contexts/FundContext';
 import { PremiumCard } from '@/components/ui/PremiumCard';
 import { POVBrandHeader } from '@/components/ui/POVLogo';
@@ -12,6 +12,10 @@ import { useFundMetrics } from '@/hooks/useFundMetrics';
 import { dollarsToCents, formatCents } from '@/lib/units';
 import type { UnifiedFundMetrics } from '@shared/types/metrics';
 import { getErrorMessage } from '@/lib/http-response';
+import { useFlag } from '@/shared/useFlags';
+import { ContextRail } from '@/components/context-rail/ContextRail';
+import { ContextRailTrigger } from '@/components/context-rail/ContextRailTrigger';
+import { buildContextRailSections } from '@/components/context-rail/context-rail-view-model';
 
 function formatDollars(value: number): string {
   return formatCents(dollarsToCents(value), { compact: true });
@@ -145,6 +149,10 @@ export default function ModernDashboard() {
   const { currentFund, isLoading } = useFundContext();
   const [activeView, setActiveView] = useState('overview');
   const metricsQuery = useFundMetrics({ enabled: Boolean(currentFund) });
+  const contextRailEnabled = useFlag('enable_context_rail');
+  const contextRailSections = buildContextRailSections({
+    asOfDate: metricsQuery.data?.actual.asOfDate ?? null,
+  });
 
   const handleCreateShare = async (
     config: CreateShareLinkRequest
@@ -196,6 +204,43 @@ export default function ModernDashboard() {
     );
   }
 
+  const dashboardTabs = (
+    <Tabs value={activeView} className="space-y-8">
+      {/* Overview Tab */}
+      <TabsContent value="overview" className="space-y-8">
+        <PremiumCard
+          title="Supported overview metrics"
+          subtitle="Backed by the unified metrics layer for the selected fund"
+        >
+          <OverviewMetricsPanel
+            metrics={metricsQuery.data}
+            isLoading={metricsQuery.isLoading}
+            error={metricsQuery.error}
+          />
+        </PremiumCard>
+      </TabsContent>
+
+      {/* Performance Tab */}
+      <TabsContent value="performance" className="space-y-8">
+        <PremiumCard
+          title="Supported performance metrics"
+          subtitle="Current fund performance from supported metrics contracts"
+        >
+          <PerformanceMetricsPanel
+            metrics={metricsQuery.data}
+            isLoading={metricsQuery.isLoading}
+            error={metricsQuery.error}
+          />
+        </PremiumCard>
+      </TabsContent>
+
+      {/* Cashflow Management Tab */}
+      <TabsContent value="cashflow" className="space-y-8">
+        <CashflowDashboard fundId={String(currentFund?.id || 'default')} className="max-w-none" />
+      </TabsContent>
+    </Tabs>
+  );
+
   return (
     <div className="min-h-screen bg-pov-gray">
       <POVBrandHeader
@@ -235,6 +280,9 @@ export default function ModernDashboard() {
           </div>
 
           <div className="flex items-center space-x-3">
+            {contextRailEnabled && (
+              <ContextRailTrigger sections={contextRailSections} className="xl:hidden" />
+            )}
             <ShareConfigModal
               fundId={String(currentFund.id || 'demo-fund')}
               fundName={currentFund.name || 'Demo Fund'}
@@ -252,43 +300,14 @@ export default function ModernDashboard() {
           </div>
         </div>
 
-        <Tabs value={activeView} className="space-y-8">
-          {/* Overview Tab */}
-          <TabsContent value="overview" className="space-y-8">
-            <PremiumCard
-              title="Supported overview metrics"
-              subtitle="Backed by the unified metrics layer for the selected fund"
-            >
-              <OverviewMetricsPanel
-                metrics={metricsQuery.data}
-                isLoading={metricsQuery.isLoading}
-                error={metricsQuery.error}
-              />
-            </PremiumCard>
-          </TabsContent>
-
-          {/* Performance Tab */}
-          <TabsContent value="performance" className="space-y-8">
-            <PremiumCard
-              title="Supported performance metrics"
-              subtitle="Current fund performance from supported metrics contracts"
-            >
-              <PerformanceMetricsPanel
-                metrics={metricsQuery.data}
-                isLoading={metricsQuery.isLoading}
-                error={metricsQuery.error}
-              />
-            </PremiumCard>
-          </TabsContent>
-
-          {/* Cashflow Management Tab */}
-          <TabsContent value="cashflow" className="space-y-8">
-            <CashflowDashboard
-              fundId={String(currentFund?.id || 'default')}
-              className="max-w-none"
-            />
-          </TabsContent>
-        </Tabs>
+        {contextRailEnabled ? (
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <section className="min-w-0">{dashboardTabs}</section>
+            <ContextRail sections={contextRailSections} className="hidden xl:block" />
+          </div>
+        ) : (
+          dashboardTabs
+        )}
       </div>
     </div>
   );

--- a/shared/feature-flags/flag-definitions.ts
+++ b/shared/feature-flags/flag-definitions.ts
@@ -215,6 +215,16 @@ export const POLISH_FLAGS: Record<string, FeatureFlag> = {
     dependencies: [],
   },
 
+  enable_context_rail: {
+    key: 'enable_context_rail',
+    name: 'Dashboard Context Rail',
+    description:
+      'Fourth-zone context rail on the GP dashboard (freshness/attention/activity), inline on xl+ and a Sheet below xl.',
+    enabled: false,
+    rolloutPercentage: 0,
+    dependencies: [],
+  },
+
   enable_route_redirects: {
     key: 'enable_route_redirects',
     name: 'Legacy Route Redirects',

--- a/tests/unit/components/context-rail/ContextRail.test.tsx
+++ b/tests/unit/components/context-rail/ContextRail.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ContextRail } from '@/components/context-rail/ContextRail';
+import type { ContextRailSection } from '@/components/context-rail/context-rail-types';
+
+const sections: ContextRailSection[] = [
+  {
+    id: 'freshness',
+    title: 'Freshness',
+    items: [{ id: 'f1', kind: 'freshness', label: 'Fund metrics', detail: 'As of Apr 24, 2026' }],
+    emptyText: 'No freshness signal yet.',
+  },
+  {
+    id: 'attention',
+    title: 'Needs attention',
+    items: [],
+    emptyText: 'No blockers or due items surfaced yet.',
+  },
+];
+
+describe('ContextRail', () => {
+  it('exposes a named complementary landmark', () => {
+    render(<ContextRail sections={sections} />);
+    expect(screen.getByRole('complementary', { name: 'Context rail' })).toBeInTheDocument();
+  });
+
+  it('renders item label + detail for populated sections', () => {
+    render(<ContextRail sections={sections} />);
+    expect(screen.getByText('Fund metrics')).toBeInTheDocument();
+    expect(screen.getByText('As of Apr 24, 2026')).toBeInTheDocument();
+  });
+
+  it('renders empty text for empty sections', () => {
+    render(<ContextRail sections={sections} />);
+    expect(screen.getByText('No blockers or due items surfaced yet.')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/context-rail/ContextRailTrigger.test.tsx
+++ b/tests/unit/components/context-rail/ContextRailTrigger.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ContextRailTrigger } from '@/components/context-rail/ContextRailTrigger';
+import type { ContextRailSection } from '@/components/context-rail/context-rail-types';
+
+const sections: ContextRailSection[] = [
+  { id: 'freshness', title: 'Freshness', items: [], emptyText: 'No freshness signal yet.' },
+];
+
+describe('ContextRailTrigger', () => {
+  it('renders a visible trigger and opens the rail in a Sheet', async () => {
+    const user = userEvent.setup();
+    render(<ContextRailTrigger sections={sections} />);
+
+    const trigger = screen.getByRole('button', { name: /context/i });
+    expect(trigger).toBeInTheDocument();
+    // Closed: rail content not mounted yet (Radix Dialog mounts on open).
+    expect(screen.queryByRole('complementary', { name: 'Context rail' })).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(await screen.findByRole('complementary', { name: 'Context rail' })).toBeInTheDocument();
+    expect(screen.getByText('Freshness')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/context-rail/context-rail-view-model.test.ts
+++ b/tests/unit/components/context-rail/context-rail-view-model.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildContextRailSections } from '@/components/context-rail/context-rail-view-model';
+
+describe('buildContextRailSections', () => {
+  it('returns the three canonical sections', () => {
+    const sections = buildContextRailSections({});
+    expect(sections.map((s) => s.id)).toEqual(['freshness', 'attention', 'activity']);
+    for (const section of sections) {
+      expect(section.title.length).toBeGreaterThan(0);
+      expect(section.emptyText.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('populates a freshness item from a valid asOfDate (UTC, no fabrication elsewhere)', () => {
+    const sections = buildContextRailSections({ asOfDate: '2026-04-24T00:00:00.000Z' });
+    const freshness = sections.find((s) => s.id === 'freshness');
+    expect(freshness?.items).toHaveLength(1);
+    expect(freshness?.items[0]).toMatchObject({ kind: 'freshness', label: 'Fund metrics' });
+    expect(freshness?.items[0]?.detail).toBe('As of Apr 24, 2026');
+    // attention/activity stay empty until backends land
+    expect(sections.find((s) => s.id === 'attention')?.items).toHaveLength(0);
+    expect(sections.find((s) => s.id === 'activity')?.items).toHaveLength(0);
+  });
+
+  it('leaves freshness empty when asOfDate is missing or invalid', () => {
+    for (const asOfDate of [undefined, null, '', 'not-a-date']) {
+      const sections = buildContextRailSections({ asOfDate });
+      expect(sections.find((s) => s.id === 'freshness')?.items).toHaveLength(0);
+    }
+  });
+});

--- a/tests/unit/pages/dashboard-modern.test.tsx
+++ b/tests/unit/pages/dashboard-modern.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ModernDashboard from '@/pages/dashboard-modern';
@@ -29,7 +29,7 @@ vi.mock('@/components/dashboard/CashflowDashboard', () => ({
 }));
 
 vi.mock('@/components/sharing/ShareConfigModal', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 describe('ModernDashboard', () => {
@@ -74,6 +74,10 @@ describe('ModernDashboard', () => {
     });
   });
 
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
   it('renders supported overview metrics instead of broad deferred copy', () => {
     render(<ModernDashboard />);
 
@@ -94,6 +98,21 @@ describe('ModernDashboard', () => {
     expect(screen.getByText('Share with LPs')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^filter$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /export/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the context rail and trigger when the flag is off (default)', () => {
+    render(<ModernDashboard />);
+    expect(screen.queryByRole('complementary', { name: 'Context rail' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^context$/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the inline context rail and the below-xl trigger when the flag is on', () => {
+    window.localStorage.setItem('ff_enable_context_rail', '1');
+    render(<ModernDashboard />);
+    expect(screen.getByRole('complementary', { name: 'Context rail' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^context$/i })).toBeInTheDocument();
+    // honest freshness item from the mocked asOfDate (2026-04-24)
+    expect(screen.getByText('As of Apr 24, 2026')).toBeInTheDocument();
   });
 
   it('renders supported performance metrics while keeping unsupported claims unavailable', async () => {


### PR DESCRIPTION
## What

Adds the dashboard's "fourth zone" — a **context rail** — behind the new
`enable_context_rail` flag (default off). It renders **inline on `xl+`** and
exposes a header **"Context" toggle that opens the rail as a `Sheet` below `xl`**,
so the zone is never silently hidden on 1366×768 GP laptops.

Shell-stage only (PR 6 of the trust-first migration). No operating-object
backend exists yet (per the PR 0-S readiness audit: task/assumption/comment =
NONE), so the rail shows honest sections with explicit empty states. The single
populated item is real **data freshness** derived from `metrics.actual.asOfDate`
— no fabricated data.

## Changes

- **New** `client/src/components/context-rail/`
  - `context-rail-types.ts` — item-kind + section contracts (enumerates
    freshness/due/blocker/owner/artifact/activity for future use)
  - `context-rail-view-model.ts` — pure `buildContextRailSections()`; UTC-safe
    freshness formatting; attention/activity stay empty until backends land
  - `ContextRail.tsx` — presentational rail (named `complementary` landmark,
    per-section empty states)
  - `ContextRailTrigger.tsx` — below-`xl` affordance wrapping the **same**
    `ContextRail` in a right `Sheet` (no duplicated markup)
- **Edit** `dashboard-modern.tsx` — flag-gated: inline rail in an
  `xl:grid-cols-[minmax(0,1fr)_320px]` grid + `xl:hidden` trigger in the header
- **Edit** `flag-definitions.ts` — register `enable_context_rail` (POLISH group,
  default off, no deps)
- **Tests** — view-model (node), `ContextRail`/`ContextRailTrigger` (jsdom),
  plus flag on/off wiring tests added to `dashboard-modern.test.tsx`

## Verification

- `npm run check` (tsc) — clean
- 16 tests pass: view-model 3 (node) · ContextRail 3 · ContextRailTrigger 1 ·
  dashboard-modern 8 (6 existing regressions + 2 new), all jsdom
- Flag OFF: dashboard behaviour byte-unchanged (existing tests green)

## Notes / deviations from the plan (KISS)

- Adapted to the **real** `dashboard-modern.tsx` layout (the plan's
  command-header/grid did not exist) and stands alone — no `ModuleToolbar`
  dependency (PR 5 was right-sized to dead-control removal).
- No barrel/index and no per-item-kind rendering — extract after a real second
  use.
- Canonical tokens only (`charcoal-NNN`, `border-beige-200`, `bg-white`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
