### PR TITLE
feat(dashboard): WorkPanel primitive (side Sheet) + URL state hook (enable_work_panel)

### DIFF
--- a/client/src/components/work-panel/WorkPanel.tsx
+++ b/client/src/components/work-panel/WorkPanel.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+
+export function WorkPanel({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  className,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <SheetContent
+        side="right"
+        className={cn('w-full overflow-y-auto p-0 sm:max-w-xl md:max-w-2xl', className)}
+        {...(description ? {} : { 'aria-describedby': undefined })}
+      >
+        <SheetHeader className="border-b border-beige-200 px-6 py-4 text-left">
+          <SheetTitle className="text-charcoal-900">{title}</SheetTitle>
+          {description ? (
+            <SheetDescription className="text-charcoal-600">{description}</SheetDescription>
+          ) : null}
+        </SheetHeader>
+        <div className="px-6 py-4">{children}</div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/client/src/components/work-panel/useWorkPanelUrlState.ts
+++ b/client/src/components/work-panel/useWorkPanelUrlState.ts
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import { useLocation, useSearch } from 'wouter';
+import { WORK_PANEL_PARAMS, type WorkPanelState } from './work-panel-types';
+
+export interface UseWorkPanelUrlState {
+  /** Current panel state, or null when no panel param is present. */
+  state: WorkPanelState | null;
+  /** Open/replace the panel; preserves all non-panel query params. */
+  openPanel: (next: WorkPanelState) => void;
+  /** Close the panel; removes ONLY the panel params, restores the rest. */
+  closePanel: () => void;
+  /** Change the active tab without otherwise touching the URL. */
+  setTab: (tab: string) => void;
+}
+
+export function useWorkPanelUrlState(): UseWorkPanelUrlState {
+  const [location, setLocation] = useLocation();
+  const search = useSearch();
+
+  const params = new URLSearchParams(search);
+  const panel = params.get(WORK_PANEL_PARAMS.panel);
+  const object = params.get(WORK_PANEL_PARAMS.object);
+  const tab = params.get(WORK_PANEL_PARAMS.tab);
+
+  const state: WorkPanelState | null = panel
+    ? { panel, ...(object ? { object } : {}), ...(tab ? { tab } : {}) }
+    : null;
+
+  const navigateWith = useCallback(
+    (mutate: (next: URLSearchParams) => void) => {
+      const next = new URLSearchParams(search);
+      mutate(next);
+      const nextSearch = next.toString();
+      setLocation(nextSearch ? `${location}?${nextSearch}` : location);
+    },
+    [location, search, setLocation]
+  );
+
+  const openPanel = useCallback(
+    (next: WorkPanelState) => {
+      navigateWith((p) => {
+        p.set(WORK_PANEL_PARAMS.panel, next.panel);
+        if (next.object) p.set(WORK_PANEL_PARAMS.object, next.object);
+        else p.delete(WORK_PANEL_PARAMS.object);
+        if (next.tab) p.set(WORK_PANEL_PARAMS.tab, next.tab);
+        else p.delete(WORK_PANEL_PARAMS.tab);
+      });
+    },
+    [navigateWith]
+  );
+
+  const closePanel = useCallback(() => {
+    navigateWith((p) => {
+      p.delete(WORK_PANEL_PARAMS.panel);
+      p.delete(WORK_PANEL_PARAMS.object);
+      p.delete(WORK_PANEL_PARAMS.tab);
+    });
+  }, [navigateWith]);
+
+  const setTab = useCallback(
+    (nextTab: string) => {
+      navigateWith((p) => {
+        if (nextTab) p.set(WORK_PANEL_PARAMS.tab, nextTab);
+        else p.delete(WORK_PANEL_PARAMS.tab);
+      });
+    },
+    [navigateWith]
+  );
+
+  return { state, openPanel, closePanel, setTab };
+}

--- a/client/src/components/work-panel/work-panel-types.ts
+++ b/client/src/components/work-panel/work-panel-types.ts
@@ -1,0 +1,21 @@
+/**
+ * WorkPanel = context-preserving drill-down (side Sheet). State is URL-addressable
+ * via ?panel=&object=&panelTab= so a panel is copyable/reloadable. `panel`
+ * presence = open.
+ */
+
+export interface WorkPanelState {
+  /** Panel kind/identity (e.g. 'scenario', 'company'). Presence = panel open. */
+  panel: string;
+  /** Optional operating-object id the panel is bound to. */
+  object?: string;
+  /** Optional active tab within the panel. */
+  tab?: string;
+}
+
+/** URL param names (single source of truth for read + write). */
+export const WORK_PANEL_PARAMS = {
+  panel: 'panel',
+  object: 'object',
+  tab: 'panelTab',
+} as const;

--- a/shared/feature-flags/flag-definitions.ts
+++ b/shared/feature-flags/flag-definitions.ts
@@ -225,6 +225,16 @@ export const POLISH_FLAGS: Record<string, FeatureFlag> = {
     dependencies: [],
   },
 
+  enable_work_panel: {
+    key: 'enable_work_panel',
+    name: 'WorkPanel Drill-down',
+    description:
+      'Context-preserving drill-down panels (side Sheet) on the GP dashboard; URL-addressable via ?panel=&object=&panelTab=.',
+    enabled: false,
+    rolloutPercentage: 0,
+    dependencies: [],
+  },
+
   enable_route_redirects: {
     key: 'enable_route_redirects',
     name: 'Legacy Route Redirects',

--- a/tests/unit/components/work-panel/WorkPanel.test.tsx
+++ b/tests/unit/components/work-panel/WorkPanel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WorkPanel } from '@/components/work-panel/WorkPanel';
+
+describe('WorkPanel', () => {
+  it('renders title, description, and children when open', () => {
+    render(
+      <WorkPanel open onClose={() => {}} title="Scenario proof" description="Read-only details">
+        <p>Panel body</p>
+      </WorkPanel>
+    );
+    expect(screen.getByText('Scenario proof')).toBeInTheDocument();
+    expect(screen.getByText('Read-only details')).toBeInTheDocument();
+    expect(screen.getByText('Panel body')).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    render(
+      <WorkPanel open={false} onClose={() => {}} title="Scenario proof">
+        <p>Panel body</p>
+      </WorkPanel>
+    );
+    expect(screen.queryByText('Panel body')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when the close affordance is used', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <WorkPanel open onClose={onClose} title="Scenario proof">
+        <p>Panel body</p>
+      </WorkPanel>
+    );
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/work-panel/useWorkPanelUrlState.test.tsx
+++ b/tests/unit/components/work-panel/useWorkPanelUrlState.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSearch } from 'wouter';
+import { createWouterWrapper } from '../../../utils/withWouter';
+import { useWorkPanelUrlState } from '@/components/work-panel/useWorkPanelUrlState';
+
+function Harness() {
+  const { state, openPanel, closePanel, setTab } = useWorkPanelUrlState();
+  const search = useSearch();
+  return (
+    <div>
+      <div data-testid="state">{state ? JSON.stringify(state) : 'null'}</div>
+      <div data-testid="search">{search}</div>
+      <button onClick={() => openPanel({ panel: 'scenario', object: 's1', tab: 'proof' })}>
+        open
+      </button>
+      <button onClick={() => setTab('detail')}>tab</button>
+      <button onClick={() => closePanel()}>close</button>
+    </div>
+  );
+}
+
+describe('useWorkPanelUrlState', () => {
+  it('starts closed when no panel param is present', () => {
+    const { Wrapper } = createWouterWrapper('/dashboard?fundId=7');
+    render(<Harness />, { wrapper: Wrapper });
+    expect(screen.getByTestId('state').textContent).toBe('null');
+  });
+
+  it('opens via the URL and preserves existing params', async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWouterWrapper('/dashboard?fundId=7');
+    render(<Harness />, { wrapper: Wrapper });
+
+    await user.click(screen.getByRole('button', { name: 'open' }));
+
+    expect(JSON.parse(screen.getByTestId('state').textContent ?? 'null')).toEqual({
+      panel: 'scenario',
+      object: 's1',
+      tab: 'proof',
+    });
+    const search = screen.getByTestId('search').textContent ?? '';
+    const params = new URLSearchParams(search);
+    expect(params.get('fundId')).toBe('7'); // preserved
+    expect(params.get('panel')).toBe('scenario');
+    expect(params.get('object')).toBe('s1');
+    expect(params.get('panelTab')).toBe('proof');
+  });
+
+  it('updates only the tab param', async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWouterWrapper('/dashboard?panel=scenario&object=s1&panelTab=proof');
+    render(<Harness />, { wrapper: Wrapper });
+
+    await user.click(screen.getByRole('button', { name: 'tab' }));
+
+    expect(
+      new URLSearchParams(screen.getByTestId('search').textContent ?? '').get('panelTab')
+    ).toBe('detail');
+    expect(JSON.parse(screen.getByTestId('state').textContent ?? 'null')).toMatchObject({
+      panel: 'scenario',
+      tab: 'detail',
+    });
+  });
+
+  it('closes by removing only the panel params, restoring the rest', async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWouterWrapper(
+      '/dashboard?fundId=7&panel=scenario&object=s1&panelTab=proof'
+    );
+    render(<Harness />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('state').textContent).not.toBe('null');
+
+    await user.click(screen.getByRole('button', { name: 'close' }));
+
+    expect(screen.getByTestId('state').textContent).toBe('null');
+    const params = new URLSearchParams(screen.getByTestId('search').textContent ?? '');
+    expect(params.get('fundId')).toBe('7'); // preserved
+    expect(params.get('panel')).toBeNull();
+    expect(params.get('object')).toBeNull();
+    expect(params.get('panelTab')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds the **WorkPanel** drill-down primitive — a context-preserving **right-side
`Sheet`** (NOT a center Dialog; per DESIGN.md:123 the decision canvas stays
visible + dimmed) — plus a `useWorkPanelUrlState` hook that makes panels
URL-addressable via `?panel=&object=&panelTab=`. Registers the `enable_work_panel`
flag (default off).

PR 7 of the trust-first migration. This is the **reusable primitive only** — the
first read-only integrations land in PR 8, so there are **no dashboard edits**
here.

## Changes

- **New** `client/src/components/work-panel/`
  - `work-panel-types.ts` — `WorkPanelState` + `WORK_PANEL_PARAMS` (single source
    of truth for URL param names)
  - `useWorkPanelUrlState.ts` — wouter-based hook: `state`, `openPanel`,
    `closePanel`, `setTab`. Reads via `useSearch()`, writes via `useLocation`'s
    `setLocation('/path?query')`. `openPanel`/`closePanel` preserve all non-panel
    query params; `closePanel` removes only `panel`/`object`/`panelTab`.
  - `WorkPanel.tsx` — controlled, presentational Sheet shell (accessible
    title/optional description, Sheet's built-in focus trap + Close); explicit
    `aria-describedby` opt-out when no description (no Radix a11y warning)
- **Edit** `shared/feature-flags/flag-definitions.ts` — register
  `enable_work_panel` (POLISH group, default off, no deps)
- **Tests** — `useWorkPanelUrlState` (open/close/tab URL round-trips + param
  preservation, via the wouter `memoryLocation` harness) and `WorkPanel`
  (open/closed render + onClose)

## Verification

- `npm run check` (tsc baseline) — 0 new errors
- 7 tests pass: `useWorkPanelUrlState` 4 · `WorkPanel` 3 (jsdom); no Radix
  console warnings

## Notes / deviations from the plan (KISS)

Right-sized to the primitive that PR 8 will actually consume. **Deferred** until a
real consumer exists (extract after a second use):

- `WorkPanelHeader` / `WorkPanelTabs` / `WorkPanelFooter` subcomponents
- the dirty-state Save/Cancel guard (needed only for **editable** panels, PR 9)
- `work-panel-contract.md` — largely derivable from code + tests; the
  non-derivable "Sheet not Dialog" rationale belongs in `DECISIONS.md`, not a new
  doc (per the repo Documentation Governance prune policy)
- reduced-motion is handled by the existing Sheet animation utilities + the
  design-system global CSS, not re-implemented per-component

Canonical tokens only (`charcoal-NNN`, `border-beige-200`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
