### PR TITLE
docs: align C1 idempotency closeout wording

### DIFF
--- a/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
+++ b/docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md
@@ -419,17 +419,19 @@ const createMutation = useMutation({
 
 ### Idempotency
 
-C1 defers idempotency key support. The submit button is disabled while the
-mutation is pending, which is the only duplicate-protection mechanism in this
-pass. A follow-on pass should add:
+C1 uses payload-scoped idempotency key support. The modal computes a stable
+payload signature for each submit, reuses the same `Idempotency-Key` when the
+same payload is retried after a transient failure, and rotates to a new key when
+the payload changes before retry. Successful creation and ordinary close reset
+the stored key so a later creation starts fresh.
 
-```ts
-// In mutationFn options
-headers: { 'Idempotency-Key': crypto.randomUUID() },
-```
-
-The backend already supports this via `x-idempotency-key` — the create service
-resolves, hashes, and replays existing scenario sets on key reuse.
+The submit path also has synchronous re-entrant protection: `onSubmit` returns
+immediately when a submit is already in flight, so rapid duplicate submit events
+cannot issue multiple POSTs before React mutation state settles. The disabled
+pending button remains user feedback, not the only duplicate-protection
+mechanism. The backend accepts the key via `x-idempotency-key` /
+`Idempotency-Key`; the create service resolves, hashes, and replays existing
+scenario sets on same-key reuse.
 
 ### Close guard
 


### PR DESCRIPTION
## Summary
- Align the active C1 methodology scenario design spec with shipped payload-scoped idempotency behavior.
- Replace the stale deferred-idempotency section with same-payload retry reuse, changed-payload key rotation, and synchronous re-entrant submit protection.

## Verification
- npx vitest run tests/unit/components/scenarios/CreateMethodologyScenarioModal.test.tsx tests/unit/lib/queryClient.test.ts tests/unit/lib/fund-scenario-workspace-api.test.ts tests/unit/pages/fund-scenario-workspace.test.tsx
- rg scan for active C1 deferred-idempotency wording
- git diff --check

## Notes
- Docs-only change; no product code changed.
- Remaining deferred items are separately routed: waterfall enum terminology and the sibling scenario comparison duplicate React key warning.
- npm run test:scenario-release-gate was not rerun because the approved closeout test spec marks it as optional unless fresh local release-gate proof is explicitly required.
