### PR TITLE
feat(cash-flow-events): draft-only lp_capital_call PATCH with xmin concurrency (PR-C3)

### DIFF
--- a/server/routes/cash-flow-events.ts
+++ b/server/routes/cash-flow-events.ts
@@ -5,22 +5,25 @@ import type { CashFlowEvent } from '@shared/schema/lp-reporting-evidence';
 import {
   CashFlowEventResponseSchema,
   LpCapitalCallSchema,
+  LpCapitalCallPatchSchema,
   type CashFlowEventResponse,
 } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
 import { firstString } from '../lib/request-values';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { parseETag, rowVersionETag } from '../lib/http-preconditions';
 import {
   createLpCapitalCallEvent,
   listCashFlowEventsForFund,
+  loadCashFlowEvent,
+  updateLpCapitalCallDraft,
 } from '../services/lp-reporting/cash-flow-event-service';
 
 const router = Router();
 
-// Whitelist mapping: build the exact response shape, then validate through the
-// strict schema so no internal column (source_hash, lock/supersede/reversal,
-// provenance) can ever leak. Money (`amount`) is a Drizzle decimal string -- pass
-// it through untouched (ADR-011).
-function toResponse(row: CashFlowEvent): CashFlowEventResponse {
+// Whitelist mapping, then strict-schema validate so no internal column
+// (source_hash, lock/supersede/reversal, provenance) can leak. Money (`amount`)
+// is a Drizzle decimal string -- pass through untouched (ADR-011).
+function toResponse(row: CashFlowEvent, etag: string): CashFlowEventResponse {
   return CashFlowEventResponseSchema.parse({
     id: row.id,
     fundId: row.fundId,
@@ -33,6 +36,8 @@ function toResponse(row: CashFlowEvent): CashFlowEventResponse {
     payload: row.payload ?? {},
     status: row.status,
     createdAt: (row.createdAt ?? row.eventDate).toISOString(),
+    updatedAt: (row.updatedAt ?? row.createdAt ?? row.eventDate).toISOString(),
+    etag,
   });
 }
 
@@ -42,36 +47,25 @@ router['post']('/api/funds/:fundId/cash-flow-events', async (req: Request, res: 
     if (fundId === null) {
       return res.status(400).json({ error: 'Invalid fund ID' });
     }
-
     if (!(await enforceProvidedFundScope(req, res, fundId))) {
       return;
     }
-
-    // Phase 1 accepts ONLY lp_capital_call; a different eventType fails the
-    // literal discriminator and is rejected here as a 400.
     const parsed = LpCapitalCallSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({
-        error: 'Invalid request body',
-        details: parsed.error.format(),
-      });
+      return res
+        .status(400)
+        .json({ error: 'Invalid request body', details: parsed.error.format() });
     }
-
-    // Confused-deputy guard: the path fundId is authoritative.
     if (parsed.data.fundId !== fundId) {
-      return res.status(400).json({
-        error: 'fundId mismatch',
-        message: 'Body fundId must match the path fundId',
-      });
+      return res
+        .status(400)
+        .json({ error: 'fundId mismatch', message: 'Body fundId must match the path fundId' });
     }
-
-    const row = await createLpCapitalCallEvent({ ...parsed.data, fundId });
-
-    if (!row) {
+    const created = await createLpCapitalCallEvent({ ...parsed.data, fundId });
+    if (!created) {
       return res.status(500).json({ error: 'Failed to create cash flow event' });
     }
-
-    return res.status(201).json(toResponse(row));
+    return res.status(201).json(toResponse(created.row, rowVersionETag(created.xmin)));
   } catch {
     return res.status(500).json({ error: 'Failed to create cash flow event' });
   }
@@ -83,17 +77,103 @@ router['get']('/api/funds/:fundId/cash-flow-events', async (req: Request, res: R
     if (fundId === null) {
       return res.status(400).json({ error: 'Invalid fund ID' });
     }
-
     if (!(await enforceProvidedFundScope(req, res, fundId))) {
       return;
     }
-
     const rows = await listCashFlowEventsForFund(fundId);
-
-    return res.status(200).json({ data: rows.map(toResponse) });
+    return res
+      .status(200)
+      .json({ data: rows.map((r) => toResponse(r.row, rowVersionETag(r.xmin))) });
   } catch {
     return res.status(500).json({ error: 'Failed to list cash flow events' });
   }
 });
+
+router['patch'](
+  '/api/funds/:fundId/cash-flow-events/:eventId',
+  async (req: Request, res: Response) => {
+    try {
+      const fundId = parseFundIdParam(firstString(req.params['fundId']));
+      if (fundId === null) {
+        return res.status(400).json({ error: 'Invalid fund ID' });
+      }
+      // eventId reuses the same canonical positive-integer parser.
+      const eventId = parseFundIdParam(firstString(req.params['eventId']));
+      if (eventId === null) {
+        return res.status(400).json({ error: 'Invalid event ID' });
+      }
+      if (!(await enforceProvidedFundScope(req, res, fundId))) {
+        return;
+      }
+      const ifMatch = firstString(req.headers['if-match']);
+      if (!ifMatch) {
+        return res
+          .status(428)
+          .json({ error: 'precondition_required', message: 'If-Match header is required' });
+      }
+      const parsed = LpCapitalCallPatchSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid request body', details: parsed.error.format() });
+      }
+      if (parsed.data.fundId !== undefined && parsed.data.fundId !== fundId) {
+        return res
+          .status(400)
+          .json({ error: 'fundId mismatch', message: 'Body fundId must match the path fundId' });
+      }
+
+      const current = await loadCashFlowEvent(fundId, eventId);
+      if (!current) {
+        return res.status(404).json({ error: 'Event not found' });
+      }
+      if (current.row.eventType !== 'lp_capital_call' || current.row.status !== 'draft') {
+        return res
+          .status(409)
+          .json({ error: 'conflict', message: 'Event is not an editable draft' });
+      }
+      const currentEtag = rowVersionETag(current.xmin);
+      if (parseETag(ifMatch) !== parseETag(currentEtag)) {
+        return res
+          .status(412)
+          .json({
+            error: 'precondition_failed',
+            message: 'Event has been modified',
+            current: currentEtag,
+          });
+      }
+
+      const updated = await updateLpCapitalCallDraft({
+        fundId,
+        eventId,
+        expectedXmin: current.xmin,
+        currentRow: current.row,
+        patch: parsed.data,
+      });
+
+      if (!updated) {
+        // Atomic update touched zero rows after a passing precondition -- disambiguate.
+        const recheck = await loadCashFlowEvent(fundId, eventId);
+        if (!recheck) {
+          return res.status(404).json({ error: 'Event not found' });
+        }
+        if (recheck.row.eventType !== 'lp_capital_call' || recheck.row.status !== 'draft') {
+          return res
+            .status(409)
+            .json({ error: 'conflict', message: 'Event is not an editable draft' });
+        }
+        return res.status(412).json({
+          error: 'precondition_failed',
+          message: 'Event has been modified',
+          current: rowVersionETag(recheck.xmin),
+        });
+      }
+
+      return res.status(200).json(toResponse(updated.row, rowVersionETag(updated.xmin)));
+    } catch {
+      return res.status(500).json({ error: 'Failed to update cash flow event' });
+    }
+  }
+);
 
 export default router;

--- a/server/services/lp-reporting/cash-flow-event-service.ts
+++ b/server/services/lp-reporting/cash-flow-event-service.ts
@@ -1,7 +1,10 @@
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db';
-import type { LpCapitalCall } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import type {
+  LpCapitalCall,
+  LpCapitalCallPatch,
+} from '@shared/contracts/lp-reporting/cash-flow-event.contract';
 import { cashFlowEvents, type CashFlowEvent } from '@shared/schema/lp-reporting-evidence';
 
 type CashFlowEventDatabase = typeof db;
@@ -10,12 +13,52 @@ interface CashFlowEventServiceOptions {
   database?: CashFlowEventDatabase;
 }
 
+export interface CashFlowEventRow {
+  row: CashFlowEvent;
+  /** Postgres xmin system column as text -- opaque per-row concurrency token. */
+  xmin: string;
+}
+
+// Explicit column map + xmin::text. getTableColumns is unused elsewhere in this
+// repo, so we list columns rather than rely on an unproven import.
+const columnsWithXmin = {
+  id: cashFlowEvents.id,
+  fundId: cashFlowEvents.fundId,
+  vehicleId: cashFlowEvents.vehicleId,
+  companyId: cashFlowEvents.companyId,
+  lpId: cashFlowEvents.lpId,
+  eventType: cashFlowEvents.eventType,
+  amount: cashFlowEvents.amount,
+  currency: cashFlowEvents.currency,
+  eventDate: cashFlowEvents.eventDate,
+  perspective: cashFlowEvents.perspective,
+  description: cashFlowEvents.description,
+  payload: cashFlowEvents.payload,
+  status: cashFlowEvents.status,
+  lockedAt: cashFlowEvents.lockedAt,
+  lockedBy: cashFlowEvents.lockedBy,
+  supersedesEventId: cashFlowEvents.supersedesEventId,
+  reversalOfEventId: cashFlowEvents.reversalOfEventId,
+  importedFrom: cashFlowEvents.importedFrom,
+  importBatchId: cashFlowEvents.importBatchId,
+  sourceHash: cashFlowEvents.sourceHash,
+  createdBy: cashFlowEvents.createdBy,
+  createdAt: cashFlowEvents.createdAt,
+  updatedAt: cashFlowEvents.updatedAt,
+  rowXmin: sql<string>`xmin::text`,
+} as const;
+
+function splitXmin(record: CashFlowEvent & { rowXmin: string }): CashFlowEventRow {
+  const { rowXmin, ...row } = record;
+  return { row: row as CashFlowEvent, xmin: rowXmin };
+}
+
 export async function createLpCapitalCallEvent(
   input: LpCapitalCall,
   options: CashFlowEventServiceOptions = {}
-): Promise<CashFlowEvent | undefined> {
+): Promise<CashFlowEventRow | undefined> {
   const database = options.database ?? db;
-  const [row] = await database
+  const [record] = await database
     .insert(cashFlowEvents)
     .values({
       fundId: input.fundId,
@@ -28,21 +71,82 @@ export async function createLpCapitalCallEvent(
       payload: input.payload,
       status: 'draft',
     })
-    .returning();
+    .returning(columnsWithXmin);
 
-  return row;
+  return record ? splitXmin(record) : undefined;
 }
 
 export async function listCashFlowEventsForFund(
   fundId: number,
   options: CashFlowEventServiceOptions = {}
-): Promise<CashFlowEvent[]> {
+): Promise<CashFlowEventRow[]> {
   const database = options.database ?? db;
-
   // Newest-first; hits idx_cash_flow_fund_date (fund_id, event_date DESC).
-  return database
-    .select()
+  const records = await database
+    .select(columnsWithXmin)
     .from(cashFlowEvents)
     .where(eq(cashFlowEvents.fundId, fundId))
     .orderBy(desc(cashFlowEvents.eventDate));
+  return records.map(splitXmin);
+}
+
+export async function loadCashFlowEvent(
+  fundId: number,
+  eventId: number,
+  options: CashFlowEventServiceOptions = {}
+): Promise<CashFlowEventRow | undefined> {
+  const database = options.database ?? db;
+  const [record] = await database
+    .select(columnsWithXmin)
+    .from(cashFlowEvents)
+    .where(and(eq(cashFlowEvents.fundId, fundId), eq(cashFlowEvents.id, eventId)))
+    .limit(1);
+  return record ? splitXmin(record) : undefined;
+}
+
+interface UpdateDraftArgs {
+  fundId: number;
+  eventId: number;
+  expectedXmin: string;
+  currentRow: CashFlowEvent;
+  patch: LpCapitalCallPatch;
+}
+
+/**
+ * Atomic draft update. WHERE pins fund/id/status='draft'/xmin, so locked or
+ * concurrently-modified rows update zero rows -> returns undefined. sourceHash
+ * is NEVER written here (manual edits are not import-identity events).
+ */
+export async function updateLpCapitalCallDraft(
+  args: UpdateDraftArgs,
+  options: CashFlowEventServiceOptions = {}
+): Promise<CashFlowEventRow | undefined> {
+  const database = options.database ?? db;
+  const { fundId, eventId, expectedXmin, currentRow, patch } = args;
+
+  const setValues: Partial<typeof cashFlowEvents.$inferInsert> = { updatedAt: new Date() };
+  if (patch.amount !== undefined) setValues.amount = patch.amount;
+  if ('description' in patch) setValues.description = patch.description ?? null;
+  if (patch.eventDate !== undefined) setValues.eventDate = new Date(patch.eventDate);
+  if (patch.payload !== undefined) {
+    const base = (currentRow.payload ?? {}) as Record<string, unknown>;
+    setValues.payload = { ...base, ...patch.payload };
+  }
+
+  const updated = await database
+    .update(cashFlowEvents)
+    .set(setValues)
+    .where(
+      and(
+        eq(cashFlowEvents.fundId, fundId),
+        eq(cashFlowEvents.id, eventId),
+        eq(cashFlowEvents.status, 'draft'),
+        sql`xmin = ${expectedXmin}::xid`
+      )
+    )
+    .returning({ id: cashFlowEvents.id });
+
+  if (updated.length === 0) return undefined;
+  // Reload for the fresh row + fresh xmin token (post-update).
+  return loadCashFlowEvent(fundId, eventId, options);
 }

--- a/shared/contracts/lp-reporting/cash-flow-event.contract.ts
+++ b/shared/contracts/lp-reporting/cash-flow-event.contract.ts
@@ -182,12 +182,49 @@ export const CashFlowEventResponseSchema = z
     payload: z.record(z.unknown()),
     status: z.enum(['draft', 'approved', 'locked', 'reversed']),
     createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    etag: z.string().min(1),
   })
   .strict();
 
 export const CashFlowEventListResponseSchema = z.object({
   data: z.array(CashFlowEventResponseSchema),
 });
+
+// ============================================================================
+// PATCH (draft edit) -- lp_capital_call only. Strict partial update.
+// `null` stores JSON/SQL null; omitted keys preserve existing values.
+// ============================================================================
+
+export const LpCapitalCallPatchSchema = z
+  .object({
+    fundId: z.number().int().positive().optional(),
+    amount: MoneyStringSchema.optional(),
+    description: z.string().max(1000).nullable().optional(),
+    eventDate: z.string().datetime().optional(),
+    payload: z
+      .object({
+        callNumber: z.number().int().positive().nullable().optional(),
+        dueDate: z.string().date().nullable().optional(),
+        purpose: z.string().max(500).nullable().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .refine(
+    (value) => {
+      const editKeys = Object.keys(value).filter((key) => key !== 'fundId');
+      if (editKeys.length === 0) return false;
+      if (editKeys.length === 1 && editKeys[0] === 'payload') {
+        return value.payload !== undefined && Object.keys(value.payload).length > 0;
+      }
+      return true;
+    },
+    { message: 'PATCH must include at least one editable field' }
+  );
+
+export type LpCapitalCallPatch = z.infer<typeof LpCapitalCallPatchSchema>;
 
 export type CashFlowEventResponse = z.infer<typeof CashFlowEventResponseSchema>;
 export type CashFlowEventListResponse = z.infer<typeof CashFlowEventListResponseSchema>;

--- a/tests/integration/cash-flow-events.test.ts
+++ b/tests/integration/cash-flow-events.test.ts
@@ -79,4 +79,51 @@ describe('cash-flow-events persistence integration', () => {
     expect(listResponse.body.data).toHaveLength(1);
     expect(listResponse.body.data[0]).toMatchObject({ id: createdId, fundId: testFundId });
   });
+
+  it('edits a draft via PATCH with If-Match and rejects a stale token (xmin)', async () => {
+    const created = await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events`)
+      .set('Authorization', authHeader)
+      .send({
+        eventType: 'lp_capital_call',
+        fundId: testFundId,
+        amount: '1000000',
+        eventDate: '2026-06-15T00:00:00.000Z',
+        perspective: 'lp_net',
+        payload: { callNumber: 1 },
+      })
+      .expect(201);
+    const id = created.body.id as number;
+    const etag1 = created.body.etag as string;
+    expect(typeof etag1).toBe('string');
+
+    const ok = await request(app)
+      .patch(`/api/funds/${testFundId}/cash-flow-events/${id}`)
+      .set('Authorization', authHeader)
+      .set('If-Match', etag1)
+      .send({ amount: '2000000', description: 'updated', payload: { dueDate: '2026-08-01' } })
+      .expect(200);
+    expect(ok.body.amount).toBe('2000000.000000');
+    expect(ok.body.description).toBe('updated');
+    expect(ok.body.payload.dueDate).toBe('2026-08-01');
+    expect(ok.body.payload.callNumber).toBe(1); // preserved
+    expect(ok.body.etag).not.toBe(etag1); // xmin advanced
+
+    // AC#12: immediate reuse of the now-stale first token -> 412, no mutation.
+    await request(app)
+      .patch(`/api/funds/${testFundId}/cash-flow-events/${id}`)
+      .set('Authorization', authHeader)
+      .set('If-Match', etag1)
+      .send({ amount: '3000000' })
+      .expect(412);
+
+    // 409: a non-draft row is not editable.
+    await pool.query(`UPDATE cash_flow_events SET status = 'approved' WHERE id = $1`, [id]);
+    await request(app)
+      .patch(`/api/funds/${testFundId}/cash-flow-events/${id}`)
+      .set('Authorization', authHeader)
+      .set('If-Match', ok.body.etag)
+      .send({ amount: '4000000' })
+      .expect(409);
+  });
 });

--- a/tests/unit/routes/cash-flow-events.contract.test.ts
+++ b/tests/unit/routes/cash-flow-events.contract.test.ts
@@ -78,6 +78,8 @@ function dbRow(overrides: Record<string, unknown> = {}) {
     payload: { callNumber: 1 },
     status: 'draft',
     createdAt: new Date('2026-06-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-15T00:00:00.000Z'),
+    rowXmin: '1',
     ...overrides,
   };
 }
@@ -126,6 +128,9 @@ describe('cash-flow-events route contracts', () => {
       currency: 'USD',
     });
     expect(typeof res.body.amount).toBe('string');
+    expect(typeof res.body.updatedAt).toBe('string');
+    expect(typeof res.body.etag).toBe('string');
+    expect(res.body.etag.length).toBeGreaterThan(0);
     expect(res.body).not.toHaveProperty('sourceHash');
     expect(res.body).not.toHaveProperty('source_hash');
     expect(dbState.db.insert).toHaveBeenCalledTimes(1);
@@ -157,6 +162,7 @@ describe('cash-flow-events route contracts', () => {
     expect(res.body.data).toHaveLength(2);
     expect(res.body.data[0].id).toBe(20);
     expect(res.body.data[1].id).toBe(11);
+    expect(typeof res.body.data[0].etag).toBe('string');
     expect(dbState.db.select).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/routes/cash-flow-events.patch.test.ts
+++ b/tests/unit/routes/cash-flow-events.patch.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+import { rowVersionETag } from '../../../server/lib/http-preconditions';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+const svc = vi.hoisted(() => ({
+  loadCashFlowEvent: vi.fn(),
+  updateLpCapitalCallDraft: vi.fn(),
+  createLpCapitalCallEvent: vi.fn(),
+  listCashFlowEventsForFund: vi.fn(),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+vi.mock('../../../server/services/lp-reporting/cash-flow-event-service', () => svc);
+
+import cashFlowEventsRouter from '../../../server/routes/cash-flow-events';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cashFlowEventsRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function draftRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    fundId: 1,
+    eventType: 'lp_capital_call',
+    amount: '1250000.000000',
+    currency: 'USD',
+    eventDate: new Date('2026-06-15T00:00:00.000Z'),
+    perspective: 'lp_net',
+    description: null,
+    payload: { callNumber: 1 },
+    status: 'draft',
+    createdAt: new Date('2026-06-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+const PATH = '/api/funds/1/cash-flow-events/10';
+
+describe('cash-flow-events PATCH route contract', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    svc.loadCashFlowEvent.mockReset();
+    svc.updateLpCapitalCallDraft.mockReset();
+  });
+
+  it('rejects a non-canonical eventId with 400 before scope/load', async () => {
+    const res = await request(makeApp())
+      .patch('/api/funds/1/cash-flow-events/01')
+      .set('If-Match', '"x"')
+      .send({ amount: '5' });
+    expect(res.status).toBe(400);
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(svc.loadCashFlowEvent).not.toHaveBeenCalled();
+  });
+
+  it('denies cross-fund scope with 403 before load', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden' });
+      return false;
+    });
+    const res = await request(makeApp()).patch(PATH).set('If-Match', '"x"').send({ amount: '5' });
+    expect(res.status).toBe(403);
+    expect(svc.loadCashFlowEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 428 when If-Match is missing', async () => {
+    const res = await request(makeApp()).patch(PATH).send({ amount: '5' });
+    expect(res.status).toBe(428);
+    expect(svc.loadCashFlowEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty patch body', async () => {
+    const res = await request(makeApp()).patch(PATH).set('If-Match', '"x"').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for unknown top-level keys', async () => {
+    const res = await request(makeApp())
+      .patch(PATH)
+      .set('If-Match', '"x"')
+      .send({ status: 'approved' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body fundId mismatches the path', async () => {
+    const res = await request(makeApp())
+      .patch(PATH)
+      .set('If-Match', '"x"')
+      .send({ fundId: 2, amount: '5' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the event does not exist', async () => {
+    svc.loadCashFlowEvent.mockResolvedValueOnce(undefined);
+    const res = await request(makeApp()).patch(PATH).set('If-Match', '"x"').send({ amount: '5' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 for a non-draft row', async () => {
+    svc.loadCashFlowEvent.mockResolvedValueOnce({
+      row: draftRow({ status: 'approved' }),
+      xmin: '5',
+    });
+    const res = await request(makeApp())
+      .patch(PATH)
+      .set('If-Match', rowVersionETag('5'))
+      .send({ amount: '5' });
+    expect(res.status).toBe(409);
+    expect(svc.updateLpCapitalCallDraft).not.toHaveBeenCalled();
+  });
+
+  it('returns 412 for a stale If-Match', async () => {
+    svc.loadCashFlowEvent.mockResolvedValueOnce({ row: draftRow(), xmin: '5' });
+    const res = await request(makeApp())
+      .patch(PATH)
+      .set('If-Match', rowVersionETag('999'))
+      .send({ amount: '5' });
+    expect(res.status).toBe(412);
+    expect(svc.updateLpCapitalCallDraft).not.toHaveBeenCalled();
+  });
+
+  it('200s a happy draft edit and returns a fresh etag', async () => {
+    svc.loadCashFlowEvent.mockResolvedValueOnce({ row: draftRow(), xmin: '5' });
+    svc.updateLpCapitalCallDraft.mockResolvedValueOnce({
+      row: draftRow({ amount: '7.000000' }),
+      xmin: '6',
+    });
+    const res = await request(makeApp())
+      .patch(PATH)
+      .set('If-Match', rowVersionETag('5'))
+      .send({ amount: '7' });
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe('7.000000');
+    expect(res.body.etag).toBe(rowVersionETag('6'));
+    expect(res.body).not.toHaveProperty('sourceHash');
+    expect(res.body).not.toHaveProperty('lockedAt');
+  });
+
+  it('disambiguates a zero-row update to 412 (token changed under us)', async () => {
+    svc.loadCashFlowEvent
+      .mockResolvedValueOnce({ row: draftRow(), xmin: '5' })
+      .mockResolvedValueOnce({ row: draftRow(), xmin: '7' });
+    svc.updateLpCapitalCallDraft.mockResolvedValueOnce(undefined);
+    const res = await request(makeApp())
+      .patch(PATH)
+      .set('If-Match', rowVersionETag('5'))
+      .send({ amount: '7' });
+    expect(res.status).toBe(412);
+    expect(res.body.current).toBe(rowVersionETag('7'));
+  });
+});

--- a/tests/unit/services/lp-reporting/cash-flow-event-service.test.ts
+++ b/tests/unit/services/lp-reporting/cash-flow-event-service.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CashFlowEvent } from '../../../../shared/schema/lp-reporting-evidence';
+
+const captured = vi.hoisted(() => ({
+  setValues: undefined as unknown,
+  returnRows: [] as unknown[],
+  selectRows: [] as unknown[],
+}));
+const dbMock = vi.hoisted(() => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: vi.fn(async () => captured.selectRows) })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => captured.selectRows),
+          orderBy: vi.fn(async () => captured.selectRows),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((v: unknown) => {
+        captured.setValues = v;
+        return { where: vi.fn(() => ({ returning: vi.fn(async () => captured.returnRows) })) };
+      }),
+    })),
+  },
+}));
+vi.mock('../../../../server/db', () => dbMock);
+
+import {
+  createLpCapitalCallEvent,
+  loadCashFlowEvent,
+  updateLpCapitalCallDraft,
+} from '../../../../server/services/lp-reporting/cash-flow-event-service';
+
+const record = (o: Record<string, unknown> = {}) => ({
+  id: 10,
+  fundId: 1,
+  vehicleId: null,
+  companyId: null,
+  lpId: null,
+  eventType: 'lp_capital_call',
+  amount: '5.000000',
+  currency: 'USD',
+  eventDate: new Date('2026-06-15T00:00:00.000Z'),
+  perspective: 'lp_net',
+  description: null,
+  payload: { callNumber: 1 },
+  status: 'draft',
+  lockedAt: null,
+  lockedBy: null,
+  supersedesEventId: null,
+  reversalOfEventId: null,
+  importedFrom: null,
+  importBatchId: null,
+  sourceHash: null,
+  createdBy: null,
+  createdAt: new Date('2026-06-15T00:00:00.000Z'),
+  updatedAt: new Date('2026-06-15T00:00:00.000Z'),
+  rowXmin: '5',
+  ...o,
+});
+
+function serviceRow(overrides: Record<string, unknown> = {}): CashFlowEvent {
+  const { rowXmin, ...row } = record(overrides);
+  void rowXmin;
+  return row as CashFlowEvent;
+}
+
+describe('cash-flow-event-service', () => {
+  beforeEach(() => {
+    captured.setValues = undefined;
+    captured.returnRows = [];
+    captured.selectRows = [];
+    dbMock.db.insert.mockClear();
+    dbMock.db.select.mockClear();
+    dbMock.db.update.mockClear();
+  });
+
+  it('createLpCapitalCallEvent splits xmin from the inserted row', async () => {
+    captured.selectRows = [record()];
+    const out = await createLpCapitalCallEvent({
+      eventType: 'lp_capital_call',
+      fundId: 1,
+      amount: '5',
+      eventDate: '2026-06-15T00:00:00.000Z',
+      perspective: 'lp_net',
+      payload: { callNumber: 1 },
+    });
+    expect(out?.xmin).toBe('5');
+    expect(out?.row).not.toHaveProperty('rowXmin');
+    expect(out?.row.id).toBe(10);
+  });
+
+  it('loadCashFlowEvent splits xmin from the row', async () => {
+    captured.selectRows = [record()];
+    const out = await loadCashFlowEvent(1, 10);
+    expect(out?.xmin).toBe('5');
+    expect(out?.row).not.toHaveProperty('rowXmin');
+    expect(out?.row.id).toBe(10);
+  });
+
+  it('updateLpCapitalCallDraft never writes sourceHash', async () => {
+    captured.returnRows = [{ id: 10 }];
+    captured.selectRows = [record({ rowXmin: '6' })];
+    const out = await updateLpCapitalCallDraft({
+      fundId: 1,
+      eventId: 10,
+      expectedXmin: '5',
+      currentRow: serviceRow(),
+      patch: { amount: '7' },
+    });
+    expect(out?.xmin).toBe('6');
+    expect(Object.keys(captured.setValues as object)).not.toContain('sourceHash');
+    expect(captured.setValues).toMatchObject({ amount: '7' });
+  });
+
+  it('returns undefined (no reload) when the atomic update touches zero rows', async () => {
+    captured.returnRows = [];
+    const out = await updateLpCapitalCallDraft({
+      fundId: 1,
+      eventId: 10,
+      expectedXmin: '5',
+      currentRow: serviceRow(),
+      patch: { amount: '7' },
+    });
+    expect(out).toBeUndefined();
+    expect(dbMock.db.select).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PR-C3 — Server draft-edit contract (Candidate C Phase 2)

Smallest editable loop for persisted `lp_capital_call` cash events: a draft-only PATCH with per-row optimistic concurrency.

Plan: `.claude/artifacts/candidate-c-phase2-plan.md` · Spec: `.claude/artifacts/prC3-spec.md`

### What
- `PATCH /api/funds/:fundId/cash-flow-events/:eventId` — edits draft `lp_capital_call` rows only.
- Concurrency token = Postgres **`xmin`** system column (no migration; `updatedAt` is display-only). Chosen over an `updatedAt`-derived ETag because `rowVersionETag(Date)` collapses to millisecond precision and would flake the immediate stale-token test; `xmin` advances on every UPDATE, so it is deterministic.
- Atomic update pins `fund/id/status='draft'/xmin`; locked or non-draft → `409`, stale token → `412`, missing `If-Match` → `428`.
- Route stays DB-free (persistence in the service); `sourceHash` is never written on manual edits.

### Files
- contract: `updatedAt`+`etag` response fields, strict `LpCapitalCallPatchSchema` (empty-patch refine)
- service: `xmin` projection, `loadCashFlowEvent`, atomic `updateLpCapitalCallDraft`
- route: PATCH handler reusing `parseFundIdParam` + `http-preconditions` helpers
- tests: route status matrix (11), service unit (4), contract (7), integration AC#12

### Verification
- `npm run check` (baseline, separate client/server/shared compile): 0 new errors
- `npm run lint` incl. `route-persistence-imports` guard: pass (route DB-free)
- 22 server unit tests pass locally
- Integration (`tests/integration/cash-flow-events.test.ts`, real Postgres incl. AC#12 stale-token `412` + non-draft `409`) runs via the dispatched full-suite CI (`run_full_suite=true`) on this branch — integration is not run on PRs by default.

### Out of scope (deferred to later candidates)
approve/lock, supersede/reverse, other event types, source-hash idempotency, and the client surface (PR-C4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
