### PR TITLE
feat(dashboard): read-only WorkPanel stress-scenario View proof (enable_work_panel)

### DIFF
--- a/client/src/components/dashboard/CashflowDashboard.tsx
+++ b/client/src/components/dashboard/CashflowDashboard.tsx
@@ -27,6 +27,7 @@ import {
   Cell,
 } from 'recharts';
 import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/charts/LazyResponsiveContainer';
+import { StressScenarioProofPanel } from './StressScenarioProofPanel';
 import {
   TrendingUp,
   TrendingDown,
@@ -47,9 +48,11 @@ import {
 } from '@/hooks/useLiquidityAnalytics';
 import { useFundContext } from '@/contexts/FundContext';
 import { isDemoMode } from '@/core/demo/persona';
+import { useWorkPanelUrlState } from '@/components/work-panel/useWorkPanelUrlState';
 import { presson } from '@/theme/presson.tokens';
 import { colors as brandColors, getChartColor } from '@/lib/brand-tokens';
 import { getImpactBadgeClass, getImpactTextClass } from '@/lib/display/impact-semantics';
+import { useFlag } from '@/shared/useFlags';
 import { toStressScenarioViewModel } from './stress-test-view-model';
 
 const STATUS_SUCCESS = brandColors.success;
@@ -119,6 +122,8 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
   );
 
   const liquidityMetrics = useLiquidityMetrics(analytics.cashFlowAnalysis);
+  const workPanelEnabled = useFlag('enable_work_panel');
+  const workPanel = useWorkPanelUrlState();
 
   // Generate chart data
   const cashFlowChartData = useMemo(() => {
@@ -673,6 +678,24 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
                             <Badge className={getImpactBadgeClass(vm.impactSeverity)}>
                               {vm.impactSeverity} impact
                             </Badge>
+                            {workPanelEnabled && (
+                              <div className="mt-2">
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-auto p-0 text-xs text-charcoal-600 hover:text-charcoal-900"
+                                  onClick={() =>
+                                    workPanel.openPanel({
+                                      panel: 'scenario',
+                                      object: String(index),
+                                      tab: 'proof',
+                                    })
+                                  }
+                                >
+                                  View proof
+                                </Button>
+                              </div>
+                            )}
                           </div>
                         </div>
                       );
@@ -720,6 +743,14 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
           </Card>
         </TabsContent>
       </Tabs>
+      {workPanelEnabled && (
+        <StressScenarioProofPanel
+          scenarios={analytics.stressTestResult?.scenarios ?? []}
+          baselineCash={stressBaselineCash}
+          state={workPanel.state}
+          onClose={workPanel.closePanel}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/dashboard/StressScenarioProofPanel.tsx
+++ b/client/src/components/dashboard/StressScenarioProofPanel.tsx
@@ -1,0 +1,62 @@
+import { Badge } from '@/components/ui/badge';
+import { WorkPanel } from '@/components/work-panel/WorkPanel';
+import type { WorkPanelState } from '@/components/work-panel/work-panel-types';
+import type { StressTestScenario } from '@/core/LiquidityEngine';
+import { getImpactBadgeClass, getImpactTextClass } from '@/lib/display/impact-semantics';
+import { toStressScenarioProofRows, toStressScenarioViewModel } from './stress-test-view-model';
+
+export function StressScenarioProofPanel({
+  scenarios,
+  baselineCash,
+  state,
+  onClose,
+}: {
+  scenarios: StressTestScenario[];
+  baselineCash: number;
+  state: WorkPanelState | null;
+  onClose: () => void;
+}) {
+  const isOpen = state?.panel === 'scenario';
+  const index = state?.object != null ? Number(state.object) : Number.NaN;
+  const scenario = Number.isInteger(index) && index >= 0 ? scenarios[index] : undefined;
+
+  if (!scenario) {
+    return (
+      <WorkPanel open={isOpen} onClose={onClose} title="Scenario proof">
+        <p className="text-sm text-charcoal-600">
+          This scenario is unavailable. Run the stress test to view its proof.
+        </p>
+      </WorkPanel>
+    );
+  }
+
+  const vm = toStressScenarioViewModel(scenario, baselineCash);
+  const rows = toStressScenarioProofRows(vm, baselineCash);
+
+  return (
+    <WorkPanel open={isOpen} onClose={onClose} title={vm.name} description={vm.description}>
+      <dl className="space-y-3">
+        {rows.map((row) => (
+          <div key={row.key} className="flex items-center justify-between gap-4">
+            <dt className="text-sm text-charcoal-600">{row.label}</dt>
+            <dd
+              className={
+                row.key === 'impact'
+                  ? `text-sm font-medium ${getImpactTextClass({
+                      direction: vm.impactDirection,
+                      severity: vm.impactSeverity,
+                    })}`
+                  : 'text-sm font-medium text-charcoal-900'
+              }
+            >
+              {row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <div className="mt-4">
+        <Badge className={getImpactBadgeClass(vm.impactSeverity)}>{vm.impactSeverity} impact</Badge>
+      </div>
+    </WorkPanel>
+  );
+}

--- a/client/src/components/dashboard/stress-test-view-model.ts
+++ b/client/src/components/dashboard/stress-test-view-model.ts
@@ -1,5 +1,6 @@
 import type { StressTestScenario } from '@/core/LiquidityEngine';
 import type { ImpactDirection, ImpactSeverity } from '@/lib/display/impact-semantics';
+import { dollarsToCents, formatCents } from '@/lib/units';
 
 export type StressScenarioViewModel = {
   name: string;
@@ -35,4 +36,38 @@ export function toStressScenarioViewModel(
     impactSeverity: scenario.impactRating,
     probability: scenario.probability,
   };
+}
+
+export interface StressScenarioProofRow {
+  key: 'baseline' | 'ending' | 'impact' | 'probability';
+  label: string;
+  value: string;
+}
+
+function formatProofMoney(value: number): string {
+  return formatCents(dollarsToCents(value), { compact: true });
+}
+
+/**
+ * Read-only "proof" rows for a stress scenario: the derivation that justifies the
+ * displayed impact (baseline -> ending -> signed delta -> probability). Severity is
+ * surfaced as a badge by the panel, not as a row, to avoid duplication.
+ */
+export function toStressScenarioProofRows(
+  vm: StressScenarioViewModel,
+  baselineCash: number
+): StressScenarioProofRow[] {
+  const signedImpact = `${vm.liquidityImpact >= 0 ? '+' : '-'}${formatProofMoney(
+    Math.abs(vm.liquidityImpact)
+  )}`;
+  return [
+    { key: 'baseline', label: 'Baseline cash position', value: formatProofMoney(baselineCash) },
+    { key: 'ending', label: 'Projected ending cash', value: formatProofMoney(vm.endingCash) },
+    { key: 'impact', label: 'Liquidity impact vs baseline', value: signedImpact },
+    {
+      key: 'probability',
+      label: 'Scenario probability',
+      value: `${Math.round(vm.probability * 100)}%`,
+    },
+  ];
 }

--- a/tests/unit/components/dashboard/StressScenarioProofPanel.test.tsx
+++ b/tests/unit/components/dashboard/StressScenarioProofPanel.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StressScenarioProofPanel } from '@/components/dashboard/StressScenarioProofPanel';
+import type { StressTestScenario } from '@/core/LiquidityEngine';
+
+const scenarios: StressTestScenario[] = [
+  {
+    name: 'Distribution delay',
+    description: 'LP distributions arrive later than expected',
+    endingCash: 3_000_000,
+    impactRating: 'medium',
+    probability: 0.35,
+  },
+  {
+    name: 'Market downturn',
+    description: 'Combined adverse market stress',
+    endingCash: 1_000_000,
+    impactRating: 'high',
+    probability: 0.15,
+  },
+];
+
+describe('StressScenarioProofPanel', () => {
+  it('renders nothing when no panel state is present', () => {
+    render(
+      <StressScenarioProofPanel
+        scenarios={scenarios}
+        baselineCash={5_000_000}
+        state={null}
+        onClose={() => {}}
+      />
+    );
+
+    expect(screen.queryByText('Distribution delay')).not.toBeInTheDocument();
+  });
+
+  it('shows the matched scenario proof when the panel is open', () => {
+    render(
+      <StressScenarioProofPanel
+        scenarios={scenarios}
+        baselineCash={5_000_000}
+        state={{ panel: 'scenario', object: '0', tab: 'proof' }}
+        onClose={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Distribution delay')).toBeInTheDocument();
+    expect(screen.getByText('LP distributions arrive later than expected')).toBeInTheDocument();
+    expect(screen.getByText('Baseline cash position')).toBeInTheDocument();
+    expect(screen.getByText('$5.0M')).toBeInTheDocument();
+    expect(screen.getByText('$3.0M')).toBeInTheDocument();
+    expect(screen.getByText('-$2.0M')).toBeInTheDocument();
+    expect(screen.getByText('35%')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close affordance is used', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <StressScenarioProofPanel
+        scenarios={scenarios}
+        baselineCash={5_000_000}
+        state={{ panel: 'scenario', object: '0' }}
+        onClose={onClose}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an unavailable message when the scenario index is out of range', () => {
+    render(
+      <StressScenarioProofPanel
+        scenarios={scenarios}
+        baselineCash={5_000_000}
+        state={{ panel: 'scenario', object: '9' }}
+        onClose={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/this scenario is unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/dashboard/stress-test-view-model.test.tsx
+++ b/tests/unit/components/dashboard/stress-test-view-model.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { toStressScenarioViewModel } from '@/components/dashboard/stress-test-view-model';
+import {
+  toStressScenarioProofRows,
+  toStressScenarioViewModel,
+} from '@/components/dashboard/stress-test-view-model';
 import type { StressTestScenario } from '@/core/LiquidityEngine';
 import { getImpactTextClass } from '@/lib/display/impact-semantics';
 
@@ -54,5 +57,28 @@ describe('toStressScenarioViewModel', () => {
     expect(
       getImpactTextClass({ direction: vm.impactDirection, severity: vm.impactSeverity })
     ).not.toBe('text-presson-positive');
+  });
+});
+
+describe('toStressScenarioProofRows', () => {
+  it('produces labeled proof rows with a signed impact for an unfavorable scenario', () => {
+    const vm = toStressScenarioViewModel(
+      makeScenario({ endingCash: 3_000_000, impactRating: 'medium', probability: 0.35 }),
+      5_000_000
+    );
+    const rows = toStressScenarioProofRows(vm, 5_000_000);
+    const byKey = Object.fromEntries(rows.map((r) => [r.key, r.value]));
+
+    expect(byKey.baseline).toBe('$5.0M');
+    expect(byKey.ending).toBe('$3.0M');
+    expect(byKey.impact).toBe('-$2.0M');
+    expect(byKey.probability).toBe('35%');
+  });
+
+  it('shows a positive signed impact for a favorable scenario', () => {
+    const vm = toStressScenarioViewModel(makeScenario({ endingCash: 7_000_000 }), 5_000_000);
+    const rows = toStressScenarioProofRows(vm, 5_000_000);
+
+    expect(rows.find((r) => r.key === 'impact')?.value).toBe('+$2.0M');
   });
 });


### PR DESCRIPTION
## PR 8 — First WorkPanel integration (read-only): stress-scenario "View proof"

Flag: `enable_work_panel` (POLISH, already registered, **default off**). With the
flag off there is no behavior change.

This is where the dashboard finally **consumes** the PR7 WorkPanel primitive +
`useWorkPanelUrlState` hook.

### What it does

Each stress-test scenario row (Cashflow tab → Stress Test sub-tab) gains a
**"View proof"** trigger. Clicking it opens the right-side Sheet WorkPanel with a
read-only derivation of the scenario's impact:

- Baseline cash position
- Projected ending cash
- Liquidity impact vs baseline (signed; canonical impact text color)
- Scenario probability
- Severity badge

The panel is URL-addressable via the existing hook (`?panel=scenario&object=&panelTab=`),
so it is copyable/reloadable. Closing removes only the panel params and restores the
prior dashboard + cashflow + stress-test tab state (query-only navigation, no remount).
A copied URL whose scenario index does not resolve (e.g. before the stress test has
run) shows an explicit "unavailable" message — never a blank or fabricated panel.

Read-only by design: no object backend yet (per the PR 0-S readiness audit), so no
create/save and **no dirty-state guard**.

### Scope decisions (verified against `main`, not assumed)

- **Integrated in `CashflowDashboard.tsx`, not `dashboard-modern.tsx`.** The stress
  scenario data + affordance are local to CashflowDashboard; wiring the panel into the
  parent would require threading view-models up via callbacks (more coupling). The
  parent's test fully mocks CashflowDashboard, so this carries zero regression risk
  there.
- **Context-rail blocker integration deferred.** `buildContextRailSections` hard-codes
  `attention: { items: [] }` — no clickable blocker source exists on the dashboard yet.
- **Portfolio "View details" deferred.** The portfolio table is a separate page, not
  the dashboard.

### Files

- `client/src/components/dashboard/stress-test-view-model.ts` — pure
  `toStressScenarioProofRows()` helper (canonical `formatCents`/`dollarsToCents`).
- `client/src/components/dashboard/StressScenarioProofPanel.tsx` — NEW presentational
  panel (props-driven; graceful "unavailable" state).
- `client/src/components/dashboard/CashflowDashboard.tsx` — flag +
  `useWorkPanelUrlState` + per-row trigger + panel render (all behind the flag).
- `tests/unit/components/dashboard/stress-test-view-model.test.tsx` — +2 proof-row cases.
- `tests/unit/components/dashboard/StressScenarioProofPanel.test.tsx` — NEW (4 cases).

### Verification

- `npm run check`: 0 new TypeScript errors.
- Targeted client tests: 19/19 pass (11 new/extended + 8 `dashboard-modern` regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
