### PR TITLE
fix: make lifecycle DB proof own primary pool teardown

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -5,6 +5,7 @@
  */
 
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { Pool as NodePostgresPool, PoolClient as NodePostgresPoolClient } from 'pg';
 import { neon as createNeonHttpClient } from '@neondatabase/serverless';
 import { drizzle as drizzleNeonHttp } from 'drizzle-orm/neon-http';
 import { createRequire } from 'node:module';
@@ -22,6 +23,23 @@ const storageBootMode = resolveStorageBootMode(process.env);
 // Dynamic imports based on environment
 let db: NodePgDatabase<CombinedSchema>;
 let pool: unknown;
+let isClosingNodePostgresPool = false;
+
+function isExpectedNodePostgresCloseError(error: unknown): boolean {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? String((error as { code?: unknown }).code)
+      : '';
+  const message = error instanceof Error ? error.message : String(error);
+  return code === '57P01' || /terminating connection due to administrator command/i.test(message);
+}
+
+function handleNodePostgresPoolError(error: unknown): void {
+  if (isClosingNodePostgresPool && isExpectedNodePostgresCloseError(error)) {
+    return;
+  }
+  throw error;
+}
 
 async function loadDatabaseMock(): Promise<NodePgDatabase<CombinedSchema>> {
   // Import the database mock for testing
@@ -70,7 +88,11 @@ if (storageBootMode === 'test-mock-db' || storageBootMode === 'explicit-memory')
       connectionTimeoutMillis: 2000,
       idleTimeoutMillis: 30000,
       allowExitOnIdle: true,
+    }) as NodePostgresPool;
+    pgPool.on('connect', (client: NodePostgresPoolClient) => {
+      client.on('error', handleNodePostgresPoolError);
     });
+    pgPool.on('error', handleNodePostgresPoolError);
     pool = pgPool;
     db = drizzle(pgPool, { schema: combinedSchema });
   } else {
@@ -84,6 +106,14 @@ if (storageBootMode === 'test-mock-db' || storageBootMode === 'explicit-memory')
     // @ts-expect-error - Neon Pool type doesn't perfectly align with drizzle neon-serverless signature
     db = drizzle(pool, { schema: combinedSchema });
   }
+}
+
+export async function closeDatabasePool(): Promise<void> {
+  if (!pool || typeof (pool as { end?: unknown }).end !== 'function') {
+    return;
+  }
+  isClosingNodePostgresPool = true;
+  await (pool as { end: () => Promise<void> }).end();
 }
 
 export { db, pool };

--- a/tests/integration/fund-lifecycle-db.test.ts
+++ b/tests/integration/fund-lifecycle-db.test.ts
@@ -221,8 +221,15 @@ describe('fund lifecycle DB proof', () => {
   afterAll(async () => {
     isStoppingPostgres = true;
     const active = runtime;
+    let closePrimaryDbPool: (() => Promise<void>) | null = null;
     let closePgCircuitPool: (() => Promise<void>) | null = null;
 
+    try {
+      const primaryDb = await import('../../server/db');
+      closePrimaryDbPool = primaryDb.closeDatabasePool;
+    } catch {
+      // The primary db module may never load if startup failed before route import.
+    }
     try {
       const db = await import('../../server/db/pg-circuit');
       closePgCircuitPool = db.closePool;
@@ -241,7 +248,11 @@ describe('fund lifecycle DB proof', () => {
     } catch {
       // Idempotency middleware may never load if startup failed before route import.
     }
-    await tolerateExpectedPostgresStop([closePgCircuitPool?.(), active?.pool.end()]);
+    await tolerateExpectedPostgresStop([
+      closePrimaryDbPool?.(),
+      closePgCircuitPool?.(),
+      active?.pool.end(),
+    ]);
     await stopPostgresContainer(active?.postgres);
     restoreEnv(originalEnv);
     vi.resetModules();


### PR DESCRIPTION
The first non-skipped release proof reached the fund lifecycle DB stage and exposed an unclosed primary server/db node-postgres pool. Closing that pool in the test teardown keeps container shutdown from surfacing expected Postgres termination events as unhandled Vitest errors.

Constraint: Scope is limited to the first blocker found by npm run release:check with DB proof enabled.

Rejected: Fix the later scenario release gate teardown failure | separate blocker after stages 1-6 passed.

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Keep Testcontainers DB proof teardown explicit for every route-owned pool before stopping containers.

Tested: npx cross-env TZ=UTC vitest run -c vitest.config.testcontainers.ts tests/integration/fund-lifecycle-db.test.ts

Tested: NODE_OPTIONS=--max-old-space-size=4096 npm run release:check (WSL Node 20.19.5/npm 10.8.2/Docker 28.3.2) passed stages 1-6.

Not-tested: Full release-proof pass remains blocked at Scenario release gate by two unhandled teardown errors in tests/integration/scenarios/scenario-release-gate.integration.test.ts.
