### PR TITLE
fix: prevent dirty cash-event drafts from approving stale values

### DIFF
--- a/client/src/components/dashboard/CashEventsPanel.tsx
+++ b/client/src/components/dashboard/CashEventsPanel.tsx
@@ -114,23 +114,25 @@ export function CashEventsPanel({
     effectiveStatus === 'draft' &&
     effectiveEtag != null &&
     !isTransitionRefreshPending;
+  const patch = loadedEvent && form ? buildLpCapitalCallPatch(loadedEvent, form) : {};
+  const isDirty = Object.keys(patch).length > 0;
   const showApprove =
     isLifecycleTarget && effectiveStatus === 'draft' && !isTransitionRefreshPending;
   const showLock =
     isLifecycleTarget && effectiveStatus === 'approved' && !isTransitionRefreshPending;
-  const canApprove = showApprove && effectiveEtag != null && !approveMutation.isPending;
+  const canApprove = showApprove && effectiveEtag != null && !isDirty && !approveMutation.isPending;
   const canLock = showLock && effectiveEtag != null && !lockMutation.isPending;
   const disabledTransitionReason =
     (showApprove || showLock) && effectiveEtag == null
       ? "This record can't be advanced yet."
-      : null;
+      : showApprove && isDirty
+        ? 'Save or cancel unsaved changes before approving.'
+        : null;
   const disabledTransitionReasonId =
     disabledTransitionReason && effectiveEvent
       ? `cash-event-${effectiveEvent.id}-transition-reason`
       : undefined;
 
-  const patch = loadedEvent && form ? buildLpCapitalCallPatch(loadedEvent, form) : {};
-  const isDirty = Object.keys(patch).length > 0;
   const canSave =
     isEditable && isDirty && form != null && isCashEventFormValid(form) && !mutation.isPending;
   const panelDescription =

--- a/tests/unit/components/dashboard/CashEventsPanel.test.tsx
+++ b/tests/unit/components/dashboard/CashEventsPanel.test.tsx
@@ -276,6 +276,37 @@ describe('CashEventsPanel lifecycle controls', () => {
     expect(mockApprove).not.toHaveBeenCalled();
   });
 
+  it('disables Approve and does not POST while draft edits are unsaved', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+
+    await user.clear(screen.getByLabelText('Amount'));
+    await user.type(screen.getByLabelText('Amount'), '2000000');
+
+    const approve = screen.getByRole('button', { name: /approve/i });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    expect(approve).toBeDisabled();
+    await user.click(approve).catch(() => {});
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+
+  it('re-enables Approve after dirty draft edits are cancelled', async () => {
+    const user = userEvent.setup();
+    mockUseFlag.mockReturnValue(true);
+    render(
+      <CashEventsPanel fundId="1" state={{ panel: 'cash-events', object: '10' }} {...noopProps()} />
+    );
+
+    await user.clear(screen.getByLabelText('Amount'));
+    await user.type(screen.getByLabelText('Amount'), '2000000');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeEnabled();
+  });
+
   it('surfaces a 412 conflict via role=alert on approve', async () => {
     const user = userEvent.setup();
     mockUseFlag.mockReturnValue(true);


### PR DESCRIPTION
Approving a draft event only sends the loaded etag, so pending form edits could be dropped while stale server values advanced to approved. The panel now treats unsaved edits as a transition blocker and keeps approval available again after the user saves or cancels those edits.

Constraint: Approval transition payload does not include the pending edit patch

Rejected: Auto-save before approve | broader flow change with more failure states

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Do not allow lifecycle transitions from an editable draft while buildLpCapitalCallPatch reports unsaved changes

Tested: npx cross-env TZ=UTC vitest run tests/unit/components/dashboard/CashEventsPanel.test.tsx --project=client

Tested: git diff --check -- client/src/components/dashboard/CashEventsPanel.tsx tests/unit/components/dashboard/CashEventsPanel.test.tsx