### PR TITLE
test(lp-reporting): add NAV/capital-account truth cases

### DIFF
--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-06-15T00:00:00.000Z",
+  "generatedAt": "2026-06-16T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 168,
+      "staleDays": 169,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1176,7 +1176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1192,7 +1192,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1208,7 +1208,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1223,7 +1223,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1305,7 +1305,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 70,
+      "staleDays": 71,
       "status": "UNKNOWN"
     },
     {
@@ -1323,7 +1323,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1340,7 +1340,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1357,7 +1357,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1373,7 +1373,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1403,7 +1403,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1418,7 +1418,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -1434,7 +1434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1449,7 +1449,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1464,7 +1464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1479,7 +1479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1494,7 +1494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1522,7 +1522,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 168,
+      "staleDays": 169,
       "status": "ACTIVE"
     },
     {
@@ -1538,7 +1538,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "UNKNOWN"
     },
     {
@@ -1565,7 +1565,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -1580,7 +1580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -1595,7 +1595,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1610,7 +1610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1625,7 +1625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1678,7 +1678,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 168,
+      "staleDays": 169,
       "status": "ACTIVE"
     },
     {
@@ -1692,7 +1692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1706,7 +1706,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1720,7 +1720,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -1791,7 +1791,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1806,7 +1806,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1821,7 +1821,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -1836,7 +1836,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1851,7 +1851,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1866,7 +1866,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1881,7 +1881,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1896,7 +1896,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1911,7 +1911,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1930,7 +1930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ready"
     },
     {
@@ -1949,7 +1949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ready"
     },
     {
@@ -1968,7 +1968,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ready"
     },
     {
@@ -1983,7 +1983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -1998,7 +1998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2037,7 +2037,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -2052,7 +2052,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -2067,7 +2067,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 25,
+      "staleDays": 26,
       "status": "UNKNOWN"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2135,7 +2135,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2150,7 +2150,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2165,7 +2165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2180,7 +2180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2196,7 +2196,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -2212,7 +2212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2227,7 +2227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2242,7 +2242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2257,7 +2257,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2272,7 +2272,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2288,7 +2288,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -2303,7 +2303,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2318,7 +2318,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2333,7 +2333,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2349,7 +2349,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2364,7 +2364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2379,7 +2379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2394,7 +2394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2408,7 +2408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2423,7 +2423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2439,7 +2439,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2455,7 +2455,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2471,7 +2471,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2566,7 +2566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2582,7 +2582,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2597,7 +2597,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2612,7 +2612,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2627,7 +2627,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2643,7 +2643,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2659,7 +2659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2674,7 +2674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2692,7 +2692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2722,7 +2722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2737,7 +2737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2752,7 +2752,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2768,7 +2768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -2783,7 +2783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2798,7 +2798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO-v2.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -2813,7 +2813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -2828,7 +2828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/immediate-actions-summary.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -2843,7 +2843,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2858,7 +2858,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -2873,7 +2873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2888,7 +2888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2903,7 +2903,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2918,7 +2918,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2933,7 +2933,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2948,7 +2948,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -2963,7 +2963,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-baseline-report-2025-12-23.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -2978,7 +2978,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-remediation-summary.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -2993,7 +2993,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/week2-execution-report.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -3008,7 +3008,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -3023,7 +3023,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3038,7 +3038,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3074,7 +3074,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3091,7 +3091,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -3106,7 +3106,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -3121,7 +3121,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3136,7 +3136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3165,7 +3165,7 @@
       "lastUpdated": "2026-05-21",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 25,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -3180,7 +3180,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -3195,7 +3195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3210,7 +3210,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -3237,7 +3237,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3252,7 +3252,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3267,7 +3267,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-QUICK-START.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3282,7 +3282,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3297,7 +3297,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3312,7 +3312,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3327,7 +3327,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3342,7 +3342,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "README.md",
-      "staleDays": 79,
+      "staleDays": 80,
       "status": "ACTIVE"
     },
     {
@@ -3357,7 +3357,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3372,7 +3372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3387,7 +3387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3404,7 +3404,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3419,7 +3419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3434,7 +3434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -3449,7 +3449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3464,7 +3464,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3479,7 +3479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3494,7 +3494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3509,7 +3509,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -3524,7 +3524,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3539,7 +3539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3554,7 +3554,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -3569,7 +3569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3584,7 +3584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3599,7 +3599,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3614,7 +3614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3629,7 +3629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -3644,7 +3644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3659,7 +3659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -3674,7 +3674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3689,7 +3689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3704,7 +3704,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3719,7 +3719,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -3734,7 +3734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3749,7 +3749,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3764,7 +3764,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3779,7 +3779,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3795,7 +3795,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "active"
     },
     {
@@ -3810,7 +3810,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3825,7 +3825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3840,7 +3840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3855,7 +3855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3870,7 +3870,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 70,
+      "staleDays": 71,
       "status": "ACTIVE"
     },
     {
@@ -3885,7 +3885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3900,7 +3900,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -3915,7 +3915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3930,7 +3930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -3945,7 +3945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3960,7 +3960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3975,7 +3975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -3990,7 +3990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4005,7 +4005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4020,7 +4020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4035,7 +4035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4050,7 +4050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4065,7 +4065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4080,7 +4080,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -4095,7 +4095,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -4110,7 +4110,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 79,
+      "staleDays": 80,
       "status": "ACTIVE"
     },
     {
@@ -4125,7 +4125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4152,7 +4152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4167,7 +4167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4182,7 +4182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4197,7 +4197,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4212,7 +4212,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4227,7 +4227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4242,7 +4242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4281,7 +4281,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "ACTIVE"
     },
     {
@@ -4296,7 +4296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4311,7 +4311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4326,7 +4326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4362,7 +4362,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 18,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -4377,7 +4377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4392,7 +4392,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 56,
+      "staleDays": 57,
       "status": "HISTORICAL"
     },
     {
@@ -4407,7 +4407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4422,7 +4422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4437,7 +4437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4452,7 +4452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -4467,7 +4467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4482,7 +4482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4497,7 +4497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4512,7 +4512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4527,7 +4527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4542,7 +4542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4583,7 +4583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -4598,7 +4598,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4613,7 +4613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4628,7 +4628,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 71,
+      "staleDays": 72,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4643,7 +4643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4658,7 +4658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4673,7 +4673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4688,7 +4688,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4702,7 +4702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -4717,7 +4717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4732,7 +4732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4747,7 +4747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4762,7 +4762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4777,7 +4777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -4792,7 +4792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4807,7 +4807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4822,7 +4822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4837,7 +4837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4852,7 +4852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4867,7 +4867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4882,7 +4882,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4897,7 +4897,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4926,7 +4926,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -4941,7 +4941,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4956,7 +4956,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4971,7 +4971,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -4986,7 +4986,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5001,7 +5001,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5016,7 +5016,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5031,7 +5031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -5046,7 +5046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5061,7 +5061,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5076,7 +5076,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5091,7 +5091,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5106,7 +5106,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5121,7 +5121,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -5136,7 +5136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5151,7 +5151,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5166,7 +5166,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5181,7 +5181,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5196,7 +5196,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 38,
+      "staleDays": 39,
       "status": "ACTIVE"
     },
     {
@@ -5211,7 +5211,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 38,
+      "staleDays": 39,
       "status": "ACTIVE"
     },
     {
@@ -5226,7 +5226,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -5241,7 +5241,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "ACTIVE"
     },
     {
@@ -5256,7 +5256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5271,7 +5271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5286,7 +5286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5301,7 +5301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5327,7 +5327,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -5342,7 +5342,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "Implemented"
     },
     {
@@ -5357,7 +5357,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "ACTIVE"
     },
     {
@@ -5372,7 +5372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5423,7 +5423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5438,7 +5438,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ARCHIVED"
     },
     {
@@ -5453,7 +5453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5468,7 +5468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5483,7 +5483,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -5498,7 +5498,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "HISTORICAL"
     },
     {
@@ -5513,7 +5513,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "HISTORICAL"
     },
     {
@@ -5528,7 +5528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5543,7 +5543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5558,7 +5558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5573,7 +5573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5588,7 +5588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5603,7 +5603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5618,7 +5618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5633,7 +5633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5648,7 +5648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5663,7 +5663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5678,7 +5678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5693,7 +5693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5708,7 +5708,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5723,7 +5723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5738,7 +5738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5753,7 +5753,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5768,7 +5768,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5783,7 +5783,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 77,
+      "staleDays": 78,
       "status": "ACTIVE"
     },
     {
@@ -5798,7 +5798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5813,7 +5813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5827,7 +5827,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -5841,7 +5841,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -5856,7 +5856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -5871,7 +5871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5886,7 +5886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5901,7 +5901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5916,7 +5916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5931,7 +5931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5946,7 +5946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5961,7 +5961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5976,7 +5976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -5991,7 +5991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6006,7 +6006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6021,7 +6021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6036,7 +6036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6051,7 +6051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6066,7 +6066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6081,7 +6081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6096,7 +6096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -6111,7 +6111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6126,7 +6126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6168,7 +6168,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -6216,7 +6216,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -6261,7 +6261,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -6292,7 +6292,7 @@
       "lastUpdated": "2026-06-15",
       "owner": "Platform Team",
       "path": "docs/design/audits/server-object-readiness.md",
-      "staleDays": 0,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -6331,7 +6331,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "ACTIVE"
     },
     {
@@ -6347,7 +6347,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -6362,7 +6362,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6377,7 +6377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6392,7 +6392,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6407,7 +6407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6421,7 +6421,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -6436,7 +6436,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6451,7 +6451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6466,7 +6466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6481,7 +6481,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6495,7 +6495,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -6510,7 +6510,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6525,7 +6525,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -6540,7 +6540,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6555,7 +6555,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6570,7 +6570,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6585,7 +6585,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6600,7 +6600,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6615,7 +6615,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6630,7 +6630,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6645,7 +6645,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6660,7 +6660,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -6675,7 +6675,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6708,7 +6708,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 18,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -6723,7 +6723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6756,7 +6756,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 18,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -6771,7 +6771,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6786,7 +6786,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6801,7 +6801,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6816,7 +6816,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 56,
+      "staleDays": 57,
       "status": "HISTORICAL"
     },
     {
@@ -6831,7 +6831,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 29,
+      "staleDays": 30,
       "status": "ACTIVE"
     },
     {
@@ -6846,7 +6846,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6861,7 +6861,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6876,7 +6876,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6891,7 +6891,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6906,7 +6906,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6921,7 +6921,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6936,7 +6936,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6951,7 +6951,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6966,7 +6966,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6981,7 +6981,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -6996,7 +6996,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7011,7 +7011,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7026,7 +7026,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -7041,7 +7041,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7056,7 +7056,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7071,7 +7071,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7086,7 +7086,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7101,7 +7101,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7116,7 +7116,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -7131,7 +7131,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7146,7 +7146,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7161,7 +7161,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7182,7 +7182,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "active"
     },
     {
@@ -7196,7 +7196,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -7211,7 +7211,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7226,7 +7226,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7241,7 +7241,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7256,7 +7256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7271,7 +7271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7286,7 +7286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7301,7 +7301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7316,7 +7316,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7331,7 +7331,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7346,7 +7346,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -7361,7 +7361,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -7376,7 +7376,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -7391,7 +7391,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -7406,7 +7406,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7421,7 +7421,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7436,7 +7436,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7451,7 +7451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7466,7 +7466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7481,7 +7481,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7496,7 +7496,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7511,7 +7511,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7526,7 +7526,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7541,7 +7541,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7556,7 +7556,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7571,7 +7571,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7586,7 +7586,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7601,7 +7601,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7616,7 +7616,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7631,7 +7631,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7646,7 +7646,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7661,7 +7661,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7676,7 +7676,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7691,7 +7691,41 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 147,
+      "staleDays": 148,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "both",
+        "categories": [
+          "testing",
+          "validation",
+          "parity"
+        ],
+        "keywords": [
+          "lp-metrics",
+          "truth-cases",
+          "nav",
+          "capital-account",
+          "validation"
+        ],
+        "last_updated": "2026-06-16",
+        "owner": "Platform Team",
+        "related_code": [
+          "server/services/lp-reporting/metrics-engine.ts",
+          "tests/unit/truth-cases/lp-metrics.test.ts"
+        ],
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-16",
+      "owner": "Platform Team",
+      "path": "docs/parity/convention-matrix.md",
+      "staleDays": 0,
       "status": "ACTIVE"
     },
     {
@@ -7706,7 +7740,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7721,7 +7755,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7737,7 +7771,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 71,
+      "staleDays": 72,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7752,7 +7786,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7767,7 +7801,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7782,7 +7816,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7797,7 +7831,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7812,7 +7846,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7839,7 +7873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7854,7 +7888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -7869,7 +7903,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 79,
+      "staleDays": 80,
       "status": "ACTIVE"
     },
     {
@@ -7886,7 +7920,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 69,
+      "staleDays": 70,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -7901,7 +7935,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 29,
+      "staleDays": 30,
       "status": "BACKLOG"
     },
     {
@@ -7915,7 +7949,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -7932,7 +7966,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 15,
+      "staleDays": 16,
       "status": "ACTIVE"
     },
     {
@@ -7952,7 +7986,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -7981,7 +8015,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-13-gp-trust-readiness-register.md",
-      "staleDays": 2,
+      "staleDays": 3,
       "status": "ACTIVE"
     },
     {
@@ -8018,7 +8052,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -8033,7 +8067,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -8048,7 +8082,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8063,7 +8097,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -8078,7 +8112,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8093,7 +8127,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8108,7 +8142,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8123,7 +8157,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8138,7 +8172,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8153,7 +8187,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8168,7 +8202,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8183,7 +8217,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8198,7 +8232,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8213,7 +8247,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8228,7 +8262,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8243,7 +8277,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8258,7 +8292,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8273,7 +8307,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8288,7 +8322,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8303,7 +8337,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8318,7 +8352,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 25,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -8333,7 +8367,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8347,7 +8381,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -8374,7 +8408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8389,7 +8423,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -8404,7 +8438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8419,7 +8453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8434,7 +8468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8449,7 +8483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8464,7 +8498,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8479,7 +8513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8494,7 +8528,7 @@
       "lastUpdated": "2026-06-12",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 3,
+      "staleDays": 4,
       "status": "PROVEN"
     },
     {
@@ -8509,7 +8543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8524,7 +8558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8539,7 +8573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8554,7 +8588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8569,7 +8603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8584,7 +8618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8599,7 +8633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8614,7 +8648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8629,7 +8663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8644,7 +8678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8679,7 +8713,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "COMPLETED"
     },
     {
@@ -8710,7 +8744,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "REFERENCE"
     },
     {
@@ -8741,7 +8775,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "REFERENCE"
     },
     {
@@ -8772,7 +8806,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "REFERENCE"
     },
     {
@@ -8805,7 +8839,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "REFERENCE"
     },
     {
@@ -8836,7 +8870,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "REFERENCE"
     },
     {
@@ -8868,7 +8902,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "REFERENCE"
     },
     {
@@ -8883,7 +8917,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -8898,7 +8932,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8913,7 +8947,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8928,7 +8962,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8943,7 +8977,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8958,7 +8992,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -8986,7 +9020,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 77,
+      "staleDays": 78,
       "status": "ACTIVE"
     },
     {
@@ -9001,7 +9035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9016,7 +9050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9031,7 +9065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9046,7 +9080,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9061,7 +9095,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9076,7 +9110,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9091,7 +9125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9106,7 +9140,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9121,7 +9155,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9136,7 +9170,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9151,7 +9185,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9166,7 +9200,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9181,7 +9215,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9196,7 +9230,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9211,7 +9245,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9226,7 +9260,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9241,7 +9275,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-01-to-01-07-extraction.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -9256,7 +9290,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-08-to-01-18-extraction.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -9271,7 +9305,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-18-extraction.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -9285,7 +9319,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -9299,7 +9333,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -9313,7 +9347,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -9327,7 +9361,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "UNKNOWN"
     },
     {
@@ -9341,7 +9375,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -9355,7 +9389,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "UNKNOWN"
     },
     {
@@ -9370,7 +9404,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9385,7 +9419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9400,7 +9434,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -9441,7 +9475,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "VERIFIED"
     },
     {
@@ -9789,7 +9823,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "DRAFT"
     },
     {
@@ -9987,7 +10021,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10069,7 +10103,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "VERIFIED"
     },
     {
@@ -10142,7 +10176,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "DRAFT"
     },
     {
@@ -10186,7 +10220,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "DRAFT"
     },
     {
@@ -10316,7 +10350,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "DRAFT"
     },
     {
@@ -10363,7 +10397,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "DRAFT"
     },
     {
@@ -10405,7 +10439,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "DRAFT"
     },
     {
@@ -10554,7 +10588,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10580,7 +10614,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10611,7 +10645,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10640,7 +10674,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10669,7 +10703,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10699,7 +10733,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10729,7 +10763,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10759,7 +10793,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "DRAFT"
     },
     {
@@ -10792,7 +10826,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "DRAFT"
     },
     {
@@ -10857,7 +10891,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -10872,7 +10906,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -10887,7 +10921,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -10914,7 +10948,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -10942,7 +10976,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -10971,7 +11005,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -10999,7 +11033,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -11027,7 +11061,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -11054,7 +11088,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 17,
+      "staleDays": 18,
       "status": "COMPLETE"
     },
     {
@@ -11095,7 +11129,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 8,
+      "staleDays": 9,
       "status": "ACTIVE"
     },
     {
@@ -11112,7 +11146,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 2,
+      "staleDays": 3,
       "status": "COMPLETE"
     },
     {
@@ -11141,7 +11175,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 7,
+      "staleDays": 8,
       "status": "ACTIVE"
     },
     {
@@ -11170,7 +11204,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -11223,7 +11257,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 2,
+      "staleDays": 3,
       "status": "COMPLETE"
     },
     {
@@ -11252,7 +11286,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 7,
+      "staleDays": 8,
       "status": "ACTIVE"
     },
     {
@@ -11281,7 +11315,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -11328,7 +11362,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/superpowers/specs/2026-06-13-gp-trust-readiness-audit-design.md",
-      "staleDays": 2,
+      "staleDays": 3,
       "status": "ACTIVE"
     },
     {
@@ -11367,7 +11401,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -11382,7 +11416,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11397,7 +11431,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11412,7 +11446,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11427,7 +11461,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11454,7 +11488,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11469,7 +11503,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11484,7 +11518,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11499,7 +11533,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11514,7 +11548,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11529,7 +11563,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11544,7 +11578,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "HISTORICAL"
     },
     {
@@ -11559,7 +11593,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11574,7 +11608,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11589,7 +11623,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11604,7 +11638,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11619,7 +11653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11634,7 +11668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11649,7 +11683,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11664,7 +11698,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11679,7 +11713,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 18,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -11725,7 +11759,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 168,
+      "staleDays": 169,
       "status": "ACTIVE"
     },
     {
@@ -11740,7 +11774,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     },
     {
@@ -11755,11 +11789,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 147,
+      "staleDays": 148,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-06-15T00:00:00.000Z",
+  "generatedAt": "2026-06-16T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -12925,7 +12959,7 @@
   ],
   "stats": {
     "by_status": {
-      "ACTIVE": 445,
+      "ACTIVE": 446,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 3,
@@ -12946,7 +12980,7 @@
     },
     "missing_frontmatter": 20,
     "stale_docs": 102,
-    "total_docs": 656
+    "total_docs": 657
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,17 +1,17 @@
 ---
-last_updated: 2026-06-15
+last_updated: 2026-06-16
 ---
 
 # Staleness Report
 
-*Generated: 2026-06-15T00:00:00.000Z*
+*Generated: 2026-06-16T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 656 |
+| Total Documents | 657 |
 | Stale Documents | 102 |
 | Missing Frontmatter | 20 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-06-15
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 445 |
+| ACTIVE | 446 |
 | UNKNOWN | 115 |
 | DRAFT | 30 |
 | HISTORICAL | 29 |
@@ -85,15 +85,15 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md` | Never | 999 | YES - verify! | Unassigned |
 | `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md` | Never | 999 | No | Unassigned |
 | `docs/tooling-catalog.md` | Never | 999 | No | Unassigned |
-| `cheatsheets/agent-architecture.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/ai-code-review.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/api.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/capability-checklist.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/claude-commands.md` | 2026-01-19 | 147 | No | Unassigned |
-| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 147 | No | Unassigned |
+| `cheatsheets/agent-architecture.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/ai-code-review.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/api.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/capability-checklist.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/claude-commands.md` | 2026-01-19 | 148 | No | Unassigned |
+| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 148 | No | Unassigned |
 
 *...and 52 more stale documents.*
 
@@ -101,13 +101,13 @@ Documents that need review (older than their cadence threshold):
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **CHANGELOG.md** (26 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (147 days old)
-- [ ] **cheatsheets/schema-alignment.md** (147 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (147 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (147 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (147 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (147 days old)
+- [ ] **CHANGELOG.md** (27 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (148 days old)
+- [ ] **cheatsheets/schema-alignment.md** (148 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (148 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (148 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (148 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (148 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)

--- a/docs/lp-metrics.truth-cases.json
+++ b/docs/lp-metrics.truth-cases.json
@@ -1,0 +1,442 @@
+[
+  {
+    "id": "LPM-001",
+    "category": "baseline",
+    "description": "three calls, one distribution, one active mark, one future mark excluded",
+    "input": {
+      "fundId": 1,
+      "asOfDate": "2024-12-31",
+      "perspective": "lp_net",
+      "cashFlowEvents": [
+        {
+          "id": 1,
+          "eventType": "lp_capital_call",
+          "amount": "1000000.000000",
+          "eventDate": "2024-01-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 2,
+          "eventType": "lp_capital_call",
+          "amount": "2000000.000000",
+          "eventDate": "2024-04-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 3,
+          "eventType": "lp_capital_call",
+          "amount": "3000000.000000",
+          "eventDate": "2024-07-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 4,
+          "eventType": "lp_distribution",
+          "amount": "1500000.000000",
+          "eventDate": "2024-12-15",
+          "perspective": "lp_net",
+          "status": "approved"
+        }
+      ],
+      "valuationMarks": [
+        {
+          "id": 10,
+          "fairValue": "5000000.000000",
+          "markDate": "2024-09-30",
+          "asOfDate": "2024-09-30",
+          "status": "approved",
+          "confidenceLevel": "high"
+        },
+        {
+          "id": 11,
+          "fairValue": "7000000.000000",
+          "markDate": "2025-06-30",
+          "asOfDate": "2025-06-30",
+          "status": "approved",
+          "confidenceLevel": "low"
+        }
+      ]
+    },
+    "expected": {
+      "contributionsTotal": "6000000.000000",
+      "distributionsTotal": "1500000.000000",
+      "currentNav": "5000000.000000",
+      "dpi": "0.250000",
+      "rvpi": "0.833333",
+      "tvpi": "1.083333",
+      "moic": "1.083333",
+      "markConfidenceMix": { "high": 1, "medium": 0, "low": 0 },
+      "excludedFutureMarks": [11],
+      "netIrrConverges": true,
+      "warningCodes": []
+    },
+    "tags": ["baseline"]
+  },
+  {
+    "id": "LPM-002",
+    "category": "recallable",
+    "description": "recallable distribution nets down contributions; does not count as a distribution",
+    "input": {
+      "fundId": 1,
+      "asOfDate": "2024-12-31",
+      "perspective": "lp_net",
+      "cashFlowEvents": [
+        {
+          "id": 1,
+          "eventType": "lp_capital_call",
+          "amount": "5000000.000000",
+          "eventDate": "2024-01-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 2,
+          "eventType": "recallable_distribution",
+          "amount": "1000000.000000",
+          "eventDate": "2024-06-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 3,
+          "eventType": "lp_distribution",
+          "amount": "2000000.000000",
+          "eventDate": "2024-09-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        }
+      ],
+      "valuationMarks": [
+        {
+          "id": 10,
+          "fairValue": "6000000.000000",
+          "markDate": "2024-09-30",
+          "asOfDate": "2024-09-30",
+          "status": "approved",
+          "confidenceLevel": "high"
+        }
+      ]
+    },
+    "expected": {
+      "contributionsTotal": "4000000.000000",
+      "distributionsTotal": "2000000.000000",
+      "currentNav": "6000000.000000",
+      "dpi": "0.500000",
+      "rvpi": "1.500000",
+      "tvpi": "2.000000",
+      "moic": "2.000000",
+      "markConfidenceMix": { "high": 1, "medium": 0, "low": 0 },
+      "excludedFutureMarks": [],
+      "netIrrConverges": true,
+      "warningCodes": []
+    },
+    "tags": ["recallable"]
+  },
+  {
+    "id": "LPM-003",
+    "category": "realized-proceeds",
+    "description": "realized_proceeds count toward distributions alongside lp_distribution",
+    "input": {
+      "fundId": 1,
+      "asOfDate": "2024-12-31",
+      "perspective": "lp_net",
+      "cashFlowEvents": [
+        {
+          "id": 1,
+          "eventType": "lp_capital_call",
+          "amount": "10000000.000000",
+          "eventDate": "2024-01-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 2,
+          "eventType": "lp_distribution",
+          "amount": "3000000.000000",
+          "eventDate": "2024-08-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 3,
+          "eventType": "realized_proceeds",
+          "amount": "2000000.000000",
+          "eventDate": "2024-10-01",
+          "perspective": "fund_gross",
+          "status": "approved"
+        }
+      ],
+      "valuationMarks": [
+        {
+          "id": 10,
+          "fairValue": "8000000.000000",
+          "markDate": "2024-09-30",
+          "asOfDate": "2024-09-30",
+          "status": "approved",
+          "confidenceLevel": "high"
+        }
+      ]
+    },
+    "expected": {
+      "contributionsTotal": "10000000.000000",
+      "distributionsTotal": "5000000.000000",
+      "currentNav": "8000000.000000",
+      "dpi": "0.500000",
+      "rvpi": "0.800000",
+      "tvpi": "1.300000",
+      "moic": "1.300000",
+      "markConfidenceMix": { "high": 1, "medium": 0, "low": 0 },
+      "excludedFutureMarks": [],
+      "netIrrConverges": true,
+      "warningCodes": []
+    },
+    "tags": ["realized-proceeds"]
+  },
+  {
+    "id": "LPM-004",
+    "category": "reversal",
+    "description": "a reversed call and its reversal marker are both excluded from the math",
+    "input": {
+      "fundId": 1,
+      "asOfDate": "2024-12-31",
+      "perspective": "lp_net",
+      "cashFlowEvents": [
+        {
+          "id": 1,
+          "eventType": "lp_capital_call",
+          "amount": "4000000.000000",
+          "eventDate": "2024-01-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 2,
+          "eventType": "lp_capital_call",
+          "amount": "1000000.000000",
+          "eventDate": "2024-03-01",
+          "perspective": "lp_net",
+          "status": "reversed"
+        },
+        {
+          "id": 3,
+          "eventType": "reversal",
+          "amount": "1000000.000000",
+          "eventDate": "2024-03-02",
+          "perspective": "lp_net",
+          "status": "approved",
+          "reversalOfEventId": 2
+        },
+        {
+          "id": 4,
+          "eventType": "lp_distribution",
+          "amount": "1000000.000000",
+          "eventDate": "2024-11-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        }
+      ],
+      "valuationMarks": [
+        {
+          "id": 10,
+          "fairValue": "4000000.000000",
+          "markDate": "2024-09-30",
+          "asOfDate": "2024-09-30",
+          "status": "approved",
+          "confidenceLevel": "high"
+        }
+      ]
+    },
+    "expected": {
+      "contributionsTotal": "4000000.000000",
+      "distributionsTotal": "1000000.000000",
+      "currentNav": "4000000.000000",
+      "dpi": "0.250000",
+      "rvpi": "1.000000",
+      "tvpi": "1.250000",
+      "moic": "1.250000",
+      "markConfidenceMix": { "high": 1, "medium": 0, "low": 0 },
+      "excludedFutureMarks": [],
+      "netIrrConverges": true,
+      "warningCodes": []
+    },
+    "tags": ["reversal", "edge-case"]
+  },
+  {
+    "id": "LPM-005",
+    "category": "mark-selection",
+    "description": "superseded mark is the most-recent for its company yet must be dropped; per-company dedup then keeps the next most-recent approved mark",
+    "input": {
+      "fundId": 1,
+      "asOfDate": "2024-12-31",
+      "perspective": "lp_net",
+      "cashFlowEvents": [
+        {
+          "id": 1,
+          "eventType": "lp_capital_call",
+          "amount": "2000000.000000",
+          "eventDate": "2024-01-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        }
+      ],
+      "valuationMarks": [
+        {
+          "id": 1,
+          "fairValue": "1000000.000000",
+          "markDate": "2024-03-31",
+          "asOfDate": "2024-03-31",
+          "status": "approved",
+          "confidenceLevel": "high",
+          "companyId": 100
+        },
+        {
+          "id": 2,
+          "fairValue": "1500000.000000",
+          "markDate": "2024-06-30",
+          "asOfDate": "2024-06-30",
+          "status": "approved",
+          "confidenceLevel": "high",
+          "companyId": 100
+        },
+        {
+          "id": 3,
+          "fairValue": "9999999.000000",
+          "markDate": "2024-09-30",
+          "asOfDate": "2024-09-30",
+          "status": "superseded",
+          "confidenceLevel": "low",
+          "companyId": 100
+        },
+        {
+          "id": 4,
+          "fairValue": "500000.000000",
+          "markDate": "2024-06-30",
+          "asOfDate": "2024-06-30",
+          "status": "approved",
+          "confidenceLevel": "medium",
+          "companyId": 200
+        }
+      ]
+    },
+    "expected": {
+      "contributionsTotal": "2000000.000000",
+      "distributionsTotal": "0.000000",
+      "currentNav": "2000000.000000",
+      "dpi": "0.000000",
+      "rvpi": "1.000000",
+      "tvpi": "1.000000",
+      "moic": "1.000000",
+      "markConfidenceMix": { "high": 1, "medium": 1, "low": 0 },
+      "excludedFutureMarks": [],
+      "netIrrConverges": true,
+      "warningCodes": []
+    },
+    "tags": ["mark-selection", "edge-case"]
+  },
+  {
+    "id": "LPM-006",
+    "category": "zero-contributions",
+    "description": "recallable exactly cancels the only call; ratios are null with a ZERO_CONTRIBUTIONS warning",
+    "input": {
+      "fundId": 1,
+      "asOfDate": "2024-12-31",
+      "perspective": "lp_net",
+      "cashFlowEvents": [
+        {
+          "id": 1,
+          "eventType": "lp_capital_call",
+          "amount": "1000000.000000",
+          "eventDate": "2024-01-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 2,
+          "eventType": "recallable_distribution",
+          "amount": "1000000.000000",
+          "eventDate": "2024-06-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 3,
+          "eventType": "lp_distribution",
+          "amount": "500000.000000",
+          "eventDate": "2024-09-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        }
+      ],
+      "valuationMarks": [
+        {
+          "id": 10,
+          "fairValue": "2000000.000000",
+          "markDate": "2024-09-30",
+          "asOfDate": "2024-09-30",
+          "status": "approved",
+          "confidenceLevel": "high"
+        }
+      ]
+    },
+    "expected": {
+      "contributionsTotal": "0.000000",
+      "distributionsTotal": "500000.000000",
+      "currentNav": "2000000.000000",
+      "dpi": null,
+      "rvpi": null,
+      "tvpi": null,
+      "moic": null,
+      "markConfidenceMix": { "high": 1, "medium": 0, "low": 0 },
+      "excludedFutureMarks": [],
+      "netIrrConverges": true,
+      "warningCodes": ["ZERO_CONTRIBUTIONS"]
+    },
+    "tags": ["zero-contributions", "edge-case"]
+  },
+  {
+    "id": "LPM-007",
+    "category": "no-marks",
+    "description": "no valuation marks; NAV is zero and RVPI is zero",
+    "input": {
+      "fundId": 1,
+      "asOfDate": "2024-12-31",
+      "perspective": "lp_net",
+      "cashFlowEvents": [
+        {
+          "id": 1,
+          "eventType": "lp_capital_call",
+          "amount": "3000000.000000",
+          "eventDate": "2024-01-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        },
+        {
+          "id": 2,
+          "eventType": "lp_distribution",
+          "amount": "3600000.000000",
+          "eventDate": "2024-12-01",
+          "perspective": "lp_net",
+          "status": "approved"
+        }
+      ],
+      "valuationMarks": []
+    },
+    "expected": {
+      "contributionsTotal": "3000000.000000",
+      "distributionsTotal": "3600000.000000",
+      "currentNav": "0.000000",
+      "dpi": "1.200000",
+      "rvpi": "0.000000",
+      "tvpi": "1.200000",
+      "moic": "1.200000",
+      "markConfidenceMix": { "high": 0, "medium": 0, "low": 0 },
+      "excludedFutureMarks": [],
+      "netIrrConverges": true,
+      "warningCodes": []
+    },
+    "tags": ["no-marks", "edge-case"]
+  }
+]

--- a/docs/parity/convention-matrix.md
+++ b/docs/parity/convention-matrix.md
@@ -1,3 +1,16 @@
+---
+status: ACTIVE
+audience: both
+last_updated: 2026-06-16
+owner: 'Platform Team'
+review_cadence: P90D
+categories: [testing, validation, parity]
+keywords: [lp-metrics, truth-cases, nav, capital-account, validation]
+related_code:
+  - 'server/services/lp-reporting/metrics-engine.ts'
+  - 'tests/unit/truth-cases/lp-metrics.test.ts'
+---
+
 # Convention matrix — LP metrics validation
 
 Comparison contract for cross-checking

--- a/docs/parity/convention-matrix.md
+++ b/docs/parity/convention-matrix.md
@@ -1,0 +1,28 @@
+# Convention matrix — LP metrics validation
+
+Comparison contract for cross-checking
+`server/services/lp-reporting/metrics-engine.ts`. Any independent derivation
+(hand or plugin) must honor these or divergences are noise.
+
+| Quantity                      | Definition (authoritative)                                                                            | Source              |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------- |
+| Money on wire                 | decimal string, 6 dp, NUMERIC(20,6)                                                                   | ADR-011             |
+| contributions                 | Σ\|lp_capital_call\| − Σ\|recallable_distribution\|                                                   | metrics-engine.ts   |
+| distributions                 | Σ\|lp_distribution\| + Σ\|realized_proceeds\|                                                         | metrics-engine.ts   |
+| currentNav                    | Σ fairValue of active marks                                                                           | metrics-engine.ts   |
+| active mark                   | markDate ≤ asOfDate; status ∉ {superseded, reversed}; one per companyId (or id), most recent markDate | selectActiveMarks() |
+| excluded events               | status = reversed, or eventType = reversal                                                            | isLiveEvent()       |
+| DPI                           | distributions / contributions                                                                         | —                   |
+| RVPI                          | currentNav / contributions                                                                            | —                   |
+| TVPI                          | DPI + RVPI (summed as Decimals before render)                                                         | —                   |
+| MOIC                          | (distributions + currentNav) / contributions                                                          | —                   |
+| ratios when contributions = 0 | null + ZERO_CONTRIBUTIONS warning                                                                     | metrics-engine.ts   |
+| XIRR                          | Actual/365.25 day-count; bounds [-0.999999, 200]                                                      | ADR-005, ADR-010    |
+
+Notes:
+
+- XIRR rate magnitude is validated in `docs/xirr.truth-cases.json`. LP-metrics
+  cases assert XIRR only at convergence level (a rate exists / converged), not
+  the rate value, to avoid duplicating the solver's truth set.
+- Fee logic is out of scope here; the fee authority is ADR-006 +
+  `shared/lib/economics/economics-engine.ts` (NOT `shared/lib/fund-calc.ts`).

--- a/tests/unit/truth-cases/lp-metrics.test.ts
+++ b/tests/unit/truth-cases/lp-metrics.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Truth-Case Runner -- LP Reporting Metrics (NAV / capital-account aggregation).
+ *
+ * Independent, hand-derived expected values for computeMetrics().  Each
+ * expected number is derived from the financial definitions in the convention
+ * matrix (docs/parity/convention-matrix.md), NOT by running the engine, so
+ * these cases are a genuine oracle rather than a regression snapshot.
+ *
+ * @see server/services/lp-reporting/metrics-engine.ts
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  computeMetrics,
+  type ComputeMetricsInput,
+} from '../../../server/services/lp-reporting/metrics-engine';
+import lpMetricsCases from '../../../docs/lp-metrics.truth-cases.json';
+
+interface LpMetricsExpected {
+  contributionsTotal: string;
+  distributionsTotal: string;
+  currentNav: string;
+  dpi: string | null;
+  rvpi: string | null;
+  tvpi: string | null;
+  moic: string | null;
+  markConfidenceMix: { high: number; medium: number; low: number };
+  excludedFutureMarks: number[];
+  netIrrConverges: boolean;
+  warningCodes: string[];
+}
+
+interface LpMetricsTruthCase {
+  id: string;
+  category: string;
+  description: string;
+  input: ComputeMetricsInput;
+  expected: LpMetricsExpected;
+  tags: string[];
+}
+
+const cases = lpMetricsCases as unknown as LpMetricsTruthCase[];
+
+describe('Truth Cases: LP Metrics (NAV / capital account)', () => {
+  cases.forEach((tc) => {
+    it(`${tc.id}: ${tc.description}`, () => {
+      const { results, diagnostics } = computeMetrics(tc.input);
+      const e = tc.expected;
+
+      expect(results.contributionsTotal).toBe(e.contributionsTotal);
+      expect(results.distributionsTotal).toBe(e.distributionsTotal);
+      expect(results.currentNav).toBe(e.currentNav);
+      expect(results.dpi).toBe(e.dpi);
+      expect(results.rvpi).toBe(e.rvpi);
+      expect(results.tvpi).toBe(e.tvpi);
+      expect(results.moic).toBe(e.moic);
+      expect(results.markConfidenceMix).toEqual(e.markConfidenceMix);
+      expect(diagnostics.excludedFutureMarks).toEqual(e.excludedFutureMarks);
+
+      if (e.netIrrConverges) {
+        expect(results.xirrDiagnostic.net.convergence).toBe('converged');
+        expect(results.xirrDiagnostic.gross.convergence).toBe('converged');
+      }
+
+      const actualWarningCodes = diagnostics.warnings.map((w) => w.code);
+      e.warningCodes.forEach((code) => expect(actualWarningCodes).toContain(code));
+      if (e.warningCodes.length === 0) {
+        expect(actualWarningCodes).not.toContain('ZERO_CONTRIBUTIONS');
+      }
+    });
+  });
+
+  it('LP metrics truth table summary', () => {
+    expect(cases.length).toBeGreaterThanOrEqual(7);
+    const tagSet = new Set(cases.flatMap((tc) => tc.tags));
+    ['baseline', 'recallable', 'edge-case'].forEach((t) => expect(tagSet.has(t)).toBe(true));
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first deterministic truth-case module for the LP-reporting metrics engine (`computeMetrics()` in `server/services/lp-reporting/metrics-engine.ts`), covering the NAV / capital-account surface that previously had **no JSON truth coverage** (only an inline test fixture).

- `docs/lp-metrics.truth-cases.json` — 7 hand-derived cases (LPM-001..007)
- `tests/unit/truth-cases/lp-metrics.test.ts` — runner, wired into `npm run phoenix:truth`
- `docs/parity/convention-matrix.md` — the comparison contract (ADR-011 6dp money, metric definitions, XIRR convention)

## Coverage

Behaviors newly pinned with hand-checked expected values: recallable netting, realized-proceeds, reversed/reversal exclusion, superseded + per-company mark dedup, the zero-contributions warning, and the no-marks edge.

Expected values were derived **independently** from the engine's financial definitions (not snapshotted from the engine), so these are a genuine oracle rather than a regression photograph.

## Verification

- `npm run phoenix:truth` -> **273/273** green (lp-metrics = 8 tests; total up from ~265)
- `npm run check` (all 3 tsconfigs) clean; eslint clean
- Independent specialist (`phoenix-truth-case-runner`) re-derived all 7 cases as correct
- **Negative control proven**: neutering the superseded-mark filter makes LPM-005 fail (NAV `10499999` vs `2000000`); engine left pristine (empty diff)

Test-fixture-only change; no production calc logic modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)