### PR TITLE
feat(operating-objects): backend-first task object (table + migration + create/list route)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -17,6 +17,7 @@ import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
 import fundMoicRouter from './routes/fund-moic.js';
 import reallocationRouter from './routes/reallocation.js';
 import cashFlowEventsRouter from './routes/cash-flow-events.js';
+import operatingObjectTasksRouter from './routes/operating-object-tasks.js';
 import backtestingRouter from './routes/backtesting.js';
 import fundsRouter from './routes/funds.js';
 import fundMetricsRouter from './routes/fund-metrics.js';
@@ -222,6 +223,10 @@ export function makeApp() {
   // Cash-flow-events API (Candidate C, Phase 1) - mounted at root; the router
   // self-defines its full /api/funds/:fundId/cash-flow-events paths (mirrors reallocation).
   app.use(cashFlowEventsRouter);
+
+  // Operating-object Tasks API (backend-first; minimal create/list) - mounted at
+  // root; the router self-defines /api/funds/:fundId/tasks (mirrors cash-flow-events).
+  app.use(operatingObjectTasksRouter);
 
   // Deal Pipeline API (Sprint 1 - Deal tracking, DD, scoring)
   app.use('/api/deals', dealPipelineRouter);

--- a/server/migrations/20260616_operating_object_tasks_v1.down.sql
+++ b/server/migrations/20260616_operating_object_tasks_v1.down.sql
@@ -1,0 +1,2 @@
+-- Drops the tasks table and its index (index drops with the table).
+DROP TABLE IF EXISTS tasks;

--- a/server/migrations/20260616_operating_object_tasks_v1.up.sql
+++ b/server/migrations/20260616_operating_object_tasks_v1.up.sql
@@ -1,0 +1,21 @@
+-- Operating-object program (backend-first per
+-- docs/design/audits/server-object-readiness.md). First object: fund-scoped tasks.
+-- Minimal shape: create + list only; lifecycle transitions are a later PR.
+
+CREATE TABLE IF NOT EXISTS tasks (
+  id SERIAL PRIMARY KEY,
+  fund_id INTEGER NOT NULL REFERENCES funds(id) ON DELETE CASCADE,
+  title VARCHAR(200) NOT NULL,
+  status VARCHAR(16) NOT NULL DEFAULT 'open',
+  owner_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  due_date DATE,
+  description TEXT,
+  created_by INTEGER REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  CONSTRAINT tasks_status_check CHECK (status IN ('open', 'in_progress', 'done')),
+  CONSTRAINT tasks_title_nonempty_check CHECK (length(btrim(title)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_fund_created
+  ON tasks(fund_id, created_at DESC);

--- a/server/routes/operating-object-tasks.ts
+++ b/server/routes/operating-object-tasks.ts
@@ -1,0 +1,95 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { parseFundIdParam } from '@shared/number';
+import {
+  TaskCreateSchema,
+  TaskResponseSchema,
+  type TaskResponse,
+} from '@shared/contracts/operating-objects/task.contract';
+import type { Task } from '@shared/schema/operating-objects';
+import { firstString } from '../lib/request-values';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { rowVersionETag } from '../lib/http-preconditions';
+import { createTask, listTasksForFund } from '../services/operating-objects/task-service';
+
+const router = Router();
+
+function numericIdentity(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return Number.parseInt(value, 10);
+  return null;
+}
+
+// Best-effort creator id. JWT subs are not guaranteed numeric and created_by is a
+// nullable users.id FK, so an unresolved identity stores NULL (never 401).
+// enforceProvidedFundScope populates req.user from a verified token.
+function resolveActorId(req: Request): number | null {
+  return numericIdentity(req.user?.id) ?? numericIdentity(req.user?.sub) ?? null;
+}
+
+// Whitelist map -> strict-schema validate so no internal column (created_by) can
+// leak. dueDate is a Drizzle `date` (already a string); timestamps are Date -> ISO.
+function toResponse(row: Task, etag: string): TaskResponse {
+  return TaskResponseSchema.parse({
+    id: row.id,
+    fundId: row.fundId,
+    title: row.title,
+    status: row.status,
+    ownerId: row.ownerId,
+    dueDate: row.dueDate,
+    description: row.description,
+    createdAt: (row.createdAt ?? new Date()).toISOString(),
+    updatedAt: (row.updatedAt ?? row.createdAt ?? new Date()).toISOString(),
+    etag,
+  });
+}
+
+router['post']('/api/funds/:fundId/tasks', async (req: Request, res: Response) => {
+  try {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
+      return res.status(400).json({ error: 'Invalid fund ID' });
+    }
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+    const parsed = TaskCreateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid request body', details: parsed.error.format() });
+    }
+    if (parsed.data.fundId !== fundId) {
+      return res
+        .status(400)
+        .json({ error: 'fundId mismatch', message: 'Body fundId must match the path fundId' });
+    }
+    const created = await createTask({ ...parsed.data, createdBy: resolveActorId(req) });
+    if (!created) {
+      return res.status(500).json({ error: 'Failed to create task' });
+    }
+    return res.status(201).json(toResponse(created.row, rowVersionETag(created.xmin)));
+  } catch {
+    return res.status(500).json({ error: 'Failed to create task' });
+  }
+});
+
+router['get']('/api/funds/:fundId/tasks', async (req: Request, res: Response) => {
+  try {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
+      return res.status(400).json({ error: 'Invalid fund ID' });
+    }
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+    const rows = await listTasksForFund(fundId);
+    return res
+      .status(200)
+      .json({ data: rows.map((r) => toResponse(r.row, rowVersionETag(r.xmin))) });
+  } catch {
+    return res.status(500).json({ error: 'Failed to list tasks' });
+  }
+});
+
+export default router;

--- a/server/services/operating-objects/task-service.ts
+++ b/server/services/operating-objects/task-service.ts
@@ -1,0 +1,78 @@
+import { desc, eq, sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import type { TaskCreate } from '@shared/contracts/operating-objects/task.contract';
+import { tasks, type Task } from '@shared/schema/operating-objects';
+
+type TaskDatabase = typeof db;
+
+interface TaskServiceOptions {
+  database?: TaskDatabase;
+}
+
+export interface TaskRow {
+  row: Task;
+  /** Postgres xmin system column as text -- opaque per-row concurrency token. */
+  xmin: string;
+}
+
+// Explicit column map + xmin::text (mirrors cash-flow-event-service). List the
+// columns rather than rely on an unproven getTableColumns import.
+const columnsWithXmin = {
+  id: tasks.id,
+  fundId: tasks.fundId,
+  title: tasks.title,
+  status: tasks.status,
+  ownerId: tasks.ownerId,
+  dueDate: tasks.dueDate,
+  description: tasks.description,
+  createdBy: tasks.createdBy,
+  createdAt: tasks.createdAt,
+  updatedAt: tasks.updatedAt,
+  rowXmin: sql<string>`xmin::text`,
+} as const;
+
+function splitXmin(record: Task & { rowXmin: string }): TaskRow {
+  const { rowXmin, ...row } = record;
+  return { row: row as Task, xmin: rowXmin };
+}
+
+interface CreateTaskArgs extends TaskCreate {
+  /** Best-effort creator id (nullable users.id FK); NULL when identity is not numeric. */
+  createdBy: number | null;
+}
+
+export async function createTask(
+  input: CreateTaskArgs,
+  options: TaskServiceOptions = {}
+): Promise<TaskRow | undefined> {
+  const database = options.database ?? db;
+  const [record] = await database
+    .insert(tasks)
+    .values({
+      fundId: input.fundId,
+      title: input.title,
+      status: 'open',
+      ownerId: input.ownerId ?? null,
+      dueDate: input.dueDate ?? null,
+      description: input.description ?? null,
+      createdBy: input.createdBy,
+    })
+    .returning(columnsWithXmin);
+
+  return record ? splitXmin(record) : undefined;
+}
+
+export async function listTasksForFund(
+  fundId: number,
+  options: TaskServiceOptions = {}
+): Promise<TaskRow[]> {
+  const database = options.database ?? db;
+  // Newest-first; hits idx_tasks_fund_created (fund_id, created_at DESC).
+  const records = await database
+    .select(columnsWithXmin)
+    .from(tasks)
+    .where(eq(tasks.fundId, fundId))
+    .orderBy(desc(tasks.createdAt));
+  return records.map(splitXmin);
+}

--- a/shared/contracts/operating-objects/task.contract.ts
+++ b/shared/contracts/operating-objects/task.contract.ts
@@ -1,0 +1,55 @@
+/**
+ * Operating Objects -- Task Contract (CREATE + response shapes)
+ *
+ * Fund-scoped work items. Backend-first per
+ * docs/design/audits/server-object-readiness.md (PR-T1, minimal: create + list).
+ * No money fields. `status` is server-controlled ('open' at create); lifecycle
+ * transitions are a later PR. `etag` (opaque xmin row token) is carried from day
+ * one so a future edit/transition PR needs no contract change.
+ *
+ * @module shared/contracts/operating-objects/task.contract
+ * @see docs/design/audits/server-object-readiness.md
+ */
+
+import { z } from 'zod';
+
+export const TaskStatusSchema = z.enum(['open', 'in_progress', 'done']);
+export type TaskStatus = z.infer<typeof TaskStatusSchema>;
+
+// CREATE: client supplies title (+ optional owner/dueDate/description). `status`
+// is server-controlled (always 'open'); id/etag/timestamps are server-assigned.
+export const TaskCreateSchema = z
+  .object({
+    fundId: z.number().int().positive(),
+    title: z.string().trim().min(1).max(200),
+    ownerId: z.number().int().positive().optional(),
+    dueDate: z.string().date().optional(),
+    description: z.string().max(2000).optional(),
+  })
+  .strict();
+
+export type TaskCreate = z.infer<typeof TaskCreateSchema>;
+
+// RESPONSE (server -> client). `.strict()` so internal provenance (created_by)
+// can never leak. dueDate is date-only; timestamps are ISO datetimes.
+export const TaskResponseSchema = z
+  .object({
+    id: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    title: z.string().min(1),
+    status: TaskStatusSchema,
+    ownerId: z.number().int().positive().nullable(),
+    dueDate: z.string().date().nullable(),
+    description: z.string().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    etag: z.string().min(1),
+  })
+  .strict();
+
+export type TaskResponse = z.infer<typeof TaskResponseSchema>;
+
+export const TaskListResponseSchema = z.object({
+  data: z.array(TaskResponseSchema),
+});
+export type TaskListResponse = z.infer<typeof TaskListResponseSchema>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -32,6 +32,7 @@ export * from './schema/scenario';
 export * from './schema/shares';
 export * from './schema/user';
 export * from './schema/lp-reporting-evidence';
+export * from './schema/operating-objects';
 export * from './schemas/flags';
 export * from './schemas/reserve-approvals';
 

--- a/shared/schema/index.ts
+++ b/shared/schema/index.ts
@@ -19,3 +19,4 @@ export * from './scenario';
 export * from './shares';
 export * from './user';
 export * from './lp-reporting-evidence';
+export * from './operating-objects';

--- a/shared/schema/operating-objects.ts
+++ b/shared/schema/operating-objects.ts
@@ -1,0 +1,64 @@
+/**
+ * Operating Objects -- Foundation Schema
+ *
+ * Drizzle bindings for the operating-object program (backend-first per
+ * docs/design/audits/server-object-readiness.md). First object: `tasks`
+ * (fund-scoped work items, minimal create/list). assumption/comment follow in
+ * later PRs and slot in beside `tasks` here.
+ *
+ * Mirrors server/migrations/20260616_operating_object_tasks_v1.up.sql. Use the
+ * exported $inferSelect / $inferInsert types in services/contracts; never
+ * hand-declare a column type in a consumer.
+ *
+ * @module shared/schema/operating-objects
+ * @see docs/design/audits/server-object-readiness.md
+ */
+
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  date,
+  index,
+  integer,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { funds } from './fund';
+import { users } from './user';
+
+// ============================================================================
+// TASKS (fund-scoped work items)
+// ============================================================================
+
+export const tasks = pgTable(
+  'tasks',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    title: varchar('title', { length: 200 }).notNull(),
+    status: varchar('status', { length: 16 }).notNull().default('open'),
+    ownerId: integer('owner_id').references(() => users.id, { onDelete: 'set null' }),
+    dueDate: date('due_date'),
+    description: text('description'),
+    createdBy: integer('created_by').references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    statusCheck: check(
+      'tasks_status_check',
+      sql`${table.status} IN ('open', 'in_progress', 'done')`
+    ),
+    titleNonEmptyCheck: check('tasks_title_nonempty_check', sql`length(btrim(${table.title})) > 0`),
+    fundCreatedIdx: index('idx_tasks_fund_created').on(table.fundId, table.createdAt.desc()),
+  })
+);
+
+export type Task = typeof tasks.$inferSelect;
+export type InsertTask = typeof tasks.$inferInsert;

--- a/tests/unit/contract/operating-objects/task.contract.test.ts
+++ b/tests/unit/contract/operating-objects/task.contract.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  TaskCreateSchema,
+  TaskResponseSchema,
+  TaskStatusSchema,
+} from '@shared/contracts/operating-objects/task.contract';
+
+describe('TaskCreateSchema', () => {
+  const valid = { fundId: 1, title: 'Follow up with LP' };
+
+  it('accepts a minimal valid create', () => {
+    expect(TaskCreateSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('accepts optional owner/dueDate/description', () => {
+    const parsed = TaskCreateSchema.safeParse({
+      ...valid,
+      ownerId: 42,
+      dueDate: '2026-07-01',
+      description: 'context',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects unknown top-level keys (.strict)', () => {
+    expect(TaskCreateSchema.safeParse({ ...valid, status: 'done' }).success).toBe(false);
+  });
+
+  it('rejects an empty or whitespace-only title', () => {
+    expect(TaskCreateSchema.safeParse({ fundId: 1, title: '' }).success).toBe(false);
+    expect(TaskCreateSchema.safeParse({ fundId: 1, title: '   ' }).success).toBe(false);
+  });
+
+  it('trims the title', () => {
+    const parsed = TaskCreateSchema.parse({ fundId: 1, title: '  hi  ' });
+    expect(parsed.title).toBe('hi');
+  });
+
+  it('rejects a title longer than 200 chars', () => {
+    expect(TaskCreateSchema.safeParse({ fundId: 1, title: 'x'.repeat(201) }).success).toBe(false);
+  });
+
+  it('rejects a non-ISO-date dueDate', () => {
+    expect(TaskCreateSchema.safeParse({ ...valid, dueDate: '2026-07-01T00:00:00Z' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects a non-positive fundId', () => {
+    expect(TaskCreateSchema.safeParse({ fundId: 0, title: 'x' }).success).toBe(false);
+  });
+});
+
+describe('TaskStatusSchema', () => {
+  it('covers exactly the three lifecycle states', () => {
+    expect(TaskStatusSchema.options).toEqual(['open', 'in_progress', 'done']);
+  });
+});
+
+describe('TaskResponseSchema', () => {
+  const row = {
+    id: 10,
+    fundId: 1,
+    title: 'Follow up',
+    status: 'open',
+    ownerId: null,
+    dueDate: null,
+    description: null,
+    createdAt: '2026-06-16T00:00:00.000Z',
+    updatedAt: '2026-06-16T00:00:00.000Z',
+    etag: 'W/"abc123"',
+  };
+
+  it('round-trips a valid response', () => {
+    expect(TaskResponseSchema.safeParse(row).success).toBe(true);
+  });
+
+  it('requires a non-empty etag', () => {
+    expect(TaskResponseSchema.safeParse({ ...row, etag: '' }).success).toBe(false);
+  });
+
+  it('rejects internal provenance leakage (.strict on created_by)', () => {
+    expect(TaskResponseSchema.safeParse({ ...row, createdBy: 7 }).success).toBe(false);
+  });
+});

--- a/tests/unit/routes/operating-object-tasks.contract.test.ts
+++ b/tests/unit/routes/operating-object-tasks.contract.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const dbState = vi.hoisted(() => {
+  const state = {
+    insertResult: [] as unknown[],
+    selectResult: [] as unknown[],
+    insertedValues: undefined as unknown,
+  };
+  const db = {
+    insert: vi.fn(() => ({
+      values: vi.fn((payload: unknown) => {
+        state.insertedValues = payload;
+        return { returning: vi.fn(() => Promise.resolve(state.insertResult)) };
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(() => Promise.resolve(state.selectResult)),
+        })),
+      })),
+    })),
+  };
+  return { db, state };
+});
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+import tasksRouter from '../../../server/routes/operating-object-tasks';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(tasksRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function denyOnce() {
+  fundScopeState.enforceProvidedFundScope.mockImplementationOnce(async (_req, res) => {
+    res.status(403).json({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    return false;
+  });
+}
+
+function validBody(fundId = 1) {
+  return { fundId, title: 'Follow up with LP' };
+}
+
+function dbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    fundId: 1,
+    title: 'Follow up with LP',
+    status: 'open',
+    ownerId: null,
+    dueDate: null,
+    description: null,
+    createdBy: null,
+    createdAt: new Date('2026-06-16T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-16T00:00:00.000Z'),
+    rowXmin: '1',
+    ...overrides,
+  };
+}
+
+describe('operating-object tasks route contracts', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    dbState.db.insert.mockClear();
+    dbState.db.select.mockClear();
+    dbState.state.insertResult = [];
+    dbState.state.selectResult = [];
+    dbState.state.insertedValues = undefined;
+  });
+
+  it('POST rejects a non-canonical fundId before the scope check and any DB write', async () => {
+    const res = await request(makeApp()).post('/api/funds/01/tasks').send(validBody(1));
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST denies a cross-fund scope before any DB write', async () => {
+    denyOnce();
+    const res = await request(makeApp()).post('/api/funds/2/tasks').send(validBody(2));
+    expect(res.status).toBe(403);
+    expect(fundScopeState.enforceProvidedFundScope).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2
+    );
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST creates a task and returns 201 with an etag and no created_by leak', async () => {
+    dbState.state.insertResult = [dbRow()];
+    const res = await request(makeApp()).post('/api/funds/1/tasks').send(validBody(1));
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      id: 10,
+      fundId: 1,
+      title: 'Follow up with LP',
+      status: 'open',
+    });
+    expect(typeof res.body.etag).toBe('string');
+    expect(res.body.etag.length).toBeGreaterThan(0);
+    expect(res.body).not.toHaveProperty('createdBy');
+    expect(res.body).not.toHaveProperty('created_by');
+    expect(dbState.db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST stores status open and the parsed fundId on insert', async () => {
+    dbState.state.insertResult = [dbRow()];
+    await request(makeApp()).post('/api/funds/1/tasks').send(validBody(1));
+    expect(dbState.state.insertedValues).toMatchObject({ status: 'open', fundId: 1 });
+  });
+
+  it('POST rejects a body fundId that does not match the path fundId', async () => {
+    const res = await request(makeApp()).post('/api/funds/1/tasks').send(validBody(2));
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'fundId mismatch' });
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST rejects a whitespace-only title', async () => {
+    const res = await request(makeApp())
+      .post('/api/funds/1/tasks')
+      .send({ fundId: 1, title: '   ' });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid request body' });
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('POST rejects unknown body keys (.strict)', async () => {
+    const res = await request(makeApp())
+      .post('/api/funds/1/tasks')
+      .send({ ...validBody(1), status: 'done' });
+    expect(res.status).toBe(400);
+    expect(dbState.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('GET lists tasks newest-first (pass-through of the indexed DESC query)', async () => {
+    dbState.state.selectResult = [dbRow({ id: 20 }), dbRow({ id: 11 })];
+    const res = await request(makeApp()).get('/api/funds/1/tasks');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].id).toBe(20);
+    expect(res.body.data[1].id).toBe(11);
+    expect(typeof res.body.data[0].etag).toBe('string');
+    expect(dbState.db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET denies a cross-fund scope before any DB read', async () => {
+    denyOnce();
+    const res = await request(makeApp()).get('/api/funds/2/tasks');
+    expect(res.status).toBe(403);
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/operating-objects/task-service.test.ts
+++ b/tests/unit/services/operating-objects/task-service.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const captured = vi.hoisted(() => ({
+  insertedValues: undefined as unknown,
+  selectRows: [] as unknown[],
+}));
+const dbMock = vi.hoisted(() => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn((v: unknown) => {
+        captured.insertedValues = v;
+        return { returning: vi.fn(async () => captured.selectRows) };
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(async () => captured.selectRows),
+        })),
+      })),
+    })),
+  },
+}));
+vi.mock('../../../../server/db', () => dbMock);
+
+import {
+  createTask,
+  listTasksForFund,
+} from '../../../../server/services/operating-objects/task-service';
+
+const record = (o: Record<string, unknown> = {}) => ({
+  id: 10,
+  fundId: 1,
+  title: 'Follow up',
+  status: 'open',
+  ownerId: null,
+  dueDate: null,
+  description: null,
+  createdBy: null,
+  createdAt: new Date('2026-06-16T00:00:00.000Z'),
+  updatedAt: new Date('2026-06-16T00:00:00.000Z'),
+  rowXmin: '5',
+  ...o,
+});
+
+describe('task-service', () => {
+  beforeEach(() => {
+    captured.insertedValues = undefined;
+    captured.selectRows = [];
+    dbMock.db.insert.mockClear();
+    dbMock.db.select.mockClear();
+  });
+
+  it('createTask splits xmin from the inserted row and forces status open', async () => {
+    captured.selectRows = [record()];
+    const out = await createTask({ fundId: 1, title: 'Follow up', createdBy: 7 });
+    expect(out?.xmin).toBe('5');
+    expect(out?.row).not.toHaveProperty('rowXmin');
+    expect(out?.row.id).toBe(10);
+    expect(captured.insertedValues).toMatchObject({ status: 'open', createdBy: 7, fundId: 1 });
+  });
+
+  it('createTask coerces omitted optionals to NULL', async () => {
+    captured.selectRows = [record()];
+    await createTask({ fundId: 1, title: 'x', createdBy: null });
+    const v = captured.insertedValues as Record<string, unknown>;
+    expect(v['ownerId']).toBeNull();
+    expect(v['dueDate']).toBeNull();
+    expect(v['description']).toBeNull();
+  });
+
+  it('createTask returns undefined when the insert yields no row', async () => {
+    captured.selectRows = [];
+    const out = await createTask({ fundId: 1, title: 'x', createdBy: null });
+    expect(out).toBeUndefined();
+  });
+
+  it('listTasksForFund splits xmin for each row (newest-first pass-through)', async () => {
+    captured.selectRows = [record({ id: 20, rowXmin: '6' }), record({ id: 11, rowXmin: '7' })];
+    const out = await listTasksForFund(1);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.xmin).toBe('6');
+    expect(out[0]?.row).not.toHaveProperty('rowXmin');
+    expect(out[1]?.row.id).toBe(11);
+  });
+});


### PR DESCRIPTION
## What

First **operating-object** backend, per `docs/design/audits/server-object-readiness.md`. The audit marks `task` as verdict **NONE** (no route/table/worker) and requires a schema + migration + route PR **before any UI**. This is that PR for `task`, and it establishes the `operating-objects/` namespace that `assumption`/`comment` will follow.

## Scope — minimal (YAGNI floor)

Create + list only, fund-scoped. **No** lifecycle transitions, **no** versioning, **no** client UI, **no** feature flag (flags gate client mounts; there is no client surface). Integration test (real Postgres) deferred as a fast-follow, mirroring PR-C1 → #867.

Endpoints (mounted on `makeApp`, self-defined paths, mirroring `cash-flow-events`):
- `POST /api/funds/:fundId/tasks` — create (status server-controlled `'open'`)
- `GET  /api/funds/:fundId/tasks` — list, newest-first

## Design (mirrors the cash_event pattern)

- **Schema/migration:** `shared/schema/operating-objects.ts` (`tasks` table) + barrel re-exports; journaled `server/migrations/20260616_operating_object_tasks_v1.{up,down}.sql` for prod-replay parity (CI builds the test DB via `db:push`).
- **Contract:** `shared/contracts/operating-objects/task.contract.ts` — `.strict()` create/response. `status` is server-controlled (`.strict()` rejects a client attempt to set it); response carries an `etag` (from `xmin`) so a future edit/transition PR is purely additive; `created_by` is internal and **omitted** from the response, `owner_id` is user-facing and included. `dueDate` is date-only (`z.string().date()`).
- **Service/route:** `task-service.ts` owns persistence behind a `{database}` DI seam; the route imports the service (never `server/db`/`server/storage`), keeping `guard:route-imports:check` green. Auth via inline `enforceProvidedFundScope` (the global `/api` guard authenticates; no `requireAuth`, no role gate). Body `fundId` must match path (400).

## Verification (run independently)

- `npm run check` (tsc): **0 new errors**
- `npm run lint` (`--max-warnings 0`): PASS
- `guard:route-imports:check`: PASS
- `TZ=UTC vitest --project=server` (contract/route/service): **25/25 pass**
- `git diff --check`: clean

## Notes

- Purely additive — no existing surface touched; dark by absence of UI.
- PR-gate runs the unit tests (mocked DB). Integration coverage is a deferred fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)