### PR TITLE
fix: secondary-surface production safety (PR-1) — truthful alerts, build-exclude Tear Sheet, opt-in source maps

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -284,6 +284,9 @@ jobs:
         env:
           NODE_ENV: production
 
+      - name: Verify production bundle
+        run: npm run build:verify
+
       - name: Bundle size check
         run: npm run bundle:check || true
 

--- a/client/src/components/reports/reports.tsx
+++ b/client/src/components/reports/reports.tsx
@@ -84,6 +84,14 @@ const REPORT_SURFACES: ReportSurface[] = [
   },
 ];
 
+// Tear Sheets are a DEV-only surface (gated in client/src/pages/reports.tsx). Drop the
+// entry in production so the Reporting Surfaces list does not advertise a tab that is
+// build-excluded and not rendered.
+const SHOW_TEAR_SHEETS = import.meta.env.DEV;
+const VISIBLE_REPORT_SURFACES = REPORT_SURFACES.filter(
+  (surface) => SHOW_TEAR_SHEETS || surface.id !== 'tear-sheets'
+);
+
 function formatMetricLabel(metric: string): string {
   switch (metric) {
     case 'totalValue':
@@ -472,7 +480,7 @@ export default function Reports() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            {REPORT_SURFACES.map((surface, index) => {
+            {VISIBLE_REPORT_SURFACES.map((surface, index) => {
               const Icon = surface.icon;
               const statusVariant =
                 surface.status === 'live'
@@ -532,7 +540,7 @@ export default function Reports() {
                     </div>
                   </div>
 
-                  {index < REPORT_SURFACES.length - 1 && <Separator />}
+                  {index < VISIBLE_REPORT_SURFACES.length - 1 && <Separator />}
                 </div>
               );
             })}

--- a/client/src/lib/variance-alert-summary.ts
+++ b/client/src/lib/variance-alert-summary.ts
@@ -1,0 +1,33 @@
+/**
+ * Truthful alert-summary state for the variance dashboard.
+ *
+ * The page previously used `dashboardData?.data?.summary?.totalActiveAlerts || 0`,
+ * which collapses an API failure (undefined) into a valid-looking `0` and renders
+ * "Stable" / "No active alerts". For an LP/GP-facing surface that is a fabricated
+ * fact. This module makes the distinction explicit so the UI can render LOADING /
+ * FAILED / UNAVAILABLE instead of a fake zero.
+ */
+export type AlertSummaryState =
+  | { state: 'LOADING' }
+  | { state: 'FAILED'; message: string }
+  | { state: 'UNAVAILABLE'; reason: string }
+  | { state: 'LIVE'; count: number };
+
+export interface AlertSummaryInput {
+  isLoading: boolean;
+  isError: boolean;
+  totalActiveAlerts: number | null | undefined;
+}
+
+export function deriveAlertSummaryState(input: AlertSummaryInput): AlertSummaryState {
+  if (input.isLoading) {
+    return { state: 'LOADING' };
+  }
+  if (input.isError) {
+    return { state: 'FAILED', message: 'Unable to load alert summary.' };
+  }
+  if (typeof input.totalActiveAlerts !== 'number' || !Number.isFinite(input.totalActiveAlerts)) {
+    return { state: 'UNAVAILABLE', reason: 'No alert summary available yet.' };
+  }
+  return { state: 'LIVE', count: input.totalActiveAlerts };
+}

--- a/client/src/pages/reports.tsx
+++ b/client/src/pages/reports.tsx
@@ -2,8 +2,14 @@ import { lazy, Suspense } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import ReportsComponent from '@/components/reports/reports';
 
-// Lazy-load PDF generation to reduce initial bundle size (saves ~430 KB gzipped)
-const TearSheetDashboard = lazy(() => import('@/components/reports/tear-sheet-dashboard'));
+// Tear Sheets are mock-backed and ship a client-side PDF export that fabricates fund
+// facts. Build-exclude the entire dashboard (and its chunk) from production:
+// `import.meta.env.DEV` is statically replaced with `false` in production builds, so the
+// dynamic import in the dead branch is dropped by Rollup and no chunk is emitted.
+const SHOW_TEAR_SHEETS = import.meta.env.DEV;
+const TearSheetDashboard = SHOW_TEAR_SHEETS
+  ? lazy(() => import('@/components/reports/tear-sheet-dashboard'))
+  : null;
 
 export default function Reports() {
   return (
@@ -11,33 +17,37 @@ export default function Reports() {
       <div className="p-6">
         <div className="mb-6">
           <h1 className="text-2xl font-bold text-pov-charcoal">Reports & Documentation</h1>
-          <p className="text-charcoal-600 mt-1">Generate comprehensive fund reports and tear sheets</p>
+          <p className="text-charcoal-600 mt-1">
+            Generate comprehensive fund reports and tear sheets
+          </p>
         </div>
 
         <Tabs defaultValue="reports" className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className={`grid w-full ${SHOW_TEAR_SHEETS ? 'grid-cols-2' : 'grid-cols-1'}`}>
             <TabsTrigger value="reports">Fund Reports</TabsTrigger>
-            <TabsTrigger value="tear-sheets">Tear Sheets</TabsTrigger>
+            {SHOW_TEAR_SHEETS && <TabsTrigger value="tear-sheets">Tear Sheets</TabsTrigger>}
           </TabsList>
 
           <TabsContent value="reports" className="mt-6">
             <ReportsComponent />
           </TabsContent>
 
-          <TabsContent value="tear-sheets" className="mt-6">
-            <Suspense
-              fallback={
-                <div className="flex items-center justify-center p-12" role="status">
-                  <div className="text-center">
-                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pov-charcoal mx-auto mb-4"></div>
-                    <p className="text-charcoal-600">Preparing tear sheet workspace...</p>
+          {SHOW_TEAR_SHEETS && TearSheetDashboard && (
+            <TabsContent value="tear-sheets" className="mt-6">
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center p-12" role="status">
+                    <div className="text-center">
+                      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pov-charcoal mx-auto mb-4"></div>
+                      <p className="text-charcoal-600">Preparing tear sheet workspace...</p>
+                    </div>
                   </div>
-                </div>
-              }
-            >
-              <TearSheetDashboard />
-            </Suspense>
-          </TabsContent>
+                }
+              >
+                <TearSheetDashboard />
+              </Suspense>
+            </TabsContent>
+          )}
         </Tabs>
       </div>
     </div>

--- a/client/src/pages/variance-tracking.tsx
+++ b/client/src/pages/variance-tracking.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
 import { useFundContext } from '@/contexts/FundContext';
 import { computeRemainingCapital } from '@/lib/variance-remaining-capital';
+import { deriveAlertSummaryState } from '@/lib/variance-alert-summary';
 import {
   useVarianceDashboard,
   useBaselines,
@@ -275,40 +276,85 @@ export default function VarianceTrackingPage() {
         )[0]
       : null;
   const hasReports = reports.length > 0;
-  const totalActiveAlerts = dashboardData?.data?.summary?.totalActiveAlerts || 0;
+  const alertSummary = deriveAlertSummaryState({
+    isLoading: dashboardLoading,
+    isError: Boolean(dashboardError),
+    totalActiveAlerts: dashboardData?.data?.summary?.totalActiveAlerts,
+  });
+  const totalActiveAlerts = alertSummary.state === 'LIVE' ? alertSummary.count : 0;
   const lastAnalysisDate = dashboardData?.data?.summary?.lastAnalysisDate;
   const alertCounts =
     dashboardData?.data?.alertsBySeverity ?? dashboardData?.data?.alertsByseverity;
   const isAnalysisRunning = performAnalysisMutation.isPending;
-  const analysisStatus = isAnalysisRunning
-    ? {
-        value: 'Running',
-        description: 'Variance analysis is in progress',
-        badgeText: 'In progress',
-        badgeVariant: 'secondary' as const,
-      }
-    : !lastAnalysisDate
+  const analysisStatus =
+    alertSummary.state === 'LOADING'
       ? {
-          value: 'Not Run',
-          description: 'Run analysis to generate the first report',
-          badgeText: 'No report',
+          value: 'Loading',
+          description: 'Loading alert summary',
+          badgeText: 'Loading',
           badgeVariant: 'secondary' as const,
         }
-      : totalActiveAlerts > 0
+      : alertSummary.state === 'FAILED'
         ? {
-            value: 'Attention',
-            description: 'Active alerts need review',
-            badgeText: `${totalActiveAlerts} active`,
+            value: 'Unavailable',
+            description: 'Alert summary failed to load',
+            badgeText: 'Data error',
             badgeVariant: 'destructive' as const,
           }
-        : {
-            value: 'Stable',
-            description: hasReports
-              ? 'Driven by latest variance report'
-              : 'Most recent analysis completed',
-            badgeText: 'No active alerts',
-            badgeVariant: 'default' as const,
-          };
+        : alertSummary.state === 'UNAVAILABLE'
+          ? {
+              value: 'Unavailable',
+              description: 'No alert summary available yet',
+              badgeText: 'No data',
+              badgeVariant: 'secondary' as const,
+            }
+          : isAnalysisRunning
+            ? {
+                value: 'Running',
+                description: 'Variance analysis is in progress',
+                badgeText: 'In progress',
+                badgeVariant: 'secondary' as const,
+              }
+            : !lastAnalysisDate
+              ? {
+                  value: 'Not Run',
+                  description: 'Run analysis to generate the first report',
+                  badgeText: 'No report',
+                  badgeVariant: 'secondary' as const,
+                }
+              : totalActiveAlerts > 0
+                ? {
+                    value: 'Attention',
+                    description: 'Active alerts need review',
+                    badgeText: `${totalActiveAlerts} active`,
+                    badgeVariant: 'destructive' as const,
+                  }
+                : {
+                    value: 'Stable',
+                    description: hasReports
+                      ? 'Driven by latest variance report'
+                      : 'Most recent analysis completed',
+                    badgeText: 'No active alerts',
+                    badgeVariant: 'default' as const,
+                  };
+
+  const activeAlertsValue: string | number =
+    alertSummary.state === 'LIVE'
+      ? alertSummary.count
+      : alertSummary.state === 'LOADING'
+        ? '…'
+        : '—';
+  const activeAlertsBadge =
+    alertSummary.state === 'LIVE'
+      ? {
+          text: `${alertCounts?.critical || 0} Critical`,
+          variant: ((alertCounts?.critical || 0) > 0 ? 'destructive' : 'secondary') as
+            | 'destructive'
+            | 'secondary',
+        }
+      : alertSummary.state === 'FAILED'
+        ? { text: 'Unavailable', variant: 'destructive' as const }
+        : { text: 'No data', variant: 'secondary' as const };
 
   // Handle baseline creation
   const handleCreateBaseline = async () => {
@@ -659,12 +705,9 @@ export default function VarianceTrackingPage() {
       <StatCardGrid>
         <StatCard
           title="Active Alerts"
-          value={dashboardData?.data?.summary?.totalActiveAlerts || 0}
+          value={activeAlertsValue}
           icon={AlertTriangle}
-          badge={{
-            text: `${alertCounts?.critical || 0} Critical`,
-            variant: (alertCounts?.critical || 0) > 0 ? 'destructive' : 'secondary',
-          }}
+          badge={activeAlertsBadge}
         />
         <StatCard
           title="Total Baselines"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:workers": "node scripts/build-workers.mjs",
     "build:prod": "npm run build:web && npm run build:server",
     "build": "npm run build:prod",
+    "build:verify": "node scripts/check-prod-bundle.mjs",
     "preview": "npx vite preview",
     "postbuild": "node scripts/verify-build.mjs",
     "vercel-build": "npm run clean:spa-dist && npx vite build",

--- a/scripts/check-prod-bundle.mjs
+++ b/scripts/check-prod-bundle.mjs
@@ -1,0 +1,79 @@
+// Production-bundle safety verifier.
+//
+// Asserts that quarantined source modules are NOT present in the built client
+// manifest, and that no source-map files were emitted unless explicitly enabled.
+// Reusable: extend QUARANTINED_MODULES as more surfaces are build-excluded.
+//
+// Run after `npm run build` via `npm run build:verify`.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST_DIR = resolve(process.cwd(), 'dist/public');
+const MANIFEST_PATH = join(DIST_DIR, '.vite/manifest.json');
+
+// Source-path substrings that must never appear in a production build manifest.
+export const QUARANTINED_MODULES = ['tear-sheet-dashboard'];
+
+/** Pure: return manifest entries whose key/src/file matches a forbidden substring. */
+export function findForbiddenModules(manifest, forbiddenSubstrings) {
+  const hits = [];
+  for (const key of Object.keys(manifest)) {
+    const entry = manifest[key] ?? {};
+    const haystacks = [key, entry.src ?? '', entry.file ?? ''];
+    for (const needle of forbiddenSubstrings) {
+      if (haystacks.some((h) => String(h).includes(needle))) {
+        hits.push({ needle, key, file: entry.file ?? '' });
+      }
+    }
+  }
+  return hits;
+}
+
+/** Pure: return the subset of file paths that are source maps. */
+export function findSourceMaps(filePaths) {
+  return filePaths.filter((p) => p.endsWith('.map'));
+}
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+function main() {
+  if (!existsSync(MANIFEST_PATH)) {
+    console.error(
+      `[check-prod-bundle] manifest not found at ${MANIFEST_PATH}. Run "npm run build" first.`
+    );
+    process.exit(1);
+  }
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+  const moduleHits = findForbiddenModules(manifest, QUARANTINED_MODULES);
+
+  const allowSourceMaps = process.env['VITE_SOURCEMAP'] === 'true';
+  const sourceMaps = allowSourceMaps ? [] : findSourceMaps(walk(DIST_DIR));
+
+  let failed = false;
+  if (moduleHits.length > 0) {
+    failed = true;
+    console.error('[check-prod-bundle] FAIL: quarantined modules present in production bundle:');
+    for (const hit of moduleHits) console.error(`  - "${hit.needle}" via ${hit.key} -> ${hit.file}`);
+  }
+  if (sourceMaps.length > 0) {
+    failed = true;
+    console.error('[check-prod-bundle] FAIL: source maps emitted without VITE_SOURCEMAP=true:');
+    for (const map of sourceMaps) console.error(`  - ${map}`);
+  }
+  if (failed) process.exit(1);
+  console.log('[check-prod-bundle] OK: no quarantined modules or stray source maps.');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main();
+}

--- a/tests/unit/lib/variance-alert-summary.test.ts
+++ b/tests/unit/lib/variance-alert-summary.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { deriveAlertSummaryState } from '@/lib/variance-alert-summary';
+
+describe('deriveAlertSummaryState', () => {
+  it('reports LOADING while the query is in flight', () => {
+    expect(
+      deriveAlertSummaryState({ isLoading: true, isError: false, totalActiveAlerts: undefined })
+    ).toEqual({ state: 'LOADING' });
+  });
+
+  it('reports FAILED on query error instead of a fake zero', () => {
+    expect(
+      deriveAlertSummaryState({ isLoading: false, isError: true, totalActiveAlerts: undefined })
+    ).toEqual({ state: 'FAILED', message: 'Unable to load alert summary.' });
+  });
+
+  it('reports UNAVAILABLE when the count is missing but there is no error', () => {
+    expect(
+      deriveAlertSummaryState({ isLoading: false, isError: false, totalActiveAlerts: undefined })
+    ).toEqual({ state: 'UNAVAILABLE', reason: 'No alert summary available yet.' });
+  });
+
+  it('preserves a real zero as a LIVE value (not collapsed away)', () => {
+    expect(
+      deriveAlertSummaryState({ isLoading: false, isError: false, totalActiveAlerts: 0 })
+    ).toEqual({ state: 'LIVE', count: 0 });
+  });
+
+  it('returns the live count when present', () => {
+    expect(
+      deriveAlertSummaryState({ isLoading: false, isError: false, totalActiveAlerts: 3 })
+    ).toEqual({ state: 'LIVE', count: 3 });
+  });
+});

--- a/tests/unit/scripts/check-prod-bundle.test.mjs
+++ b/tests/unit/scripts/check-prod-bundle.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { findForbiddenModules, findSourceMaps } from '../../../scripts/check-prod-bundle.mjs';
+
+describe('findForbiddenModules', () => {
+  it('flags a manifest entry whose source path matches a forbidden substring', () => {
+    const manifest = {
+      'client/src/components/reports/tear-sheet-dashboard.tsx': {
+        file: 'assets/tear-sheet-dashboard-abc123.js',
+        src: 'client/src/components/reports/tear-sheet-dashboard.tsx',
+        isDynamicEntry: true,
+      },
+    };
+    const hits = findForbiddenModules(manifest, ['tear-sheet-dashboard']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].needle).toBe('tear-sheet-dashboard');
+  });
+
+  it('returns no hits when the forbidden module is absent', () => {
+    const manifest = {
+      'client/src/pages/reports.tsx': {
+        file: 'assets/reports-def456.js',
+        src: 'client/src/pages/reports.tsx',
+      },
+    };
+    expect(findForbiddenModules(manifest, ['tear-sheet-dashboard'])).toEqual([]);
+  });
+});
+
+describe('findSourceMaps', () => {
+  it('returns only .map files', () => {
+    expect(findSourceMaps(['a.js', 'a.js.map', 'b.css', 'b.css.map'])).toEqual([
+      'a.js.map',
+      'b.css.map',
+    ]);
+  });
+
+  it('returns empty when no maps present', () => {
+    expect(findSourceMaps(['a.js', 'b.css'])).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -342,7 +342,7 @@ export default defineConfig(({ mode }: { mode: string }) => {
     build: {
       outDir: path.resolve(import.meta.dirname, 'dist/public'),
       emptyOutDir: true,
-      sourcemap: process.env['VITE_SOURCEMAP'] === 'true' ? true : true, // Always enable source maps for profiling (keeping environment option)
+      sourcemap: process.env['VITE_SOURCEMAP'] === 'true', // Off by default in production; opt in with VITE_SOURCEMAP=true. Avoids publishing maps that ease extraction of source/mock literals.
       minify: 'esbuild',
       target: 'es2020', // More compatible target for production
       cssMinify: 'lightningcss',


### PR DESCRIPTION
## Secondary-Surface Production Safety (PR-1 / P0A)

Stops the variance dashboard and the Reports surface from externalizing fabricated
facts in production. Three independent P0A truthfulness fixes plus one reusable
build-verification primitive. Scope is strictly PR-1 — no route-governance, MOIC,
ADR-hygiene, or branding changes (deferred to Plans B–E).

### Changes (5 commits)

1. **`fix(variance)` — truthful Active Alerts state.** New framework-free
   `client/src/lib/variance-alert-summary.ts` (`deriveAlertSummaryState`) replaces
   `dashboardData?.data?.summary?.totalActiveAlerts || 0`, which collapsed an API
   failure (`undefined`) into a fake `0 / Stable`. The dashboard now renders
   LOADING / FAILED / UNAVAILABLE distinctly, and preserves a *real* `0` as LIVE.
   Unit-tested (5 tests, node project).
2. **`test(build)` — reusable production-bundle verifier.** New
   `scripts/check-prod-bundle.mjs` (pure `findForbiddenModules` / `findSourceMaps`
   + CLI) and `build:verify` npm script. Asserts quarantined source modules and
   stray source maps never ship. Unit-tested (4 tests). Extensible for Plan B.
3. **`fix(reports)` — build-exclude the mock Tear Sheet dashboard.** Gates the
   lazy import, tab trigger, and tab content behind `import.meta.env.DEV`, so the
   `tear-sheet-dashboard` chunk (and its client-side PDF export that fabricates a
   fund) is dropped by Rollup in production.
4. **`fix(build)` — opt-in production source maps.** `vite.config.ts:345` dead
   `? true : true` ternary → `process.env['VITE_SOURCEMAP'] === 'true'`. Maps are
   off by default in production, opt-in via `VITE_SOURCEMAP=true`.
5. **`ci(build)` — gate the production bundle on `build:verify`.** Runs
   `npm run build:verify` as a hard step in the existing **Build Production** job
   of `ci-unified.yml`, immediately after `npm run build`. That job already feeds
   the required **CI Gate Status** aggregator, so a quarantined module or stray
   source map now reds the gate. No new required check; docs-only PRs still skip
   the build job (the gate expects `skipped`), so branch protection is not
   deadlocked.

### Verification

- `npm run check` (tsc strict, client/server/shared): **0 errors**
- `npm run lint` (`eslint --max-warnings 0` + guardrails): **pass**
- `npm test` (full suite, both projects): **7067 passed, 90 skipped, 0 failed**
  (one app-bootstrap RUM test flaked once under full-suite resource contention;
  confirmed green standalone and on the warm pre-push run)
- **Build gate (load-bearing, RED→GREEN proven):**
  - Negative control on pre-edit code: `build:verify` **FAILS** — `tear-sheet-dashboard`
    present in the manifest + source maps emitted.
  - After fixes, default `npm run build` → `build:verify` → **`[check-prod-bundle] OK`**
    (no tear-sheet chunk, no source maps).
  - Opt-in `VITE_SOURCEMAP=true npm run build` → 129 `.map` files emitted, no
    tear-sheet artifacts, `build:verify` still **OK** (map check skipped).

### Follow-up (not in this PR)

- Plans B–E (mock-route build exclusion, MOIC live-primary, ADR hygiene, branding
  legal-name) remain separate, decision-gated.

### References (local working artifacts)

- Plan: `docs/superpowers/plans/2026-06-17-secondary-surface-production-safety.md`
- Evaluation/amendment: `.claude/artifacts/secondary-surface-proposal-evaluation.md`
- Original proposal: `docs/CRITICAL-REVIEW-secondary-surface-governance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
