### PR TITLE
feat(cash-event): approve/lock lifecycle UI (L1)

### DIFF
--- a/client/src/components/dashboard/CashEventsPanel.tsx
+++ b/client/src/components/dashboard/CashEventsPanel.tsx
@@ -11,7 +11,9 @@ import {
   buildLpCapitalCallPatch,
   formFromEvent,
   isCashEventFormValid,
+  useApproveCashFlowEvent,
   useCashFlowEvents,
+  useLockCashFlowEvent,
   useUpdateCashFlowEvent,
   type CashEventEditForm,
   type CashFlowEventMutationError,
@@ -31,6 +33,13 @@ function conflictMessage(error: CashFlowEventMutationError): string {
     return 'This event is no longer an editable draft. The latest version is now shown.';
   }
   return error.message || 'Failed to save changes.';
+}
+
+function optionalAuditValue(event: CashFlowEventResponse, key: 'lockedAt' | 'lockedBy') {
+  const value = (event as CashFlowEventResponse & Record<typeof key, unknown>)[key];
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number') return String(value);
+  return null;
 }
 
 export function CashEventsPanel({
@@ -53,10 +62,16 @@ export function CashEventsPanel({
   const query = useCashFlowEvents(fundId, { enabled: isOpen });
   const events = query.data;
   const mutation = useUpdateCashFlowEvent(fundId);
+  const approveMutation = useApproveCashFlowEvent(fundId);
+  const lockMutation = useLockCashFlowEvent(fundId);
 
   const selectedEvent =
     objectId != null ? events?.find((event) => String(event.id) === objectId) : undefined;
 
+  const [transitionOverride, setTransitionOverride] = useState<CashFlowEventResponse | null>(null);
+  const [pendingTransitionStatus, setPendingTransitionStatus] = useState<
+    'approved' | 'locked' | null
+  >(null);
   const [loadedEvent, setLoadedEvent] = useState<CashFlowEventResponse | null>(null);
   const [form, setForm] = useState<CashEventEditForm | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -72,21 +87,47 @@ export function CashEventsPanel({
       setLoadedEvent(null);
       setForm(null);
     }
+    setErrorMsg(null);
+    setTransitionOverride(null);
+    setPendingTransitionStatus(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editKey]);
 
   // Clear any stale conflict note when switching to a different row.
   useEffect(() => {
     setErrorMsg(null);
+    setTransitionOverride(null);
+    setPendingTransitionStatus(null);
   }, [objectId]);
 
+  const effectiveEvent = transitionOverride ?? selectedEvent;
+  const effectiveStatus = pendingTransitionStatus ?? effectiveEvent?.status;
+  const effectiveEtag =
+    typeof effectiveEvent?.etag === 'string' && effectiveEvent.etag.length > 0
+      ? effectiveEvent.etag
+      : null;
+  const isLifecycleTarget =
+    editFlag && effectiveEvent != null && effectiveEvent.eventType === 'lp_capital_call';
+  const isTransitionRefreshPending = pendingTransitionStatus != null;
   const isEditable =
-    editFlag &&
-    selectedEvent != null &&
-    selectedEvent.eventType === 'lp_capital_call' &&
-    selectedEvent.status === 'draft' &&
-    typeof selectedEvent.etag === 'string' &&
-    selectedEvent.etag.length > 0;
+    isLifecycleTarget &&
+    effectiveStatus === 'draft' &&
+    effectiveEtag != null &&
+    !isTransitionRefreshPending;
+  const showApprove =
+    isLifecycleTarget && effectiveStatus === 'draft' && !isTransitionRefreshPending;
+  const showLock =
+    isLifecycleTarget && effectiveStatus === 'approved' && !isTransitionRefreshPending;
+  const canApprove = showApprove && effectiveEtag != null && !approveMutation.isPending;
+  const canLock = showLock && effectiveEtag != null && !lockMutation.isPending;
+  const disabledTransitionReason =
+    (showApprove || showLock) && effectiveEtag == null
+      ? "This record can't be advanced yet."
+      : null;
+  const disabledTransitionReasonId =
+    disabledTransitionReason && effectiveEvent
+      ? `cash-event-${effectiveEvent.id}-transition-reason`
+      : undefined;
 
   const patch = loadedEvent && form ? buildLpCapitalCallPatch(loadedEvent, form) : {};
   const isDirty = Object.keys(patch).length > 0;
@@ -123,6 +164,54 @@ export function CashEventsPanel({
             void query.refetch();
           }
         },
+      }
+    );
+  };
+
+  const handleTransitionSuccess = (
+    updated: CashFlowEventResponse | undefined,
+    status: 'approved' | 'locked'
+  ) => {
+    setErrorMsg(null);
+    if (updated) {
+      setTransitionOverride(updated);
+      setPendingTransitionStatus(null);
+      setLoadedEvent(updated);
+      setForm(formFromEvent(updated));
+      return;
+    }
+    setTransitionOverride(null);
+    setPendingTransitionStatus(status);
+    setLoadedEvent(null);
+    setForm(null);
+    void query.refetch();
+  };
+
+  const handleTransitionError = (error: CashFlowEventMutationError) => {
+    setErrorMsg(conflictMessage(error));
+    if (error.status === 412 || error.status === 409 || error.status === 428) {
+      void query.refetch();
+    }
+  };
+
+  const handleApprove = () => {
+    if (!effectiveEvent || !effectiveEtag || !canApprove) return;
+    approveMutation.mutate(
+      { eventId: effectiveEvent.id, etag: effectiveEtag },
+      {
+        onSuccess: (updated) => handleTransitionSuccess(updated, 'approved'),
+        onError: handleTransitionError,
+      }
+    );
+  };
+
+  const handleLock = () => {
+    if (!effectiveEvent || !effectiveEtag || !canLock) return;
+    lockMutation.mutate(
+      { eventId: effectiveEvent.id, etag: effectiveEtag },
+      {
+        onSuccess: (updated) => handleTransitionSuccess(updated, 'locked'),
+        onError: handleTransitionError,
       }
     );
   };
@@ -188,7 +277,7 @@ export function CashEventsPanel({
             </p>
           ) : null}
 
-          {isEditable && form ? (
+          {isEditable && form && effectiveEvent ? (
             <form
               className="space-y-4"
               onSubmit={(submitEvent) => {
@@ -251,7 +340,29 @@ export function CashEventsPanel({
                 />
               </div>
 
+              {disabledTransitionReason && disabledTransitionReasonId ? (
+                <p
+                  id={disabledTransitionReasonId}
+                  role="note"
+                  className="text-sm text-charcoal-600"
+                >
+                  {disabledTransitionReason}
+                </p>
+              ) : null}
+
               <div className="flex items-center justify-end gap-2 border-t border-beige-200 pt-4">
+                {showApprove ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleApprove}
+                    disabled={!canApprove}
+                    aria-describedby={disabledTransitionReasonId}
+                  >
+                    {approveMutation.isPending ? 'Approving...' : 'Approve'}
+                  </Button>
+                ) : null}
                 <Button
                   type="button"
                   variant="outline"
@@ -266,15 +377,66 @@ export function CashEventsPanel({
                 </Button>
               </div>
             </form>
-          ) : (
-            <dl className="space-y-3 text-sm">
-              <ReadOnlyRow label="Type" value={selectedEvent.eventType} />
-              <ReadOnlyRow label="Status" value={selectedEvent.status} />
-              <ReadOnlyRow label="Amount" value={selectedEvent.amount} />
-              <ReadOnlyRow label="Event date" value={formatEventDate(selectedEvent.eventDate)} />
-              <ReadOnlyRow label="Description" value={selectedEvent.description ?? '—'} />
-            </dl>
-          )}
+          ) : effectiveEvent ? (
+            <>
+              <dl className="space-y-3 text-sm">
+                <ReadOnlyRow label="Type" value={effectiveEvent.eventType} />
+                <ReadOnlyRow label="Status" value={effectiveStatus ?? effectiveEvent.status} />
+                <ReadOnlyRow label="Amount" value={effectiveEvent.amount} />
+                <ReadOnlyRow label="Event date" value={formatEventDate(effectiveEvent.eventDate)} />
+                <ReadOnlyRow label="Description" value={effectiveEvent.description ?? '—'} />
+                {optionalAuditValue(effectiveEvent, 'lockedAt') ? (
+                  <ReadOnlyRow
+                    label="Locked at"
+                    value={optionalAuditValue(effectiveEvent, 'lockedAt') ?? ''}
+                  />
+                ) : null}
+                {optionalAuditValue(effectiveEvent, 'lockedBy') ? (
+                  <ReadOnlyRow
+                    label="Locked by"
+                    value={optionalAuditValue(effectiveEvent, 'lockedBy') ?? ''}
+                  />
+                ) : null}
+              </dl>
+
+              {disabledTransitionReason && disabledTransitionReasonId ? (
+                <p
+                  id={disabledTransitionReasonId}
+                  role="note"
+                  className="text-sm text-charcoal-600"
+                >
+                  {disabledTransitionReason}
+                </p>
+              ) : null}
+
+              {showApprove || showLock ? (
+                <div className="flex items-center justify-end gap-2 border-t border-beige-200 pt-4">
+                  {showApprove ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={handleApprove}
+                      disabled={!canApprove}
+                      aria-describedby={disabledTransitionReasonId}
+                    >
+                      {approveMutation.isPending ? 'Approving...' : 'Approve'}
+                    </Button>
+                  ) : null}
+                  {showLock ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={handleLock}
+                      disabled={!canLock}
+                      aria-describedby={disabledTransitionReasonId}
+                    >
+                      {lockMutation.isPending ? 'Locking...' : 'Lock'}
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+            </>
+          ) : null}
         </div>
       )}
     </WorkPanel>

--- a/client/src/hooks/useCashFlowEvents.ts
+++ b/client/src/hooks/useCashFlowEvents.ts
@@ -111,3 +111,69 @@ export function useUpdateCashFlowEvent(
     },
   });
 }
+
+export interface TransitionCashFlowEventVariables {
+  eventId: number;
+  /** Opaque etag of the loaded row; echoed verbatim as If-Match. */
+  etag: string;
+}
+
+function useTransitionCashFlowEvent(
+  fundId: string | undefined,
+  action: 'approve' | 'lock'
+): UseMutationResult<
+  CashFlowEventResponse,
+  CashFlowEventMutationError,
+  TransitionCashFlowEventVariables
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    CashFlowEventResponse,
+    CashFlowEventMutationError,
+    TransitionCashFlowEventVariables
+  >({
+    mutationFn: async ({ eventId, etag }) => {
+      if (!fundId) {
+        throw { status: 0, message: 'No fund ID available' } as CashFlowEventMutationError;
+      }
+      try {
+        return await apiRequest<CashFlowEventResponse>(
+          'POST',
+          `/api/funds/${fundId}/cash-flow-events/${eventId}/${action}`,
+          undefined,
+          { headers: { 'If-Match': etag } }
+        );
+      } catch (error: unknown) {
+        const err = error as { status?: number; message?: string };
+        throw {
+          status: err.status ?? 500,
+          message: err.message ?? `Failed to ${action} cash flow event`,
+        } as CashFlowEventMutationError;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cash-flow-events', fundId] });
+    },
+  });
+}
+
+export function useApproveCashFlowEvent(
+  fundId: string | undefined
+): UseMutationResult<
+  CashFlowEventResponse,
+  CashFlowEventMutationError,
+  TransitionCashFlowEventVariables
+> {
+  return useTransitionCashFlowEvent(fundId, 'approve');
+}
+
+export function useLockCashFlowEvent(
+  fundId: string | undefined
+): UseMutationResult<
+  CashFlowEventResponse,
+  CashFlowEventMutationError,
+  TransitionCashFlowEventVariables
+> {
+  return useTransitionCashFlowEvent(fundId, 'lock');
+}

--- a/tests/unit/components/dashboard/CashEventsPanel.test.tsx
+++ b/tests/unit/components/dashboard/CashEventsPanel.test.tsx
@@ -2,15 +2,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { mockUseCashFlowEvents, mockUseUpdate, mockUseFlag, mockMutate, mockRefetch } = vi.hoisted(
-  () => ({
-    mockUseCashFlowEvents: vi.fn(),
-    mockUseUpdate: vi.fn(),
-    mockUseFlag: vi.fn(),
-    mockMutate: vi.fn(),
-    mockRefetch: vi.fn(),
-  })
-);
+const {
+  mockUseCashFlowEvents,
+  mockUseUpdate,
+  mockUseApprove,
+  mockUseLock,
+  mockUseFlag,
+  mockMutate,
+  mockApprove,
+  mockLock,
+  mockRefetch,
+} = vi.hoisted(() => ({
+  mockUseCashFlowEvents: vi.fn(),
+  mockUseUpdate: vi.fn(),
+  mockUseApprove: vi.fn(),
+  mockUseLock: vi.fn(),
+  mockUseFlag: vi.fn(),
+  mockMutate: vi.fn(),
+  mockApprove: vi.fn(),
+  mockLock: vi.fn(),
+  mockRefetch: vi.fn(),
+}));
 
 vi.mock('@/shared/useFlags', () => ({ useFlag: (key: string) => mockUseFlag(key) }));
 
@@ -21,6 +33,8 @@ vi.mock('@/hooks/useCashFlowEvents', async (importActual) => {
     useCashFlowEvents: (fundId: string | undefined, options?: { enabled?: boolean }) =>
       mockUseCashFlowEvents(fundId, options),
     useUpdateCashFlowEvent: (fundId: string | undefined) => mockUseUpdate(fundId),
+    useApproveCashFlowEvent: (fundId: string | undefined) => mockUseApprove(fundId),
+    useLockCashFlowEvent: (fundId: string | undefined) => mockUseLock(fundId),
   };
 });
 
@@ -60,6 +74,12 @@ beforeEach(() => {
   mockRefetch.mockReset();
   mockUseUpdate.mockReset();
   mockUseUpdate.mockReturnValue({ mutate: mockMutate, isPending: false });
+  mockUseApprove.mockReset();
+  mockUseApprove.mockReturnValue({ mutate: mockApprove, isPending: false });
+  mockUseLock.mockReset();
+  mockUseLock.mockReturnValue({ mutate: mockLock, isPending: false });
+  mockApprove.mockReset();
+  mockLock.mockReset();
 });
 
 describe('CashEventsPanel', () => {
@@ -194,5 +214,90 @@ describe('CashEventsPanel', () => {
     );
     expect(screen.getByRole('alert')).toHaveTextContent(/changed since you opened it/i);
     expect(mockRefetch).toHaveBeenCalled();
+  });
+});
+
+describe('CashEventsPanel lifecycle controls', () => {
+  const lockedEvent = { ...draftEvent, id: 12, status: 'locked', etag: 'W/"v3"' };
+  const noEtagDraft = { ...draftEvent, etag: '' };
+  const approvedReturn = { ...draftEvent, status: 'approved', etag: 'W/"v2"' };
+
+  it('draft shows Save and Approve', () => {
+    mockUseFlag.mockReturnValue(true);
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument();
+  });
+
+  it('approved shows Lock and no Save/Approve', () => {
+    mockUseFlag.mockReturnValue(true);
+    mockUseCashFlowEvents.mockReturnValue({
+      data: [approvedEvent],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '11' }} {...noopProps()} />
+    );
+    expect(screen.getByRole('button', { name: /lock/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /approve/i })).toBeNull();
+  });
+
+  it('locked shows no mutation controls', () => {
+    mockUseFlag.mockReturnValue(true);
+    mockUseCashFlowEvents.mockReturnValue({
+      data: [lockedEvent],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '12' }} {...noopProps()} />
+    );
+    expect(screen.queryByRole('button', { name: /save|approve|lock/i })).toBeNull();
+  });
+
+  it('disables Approve and does not POST when etag is empty', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    mockUseCashFlowEvents.mockReturnValue({
+      data: [noEtagDraft],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    const approve = screen.getByRole('button', { name: /approve/i });
+    expect(approve).toBeDisabled();
+    await user.click(approve).catch(() => {});
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 412 conflict via role=alert on approve', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    mockApprove.mockImplementation((_v, opts) =>
+      opts.onError({ status: 412, message: 'Event has been modified' })
+    );
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    await user.click(screen.getByRole('button', { name: /approve/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/modified|conflict|changed/i);
+  });
+
+  it('after approve success the detail reflects approved and drops draft controls', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    mockApprove.mockImplementation((_v, opts) => opts.onSuccess(approvedReturn));
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+    await user.click(screen.getByRole('button', { name: /approve/i }));
+    expect(screen.getByRole('button', { name: /lock/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
   });
 });

--- a/tests/unit/hooks/useCashFlowEvents.test.tsx
+++ b/tests/unit/hooks/useCashFlowEvents.test.tsx
@@ -6,7 +6,9 @@ import {
   buildLpCapitalCallPatch,
   formFromEvent,
   isCashEventFormValid,
+  useApproveCashFlowEvent,
   useCashFlowEvents,
+  useLockCashFlowEvent,
   useUpdateCashFlowEvent,
 } from '@/hooks/useCashFlowEvents';
 import type { CashFlowEventResponse } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
@@ -176,5 +178,59 @@ describe('useUpdateCashFlowEvent (mutation)', () => {
     await expect(
       result.current.mutateAsync({ eventId: 10, etag: 'W/"abc"', patch: { amount: '5' } })
     ).rejects.toMatchObject({ status: 412, message: 'Event has been modified' });
+  });
+});
+
+describe('useApproveCashFlowEvent / useLockCashFlowEvent', () => {
+  it('approve POSTs bodyless to the approve URL with If-Match and invalidates', async () => {
+    mockFetchJson({ ...sampleEvent, status: 'approved', etag: 'W/"v2"' });
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useApproveCashFlowEvent('1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await result.current.mutateAsync({ eventId: 10, etag: 'W/"v1"' });
+
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/funds/1/cash-flow-events/10/approve');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+    expect(init.headers).toEqual(expect.objectContaining({ 'If-Match': 'W/"v1"' }));
+    expect(init.headers).not.toHaveProperty('Idempotency-Key');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['cash-flow-events', '1'] });
+  });
+
+  it('lock POSTs to the lock URL', async () => {
+    mockFetchJson({ ...sampleEvent, status: 'locked', etag: 'W/"v3"' });
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useLockCashFlowEvent('1'), {
+      wrapper: createWrapper(client),
+    });
+    await result.current.mutateAsync({ eventId: 10, etag: 'W/"v2"' });
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/funds/1/cash-flow-events/10/lock');
+    expect(init.method).toBe('POST');
+  });
+
+  it('preserves server status + message on 412 conflict', async () => {
+    mockFetchJson({ message: 'Event has been modified' }, false, 412);
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useApproveCashFlowEvent('1'), {
+      wrapper: createWrapper(client),
+    });
+    await expect(
+      result.current.mutateAsync({ eventId: 10, etag: 'W/"stale"' })
+    ).rejects.toMatchObject({ status: 412, message: expect.stringMatching(/modified/i) });
+  });
+
+  it('does not POST when fundId is missing', async () => {
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useApproveCashFlowEvent(undefined), {
+      wrapper: createWrapper(client),
+    });
+    await expect(result.current.mutateAsync({ eventId: 10, etag: 'W/"v1"' })).rejects.toMatchObject(
+      { status: 0 }
+    );
   });
 });


### PR DESCRIPTION
## L1 — Cash Event Lifecycle UI

Completes the `lp_capital_call` operating-object lifecycle in the WorkPanel, on top of the existing server contract + `If-Match` concurrency model. Behind `enable_cash_event_edit` (existing flag; no new flag).

### Changes
- `useApproveCashFlowEvent` / `useLockCashFlowEvent` hooks (+ internal `useTransitionCashFlowEvent`): bodyless `POST /api/funds/:fundId/cash-flow-events/:eventId/{approve,lock}` with `If-Match`, invalidate `['cash-flow-events', fundId]`.
- `CashEventsPanel` status-specific controls: draft → Save + Approve, approved → Lock, locked → terminal read-only.

### Correctness
- **No `Idempotency-Key`** on transitions (preconditioned lifecycle, not create-idempotent) — asserted by a hook test.
- **Post-transition state**: reflects the returned row immediately (form drops after approve, Lock drops after lock); falls back to read-only pending + refetch if no row returned.
- Disabled Approve/Lock on empty `etag` (no POST) or while pending; reason exposed via `aria-describedby`/`role=note`.
- 428/409/412 surfaced via existing `role=alert`; no fabricated approve-audit fields (`lockedAt`/`lockedBy` shown only if returned).

### Verification
- client 36/36 (panel + hooks), server regression 57/57 (cash-flow-events routes/services — client built to the real contract)
- `npm run check` 0 errors, `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)