### PR TITLE
feat(operating-objects): task edit/lifecycle PATCH (fields + free status transitions)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -92,7 +92,10 @@ export function makeApp() {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Vary', 'Origin');
       res.setHeader('Access-Control-Allow-Credentials', 'true');
-      res.setHeader('Access-Control-Allow-Headers', 'content-type, authorization, x-request-id');
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'content-type, authorization, x-request-id, if-match'
+      );
       res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
     }
     if (req.method === 'OPTIONS') return res.sendStatus(ok ? 200 : 403);

--- a/server/routes/operating-object-tasks.ts
+++ b/server/routes/operating-object-tasks.ts
@@ -3,14 +3,20 @@ import type { Request, Response } from 'express';
 import { parseFundIdParam } from '@shared/number';
 import {
   TaskCreateSchema,
+  TaskPatchSchema,
   TaskResponseSchema,
   type TaskResponse,
 } from '@shared/contracts/operating-objects/task.contract';
 import type { Task } from '@shared/schema/operating-objects';
 import { firstString } from '../lib/request-values';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
-import { rowVersionETag } from '../lib/http-preconditions';
-import { createTask, listTasksForFund } from '../services/operating-objects/task-service';
+import { parseETag, rowVersionETag } from '../lib/http-preconditions';
+import {
+  createTask,
+  listTasksForFund,
+  loadTask,
+  updateTask,
+} from '../services/operating-objects/task-service';
 
 const router = Router();
 
@@ -89,6 +95,83 @@ router['get']('/api/funds/:fundId/tasks', async (req: Request, res: Response) =>
       .json({ data: rows.map((r) => toResponse(r.row, rowVersionETag(r.xmin))) });
   } catch {
     return res.status(500).json({ error: 'Failed to list tasks' });
+  }
+});
+
+// Edit fields + status under optimistic concurrency. Error order mirrors
+// cash-flow-events: parse (400) -> scope (403) -> If-Match present (428) -> body
+// (400) -> fundId-match (400) -> load (404) -> etag (412) -> atomic apply ->
+// zero-row disambiguation. NO 409: tasks have no immutable state, transitions are
+// free, so a zero-row update after a passing precondition means concurrent
+// modify (412) or delete (404) only.
+router['patch']('/api/funds/:fundId/tasks/:taskId', async (req: Request, res: Response) => {
+  try {
+    const fundId = parseFundIdParam(firstString(req.params['fundId']));
+    if (fundId === null) {
+      return res.status(400).json({ error: 'Invalid fund ID' });
+    }
+    // taskId reuses the same canonical positive-integer parser.
+    const taskId = parseFundIdParam(firstString(req.params['taskId']));
+    if (taskId === null) {
+      return res.status(400).json({ error: 'Invalid task ID' });
+    }
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      return;
+    }
+    // If-Match required, checked BEFORE body validation (mirrors cash-flow-events).
+    const ifMatch = firstString(req.headers['if-match']);
+    if (!ifMatch) {
+      return res
+        .status(428)
+        .json({ error: 'precondition_required', message: 'If-Match header is required' });
+    }
+    const parsed = TaskPatchSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid request body', details: parsed.error.format() });
+    }
+    if (parsed.data.fundId !== undefined && parsed.data.fundId !== fundId) {
+      return res
+        .status(400)
+        .json({ error: 'fundId mismatch', message: 'Body fundId must match the path fundId' });
+    }
+
+    const current = await loadTask(fundId, taskId);
+    if (!current) {
+      return res.status(404).json({ error: 'Task not found' });
+    }
+    const currentEtag = rowVersionETag(current.xmin);
+    if (parseETag(ifMatch) !== parseETag(currentEtag)) {
+      return res.status(412).json({
+        error: 'precondition_failed',
+        message: 'Task has been modified',
+        current: currentEtag,
+      });
+    }
+
+    const updated = await updateTask({
+      fundId,
+      taskId,
+      expectedXmin: current.xmin,
+      patch: parsed.data,
+    });
+    if (!updated) {
+      // Atomic update touched zero rows after a passing precondition -- disambiguate.
+      const recheck = await loadTask(fundId, taskId);
+      if (!recheck) {
+        return res.status(404).json({ error: 'Task not found' });
+      }
+      return res.status(412).json({
+        error: 'precondition_failed',
+        message: 'Task has been modified',
+        current: rowVersionETag(recheck.xmin),
+      });
+    }
+
+    return res.status(200).json(toResponse(updated.row, rowVersionETag(updated.xmin)));
+  } catch {
+    return res.status(500).json({ error: 'Failed to update task' });
   }
 });
 

--- a/server/services/operating-objects/task-service.ts
+++ b/server/services/operating-objects/task-service.ts
@@ -1,7 +1,7 @@
-import { desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db';
-import type { TaskCreate } from '@shared/contracts/operating-objects/task.contract';
+import type { TaskCreate, TaskPatch } from '@shared/contracts/operating-objects/task.contract';
 import { tasks, type Task } from '@shared/schema/operating-objects';
 
 type TaskDatabase = typeof db;
@@ -75,4 +75,61 @@ export async function listTasksForFund(
     .where(eq(tasks.fundId, fundId))
     .orderBy(desc(tasks.createdAt));
   return records.map(splitXmin);
+}
+
+export async function loadTask(
+  fundId: number,
+  taskId: number,
+  options: TaskServiceOptions = {}
+): Promise<TaskRow | undefined> {
+  const database = options.database ?? db;
+  const [record] = await database
+    .select(columnsWithXmin)
+    .from(tasks)
+    .where(and(eq(tasks.fundId, fundId), eq(tasks.id, taskId)))
+    .limit(1);
+  return record ? splitXmin(record) : undefined;
+}
+
+interface UpdateTaskArgs {
+  fundId: number;
+  taskId: number;
+  expectedXmin: string;
+  patch: TaskPatch;
+}
+
+/**
+ * Atomic edit. WHERE pins fund/id/xmin (NO status gate -- any task is editable;
+ * transitions are free). A concurrently-modified or deleted row updates zero rows
+ * -> returns undefined so the caller disambiguates (404 vs 412). Sets only the
+ * provided fields plus updatedAt. title/status use `!== undefined` (never null);
+ * the nullable fields use `'key' in patch` so an explicit null clears and an
+ * absent key is untouched. dueDate is a DATE column (date-only string) and is
+ * written VERBATIM -- never `new Date()` (the cash_event mirror does that for its
+ * timestamp eventDate; here it would TZ-shift / datetime-serialize). On success
+ * reloads for the fresh post-update xmin so the response etag rotates.
+ */
+export async function updateTask(
+  args: UpdateTaskArgs,
+  options: TaskServiceOptions = {}
+): Promise<TaskRow | undefined> {
+  const database = options.database ?? db;
+  const { fundId, taskId, expectedXmin, patch } = args;
+
+  const setValues: Partial<typeof tasks.$inferInsert> = { updatedAt: new Date() };
+  if (patch.title !== undefined) setValues.title = patch.title;
+  if (patch.status !== undefined) setValues.status = patch.status;
+  if ('ownerId' in patch) setValues.ownerId = patch.ownerId ?? null;
+  if ('dueDate' in patch) setValues.dueDate = patch.dueDate ?? null;
+  if ('description' in patch) setValues.description = patch.description ?? null;
+
+  const updated = await database
+    .update(tasks)
+    .set(setValues)
+    .where(and(eq(tasks.fundId, fundId), eq(tasks.id, taskId), sql`xmin = ${expectedXmin}::xid`))
+    .returning({ id: tasks.id });
+
+  if (updated.length === 0) return undefined;
+  // Reload for the fresh row + fresh xmin token (post-update); etag rotates.
+  return loadTask(fundId, taskId, options);
 }

--- a/shared/contracts/operating-objects/task.contract.ts
+++ b/shared/contracts/operating-objects/task.contract.ts
@@ -30,6 +30,33 @@ export const TaskCreateSchema = z
 
 export type TaskCreate = z.infer<typeof TaskCreateSchema>;
 
+// PATCH (edit fields + status). All keys optional and `.strict()` (unknown keys
+// reject). `fundId` is a path-consistency check only (NOT an editable field), so
+// the refine requires >=1 ACTUAL editable field -- a fundId-only body is a 400,
+// never a no-op that rotates the row version. Nullable fields accept explicit
+// `null` to clear (owner_id set-null FK, due_date, description); the service uses
+// `'key' in patch` to tell absent from explicit-null. `status` is enum-only --
+// free transitions (any state -> any state), no terminal/immutable state. dueDate
+// stays date-only (`z.string().date()`); it is NEVER serialized through a Date.
+const TASK_EDITABLE_KEYS = ['title', 'ownerId', 'dueDate', 'description', 'status'] as const;
+
+export const TaskPatchSchema = z
+  .object({
+    fundId: z.number().int().positive().optional(),
+    title: z.string().trim().min(1).max(200).optional(),
+    ownerId: z.number().int().positive().nullable().optional(),
+    dueDate: z.string().date().nullable().optional(),
+    description: z.string().max(2000).nullable().optional(),
+    status: TaskStatusSchema.optional(),
+  })
+  .strict()
+  .refine((patch) => TASK_EDITABLE_KEYS.some((key) => key in patch), {
+    message:
+      'At least one editable field (title, ownerId, dueDate, description, status) is required',
+  });
+
+export type TaskPatch = z.infer<typeof TaskPatchSchema>;
+
 // RESPONSE (server -> client). `.strict()` so internal provenance (created_by)
 // can never leak. dueDate is date-only; timestamps are ISO datetimes.
 export const TaskResponseSchema = z

--- a/tests/unit/contract/operating-objects/task.contract.test.ts
+++ b/tests/unit/contract/operating-objects/task.contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   TaskCreateSchema,
+  TaskPatchSchema,
   TaskResponseSchema,
   TaskStatusSchema,
 } from '@shared/contracts/operating-objects/task.contract';
@@ -82,5 +83,57 @@ describe('TaskResponseSchema', () => {
 
   it('rejects internal provenance leakage (.strict on created_by)', () => {
     expect(TaskResponseSchema.safeParse({ ...row, createdBy: 7 }).success).toBe(false);
+  });
+});
+
+describe('TaskPatchSchema', () => {
+  it('accepts a single-field edit', () => {
+    expect(TaskPatchSchema.safeParse({ title: 'New title' }).success).toBe(true);
+  });
+
+  it('accepts a status-only edit (free transition)', () => {
+    expect(TaskPatchSchema.safeParse({ status: 'done' }).success).toBe(true);
+  });
+
+  it('accepts explicit null to clear each nullable field', () => {
+    expect(TaskPatchSchema.safeParse({ ownerId: null }).success).toBe(true);
+    expect(TaskPatchSchema.safeParse({ dueDate: null }).success).toBe(true);
+    expect(TaskPatchSchema.safeParse({ description: null }).success).toBe(true);
+  });
+
+  it('rejects a null title (NOT NULL column)', () => {
+    expect(TaskPatchSchema.safeParse({ title: null }).success).toBe(false);
+  });
+
+  it('rejects an empty patch (no editable field)', () => {
+    expect(TaskPatchSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects a fundId-only patch (fundId is not an editable field)', () => {
+    expect(TaskPatchSchema.safeParse({ fundId: 1 }).success).toBe(false);
+  });
+
+  it('accepts fundId alongside an editable field (path-consistency check)', () => {
+    expect(TaskPatchSchema.safeParse({ fundId: 1, title: 'x' }).success).toBe(true);
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    expect(TaskPatchSchema.safeParse({ title: 'x', bogus: 1 }).success).toBe(false);
+  });
+
+  it('rejects an invalid status value', () => {
+    expect(TaskPatchSchema.safeParse({ status: 'archived' }).success).toBe(false);
+  });
+
+  it('rejects a datetime dueDate (date-only only)', () => {
+    expect(TaskPatchSchema.safeParse({ dueDate: '2026-07-01T00:00:00Z' }).success).toBe(false);
+  });
+
+  it('rejects a whitespace-only title', () => {
+    expect(TaskPatchSchema.safeParse({ title: '   ' }).success).toBe(false);
+  });
+
+  it('trims the title', () => {
+    expect(TaskPatchSchema.parse({ title: '  hi  ' }).title).toBe('hi');
   });
 });

--- a/tests/unit/routes/operating-object-tasks.contract.test.ts
+++ b/tests/unit/routes/operating-object-tasks.contract.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Request, Response } from 'express';
 import express from 'express';
 import request from 'supertest';
+import { rowVersionETag } from '../../../server/lib/http-preconditions';
 
 const fundScopeState = vi.hoisted(() => ({
   enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
@@ -10,8 +11,11 @@ const fundScopeState = vi.hoisted(() => ({
 const dbState = vi.hoisted(() => {
   const state = {
     insertResult: [] as unknown[],
-    selectResult: [] as unknown[],
+    selectResult: [] as unknown[], // list path (.orderBy)
+    loadQueue: [] as unknown[][], // each .limit(1) shifts one array (loadTask)
+    updateResult: [] as unknown[], // .returning({ id })
     insertedValues: undefined as unknown,
+    updatedValues: undefined as unknown,
   };
   const db = {
     insert: vi.fn(() => ({
@@ -20,10 +24,21 @@ const dbState = vi.hoisted(() => {
         return { returning: vi.fn(() => Promise.resolve(state.insertResult)) };
       }),
     })),
+    update: vi.fn(() => ({
+      set: vi.fn((payload: unknown) => {
+        state.updatedValues = payload;
+        return {
+          where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve(state.updateResult)) })),
+        };
+      }),
+    })),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
           orderBy: vi.fn(() => Promise.resolve(state.selectResult)),
+          limit: vi.fn(() =>
+            Promise.resolve(state.loadQueue.length > 0 ? state.loadQueue.shift() : [])
+          ),
         })),
       })),
     })),
@@ -80,10 +95,14 @@ describe('operating-object tasks route contracts', () => {
     fundScopeState.enforceProvidedFundScope.mockReset();
     fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
     dbState.db.insert.mockClear();
+    dbState.db.update.mockClear();
     dbState.db.select.mockClear();
     dbState.state.insertResult = [];
     dbState.state.selectResult = [];
+    dbState.state.loadQueue = [];
+    dbState.state.updateResult = [];
     dbState.state.insertedValues = undefined;
+    dbState.state.updatedValues = undefined;
   });
 
   it('POST rejects a non-canonical fundId before the scope check and any DB write', async () => {
@@ -169,5 +188,206 @@ describe('operating-object tasks route contracts', () => {
     const res = await request(makeApp()).get('/api/funds/2/tasks');
     expect(res.status).toBe(403);
     expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('operating-object tasks PATCH route', () => {
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    dbState.db.insert.mockClear();
+    dbState.db.update.mockClear();
+    dbState.db.select.mockClear();
+    dbState.state.insertResult = [];
+    dbState.state.selectResult = [];
+    dbState.state.loadQueue = [];
+    dbState.state.updateResult = [];
+    dbState.state.insertedValues = undefined;
+    dbState.state.updatedValues = undefined;
+  });
+
+  const etagFor = (xmin: string) => rowVersionETag(xmin);
+
+  it('rejects a non-canonical fundId before scope/If-Match/DB', async () => {
+    const res = await request(makeApp())
+      .patch('/api/funds/01/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+    expect(fundScopeState.enforceProvidedFundScope).not.toHaveBeenCalled();
+    expect(dbState.db.select).not.toHaveBeenCalled();
+    expect(dbState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-canonical taskId', async () => {
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/01')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid task ID' });
+    expect(dbState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('denies a cross-fund scope before If-Match and any DB access', async () => {
+    denyOnce();
+    const res = await request(makeApp())
+      .patch('/api/funds/2/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'x' });
+    expect(res.status).toBe(403);
+    expect(dbState.db.select).not.toHaveBeenCalled();
+    expect(dbState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('requires If-Match (428) BEFORE body validation', async () => {
+    // Invalid body (empty) + missing If-Match must still 428, proving order.
+    const res = await request(makeApp()).patch('/api/funds/1/tasks/10').send({});
+    expect(res.status).toBe(428);
+    expect(res.body).toMatchObject({ error: 'precondition_required' });
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty patch (400) when If-Match is present', async () => {
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid request body' });
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects a fundId-only patch (400, no DB read)', async () => {
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ fundId: 1 });
+    expect(res.status).toBe(400);
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown body keys (.strict)', async () => {
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'x', bogus: 1 });
+    expect(res.status).toBe(400);
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body fundId that does not match the path (400, no DB read)', async () => {
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ fundId: 2, title: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'fundId mismatch' });
+    expect(dbState.db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the task does not exist', async () => {
+    dbState.state.loadQueue = [[]];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'x' });
+    expect(res.status).toBe(404);
+    expect(dbState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 412 on a stale If-Match', async () => {
+    dbState.state.loadQueue = [[dbRow({ rowXmin: '1' })]];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('2'))
+      .send({ title: 'x' });
+    expect(res.status).toBe(412);
+    expect(res.body).toMatchObject({ error: 'precondition_failed', current: etagFor('1') });
+    expect(dbState.db.update).not.toHaveBeenCalled();
+  });
+
+  it('edits a field and rotates the etag (200)', async () => {
+    dbState.state.loadQueue = [
+      [dbRow({ rowXmin: '1' })],
+      [dbRow({ rowXmin: '2', title: 'Updated' })],
+    ];
+    dbState.state.updateResult = [{ id: 10 }];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'Updated' });
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Updated');
+    expect(res.body.etag).toBe(etagFor('2'));
+    expect(res.body.etag).not.toBe(etagFor('1'));
+    expect(dbState.state.updatedValues).toMatchObject({ title: 'Updated' });
+    expect(dbState.db.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a free status transition open -> done', async () => {
+    dbState.state.loadQueue = [
+      [dbRow({ rowXmin: '1', status: 'open' })],
+      [dbRow({ rowXmin: '2', status: 'done' })],
+    ];
+    dbState.state.updateResult = [{ id: 10 }];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ status: 'done' });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('done');
+    expect(dbState.state.updatedValues).toMatchObject({ status: 'done' });
+  });
+
+  it('allows reopen done -> open (no terminal state, no 409)', async () => {
+    dbState.state.loadQueue = [
+      [dbRow({ rowXmin: '1', status: 'done' })],
+      [dbRow({ rowXmin: '2', status: 'open' })],
+    ];
+    dbState.state.updateResult = [{ id: 10 }];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ status: 'open' });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('open');
+  });
+
+  it('clears a nullable field via explicit null', async () => {
+    dbState.state.loadQueue = [
+      [dbRow({ rowXmin: '1', ownerId: 42 })],
+      [dbRow({ rowXmin: '2', ownerId: null })],
+    ];
+    dbState.state.updateResult = [{ id: 10 }];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ ownerId: null });
+    expect(res.status).toBe(200);
+    expect(res.body.ownerId).toBeNull();
+    expect(dbState.state.updatedValues).toMatchObject({ ownerId: null });
+  });
+
+  it('returns 412 when the atomic update touches zero rows but the row still exists', async () => {
+    dbState.state.loadQueue = [[dbRow({ rowXmin: '1' })], [dbRow({ rowXmin: '9' })]];
+    dbState.state.updateResult = [];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'x' });
+    expect(res.status).toBe(412);
+    expect(res.body).toMatchObject({ current: etagFor('9') });
+  });
+
+  it('returns 404 when the row vanishes between precondition and update', async () => {
+    dbState.state.loadQueue = [[dbRow({ rowXmin: '1' })], []];
+    dbState.state.updateResult = [];
+    const res = await request(makeApp())
+      .patch('/api/funds/1/tasks/10')
+      .set('If-Match', etagFor('1'))
+      .send({ title: 'x' });
+    expect(res.status).toBe(404);
   });
 });

--- a/tests/unit/services/operating-objects/task-service.test.ts
+++ b/tests/unit/services/operating-objects/task-service.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const captured = vi.hoisted(() => ({
   insertedValues: undefined as unknown,
-  selectRows: [] as unknown[],
+  updatedValues: undefined as unknown,
+  selectRows: [] as unknown[], // list path (.orderBy)
+  loadQueue: [] as unknown[][], // each .limit(1) shifts one array (loadTask)
+  updateResult: [] as unknown[], // .returning({ id })
 }));
 const dbMock = vi.hoisted(() => ({
   db: {
@@ -12,10 +15,19 @@ const dbMock = vi.hoisted(() => ({
         return { returning: vi.fn(async () => captured.selectRows) };
       }),
     })),
+    update: vi.fn(() => ({
+      set: vi.fn((v: unknown) => {
+        captured.updatedValues = v;
+        return { where: vi.fn(() => ({ returning: vi.fn(async () => captured.updateResult) })) };
+      }),
+    })),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
           orderBy: vi.fn(async () => captured.selectRows),
+          limit: vi.fn(async () =>
+            captured.loadQueue.length > 0 ? captured.loadQueue.shift() : []
+          ),
         })),
       })),
     })),
@@ -26,6 +38,8 @@ vi.mock('../../../../server/db', () => dbMock);
 import {
   createTask,
   listTasksForFund,
+  loadTask,
+  updateTask,
 } from '../../../../server/services/operating-objects/task-service';
 
 const record = (o: Record<string, unknown> = {}) => ({
@@ -46,8 +60,12 @@ const record = (o: Record<string, unknown> = {}) => ({
 describe('task-service', () => {
   beforeEach(() => {
     captured.insertedValues = undefined;
+    captured.updatedValues = undefined;
     captured.selectRows = [];
+    captured.loadQueue = [];
+    captured.updateResult = [];
     dbMock.db.insert.mockClear();
+    dbMock.db.update.mockClear();
     dbMock.db.select.mockClear();
   });
 
@@ -82,5 +100,90 @@ describe('task-service', () => {
     expect(out[0]?.xmin).toBe('6');
     expect(out[0]?.row).not.toHaveProperty('rowXmin');
     expect(out[1]?.row.id).toBe(11);
+  });
+
+  it('loadTask splits xmin and returns the row', async () => {
+    captured.loadQueue = [[record({ id: 10, rowXmin: '9' })]];
+    const out = await loadTask(1, 10);
+    expect(out?.xmin).toBe('9');
+    expect(out?.row.id).toBe(10);
+    expect(out?.row).not.toHaveProperty('rowXmin');
+  });
+
+  it('loadTask returns undefined when no row matches', async () => {
+    captured.loadQueue = [[]];
+    expect(await loadTask(1, 999)).toBeUndefined();
+  });
+
+  it('updateTask sets only provided fields + updatedAt and reloads the fresh xmin', async () => {
+    captured.updateResult = [{ id: 10 }];
+    captured.loadQueue = [[record({ rowXmin: '2', title: 'Updated' })]];
+    const out = await updateTask({
+      fundId: 1,
+      taskId: 10,
+      expectedXmin: '1',
+      patch: { title: 'Updated' },
+    });
+    expect(out?.xmin).toBe('2'); // post-update reload, NOT the preloaded xmin
+    expect(out?.row.title).toBe('Updated');
+    const v = captured.updatedValues as Record<string, unknown>;
+    expect(v['title']).toBe('Updated');
+    expect(v['updatedAt']).toBeInstanceOf(Date);
+    expect('ownerId' in v).toBe(false);
+    expect('dueDate' in v).toBe(false);
+    expect('description' in v).toBe(false);
+  });
+
+  it('updateTask clears nullable fields on explicit null (in-semantics)', async () => {
+    captured.updateResult = [{ id: 10 }];
+    captured.loadQueue = [[record()]];
+    await updateTask({
+      fundId: 1,
+      taskId: 10,
+      expectedXmin: '1',
+      patch: { ownerId: null, dueDate: null, description: null },
+    });
+    const v = captured.updatedValues as Record<string, unknown>;
+    expect(v['ownerId']).toBeNull();
+    expect(v['dueDate']).toBeNull();
+    expect(v['description']).toBeNull();
+  });
+
+  it('updateTask writes dueDate as a date-only string, never a Date', async () => {
+    captured.updateResult = [{ id: 10 }];
+    captured.loadQueue = [[record({ dueDate: '2026-07-01' })]];
+    await updateTask({
+      fundId: 1,
+      taskId: 10,
+      expectedXmin: '1',
+      patch: { dueDate: '2026-07-01' },
+    });
+    const v = captured.updatedValues as Record<string, unknown>;
+    expect(typeof v['dueDate']).toBe('string');
+    expect(v['dueDate']).toBe('2026-07-01');
+  });
+
+  it('updateTask sets status verbatim (free transition)', async () => {
+    captured.updateResult = [{ id: 10 }];
+    captured.loadQueue = [[record({ status: 'done' })]];
+    await updateTask({
+      fundId: 1,
+      taskId: 10,
+      expectedXmin: '1',
+      patch: { status: 'done' },
+    });
+    expect((captured.updatedValues as Record<string, unknown>)['status']).toBe('done');
+  });
+
+  it('updateTask returns undefined and does NOT reload when zero rows update', async () => {
+    captured.updateResult = [];
+    const out = await updateTask({
+      fundId: 1,
+      taskId: 10,
+      expectedXmin: '1',
+      patch: { title: 'x' },
+    });
+    expect(out).toBeUndefined();
+    expect(dbMock.db.select).not.toHaveBeenCalled(); // no reload on the zero-row path
   });
 });


### PR DESCRIPTION
## What

Adds server-side edit/lifecycle for the `task` operating-object — the additive
follow-on to PR-T1 (#871), which shipped `task` create + list.

Single endpoint: **`PATCH /api/funds/:fundId/tasks/:taskId`** — edits
`title` / `ownerId` / `dueDate` / `description` **and** moves `status` in one
request, under `If-Match`/`xmin` optimistic concurrency.

## Behavior

- **Free status transitions** (`open` | `in_progress` | `done`, any state → any
  state — reopen and skip both allowed). No `409` illegal-transition path: tasks
  have no immutable/terminal state (the deliberate divergence from
  `cash-flow-events`, which gates edits to `draft` and has a terminal `locked`).
- **Concurrency:** `If-Match` required → `428` missing, `412` stale; the atomic
  `UPDATE … WHERE fund_id=$ AND id=$ AND xmin=$::xid` returns zero rows on a
  concurrent modify/delete, then disambiguates to `412` (still exists) or `404`
  (gone). On success the service reloads to return the **post-update** xmin so
  the response `etag` rotates.
- **Error order** mirrors `cash-flow-events`: parse → scope → `If-Match` (428) →
  body (400) → fundId-match (400) → load (404) → etag (412) → apply.
- **Auth unchanged:** `enforceProvidedFundScope` (no `requireAuth`, no role gate).
- `dueDate` (Drizzle `date`) is written verbatim as a date-only string — never
  through `new Date()` (avoids the TZ-shift / datetime-serialization trap).
- CORS `Access-Control-Allow-Headers` gains `if-match` (also unblocks the
  existing `cash_event` PATCH for cross-origin callers).

## Scope

Purely additive — **no migration, no schema change, no mount change** (the table
already carries the `status` CHECK, `updated_at`, and the `xmin` system column;
the router is already mounted). 7 files:

| File | Change |
| --- | --- |
| `shared/contracts/operating-objects/task.contract.ts` | `TaskPatchSchema` (`.strict()`, all-optional, `.refine` ≥1 editable field excluding `fundId`, nullable-clearable) |
| `server/services/operating-objects/task-service.ts` | `loadTask` + `updateTask` (atomic xmin update, success-reload, `'key' in patch` clears) |
| `server/routes/operating-object-tasks.ts` | the `PATCH` handler |
| `server/app.ts` | one line — `if-match` in the CORS allowlist |
| 3 × `tests/unit/**/operating-objects/*` | 35 new unit tests |

## Design review

Red-teamed via a multi-model deliberation before implementation. Five findings
folded in: success-path xmin reload, `If-Match`-before-body ordering, date-only
write, `fundId`-excluded refine, single-token `If-Match`. Three judgment calls
decided: `ownerId` stays FK-only-validated (parity with create), CORS fix
applied, 415 coverage deferred.

## Verification

- `npm run check` — 0 new TypeScript errors
- `npm run lint` — pass
- `npm run guard:route-imports:check` — pass (route delegates to the service)
- Targeted server unit tests — **60 passed** (contract 24, service 11, route 25)
- `git diff --check` — clean

## Deferred (fast-follow, mirrors PR-T1)

- Real-Postgres integration test (create → edit → 412/404, fund-scope deny).
- `415` content-type coverage — enforced by the global app guard, which the
  router-only unit harness bypasses; belongs in the integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
