### PR TITLE
feat(task): list hook + readiness audit correction (L2a)

### DIFF
--- a/client/src/hooks/useTasks.ts
+++ b/client/src/hooks/useTasks.ts
@@ -1,0 +1,25 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type {
+  TaskListResponse,
+  TaskResponse,
+} from '@shared/contracts/operating-objects/task.contract';
+import { apiRequest } from '@/lib/queryClient';
+
+export function useTasks(fundId: string | undefined): UseQueryResult<TaskResponse[], Error> {
+  return useQuery<TaskResponse[], Error>({
+    queryKey: ['tasks', fundId],
+    queryFn: async () => {
+      if (!fundId) {
+        throw new Error('No fund ID available');
+      }
+
+      const response = await apiRequest<TaskListResponse>('GET', `/api/funds/${fundId}/tasks`);
+      return response.data;
+    },
+    enabled: Boolean(fundId),
+    staleTime: 60_000,
+    gcTime: 600_000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/docs/design/audits/server-object-readiness.md
+++ b/docs/design/audits/server-object-readiness.md
@@ -2,7 +2,7 @@
 status: ACTIVE
 audience: both
 last_updated: 2026-06-15
-owner: "Platform Team"
+owner: 'Platform Team'
 review_cadence: P90D
 categories: [design, audits, backend-readiness, persistence]
 keywords: [server-object, readiness, persistence, lp-snapshot, cash-event]
@@ -24,13 +24,13 @@ routes (`server/routes/**`), schema + migrations (`shared/schema*`,
 
 ## Readiness matrix
 
-| Object          | Server route                             | DB table / schema                 | Migration | Worker / queue            | Verdict             |
-| --------------- | ---------------------------------------- | --------------------------------- | --------- | ------------------------- | ------------------- |
-| **cash_event**  | YES — `server/routes/cashflow.ts` (CRUD) | YES — `cashFlowEvents`            | YES       | YES — capital-call worker | **HAS_PERSISTENCE** |
-| **lp_snapshot** | YES — `server/routes/shares.ts`          | YES — `shares` + `shareSnapshots` | YES       | YES — report-generation   | **HAS_PERSISTENCE** |
-| **task**        | NONE                                     | NONE                              | NONE      | NONE                      | **NONE**            |
-| **assumption**  | NONE                                     | NONE                              | NONE      | NONE                      | **NONE**            |
-| **comment**     | NONE                                     | NONE                              | NONE      | NONE                      | **NONE**            |
+| Object          | Server route                                                  | DB table / schema                                    | Migration                                                            | Worker / queue                      | Verdict             |
+| --------------- | ------------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------- | ------------------- |
+| **cash_event**  | YES — `server/routes/cashflow.ts` (CRUD)                      | YES — `cashFlowEvents`                               | YES                                                                  | YES — capital-call worker           | **HAS_PERSISTENCE** |
+| **lp_snapshot** | YES — `server/routes/shares.ts`                               | YES — `shares` + `shareSnapshots`                    | YES                                                                  | YES — report-generation             | **HAS_PERSISTENCE** |
+| **task**        | YES — `server/routes/operating-object-tasks.ts` (create/list) | YES — `tasks` (`shared/schema/operating-objects.ts`) | YES (PR-T1 — `server/migrations/20260616_operating_object_tasks_v1`) | N/A (none required for create/list) | **HAS_PERSISTENCE** |
+| **assumption**  | NONE                                                          | NONE                                                 | NONE                                                                 | NONE                                | **NONE**            |
+| **comment**     | NONE                                                          | NONE                                                 | NONE                                                                 | NONE                                | **NONE**            |
 
 ---
 

--- a/tests/unit/hooks/useTasks.test.tsx
+++ b/tests/unit/hooks/useTasks.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useTasks } from '@/hooks/useTasks';
+import {
+  TaskCreateSchema,
+  TaskResponseSchema,
+} from '@shared/contracts/operating-objects/task.contract';
+
+function createWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+function mockFetchJson(payload: unknown, ok = true, status = ok ? 200 : 500) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status,
+      statusText: ok ? 'OK' : 'Error',
+      text: vi.fn().mockResolvedValue(JSON.stringify(payload)),
+      json: vi.fn().mockResolvedValue(payload),
+    })
+  );
+}
+const sampleTask = {
+  id: 1,
+  fundId: 7,
+  title: 'Follow up',
+  status: 'open',
+  ownerId: null,
+  dueDate: null,
+  description: null,
+  createdAt: '2026-06-17T00:00:00.000Z',
+  updatedAt: '2026-06-17T00:00:00.000Z',
+  etag: 'W/"t1"',
+};
+
+describe('useTasks', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('GETs the fund-scoped tasks URL and returns data[]', async () => {
+    mockFetchJson({ data: [sampleTask] });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useTasks('7'), { wrapper: createWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/funds/7/tasks',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(result.current.data).toEqual([sampleTask]);
+  });
+
+  it('is disabled when fundId is missing (no fetch)', () => {
+    mockFetchJson({ data: [] });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useTasks(undefined), { wrapper: createWrapper(client) });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('create contract requires fundId and rejects client-owned fields', () => {
+    expect(TaskCreateSchema.safeParse({ title: 'x' }).success).toBe(false); // missing fundId
+    expect(TaskCreateSchema.safeParse({ fundId: 7, title: 'x', status: 'open' }).success).toBe(
+      false
+    ); // strict: no status
+    expect(TaskCreateSchema.safeParse({ fundId: 7, title: 'x' }).success).toBe(true);
+  });
+
+  it('response contract requires non-empty etag and forbids createdBy', () => {
+    expect(TaskResponseSchema.safeParse({ ...sampleTask, etag: '' }).success).toBe(false);
+    expect(TaskResponseSchema.safeParse({ ...sampleTask, createdBy: 5 }).success).toBe(false); // strict
+    expect(TaskResponseSchema.safeParse(sampleTask).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## L2a — Task Readiness + List Hook

Closes the gap between the landed backend-first `task` object (PR-T1/T2) and client usage. **No create mutation** (deferred to L2b, gated on task-create idempotency).

### Changes
- `useTasks(fundId)`: read-only TanStack Query list hook — `GET /api/funds/:fundId/tasks`, key `['tasks', fundId]`, `enabled: Boolean(fundId)`, returns `response.data`.
- `server-object-readiness.md`: flips the stale `task` row `NONE` → `HAS_PERSISTENCE` (route + `tasks` table + PR-T1 migration `20260616_operating_object_tasks_v1`). `assumption`/`comment` left `NONE`.

### Verification
- 64/64 across task suites (4 new `useTasks` + 24 contract + 11 service + 25 route — existing stayed green)
- create/response contract assertions verified against the real `.strict()` schemas (fundId required, no client status, non-empty etag, no `createdBy` leak)
- `npm run check` 0 errors, `npm run docs:routing:check` PASS, `npm run lint` pass

### Next (recorded, not in this PR)
Fork decision = **L3a** (investment-event persistence ADR) per strategy R1 — task UI (L2b) is not on the product spine and is not the immediate blocking dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)