### PR TITLE
feat(cash-flow-events): client editable WorkPanel for draft lp_capital_call (PR-C4)

### DIFF
--- a/client/src/components/dashboard/CashEventsPanel.tsx
+++ b/client/src/components/dashboard/CashEventsPanel.tsx
@@ -1,6 +1,21 @@
+import { useEffect, useState } from 'react';
 import { WorkPanel } from '@/components/work-panel/WorkPanel';
 import type { WorkPanelState } from '@/components/work-panel/work-panel-types';
-import { useCashFlowEvents } from '@/hooks/useCashFlowEvents';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useFlag } from '@/shared/useFlags';
+import type { CashFlowEventResponse } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import {
+  buildLpCapitalCallPatch,
+  formFromEvent,
+  isCashEventFormValid,
+  useCashFlowEvents,
+  useUpdateCashFlowEvent,
+  type CashEventEditForm,
+  type CashFlowEventMutationError,
+} from '@/hooks/useCashFlowEvents';
 
 const PANEL_KEY = 'cash-events';
 
@@ -8,42 +23,269 @@ function formatEventDate(iso: string): string {
   return new Date(iso).toLocaleDateString();
 }
 
+function conflictMessage(error: CashFlowEventMutationError): string {
+  if (error.status === 412) {
+    return 'This event changed since you opened it. The latest version is now shown — review and save again.';
+  }
+  if (error.status === 409) {
+    return 'This event is no longer an editable draft. The latest version is now shown.';
+  }
+  return error.message || 'Failed to save changes.';
+}
+
 export function CashEventsPanel({
   fundId,
   state,
   onClose,
+  onSelect,
+  onBack,
 }: {
   fundId: string | undefined;
   state: WorkPanelState | null;
   onClose: () => void;
+  onSelect: (eventId: string) => void;
+  onBack: () => void;
 }) {
   const isOpen = state?.panel === PANEL_KEY;
-  const { data: events, isLoading } = useCashFlowEvents(fundId, { enabled: isOpen });
+  const objectId = isOpen ? (state?.object ?? null) : null;
+  const editFlag = useFlag('enable_cash_event_edit');
+
+  const query = useCashFlowEvents(fundId, { enabled: isOpen });
+  const events = query.data;
+  const mutation = useUpdateCashFlowEvent(fundId);
+
+  const selectedEvent =
+    objectId != null ? events?.find((event) => String(event.id) === objectId) : undefined;
+
+  const [loadedEvent, setLoadedEvent] = useState<CashFlowEventResponse | null>(null);
+  const [form, setForm] = useState<CashEventEditForm | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // F4: reset baseline + form when the row identity OR etag changes
+  // (initial open, post-save refetch, 412/409 refetch). Unchanged etag => no reset.
+  const editKey = selectedEvent ? `${selectedEvent.id}:${selectedEvent.etag}` : null;
+  useEffect(() => {
+    if (selectedEvent) {
+      setLoadedEvent(selectedEvent);
+      setForm(formFromEvent(selectedEvent));
+    } else {
+      setLoadedEvent(null);
+      setForm(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editKey]);
+
+  // Clear any stale conflict note when switching to a different row.
+  useEffect(() => {
+    setErrorMsg(null);
+  }, [objectId]);
+
+  const isEditable =
+    editFlag &&
+    selectedEvent != null &&
+    selectedEvent.eventType === 'lp_capital_call' &&
+    selectedEvent.status === 'draft' &&
+    typeof selectedEvent.etag === 'string' &&
+    selectedEvent.etag.length > 0;
+
+  const patch = loadedEvent && form ? buildLpCapitalCallPatch(loadedEvent, form) : {};
+  const isDirty = Object.keys(patch).length > 0;
+  const canSave =
+    isEditable && isDirty && form != null && isCashEventFormValid(form) && !mutation.isPending;
+  const panelDescription =
+    objectId == null ? 'Persisted capital-call events for this fund.' : undefined;
+
+  const guardedLeave = (action: () => void) => {
+    if (isDirty && !window.confirm('Discard unsaved changes?')) {
+      return;
+    }
+    action();
+  };
+
+  const setField = (key: keyof CashEventEditForm, value: string) => {
+    setErrorMsg(null);
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
+  };
+
+  const handleSave = () => {
+    if (!selectedEvent || !loadedEvent || !form || !canSave) return;
+    mutation.mutate(
+      { eventId: selectedEvent.id, etag: loadedEvent.etag, patch },
+      {
+        onSuccess: (updated) => {
+          setLoadedEvent(updated);
+          setForm(formFromEvent(updated));
+          setErrorMsg(null);
+        },
+        onError: (error) => {
+          setErrorMsg(conflictMessage(error));
+          if (error.status === 412 || error.status === 409) {
+            void query.refetch();
+          }
+        },
+      }
+    );
+  };
+
+  const handleCancel = () => {
+    if (loadedEvent) {
+      setForm(formFromEvent(loadedEvent));
+    }
+    setErrorMsg(null);
+  };
 
   return (
     <WorkPanel
       open={isOpen}
-      onClose={onClose}
+      onClose={() => guardedLeave(onClose)}
       title="Cash events"
-      description="Persisted capital-call events for this fund (read-only)."
+      {...(panelDescription ? { description: panelDescription } : {})}
     >
-      {isLoading ? (
+      {query.isLoading ? (
         <p className="text-sm text-charcoal-600">Loading cash events...</p>
-      ) : !events || events.length === 0 ? (
-        <p className="text-sm text-charcoal-600">No cash events recorded for this fund yet.</p>
+      ) : objectId == null ? (
+        !events || events.length === 0 ? (
+          <p className="text-sm text-charcoal-600">No cash events recorded for this fund yet.</p>
+        ) : (
+          <ul className="space-y-3">
+            {events.map((event) => (
+              <li key={event.id}>
+                <button
+                  type="button"
+                  onClick={() => guardedLeave(() => onSelect(String(event.id)))}
+                  className="flex w-full items-center justify-between gap-4 rounded-md px-2 py-2 text-left hover:bg-beige-100"
+                >
+                  <span>
+                    <span className="block text-sm font-medium text-charcoal-900">
+                      {event.eventType}
+                    </span>
+                    <span className="block text-xs text-charcoal-600">
+                      {formatEventDate(event.eventDate)}
+                    </span>
+                  </span>
+                  <span className="text-sm font-medium text-charcoal-900">{event.amount}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )
+      ) : !selectedEvent ? (
+        <div className="space-y-4">
+          <p className="text-sm text-charcoal-600">This cash event was not found.</p>
+          <Button variant="outline" size="sm" onClick={() => guardedLeave(onBack)}>
+            Back to list
+          </Button>
+        </div>
       ) : (
-        <ul className="space-y-3">
-          {events.map((event) => (
-            <li key={event.id} className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium text-charcoal-900">{event.eventType}</p>
-                <p className="text-xs text-charcoal-600">{formatEventDate(event.eventDate)}</p>
+        <div className="space-y-5">
+          <Button variant="ghost" size="sm" onClick={() => guardedLeave(onBack)}>
+            Back to list
+          </Button>
+
+          {errorMsg ? (
+            <p role="alert" className="text-sm text-error-dark">
+              {errorMsg}
+            </p>
+          ) : null}
+
+          {isEditable && form ? (
+            <form
+              className="space-y-4"
+              onSubmit={(submitEvent) => {
+                submitEvent.preventDefault();
+                handleSave();
+              }}
+            >
+              <div className="space-y-1">
+                <Label htmlFor="cash-event-amount">Amount</Label>
+                <Input
+                  id="cash-event-amount"
+                  type="text"
+                  inputMode="decimal"
+                  value={form.amount}
+                  onChange={(changeEvent) => setField('amount', changeEvent.target.value)}
+                />
               </div>
-              <span className="text-sm font-medium text-charcoal-900">{event.amount}</span>
-            </li>
-          ))}
-        </ul>
+              <div className="space-y-1">
+                <Label htmlFor="cash-event-date">Event date</Label>
+                <Input
+                  id="cash-event-date"
+                  type="date"
+                  value={form.eventDate}
+                  onChange={(changeEvent) => setField('eventDate', changeEvent.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cash-event-description">Description</Label>
+                <Textarea
+                  id="cash-event-description"
+                  value={form.description}
+                  onChange={(changeEvent) => setField('description', changeEvent.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cash-event-call-number">Call number</Label>
+                <Input
+                  id="cash-event-call-number"
+                  type="text"
+                  inputMode="numeric"
+                  value={form.callNumber}
+                  onChange={(changeEvent) => setField('callNumber', changeEvent.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cash-event-due-date">Due date</Label>
+                <Input
+                  id="cash-event-due-date"
+                  type="date"
+                  value={form.dueDate}
+                  onChange={(changeEvent) => setField('dueDate', changeEvent.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cash-event-purpose">Purpose</Label>
+                <Textarea
+                  id="cash-event-purpose"
+                  value={form.purpose}
+                  onChange={(changeEvent) => setField('purpose', changeEvent.target.value)}
+                />
+              </div>
+
+              <div className="flex items-center justify-end gap-2 border-t border-beige-200 pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCancel}
+                  disabled={!isDirty || mutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" size="sm" disabled={!canSave}>
+                  {mutation.isPending ? 'Saving...' : 'Save'}
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <dl className="space-y-3 text-sm">
+              <ReadOnlyRow label="Type" value={selectedEvent.eventType} />
+              <ReadOnlyRow label="Status" value={selectedEvent.status} />
+              <ReadOnlyRow label="Amount" value={selectedEvent.amount} />
+              <ReadOnlyRow label="Event date" value={formatEventDate(selectedEvent.eventDate)} />
+              <ReadOnlyRow label="Description" value={selectedEvent.description ?? '—'} />
+            </dl>
+          )}
+        </div>
       )}
     </WorkPanel>
+  );
+}
+
+function ReadOnlyRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <dt className="text-charcoal-600">{label}</dt>
+      <dd className="font-medium text-charcoal-900">{value}</dd>
+    </div>
   );
 }

--- a/client/src/components/dashboard/CashflowDashboard.tsx
+++ b/client/src/components/dashboard/CashflowDashboard.tsx
@@ -764,7 +764,13 @@ export default function CashflowDashboard({ fundId, className = '' }: CashflowDa
         />
       )}
       {cashEventEnabled && (
-        <CashEventsPanel fundId={fundId} state={workPanel.state} onClose={workPanel.closePanel} />
+        <CashEventsPanel
+          fundId={fundId}
+          state={workPanel.state}
+          onClose={workPanel.closePanel}
+          onSelect={(eventId) => workPanel.openPanel({ panel: 'cash-events', object: eventId })}
+          onBack={() => workPanel.openPanel({ panel: 'cash-events' })}
+        />
       )}
     </div>
   );

--- a/client/src/hooks/useCashFlowEvents.ts
+++ b/client/src/hooks/useCashFlowEvents.ts
@@ -1,6 +1,10 @@
-import type { UseQueryResult } from '@tanstack/react-query';
-import { useQuery } from '@tanstack/react-query';
-import type { CashFlowEventResponse } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  CashFlowEventResponse,
+  LpCapitalCallPatch,
+} from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import { apiRequest } from '@/lib/queryClient';
 import { getErrorMessage } from '@/lib/http-response';
 
 interface UseCashFlowEventsOptions {
@@ -40,5 +44,147 @@ export function useCashFlowEvents(
     staleTime: 60_000,
     gcTime: 600_000,
     refetchOnWindowFocus: false,
+  });
+}
+
+// ============================================================================
+// Draft-edit form model (pure) — lp_capital_call only.
+// String-typed throughout: money stays a string (ADR-011); '' means "clear".
+// ============================================================================
+
+export interface CashEventEditForm {
+  amount: string;
+  description: string;
+  /** Date portion only, 'YYYY-MM-DD'. */
+  eventDate: string;
+  callNumber: string;
+  dueDate: string;
+  purpose: string;
+}
+
+const DECIMAL_RE = /^-?\d+(\.\d{1,6})?$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const POSITIVE_INT_RE = /^[1-9]\d*$/;
+
+function payloadString(payload: Record<string, unknown>, key: string): string {
+  const value = payload[key];
+  return value === null || value === undefined ? '' : String(value);
+}
+
+/** Project a persisted event into the editable string form. */
+export function formFromEvent(event: CashFlowEventResponse): CashEventEditForm {
+  return {
+    amount: event.amount,
+    description: event.description ?? '',
+    eventDate: event.eventDate.slice(0, 10),
+    callNumber: payloadString(event.payload, 'callNumber'),
+    dueDate: payloadString(event.payload, 'dueDate'),
+    purpose: payloadString(event.payload, 'purpose'),
+  };
+}
+
+/** Mirror of the server contract; gates the Save button. */
+export function isCashEventFormValid(form: CashEventEditForm): boolean {
+  if (!DECIMAL_RE.test(form.amount)) return false;
+  if (!DATE_RE.test(form.eventDate)) return false;
+  if (form.description.length > 1000) return false;
+  if (form.callNumber !== '' && !POSITIVE_INT_RE.test(form.callNumber)) return false;
+  if (form.dueDate !== '' && !DATE_RE.test(form.dueDate)) return false;
+  if (form.purpose.length > 500) return false;
+  return true;
+}
+
+/**
+ * Serialize ONLY changed fields. '' on a nullable field -> null (clear).
+ * eventDate swaps only the date portion, preserving the original ISO time.
+ * `payload` is included only when at least one payload sub-key changed.
+ * Returns {} when nothing changed (caller treats that as "not dirty").
+ */
+export function buildLpCapitalCallPatch(
+  event: CashFlowEventResponse,
+  form: CashEventEditForm
+): LpCapitalCallPatch {
+  const base = formFromEvent(event);
+  const patch: LpCapitalCallPatch = {};
+
+  if (form.amount !== base.amount) {
+    patch.amount = form.amount;
+  }
+  if (form.description !== base.description) {
+    patch.description = form.description === '' ? null : form.description;
+  }
+  if (form.eventDate !== base.eventDate) {
+    patch.eventDate = `${form.eventDate}${event.eventDate.slice(10)}`;
+  }
+
+  const payload: NonNullable<LpCapitalCallPatch['payload']> = {};
+  if (form.callNumber !== base.callNumber) {
+    payload.callNumber = form.callNumber === '' ? null : Number(form.callNumber);
+  }
+  if (form.dueDate !== base.dueDate) {
+    payload.dueDate = form.dueDate === '' ? null : form.dueDate;
+  }
+  if (form.purpose !== base.purpose) {
+    payload.purpose = form.purpose === '' ? null : form.purpose;
+  }
+  if (Object.keys(payload).length > 0) {
+    patch.payload = payload;
+  }
+
+  return patch;
+}
+
+// ============================================================================
+// Draft-edit mutation — PATCH with If-Match. First If-Match client in the repo.
+// ============================================================================
+
+export interface UpdateCashFlowEventVariables {
+  eventId: number;
+  /** Opaque etag of the loaded row; echoed verbatim as If-Match. */
+  etag: string;
+  patch: LpCapitalCallPatch;
+}
+
+export interface CashFlowEventMutationError {
+  status: number;
+  message: string;
+}
+
+export function useUpdateCashFlowEvent(
+  fundId: string | undefined
+): UseMutationResult<
+  CashFlowEventResponse,
+  CashFlowEventMutationError,
+  UpdateCashFlowEventVariables
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    CashFlowEventResponse,
+    CashFlowEventMutationError,
+    UpdateCashFlowEventVariables
+  >({
+    mutationFn: async ({ eventId, etag, patch }) => {
+      if (!fundId) {
+        throw { status: 0, message: 'No fund ID available' } as CashFlowEventMutationError;
+      }
+      try {
+        return await apiRequest<CashFlowEventResponse>(
+          'PATCH',
+          `/api/funds/${fundId}/cash-flow-events/${eventId}`,
+          patch,
+          { headers: { 'If-Match': etag } }
+        );
+      } catch (error: unknown) {
+        const err = error as { status?: number; message?: string };
+        throw {
+          status: err.status ?? 500,
+          message: err.message ?? 'Failed to update cash flow event',
+        } as CashFlowEventMutationError;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cash-flow-events', fundId] });
+    },
   });
 }

--- a/shared/feature-flags/flag-definitions.ts
+++ b/shared/feature-flags/flag-definitions.ts
@@ -245,6 +245,16 @@ export const POLISH_FLAGS: Record<string, FeatureFlag> = {
     dependencies: [],
   },
 
+  enable_cash_event_edit: {
+    key: 'enable_cash_event_edit',
+    name: 'Cash Event Draft Editing',
+    description:
+      'Draft-only editing of persisted lp_capital_call cash events in the WorkPanel detail view (PATCH with If-Match concurrency). Read-only without this flag.',
+    enabled: false,
+    rolloutPercentage: 0,
+    dependencies: ['enable_cash_event_object'],
+  },
+
   enable_route_redirects: {
     key: 'enable_route_redirects',
     name: 'Legacy Route Redirects',

--- a/tests/unit/components/dashboard/CashEventsPanel.test.tsx
+++ b/tests/unit/components/dashboard/CashEventsPanel.test.tsx
@@ -1,69 +1,198 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { mockUseCashFlowEvents } = vi.hoisted(() => ({ mockUseCashFlowEvents: vi.fn() }));
+const { mockUseCashFlowEvents, mockUseUpdate, mockUseFlag, mockMutate, mockRefetch } = vi.hoisted(
+  () => ({
+    mockUseCashFlowEvents: vi.fn(),
+    mockUseUpdate: vi.fn(),
+    mockUseFlag: vi.fn(),
+    mockMutate: vi.fn(),
+    mockRefetch: vi.fn(),
+  })
+);
 
-vi.mock('@/hooks/useCashFlowEvents', () => ({
-  useCashFlowEvents: (fundId: string | undefined, options?: { enabled?: boolean }) =>
-    mockUseCashFlowEvents(fundId, options),
-}));
+vi.mock('@/shared/useFlags', () => ({ useFlag: (key: string) => mockUseFlag(key) }));
+
+vi.mock('@/hooks/useCashFlowEvents', async (importActual) => {
+  const actual = await importActual<typeof import('@/hooks/useCashFlowEvents')>();
+  return {
+    ...actual,
+    useCashFlowEvents: (fundId: string | undefined, options?: { enabled?: boolean }) =>
+      mockUseCashFlowEvents(fundId, options),
+    useUpdateCashFlowEvent: (fundId: string | undefined) => mockUseUpdate(fundId),
+  };
+});
 
 import { CashEventsPanel } from '@/components/dashboard/CashEventsPanel';
 
-const sampleEvent = {
+const draftEvent = {
   id: 10,
   fundId: 1,
   eventType: 'lp_capital_call',
   amount: '1250000.000000',
   currency: 'USD',
-  eventDate: '2026-06-15T00:00:00.000Z',
+  eventDate: '2026-06-15T14:30:00.000Z',
   perspective: 'lp_net',
   description: null,
   payload: { callNumber: 1 },
   status: 'draft',
   createdAt: '2026-06-15T00:00:00.000Z',
+  updatedAt: '2026-06-15T00:00:00.000Z',
+  etag: 'W/"abc"',
 };
+const approvedEvent = { ...draftEvent, id: 11, status: 'approved', etag: 'W/"xyz"' };
+
+function noopProps() {
+  return { onClose: vi.fn(), onSelect: vi.fn(), onBack: vi.fn() };
+}
+
+beforeEach(() => {
+  mockUseFlag.mockReset();
+  mockUseFlag.mockReturnValue(false);
+  mockUseCashFlowEvents.mockReset();
+  mockUseCashFlowEvents.mockReturnValue({
+    data: [draftEvent],
+    isLoading: false,
+    refetch: mockRefetch,
+  });
+  mockMutate.mockReset();
+  mockRefetch.mockReset();
+  mockUseUpdate.mockReset();
+  mockUseUpdate.mockReturnValue({ mutate: mockMutate, isPending: false });
+});
 
 describe('CashEventsPanel', () => {
   it('renders nothing when no panel state is present', () => {
-    mockUseCashFlowEvents.mockReturnValue({ data: [], isLoading: false });
-    render(<CashEventsPanel fundId="1" state={null} onClose={() => {}} />);
+    render(<CashEventsPanel fundId="1" state={null} {...noopProps()} />);
     expect(screen.queryByText('Cash events')).not.toBeInTheDocument();
   });
 
   it('does not enable the query when the panel is closed', () => {
-    mockUseCashFlowEvents.mockReturnValue({ data: [], isLoading: false });
-    render(<CashEventsPanel fundId="1" state={null} onClose={() => {}} />);
+    render(<CashEventsPanel fundId="1" state={null} {...noopProps()} />);
     expect(mockUseCashFlowEvents).toHaveBeenCalledWith('1', { enabled: false });
   });
 
   it('lists persisted events when the panel is open', () => {
-    mockUseCashFlowEvents.mockReturnValue({ data: [sampleEvent], isLoading: false });
-    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={() => {}} />);
+    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} {...noopProps()} />);
     expect(mockUseCashFlowEvents).toHaveBeenCalledWith('1', { enabled: true });
     expect(screen.getByText('lp_capital_call')).toBeInTheDocument();
     expect(screen.getByText('1250000.000000')).toBeInTheDocument();
   });
 
-  it('shows a loading state while fetching', () => {
-    mockUseCashFlowEvents.mockReturnValue({ data: undefined, isLoading: true });
-    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={() => {}} />);
-    expect(screen.getByText(/loading cash events/i)).toBeInTheDocument();
+  it('remains read-only (no edit inputs) when the edit flag is off', () => {
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    expect(screen.queryByLabelText('Amount')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
   });
 
-  it('shows an empty state when there are no events', () => {
-    mockUseCashFlowEvents.mockReturnValue({ data: [], isLoading: false });
-    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={() => {}} />);
-    expect(screen.getByText(/no cash events recorded/i)).toBeInTheDocument();
-  });
-
-  it('calls onClose when the close affordance is used', async () => {
+  it('selects a row, guarded by the leave check', async () => {
     const user = userEvent.setup();
-    const onClose = vi.fn();
-    mockUseCashFlowEvents.mockReturnValue({ data: [sampleEvent], isLoading: false });
-    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} onClose={onClose} />);
+    const props = noopProps();
+    render(<CashEventsPanel fundId="1" state={{ panel: 'cash-events' }} {...props} />);
+    await user.click(screen.getByRole('button', { name: /lp_capital_call/ }));
+    expect(props.onSelect).toHaveBeenCalledWith('10');
+  });
+
+  it('shows a not-found state when the object is not in the list', () => {
+    mockUseFlag.mockReturnValue(true);
+    render(
+      <CashEventsPanel
+        fundId="1"
+        state={{ panel: 'cash-events', object: '999' }}
+        {...noopProps()}
+      />
+    );
+    expect(screen.getByText(/was not found/i)).toBeInTheDocument();
+  });
+
+  it('opens an editable form for a draft lp_capital_call when the flag is on', () => {
+    mockUseFlag.mockReturnValue(true);
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    expect(screen.getByLabelText('Amount')).toHaveValue('1250000.000000');
+    expect(screen.getByLabelText('Event date')).toHaveValue('2026-06-15');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('keeps approved rows read-only with no Save', () => {
+    mockUseFlag.mockReturnValue(true);
+    mockUseCashFlowEvents.mockReturnValue({
+      data: [approvedEvent],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '11' }} {...noopProps()} />
+    );
+    expect(screen.queryByLabelText('Amount')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  it('enables Save only when dirty and valid', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    const amount = screen.getByLabelText('Amount');
+    const save = screen.getByRole('button', { name: 'Save' });
+    expect(save).toBeDisabled();
+    await user.clear(amount);
+    await user.type(amount, '2000000');
+    expect(save).toBeEnabled();
+    await user.clear(amount);
+    await user.type(amount, '1.2.3');
+    expect(save).toBeDisabled();
+  });
+
+  it('Cancel restores the original values', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    const amount = screen.getByLabelText('Amount');
+    await user.clear(amount);
+    await user.type(amount, '2000000');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.getByLabelText('Amount')).toHaveValue('1250000.000000');
+  });
+
+  it('prompts before discarding unsaved changes on close', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const props = noopProps();
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...props} />
+    );
+    await user.clear(screen.getByLabelText('Amount'));
+    await user.type(screen.getByLabelText('Amount'), '2000000');
     await user.click(screen.getByRole('button', { name: /close/i }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('sends the PATCH on Save and surfaces a 412 conflict with a refetch', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    mockMutate.mockImplementation((_vars, opts) => opts.onError({ status: 412, message: 'stale' }));
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    await user.clear(screen.getByLabelText('Amount'));
+    await user.type(screen.getByLabelText('Amount'), '2000000');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 10, etag: 'W/"abc"', patch: { amount: '2000000' } }),
+      expect.any(Object)
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(/changed since you opened it/i);
+    expect(mockRefetch).toHaveBeenCalled();
   });
 });

--- a/tests/unit/hooks/useCashFlowEvents.test.tsx
+++ b/tests/unit/hooks/useCashFlowEvents.test.tsx
@@ -2,64 +2,81 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useCashFlowEvents } from '@/hooks/useCashFlowEvents';
+import {
+  buildLpCapitalCallPatch,
+  formFromEvent,
+  isCashEventFormValid,
+  useCashFlowEvents,
+  useUpdateCashFlowEvent,
+} from '@/hooks/useCashFlowEvents';
+import type { CashFlowEventResponse } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
 
-const sampleEvent = {
+const sampleEvent: CashFlowEventResponse = {
   id: 10,
   fundId: 1,
   eventType: 'lp_capital_call',
   amount: '1250000.000000',
   currency: 'USD',
-  eventDate: '2026-06-15T00:00:00.000Z',
+  eventDate: '2026-06-15T14:30:00.000Z',
   perspective: 'lp_net',
   description: null,
   payload: { callNumber: 1 },
   status: 'draft',
   createdAt: '2026-06-15T00:00:00.000Z',
+  updatedAt: '2026-06-15T00:00:00.000Z',
+  etag: 'W/"abc"',
 };
 
-function createWrapper() {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function createWrapper(client: QueryClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+    return React.createElement(QueryClientProvider, { client }, children);
   };
 }
 
-function mockFetchJson(payload: unknown, ok = true) {
+function mockFetchJson(payload: unknown, ok = true, status = ok ? 200 : 500) {
   vi.stubGlobal(
     'fetch',
     vi.fn().mockResolvedValue({
       ok,
-      status: ok ? 200 : 500,
+      status,
+      statusText: ok ? 'OK' : 'Error',
+      text: vi
+        .fn()
+        .mockResolvedValue(typeof payload === 'string' ? payload : JSON.stringify(payload)),
       json: vi.fn().mockResolvedValue(payload),
     })
   );
 }
 
-describe('useCashFlowEvents', () => {
+describe('useCashFlowEvents (query)', () => {
   beforeEach(() => {
     mockFetchJson({ data: [sampleEvent] });
   });
-
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
   it('does not fetch when there is no fund id', async () => {
-    renderHook(() => useCashFlowEvents(undefined), { wrapper: createWrapper() });
+    renderHook(() => useCashFlowEvents(undefined), {
+      wrapper: createWrapper(new QueryClient({ defaultOptions: { queries: { retry: false } } })),
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it('does not fetch when disabled', async () => {
-    renderHook(() => useCashFlowEvents('1', { enabled: false }), { wrapper: createWrapper() });
+    renderHook(() => useCashFlowEvents('1', { enabled: false }), {
+      wrapper: createWrapper(new QueryClient({ defaultOptions: { queries: { retry: false } } })),
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it('fetches the fund-scoped endpoint and unwraps the data array', async () => {
-    const { result } = renderHook(() => useCashFlowEvents('1'), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useCashFlowEvents('1'), {
+      wrapper: createWrapper(new QueryClient({ defaultOptions: { queries: { retry: false } } })),
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(fetch).toHaveBeenCalledWith('/api/funds/1/cash-flow-events');
     expect(result.current.data).toEqual([sampleEvent]);
@@ -67,8 +84,97 @@ describe('useCashFlowEvents', () => {
 
   it('surfaces API error messages', async () => {
     mockFetchJson({ message: 'Cash events unavailable' }, false);
-    const { result } = renderHook(() => useCashFlowEvents('1'), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useCashFlowEvents('1'), {
+      wrapper: createWrapper(new QueryClient({ defaultOptions: { queries: { retry: false } } })),
+    });
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error?.message).toBe('Cash events unavailable');
+  });
+});
+
+describe('buildLpCapitalCallPatch', () => {
+  it('returns an empty patch when nothing changed', () => {
+    expect(buildLpCapitalCallPatch(sampleEvent, formFromEvent(sampleEvent))).toEqual({});
+  });
+
+  it('serializes only changed top-level fields', () => {
+    const form = { ...formFromEvent(sampleEvent), amount: '2000000' };
+    expect(buildLpCapitalCallPatch(sampleEvent, form)).toEqual({ amount: '2000000' });
+  });
+
+  it('clears a nullable field when cleared to empty string', () => {
+    const withDesc = { ...sampleEvent, description: 'old' };
+    const form = { ...formFromEvent(withDesc), description: '' };
+    expect(buildLpCapitalCallPatch(withDesc, form)).toEqual({ description: null });
+  });
+
+  it('preserves the original time component when only the date changes', () => {
+    const form = { ...formFromEvent(sampleEvent), eventDate: '2026-08-01' };
+    expect(buildLpCapitalCallPatch(sampleEvent, form)).toEqual({
+      eventDate: '2026-08-01T14:30:00.000Z',
+    });
+  });
+
+  it('builds a shallow payload patch with only changed sub-keys', () => {
+    const form = { ...formFromEvent(sampleEvent), dueDate: '2026-09-01', callNumber: '' };
+    expect(buildLpCapitalCallPatch(sampleEvent, form)).toEqual({
+      payload: { callNumber: null, dueDate: '2026-09-01' },
+    });
+  });
+});
+
+describe('isCashEventFormValid', () => {
+  it('accepts a well-formed form', () => {
+    expect(isCashEventFormValid(formFromEvent(sampleEvent))).toBe(true);
+  });
+  it('rejects a malformed amount', () => {
+    expect(isCashEventFormValid({ ...formFromEvent(sampleEvent), amount: '1.2.3' })).toBe(false);
+  });
+  it('rejects a non-positive call number', () => {
+    expect(isCashEventFormValid({ ...formFromEvent(sampleEvent), callNumber: '0' })).toBe(false);
+  });
+});
+
+describe('useUpdateCashFlowEvent (mutation)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('sends PATCH with If-Match and the serialized patch, then invalidates the list', async () => {
+    mockFetchJson({ ...sampleEvent, amount: '2000000.000000', etag: 'W/"def"' });
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateCashFlowEvent('1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await result.current.mutateAsync({
+      eventId: 10,
+      etag: 'W/"abc"',
+      patch: { amount: '2000000' },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/funds/1/cash-flow-events/10',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ amount: '2000000' }),
+        headers: expect.objectContaining({ 'If-Match': 'W/"abc"' }),
+      })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['cash-flow-events', '1'] });
+  });
+
+  it('surfaces { status, message } on a 412 conflict', async () => {
+    mockFetchJson({ error: 'precondition_failed', message: 'Event has been modified' }, false, 412);
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useUpdateCashFlowEvent('1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await expect(
+      result.current.mutateAsync({ eventId: 10, etag: 'W/"abc"', patch: { amount: '5' } })
+    ).rejects.toMatchObject({ status: 412, message: 'Event has been modified' });
   });
 });


### PR DESCRIPTION
## Summary
PR-C4 of Candidate C Phase 2 — the client editable surface for the cash-event operating object. Builds the smallest editable loop on top of the PR-C3 server contract (#865): select a persisted draft `lp_capital_call`, edit safe fields, save with `If-Match` concurrency, see it reload.

Server contract is unchanged — this is client-only and fully local-verifiable.

## What's in it
- **Flag** `enable_cash_event_edit` (off, rollout 0, depends on `enable_cash_event_object`). Read-only without it.
- **Mutation hook** `useUpdateCashFlowEvent` — `PATCH /api/funds/:fundId/cash-flow-events/:eventId` with the row's opaque `etag` echoed verbatim as `If-Match`; invalidates `['cash-flow-events', fundId]` on success. First `If-Match` client in the repo.
- **Pure form model** — changed-fields-only serialization; `''` clears a nullable field (`description`/payload keys → `null`); `eventDate` is edited date-only but preserves the row's original ISO time component on save (contract requires full datetime for `eventDate`, date-only for `payload.dueDate`); client validation mirrors the contract and gates Save.
- **CashEventsPanel** — list/detail selection via `?panel=cash-events&object=<id>`; draft-only editable form (non-draft / non-`lp_capital_call` render read-only, no Save); local Save/Cancel; dirty-exit guard on close/Back/row-switch; `412`/`409` show a conflict message and refetch the latest row.
- **CashflowDashboard** — wires `onSelect`/`onBack` to the `object` URL param.

## Concurrency
Client treats `etag` as opaque — never derives or parses it. On `412` (stale) or `409` (no longer a draft), the panel surfaces the message and refetches; the fresh `etag` resets the form to the latest server values.

## Accepted Phase-2 limitation
Browser back/forward that changes `object` directly cannot be intercepted by the panel's dirty guard (in-app close/Back/row-switch are guarded).

## Verification
- `npm run check` — 0 new TypeScript errors
- `npm run lint` — 0 (EXIT 0)
- `TZ=UTC npx vitest run tests/unit/hooks/useCashFlowEvents.test.tsx tests/unit/components/dashboard/CashEventsPanel.test.tsx --project=client` — 26/26 pass

Maps to plan §Client Acceptance Criteria 1–8 (`.claude/artifacts/candidate-c-phase2-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)