### PR TITLE
feat(cash-flow-events): approve/lock lifecycle for draft lp_capital_c…

### DIFF
--- a/ml-service/requirements.txt
+++ b/ml-service/requirements.txt
@@ -5,4 +5,4 @@ pandas==2.2.2
 joblib==1.4.2
 numpy==1.26.4
 pydantic==2.8.0
-python-multipart==0.0.27
+python-multipart==0.0.30

--- a/server/routes/cash-flow-events.ts
+++ b/server/routes/cash-flow-events.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
+import { z } from 'zod';
 import { parseFundIdParam } from '@shared/number';
 import type { CashFlowEvent } from '@shared/schema/lp-reporting-evidence';
 import {
@@ -16,6 +17,9 @@ import {
   listCashFlowEventsForFund,
   loadCashFlowEvent,
   updateLpCapitalCallDraft,
+  approveLpCapitalCallEvent,
+  lockLpCapitalCallEvent,
+  type CashFlowEventRow,
 } from '../services/lp-reporting/cash-flow-event-service';
 
 const router = Router();
@@ -39,6 +43,106 @@ function toResponse(row: CashFlowEvent, etag: string): CashFlowEventResponse {
     updatedAt: (row.updatedAt ?? row.createdAt ?? row.eventDate).toISOString(),
     etag,
   });
+}
+
+// Lifecycle transitions carry no body; the transition is the URL + If-Match.
+// Strict-reject any non-empty body (repo contract style); `?? {}` lets a no-body
+// POST through (express leaves req.body undefined for an empty request).
+const LifecycleBodySchema = z.object({}).strict();
+
+function numericIdentity(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return Number.parseInt(value, 10);
+  return null;
+}
+
+// Best-effort actor id for lockedBy. JWT subs are not guaranteed numeric and
+// lockedBy is a nullable users.id FK, so an unresolved identity stores NULL
+// (never 401). enforceProvidedFundScope populates req.user from a verified token.
+function resolveActorId(req: Request): number | null {
+  return numericIdentity(req.user?.id) ?? numericIdentity(req.user?.sub) ?? null;
+}
+
+interface TransitionConfig {
+  requiredStatus: 'draft' | 'approved';
+  apply: (
+    fundId: number,
+    eventId: number,
+    expectedXmin: string,
+    req: Request
+  ) => Promise<CashFlowEventRow | undefined>;
+}
+
+// Shared draft->approved / approved->locked transition. Mirrors the PATCH guard
+// order: parse (400) -> scope (401/403) -> If-Match (428) -> load (404) ->
+// status/type (409) -> etag (412) -> atomic apply -> zero-row disambiguation.
+async function handleTransition(
+  req: Request,
+  res: Response,
+  config: TransitionConfig
+): Promise<Response | void> {
+  const fundId = parseFundIdParam(firstString(req.params['fundId']));
+  if (fundId === null) {
+    return res.status(400).json({ error: 'Invalid fund ID' });
+  }
+  const eventId = parseFundIdParam(firstString(req.params['eventId']));
+  if (eventId === null) {
+    return res.status(400).json({ error: 'Invalid event ID' });
+  }
+  if (!(await enforceProvidedFundScope(req, res, fundId))) {
+    return;
+  }
+  const ifMatch = firstString(req.headers['if-match']);
+  if (!ifMatch) {
+    return res
+      .status(428)
+      .json({ error: 'precondition_required', message: 'If-Match header is required' });
+  }
+  const body = LifecycleBodySchema.safeParse(req.body ?? {});
+  if (!body.success) {
+    return res.status(400).json({ error: 'Invalid request body', details: body.error.format() });
+  }
+
+  const current = await loadCashFlowEvent(fundId, eventId);
+  if (!current) {
+    return res.status(404).json({ error: 'Event not found' });
+  }
+  if (current.row.eventType !== 'lp_capital_call' || current.row.status !== config.requiredStatus) {
+    return res
+      .status(409)
+      .json({ error: 'conflict', message: `Event is not ${config.requiredStatus}` });
+  }
+  const currentEtag = rowVersionETag(current.xmin);
+  if (parseETag(ifMatch) !== parseETag(currentEtag)) {
+    return res.status(412).json({
+      error: 'precondition_failed',
+      message: 'Event has been modified',
+      current: currentEtag,
+    });
+  }
+
+  const updated = await config.apply(fundId, eventId, current.xmin, req);
+  if (!updated) {
+    const recheck = await loadCashFlowEvent(fundId, eventId);
+    if (!recheck) {
+      return res.status(404).json({ error: 'Event not found' });
+    }
+    if (
+      recheck.row.eventType !== 'lp_capital_call' ||
+      recheck.row.status !== config.requiredStatus
+    ) {
+      return res
+        .status(409)
+        .json({ error: 'conflict', message: `Event is not ${config.requiredStatus}` });
+    }
+    return res.status(412).json({
+      error: 'precondition_failed',
+      message: 'Event has been modified',
+      current: rowVersionETag(recheck.xmin),
+    });
+  }
+
+  return res.status(200).json(toResponse(updated.row, rowVersionETag(updated.xmin)));
 }
 
 router['post']('/api/funds/:fundId/cash-flow-events', async (req: Request, res: Response) => {
@@ -134,13 +238,11 @@ router['patch'](
       }
       const currentEtag = rowVersionETag(current.xmin);
       if (parseETag(ifMatch) !== parseETag(currentEtag)) {
-        return res
-          .status(412)
-          .json({
-            error: 'precondition_failed',
-            message: 'Event has been modified',
-            current: currentEtag,
-          });
+        return res.status(412).json({
+          error: 'precondition_failed',
+          message: 'Event has been modified',
+          current: currentEtag,
+        });
       }
 
       const updated = await updateLpCapitalCallDraft({
@@ -172,6 +274,41 @@ router['patch'](
       return res.status(200).json(toResponse(updated.row, rowVersionETag(updated.xmin)));
     } catch {
       return res.status(500).json({ error: 'Failed to update cash flow event' });
+    }
+  }
+);
+
+router['post'](
+  '/api/funds/:fundId/cash-flow-events/:eventId/approve',
+  async (req: Request, res: Response) => {
+    try {
+      await handleTransition(req, res, {
+        requiredStatus: 'draft',
+        apply: (fundId, eventId, expectedXmin) =>
+          approveLpCapitalCallEvent({ fundId, eventId, expectedXmin }),
+      });
+    } catch {
+      return res.status(500).json({ error: 'Failed to approve cash flow event' });
+    }
+  }
+);
+
+router['post'](
+  '/api/funds/:fundId/cash-flow-events/:eventId/lock',
+  async (req: Request, res: Response) => {
+    try {
+      await handleTransition(req, res, {
+        requiredStatus: 'approved',
+        apply: (fundId, eventId, expectedXmin, request) =>
+          lockLpCapitalCallEvent({
+            fundId,
+            eventId,
+            expectedXmin,
+            lockedBy: resolveActorId(request),
+          }),
+      });
+    } catch {
+      return res.status(500).json({ error: 'Failed to lock cash flow event' });
     }
   }
 );

--- a/server/services/lp-reporting/cash-flow-event-service.ts
+++ b/server/services/lp-reporting/cash-flow-event-service.ts
@@ -150,3 +150,78 @@ export async function updateLpCapitalCallDraft(
   // Reload for the fresh row + fresh xmin token (post-update).
   return loadCashFlowEvent(fundId, eventId, options);
 }
+
+interface ApproveArgs {
+  fundId: number;
+  eventId: number;
+  expectedXmin: string;
+}
+
+/**
+ * Atomic draft->approved transition. WHERE pins fund/id/status='draft'/xmin, so a
+ * locked, already-approved, or concurrently-modified row updates zero rows ->
+ * returns undefined. Writes ONLY status + updatedAt (no approve-audit columns
+ * exist). sourceHash is never written.
+ */
+export async function approveLpCapitalCallEvent(
+  args: ApproveArgs,
+  options: CashFlowEventServiceOptions = {}
+): Promise<CashFlowEventRow | undefined> {
+  const database = options.database ?? db;
+  const { fundId, eventId, expectedXmin } = args;
+
+  const updated = await database
+    .update(cashFlowEvents)
+    .set({ status: 'approved', updatedAt: new Date() })
+    .where(
+      and(
+        eq(cashFlowEvents.fundId, fundId),
+        eq(cashFlowEvents.id, eventId),
+        eq(cashFlowEvents.status, 'draft'),
+        sql`xmin = ${expectedXmin}::xid`
+      )
+    )
+    .returning({ id: cashFlowEvents.id });
+
+  if (updated.length === 0) return undefined;
+  return loadCashFlowEvent(fundId, eventId, options);
+}
+
+interface LockArgs {
+  fundId: number;
+  eventId: number;
+  expectedXmin: string;
+  /** Best-effort actor id (nullable users.id FK); NULL when identity is not numeric. */
+  lockedBy: number | null;
+}
+
+/**
+ * Atomic approved->locked transition. WHERE pins fund/id/status='approved'/xmin.
+ * Sets lockedAt=now() (DB check requires it for locked), updatedAt=now() (the
+ * client-visible mutation timestamp; lockedAt is not in the response serializer),
+ * and best-effort lockedBy. sourceHash is never written; locked rows are terminal.
+ */
+export async function lockLpCapitalCallEvent(
+  args: LockArgs,
+  options: CashFlowEventServiceOptions = {}
+): Promise<CashFlowEventRow | undefined> {
+  const database = options.database ?? db;
+  const { fundId, eventId, expectedXmin, lockedBy } = args;
+  const now = new Date();
+
+  const updated = await database
+    .update(cashFlowEvents)
+    .set({ status: 'locked', lockedAt: now, lockedBy, updatedAt: now })
+    .where(
+      and(
+        eq(cashFlowEvents.fundId, fundId),
+        eq(cashFlowEvents.id, eventId),
+        eq(cashFlowEvents.status, 'approved'),
+        sql`xmin = ${expectedXmin}::xid`
+      )
+    )
+    .returning({ id: cashFlowEvents.id });
+
+  if (updated.length === 0) return undefined;
+  return loadCashFlowEvent(fundId, eventId, options);
+}

--- a/tests/integration/cash-flow-events.test.ts
+++ b/tests/integration/cash-flow-events.test.ts
@@ -126,4 +126,85 @@ describe('cash-flow-events persistence integration', () => {
       .send({ amount: '4000000' })
       .expect(409);
   });
+
+  it('approves then locks a draft, rejecting stale tokens and wrong-status transitions', async () => {
+    const created = await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events`)
+      .set('Authorization', authHeader)
+      .send({
+        eventType: 'lp_capital_call',
+        fundId: testFundId,
+        amount: '1000000',
+        eventDate: '2026-06-15T00:00:00.000Z',
+        perspective: 'lp_net',
+        payload: { callNumber: 1 },
+      })
+      .expect(201);
+    const id = created.body.id as number;
+    const staleEtag = created.body.etag as string;
+
+    // Advance xmin via a draft edit so the create-time token is now stale.
+    const edited = await request(app)
+      .patch(`/api/funds/${testFundId}/cash-flow-events/${id}`)
+      .set('Authorization', authHeader)
+      .set('If-Match', staleEtag)
+      .send({ description: 'pre-approve edit' })
+      .expect(200);
+    const draftEtag = edited.body.etag as string;
+    expect(draftEtag).not.toBe(staleEtag);
+
+    // approve with the now-stale token -> 412, no transition.
+    await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
+      .set('Authorization', authHeader)
+      .set('If-Match', staleEtag)
+      .expect(412);
+
+    // approve with the fresh token -> 200 approved.
+    const approved = await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
+      .set('Authorization', authHeader)
+      .set('If-Match', draftEtag)
+      .expect(200);
+    expect(approved.body.status).toBe('approved');
+    const approvedEtag = approved.body.etag as string;
+    expect(approvedEtag).not.toBe(draftEtag);
+
+    // lock on draft-required transition is rejected; approve again on approved -> 409.
+    await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
+      .set('Authorization', authHeader)
+      .set('If-Match', approvedEtag)
+      .expect(409);
+
+    // lock with the fresh approved token -> 200 locked.
+    const locked = await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events/${id}/lock`)
+      .set('Authorization', authHeader)
+      .set('If-Match', approvedEtag)
+      .expect(200);
+    expect(locked.body.status).toBe('locked');
+    expect(locked.body.etag).not.toBe(approvedEtag);
+
+    // Persisted lifecycle columns: locked terminal, lockedAt set, lockedBy NULL (non-numeric sub).
+    const dbRow = await pool.query(
+      'SELECT status, locked_at, locked_by FROM cash_flow_events WHERE id = $1',
+      [id]
+    );
+    expect(dbRow.rows[0].status).toBe('locked');
+    expect(dbRow.rows[0].locked_at).not.toBeNull();
+    expect(dbRow.rows[0].locked_by).toBeNull();
+
+    // locked is terminal: further transitions -> 409.
+    await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events/${id}/lock`)
+      .set('Authorization', authHeader)
+      .set('If-Match', locked.body.etag)
+      .expect(409);
+    await request(app)
+      .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
+      .set('Authorization', authHeader)
+      .set('If-Match', locked.body.etag)
+      .expect(409);
+  });
 });

--- a/tests/unit/routes/cash-flow-events.contract.lifecycle.test.ts
+++ b/tests/unit/routes/cash-flow-events.contract.lifecycle.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+import { rowVersionETag } from '../../../server/lib/http-preconditions';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+const svc = vi.hoisted(() => ({
+  loadCashFlowEvent: vi.fn(),
+  approveLpCapitalCallEvent: vi.fn(),
+  lockLpCapitalCallEvent: vi.fn(),
+  updateLpCapitalCallDraft: vi.fn(),
+  createLpCapitalCallEvent: vi.fn(),
+  listCashFlowEventsForFund: vi.fn(),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+vi.mock('../../../server/services/lp-reporting/cash-flow-event-service', () => svc);
+
+import cashFlowEventsRouter from '../../../server/routes/cash-flow-events';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cashFlowEventsRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    fundId: 1,
+    eventType: 'lp_capital_call',
+    amount: '1250000.000000',
+    currency: 'USD',
+    eventDate: new Date('2026-06-15T00:00:00.000Z'),
+    perspective: 'lp_net',
+    description: null,
+    payload: { callNumber: 1 },
+    status: 'draft',
+    createdAt: new Date('2026-06-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+interface Variant {
+  op: 'approve' | 'lock';
+  source: 'draft' | 'approved';
+  target: 'approved' | 'locked';
+  fn: () => ReturnType<typeof vi.fn>;
+  wrongStatuses: string[];
+}
+
+const VARIANTS: Variant[] = [
+  {
+    op: 'approve',
+    source: 'draft',
+    target: 'approved',
+    fn: () => svc.approveLpCapitalCallEvent,
+    wrongStatuses: ['approved', 'locked', 'reversed'],
+  },
+  {
+    op: 'lock',
+    source: 'approved',
+    target: 'locked',
+    fn: () => svc.lockLpCapitalCallEvent,
+    wrongStatuses: ['draft', 'locked', 'reversed'],
+  },
+];
+
+describe('cash-flow-events lifecycle route contract', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    svc.loadCashFlowEvent.mockReset();
+    svc.approveLpCapitalCallEvent.mockReset();
+    svc.lockLpCapitalCallEvent.mockReset();
+  });
+
+  for (const v of VARIANTS) {
+    const PATH = `/api/funds/1/cash-flow-events/10/${v.op}`;
+    describe(v.op, () => {
+      it('rejects a non-canonical eventId with 400 before scope/load', async () => {
+        const res = await request(makeApp())
+          .post(`/api/funds/1/cash-flow-events/01/${v.op}`)
+          .set('If-Match', '"x"');
+        expect(res.status).toBe(400);
+        expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+        expect(svc.loadCashFlowEvent).not.toHaveBeenCalled();
+      });
+
+      it('denies cross-fund scope with 403 before load', async () => {
+        fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+          res.status(403).json({ error: 'Forbidden' });
+          return false;
+        });
+        const res = await request(makeApp()).post(PATH).set('If-Match', '"x"');
+        expect(res.status).toBe(403);
+        expect(svc.loadCashFlowEvent).not.toHaveBeenCalled();
+      });
+
+      it('returns 428 when If-Match is missing', async () => {
+        const res = await request(makeApp()).post(PATH);
+        expect(res.status).toBe(428);
+        expect(svc.loadCashFlowEvent).not.toHaveBeenCalled();
+      });
+
+      it('returns 404 when the event does not exist', async () => {
+        svc.loadCashFlowEvent.mockResolvedValueOnce(undefined);
+        const res = await request(makeApp()).post(PATH).set('If-Match', '"x"');
+        expect(res.status).toBe(404);
+      });
+
+      for (const wrong of v.wrongStatuses) {
+        it(`returns 409 when the row status is ${wrong} (not ${v.source})`, async () => {
+          svc.loadCashFlowEvent.mockResolvedValueOnce({ row: row({ status: wrong }), xmin: '5' });
+          const res = await request(makeApp()).post(PATH).set('If-Match', rowVersionETag('5'));
+          expect(res.status).toBe(409);
+          expect(v.fn()).not.toHaveBeenCalled();
+        });
+      }
+
+      it('rejects a non-empty body with 400 before load', async () => {
+        const res = await request(makeApp())
+          .post(PATH)
+          .set('If-Match', rowVersionETag('5'))
+          .send({ status: 'approved' });
+        expect(res.status).toBe(400);
+        expect(svc.loadCashFlowEvent).not.toHaveBeenCalled();
+      });
+
+      it('returns 409 for a non-lp_capital_call row', async () => {
+        svc.loadCashFlowEvent.mockResolvedValueOnce({
+          row: row({ status: v.source, eventType: 'fund_expense' }),
+          xmin: '5',
+        });
+        const res = await request(makeApp()).post(PATH).set('If-Match', rowVersionETag('5'));
+        expect(res.status).toBe(409);
+        expect(v.fn()).not.toHaveBeenCalled();
+      });
+
+      it('returns 412 for a stale If-Match', async () => {
+        svc.loadCashFlowEvent.mockResolvedValueOnce({ row: row({ status: v.source }), xmin: '5' });
+        const res = await request(makeApp()).post(PATH).set('If-Match', rowVersionETag('999'));
+        expect(res.status).toBe(412);
+        expect(v.fn()).not.toHaveBeenCalled();
+      });
+
+      it(`200s a happy ${v.op} and returns a fresh etag + ${v.target} status`, async () => {
+        svc.loadCashFlowEvent.mockResolvedValueOnce({ row: row({ status: v.source }), xmin: '5' });
+        v.fn().mockResolvedValueOnce({ row: row({ status: v.target }), xmin: '6' });
+        const res = await request(makeApp()).post(PATH).set('If-Match', rowVersionETag('5'));
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(v.target);
+        expect(res.body.etag).toBe(rowVersionETag('6'));
+        expect(res.body).not.toHaveProperty('sourceHash');
+        expect(res.body).not.toHaveProperty('lockedBy');
+      });
+
+      it('disambiguates a zero-row apply to 412 (token changed, still source status)', async () => {
+        svc.loadCashFlowEvent
+          .mockResolvedValueOnce({ row: row({ status: v.source }), xmin: '5' })
+          .mockResolvedValueOnce({ row: row({ status: v.source }), xmin: '7' });
+        v.fn().mockResolvedValueOnce(undefined);
+        const res = await request(makeApp()).post(PATH).set('If-Match', rowVersionETag('5'));
+        expect(res.status).toBe(412);
+        expect(res.body.current).toBe(rowVersionETag('7'));
+      });
+
+      it('disambiguates a zero-row apply to 404 (row vanished on recheck)', async () => {
+        svc.loadCashFlowEvent
+          .mockResolvedValueOnce({ row: row({ status: v.source }), xmin: '5' })
+          .mockResolvedValueOnce(undefined);
+        v.fn().mockResolvedValueOnce(undefined);
+        const res = await request(makeApp()).post(PATH).set('If-Match', rowVersionETag('5'));
+        expect(res.status).toBe(404);
+      });
+
+      it('disambiguates a zero-row apply to 409 (status changed on recheck)', async () => {
+        svc.loadCashFlowEvent
+          .mockResolvedValueOnce({ row: row({ status: v.source }), xmin: '5' })
+          .mockResolvedValueOnce({ row: row({ status: v.target }), xmin: '7' });
+        v.fn().mockResolvedValueOnce(undefined);
+        const res = await request(makeApp()).post(PATH).set('If-Match', rowVersionETag('5'));
+        expect(res.status).toBe(409);
+      });
+    });
+  }
+
+  it('lock passes a numeric req.user identity through as lockedBy', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (req) => {
+      req.user = {
+        id: '42',
+        sub: '42',
+        email: 'a@b.c',
+        roles: [],
+        fundIds: [],
+        ip: 'x',
+        userAgent: 'y',
+      };
+      return true;
+    });
+    svc.loadCashFlowEvent.mockResolvedValueOnce({ row: row({ status: 'approved' }), xmin: '5' });
+    svc.lockLpCapitalCallEvent.mockResolvedValueOnce({ row: row({ status: 'locked' }), xmin: '6' });
+    await request(makeApp())
+      .post('/api/funds/1/cash-flow-events/10/lock')
+      .set('If-Match', rowVersionETag('5'))
+      .expect(200);
+    expect(svc.lockLpCapitalCallEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ fundId: 1, eventId: 10, expectedXmin: '5', lockedBy: 42 })
+    );
+  });
+
+  it('lock stores NULL lockedBy when identity is absent', async () => {
+    svc.loadCashFlowEvent.mockResolvedValueOnce({ row: row({ status: 'approved' }), xmin: '5' });
+    svc.lockLpCapitalCallEvent.mockResolvedValueOnce({ row: row({ status: 'locked' }), xmin: '6' });
+    await request(makeApp())
+      .post('/api/funds/1/cash-flow-events/10/lock')
+      .set('If-Match', rowVersionETag('5'))
+      .expect(200);
+    expect(svc.lockLpCapitalCallEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ lockedBy: null })
+    );
+  });
+});

--- a/tests/unit/services/lp-reporting/cash-flow-event-service.test.ts
+++ b/tests/unit/services/lp-reporting/cash-flow-event-service.test.ts
@@ -33,6 +33,8 @@ import {
   createLpCapitalCallEvent,
   loadCashFlowEvent,
   updateLpCapitalCallDraft,
+  approveLpCapitalCallEvent,
+  lockLpCapitalCallEvent,
 } from '../../../../server/services/lp-reporting/cash-flow-event-service';
 
 const record = (o: Record<string, unknown> = {}) => ({
@@ -125,6 +127,64 @@ describe('cash-flow-event-service', () => {
       expectedXmin: '5',
       currentRow: serviceRow(),
       patch: { amount: '7' },
+    });
+    expect(out).toBeUndefined();
+    expect(dbMock.db.select).not.toHaveBeenCalled();
+  });
+
+  it('approveLpCapitalCallEvent writes only status + updatedAt, never sourceHash/lockedBy', async () => {
+    captured.returnRows = [{ id: 10 }];
+    captured.selectRows = [record({ status: 'approved', rowXmin: '6' })];
+    const out = await approveLpCapitalCallEvent({ fundId: 1, eventId: 10, expectedXmin: '5' });
+    expect(out?.xmin).toBe('6');
+    expect(out?.row.status).toBe('approved');
+    const keys = Object.keys(captured.setValues as object);
+    expect(keys).toContain('status');
+    expect(keys).toContain('updatedAt');
+    expect(keys).not.toContain('sourceHash');
+    expect(keys).not.toContain('lockedBy');
+    expect(captured.setValues).toMatchObject({ status: 'approved' });
+  });
+
+  it('approveLpCapitalCallEvent returns undefined (no reload) on zero-row update', async () => {
+    captured.returnRows = [];
+    const out = await approveLpCapitalCallEvent({ fundId: 1, eventId: 10, expectedXmin: '5' });
+    expect(out).toBeUndefined();
+    expect(dbMock.db.select).not.toHaveBeenCalled();
+  });
+
+  it('lockLpCapitalCallEvent writes status + lockedAt + lockedBy, never sourceHash', async () => {
+    captured.returnRows = [{ id: 10 }];
+    captured.selectRows = [record({ status: 'locked', rowXmin: '6' })];
+    const out = await lockLpCapitalCallEvent({
+      fundId: 1,
+      eventId: 10,
+      expectedXmin: '5',
+      lockedBy: 42,
+    });
+    expect(out?.xmin).toBe('6');
+    expect(out?.row.status).toBe('locked');
+    const set = captured.setValues as Record<string, unknown>;
+    expect(set).toMatchObject({ status: 'locked', lockedBy: 42 });
+    expect(set['lockedAt']).toBeInstanceOf(Date);
+    expect(set['updatedAt']).toBeInstanceOf(Date);
+    expect(Object.keys(set)).not.toContain('sourceHash');
+  });
+
+  it('lockLpCapitalCallEvent accepts a NULL lockedBy', async () => {
+    captured.returnRows = [{ id: 10 }];
+    captured.selectRows = [record({ status: 'locked', rowXmin: '6' })];
+    await lockLpCapitalCallEvent({ fundId: 1, eventId: 10, expectedXmin: '5', lockedBy: null });
+    expect((captured.setValues as Record<string, unknown>)['lockedBy']).toBeNull();
+  });
+
+  it('lockLpCapitalCallEvent returns undefined (no reload) on zero-row update', async () => {
+    captured.returnRows = [];
+    const out = await lockLpCapitalCallEvent({
+      fundId: 1,
+      eventId: 10,
+      expectedXmin: '5',
+      lockedBy: 1,
     });
     expect(out).toBeUndefined();
     expect(dbMock.db.select).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

PR-C5 adds server-first lifecycle transitions for draft `lp_capital_call` cash events, the documented continuation of Candidate C Phase 2 (PR-C3 server draft-edit #865, PR-C4 client editable WorkPanel #866). Two new endpoints move a draft through `draft -> approved -> locked`. The whole cash_event feature remains flag-dark; client lifecycle UI is a future PR-C6.

## What changed (5 files, zero migration, no contract change)

- **`server/routes/cash-flow-events.ts`** — dedicated `POST .../:eventId/approve` and `POST .../:eventId/lock`, sharing a `handleTransition` helper that mirrors the PR-C3 PATCH guard order: parse (400) -> fund-scope (401/403) -> `If-Match` (428) -> strict empty-body (400) -> load (404) -> type/status (409) -> etag (412) -> atomic apply -> zero-row disambiguation (404/409/412).
- **`server/services/lp-reporting/cash-flow-event-service.ts`** — `approveLpCapitalCallEvent` (writes `status` + `updatedAt` only) and `lockLpCapitalCallEvent` (writes `status` + `lockedAt` + best-effort `lockedBy` + `updatedAt`, single shared `now`). Both use an atomic `WHERE fundId AND id AND status=<src> AND xmin=$x::xid` predicate; `sourceHash` is never written.
- **`tests/unit/routes/cash-flow-events.contract.lifecycle.test.ts`** (new) — parameterized approve/lock contract: 400/403/428/404, all wrong-source statuses (incl. `locked`/`reversed`), non-`lp_capital_call`, non-empty-body 400, 412, happy 200 + fresh etag, and zero-row disambiguation to 404/409/412; plus `lockedBy` numeric-passthrough and NULL cases.
- **`tests/unit/services/lp-reporting/cash-flow-event-service.test.ts`** — set-payload assertions, `sourceHash`-never, `lockedBy` number/NULL, lock advances `updatedAt`, zero-row -> undefined.
- **`tests/integration/cash-flow-events.test.ts`** — one real-Postgres lifecycle case (create -> edit -> approve-stale-412 -> approve-200 -> 409 -> lock-200 -> assert `locked_at` NOT NULL, `locked_by` NULL -> terminal 409s).

## Key decisions (red-team-refined)

- **Auth:** the global `/api` `requireApiAuth` (`server/app.ts:175`) authenticates before this router; the router keeps inline `enforceProvidedFundScope` for fund-scope. No per-route `requireAuth()` (redundant, and it 401s in `NODE_ENV=test`). No role gate (matches the metric-runs lifecycle precedent).
- **Concurrency:** Postgres `xmin` via `If-Match` (same model as PR-C3). No `version` column, no migration; transitions are short-lived and fail-closed (spurious mismatch -> 412 -> refetch).
- **Transitions:** forward-only; `locked` is terminal-immutable; no un-approve.
- **Lock audit:** `lockedBy` is best-effort — written when the token carries a numeric identity, else NULL (nullable FK; never 401). Approve has no audit columns (none exist).

## Verification

- `npm run check`: 0 new TypeScript errors.
- `npm run lint`: clean (exit 0); route-persistence import guard passes.
- Targeted server unit tests: 57/57 pass (lifecycle 30, patch 11, service 9, contract 7).
- Integration test does not run on this PR (test-smart -> smoke only); validated via a full-suite dispatch (`run_full_suite=true`) with the Test-integration log inspected for `cash-flow-events.test.ts`.

## Deferrals (documented, not blocking)

- No metric-runs-style idempotent retry; repeated transitions return 412/409 (client refetches), consistent with the shipped PR-C3 If-Match model.
- Response serializer omits `lockedAt`/`lockedBy`; a future PR-C6 must decide whether to expose lock provenance (contract change) or design the UI without it.
- If durable attribution is later required, add `approved_at`/`approved_by` (and guaranteed `locked_by`) as the first item of a future version/history migration.
