### PR TITLE
fix(test): restore cash-flow lifecycle integration JSON contract

### DIFF
--- a/tests/integration/cash-flow-events.test.ts
+++ b/tests/integration/cash-flow-events.test.ts
@@ -158,6 +158,7 @@ describe('cash-flow-events persistence integration', () => {
       .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
       .set('Authorization', authHeader)
       .set('If-Match', staleEtag)
+      .send({})
       .expect(412);
 
     // approve with the fresh token -> 200 approved.
@@ -165,6 +166,7 @@ describe('cash-flow-events persistence integration', () => {
       .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
       .set('Authorization', authHeader)
       .set('If-Match', draftEtag)
+      .send({})
       .expect(200);
     expect(approved.body.status).toBe('approved');
     const approvedEtag = approved.body.etag as string;
@@ -175,6 +177,7 @@ describe('cash-flow-events persistence integration', () => {
       .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
       .set('Authorization', authHeader)
       .set('If-Match', approvedEtag)
+      .send({})
       .expect(409);
 
     // lock with the fresh approved token -> 200 locked.
@@ -182,6 +185,7 @@ describe('cash-flow-events persistence integration', () => {
       .post(`/api/funds/${testFundId}/cash-flow-events/${id}/lock`)
       .set('Authorization', authHeader)
       .set('If-Match', approvedEtag)
+      .send({})
       .expect(200);
     expect(locked.body.status).toBe('locked');
     expect(locked.body.etag).not.toBe(approvedEtag);
@@ -200,11 +204,13 @@ describe('cash-flow-events persistence integration', () => {
       .post(`/api/funds/${testFundId}/cash-flow-events/${id}/lock`)
       .set('Authorization', authHeader)
       .set('If-Match', locked.body.etag)
+      .send({})
       .expect(409);
     await request(app)
       .post(`/api/funds/${testFundId}/cash-flow-events/${id}/approve`)
       .set('Authorization', authHeader)
       .set('If-Match', locked.body.etag)
+      .send({})
       .expect(409);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the main-branch full-suite regression from PR-C5 by making the cash-flow lifecycle transition integration requests realistic under `makeApp()`.

The failed main run hit `tests/integration/cash-flow-events.test.ts:161`: expected route-level `412`, got global `415`, because the transition `POST` had no JSON body and therefore no `Content-Type: application/json`. Production behavior is unchanged; the global mutation guard in `server/app.ts` is the intended contract.

## Changes

- Add `.send({})` to the six transition `POST` requests in `tests/integration/cash-flow-events.test.ts`.
- Preserve all existing assertions for stale ETags, approved/locked lifecycle transitions, and terminal-state `409`s.

## Verification

- `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/cash-flow-events.contract.lifecycle.test.ts tests/unit/routes/cash-flow-events.contract.test.ts tests/unit/routes/cash-flow-events.patch.test.ts` — 48 passed.
- `npx eslint tests/integration/cash-flow-events.test.ts --max-warnings 0 --cache --cache-location .cache/eslint`
- `npm run check`
- `npm run lint`

## Not Tested Locally

- Local targeted integration could not complete because this machine's fallback DB lacks the `cash_flow_events` schema. The PR/full-suite GitHub run with containerized Postgres is the merge authority for this regression.