### PR TITLE
feat(cash-flow-events): read-only WorkPanel list on cashflow dashboard (enable_cash_event_object)

### DIFF
--- a/client/src/components/dashboard/CashEventsPanel.tsx
+++ b/client/src/components/dashboard/CashEventsPanel.tsx
@@ -1,0 +1,49 @@
+import { WorkPanel } from '@/components/work-panel/WorkPanel';
+import type { WorkPanelState } from '@/components/work-panel/work-panel-types';
+import { useCashFlowEvents } from '@/hooks/useCashFlowEvents';
+
+const PANEL_KEY = 'cash-events';
+
+function formatEventDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+export function CashEventsPanel({
+  fundId,
+  state,
+  onClose,
+}: {
+  fundId: string | undefined;
+  state: WorkPanelState | null;
+  onClose: () => void;
+}) {
+  const isOpen = state?.panel === PANEL_KEY;
+  const { data: events, isLoading } = useCashFlowEvents(fundId, { enabled: isOpen });
+
+  return (
+    <WorkPanel
+      open={isOpen}
+      onClose={onClose}
+      title="Cash events"
+      description="Persisted capital-call events for this fund (read-only)."
+    >
+      {isLoading ? (
+        <p className="text-sm text-charcoal-600">Loading cash events...</p>
+      ) : !events || events.length === 0 ? (
+        <p className="text-sm text-charcoal-600">No cash events recorded for this fund yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {events.map((event) => (
+            <li key={event.id} className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium text-charcoal-900">{event.eventType}</p>
+                <p className="text-xs text-charcoal-600">{formatEventDate(event.eventDate)}</p>
+              </div>
+              <span className="text-sm font-medium text-charcoal-900">{event.amount}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </WorkPanel>
+  );
+}

--- a/client/src/components/dashboard/CashflowDashboard.tsx
+++ b/client/src/components/dashboard/CashflowDashboard.tsx
@@ -28,6 +28,7 @@ import {
 } from 'recharts';
 import { LazyResponsiveContainer as ResponsiveContainer } from '@/components/charts/LazyResponsiveContainer';
 import { StressScenarioProofPanel } from './StressScenarioProofPanel';
+import { CashEventsPanel } from './CashEventsPanel';
 import {
   TrendingUp,
   TrendingDown,
@@ -124,6 +125,7 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
   const liquidityMetrics = useLiquidityMetrics(analytics.cashFlowAnalysis);
   const workPanelEnabled = useFlag('enable_work_panel');
   const workPanel = useWorkPanelUrlState();
+  const cashEventEnabled = useFlag('enable_cash_event_object');
 
   // Generate chart data
   const cashFlowChartData = useMemo(() => {
@@ -248,6 +250,16 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
             <Download className="h-4 w-4 mr-2" />
             Export cashflow
           </Button>
+          {cashEventEnabled && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => workPanel.openPanel({ panel: 'cash-events' })}
+            >
+              <DollarSign className="h-4 w-4 mr-2" />
+              Cash events
+            </Button>
+          )}
         </div>
       </div>
 
@@ -750,6 +762,9 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
           state={workPanel.state}
           onClose={workPanel.closePanel}
         />
+      )}
+      {cashEventEnabled && (
+        <CashEventsPanel fundId={fundId} state={workPanel.state} onClose={workPanel.closePanel} />
       )}
     </div>
   );

--- a/client/src/hooks/useCashFlowEvents.ts
+++ b/client/src/hooks/useCashFlowEvents.ts
@@ -1,0 +1,44 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { CashFlowEventResponse } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import { getErrorMessage } from '@/lib/http-response';
+
+interface UseCashFlowEventsOptions {
+  /** Enable/disable the query (e.g. only fetch when the panel is open). */
+  enabled?: boolean;
+}
+
+/**
+ * Read-only list of persisted cash-flow events for a fund, newest-first.
+ * Reads GET /api/funds/:fundId/cash-flow-events (server returns { data: [...] }).
+ */
+export function useCashFlowEvents(
+  fundId: string | undefined,
+  options: UseCashFlowEventsOptions = {}
+): UseQueryResult<CashFlowEventResponse[], Error> {
+  const { enabled = true } = options;
+
+  return useQuery<CashFlowEventResponse[], Error>({
+    queryKey: ['cash-flow-events', fundId],
+    queryFn: async () => {
+      if (!fundId) {
+        throw new Error('No fund ID available');
+      }
+
+      const response = await fetch(`/api/funds/${fundId}/cash-flow-events`);
+      if (!response.ok) {
+        const errorData: unknown = await response.json().catch(() => null);
+        throw new Error(
+          getErrorMessage(errorData) || `HTTP ${response.status}: Failed to fetch cash flow events`
+        );
+      }
+
+      const body = (await response.json()) as { data: CashFlowEventResponse[] };
+      return body.data;
+    },
+    enabled: enabled && !!fundId,
+    staleTime: 60_000,
+    gcTime: 600_000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/shared/feature-flags/flag-definitions.ts
+++ b/shared/feature-flags/flag-definitions.ts
@@ -235,6 +235,16 @@ export const POLISH_FLAGS: Record<string, FeatureFlag> = {
     dependencies: [],
   },
 
+  enable_cash_event_object: {
+    key: 'enable_cash_event_object',
+    name: 'Cash Event Operating Object',
+    description:
+      'Read-only WorkPanel list of persisted cash-flow events (lp_capital_call) on the cashflow dashboard. Reads /api/funds/:fundId/cash-flow-events.',
+    enabled: false,
+    rolloutPercentage: 0,
+    dependencies: [],
+  },
+
   enable_route_redirects: {
     key: 'enable_route_redirects',
     name: 'Legacy Route Redirects',

--- a/tests/unit/components/dashboard/CashEventsPanel.test.tsx
+++ b/tests/unit/components/dashboard/CashEventsPanel.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { mockUseCashFlowEvents } = vi.hoisted(() => ({ mockUseCashFlowEvents: vi.fn() }));
+
+vi.mock('@/hooks/useCashFlowEvents', () => ({
+  useCashFlowEvents: (fundId: string | undefined, options?: { enabled?: boolean }) =>
+    mockUseCashFlowEvents(fundId, options),
+}));
+
+import { CashEventsPanel } from '@/components/dashboard/CashEventsPanel';
+
+const sampleEvent = {
+  id: 10,
+  fundId: 1,
+  eventType: 'lp_capital_call',
+  amount: '1250000.000000',
+  currency: 'USD',
+  eventDate: '2026-06-15T00:00:00.000Z',
+  perspective: 'lp_net',
+  description: null,
+  payload: { callNumber: 1 },
+  status: 'draft',
+  createdAt: '2026-06-15T00:00:00.000Z',
+};
+
+describe('CashEventsPanel', () => {
+  it('renders nothing when no panel state is present', () => {
+    mockUseCashFlowEvents.mockReturnValue({ data: [], isLoading: false });
+    render(<CashEventsPanel fundId="1" state={null} onClose={() => {}} />);
+    expect(screen.queryByText('Cash events')).not.toBeInTheDocument();
+  });
+
+  it('does not enable the query when the panel is closed', () => {
+    mockUseCashFlowEvents.mockReturnValue({ data: [], isLoading: false });
+    render(<CashEventsPanel fundId="1" state={null} onClose={() => {}} />);
+    expect(mockUseCashFlowEvents).toHaveBeenCalledWith('1', { enabled: false });
+  });
+
+  it('lists persisted events when the panel is open', () => {
+    mockUseCashFlowEvents.mockReturnValue({ data: [sampleEvent], isLoading: false });
+    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={() => {}} />);
+    expect(mockUseCashFlowEvents).toHaveBeenCalledWith('1', { enabled: true });
+    expect(screen.getByText('lp_capital_call')).toBeInTheDocument();
+    expect(screen.getByText('1250000.000000')).toBeInTheDocument();
+  });
+
+  it('shows a loading state while fetching', () => {
+    mockUseCashFlowEvents.mockReturnValue({ data: undefined, isLoading: true });
+    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={() => {}} />);
+    expect(screen.getByText(/loading cash events/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no events', () => {
+    mockUseCashFlowEvents.mockReturnValue({ data: [], isLoading: false });
+    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={() => {}} />);
+    expect(screen.getByText(/no cash events recorded/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close affordance is used', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    mockUseCashFlowEvents.mockReturnValue({ data: [sampleEvent], isLoading: false });
+    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/hooks/useCashFlowEvents.test.tsx
+++ b/tests/unit/hooks/useCashFlowEvents.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCashFlowEvents } from '@/hooks/useCashFlowEvents';
+
+const sampleEvent = {
+  id: 10,
+  fundId: 1,
+  eventType: 'lp_capital_call',
+  amount: '1250000.000000',
+  currency: 'USD',
+  eventDate: '2026-06-15T00:00:00.000Z',
+  perspective: 'lp_net',
+  description: null,
+  payload: { callNumber: 1 },
+  status: 'draft',
+  createdAt: '2026-06-15T00:00:00.000Z',
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function mockFetchJson(payload: unknown, ok = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 500,
+      json: vi.fn().mockResolvedValue(payload),
+    })
+  );
+}
+
+describe('useCashFlowEvents', () => {
+  beforeEach(() => {
+    mockFetchJson({ data: [sampleEvent] });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('does not fetch when there is no fund id', async () => {
+    renderHook(() => useCashFlowEvents(undefined), { wrapper: createWrapper() });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when disabled', async () => {
+    renderHook(() => useCashFlowEvents('1', { enabled: false }), { wrapper: createWrapper() });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches the fund-scoped endpoint and unwraps the data array', async () => {
+    const { result } = renderHook(() => useCashFlowEvents('1'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetch).toHaveBeenCalledWith('/api/funds/1/cash-flow-events');
+    expect(result.current.data).toEqual([sampleEvent]);
+  });
+
+  it('surfaces API error messages', async () => {
+    mockFetchJson({ message: 'Cash events unavailable' }, false);
+    const { result } = renderHook(() => useCashFlowEvents('1'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Cash events unavailable');
+  });
+});


### PR DESCRIPTION
## Summary

PR-C2 (client) of Candidate C: surface the persisted cash-event loop **read-only** on the cashflow
dashboard. Builds on PR-C1 (#862 — route + service + response contract live on main).

## Changes (6 files, +261)

- **`shared/feature-flags/flag-definitions.ts`** — new off-by-default flag `enable_cash_event_object`
  (mirrors `enable_work_panel`; `FlagKey` auto-derives).
- **`client/src/hooks/useCashFlowEvents.ts`** (new) — TanStack Query hook, fund-scoped, lazy
  (`enabled` only when the panel is open), unwraps the `{ data: [...] }` envelope.
- **`client/src/components/dashboard/CashEventsPanel.tsx`** (new) — read-only `WorkPanel` list
  (loading / empty / list), opens on `?panel=cash-events`. Charcoal tokens, no mutations.
- **`client/src/components/dashboard/CashflowDashboard.tsx`** — flag-gated trigger button + panel
  render (mirrors the #859 `StressScenarioProofPanel` wiring exactly).
- **2 × `.test.tsx`** — hook test (QueryClient + fetch stub) + panel test (mocks the hook).

## Behavior

Off by default. Enable via `?ff_enable_cash_event_object=1` or
`localStorage.setItem('ff_enable_cash_event_object','1')`. A "Cash events" button in the dashboard
header opens a read-only side panel listing persisted `lp_capital_call` events newest-first for the
fund. Independent of `enable_work_panel`. No create/edit (Phase 2).

## Verification

- `npm run check`: 0 new TS errors.
- **`npm run lint`: PASS** (full guard chain incl. route-persistence/console guards — run pre-push
  this time after PR-C1's CI-only lint surprise).
- Client unit: 10/10 (4 hook + 6 panel); negative-control proven (breaking the panel key flips the
  open-state tests RED).
- Pre-push targeted suite: 106 passed.

## Out of scope (Phase 2)

Editable lifecycle (WorkPanelFooter + dirty-guard + status transitions), amount currency formatting,
pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
