### PR TITLE
feat(sharing): return immutable snapshot from share-create + show real as-of date + portfolio preview

### DIFF
--- a/client/src/components/sharing/ShareConfigModal.tsx
+++ b/client/src/components/sharing/ShareConfigModal.tsx
@@ -28,6 +28,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Share2, Copy, Eye, Clock, Shield, Users } from 'lucide-react';
 import type { CreateShareLinkRequest } from '@shared/sharing-schema';
 import { LP_HIDDEN_METRICS } from '@shared/sharing-schema';
+import type { PublicShareSnapshotPayload } from '@shared/contracts/public-share-snapshot.contract';
 import { useFlag } from '@/shared/useFlags';
 
 type ShareAccessLevel = CreateShareLinkRequest['accessLevel'];
@@ -35,12 +36,15 @@ type CreatedShareSnapshot = {
   shareId: string;
   capturedAt: string;
   config: CreateShareLinkRequest;
+  snapshotPayload?: PublicShareSnapshotPayload;
 };
 
 interface ShareConfigModalProps {
   fundId: string;
   fundName: string;
-  onCreateShare: (config: CreateShareLinkRequest) => Promise<{ shareUrl: string; shareId: string }>;
+  onCreateShare: (
+    config: CreateShareLinkRequest
+  ) => Promise<{ shareUrl: string; shareId: string; snapshot?: PublicShareSnapshotPayload }>;
   children?: React.ReactNode;
 }
 
@@ -64,6 +68,11 @@ const ACCESS_LABELS: Record<ShareAccessLevel, string> = {
 const humanizeMetric = (metric: string) =>
   metric.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
 
+const formatPreviewMoic = (moic: number | null, moicHidden: boolean): string => {
+  if (moic !== null) return `${moic.toFixed(2)}x`;
+  return moicHidden ? 'Hidden' : '—';
+};
+
 export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
   fundId,
   fundName,
@@ -86,6 +95,8 @@ export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
   });
   const lpSnapshotMode = useFlag('enable_lp_snapshot_mode');
   const [snapshot, setSnapshot] = useState<CreatedShareSnapshot | null>(null);
+  const snapshotPayload = snapshot?.snapshotPayload ?? null;
+  const moicHidden = snapshotPayload?.hiddenMetricPolicy.applied.includes('moic') ?? false;
 
   const handleCreateShare = async () => {
     const submittedConfig = { ...config, hiddenMetrics: [...config.hiddenMetrics] };
@@ -97,6 +108,7 @@ export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
         shareId: result.shareId,
         capturedAt: new Date().toISOString(),
         config: submittedConfig,
+        ...(result.snapshot ? { snapshotPayload: result.snapshot } : {}),
       });
     } catch (error) {
       console.error('Failed to create share link:', error);
@@ -186,10 +198,20 @@ export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
                   <dd className="truncate font-mono text-charcoal-900">{snapshot.shareId}</dd>
                   <dt className="text-charcoal-600">Captured</dt>
                   <dd className="text-charcoal-900">
-                    {new Date(snapshot.capturedAt).toLocaleString()}
+                    {new Date(snapshotPayload?.generatedAt ?? snapshot.capturedAt).toLocaleString()}
                   </dd>
+                  {snapshotPayload && (
+                    <>
+                      <dt className="text-charcoal-600">Data as of</dt>
+                      <dd className="text-charcoal-900">
+                        {new Date(snapshotPayload.asOfDate).toLocaleDateString()}
+                      </dd>
+                    </>
+                  )}
                   <dt className="text-charcoal-600">Access</dt>
-                  <dd className="text-charcoal-900">{ACCESS_LABELS[snapshot.config.accessLevel]}</dd>
+                  <dd className="text-charcoal-900">
+                    {ACCESS_LABELS[snapshot.config.accessLevel]}
+                  </dd>
                   <dt className="text-charcoal-600">Expires</dt>
                   <dd className="text-charcoal-900">
                     {snapshot.config.expiresInDays
@@ -213,6 +235,26 @@ export const ShareConfigModal: React.FC<ShareConfigModalProps> = ({
                     </div>
                   )}
                 </div>
+                {snapshotPayload && snapshotPayload.portfolioCompanies.length > 0 && (
+                  <div>
+                    <p className="text-sm font-medium text-charcoal-700">
+                      Portfolio companies LPs will see
+                    </p>
+                    <ul className="mt-1 space-y-1">
+                      {snapshotPayload.portfolioCompanies.map((company) => (
+                        <li
+                          key={company.name}
+                          className="flex items-center justify-between gap-2 text-sm"
+                        >
+                          <span className="truncate text-charcoal-900">{company.name}</span>
+                          <span className="text-charcoal-600">
+                            {company.stage ?? '—'} · {formatPreviewMoic(company.moic, moicHidden)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
             )}
 

--- a/client/src/pages/dashboard-modern.tsx
+++ b/client/src/pages/dashboard-modern.tsx
@@ -8,6 +8,7 @@ import { Activity, Share2 } from 'lucide-react';
 import CashflowDashboard from '@/components/dashboard/CashflowDashboard';
 import ShareConfigModal from '@/components/sharing/ShareConfigModal';
 import type { CreateShareLinkRequest } from '@shared/sharing-schema';
+import type { PublicShareSnapshotPayload } from '@shared/contracts/public-share-snapshot.contract';
 import { useFundMetrics } from '@/hooks/useFundMetrics';
 import { dollarsToCents, formatCents } from '@/lib/units';
 import type { UnifiedFundMetrics } from '@shared/types/metrics';
@@ -156,7 +157,7 @@ export default function ModernDashboard() {
 
   const handleCreateShare = async (
     config: CreateShareLinkRequest
-  ): Promise<{ shareUrl: string; shareId: string }> => {
+  ): Promise<{ shareUrl: string; shareId: string; snapshot?: PublicShareSnapshotPayload }> => {
     const response = await fetch('/api/shares', {
       method: 'POST',
       headers: {
@@ -171,7 +172,11 @@ export default function ModernDashboard() {
       throw new Error(getErrorMessage(body) ?? 'Failed to create share link');
     }
 
-    const share = (body as { share?: { id?: string; shareUrl?: string } }).share;
+    const typed = body as {
+      share?: { id?: string; shareUrl?: string };
+      snapshot?: PublicShareSnapshotPayload;
+    };
+    const share = typed.share;
     if (!share?.id || !share.shareUrl) {
       throw new Error('Share API returned an invalid response');
     }
@@ -179,6 +184,7 @@ export default function ModernDashboard() {
     return {
       shareId: share.id,
       shareUrl: `${window.location.origin}${share.shareUrl}`,
+      ...(typed.snapshot ? { snapshot: typed.snapshot } : {}),
     };
   };
 

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -13,7 +13,13 @@ import { v4 as uuidv4 } from 'uuid';
 import crypto from 'node:crypto';
 import { and, desc, eq, sql } from 'drizzle-orm';
 import { db } from '../db';
-import { shares, shareAnalytics, SHARE_ACCESS_LEVELS, type Share } from '@shared/schema/shares';
+import {
+  shares,
+  shareAnalytics,
+  SHARE_ACCESS_LEVELS,
+  type Share,
+  type ShareSnapshotRecord,
+} from '@shared/schema/shares';
 import { LP_HIDDEN_METRICS } from '@shared/sharing-schema';
 import { firstString } from '../lib/request-values';
 import { parseETag } from '../lib/http-preconditions';
@@ -249,7 +255,7 @@ function buildShareInsertValues(params: {
 async function createShareWithSnapshot(
   values: typeof shares.$inferInsert,
   generatedBy: string
-): Promise<Share> {
+): Promise<{ share: Share; snapshot: ShareSnapshotRecord }> {
   return db.transaction(async (tx) => {
     const [createdShare] = await tx.insert(shares).values(values).returning();
 
@@ -257,8 +263,8 @@ async function createShareWithSnapshot(
       throw new Error('Failed to create share');
     }
 
-    await createShareSnapshot(createdShare, generatedBy, tx);
-    return createdShare;
+    const snapshot = await createShareSnapshot(createdShare, generatedBy, tx);
+    return { share: createdShare, snapshot };
   });
 }
 
@@ -415,7 +421,7 @@ managementRouter.post('/', async (req: Request, res: Response, next: NextFunctio
 
     const shareId = uuidv4();
     const now = new Date();
-    const share = await createShareWithSnapshot(
+    const { share, snapshot } = await createShareWithSnapshot(
       buildShareInsertValues({
         body,
         shareId,
@@ -433,6 +439,7 @@ managementRouter.post('/', async (req: Request, res: Response, next: NextFunctio
     return res.status(201).json({
       success: true,
       share: serializeManagementShare(share),
+      snapshot: snapshot.payload,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/tests/unit/components/sharing/ShareConfigModal.test.tsx
+++ b/tests/unit/components/sharing/ShareConfigModal.test.tsx
@@ -82,4 +82,38 @@ describe('ShareConfigModal', () => {
     });
     expect(screen.getByText('Management Fees')).toBeInTheDocument();
   });
+
+  it('shows the server as-of date and portfolio preview from the snapshot payload', async () => {
+    mockUseFlag.mockReturnValue(true);
+    const onCreate = vi.fn().mockResolvedValue({
+      shareUrl: '/shared/s1',
+      shareId: 'share-1',
+      snapshot: {
+        payloadVersion: 'public-share-snapshot.v1',
+        snapshotId: 'snap-1',
+        shareId: 'share-1',
+        title: 'Fund I',
+        message: null,
+        asOfDate: '2026-03-31T00:00:00.000Z',
+        generatedAt: '2026-06-15T12:00:00.000Z',
+        metrics: [],
+        portfolioCompanies: [
+          { name: 'Alpha AI', stage: 'Seed', moic: 2.1, status: 'active' },
+          { name: 'Beta Bio', stage: 'Series A', moic: null, status: 'active' },
+        ],
+        hiddenMetricPolicy: { requested: ['moic'], applied: ['moic'] },
+        sourceCalculationRunIds: [],
+      },
+    });
+
+    renderShareConfigModal(onCreate);
+    await createShareLink();
+
+    expect(screen.getByText('Data as of')).toBeInTheDocument();
+    expect(screen.getByText('Portfolio companies LPs will see')).toBeInTheDocument();
+    expect(screen.getByText('Alpha AI')).toBeInTheDocument();
+    expect(screen.getByText('Seed · 2.10x')).toBeInTheDocument();
+    // moic in applied hidden policy -> redacted to null -> shown as Hidden, not "—"
+    expect(screen.getByText('Series A · Hidden')).toBeInTheDocument();
+  });
 });

--- a/tests/unit/routes/shares.contract.test.ts
+++ b/tests/unit/routes/shares.contract.test.ts
@@ -447,6 +447,28 @@ describe('shares management boundary contracts', () => {
     );
   });
 
+  it('POST / returns the created immutable snapshot payload in the response', async () => {
+    const createdShare = makeShare({ id: 'snap-share', fundId: '2', createdBy: 'u1' });
+    dbState.state.selectResults.push([]);
+    dbState.state.txInsertResults.push([createdShare]);
+    snapshotState.createShareSnapshot.mockResolvedValueOnce(
+      makeSnapshot({ shareId: 'snap-share' })
+    );
+
+    const response = await request(makeManagementApp({ user: makeUser({ fundIds: [2] }) }))
+      .post('/')
+      .set('Idempotency-Key', 'snap-create-2')
+      .send(validCreateBody('2'));
+
+    expect(response.status).toBe(201);
+    expect(response.body.share).toMatchObject({ id: 'snap-share', fundId: '2' });
+    expect(response.body.snapshot).toMatchObject({
+      payloadVersion: 'public-share-snapshot.v1',
+      shareId: 'snap-share',
+    });
+    expect(response.body.snapshot.portfolioCompanies).toHaveLength(1);
+  });
+
   it('GET / allows the strict string req.context.fundId path', async () => {
     dbState.state.selectResults.push([makeShare({ id: 'context-share', fundId: '2' })]);
 


### PR DESCRIPTION
## What

Fast-follow on the `enable_lp_snapshot_mode` LP share-review surface (#854). The share-create
endpoint already builds an immutable snapshot but discarded it from the response, so the modal
fabricated `capturedAt: new Date()` (the GP's browser clock) as a stand-in for the snapshot's real
freshness. This wires the actual server snapshot through to the modal.

## Changes

- **`server/routes/shares.ts`** — `createShareWithSnapshot` now returns the created snapshot record
  alongside the share; `POST /api/shares` adds `snapshot: snapshot.payload` to the 201 body. Additive
  and back-compat (optional field); idempotent-replay path unchanged.
- **`client/src/pages/dashboard-modern.tsx`** — `handleCreateShare` passes the returned `snapshot`
  payload through.
- **`client/src/components/sharing/ShareConfigModal.tsx`** — when the payload is present: drives
  "Captured" from the server `generatedAt`, adds a "Data as of" row (the real frozen metric date),
  and renders a portfolio-company preview (`name — stage · MOIC`) that honors hidden-metric
  redaction (redacted MOIC shows "Hidden").

## Tests

- `tests/unit/routes/shares.contract.test.ts` — POST response now includes the snapshot payload.
- `tests/unit/components/sharing/ShareConfigModal.test.tsx` — As-of row + portfolio preview render;
  redacted MOIC shows "Hidden".
- Verified locally: client modal 4/4, server contract 47/47, `npm run check` 0 new TS errors.

## Notes

`asOfDate` is intentionally older than "now" — it is displayed as a freshness signal, not corrected.
Snapshot is an optional response/return field throughout (no breaking change to existing consumers).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
