### PR TITLE
feat(dashboard): keyboard-accessible metric explanations via Radix tooltip

### DIFF
--- a/client/src/components/layout/HeaderMetricCard.tsx
+++ b/client/src/components/layout/HeaderMetricCard.tsx
@@ -4,11 +4,13 @@ import {
   BarChart3,
   Calendar,
   DollarSign,
+  Info,
   PieChart,
   Target,
   TrendingUp,
 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { HeaderMetricIcon, HeaderMetricTheme } from '@/types/fund-header-metrics';
 
 export interface HeaderMetricCardView {
@@ -58,16 +60,28 @@ export function HeaderMetricCard({
     <Card
       className={`${CARD_CLASS_NAMES[card.theme]} shadow-sm hover:shadow-md transition-shadow`}
       data-testid={testId}
-      title={card.titleText}
     >
       <CardContent className="p-2">
         <div className="flex items-center justify-between gap-2">
           <div className="min-w-0">
-            <p className={`text-xs ${LABEL_CLASS_NAMES[card.theme]} font-medium`}>{card.title}</p>
-            <p
-              className="truncate text-sm font-bold leading-tight text-pov-charcoal tabular-nums"
-              title={card.titleText}
-            >
+            <div className="flex items-center gap-1">
+              <p className={`text-xs ${LABEL_CLASS_NAMES[card.theme]} font-medium`}>{card.title}</p>
+              {card.titleText && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger
+                      type="button"
+                      aria-label={card.titleText}
+                      className="flex-shrink-0 rounded text-charcoal-400 hover:text-charcoal-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400"
+                    >
+                      <Info className="h-3 w-3" />
+                    </TooltipTrigger>
+                    <TooltipContent>{card.titleText}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+            </div>
+            <p className="truncate text-sm font-bold leading-tight text-pov-charcoal tabular-nums">
               {card.displayValue}
             </p>
           </div>

--- a/tests/unit/components/layout/dynamic-fund-header.test.tsx
+++ b/tests/unit/components/layout/dynamic-fund-header.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UnifiedFundMetrics } from '@shared/types/metrics';
 import DynamicFundHeader from '@/components/layout/dynamic-fund-header';
@@ -122,7 +122,8 @@ function makeMetrics(
 
 function metricLabel(name: string) {
   const matches = screen.getAllByText(name);
-  return matches[matches.length - 1];
+  const label = matches[matches.length - 1];
+  return label.parentElement ?? label;
 }
 
 describe('DynamicFundHeader', () => {
@@ -339,11 +340,36 @@ describe('DynamicFundHeader', () => {
     const tvpiCard = screen.getByTestId('compact-kpi-tvpi');
     expect(tvpiCard).toHaveTextContent('TVPI');
     expect(tvpiCard).toHaveTextContent('N/A');
-    expect(tvpiCard).toHaveAttribute(
-      'title',
-      'TVPI is unavailable until paid-in capital is available.'
-    );
+    expect(
+      within(tvpiCard).getByRole('button', {
+        name: 'TVPI is unavailable until paid-in capital is available.',
+      })
+    ).toBeInTheDocument();
     expect(screen.queryByText('0.00')).not.toBeInTheDocument();
+  });
+
+  it('exposes the compact KPI explanation through a keyboard-focusable info control', () => {
+    mockUseFlag.mockReturnValue(true);
+    mockUseFundMetrics.mockReturnValue({
+      data: makeMetrics({
+        totalCalled: 0,
+        totalValue: 0,
+        tvpi: 0,
+      }),
+      isLoading: false,
+      error: null,
+    });
+
+    render(<DynamicFundHeader />);
+
+    const tvpiCard = screen.getByTestId('compact-kpi-tvpi');
+    const info = within(tvpiCard).getByRole('button', {
+      name: 'TVPI is unavailable until paid-in capital is available.',
+    });
+    act(() => {
+      info.focus();
+    });
+    expect(info).toHaveFocus();
   });
 
   it('keeps compact DPI truthful when distributions have not been recorded', () => {
@@ -353,10 +379,11 @@ describe('DynamicFundHeader', () => {
 
     const panel = screen.getByTestId('compact-kpi-dpi');
     expect(panel).toHaveTextContent('—');
-    expect(panel).toHaveAttribute(
-      'title',
-      'DPI is unavailable because no distributions have been recorded.'
-    );
+    expect(
+      within(panel).getByRole('button', {
+        name: 'DPI is unavailable because no distributions have been recorded.',
+      })
+    ).toBeInTheDocument();
     expect(screen.queryByText('DPI:')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'DPI' })).not.toBeInTheDocument();
   });
@@ -392,10 +419,11 @@ describe('DynamicFundHeader', () => {
     const navCard = screen.getByTestId('compact-kpi-nav');
     expect(navCard).toHaveTextContent('NAV');
     expect(navCard).toHaveTextContent('—');
-    expect(navCard).toHaveAttribute(
-      'title',
-      'NAV is unavailable until investment facts are recorded for valued portfolio companies.'
-    );
+    expect(
+      within(navCard).getByRole('button', {
+        name: 'NAV is unavailable until investment facts are recorded for valued portfolio companies.',
+      })
+    ).toBeInTheDocument();
     expect(screen.queryByText('$46.0M')).not.toBeInTheDocument();
   });
 
@@ -443,10 +471,11 @@ describe('DynamicFundHeader', () => {
 
     const panel = screen.getByTestId('compact-kpi-dpi');
     expect(panel).toHaveTextContent('—');
-    expect(panel).toHaveAttribute(
-      'title',
-      'Metrics unavailable because the live metrics source is unavailable.'
-    );
+    expect(
+      within(panel).getByRole('button', {
+        name: 'Metrics unavailable because the live metrics source is unavailable.',
+      })
+    ).toBeInTheDocument();
     expect(screen.queryByText('$12M')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/components/wizard/fund-construction-kpi-header.test.tsx
+++ b/tests/unit/components/wizard/fund-construction-kpi-header.test.tsx
@@ -29,7 +29,9 @@ describe('FundConstructionKpiHeader', () => {
     const investedCard = screen.getByTestId('construction-kpi-totalInvested');
     expect(investedCard).toHaveTextContent('Total Invested');
     expect(investedCard).toHaveTextContent('$75.0M');
-    expect(investedCard).toHaveAttribute('title', 'Planned capital from Builder Fund I');
+    expect(
+      within(investedCard).getByRole('button', { name: 'Planned capital from Builder Fund I' })
+    ).toBeInTheDocument();
 
     expect(screen.getByTestId('construction-kpi-dpi')).toHaveTextContent('DPI');
     expect(screen.getByTestId('construction-kpi-dpi')).not.toHaveTextContent('No distributions');


### PR DESCRIPTION
## What

The compact header metric cards explained each metric (and *why* a metric was unavailable) only
through a native `title=` attribute — mouse-hover only, not keyboard-reachable, and unreliable for
screen readers. This replaces it with a keyboard-focusable Radix tooltip using the repo-idiomatic
Info-icon pattern already used by `MetricsCard`.

## Changes

- **`client/src/components/layout/HeaderMetricCard.tsx`** — removed both `title=` attributes; added a
  small muted Info (i) control next to each metric label, wrapped in a local `TooltipProvider`
  (`MetricsCard` pattern, so the component is self-contained). The trigger is a real focusable
  `<button>` whose `aria-label` is the explanation, so the text is always in the accessibility tree
  and shown visually on hover/focus. Charcoal tokens only; `focus-visible` ring for keyboard users.

## Tests

- `tests/unit/components/layout/dynamic-fund-header.test.tsx` — the four `title`-attribute
  assertions now assert the Info control's accessible name; added a keyboard-focus test proving the
  control is reachable and named by the explanation. The `metricLabel` helper was adjusted by one DOM
  level to account for the new label wrapper (all `.parentElement` callers still resolve to the card
  body that holds the value).
- `tests/unit/components/wizard/fund-construction-kpi-header.test.tsx` — its single `title`
  assertion converted the same way.
- Verified locally: 18/18 across both files; `npm run check` 0 new TS errors.

## Notes

`metric-state.ts` / `MetricValue` are intentionally untouched (genuinely unconsumed — out of scope).
`titleText` is populated on every card, so every card gains the Info control by design.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
