### PR TITLE
feat(cash-flow-events): persist lp_capital_call events via fund-scoped route

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -16,6 +16,7 @@ import allocationScenariosRouter from './routes/allocation-scenarios.js';
 import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
 import fundMoicRouter from './routes/fund-moic.js';
 import reallocationRouter from './routes/reallocation.js';
+import cashFlowEventsRouter from './routes/cash-flow-events.js';
 import backtestingRouter from './routes/backtesting.js';
 import fundsRouter from './routes/funds.js';
 import fundMetricsRouter from './routes/fund-metrics.js';
@@ -217,6 +218,10 @@ export function makeApp() {
   // Reallocation API (Phase 1b) - mounted at root; the router self-defines its
   // full /api/funds/:fundId/reallocation/* paths (mirrors the registerRoutes mount).
   app.use(reallocationRouter);
+
+  // Cash-flow-events API (Candidate C, Phase 1) - mounted at root; the router
+  // self-defines its full /api/funds/:fundId/cash-flow-events paths (mirrors reallocation).
+  app.use(cashFlowEventsRouter);
 
   // Deal Pipeline API (Sprint 1 - Deal tracking, DD, scoring)
   app.use('/api/deals', dealPipelineRouter);

--- a/server/routes/cash-flow-events.ts
+++ b/server/routes/cash-flow-events.ts
@@ -1,26 +1,26 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { desc, eq } from 'drizzle-orm';
 import { parseFundIdParam } from '@shared/number';
-import { cashFlowEvents } from '@shared/schema/lp-reporting-evidence';
+import type { CashFlowEvent } from '@shared/schema/lp-reporting-evidence';
 import {
   CashFlowEventResponseSchema,
   LpCapitalCallSchema,
   type CashFlowEventResponse,
 } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
-import { db } from '../db';
 import { firstString } from '../lib/request-values';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import {
+  createLpCapitalCallEvent,
+  listCashFlowEventsForFund,
+} from '../services/lp-reporting/cash-flow-event-service';
 
 const router = Router();
-
-type CashFlowEventRow = typeof cashFlowEvents.$inferSelect;
 
 // Whitelist mapping: build the exact response shape, then validate through the
 // strict schema so no internal column (source_hash, lock/supersede/reversal,
 // provenance) can ever leak. Money (`amount`) is a Drizzle decimal string -- pass
 // it through untouched (ADR-011).
-function toResponse(row: CashFlowEventRow): CashFlowEventResponse {
+function toResponse(row: CashFlowEvent): CashFlowEventResponse {
   return CashFlowEventResponseSchema.parse({
     id: row.id,
     fundId: row.fundId,
@@ -65,20 +65,7 @@ router['post']('/api/funds/:fundId/cash-flow-events', async (req: Request, res: 
       });
     }
 
-    const [row] = await db
-      .insert(cashFlowEvents)
-      .values({
-        fundId,
-        eventType: 'lp_capital_call',
-        amount: parsed.data.amount,
-        currency: 'USD',
-        eventDate: new Date(parsed.data.eventDate),
-        perspective: parsed.data.perspective,
-        description: parsed.data.description ?? null,
-        payload: parsed.data.payload,
-        status: 'draft',
-      })
-      .returning();
+    const row = await createLpCapitalCallEvent({ ...parsed.data, fundId });
 
     if (!row) {
       return res.status(500).json({ error: 'Failed to create cash flow event' });
@@ -101,12 +88,7 @@ router['get']('/api/funds/:fundId/cash-flow-events', async (req: Request, res: R
       return;
     }
 
-    // Newest-first; hits idx_cash_flow_fund_date (fund_id, event_date DESC).
-    const rows = await db
-      .select()
-      .from(cashFlowEvents)
-      .where(eq(cashFlowEvents.fundId, fundId))
-      .orderBy(desc(cashFlowEvents.eventDate));
+    const rows = await listCashFlowEventsForFund(fundId);
 
     return res.status(200).json({ data: rows.map(toResponse) });
   } catch {

--- a/server/routes/cash-flow-events.ts
+++ b/server/routes/cash-flow-events.ts
@@ -1,0 +1,117 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { desc, eq } from 'drizzle-orm';
+import { parseFundIdParam } from '@shared/number';
+import { cashFlowEvents } from '@shared/schema/lp-reporting-evidence';
+import {
+  CashFlowEventResponseSchema,
+  LpCapitalCallSchema,
+  type CashFlowEventResponse,
+} from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import { db } from '../db';
+import { firstString } from '../lib/request-values';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+
+const router = Router();
+
+type CashFlowEventRow = typeof cashFlowEvents.$inferSelect;
+
+// Whitelist mapping: build the exact response shape, then validate through the
+// strict schema so no internal column (source_hash, lock/supersede/reversal,
+// provenance) can ever leak. Money (`amount`) is a Drizzle decimal string -- pass
+// it through untouched (ADR-011).
+function toResponse(row: CashFlowEventRow): CashFlowEventResponse {
+  return CashFlowEventResponseSchema.parse({
+    id: row.id,
+    fundId: row.fundId,
+    eventType: row.eventType,
+    amount: row.amount,
+    currency: row.currency,
+    eventDate: row.eventDate.toISOString(),
+    perspective: row.perspective,
+    description: row.description,
+    payload: row.payload ?? {},
+    status: row.status,
+    createdAt: (row.createdAt ?? row.eventDate).toISOString(),
+  });
+}
+
+router['post']('/api/funds/:fundId/cash-flow-events', async (req: Request, res: Response) => {
+  try {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
+      return res.status(400).json({ error: 'Invalid fund ID' });
+    }
+
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+
+    // Phase 1 accepts ONLY lp_capital_call; a different eventType fails the
+    // literal discriminator and is rejected here as a 400.
+    const parsed = LpCapitalCallSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Invalid request body',
+        details: parsed.error.format(),
+      });
+    }
+
+    // Confused-deputy guard: the path fundId is authoritative.
+    if (parsed.data.fundId !== fundId) {
+      return res.status(400).json({
+        error: 'fundId mismatch',
+        message: 'Body fundId must match the path fundId',
+      });
+    }
+
+    const [row] = await db
+      .insert(cashFlowEvents)
+      .values({
+        fundId,
+        eventType: 'lp_capital_call',
+        amount: parsed.data.amount,
+        currency: 'USD',
+        eventDate: new Date(parsed.data.eventDate),
+        perspective: parsed.data.perspective,
+        description: parsed.data.description ?? null,
+        payload: parsed.data.payload,
+        status: 'draft',
+      })
+      .returning();
+
+    if (!row) {
+      return res.status(500).json({ error: 'Failed to create cash flow event' });
+    }
+
+    return res.status(201).json(toResponse(row));
+  } catch {
+    return res.status(500).json({ error: 'Failed to create cash flow event' });
+  }
+});
+
+router['get']('/api/funds/:fundId/cash-flow-events', async (req: Request, res: Response) => {
+  try {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
+      return res.status(400).json({ error: 'Invalid fund ID' });
+    }
+
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+
+    // Newest-first; hits idx_cash_flow_fund_date (fund_id, event_date DESC).
+    const rows = await db
+      .select()
+      .from(cashFlowEvents)
+      .where(eq(cashFlowEvents.fundId, fundId))
+      .orderBy(desc(cashFlowEvents.eventDate));
+
+    return res.status(200).json({ data: rows.map(toResponse) });
+  } catch {
+    return res.status(500).json({ error: 'Failed to list cash flow events' });
+  }
+});
+
+export default router;

--- a/server/services/lp-reporting/cash-flow-event-service.ts
+++ b/server/services/lp-reporting/cash-flow-event-service.ts
@@ -1,0 +1,48 @@
+import { desc, eq } from 'drizzle-orm';
+
+import { db } from '../../db';
+import type { LpCapitalCall } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import { cashFlowEvents, type CashFlowEvent } from '@shared/schema/lp-reporting-evidence';
+
+type CashFlowEventDatabase = typeof db;
+
+interface CashFlowEventServiceOptions {
+  database?: CashFlowEventDatabase;
+}
+
+export async function createLpCapitalCallEvent(
+  input: LpCapitalCall,
+  options: CashFlowEventServiceOptions = {}
+): Promise<CashFlowEvent | undefined> {
+  const database = options.database ?? db;
+  const [row] = await database
+    .insert(cashFlowEvents)
+    .values({
+      fundId: input.fundId,
+      eventType: 'lp_capital_call',
+      amount: input.amount,
+      currency: 'USD',
+      eventDate: new Date(input.eventDate),
+      perspective: input.perspective,
+      description: input.description ?? null,
+      payload: input.payload,
+      status: 'draft',
+    })
+    .returning();
+
+  return row;
+}
+
+export async function listCashFlowEventsForFund(
+  fundId: number,
+  options: CashFlowEventServiceOptions = {}
+): Promise<CashFlowEvent[]> {
+  const database = options.database ?? db;
+
+  // Newest-first; hits idx_cash_flow_fund_date (fund_id, event_date DESC).
+  return database
+    .select()
+    .from(cashFlowEvents)
+    .where(eq(cashFlowEvents.fundId, fundId))
+    .orderBy(desc(cashFlowEvents.eventDate));
+}

--- a/shared/contracts/lp-reporting/cash-flow-event.contract.ts
+++ b/shared/contracts/lp-reporting/cash-flow-event.contract.ts
@@ -162,3 +162,32 @@ export type FundExpense = z.infer<typeof FundExpenseSchema>;
 export type RecallableDistribution = z.infer<typeof RecallableDistributionSchema>;
 export type Reversal = z.infer<typeof ReversalSchema>;
 export type CashFlowEventCreate = z.infer<typeof CashFlowEventCreateSchema>;
+
+// ============================================================================
+// RESPONSE SHAPES (server -> client) -- Phase 1
+// Money as decimal string (ADR-011). NEVER expose source_hash, lock/supersede/
+// reversal internals, or import provenance.
+// ============================================================================
+
+export const CashFlowEventResponseSchema = z
+  .object({
+    id: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    eventType: CashFlowEventTypeSchema,
+    amount: MoneyStringSchema,
+    currency: z.literal('USD'),
+    eventDate: z.string().datetime(),
+    perspective: CashFlowPerspectiveSchema,
+    description: z.string().nullable(),
+    payload: z.record(z.unknown()),
+    status: z.enum(['draft', 'approved', 'locked', 'reversed']),
+    createdAt: z.string().datetime(),
+  })
+  .strict();
+
+export const CashFlowEventListResponseSchema = z.object({
+  data: z.array(CashFlowEventResponseSchema),
+});
+
+export type CashFlowEventResponse = z.infer<typeof CashFlowEventResponseSchema>;
+export type CashFlowEventListResponse = z.infer<typeof CashFlowEventListResponseSchema>;

--- a/tests/integration/cash-flow-events.test.ts
+++ b/tests/integration/cash-flow-events.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+import type { Pool } from 'pg';
+
+let pool: Pool;
+let makeApp: typeof import('../../server/app').makeApp;
+let app: Express;
+let authHeader: string;
+let testFundId: number;
+
+describe('cash-flow-events persistence integration', () => {
+  beforeAll(async () => {
+    pool = (await import('../../server/db/pg-circuit')).pool;
+    makeApp = (await import('../../server/app')).makeApp;
+  });
+
+  beforeEach(async () => {
+    app = makeApp();
+    const { signToken } = await import('../../server/lib/auth/jwt');
+    authHeader = `Bearer ${signToken({
+      sub: 'cash-flow-events-integration-user',
+      email: 'cash-flow-events-integration@example.com',
+      role: 'admin',
+      fundIds: [],
+    })}`;
+
+    const fundResult = await pool.query(
+      `INSERT INTO funds (name, size, management_fee, carry_percentage, vintage_year)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id`,
+      ['Cash Flow Events Fund', '100000000', '0.02', '0.20', 2026]
+    );
+    testFundId = fundResult.rows[0].id as number;
+  });
+
+  afterEach(async () => {
+    if (!testFundId) return;
+    await pool.query('DELETE FROM cash_flow_events WHERE fund_id = $1', [testFundId]);
+    await pool.query('DELETE FROM funds WHERE id = $1', [testFundId]);
+  });
+
+  it('persists a created event and reloads it fund-scoped, newest-first', async () => {
+    const createResponse = await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events`)
+      .set('Authorization', authHeader)
+      .send({
+        eventType: 'lp_capital_call',
+        fundId: testFundId,
+        amount: '1250000',
+        eventDate: '2026-06-15T00:00:00.000Z',
+        perspective: 'lp_net',
+        payload: { callNumber: 1, dueDate: '2026-07-15' },
+      })
+      .expect(201);
+
+    expect(createResponse.body).toMatchObject({
+      fundId: testFundId,
+      eventType: 'lp_capital_call',
+      status: 'draft',
+      currency: 'USD',
+    });
+    expect(typeof createResponse.body.amount).toBe('string');
+    const createdId = createResponse.body.id as number;
+
+    // Persisted row exists in the table, fund-scoped.
+    const dbRows = await pool.query('SELECT id, status FROM cash_flow_events WHERE fund_id = $1', [
+      testFundId,
+    ]);
+    expect(dbRows.rows).toHaveLength(1);
+    expect(dbRows.rows[0]).toMatchObject({ id: createdId, status: 'draft' });
+
+    // Reload via the route.
+    const listResponse = await request(app)
+      .get(`/api/funds/${testFundId}/cash-flow-events`)
+      .set('Authorization', authHeader)
+      .expect(200);
+
+    expect(listResponse.body.data).toHaveLength(1);
+    expect(listResponse.body.data[0]).toMatchObject({ id: createdId, fundId: testFundId });
+  });
+});

--- a/tests/unit/routes/cash-flow-events.contract.test.ts
+++ b/tests/unit/routes/cash-flow-events.contract.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const dbState = vi.hoisted(() => {
+  const state = {
+    insertResult: [] as unknown[],
+    selectResult: [] as unknown[],
+    insertedValues: undefined as unknown,
+  };
+  const db = {
+    insert: vi.fn(() => ({
+      values: vi.fn((payload: unknown) => {
+        state.insertedValues = payload;
+        return { returning: vi.fn(() => Promise.resolve(state.insertResult)) };
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(() => Promise.resolve(state.selectResult)),
+        })),
+      })),
+    })),
+  };
+  return { db, state };
+});
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+import cashFlowEventsRouter from '../../../server/routes/cash-flow-events';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cashFlowEventsRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function denyOnce() {
+  fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+    res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    return false;
+  });
+}
+
+function validBody(fundId = 1) {
+  return {
+    eventType: 'lp_capital_call',
+    fundId,
+    amount: '1250000',
+    eventDate: '2026-06-15T00:00:00.000Z',
+    perspective: 'lp_net',
+    payload: { callNumber: 1 },
+  };
+}
+
+function dbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    fundId: 1,
+    eventType: 'lp_capital_call',
+    amount: '1250000.000000',
+    currency: 'USD',
+    eventDate: new Date('2026-06-15T00:00:00.000Z'),
+    perspective: 'lp_net',
+    description: null,
+    payload: { callNumber: 1 },
+    status: 'draft',
+    createdAt: new Date('2026-06-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('cash-flow-events route contracts', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    dbState.db.insert.mockClear();
+    dbState.db.select.mockClear();
+    dbState.state.insertResult = [];
+    dbState.state.selectResult = [];
+    dbState.state.insertedValues = undefined;
+  });
+
+  it('POST rejects a non-canonical fundId before the scope check and any DB write', async () => {
+    const res = await request(makeApp()).post('/api/funds/01/cash-flow-events').send(validBody(1));
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST denies a cross-fund scope before any DB write', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/api/funds/2/cash-flow-events').send(validBody(2));
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST creates a draft event and returns 201 with the decimal-string amount', async () => {
+    dbState.state.insertResult = [dbRow()];
+    const res = await request(makeApp()).post('/api/funds/1/cash-flow-events').send(validBody(1));
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      id: 10,
+      fundId: 1,
+      eventType: 'lp_capital_call',
+      amount: '1250000.000000',
+      status: 'draft',
+      currency: 'USD',
+    });
+    expect(typeof res.body.amount).toBe('string');
+    expect(res.body).not.toHaveProperty('sourceHash');
+    expect(res.body).not.toHaveProperty('source_hash');
+    expect(dbState.db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST rejects a body fundId that does not match the path fundId', async () => {
+    const res = await request(makeApp()).post('/api/funds/1/cash-flow-events').send(validBody(2));
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'fundId mismatch' });
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST rejects a non-lp_capital_call eventType in Phase 1', async () => {
+    const res = await request(makeApp())
+      .post('/api/funds/1/cash-flow-events')
+      .send({ ...validBody(1), eventType: 'fund_expense' });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid request body' });
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('GET lists events newest-first (pass-through of the indexed DESC query)', async () => {
+    dbState.state.selectResult = [
+      dbRow({ id: 20, eventDate: new Date('2026-06-15T00:00:00.000Z') }),
+      dbRow({ id: 11, eventDate: new Date('2026-06-10T00:00:00.000Z') }),
+    ];
+    const res = await request(makeApp()).get('/api/funds/1/cash-flow-events');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].id).toBe(20);
+    expect(res.body.data[1].id).toBe(11);
+    expect(dbState.db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET denies a cross-fund scope before any DB read', async () => {
+    denyOnce();
+    const res = await request(makeApp()).get('/api/funds/2/cash-flow-events');
+    expect(res.status).toBe(403);
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of Candidate C (cash-event operating object): real persistence for the GP cash ledger.

Adds a thin, fund-scoped router `/api/funds/:fundId/cash-flow-events` (create-draft + list,
`lp_capital_call` only) backed by the existing migration-defined `cash_flow_events` table, mounted on
the `makeApp` (prod) surface. No new migration — the table is already migrated and journal-reconciled
(issue #781).

## Changes (5 files, +402)

- **`shared/contracts/lp-reporting/cash-flow-event.contract.ts`** — append
  `CashFlowEventResponseSchema` / `CashFlowEventListResponseSchema`. `amount` is a decimal string
  (ADR-011); the strict schema structurally redacts `source_hash` and all lock/supersede/reversal/
  import-provenance internals.
- **`server/routes/cash-flow-events.ts`** (new) — root-mounted POST/GET. `parseFundIdParam` +
  `enforceProvidedFundScope` guard (mirrors `dashboard-summary.ts`), confused-deputy body/path
  `fundId` check, append-only `status='draft'` insert (`source_hash` left NULL → partial-unique index
  never collides). Response built by parsing through the strict schema.
- **`server/app.ts`** — mount on `makeApp` immediately after `reallocationRouter` (prod-correct
  surface; mirrors the reallocation precedent).
- **`tests/unit/routes/cash-flow-events.contract.test.ts`** — 7 contract tests.
- **`tests/integration/cash-flow-events.test.ts`** — real-DB POST -> persist -> reload.

## Verification

- `npm run check`: 0 new TS errors.
- Unit contract: 7/7 — non-canonical fundId pre-guard, cross-fund 403 on POST+GET before any DB op,
  201 with decimal-string amount + `source_hash` redaction, body/path fundId mismatch,
  non-`lp_capital_call` rejection, newest-first list. Negative-control verified (guard neuter flips
  RED, restore green).
- Pre-push unit suite: 825 passed / 2 skipped.

## Integration gate (read before merge)

`tests/integration/cash-flow-events.test.ts` does **not** run on this PR's own checks (integration is
gated off PRs). It is validated by a `run_full_suite` dispatch on this branch:

```
gh workflow run ci-unified.yml --ref feat/cash-flow-events-persistence -f run_full_suite=true
```

The Test-integration log showing this file passing is the gate. CI builds the test DB via `db:push`,
so `cash_flow_events` is present.

## Out of scope / follow-ups

- PR-C2 (client): `enable_cash_event_object` flag + `useCashFlowEvents` hook + read-only WorkPanel list.
- Phase 2: editable lifecycle (status transitions, supersede/reverse, `source_hash` idempotency).
- Prod `to_regclass('public.cash_flow_events')` presence check (prod schema applied out-of-band; does
  not affect CI or this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
