### PR TITLE
Stop LP dashboard from depending on mock-only routes

### DIFF
--- a/client/src/components/lp/DistributionsWidget.tsx
+++ b/client/src/components/lp/DistributionsWidget.tsx
@@ -39,18 +39,20 @@ export function DistributionsWidget() {
 
   const getDistributionTypeBadge = (type: string) => {
     switch (type) {
-      case 'special':
+      case 'capital_gains':
         return (
           <Badge variant="default" className="bg-presson-info text-pov-white">
-            Special
+            Gains
           </Badge>
         );
-      case 'final':
-        return <Badge variant="destructive">Final</Badge>;
+      case 'dividend':
+        return <Badge variant="secondary">Dividend</Badge>;
       case 'return_of_capital':
         return <Badge variant="secondary">ROC</Badge>;
+      case 'mixed':
+        return <Badge variant="outline">Mixed</Badge>;
       default:
-        return <Badge variant="outline">Regular</Badge>;
+        return <Badge variant="outline">Distribution</Badge>;
     }
   };
 

--- a/client/src/components/lp/DocumentsWidget.tsx
+++ b/client/src/components/lp/DocumentsWidget.tsx
@@ -20,14 +20,12 @@ import { useLocation } from 'wouter';
 
 const getDocumentTypeLabel = (type: DocumentType): string => {
   const labels: Record<DocumentType, string> = {
-    k1: 'K-1',
-    capital_statement: 'Capital Statement',
     quarterly_report: 'Quarterly Report',
     annual_report: 'Annual Report',
-    subscription_agreement: 'Subscription',
+    k1: 'K-1',
+    lpa: 'LPA',
     side_letter: 'Side Letter',
-    legal: 'Legal',
-    tax: 'Tax',
+    fund_overview: 'Fund Overview',
     other: 'Other',
   };
   return labels[type] || type;
@@ -36,14 +34,12 @@ const getDocumentTypeLabel = (type: DocumentType): string => {
 const getDocumentTypeColor = (type: DocumentType): string => {
   // TODO(design): document types exceed six categorical colors; define an extended token palette before assigning unique hues to every type.
   const colors: Record<DocumentType, string> = {
-    k1: 'bg-pov-charcoal',
-    capital_statement: 'bg-presson-positive',
     quarterly_report: 'bg-presson-info',
     annual_report: 'bg-success',
-    subscription_agreement: 'bg-presson-warning',
+    k1: 'bg-pov-charcoal',
+    lpa: 'bg-presson-positive',
     side_letter: 'bg-presson-negative',
-    legal: 'bg-charcoal-700',
-    tax: 'bg-error',
+    fund_overview: 'bg-presson-warning',
     other: 'bg-charcoal-500',
   };
   return colors[type] || 'bg-charcoal-500';
@@ -71,8 +67,9 @@ export function DocumentsWidget() {
 
   const handleDownload = (doc: LPDocument, e: React.MouseEvent) => {
     e.stopPropagation();
-    // In real implementation, this would trigger a download
-    window.open(doc.downloadUrl, '_blank');
+    if (doc.downloadUrl) {
+      window.open(doc.downloadUrl, '_blank');
+    }
   };
 
   if (isLoading) {
@@ -142,6 +139,8 @@ export function DocumentsWidget() {
                   size="sm"
                   className="opacity-0 group-hover:opacity-100 transition-opacity"
                   onClick={(e) => handleDownload(doc, e)}
+                  disabled={!doc.downloadUrl}
+                  title={doc.downloadUrl ? 'Download document' : 'Open document details to download'}
                 >
                   <Download className="h-4 w-4" />
                 </Button>

--- a/client/src/components/lp/NotificationsWidget.tsx
+++ b/client/src/components/lp/NotificationsWidget.tsx
@@ -45,9 +45,9 @@ const getNotificationIcon = (type: NotificationType) => {
       return <Banknote className="h-4 w-4" />;
     case 'document':
       return <FileText className="h-4 w-4" />;
-    case 'report':
+    case 'report_ready':
       return <TrendingUp className="h-4 w-4" />;
-    case 'fund_update':
+    case 'system':
       return <Info className="h-4 w-4" />;
     default:
       return <Bell className="h-4 w-4" />;
@@ -62,9 +62,9 @@ const getNotificationIconColor = (type: NotificationType): string => {
       return 'text-presson-positive bg-presson-positive/10';
     case 'document':
       return 'text-presson-info bg-presson-info/10';
-    case 'report':
+    case 'report_ready':
       return 'text-success-dark bg-success/10';
-    case 'fund_update':
+    case 'system':
       return 'text-presson-warning bg-presson-warning/10';
     default:
       return 'text-charcoal-600 bg-pov-gray';

--- a/client/src/hooks/useLPDistributions.ts
+++ b/client/src/hooks/useLPDistributions.ts
@@ -18,14 +18,14 @@ export interface Distribution {
   fundId: number;
   fundName: string;
   distributionNumber: number;
-  distributionType: 'regular' | 'special' | 'final' | 'return_of_capital';
+  distributionType: 'return_of_capital' | 'capital_gains' | 'dividend' | 'mixed';
   grossAmount: string;
   netAmount: string;
   distributionDate: string;
   recordDate: string;
   paymentDate: string | null;
   paymentMethod: 'wire' | 'check' | 'ach' | null;
-  status: 'announced' | 'pending' | 'paid' | 'processed';
+  status: 'pending' | 'processing' | 'completed';
   taxYear: number | null;
 }
 
@@ -43,6 +43,86 @@ interface UseLPDistributionsOptions {
   year?: number;
   limit?: number;
   enabled?: boolean;
+}
+
+type ServerDistribution = {
+  id: string;
+  fundId: number;
+  fundName: string;
+  distributionNumber: number;
+  distributionType: Distribution['distributionType'];
+  totalAmount?: string;
+  grossAmount?: string;
+  netAmount?: string;
+  distributionDate: string;
+  recordDate?: string;
+  paymentDate?: string | null;
+  paymentMethod?: Distribution['paymentMethod'];
+  status: Distribution['status'];
+  taxYear?: number | null;
+};
+
+type ServerDistributionsResponse = {
+  distributions: ServerDistribution[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  totalCount?: number;
+  totalDistributed?: string;
+  totalGrossAmount?: string;
+  totalNetAmount?: string;
+};
+
+type ServerDistributionYearSummary = {
+  year: number;
+  totalDistributed: string;
+};
+
+type ServerDistributionsSummaryResponse = {
+  summary: ServerDistributionYearSummary[];
+  totalAllTime: string;
+};
+
+function normalizeDistribution(distribution: ServerDistribution): Distribution {
+  const amount = distribution.netAmount ?? distribution.totalAmount ?? '0';
+
+  return {
+    id: distribution.id,
+    fundId: distribution.fundId,
+    fundName: distribution.fundName,
+    distributionNumber: distribution.distributionNumber,
+    distributionType: distribution.distributionType,
+    grossAmount: distribution.grossAmount ?? distribution.totalAmount ?? amount,
+    netAmount: amount,
+    distributionDate: distribution.distributionDate,
+    recordDate: distribution.recordDate ?? distribution.distributionDate,
+    paymentDate: distribution.paymentDate ?? null,
+    paymentMethod: distribution.paymentMethod ?? null,
+    status: distribution.status,
+    taxYear: distribution.taxYear ?? null,
+  };
+}
+
+function normalizeDistributionsResponse(
+  response: ServerDistributionsResponse
+): DistributionsResponse {
+  const totalAmount = response.totalNetAmount ?? response.totalDistributed ?? '0';
+
+  return {
+    distributions: response.distributions.map(normalizeDistribution),
+    nextCursor: response.nextCursor,
+    hasMore: response.hasMore,
+    totalCount: response.totalCount ?? response.distributions.length,
+    totalGrossAmount: response.totalGrossAmount ?? response.totalDistributed ?? totalAmount,
+    totalNetAmount: totalAmount,
+  };
+}
+
+function ytdDistributedFromSummary(
+  response: ServerDistributionsSummaryResponse,
+  currentYear: number
+): string {
+  return response.summary.find((yearSummary) => yearSummary.year === currentYear)
+    ?.totalDistributed ?? '0';
 }
 
 // ============================================================================
@@ -86,7 +166,8 @@ export function useLPDistributions(options: UseLPDistributionsOptions = {}) {
         );
       }
 
-      return response.json() as Promise<DistributionsResponse>;
+      const data = (await response.json()) as ServerDistributionsResponse;
+      return normalizeDistributionsResponse(data);
     },
     enabled: enabled && !!lpId,
     staleTime: 300_000, // 5 minutes
@@ -117,29 +198,33 @@ export function useLPDistributionsSummary(options: { enabled?: boolean } = {}) {
 
       const currentYear = new Date().getFullYear();
 
-      // Fetch all distributions and YTD distributions
-      const [allResponse, ytdResponse] = await Promise.all([
+      // Fetch recent rows separately from aggregate totals. The list route totals
+      // are page-derived, while the summary route totals are all-time.
+      const [recentResponse, summaryResponse] = await Promise.all([
         fetch(`/api/lp/distributions?lpId=${lpId}&limit=5`),
-        fetch(`/api/lp/distributions?lpId=${lpId}&year=${currentYear}&limit=100`),
+        fetch(`/api/lp/distributions/summary?lpId=${lpId}`),
       ]);
 
-      if (!allResponse.ok || !ytdResponse.ok) {
+      if (!recentResponse.ok || !summaryResponse.ok) {
         throw new Error('Failed to fetch distributions summary');
       }
 
-      const [allData, ytdData] = (await Promise.all([
-        allResponse.json() as Promise<DistributionsResponse>,
-        ytdResponse.json() as Promise<DistributionsResponse>,
-      ])) as [DistributionsResponse, DistributionsResponse];
+      const [recentData, summaryData] = await Promise.all([
+        recentResponse.json() as Promise<ServerDistributionsResponse>,
+        summaryResponse.json() as Promise<ServerDistributionsSummaryResponse>,
+      ]);
+
+      const allData = normalizeDistributionsResponse(recentData);
+      const ytdDistributed = ytdDistributedFromSummary(summaryData, currentYear);
 
       // Calculate pending count
       const pendingCount = allData.distributions.filter(
-        (d) => d.status === 'announced' || d.status === 'pending'
+        (d) => d.status === 'pending' || d.status === 'processing'
       ).length;
 
       return {
-        totalDistributed: allData.totalNetAmount,
-        ytdDistributed: ytdData.totalNetAmount,
+        totalDistributed: summaryData.totalAllTime,
+        ytdDistributed,
         recentDistributions: allData.distributions.slice(0, 3),
         pendingDistributions: pendingCount,
       };

--- a/client/src/hooks/useLPDocuments.ts
+++ b/client/src/hooks/useLPDocuments.ts
@@ -14,14 +14,12 @@ import { useLPContext } from '@/contexts/LPContext';
 // ============================================================================
 
 export type DocumentType =
-  | 'k1'
-  | 'capital_statement'
   | 'quarterly_report'
   | 'annual_report'
-  | 'subscription_agreement'
+  | 'k1'
+  | 'lpa'
   | 'side_letter'
-  | 'legal'
-  | 'tax'
+  | 'fund_overview'
   | 'other';
 
 export interface LPDocument {
@@ -38,7 +36,7 @@ export interface LPDocument {
   taxYear: number | null;
   isConfidential: boolean;
   createdAt: string;
-  downloadUrl: string;
+  downloadUrl?: string;
 }
 
 export interface DocumentsResponse {
@@ -54,6 +52,62 @@ interface UseLPDocumentsOptions {
   search?: string;
   limit?: number;
   enabled?: boolean;
+}
+
+type ServerLPDocument = {
+  id: string;
+  fundId: number;
+  fundName: string;
+  documentType: DocumentType;
+  title: string;
+  description: string | null;
+  fileName: string;
+  fileSize: number;
+  mimeType?: string | null;
+  documentDate?: string | null;
+  publishedAt: string;
+  accessLevel?: string | null;
+  downloadUrl?: string;
+};
+
+type ServerDocumentsResponse = {
+  documents: ServerLPDocument[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  totalCount: number;
+};
+
+function normalizeDocument(document: ServerLPDocument): LPDocument {
+  const normalized: LPDocument = {
+    id: document.id,
+    fundId: document.fundId,
+    fundName: document.fundName,
+    documentType: document.documentType,
+    title: document.title,
+    description: document.description,
+    fileName: document.fileName,
+    fileType: document.mimeType ?? 'application/octet-stream',
+    fileSizeBytes: document.fileSize,
+    reportingPeriod: document.documentDate ?? null,
+    taxYear: null,
+    isConfidential: document.accessLevel === 'sensitive',
+    createdAt: document.publishedAt,
+  };
+
+  if (document.downloadUrl) {
+    normalized.downloadUrl = document.downloadUrl;
+  }
+
+  return normalized;
+}
+
+function normalizeDocumentsResponse(response: ServerDocumentsResponse): DocumentsResponse {
+  return {
+    documents: response.documents.map(normalizeDocument),
+    nextCursor: response.nextCursor,
+    hasMore: response.hasMore,
+    totalCount: response.totalCount,
+  };
 }
 
 // ============================================================================
@@ -85,7 +139,7 @@ export function useLPDocuments(options: UseLPDocumentsOptions = {}) {
       const params = new URLSearchParams();
       params.append('lpId', lpId.toString());
       if (fundId) params.append('fundId', fundId.toString());
-      if (documentType) params.append('documentType', documentType);
+      if (documentType) params.append('type', documentType);
       if (search) params.append('search', search);
       params.append('limit', limit.toString());
 
@@ -96,7 +150,8 @@ export function useLPDocuments(options: UseLPDocumentsOptions = {}) {
         throw new Error(errorData.message || `HTTP ${response.status}: Failed to fetch documents`);
       }
 
-      return response.json() as Promise<DocumentsResponse>;
+      const data = (await response.json()) as ServerDocumentsResponse;
+      return normalizeDocumentsResponse(data);
     },
     enabled: enabled && !!lpId,
     staleTime: 300_000, // 5 minutes
@@ -133,7 +188,7 @@ export function useLPRecentDocuments(options: { limit?: number; enabled?: boolea
         );
       }
 
-      const data = (await response.json()) as DocumentsResponse;
+      const data = normalizeDocumentsResponse((await response.json()) as ServerDocumentsResponse);
 
       // Check if any documents are from the last 7 days
       const oneWeekAgo = new Date();

--- a/client/src/hooks/useLPNotifications.ts
+++ b/client/src/hooks/useLPNotifications.ts
@@ -17,8 +17,7 @@ export type NotificationType =
   | 'capital_call'
   | 'distribution'
   | 'document'
-  | 'report'
-  | 'fund_update'
+  | 'report_ready'
   | 'system';
 
 export type NotificationPriority = 'low' | 'normal' | 'high' | 'urgent';
@@ -50,6 +49,64 @@ interface UseLPNotificationsOptions {
   type?: NotificationType;
   limit?: number;
   enabled?: boolean;
+}
+
+type ServerLPNotification = {
+  id: string;
+  lpId?: number;
+  type: NotificationType;
+  priority?: NotificationPriority;
+  title: string;
+  message: string;
+  relatedEntityType: string | null;
+  relatedEntityId: string | null;
+  actionUrl: string | null;
+  read: boolean;
+  readAt: string | null;
+  createdAt: string;
+};
+
+type ServerNotificationsResponse = {
+  notifications: ServerLPNotification[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  unreadCount: number;
+};
+
+type ServerMarkAllNotificationsReadResponse = {
+  success: boolean;
+  markedCount: number;
+};
+
+function normalizeNotification(notification: ServerLPNotification, lpId: number): LPNotification {
+  return {
+    id: notification.id,
+    lpId: notification.lpId ?? lpId,
+    type: notification.type,
+    priority: notification.priority ?? 'normal',
+    title: notification.title,
+    message: notification.message,
+    relatedEntityType: notification.relatedEntityType,
+    relatedEntityId: notification.relatedEntityId,
+    actionUrl: notification.actionUrl,
+    isRead: notification.read,
+    readAt: notification.readAt,
+    createdAt: notification.createdAt,
+  };
+}
+
+function normalizeNotificationsResponse(
+  response: ServerNotificationsResponse,
+  lpId: number
+): NotificationsResponse {
+  return {
+    notifications: response.notifications.map((notification) =>
+      normalizeNotification(notification, lpId)
+    ),
+    nextCursor: response.nextCursor,
+    hasMore: response.hasMore,
+    totalUnread: response.unreadCount,
+  };
 }
 
 // ============================================================================
@@ -93,7 +150,8 @@ export function useLPNotifications(options: UseLPNotificationsOptions = {}) {
         );
       }
 
-      return response.json() as Promise<NotificationsResponse>;
+      const data = (await response.json()) as ServerNotificationsResponse;
+      return normalizeNotificationsResponse(data, lpId);
     },
     enabled: enabled && !!lpId,
     staleTime: 30_000, // 30 seconds - notifications should be fresh
@@ -153,6 +211,8 @@ export function useMarkNotificationRead() {
 
       const response = await fetch(`/api/lp/notifications/${notificationId}/read?lpId=${lpId}`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
       });
 
       if (!response.ok) {
@@ -185,8 +245,10 @@ export function useMarkAllNotificationsRead() {
         throw new Error('No LP ID available');
       }
 
-      const response = await fetch(`/api/lp/notifications/mark-all-read?lpId=${lpId}`, {
+      const response = await fetch(`/api/lp/notifications/read-all?lpId=${lpId}`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
       });
 
       if (!response.ok) {
@@ -196,7 +258,8 @@ export function useMarkAllNotificationsRead() {
         );
       }
 
-      return response.json() as Promise<{ success: boolean; count: number }>;
+      const data = (await response.json()) as ServerMarkAllNotificationsReadResponse;
+      return { success: data.success, count: data.markedCount };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lp-notifications'] });

--- a/server/app.ts
+++ b/server/app.ts
@@ -29,6 +29,11 @@ import cohortAnalysisRouter from './routes/cohort-analysis.js';
 import sensitivityRouter from './routes/sensitivity.js';
 import portfolioLotsRouter from './routes/portfolio/lots.js';
 import performanceApiRouter from './routes/performance-api.js';
+import lpApiRouter from './routes/lp-api.js';
+import lpCapitalCallsRouter from './routes/lp-capital-calls.js';
+import lpDistributionsRouter from './routes/lp-distributions.js';
+import lpDocumentsRouter from './routes/lp-documents.js';
+import lpNotificationsRouter from './routes/lp-notifications.js';
 import lpReportingImportsRouter from './routes/lp-reporting/imports.js';
 import lpReportingMetricRunsRouter from './routes/lp-reporting/metric-runs.js';
 import metricsRouter from './routes/metrics-endpoint.js';
@@ -239,6 +244,11 @@ export function makeApp() {
 
   // Sensitivity Analysis API (Phase 1A - one-way sweeps; fund-scoped)
   app.use('/api', sensitivityRouter);
+  app.use(lpApiRouter);
+  app.use(lpCapitalCallsRouter);
+  app.use(lpDistributionsRouter);
+  app.use('/api/lp', lpDocumentsRouter);
+  app.use('/api/lp', lpNotificationsRouter);
   app.use(lpReportingImportsRouter);
   app.use(lpReportingMetricRunsRouter);
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -129,6 +129,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     { load: () => import('./routes/lp-api.js') },
     // LP Reporting Dashboard health check routes
     { load: () => import('./routes/lp-health.js') },
+    // LP dashboard widget routes
+    { load: () => import('./routes/lp-capital-calls.js') },
+    { load: () => import('./routes/lp-distributions.js') },
+    { mountPath: '/api/lp', load: () => import('./routes/lp-documents.js') },
+    { mountPath: '/api/lp', load: () => import('./routes/lp-notifications.js') },
     // LP Reporting workflow routes
     { load: () => import('./routes/lp-reporting/imports.js') },
     { load: () => import('./routes/lp-reporting/metric-runs.js') },

--- a/tests/unit/hooks/useLPDashboardWidgets.http-response.test.tsx
+++ b/tests/unit/hooks/useLPDashboardWidgets.http-response.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLPRecentDocuments } from '@/hooks/useLPDocuments';
+import { useLPDistributionsSummary } from '@/hooks/useLPDistributions';
+import {
+  useLPNotifications,
+  useMarkAllNotificationsRead,
+} from '@/hooks/useLPNotifications';
+
+const { mockUseLPContext } = vi.hoisted(() => ({
+  mockUseLPContext: vi.fn(),
+}));
+
+vi.mock('@/contexts/LPContext', () => ({
+  useLPContext: () => mockUseLPContext(),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        retryDelay: 1,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('LP dashboard widget hook HTTP response handling', () => {
+  beforeEach(() => {
+    mockUseLPContext.mockReturnValue({ lpId: 17 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('maps runtime document list fields for recent document widgets', async () => {
+    const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>().mockResolvedValue(
+      jsonResponse({
+        documents: [
+          {
+            id: 'doc-1',
+            fundId: 7,
+            fundName: 'Fund VII',
+            documentType: 'quarterly_report',
+            title: 'Q4 Report',
+            description: null,
+            fileName: 'q4.pdf',
+            fileSize: 2_500_000,
+            mimeType: 'application/pdf',
+            documentDate: '2025-12-31',
+            publishedAt: '2026-01-01T00:00:00.000Z',
+            accessLevel: 'sensitive',
+          },
+        ],
+        nextCursor: null,
+        hasMore: false,
+        totalCount: 1,
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useLPRecentDocuments({ limit: 1 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/lp/documents?lpId=17&limit=1');
+    expect(result.current.data?.recentDocuments[0]).toMatchObject({
+      id: 'doc-1',
+      fileType: 'application/pdf',
+      fileSizeBytes: 2_500_000,
+      reportingPeriod: '2025-12-31',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      isConfidential: true,
+    });
+    expect(result.current.data?.recentDocuments[0]?.downloadUrl).toBeUndefined();
+  });
+
+  it('maps runtime notification read state and unread count fields', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>().mockResolvedValue(
+        jsonResponse({
+          notifications: [
+            {
+              id: 'notification-1',
+              type: 'report_ready',
+              title: 'Report ready',
+              message: 'Your quarterly report is ready.',
+              relatedEntityType: 'report',
+              relatedEntityId: 'report-1',
+              actionUrl: '/lp/reports/report-1',
+              read: false,
+              readAt: null,
+              createdAt: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+          unreadCount: 1,
+        })
+      )
+    );
+
+    const { result } = renderHook(() => useLPNotifications({ limit: 1 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.notifications[0]).toMatchObject({
+      id: 'notification-1',
+      lpId: 17,
+      type: 'report_ready',
+      priority: 'normal',
+      isRead: false,
+    });
+    expect(result.current.data?.totalUnread).toBe(1);
+  });
+
+  it('posts read-all mutations to the runtime route', async () => {
+    const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>().mockResolvedValue(
+      jsonResponse({ success: true, markedCount: 2 })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useMarkAllNotificationsRead(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/lp/notifications/read-all?lpId=17', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(result.current.data).toEqual({ success: true, count: 2 });
+  });
+
+  it('summarizes runtime distribution totals for the dashboard widget', async () => {
+    const currentYear = new Date().getFullYear();
+    const fetchMock = vi
+      .fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          distributions: [
+            {
+              id: 'dist-1',
+              fundId: 7,
+              fundName: 'Fund VII',
+              distributionNumber: 4,
+              distributionType: 'capital_gains',
+              totalAmount: '12500000',
+              distributionDate: '2026-01-15',
+              status: 'completed',
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+          totalDistributed: '12500000',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          summary: [
+            {
+              year: currentYear,
+              totalDistributed: '5000000',
+            },
+          ],
+          totalAllTime: '25000000',
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useLPDistributionsSummary(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toMatchObject({
+      totalDistributed: '25000000',
+      ytdDistributed: '5000000',
+      pendingDistributions: 0,
+    });
+    expect(result.current.data?.recentDistributions[0]).toMatchObject({
+      id: 'dist-1',
+      grossAmount: '12500000',
+      netAmount: '12500000',
+      recordDate: '2026-01-15',
+      paymentDate: null,
+      paymentMethod: null,
+      taxYear: null,
+    });
+  });
+});

--- a/tests/unit/server/lp-dashboard-runtime-routes.test.ts
+++ b/tests/unit/server/lp-dashboard-runtime-routes.test.ts
@@ -1,0 +1,468 @@
+import type { Express, NextFunction, Request, Response } from 'express';
+import type { Server } from 'node:http';
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type QueryChain = PromiseLike<unknown[]> & {
+  from: ReturnType<typeof vi.fn>;
+  leftJoin: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  offset: ReturnType<typeof vi.fn>;
+};
+
+const dbState = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+  };
+
+  function next(): unknown[] {
+    return state.selectResults.shift() ?? [];
+  }
+
+  function thenFor(result: unknown[]): QueryChain['then'] {
+    return (onfulfilled, onrejected) => Promise.resolve(result).then(onfulfilled, onrejected);
+  }
+
+  function makeQuery(result: unknown[]): QueryChain {
+    const query = {
+      from: vi.fn(() => query),
+      leftJoin: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => query),
+      offset: vi.fn(() => Promise.resolve(result)),
+      then: thenFor(result),
+    } as QueryChain;
+
+    return query;
+  }
+
+  return {
+    db: {
+      select: vi.fn(() => makeQuery(next())),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve()),
+        })),
+      })),
+    },
+    state,
+  };
+});
+
+const calculatorState = vi.hoisted(() => ({
+  calculateSummary: vi.fn(),
+}));
+
+const startupState = vi.hoisted(() => ({
+  registerCompletionHandlers: vi.fn(),
+  automationStart: vi.fn(),
+  setupWebSocketServers: vi.fn(),
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../../server/lib/auth/jwt', () => ({
+  requireAuth: () => (req: Request, _res: Response, next: NextFunction) => {
+    req.user = {
+      id: 'lp-user',
+      sub: 'lp-user',
+      email: 'lp@example.com',
+      role: 'lp',
+      roles: ['lp'],
+      fundIds: [7],
+      lpId: 9001,
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    };
+    next();
+  },
+  requireRole: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+  requireFundAccess: (req: Request, res: Response, next: NextFunction) => {
+    const fundId = Number(req.params['fundId']);
+    if (Number.isFinite(fundId) && req.user?.fundIds?.includes(fundId)) return next();
+    return res.status(403).json({ error: 'Forbidden' });
+  },
+}));
+
+vi.mock('../../../server/middleware/requireLPAccess', () => ({
+  requireLPAccess: (req: Request, _res: Response, next: NextFunction) => {
+    req.lpProfile = {
+      id: 9001,
+      name: 'Runtime LP',
+      email: 'lp@example.com',
+      entityType: 'institution',
+      fundIds: [7],
+    };
+    next();
+  },
+  requireLPFundAccess: (req: Request, res: Response, next: NextFunction) => {
+    const fundId = Number(req.params['fundId']);
+    if (req.lpProfile?.fundIds.includes(fundId)) return next();
+    return res.status(403).json({ error: 'FORBIDDEN' });
+  },
+}));
+
+vi.mock('../../../server/middleware/schema-isolation', () => ({
+  enforceSchemaIsolation: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+  handleSchemaViolation: (_err: unknown, _req: Request, _res: Response, next: NextFunction) =>
+    next(),
+}));
+
+vi.mock('../../../server/middleware/performance-monitor.js', () => ({
+  monitor: {
+    middleware: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+  },
+}));
+
+vi.mock('../../../server/services/calc-run-completion-handlers.js', () => ({
+  registerCompletionHandlers: startupState.registerCompletionHandlers,
+}));
+
+vi.mock('../../../server/services/variance-alert-automation.js', () => ({
+  varianceAlertAutomationService: {
+    start: startupState.automationStart,
+  },
+}));
+
+vi.mock('../../../server/websocket/index.js', () => ({
+  setupWebSocketServers: startupState.setupWebSocketServers,
+}));
+
+vi.mock('../../../server/config/features.js', () => ({
+  FEATURES: {
+    redis: false,
+    queues: false,
+    sessions: false,
+    portfolioIntelligence: false,
+    metrics: false,
+    statGating: false,
+  },
+  flag: vi.fn(() => false),
+  getQueueConfig: vi.fn(() => ({
+    enabled: false,
+    queueRedisUrl: null,
+    reason: 'disabled in route test',
+  })),
+  getQueueConnectionOptions: vi.fn(() => null),
+}));
+
+vi.mock('../../../server/db', () => ({ db: dbState.db }));
+
+vi.mock('../../../server/services/lp-calculator', () => ({
+  lpCalculator: calculatorState,
+}));
+
+vi.mock('../../../server/observability/lp-metrics', () => ({
+  recordLPRequest: vi.fn(),
+  recordCacheHit: vi.fn(),
+  recordError: vi.fn(),
+  recordDataPoints: vi.fn(),
+  startTimer: vi.fn(() => () => 0),
+}));
+
+vi.mock('../../../server/services/lp-audit-logger', () => {
+  const noop = vi.fn(async () => undefined);
+  return {
+    lpAuditLogger: {
+      logProfileView: noop,
+      logSummaryView: noop,
+      logCapitalAccountView: noop,
+      logFundDetailView: noop,
+      logHoldingsView: noop,
+      logPerformanceView: noop,
+      logBenchmarkView: noop,
+      logReportGeneration: noop,
+      logReportListView: noop,
+      logReportStatusView: noop,
+      logReportDownload: noop,
+      logSettingsUpdate: noop,
+      logCapitalCallsListView: noop,
+      logDistributionsListView: noop,
+      logDocumentsListView: noop,
+      logNotificationsView: noop,
+    },
+  };
+});
+
+vi.mock('../../../server/lib/crypto/cursor-signing', () => ({
+  createCursor: vi.fn(
+    ({ offset, limit }: { offset: number; limit: number }) => `cursor:${offset}:${limit}`
+  ),
+  verifyCursor: vi.fn((cursor: string) => {
+    const match = /^cursor:(\d+):(\d+)$/.exec(cursor);
+    if (!match) throw new Error('bad cursor');
+    return { offset: Number(match[1]), limit: Number(match[2]) };
+  }),
+}));
+
+vi.mock('../../../server/lib/crypto/pii-sanitizer', () => ({
+  sanitizeForLogging: (value: unknown) => value,
+}));
+
+vi.mock('../../../server/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../../../server/storage', () => ({
+  storage: {
+    getFund: vi.fn(async (id: number) => ({ id, name: `Fund ${id}` })),
+  },
+}));
+
+vi.mock('../../../server/queues/report-generation-queue', () => ({
+  isReportQueueAvailable: vi.fn(() => true),
+  enqueueReportGeneration: vi.fn(async () => ({ jobId: 'job-1', estimatedWaitMs: 0 })),
+}));
+
+type RuntimeSurface = {
+  label: string;
+  app: Express;
+};
+
+type EndpointCase = {
+  path: string;
+  assertBody: (body: Record<string, unknown>) => void;
+};
+
+const endpointCases: EndpointCase[] = [
+  {
+    path: '/api/lp/profile',
+    assertBody: (body) => expect(body).toHaveProperty('name', 'Runtime LP'),
+  },
+  {
+    path: '/api/lp/summary',
+    assertBody: (body) => expect(body).toHaveProperty('lpId', 9001),
+  },
+  {
+    path: '/api/lp/capital-calls',
+    assertBody: (body) => expect(body).toHaveProperty('calls'),
+  },
+  {
+    path: '/api/lp/distributions',
+    assertBody: (body) => expect(body).toHaveProperty('distributions'),
+  },
+  {
+    path: '/api/lp/documents',
+    assertBody: (body) => expect(body).toHaveProperty('documents'),
+  },
+  {
+    path: '/api/lp/notifications',
+    assertBody: (body) => expect(body).toHaveProperty('notifications'),
+  },
+  {
+    path: '/api/lp/notifications/unread-count',
+    assertBody: (body) => expect(body).toHaveProperty('unreadCount', 3),
+  },
+];
+
+const servers: Server[] = [];
+
+function resetState() {
+  dbState.state.selectResults = [];
+  dbState.db.select.mockClear();
+  dbState.db.update.mockClear();
+  calculatorState.calculateSummary.mockReset();
+}
+
+function summaryResult() {
+  return {
+    lpId: 9001,
+    lpName: 'Runtime LP',
+    totalCommittedCents: 10_000_000n,
+    totalCalledCents: 4_000_000n,
+    totalDistributedCents: 1_000_000n,
+    totalNAVCents: 8_000_000n,
+    totalUnfundedCents: 6_000_000n,
+    fundCount: 1,
+    irr: 0.1,
+    moic: 2.25,
+  };
+}
+
+function capitalCallRow() {
+  return {
+    id: 'call-1',
+    lpId: 9001,
+    fundId: 7,
+    fundName: 'Fund VII',
+    callNumber: 3,
+    callAmountCents: 250_000n,
+    dueDate: '2026-02-01',
+    callDate: '2026-01-15',
+    purpose: 'Follow-on reserve',
+    status: 'pending',
+    paidAmountCents: 0n,
+    createdAt: new Date('2026-01-15T00:00:00.000Z'),
+  };
+}
+
+function distributionRow() {
+  return {
+    id: 'dist-1',
+    lpId: 9001,
+    fundId: 7,
+    fundName: 'Fund VII',
+    distributionNumber: 2,
+    totalAmountCents: 125_000n,
+    distributionDate: '2026-01-20',
+    distributionType: 'capital_gains',
+    status: 'completed',
+    returnOfCapitalCents: 100_000n,
+    preferredReturnCents: 25_000n,
+    carriedInterestCents: 0n,
+    catchUpCents: 0n,
+    createdAt: new Date('2026-01-20T00:00:00.000Z'),
+  };
+}
+
+function documentRow() {
+  return {
+    id: 'doc-1',
+    fundId: 7,
+    documentType: 'quarterly_report',
+    title: 'Q4 Report',
+    description: null,
+    fileName: 'q4.pdf',
+    fileSize: 2_500_000,
+    mimeType: 'application/pdf',
+    documentDate: '2025-12-31',
+    publishedAt: new Date('2026-01-01T00:00:00.000Z'),
+    accessLevel: 'standard',
+    fundName: 'Fund VII',
+  };
+}
+
+function notificationRow() {
+  return {
+    id: 'notification-1',
+    type: 'report_ready',
+    title: 'Report ready',
+    message: 'Your quarterly report is ready.',
+    relatedEntityType: 'report',
+    relatedEntityId: 'report-1',
+    actionUrl: '/lp/reports/report-1',
+    read: false,
+    readAt: null,
+    createdAt: new Date('2026-01-02T00:00:00.000Z'),
+  };
+}
+
+function prepareEndpoint(path: string) {
+  resetState();
+
+  if (path === '/api/lp/summary') {
+    calculatorState.calculateSummary.mockResolvedValueOnce(summaryResult());
+  }
+
+  if (path === '/api/lp/capital-calls') {
+    dbState.state.selectResults = [[capitalCallRow()]];
+  }
+
+  if (path === '/api/lp/distributions') {
+    dbState.state.selectResults = [[distributionRow()]];
+  }
+
+  if (path === '/api/lp/documents') {
+    dbState.state.selectResults = [[documentRow()]];
+  }
+
+  if (path === '/api/lp/notifications') {
+    dbState.state.selectResults = [[notificationRow()], [{ count: 3 }]];
+  }
+
+  if (path === '/api/lp/notifications/unread-count') {
+    dbState.state.selectResults = [[{ count: 3 }]];
+  }
+}
+
+async function makeRegisterRoutesSurface(label: string, withApiAuth: boolean) {
+  const app = express();
+  app.set('trust proxy', false);
+  app.use(express.json());
+
+  if (withApiAuth) {
+    const { requireAuth } = await import('../../../server/lib/auth/jwt');
+    app.use('/api', requireAuth());
+  }
+
+  const { registerRoutes } = await import('../../../server/routes');
+  const server = await registerRoutes(app);
+  servers.push(server);
+
+  return { label, app };
+}
+
+async function buildSurfaces(): Promise<RuntimeSurface[]> {
+  const { makeApp } = await import('../../../server/app');
+
+  return [
+    { label: 'makeApp() live and serverless source runtime', app: makeApp() },
+    await makeRegisterRoutesSurface('bare registerRoutes(app) route-registration parity', false),
+    await makeRegisterRoutesSurface('server.ts /api auth composition parity', true),
+  ];
+}
+
+describe('LP dashboard runtime routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+  });
+
+  afterEach(async () => {
+    resetState();
+
+    while (servers.length > 0) {
+      const server = servers.pop();
+      if (server?.listening) {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    }
+  });
+
+  it('mounts dashboard API endpoints on the runtime surfaces instead of test-only fixtures', async () => {
+    const surfaces = await buildSurfaces();
+
+    for (const surface of surfaces) {
+      for (const endpoint of endpointCases) {
+        prepareEndpoint(endpoint.path);
+
+        const response = await request(surface.app).get(endpoint.path);
+
+        expect(response.status, `${surface.label} ${endpoint.path}`).toBe(200);
+        expect(response.body, `${surface.label} ${endpoint.path}`).not.toHaveProperty(
+          'error',
+          'not_found'
+        );
+        endpoint.assertBody(response.body as Record<string, unknown>);
+      }
+
+      resetState();
+      const unknownResponse = await request(surface.app).get('/api/lp/not-real-dashboard-endpoint');
+
+      expect(unknownResponse.status, `${surface.label} unknown route`).toBe(404);
+      expect(unknownResponse.body, `${surface.label} unknown route`).toHaveProperty(
+        'error',
+        'not_found'
+      );
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
The live makeApp/serverless surface did not mount the existing LP profile and widget routers, while test fixtures could still satisfy the dashboard endpoints. Mount the existing LP routers in both active server surfaces and normalize dashboard hooks to the runtime document, notification, and distribution wire contracts.

Constraint: Preserve existing LP route handlers and auth policies; mount only existing routers.

Rejected: Wire only makeApp | would leave registerRoutes stale and preserve split-brain route proof.

Rejected: Add an aggregate LP dashboard router | unnecessary architecture change for a 404 gap.

Confidence: high

Scope-risk: moderate

Directive: Keep LP dashboard regressions tied to makeApp and registerRoutes; do not replace them with fixture-only tests.

Tested: npm exec -- cross-env TZ=UTC vitest run tests/unit/server/lp-dashboard-runtime-routes.test.ts --config vitest.config.mjs --configLoader native --project=server

Tested: npm exec -- cross-env TZ=UTC vitest run tests/unit/hooks/useLPDashboardWidgets.http-response.test.tsx --config vitest.config.mjs --configLoader native --project=client

Tested: npm exec -- cross-env TZ=UTC vitest run tests/unit/server/routes-startup-automation.test.ts --config vitest.config.mjs --configLoader native --project=server

Tested: npm exec -- cross-env TZ=UTC vitest run tests/unit/scripts/build-vercel-api.test.mjs --config vitest.config.mjs --configLoader native --project=server

Tested: npm exec -- eslint --no-cache --no-ignore --max-warnings 0 server/app.ts server/routes.ts client/src/hooks/useLPDocuments.ts client/src/hooks/useLPNotifications.ts client/src/hooks/useLPDistributions.ts client/src/components/lp/DocumentsWidget.tsx client/src/components/lp/NotificationsWidget.tsx client/src/components/lp/DistributionsWidget.tsx tests/unit/server/lp-dashboard-runtime-routes.test.ts tests/unit/hooks/useLPDashboardWidgets.http-response.test.tsx

Tested: npm run check

Not-tested: full npm test suite; targeted plan gates passed.