### PR TITLE
feat(investments): UNIQUE (id, fund_id) precondition + ADR-023 L3b spec/plan

### DIFF
--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-06-17T00:00:00.000Z",
+  "generatedAt": "2026-06-21T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 170,
+      "staleDays": 174,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 82,
+      "staleDays": 86,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 60,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 60,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1176,7 +1176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1192,7 +1192,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1208,7 +1208,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1223,7 +1223,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1305,7 +1305,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 72,
+      "staleDays": 76,
       "status": "UNKNOWN"
     },
     {
@@ -1323,7 +1323,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1340,7 +1340,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1357,7 +1357,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1373,7 +1373,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1403,7 +1403,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1418,7 +1418,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -1434,7 +1434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1449,7 +1449,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1464,7 +1464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1479,7 +1479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1494,7 +1494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1522,7 +1522,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 170,
+      "staleDays": 174,
       "status": "ACTIVE"
     },
     {
@@ -1538,7 +1538,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "UNKNOWN"
     },
     {
@@ -1565,7 +1565,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -1580,7 +1580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -1595,7 +1595,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1610,7 +1610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1625,7 +1625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1678,7 +1678,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 170,
+      "staleDays": 174,
       "status": "ACTIVE"
     },
     {
@@ -1692,7 +1692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1706,7 +1706,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1720,7 +1720,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -1791,7 +1791,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1806,7 +1806,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1821,7 +1821,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -1836,7 +1836,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1851,7 +1851,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1866,7 +1866,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1881,7 +1881,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1896,7 +1896,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1911,7 +1911,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1930,7 +1930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ready"
     },
     {
@@ -1949,7 +1949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ready"
     },
     {
@@ -1968,7 +1968,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ready"
     },
     {
@@ -1983,7 +1983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -1998,7 +1998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2037,7 +2037,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -2052,7 +2052,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -2067,7 +2067,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 27,
+      "staleDays": 31,
       "status": "UNKNOWN"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2135,7 +2135,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2150,7 +2150,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2165,7 +2165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2180,7 +2180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2196,7 +2196,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -2212,7 +2212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2227,7 +2227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2242,7 +2242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2257,7 +2257,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2272,7 +2272,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2288,7 +2288,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -2303,7 +2303,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2318,7 +2318,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2333,7 +2333,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2349,7 +2349,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2364,7 +2364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2379,7 +2379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2394,7 +2394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2408,7 +2408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2423,7 +2423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2439,7 +2439,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2455,7 +2455,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2471,7 +2471,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2566,7 +2566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2582,7 +2582,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2597,7 +2597,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2612,7 +2612,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2627,7 +2627,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2643,7 +2643,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2659,7 +2659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2674,7 +2674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2692,7 +2692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2722,7 +2722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2737,7 +2737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2752,7 +2752,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2768,7 +2768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -2783,7 +2783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2798,7 +2798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO-v2.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -2813,7 +2813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -2828,7 +2828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/immediate-actions-summary.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -2843,7 +2843,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2858,7 +2858,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -2873,7 +2873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2888,7 +2888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2903,7 +2903,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2918,7 +2918,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2933,7 +2933,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2948,7 +2948,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -2963,7 +2963,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-baseline-report-2025-12-23.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -2978,7 +2978,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-remediation-summary.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -2993,7 +2993,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/week2-execution-report.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -3008,7 +3008,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -3023,7 +3023,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3038,7 +3038,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3074,7 +3074,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 82,
+      "staleDays": 86,
       "status": "ACTIVE"
     },
     {
@@ -3091,7 +3091,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -3106,7 +3106,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -3121,7 +3121,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3136,7 +3136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3165,7 +3165,7 @@
       "lastUpdated": "2026-05-21",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 27,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -3180,7 +3180,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 14,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -3195,7 +3195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3210,7 +3210,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -3237,7 +3237,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3252,7 +3252,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3267,7 +3267,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-QUICK-START.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3282,7 +3282,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3297,7 +3297,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3312,7 +3312,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3327,7 +3327,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3342,7 +3342,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "README.md",
-      "staleDays": 81,
+      "staleDays": 85,
       "status": "ACTIVE"
     },
     {
@@ -3357,7 +3357,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3372,7 +3372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3387,7 +3387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3404,7 +3404,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 82,
+      "staleDays": 86,
       "status": "ACTIVE"
     },
     {
@@ -3419,7 +3419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3434,7 +3434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -3449,7 +3449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3464,7 +3464,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3479,7 +3479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3494,7 +3494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3509,7 +3509,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -3524,7 +3524,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3539,7 +3539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3554,7 +3554,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -3569,7 +3569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3584,7 +3584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3599,7 +3599,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3614,7 +3614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3629,7 +3629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -3644,7 +3644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3659,7 +3659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -3674,7 +3674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3689,7 +3689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3704,7 +3704,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3719,7 +3719,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -3734,7 +3734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3749,7 +3749,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3764,7 +3764,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3779,7 +3779,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3795,7 +3795,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "active"
     },
     {
@@ -3810,7 +3810,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3825,7 +3825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3840,7 +3840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3855,7 +3855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3870,7 +3870,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 72,
+      "staleDays": 76,
       "status": "ACTIVE"
     },
     {
@@ -3885,7 +3885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3900,7 +3900,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -3915,7 +3915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3930,7 +3930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -3945,7 +3945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3960,7 +3960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3975,7 +3975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -3990,7 +3990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4005,7 +4005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4020,7 +4020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4035,7 +4035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4050,7 +4050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4065,7 +4065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4080,7 +4080,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 14,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -4095,7 +4095,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -4110,7 +4110,7 @@
       "lastUpdated": "2026-03-28",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 81,
+      "staleDays": 85,
       "status": "ACTIVE"
     },
     {
@@ -4125,7 +4125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4152,7 +4152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4167,7 +4167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4182,7 +4182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4197,7 +4197,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4212,7 +4212,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4227,7 +4227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4242,7 +4242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4281,7 +4281,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 60,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -4296,7 +4296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4311,7 +4311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4326,7 +4326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4362,7 +4362,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 20,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -4377,7 +4377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4392,7 +4392,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 58,
+      "staleDays": 62,
       "status": "HISTORICAL"
     },
     {
@@ -4407,7 +4407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4422,7 +4422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4437,7 +4437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4452,7 +4452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -4467,7 +4467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4482,7 +4482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4497,7 +4497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4512,7 +4512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4527,7 +4527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4542,7 +4542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4583,7 +4583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -4598,7 +4598,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4613,7 +4613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4628,7 +4628,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 73,
+      "staleDays": 77,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4643,7 +4643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4658,7 +4658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4673,7 +4673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4688,7 +4688,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4702,7 +4702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -4717,7 +4717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4732,7 +4732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4747,7 +4747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4762,7 +4762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4777,7 +4777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -4792,7 +4792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4807,7 +4807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4822,7 +4822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4837,7 +4837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4852,7 +4852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4867,7 +4867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4882,7 +4882,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4897,7 +4897,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4926,7 +4926,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -4941,7 +4941,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4956,7 +4956,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4971,7 +4971,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -4986,7 +4986,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5001,7 +5001,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5016,7 +5016,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5031,7 +5031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -5046,7 +5046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5061,7 +5061,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5076,7 +5076,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5091,7 +5091,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5106,7 +5106,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5121,7 +5121,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -5136,7 +5136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5151,7 +5151,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5166,7 +5166,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5181,7 +5181,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5196,7 +5196,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 40,
+      "staleDays": 44,
       "status": "ACTIVE"
     },
     {
@@ -5211,7 +5211,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 40,
+      "staleDays": 44,
       "status": "ACTIVE"
     },
     {
@@ -5226,7 +5226,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -5241,7 +5241,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 26,
+      "staleDays": 30,
       "status": "ACTIVE"
     },
     {
@@ -5256,7 +5256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5271,7 +5271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5286,7 +5286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5301,7 +5301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5327,7 +5327,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -5342,23 +5342,23 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "Implemented"
     },
     {
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-06-17",
-        "status": "ACCEPTED"
+        "last_updated": "2026-06-21",
+        "status": "ACCEPTED (amended 2026-06-21)"
       },
       "hasExecutionClaims": false,
       "isStale": false,
-      "lastUpdated": "2026-06-17",
+      "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/adr/ADR-023-investment-event-persistence.md",
       "staleDays": 0,
-      "status": "ACCEPTED"
+      "status": "ACCEPTED (amended 2026-06-21)"
     },
     {
       "docType": "doc",
@@ -5372,7 +5372,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 60,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -5387,7 +5387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5438,7 +5438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5453,7 +5453,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 92,
+      "staleDays": 96,
       "status": "ARCHIVED"
     },
     {
@@ -5468,7 +5468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5483,7 +5483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5498,7 +5498,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -5513,7 +5513,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 21,
+      "staleDays": 25,
       "status": "HISTORICAL"
     },
     {
@@ -5528,7 +5528,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 21,
+      "staleDays": 25,
       "status": "HISTORICAL"
     },
     {
@@ -5543,7 +5543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5558,7 +5558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5573,7 +5573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5588,7 +5588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5603,7 +5603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5618,7 +5618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5633,7 +5633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5648,7 +5648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5663,7 +5663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5678,7 +5678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5693,7 +5693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5708,7 +5708,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5723,7 +5723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5738,7 +5738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5753,7 +5753,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5768,7 +5768,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5783,7 +5783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5798,7 +5798,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 79,
+      "staleDays": 83,
       "status": "ACTIVE"
     },
     {
@@ -5813,7 +5813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5828,7 +5828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5842,7 +5842,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -5856,7 +5856,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -5871,7 +5871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -5886,7 +5886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5901,7 +5901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5916,7 +5916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5931,7 +5931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5946,7 +5946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5961,7 +5961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5976,7 +5976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -5991,7 +5991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6006,7 +6006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6021,7 +6021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6036,7 +6036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6051,7 +6051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6066,7 +6066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6081,7 +6081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6096,7 +6096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6111,7 +6111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -6126,7 +6126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6141,7 +6141,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6183,7 +6183,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 15,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -6231,7 +6231,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 15,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -6276,7 +6276,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 14,
+      "staleDays": 18,
       "status": "ACTIVE"
     },
     {
@@ -6307,7 +6307,7 @@
       "lastUpdated": "2026-06-15",
       "owner": "Platform Team",
       "path": "docs/design/audits/server-object-readiness.md",
-      "staleDays": 2,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -6346,7 +6346,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 60,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -6362,7 +6362,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -6377,7 +6377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6392,7 +6392,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6407,7 +6407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6422,7 +6422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6436,7 +6436,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -6451,7 +6451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6466,7 +6466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6481,7 +6481,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6496,7 +6496,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6510,7 +6510,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -6525,7 +6525,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6540,7 +6540,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -6555,7 +6555,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6570,7 +6570,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6585,7 +6585,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6600,7 +6600,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6615,7 +6615,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6630,7 +6630,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6645,7 +6645,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6660,7 +6660,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6675,7 +6675,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -6690,7 +6690,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6723,7 +6723,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 20,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -6738,7 +6738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6771,7 +6771,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 20,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -6786,7 +6786,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6801,7 +6801,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6816,7 +6816,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6831,7 +6831,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 58,
+      "staleDays": 62,
       "status": "HISTORICAL"
     },
     {
@@ -6846,7 +6846,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 31,
+      "staleDays": 35,
       "status": "ACTIVE"
     },
     {
@@ -6861,7 +6861,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6876,7 +6876,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6891,7 +6891,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6906,7 +6906,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6921,7 +6921,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6936,7 +6936,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6951,7 +6951,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6966,7 +6966,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6981,7 +6981,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -6996,7 +6996,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7011,7 +7011,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7026,7 +7026,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7041,7 +7041,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -7056,7 +7056,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7071,7 +7071,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7086,7 +7086,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7101,7 +7101,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7116,7 +7116,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7131,7 +7131,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -7146,7 +7146,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7161,7 +7161,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7176,7 +7176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7197,7 +7197,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "active"
     },
     {
@@ -7211,7 +7211,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -7226,7 +7226,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7241,7 +7241,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7256,7 +7256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7271,7 +7271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7286,7 +7286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7301,7 +7301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7316,7 +7316,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7331,7 +7331,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7346,7 +7346,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7361,7 +7361,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -7376,7 +7376,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -7391,7 +7391,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -7406,7 +7406,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -7421,7 +7421,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7436,7 +7436,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7451,7 +7451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7466,7 +7466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7481,7 +7481,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7496,7 +7496,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7511,7 +7511,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7526,7 +7526,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7541,7 +7541,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7556,7 +7556,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7571,7 +7571,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7586,7 +7586,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7601,7 +7601,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7616,7 +7616,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7631,7 +7631,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7646,7 +7646,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7661,7 +7661,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7676,7 +7676,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7691,7 +7691,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7706,7 +7706,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7740,7 +7740,7 @@
       "lastUpdated": "2026-06-16",
       "owner": "Platform Team",
       "path": "docs/parity/convention-matrix.md",
-      "staleDays": 1,
+      "staleDays": 5,
       "status": "ACTIVE"
     },
     {
@@ -7755,7 +7755,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7770,7 +7770,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7786,7 +7786,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 73,
+      "staleDays": 77,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7801,7 +7801,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7816,7 +7816,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7831,7 +7831,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7846,7 +7846,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7861,7 +7861,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7888,7 +7888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -7903,22 +7903,22 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-03-28",
+        "last_updated": "2026-06-19",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
       "isStale": false,
-      "lastUpdated": "2026-03-28",
+      "lastUpdated": "2026-06-19",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 81,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -7935,7 +7935,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 71,
+      "staleDays": 75,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -7950,7 +7950,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 31,
+      "staleDays": 35,
       "status": "BACKLOG"
     },
     {
@@ -7964,7 +7964,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -7981,7 +7981,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 17,
+      "staleDays": 21,
       "status": "ACTIVE"
     },
     {
@@ -8001,7 +8001,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 15,
+      "staleDays": 19,
       "status": "ACTIVE"
     },
     {
@@ -8030,7 +8030,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-13-gp-trust-readiness-register.md",
-      "staleDays": 4,
+      "staleDays": 8,
       "status": "ACTIVE"
     },
     {
@@ -8067,7 +8067,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -8082,7 +8082,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -8097,7 +8097,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8112,7 +8112,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -8127,7 +8127,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8142,7 +8142,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8157,7 +8157,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8172,7 +8172,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8187,7 +8187,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8202,7 +8202,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8217,7 +8217,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8232,7 +8232,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8247,7 +8247,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8262,7 +8262,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8277,7 +8277,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8292,7 +8292,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8307,7 +8307,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8322,7 +8322,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8337,7 +8337,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8352,7 +8352,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8367,7 +8367,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 27,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -8382,7 +8382,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8396,7 +8396,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -8423,7 +8423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8438,7 +8438,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -8453,7 +8453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8468,7 +8468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8483,7 +8483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8498,7 +8498,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8513,7 +8513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8528,7 +8528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8543,7 +8543,7 @@
       "lastUpdated": "2026-06-12",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 5,
+      "staleDays": 9,
       "status": "PROVEN"
     },
     {
@@ -8558,7 +8558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8573,7 +8573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8588,7 +8588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8603,7 +8603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8618,7 +8618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8633,7 +8633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8648,7 +8648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8663,7 +8663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8678,7 +8678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8693,7 +8693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8728,7 +8728,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "COMPLETED"
     },
     {
@@ -8759,7 +8759,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "REFERENCE"
     },
     {
@@ -8790,7 +8790,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "REFERENCE"
     },
     {
@@ -8821,7 +8821,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "REFERENCE"
     },
     {
@@ -8854,7 +8854,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "REFERENCE"
     },
     {
@@ -8885,7 +8885,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 26,
+      "staleDays": 30,
       "status": "REFERENCE"
     },
     {
@@ -8917,7 +8917,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "REFERENCE"
     },
     {
@@ -8932,7 +8932,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -8947,7 +8947,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8962,7 +8962,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8977,7 +8977,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -8992,7 +8992,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9007,7 +9007,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9035,7 +9035,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 79,
+      "staleDays": 83,
       "status": "ACTIVE"
     },
     {
@@ -9050,7 +9050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9065,7 +9065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9080,7 +9080,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9095,7 +9095,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9110,7 +9110,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9125,7 +9125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9140,7 +9140,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9155,7 +9155,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9170,7 +9170,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9185,7 +9185,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9200,7 +9200,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9215,7 +9215,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9230,7 +9230,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9245,7 +9245,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9260,7 +9260,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9275,7 +9275,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9290,7 +9290,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-01-to-01-07-extraction.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -9305,7 +9305,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-08-to-01-18-extraction.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -9320,7 +9320,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-18-extraction.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -9334,7 +9334,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -9348,7 +9348,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -9362,7 +9362,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -9376,7 +9376,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "UNKNOWN"
     },
     {
@@ -9390,7 +9390,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -9404,7 +9404,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "UNKNOWN"
     },
     {
@@ -9419,7 +9419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9434,7 +9434,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9449,7 +9449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -9490,7 +9490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "VERIFIED"
     },
     {
@@ -9838,7 +9838,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "DRAFT"
     },
     {
@@ -10036,7 +10036,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10118,7 +10118,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "VERIFIED"
     },
     {
@@ -10191,7 +10191,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "DRAFT"
     },
     {
@@ -10235,7 +10235,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "DRAFT"
     },
     {
@@ -10365,7 +10365,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "DRAFT"
     },
     {
@@ -10412,7 +10412,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "DRAFT"
     },
     {
@@ -10454,7 +10454,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 75,
+      "staleDays": 79,
       "status": "DRAFT"
     },
     {
@@ -10603,7 +10603,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10629,7 +10629,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10660,7 +10660,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10689,7 +10689,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10718,7 +10718,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10748,7 +10748,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10778,7 +10778,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10808,7 +10808,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 37,
+      "staleDays": 41,
       "status": "DRAFT"
     },
     {
@@ -10841,7 +10841,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 60,
+      "staleDays": 64,
       "status": "DRAFT"
     },
     {
@@ -10906,7 +10906,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -10921,7 +10921,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -10936,7 +10936,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -10963,7 +10963,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -10991,7 +10991,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -11020,7 +11020,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -11048,7 +11048,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -11076,7 +11076,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -11103,7 +11103,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 19,
+      "staleDays": 23,
       "status": "COMPLETE"
     },
     {
@@ -11144,7 +11144,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 10,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -11161,7 +11161,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 4,
+      "staleDays": 8,
       "status": "COMPLETE"
     },
     {
@@ -11190,7 +11190,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 9,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -11219,7 +11219,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 8,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -11249,6 +11249,26 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "authority": "docs/adr/ADR-023-investment-event-persistence.md",
+        "last_updated": "2026-06-21",
+        "owner": "Core Team",
+        "related_spec": "docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md",
+        "review_cadence": "P30D",
+        "status": "DRAFT"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-21",
+      "owner": "Core Team",
+      "path": "docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md",
+      "staleDays": 0,
+      "status": "DRAFT"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {},
       "hasExecutionClaims": true,
       "isStale": true,
@@ -11272,7 +11292,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 4,
+      "staleDays": 8,
       "status": "COMPLETE"
     },
     {
@@ -11301,7 +11321,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 9,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -11330,7 +11350,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 8,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -11377,8 +11397,25 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/superpowers/specs/2026-06-13-gp-trust-readiness-audit-design.md",
-      "staleDays": 4,
+      "staleDays": 8,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "authority": "docs/adr/ADR-023-investment-event-persistence.md (ACCEPTED) — REQUIRES amendment to decision 5 (see § ADR amendment)",
+        "last_updated": "2026-06-21",
+        "status": "DRAFT (red-team hardened 2026-06-21)",
+        "supersedes_planning": "docs/superpowers/plans/2026-06-18-secondary-surface-trust-slim.md (PR-6 stub)"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-21",
+      "owner": null,
+      "path": "docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md",
+      "staleDays": 0,
+      "status": "DRAFT (red-team hardened 2026-06-21)"
     },
     {
       "docType": "doc",
@@ -11416,7 +11453,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 28,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -11431,7 +11468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11446,7 +11483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11461,7 +11498,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11476,7 +11513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11503,7 +11540,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11518,7 +11555,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11533,7 +11570,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11548,7 +11585,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11563,7 +11600,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11578,7 +11615,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11593,7 +11630,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "HISTORICAL"
     },
     {
@@ -11608,7 +11645,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11623,7 +11660,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11638,7 +11675,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11653,7 +11690,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11668,7 +11705,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11683,7 +11720,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11698,7 +11735,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11713,7 +11750,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11728,7 +11765,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 20,
+      "staleDays": 24,
       "status": "ACTIVE"
     },
     {
@@ -11774,7 +11811,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 170,
+      "staleDays": 174,
       "status": "ACTIVE"
     },
     {
@@ -11789,7 +11826,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     },
     {
@@ -11804,11 +11841,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 149,
+      "staleDays": 153,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-06-17T00:00:00.000Z",
+  "generatedAt": "2026-06-21T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -12974,13 +13011,14 @@
   ],
   "stats": {
     "by_status": {
-      "ACCEPTED": 1,
+      "ACCEPTED (amended 2026-06-21)": 1,
       "ACTIVE": 446,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 3,
       "COMPLETED": 1,
-      "DRAFT": 30,
+      "DRAFT": 31,
+      "DRAFT (red-team hardened 2026-06-21)": 1,
       "HISTORICAL": 29,
       "HISTORICAL-SNAPSHOT": 1,
       "INDEXED": 6,
@@ -12996,7 +13034,7 @@
     },
     "missing_frontmatter": 20,
     "stale_docs": 102,
-    "total_docs": 658
+    "total_docs": 660
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,17 +1,17 @@
 ---
-last_updated: 2026-06-17
+last_updated: 2026-06-21
 ---
 
 # Staleness Report
 
-*Generated: 2026-06-17T00:00:00.000Z*
+*Generated: 2026-06-21T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 658 |
+| Total Documents | 660 |
 | Stale Documents | 102 |
 | Missing Frontmatter | 20 |
 
@@ -21,7 +21,7 @@ last_updated: 2026-06-17
 |--------|-------|
 | ACTIVE | 446 |
 | UNKNOWN | 115 |
-| DRAFT | 30 |
+| DRAFT | 31 |
 | HISTORICAL | 29 |
 | VERIFIED | 9 |
 | INDEXED | 6 |
@@ -31,13 +31,14 @@ last_updated: 2026-06-17
 | active | 2 |
 | STALE-VALIDATION | 1 |
 | Implemented | 1 |
-| ACCEPTED | 1 |
+| ACCEPTED (amended 2026-06-21) | 1 |
 | ARCHIVED | 1 |
 | HISTORICAL-SNAPSHOT | 1 |
 | TRACKED (not scheduled) | 1 |
 | BACKLOG | 1 |
 | PROVEN | 1 |
 | COMPLETED | 1 |
+| DRAFT (red-team hardened 2026-06-21) | 1 |
 
 ## Stale Documents
 
@@ -86,15 +87,15 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md` | Never | 999 | YES - verify! | Unassigned |
 | `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md` | Never | 999 | No | Unassigned |
 | `docs/tooling-catalog.md` | Never | 999 | No | Unassigned |
-| `cheatsheets/agent-architecture.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/ai-code-review.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/api.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/capability-checklist.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/claude-commands.md` | 2026-01-19 | 149 | No | Unassigned |
-| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 149 | No | Unassigned |
+| `cheatsheets/agent-architecture.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/ai-code-review.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/api.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/capability-checklist.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/claude-commands.md` | 2026-01-19 | 153 | No | Unassigned |
+| `cheatsheets/claude-md-guidelines.md` | 2026-01-19 | 153 | No | Unassigned |
 
 *...and 52 more stale documents.*
 
@@ -102,13 +103,13 @@ Documents that need review (older than their cadence threshold):
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **CHANGELOG.md** (28 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (149 days old)
-- [ ] **cheatsheets/schema-alignment.md** (149 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (149 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (149 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (149 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (149 days old)
+- [ ] **CHANGELOG.md** (32 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (153 days old)
+- [ ] **cheatsheets/schema-alignment.md** (153 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (153 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (153 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (153 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (153 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)

--- a/docs/adr/ADR-023-investment-event-persistence.md
+++ b/docs/adr/ADR-023-investment-event-persistence.md
@@ -1,6 +1,6 @@
 ---
-status: ACCEPTED
-last_updated: 2026-06-17
+status: ACCEPTED (amended 2026-06-21)
+last_updated: 2026-06-21
 ---
 
 # ADR-023: Investment Event Persistence Backbone (Rounds First Tranche)
@@ -24,6 +24,30 @@ of `prd-fund-management-roadmap-execution-20260617` (amendment-3), with the R7
 Tier-1 promotions (aggregate boundary, fund-local-vs-shared, money/precision,
 effective-date/as-of). **No code lands under this ADR.** L3b is conditionally
 authorized only after this ADR is reviewed and accepted.
+
+---
+
+## Amendment 1 — 2026-06-21 (decision 5: append-only WITH supersede correction)
+
+Decision 5 originally specified append-only with **no** correction route, binding
+`enable_investment_rounds` OFF in prod until a separate supersede tranche. Per the
+red-team-hardened, architect-approved L3b design spec
+(`docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md`),
+decision 5 is **amended**: the supersede correction edge is **folded into the
+tranche-1 PR** — a nullable `supersedes_round_id` self-FK + partial
+`UNIQUE (supersedes_round_id) WHERE … IS NOT NULL` (no correction fork) +
+service/route/test handling, mirroring `cashFlowEvents.supersedesEventId`. Rounds
+remain immutable (a correction **appends** a superseding row, never mutates).
+Because a correction path now exists within L3b, the
+flag-off-until-separate-tranche guardrail is satisfied in-tranche;
+`enable_investment_rounds` still **defaults OFF** (enabling is a soak/ops gate,
+no longer an architectural block).
+
+**Unaffected:** all other decisions; `phoenix-precision-guardian` §8
+money/precision sign-off (supersede reuses the existing `NUMERIC(20,6)` columns
+and adds no money semantics). **Architect re-sign-off on decision 5: RECEIVED
+2026-06-21.** The precondition migration is also split to a standalone precursor
+PR (de-risks the only row-affecting atom from feature CI).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md
+++ b/docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md
@@ -1,36 +1,73 @@
+---
+status: DRAFT
+audience: agents
+last_updated: 2026-06-21
+owner: 'Core Team'
+review_cadence: P30D
+authority: docs/adr/ADR-023-investment-event-persistence.md
+related_spec: docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md
+---
+
 # Investment-Round Persistence (ADR-023 L3b) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Per the workspace workflow contract, every edit/test in this plan is dispatched via Hermes (`npm run hermes:production -- --task "..."`); Claude Code plans and verifies only.**
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. **Per the workspace workflow contract,
+> every edit/test in this plan is dispatched via Hermes
+> (`npm run hermes:production -- --task "..."`); Claude Code plans and verifies
+> only.**
 
-**Goal:** Flip `POST /api/investments/:id/rounds` (501) into a backed, fund-scoped, idempotent create + list + read with an append-only supersede correction path, behind `enable_investment_rounds` (default OFF, now enable-able).
+**Goal:** Flip `POST /api/investments/:id/rounds` (501) into a backed,
+fund-scoped, idempotent create + list + read with an append-only supersede
+correction path, behind `enable_investment_rounds` (default OFF, now
+enable-able).
 
-**Architecture:** A dedicated `investment_rounds` table (NUMERIC(20,6) money), defined in the Drizzle schema (drives `db:push` → Testcontainers test DB + prod) and mirrored by a journaled `server/migrations/*.sql` pair (drives `release:check` + migration-runner test). A thin service holds idempotency + supersede logic; the existing dual-mounted `investments` router gains the round handlers. Mirrors the `task` (#871/#873) and `cash_event` (#862–#869) precedents exactly.
+**Architecture:** A dedicated `investment_rounds` table (NUMERIC(20,6) money),
+defined in the Drizzle schema (drives `db:push` → Testcontainers test DB + prod)
+and mirrored by a journaled `server/migrations/*.sql` pair (drives
+`release:check` + migration-runner test). A thin service holds idempotency +
+supersede logic; the existing dual-mounted `investments` router gains the round
+handlers. Mirrors the `task` (#871/#873) and `cash_event` (#862–#869) precedents
+exactly.
 
-**Tech Stack:** Drizzle ORM (Postgres), Zod, Express, Vitest + supertest + Testcontainers, TanStack Query, Decimal-string money per ADR-011. Node 20.19+, `TZ=UTC`.
+**Tech Stack:** Drizzle ORM (Postgres), Zod, Express, Vitest + supertest +
+Testcontainers, TanStack Query, Decimal-string money per ADR-011. Node 20.19+,
+`TZ=UTC`.
 
-**Authority:** [ADR-023](../../adr/ADR-023-investment-event-persistence.md) (amended 2026-06-21 — decision 5 now append-only WITH supersede). Spec: [2026-06-21-investment-round-persistence-l3b-design.md](../specs/2026-06-21-investment-round-persistence-l3b-design.md).
+**Authority:** [ADR-023](../../adr/ADR-023-investment-event-persistence.md)
+(amended 2026-06-21 — decision 5 now append-only WITH supersede). Spec:
+[2026-06-21-investment-round-persistence-l3b-design.md](../specs/2026-06-21-investment-round-persistence-l3b-design.md).
 
 ---
 
 ## File structure
 
 **PR-0 (precondition, tiny):**
-- Modify: `shared/schema/portfolio.ts` (add `unique('investments_id_fund_id_key')` on `investments`)
-- Create: `server/migrations/20260621_investments_id_fund_unique_v1.{up,down}.sql`
+
+- Modify: `shared/schema/portfolio.ts` (add
+  `unique('investments_id_fund_id_key')` on `investments`)
+- Create:
+  `server/migrations/20260621_investments_id_fund_unique_v1.{up,down}.sql`
 - Create: `tests/integration/migrations/investments-id-fund-unique.test.ts`
 
 **PR-1 (feature):**
+
 - Create: `shared/schema/investment-rounds.ts` (Drizzle table)
-- Modify: `shared/schema/index.ts` (export the new table) — confirm `shared/schema.ts` re-chains to it
+- Modify: `shared/schema/index.ts` (export the new table) — confirm
+  `shared/schema.ts` re-chains to it
 - Create: `server/migrations/20260621_z_investment_rounds_v1.{up,down}.sql`
 - Create: `shared/lib/canonical-hash.ts` (extract `canonicalize`+`sha256Hex`)
-- Modify: `server/services/lp-reporting/import-reconciliation-service.ts` (re-import from the new util — DRY, no behaviour change)
+- Modify: `server/services/lp-reporting/import-reconciliation-service.ts`
+  (re-import from the new util — DRY, no behaviour change)
 - Create: `shared/contracts/investments/investment-round.contract.ts`
 - Create: `server/services/investments/investment-round-service.ts`
-- Modify: `server/routes/investments.ts` (replace the 501 `/rounds` handler; add GET list/read)
+- Modify: `server/routes/investments.ts` (replace the 501 `/rounds` handler; add
+  GET list/read)
 - Rewrite: `tests/integration/investment-scenario-capability.test.ts`
 - Create: `tests/unit/services/investments/investment-round-service.test.ts`
-- Create: `client/src/lib/investment-round-edit-model.ts` (serializer) + `client/src/hooks/useCreateRound.ts`
+- Create: `client/src/lib/investment-round-edit-model.ts` (serializer) +
+  `client/src/hooks/useCreateRound.ts`
 - Create: `tests/unit/lib/investment-round-edit-model.test.ts`
 - Modify: `flags/registry.yaml` (+ regenerate `shared/generated/flag-*.ts`)
 
@@ -41,11 +78,14 @@
 ### Task 0.1: Add `UNIQUE (id, fund_id)` to `investments`
 
 **Files:**
+
 - Modify: `shared/schema/portfolio.ts:61-91`
-- Create: `server/migrations/20260621_investments_id_fund_unique_v1.up.sql`, `.down.sql`
+- Create: `server/migrations/20260621_investments_id_fund_unique_v1.up.sql`,
+  `.down.sql`
 - Test: `tests/integration/migrations/investments-id-fund-unique.test.ts`
 
-- [ ] **Step 1: Write the failing schema test** — `tests/integration/migrations/investments-id-fund-unique.test.ts`:
+- [ ] **Step 1: Write the failing schema test** —
+      `tests/integration/migrations/investments-id-fund-unique.test.ts`:
 
 ```ts
 import { describe, it, expect, beforeAll } from 'vitest';
@@ -54,7 +94,9 @@ import { getTestDb } from '../../helpers/test-db'; // existing Testcontainers he
 
 describe('investments (id, fund_id) unique', () => {
   let db: Awaited<ReturnType<typeof getTestDb>>;
-  beforeAll(async () => { db = await getTestDb(); });
+  beforeAll(async () => {
+    db = await getTestDb();
+  });
 
   it('has a unique constraint on (id, fund_id) so it can be a composite-FK target', async () => {
     const rows = await db.execute(sql`
@@ -66,21 +108,28 @@ describe('investments (id, fund_id) unique', () => {
 });
 ```
 
-> Note: confirm the real Testcontainers helper path (`tests/helpers/*`); reuse whatever `investment-scenario-capability` or LP integration tests already import. Do not invent a new harness.
+> Note: confirm the real Testcontainers helper path (`tests/helpers/*`); reuse
+> whatever `investment-scenario-capability` or LP integration tests already
+> import. Do not invent a new harness.
 
 - [ ] **Step 2: Run it — expect FAIL** (constraint absent)
 
-Run: `npm run test:integration -- tests/integration/migrations/investments-id-fund-unique.test.ts`
+Run:
+`npm run test:integration -- tests/integration/migrations/investments-id-fund-unique.test.ts`
 Expected: FAIL (0 rows).
 
-- [ ] **Step 3: Add the unique to the Drizzle schema** — in `shared/schema/portfolio.ts`, import `unique` and add to the `investments` config callback:
+- [ ] **Step 3: Add the unique to the Drizzle schema** — in
+      `shared/schema/portfolio.ts`, import `unique` and add to the `investments`
+      config callback:
 
 ```ts
 import { /* …existing… */ unique } from 'drizzle-orm/pg-core';
 // …
 export const investments = pgTable(
   'investments',
-  { /* …unchanged columns… */ },
+  {
+    /* …unchanged columns… */
+  },
   (table) => ({
     pricingConfidenceCheck: check(
       'investments_pricing_confidence_check',
@@ -94,7 +143,8 @@ export const investments = pgTable(
 );
 ```
 
-- [ ] **Step 4: Write the journaled migration** — `server/migrations/20260621_investments_id_fund_unique_v1.up.sql`:
+- [ ] **Step 4: Write the journaled migration** —
+      `server/migrations/20260621_investments_id_fund_unique_v1.up.sql`:
 
 ```sql
 -- Precondition for ADR-023 L3b: make (id, fund_id) a composite-FK target for
@@ -110,14 +160,17 @@ ALTER TABLE investments
 ALTER TABLE investments DROP CONSTRAINT IF EXISTS investments_id_fund_id_key;
 ```
 
-- [ ] **Step 5: Run test — expect PASS** (db:push picks up the Drizzle change for the Testcontainers DB)
+- [ ] **Step 5: Run test — expect PASS** (db:push picks up the Drizzle change
+      for the Testcontainers DB)
 
-Run: `npm run test:integration -- tests/integration/migrations/investments-id-fund-unique.test.ts`
+Run:
+`npm run test:integration -- tests/integration/migrations/investments-id-fund-unique.test.ts`
 Expected: PASS.
 
 - [ ] **Step 6: Type-check + commit**
 
 Run: `npm run check`
+
 ```bash
 git add shared/schema/portfolio.ts server/migrations/20260621_investments_id_fund_unique_v1.up.sql server/migrations/20260621_investments_id_fund_unique_v1.down.sql tests/integration/migrations/investments-id-fund-unique.test.ts
 git commit -m "feat(investments): add UNIQUE (id, fund_id) composite-FK target (ADR-023 L3b precondition)"
@@ -129,34 +182,53 @@ git commit -m "feat(investments): add UNIQUE (id, fund_id) composite-FK target (
 
 # PR-1 — Feature (rounds + supersede + flag + safe hygiene)
 
-The remaining tasks are sequenced. Each is one self-contained change. Detailed per-step code lives in the companion task files written at execution time; the contract and service signatures below are the locked interfaces every later task depends on.
+The remaining tasks are sequenced. Each is one self-contained change. Detailed
+per-step code lives in the companion task files written at execution time; the
+contract and service signatures below are the locked interfaces every later task
+depends on.
 
 ## Locked interfaces (referenced by all PR-1 tasks)
 
 ```ts
 // shared/contracts/investments/investment-round.contract.ts
-export const SecurityTypeSchema = z.enum(['equity','convertible_note','safe','warrant','other']);
-export const InvestmentRoundCreateSchema = z.object({
-  fundId: z.number().int().positive(),            // path-consistency check
-  roundName: z.string().trim().min(1).max(120),
-  securityType: SecurityTypeSchema,
-  roundDate: z.string().date(),                   // date-only, never through Date()
-  currency: z.string().regex(/^[A-Z]{3}$/).default('USD'),
-  investmentAmount: MoneyStringSchema,            // imported, NOT redeclared
-  roundSize: MoneyStringSchema.optional(),
-  preMoneyValuation: MoneyStringSchema.optional(),
-  supersedesRoundId: z.number().int().positive().optional(),
-}).strict();
-export const InvestmentRoundResponseSchema = z.object({ /* …cols… */ etag: z.string().min(1) }).strict();
+export const SecurityTypeSchema = z.enum([
+  'equity',
+  'convertible_note',
+  'safe',
+  'warrant',
+  'other',
+]);
+export const InvestmentRoundCreateSchema = z
+  .object({
+    fundId: z.number().int().positive(), // path-consistency check
+    roundName: z.string().trim().min(1).max(120),
+    securityType: SecurityTypeSchema,
+    roundDate: z.string().date(), // date-only, never through Date()
+    currency: z
+      .string()
+      .regex(/^[A-Z]{3}$/)
+      .default('USD'),
+    investmentAmount: MoneyStringSchema, // imported, NOT redeclared
+    roundSize: MoneyStringSchema.optional(),
+    preMoneyValuation: MoneyStringSchema.optional(),
+    supersedesRoundId: z.number().int().positive().optional(),
+  })
+  .strict();
+export const InvestmentRoundResponseSchema = z
+  .object({ /* …cols… */ etag: z.string().min(1) })
+  .strict();
 ```
 
 ```ts
 // server/services/investments/investment-round-service.ts
-export async function createRound(input, { database }?): Promise<
+export async function createRound(
+  input,
+  { database }?
+): Promise<
   | { kind: 'created'; row; xmin }
   | { kind: 'replayed'; row; xmin }
-  | { kind: 'key_reused' }            // -> 409 idempotency_key_reused
-  | { kind: 'already_superseded' }    // -> 409 round_already_superseded
+  | { kind: 'key_reused' } // -> 409 idempotency_key_reused
+  | { kind: 'already_superseded' } // -> 409 round_already_superseded
   | { kind: 'supersede_target_missing' } // -> 404
   | { kind: 'supersede_target_other_investment' } // -> 400
 >;
@@ -165,52 +237,152 @@ export async function loadRound(investmentId, roundId, { database }?);
 ```
 
 ### Task 1: `investment_rounds` Drizzle table + journaled migration + RESTRICT schema test
-Mirror `shared/schema/operating-objects.ts` and `investment_lots` (partial-unique-idempotency idiom at `portfolio.ts:123-125`). Columns + constraints per the spec § Step 1. Composite FK via `foreignKey({ columns:[t.investmentId,t.fundId], foreignColumns:[investments.id, investments.fundId] }).onDelete('restrict').onUpdate('restrict')`; self-FK `supersedesRoundId` → `investmentRounds.id` (`(): AnyPgColumn`); `uniqueIndex('investment_rounds_supersedes_uq').on(t.supersedesRoundId).where(sql\`supersedes_round_id IS NOT NULL\`)`; `unique('investment_rounds_fund_idem_key').on(t.fundId, t.idempotencyKey)`. Export from `shared/schema/index.ts`. Write the journaled `20260621_z_investment_rounds_v1.{up,down}.sql` (down drops the table). **TDD:** schema test proves (a) the table exists, (b) `DELETE FROM investments` where a round exists raises FK RESTRICT, (c) a second row with the same `supersedes_round_id` raises unique violation.
+
+Mirror `shared/schema/operating-objects.ts` and `investment_lots`
+(partial-unique-idempotency idiom at `portfolio.ts:123-125`). Columns +
+constraints per the spec § Step 1. Composite FK via
+`foreignKey({ columns:[t.investmentId,t.fundId], foreignColumns:[investments.id, investments.fundId] }).onDelete('restrict').onUpdate('restrict')`;
+self-FK `supersedesRoundId` → `investmentRounds.id` (`(): AnyPgColumn`);
+`uniqueIndex('investment_rounds_supersedes_uq').on(t.supersedesRoundId).where(sql\`supersedes_round_id
+IS NOT NULL\`)`; `unique('investment_rounds_fund_idem_key').on(t.fundId,
+t.idempotencyKey)`. Export from `shared/schema/index.ts`. Write the journaled `20260621_z_investment_rounds_v1.{up,down}.sql`(down drops the table). **TDD:** schema test proves (a) the table exists, (b)`DELETE
+FROM
+investments`where a round exists raises FK RESTRICT, (c) a second row with the same`supersedes_round_id`
+raises unique violation.
 
 ### Task 2: Extract `shared/lib/canonical-hash.ts`
-Move `canonicalize` + `sha256Hex` (currently private in `import-reconciliation-service.ts:87-110`) into `shared/lib/canonical-hash.ts` as `export function canonicalSha256(value: unknown): string`. Repoint `import-reconciliation-service.ts` to import it (its `computeImportPreviewHash`/`computeSourceRowHash` stay, now delegating). **TDD:** unit test asserts key-order independence (`{a,b}` === `{b,a}`) and that `undefined` keys are dropped. Run the existing `import-reconciliation-service.test.ts` to prove no behaviour change.
+
+Move `canonicalize` + `sha256Hex` (currently private in
+`import-reconciliation-service.ts:87-110`) into `shared/lib/canonical-hash.ts`
+as `export function canonicalSha256(value: unknown): string`. Repoint
+`import-reconciliation-service.ts` to import it (its
+`computeImportPreviewHash`/`computeSourceRowHash` stay, now delegating).
+**TDD:** unit test asserts key-order independence (`{a,b}` === `{b,a}`) and that
+`undefined` keys are dropped. Run the existing
+`import-reconciliation-service.test.ts` to prove no behaviour change.
 
 ### Task 3: Shared Zod contract
-Write `shared/contracts/investments/investment-round.contract.ts` per the locked interface. **Import** `MoneyStringSchema`/`DecimalStringSchema` from `@shared/contracts/lp-reporting/cash-flow-event.contract` (never redeclare). `.strict()` response so `created_by`/`request_hash`/`idempotency_key` can never leak. **TDD:** contract unit test — valid payload parses; 7-dp money rejects; unknown key rejects; `supersedesRoundId` optional.
+
+Write `shared/contracts/investments/investment-round.contract.ts` per the locked
+interface. **Import** `MoneyStringSchema`/`DecimalStringSchema` from
+`@shared/contracts/lp-reporting/cash-flow-event.contract` (never redeclare).
+`.strict()` response so `created_by`/`request_hash`/`idempotency_key` can never
+leak. **TDD:** contract unit test — valid payload parses; 7-dp money rejects;
+unknown key rejects; `supersedesRoundId` optional.
 
 ### Task 4: Service
-Write `server/services/investments/investment-round-service.ts` mirroring `task-service.ts` (explicit column map + `sql<string>\`xmin::text\``, `{ database }` DI seam, `splitXmin`). `createRound`:
-1. compute `requestHash = canonicalSha256({ investmentId, fundId, roundName, securityType, roundDate, currency, investmentAmount, roundSize, preMoneyValuation, supersedesRoundId })`.
-2. if `supersedesRoundId`: load it; missing → `supersede_target_missing`; different investment → `supersede_target_other_investment`; already-superseded (a row referencing it exists) → `already_superseded`.
-3. `INSERT … ON CONFLICT (fund_id, idempotency_key) DO NOTHING RETURNING <cols+xmin>`. Row returned → `created`. No row → SELECT existing by `(fund_id, idempotency_key)`, compare `request_hash`: equal → `replayed`; differ → `key_reused`.
-4. wrap the insert in try/catch: a `23505` on `investment_rounds_supersedes_uq` (concurrent supersede race) → `already_superseded`.
-`listRoundsForInvestment` returns rows where no other row's `supersedes_round_id` points at them, newest-first. **TDD:** service unit tests with a mocked DB seam cover created / replayed / key_reused / supersede happy + already_superseded.
+
+Write `server/services/investments/investment-round-service.ts` mirroring
+`task-service.ts` (explicit column map + `sql<string>\`xmin::text\``, `{
+database }`DI seam,`splitXmin`). `createRound`:
+
+1. compute
+   `requestHash = canonicalSha256({ investmentId, fundId, roundName, securityType, roundDate, currency, investmentAmount, roundSize, preMoneyValuation, supersedesRoundId })`.
+2. if `supersedesRoundId`: load it; missing → `supersede_target_missing`;
+   different investment → `supersede_target_other_investment`;
+   already-superseded (a row referencing it exists) → `already_superseded`.
+3. `INSERT … ON CONFLICT (fund_id, idempotency_key) DO NOTHING RETURNING <cols+xmin>`.
+   Row returned → `created`. No row → SELECT existing by
+   `(fund_id, idempotency_key)`, compare `request_hash`: equal → `replayed`;
+   differ → `key_reused`.
+4. wrap the insert in try/catch: a `23505` on `investment_rounds_supersedes_uq`
+   (concurrent supersede race) → `already_superseded`. `listRoundsForInvestment`
+   returns rows where no other row's `supersedes_round_id` points at them,
+   newest-first. **TDD:** service unit tests with a mocked DB seam cover created
+   / replayed / key_reused / supersede happy + already_superseded.
 
 ### Task 5: Routes (extend `server/routes/investments.ts`)
-Replace the 501 `/investments/:id/rounds` POST handler and add `GET /investments/:id/rounds` + `GET /investments/:id/rounds/:roundId`. Pattern (mirror `operating-object-tasks.ts` error ordering, but fund is **derived**): parse `:id` → load investment via service (NOT storage in the new path) → 404 if absent → `enforceProvidedFundScope(req, res, investment.fundId)` → read `Idempotency-Key` via the `getIdempotencyKey` idiom (`headers['idempotency-key'] ?? ['x-idempotency-key']`) → 428 if missing (create only) → `InvestmentRoundCreateSchema.safeParse` → 400 → body `fundId` must equal derived → 400 → `createRound(...)` → map result kinds to 201/200/409/404/400 → `InvestmentRoundResponseSchema.parse` for the body. The two GETs run the same load-investment + `enforceProvidedFundScope` before returning (closes the read-path IDOR — ADR finding D). `cases` 501 handler untouched. The round handlers import only the service (no new `../db`/`../storage`); the file's existing `storage` import stays for legacy handlers.
+
+Replace the 501 `/investments/:id/rounds` POST handler and add
+`GET /investments/:id/rounds` + `GET /investments/:id/rounds/:roundId`. Pattern
+(mirror `operating-object-tasks.ts` error ordering, but fund is **derived**):
+parse `:id` → load investment via service (NOT storage in the new path) → 404 if
+absent → `enforceProvidedFundScope(req, res, investment.fundId)` → read
+`Idempotency-Key` via the `getIdempotencyKey` idiom
+(`headers['idempotency-key'] ?? ['x-idempotency-key']`) → 428 if missing (create
+only) → `InvestmentRoundCreateSchema.safeParse` → 400 → body `fundId` must equal
+derived → 400 → `createRound(...)` → map result kinds to 201/200/409/404/400 →
+`InvestmentRoundResponseSchema.parse` for the body. The two GETs run the same
+load-investment + `enforceProvidedFundScope` before returning (closes the
+read-path IDOR — ADR finding D). `cases` 501 handler untouched. The round
+handlers import only the service (no new `../db`/`../storage`); the file's
+existing `storage` import stays for legacy handlers.
 
 ### Task 6: Integration test rewrite
-Rewrite `tests/integration/investment-scenario-capability.test.ts` against Testcontainers + a seeded fund/investment + a scoped bearer token. Assert: **201** create (full payload + `Idempotency-Key`); **200** exact retry replay; **409** same key/different body; **428** missing key; **403** cross-fund; **404** unknown investment; supersede happy (create→supersede→list shows the corrector, not the original) + **409** double-supersede. `cases` stays **501**. **Teardown:** `TRUNCATE investment_rounds RESTART IDENTITY CASCADE` (append-only rows have no delete route — #890 teardown lesson) and close any owned pool.
+
+Rewrite `tests/integration/investment-scenario-capability.test.ts` against
+Testcontainers + a seeded fund/investment + a scoped bearer token. Assert:
+**201** create (full payload + `Idempotency-Key`); **200** exact retry replay;
+**409** same key/different body; **428** missing key; **403** cross-fund;
+**404** unknown investment; supersede happy (create→supersede→list shows the
+corrector, not the original) + **409** double-supersede. `cases` stays **501**.
+**Teardown:** `TRUNCATE investment_rounds RESTART IDENTITY CASCADE` (append-only
+rows have no delete route — #890 teardown lesson) and close any owned pool.
 
 ### Task 7: Client hook + serializer
-`client/src/lib/investment-round-edit-model.ts` (framework-free, mirror `cash-event-edit-model.ts`): map currency **label → ISO-4217** and JS **number → DecimalString**; `roundDate` stays date-only. `client/src/hooks/useCreateRound.ts` (TanStack mutation) POSTs with `Content-Type: application/json` (avoids the makeApp 415 body-less guard) and a generated `Idempotency-Key`. **TDD:** serializer unit test (label→ISO, 2.5→"2.5", date-only preserved). No live UI mount (deferred).
+
+`client/src/lib/investment-round-edit-model.ts` (framework-free, mirror
+`cash-event-edit-model.ts`): map currency **label → ISO-4217** and JS **number →
+DecimalString**; `roundDate` stays date-only.
+`client/src/hooks/useCreateRound.ts` (TanStack mutation) POSTs with
+`Content-Type: application/json` (avoids the makeApp 415 body-less guard) and a
+generated `Idempotency-Key`. **TDD:** serializer unit test (label→ISO,
+2.5→"2.5", date-only preserved). No live UI mount (deferred).
 
 ### Task 8: Feature flag
-Add to `flags/registry.yaml` (mirror `enable_operations_hub` shape): `enable_investment_rounds`, `default: false`, all environments `false`, `exposeToClient: true`, `risk: medium`, `owner: 'gp-team'`, `dependencies: []`, `expiresAt: '2026-12-31'`. Regenerate: `npx tsx scripts/generate-flag-types.ts` (confirm exact invocation) and commit the regenerated `shared/generated/flag-types.ts` + `flag-defaults.ts`. Mount-gate the (future) client surface on it.
+
+Add to `flags/registry.yaml` (mirror `enable_operations_hub` shape):
+`enable_investment_rounds`, `default: false`, all environments `false`,
+`exposeToClient: true`, `risk: medium`, `owner: 'gp-team'`, `dependencies: []`,
+`expiresAt: '2026-12-31'`. Regenerate: `npx tsx scripts/generate-flag-types.ts`
+(confirm exact invocation) and commit the regenerated
+`shared/generated/flag-types.ts` + `flag-defaults.ts`. Mount-gate the (future)
+client surface on it.
 
 ### Task 9: Folded hygiene (reversible only)
-- Verify-then-prune worktrees: for each of `Updog_restore_lp_dashboard_runtime`, `updog-pr864-ci-fix`, `Updog_restore_pr881_ci` run `git -C <wt> status --porcelain` (must be empty) and confirm no commits ahead of the merged SHA, then `git worktree remove <wt>`.
+
+- Verify-then-prune worktrees: for each of `Updog_restore_lp_dashboard_runtime`,
+  `updog-pr864-ci-fix`, `Updog_restore_pr881_ci` run
+  `git -C <wt> status --porcelain` (must be empty) and confirm no commits ahead
+  of the merged SHA, then `git worktree remove <wt>`.
 - Delete merged local branches (`git branch --merged main` minus `main`).
-- Archive the 3 loose docs **only** after running the CLAUDE.md Archive Gate per file (git-log landed/obsolete + grep feature-gone + not-an-active-handoff) and citing the three checks for each in the PR body; apply the Derivability Test to `CRITICAL-REVIEW-secondary-surface-governance.md` (keep if non-derivable).
+- Archive the 3 loose docs **only** after running the CLAUDE.md Archive Gate per
+  file (git-log landed/obsolete + grep feature-gone + not-an-active-handoff) and
+  citing the three checks for each in the PR body; apply the Derivability Test
+  to `CRITICAL-REVIEW-secondary-surface-governance.md` (keep if non-derivable).
 - **Do NOT touch the 136 stashes.**
 
 ---
 
 ## Verification (whole milestone)
-- `npm run check` (baseline:check), `npm run lint` (incl. `guard:route-imports`), targeted `vitest run` for unit suites — all green.
-- Integration suite does **not** run on a feature PR automatically (test-smart skips, test-full is main-gated). Dispatch it: `gh workflow run ci-unified.yml --ref <branch> -f run_full_suite=true`, then grep the **Test-integration** log for `investment-scenario-capability` and the migrations test.
+
+- `npm run check` (baseline:check), `npm run lint` (incl.
+  `guard:route-imports`), targeted `vitest run` for unit suites — all green.
+- Integration suite does **not** run on a feature PR automatically (test-smart
+  skips, test-full is main-gated). Dispatch it:
+  `gh workflow run ci-unified.yml --ref <branch> -f run_full_suite=true`, then
+  grep the **Test-integration** log for `investment-scenario-capability` and the
+  migrations test.
 - `CI Gate Status` is the required check.
 - ADR-023 already amended (decision 5) — done in `cde71d74`.
 
 ---
 
 ## Self-review
-- **Spec coverage:** PR-0 = precondition; Tasks 1-8 = spec Steps 1-8 (Task 1=table, 2=hash util [enables Step 3 idempotency], 3=contract, 4=service, 5=routes, 6=integration test, 7=hook, 8=flag); Task 9 = reversible hygiene. Supersede covered in Tasks 1/3/4/5/6. No spec requirement unmapped.
-- **Placeholder scan:** locked interfaces + per-task file lists are concrete; the few "confirm exact path" notes (Testcontainers helper, flag-gen invocation) are verification instructions, not deferred logic — the implementer confirms by grep, the design is fixed.
-- **Type consistency:** `createRound` result-kind union (Task 4) ↔ route status mapping (Task 5) ↔ integration assertions (Task 6) all use the same kinds; `MoneyStringSchema` imported everywhere (never redeclared); `supersedesRoundId` named identically in contract/service/route/test.
-- **Granularity caveat:** Tasks 1-9 are summarized at the change-unit level (not every micro-step) because each mirrors a named, already-merged precedent file; expand each into write-test→fail→implement→pass→commit steps at execution time using the cited precedent as the literal template.
+
+- **Spec coverage:** PR-0 = precondition; Tasks 1-8 = spec Steps 1-8 (Task
+  1=table, 2=hash util [enables Step 3 idempotency], 3=contract, 4=service,
+  5=routes, 6=integration test, 7=hook, 8=flag); Task 9 = reversible hygiene.
+  Supersede covered in Tasks 1/3/4/5/6. No spec requirement unmapped.
+- **Placeholder scan:** locked interfaces + per-task file lists are concrete;
+  the few "confirm exact path" notes (Testcontainers helper, flag-gen
+  invocation) are verification instructions, not deferred logic — the
+  implementer confirms by grep, the design is fixed.
+- **Type consistency:** `createRound` result-kind union (Task 4) ↔ route status
+  mapping (Task 5) ↔ integration assertions (Task 6) all use the same kinds;
+  `MoneyStringSchema` imported everywhere (never redeclared);
+  `supersedesRoundId` named identically in contract/service/route/test.
+- **Granularity caveat:** Tasks 1-9 are summarized at the change-unit level (not
+  every micro-step) because each mirrors a named, already-merged precedent file;
+  expand each into write-test→fail→implement→pass→commit steps at execution time
+  using the cited precedent as the literal template.

--- a/docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md
+++ b/docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md
@@ -1,0 +1,216 @@
+# Investment-Round Persistence (ADR-023 L3b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Per the workspace workflow contract, every edit/test in this plan is dispatched via Hermes (`npm run hermes:production -- --task "..."`); Claude Code plans and verifies only.**
+
+**Goal:** Flip `POST /api/investments/:id/rounds` (501) into a backed, fund-scoped, idempotent create + list + read with an append-only supersede correction path, behind `enable_investment_rounds` (default OFF, now enable-able).
+
+**Architecture:** A dedicated `investment_rounds` table (NUMERIC(20,6) money), defined in the Drizzle schema (drives `db:push` → Testcontainers test DB + prod) and mirrored by a journaled `server/migrations/*.sql` pair (drives `release:check` + migration-runner test). A thin service holds idempotency + supersede logic; the existing dual-mounted `investments` router gains the round handlers. Mirrors the `task` (#871/#873) and `cash_event` (#862–#869) precedents exactly.
+
+**Tech Stack:** Drizzle ORM (Postgres), Zod, Express, Vitest + supertest + Testcontainers, TanStack Query, Decimal-string money per ADR-011. Node 20.19+, `TZ=UTC`.
+
+**Authority:** [ADR-023](../../adr/ADR-023-investment-event-persistence.md) (amended 2026-06-21 — decision 5 now append-only WITH supersede). Spec: [2026-06-21-investment-round-persistence-l3b-design.md](../specs/2026-06-21-investment-round-persistence-l3b-design.md).
+
+---
+
+## File structure
+
+**PR-0 (precondition, tiny):**
+- Modify: `shared/schema/portfolio.ts` (add `unique('investments_id_fund_id_key')` on `investments`)
+- Create: `server/migrations/20260621_investments_id_fund_unique_v1.{up,down}.sql`
+- Create: `tests/integration/migrations/investments-id-fund-unique.test.ts`
+
+**PR-1 (feature):**
+- Create: `shared/schema/investment-rounds.ts` (Drizzle table)
+- Modify: `shared/schema/index.ts` (export the new table) — confirm `shared/schema.ts` re-chains to it
+- Create: `server/migrations/20260621_z_investment_rounds_v1.{up,down}.sql`
+- Create: `shared/lib/canonical-hash.ts` (extract `canonicalize`+`sha256Hex`)
+- Modify: `server/services/lp-reporting/import-reconciliation-service.ts` (re-import from the new util — DRY, no behaviour change)
+- Create: `shared/contracts/investments/investment-round.contract.ts`
+- Create: `server/services/investments/investment-round-service.ts`
+- Modify: `server/routes/investments.ts` (replace the 501 `/rounds` handler; add GET list/read)
+- Rewrite: `tests/integration/investment-scenario-capability.test.ts`
+- Create: `tests/unit/services/investments/investment-round-service.test.ts`
+- Create: `client/src/lib/investment-round-edit-model.ts` (serializer) + `client/src/hooks/useCreateRound.ts`
+- Create: `tests/unit/lib/investment-round-edit-model.test.ts`
+- Modify: `flags/registry.yaml` (+ regenerate `shared/generated/flag-*.ts`)
+
+---
+
+# PR-0 — Precondition migration
+
+### Task 0.1: Add `UNIQUE (id, fund_id)` to `investments`
+
+**Files:**
+- Modify: `shared/schema/portfolio.ts:61-91`
+- Create: `server/migrations/20260621_investments_id_fund_unique_v1.up.sql`, `.down.sql`
+- Test: `tests/integration/migrations/investments-id-fund-unique.test.ts`
+
+- [ ] **Step 1: Write the failing schema test** — `tests/integration/migrations/investments-id-fund-unique.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getTestDb } from '../../helpers/test-db'; // existing Testcontainers helper
+
+describe('investments (id, fund_id) unique', () => {
+  let db: Awaited<ReturnType<typeof getTestDb>>;
+  beforeAll(async () => { db = await getTestDb(); });
+
+  it('has a unique constraint on (id, fund_id) so it can be a composite-FK target', async () => {
+    const rows = await db.execute(sql`
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'investments_id_fund_id_key' AND contype = 'u'
+    `);
+    expect(rows.rows.length).toBe(1);
+  });
+});
+```
+
+> Note: confirm the real Testcontainers helper path (`tests/helpers/*`); reuse whatever `investment-scenario-capability` or LP integration tests already import. Do not invent a new harness.
+
+- [ ] **Step 2: Run it — expect FAIL** (constraint absent)
+
+Run: `npm run test:integration -- tests/integration/migrations/investments-id-fund-unique.test.ts`
+Expected: FAIL (0 rows).
+
+- [ ] **Step 3: Add the unique to the Drizzle schema** — in `shared/schema/portfolio.ts`, import `unique` and add to the `investments` config callback:
+
+```ts
+import { /* …existing… */ unique } from 'drizzle-orm/pg-core';
+// …
+export const investments = pgTable(
+  'investments',
+  { /* …unchanged columns… */ },
+  (table) => ({
+    pricingConfidenceCheck: check(
+      'investments_pricing_confidence_check',
+      sql`${table.pricingConfidence} IN ('calculated', 'verified')`
+    ),
+    // Composite-FK target for investment_rounds(investment_id, fund_id).
+    // id is already unique (PK) so this is always satisfiable even where
+    // fund_id is NULL; it only makes (id, fund_id) referenceable.
+    idFundKey: unique('investments_id_fund_id_key').on(table.id, table.fundId),
+  })
+);
+```
+
+- [ ] **Step 4: Write the journaled migration** — `server/migrations/20260621_investments_id_fund_unique_v1.up.sql`:
+
+```sql
+-- Precondition for ADR-023 L3b: make (id, fund_id) a composite-FK target for
+-- investment_rounds. id is already unique (PK); NULL fund_id rows are allowed
+-- (round-create rejects NULL-fund parents at the service, no backfill needed).
+ALTER TABLE investments
+  ADD CONSTRAINT investments_id_fund_id_key UNIQUE (id, fund_id);
+```
+
+`.down.sql`:
+
+```sql
+ALTER TABLE investments DROP CONSTRAINT IF EXISTS investments_id_fund_id_key;
+```
+
+- [ ] **Step 5: Run test — expect PASS** (db:push picks up the Drizzle change for the Testcontainers DB)
+
+Run: `npm run test:integration -- tests/integration/migrations/investments-id-fund-unique.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Type-check + commit**
+
+Run: `npm run check`
+```bash
+git add shared/schema/portfolio.ts server/migrations/20260621_investments_id_fund_unique_v1.up.sql server/migrations/20260621_investments_id_fund_unique_v1.down.sql tests/integration/migrations/investments-id-fund-unique.test.ts
+git commit -m "feat(investments): add UNIQUE (id, fund_id) composite-FK target (ADR-023 L3b precondition)"
+```
+
+> PR-0 ships and merges independently before PR-1.
+
+---
+
+# PR-1 — Feature (rounds + supersede + flag + safe hygiene)
+
+The remaining tasks are sequenced. Each is one self-contained change. Detailed per-step code lives in the companion task files written at execution time; the contract and service signatures below are the locked interfaces every later task depends on.
+
+## Locked interfaces (referenced by all PR-1 tasks)
+
+```ts
+// shared/contracts/investments/investment-round.contract.ts
+export const SecurityTypeSchema = z.enum(['equity','convertible_note','safe','warrant','other']);
+export const InvestmentRoundCreateSchema = z.object({
+  fundId: z.number().int().positive(),            // path-consistency check
+  roundName: z.string().trim().min(1).max(120),
+  securityType: SecurityTypeSchema,
+  roundDate: z.string().date(),                   // date-only, never through Date()
+  currency: z.string().regex(/^[A-Z]{3}$/).default('USD'),
+  investmentAmount: MoneyStringSchema,            // imported, NOT redeclared
+  roundSize: MoneyStringSchema.optional(),
+  preMoneyValuation: MoneyStringSchema.optional(),
+  supersedesRoundId: z.number().int().positive().optional(),
+}).strict();
+export const InvestmentRoundResponseSchema = z.object({ /* …cols… */ etag: z.string().min(1) }).strict();
+```
+
+```ts
+// server/services/investments/investment-round-service.ts
+export async function createRound(input, { database }?): Promise<
+  | { kind: 'created'; row; xmin }
+  | { kind: 'replayed'; row; xmin }
+  | { kind: 'key_reused' }            // -> 409 idempotency_key_reused
+  | { kind: 'already_superseded' }    // -> 409 round_already_superseded
+  | { kind: 'supersede_target_missing' } // -> 404
+  | { kind: 'supersede_target_other_investment' } // -> 400
+>;
+export async function listRoundsForInvestment(investmentId, { database }?); // current (non-superseded) only
+export async function loadRound(investmentId, roundId, { database }?);
+```
+
+### Task 1: `investment_rounds` Drizzle table + journaled migration + RESTRICT schema test
+Mirror `shared/schema/operating-objects.ts` and `investment_lots` (partial-unique-idempotency idiom at `portfolio.ts:123-125`). Columns + constraints per the spec § Step 1. Composite FK via `foreignKey({ columns:[t.investmentId,t.fundId], foreignColumns:[investments.id, investments.fundId] }).onDelete('restrict').onUpdate('restrict')`; self-FK `supersedesRoundId` → `investmentRounds.id` (`(): AnyPgColumn`); `uniqueIndex('investment_rounds_supersedes_uq').on(t.supersedesRoundId).where(sql\`supersedes_round_id IS NOT NULL\`)`; `unique('investment_rounds_fund_idem_key').on(t.fundId, t.idempotencyKey)`. Export from `shared/schema/index.ts`. Write the journaled `20260621_z_investment_rounds_v1.{up,down}.sql` (down drops the table). **TDD:** schema test proves (a) the table exists, (b) `DELETE FROM investments` where a round exists raises FK RESTRICT, (c) a second row with the same `supersedes_round_id` raises unique violation.
+
+### Task 2: Extract `shared/lib/canonical-hash.ts`
+Move `canonicalize` + `sha256Hex` (currently private in `import-reconciliation-service.ts:87-110`) into `shared/lib/canonical-hash.ts` as `export function canonicalSha256(value: unknown): string`. Repoint `import-reconciliation-service.ts` to import it (its `computeImportPreviewHash`/`computeSourceRowHash` stay, now delegating). **TDD:** unit test asserts key-order independence (`{a,b}` === `{b,a}`) and that `undefined` keys are dropped. Run the existing `import-reconciliation-service.test.ts` to prove no behaviour change.
+
+### Task 3: Shared Zod contract
+Write `shared/contracts/investments/investment-round.contract.ts` per the locked interface. **Import** `MoneyStringSchema`/`DecimalStringSchema` from `@shared/contracts/lp-reporting/cash-flow-event.contract` (never redeclare). `.strict()` response so `created_by`/`request_hash`/`idempotency_key` can never leak. **TDD:** contract unit test — valid payload parses; 7-dp money rejects; unknown key rejects; `supersedesRoundId` optional.
+
+### Task 4: Service
+Write `server/services/investments/investment-round-service.ts` mirroring `task-service.ts` (explicit column map + `sql<string>\`xmin::text\``, `{ database }` DI seam, `splitXmin`). `createRound`:
+1. compute `requestHash = canonicalSha256({ investmentId, fundId, roundName, securityType, roundDate, currency, investmentAmount, roundSize, preMoneyValuation, supersedesRoundId })`.
+2. if `supersedesRoundId`: load it; missing → `supersede_target_missing`; different investment → `supersede_target_other_investment`; already-superseded (a row referencing it exists) → `already_superseded`.
+3. `INSERT … ON CONFLICT (fund_id, idempotency_key) DO NOTHING RETURNING <cols+xmin>`. Row returned → `created`. No row → SELECT existing by `(fund_id, idempotency_key)`, compare `request_hash`: equal → `replayed`; differ → `key_reused`.
+4. wrap the insert in try/catch: a `23505` on `investment_rounds_supersedes_uq` (concurrent supersede race) → `already_superseded`.
+`listRoundsForInvestment` returns rows where no other row's `supersedes_round_id` points at them, newest-first. **TDD:** service unit tests with a mocked DB seam cover created / replayed / key_reused / supersede happy + already_superseded.
+
+### Task 5: Routes (extend `server/routes/investments.ts`)
+Replace the 501 `/investments/:id/rounds` POST handler and add `GET /investments/:id/rounds` + `GET /investments/:id/rounds/:roundId`. Pattern (mirror `operating-object-tasks.ts` error ordering, but fund is **derived**): parse `:id` → load investment via service (NOT storage in the new path) → 404 if absent → `enforceProvidedFundScope(req, res, investment.fundId)` → read `Idempotency-Key` via the `getIdempotencyKey` idiom (`headers['idempotency-key'] ?? ['x-idempotency-key']`) → 428 if missing (create only) → `InvestmentRoundCreateSchema.safeParse` → 400 → body `fundId` must equal derived → 400 → `createRound(...)` → map result kinds to 201/200/409/404/400 → `InvestmentRoundResponseSchema.parse` for the body. The two GETs run the same load-investment + `enforceProvidedFundScope` before returning (closes the read-path IDOR — ADR finding D). `cases` 501 handler untouched. The round handlers import only the service (no new `../db`/`../storage`); the file's existing `storage` import stays for legacy handlers.
+
+### Task 6: Integration test rewrite
+Rewrite `tests/integration/investment-scenario-capability.test.ts` against Testcontainers + a seeded fund/investment + a scoped bearer token. Assert: **201** create (full payload + `Idempotency-Key`); **200** exact retry replay; **409** same key/different body; **428** missing key; **403** cross-fund; **404** unknown investment; supersede happy (create→supersede→list shows the corrector, not the original) + **409** double-supersede. `cases` stays **501**. **Teardown:** `TRUNCATE investment_rounds RESTART IDENTITY CASCADE` (append-only rows have no delete route — #890 teardown lesson) and close any owned pool.
+
+### Task 7: Client hook + serializer
+`client/src/lib/investment-round-edit-model.ts` (framework-free, mirror `cash-event-edit-model.ts`): map currency **label → ISO-4217** and JS **number → DecimalString**; `roundDate` stays date-only. `client/src/hooks/useCreateRound.ts` (TanStack mutation) POSTs with `Content-Type: application/json` (avoids the makeApp 415 body-less guard) and a generated `Idempotency-Key`. **TDD:** serializer unit test (label→ISO, 2.5→"2.5", date-only preserved). No live UI mount (deferred).
+
+### Task 8: Feature flag
+Add to `flags/registry.yaml` (mirror `enable_operations_hub` shape): `enable_investment_rounds`, `default: false`, all environments `false`, `exposeToClient: true`, `risk: medium`, `owner: 'gp-team'`, `dependencies: []`, `expiresAt: '2026-12-31'`. Regenerate: `npx tsx scripts/generate-flag-types.ts` (confirm exact invocation) and commit the regenerated `shared/generated/flag-types.ts` + `flag-defaults.ts`. Mount-gate the (future) client surface on it.
+
+### Task 9: Folded hygiene (reversible only)
+- Verify-then-prune worktrees: for each of `Updog_restore_lp_dashboard_runtime`, `updog-pr864-ci-fix`, `Updog_restore_pr881_ci` run `git -C <wt> status --porcelain` (must be empty) and confirm no commits ahead of the merged SHA, then `git worktree remove <wt>`.
+- Delete merged local branches (`git branch --merged main` minus `main`).
+- Archive the 3 loose docs **only** after running the CLAUDE.md Archive Gate per file (git-log landed/obsolete + grep feature-gone + not-an-active-handoff) and citing the three checks for each in the PR body; apply the Derivability Test to `CRITICAL-REVIEW-secondary-surface-governance.md` (keep if non-derivable).
+- **Do NOT touch the 136 stashes.**
+
+---
+
+## Verification (whole milestone)
+- `npm run check` (baseline:check), `npm run lint` (incl. `guard:route-imports`), targeted `vitest run` for unit suites — all green.
+- Integration suite does **not** run on a feature PR automatically (test-smart skips, test-full is main-gated). Dispatch it: `gh workflow run ci-unified.yml --ref <branch> -f run_full_suite=true`, then grep the **Test-integration** log for `investment-scenario-capability` and the migrations test.
+- `CI Gate Status` is the required check.
+- ADR-023 already amended (decision 5) — done in `cde71d74`.
+
+---
+
+## Self-review
+- **Spec coverage:** PR-0 = precondition; Tasks 1-8 = spec Steps 1-8 (Task 1=table, 2=hash util [enables Step 3 idempotency], 3=contract, 4=service, 5=routes, 6=integration test, 7=hook, 8=flag); Task 9 = reversible hygiene. Supersede covered in Tasks 1/3/4/5/6. No spec requirement unmapped.
+- **Placeholder scan:** locked interfaces + per-task file lists are concrete; the few "confirm exact path" notes (Testcontainers helper, flag-gen invocation) are verification instructions, not deferred logic — the implementer confirms by grep, the design is fixed.
+- **Type consistency:** `createRound` result-kind union (Task 4) ↔ route status mapping (Task 5) ↔ integration assertions (Task 6) all use the same kinds; `MoneyStringSchema` imported everywhere (never redeclared); `supersedesRoundId` named identically in contract/service/route/test.
+- **Granularity caveat:** Tasks 1-9 are summarized at the change-unit level (not every micro-step) because each mirrors a named, already-merged precedent file; expand each into write-test→fail→implement→pass→commit steps at execution time using the cited precedent as the literal template.

--- a/docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md
+++ b/docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md
@@ -1,0 +1,276 @@
+---
+status: DRAFT (red-team hardened 2026-06-21)
+last_updated: 2026-06-21
+supersedes_planning: docs/superpowers/plans/2026-06-18-secondary-surface-trust-slim.md (PR-6 stub)
+authority: docs/adr/ADR-023-investment-event-persistence.md (ACCEPTED) — REQUIRES amendment to decision 5 (see § ADR amendment)
+---
+
+# Investment-Round Persistence Backbone (ADR-023 L3b) — Design Spec
+
+**Goal:** Flip `POST /api/investments/:id/rounds` (501) into a backed,
+fund-scoped, idempotent create+list+read **with an append-only supersede
+correction path**, so the feature can ship enable-able (not blocked
+flag-off). `enable_investment_rounds` still defaults OFF; enabling is a soak/ops
+gate, no longer an architectural block.
+
+**Authority:** Architecture is fixed by
+[ADR-023](../../adr/ADR-023-investment-event-persistence.md) (architect +
+`phoenix-precision-guardian` sign-off 2026-06-17), **with one amendment**:
+decision 5 (append-only, no correction, flag-off-until-a-separate-tranche) is
+changed to **append-only WITH supersede correction in tranche 1** (see
+§ ADR amendment). All other ADR decisions stand unchanged.
+
+---
+
+## Red-team revisions (2026-06-21)
+
+This spec was stress-tested via the RedTeam ParallelAnalysis workflow. The
+panel's grounded findings (one agent; the rest of the panel failed to execute
+and is discarded — see § Process note) plus a direct adversarial pass changed
+four things from the first draft:
+
+1. **Precondition migration split out as a standalone precursor PR-0.** It is the
+   only atom that mutates existing rows / can fail at deploy with the flag off;
+   it must not be coupled to flaky feature CI. (Was bundled.)
+2. **Supersede correction folded INTO the feature PR** (user decision) so M1
+   delivers a real, enable-able capability instead of dormant flag-off plumbing
+   that strands behind an unscheduled tranche. (Reverses ADR decision 5 — see
+   amendment.)
+3. **Hygiene scope cut to reversible items only** (user decision): worktree
+   prune + merged-branch delete + doc archive fold in; the 136-entry **stash
+   pile is left untouched** (irreversible `git stash drop`, no reflog net,
+   heterogeneous real-WIP-vs-backup contents — no safe automation).
+4. **Test-isolation + idempotency-scope notes added** (append-only test rows
+   accumulate; `UNIQUE (fund_id, idempotency_key)` interaction with
+   investment-scoped routes documented).
+
+---
+
+## Roadmap context (why this is the lead milestone)
+
+The two prior planning docs have **substantially shipped**. Reconciled against
+main `c27499f4`:
+
+| Plan item | Status | Evidence |
+|---|---|---|
+| PR-1 firebreaks (quarantine + dead-nav + Branch A) | DONE | #881 |
+| Mock-surface pages full delete | DONE | #884 |
+| MOIC live-primary + provenance (Phase 7 / PR-3) | DONE | #888 |
+| LP dashboard mount on makeApp | DONE | #889 |
+| Release-gate teardown hygiene | DONE | #890 |
+| Snapshot/version archive + orphan cleanup (PR-5/6) | DONE | #885/#886/#887 |
+
+**Genuinely remaining:** the product backbone (investment-event persistence —
+ADR written #877, nothing built), operating objects `assumption`/`comment`,
+generalized provenance (PR-2/PR-4, MOIC point-solved only), and the route-mount
+parity CI guard (PR-5 completion). Investment-event is the lead per the user's
+prioritization (highest leverage: upstream of reserves/valuation/cap-table).
+
+**Adversarial caveat (recorded, accepted by the user):** leading with this means
+deferring **M4 (route-mount parity guard)**, which would give *immediate*
+recurrence-prevention for the makeApp/registerRoutes split-brain class that
+caused the real LP-404. Folding supersede into M1 (so it ships enable-able)
+mitigates the "no value" objection that motivated reconsidering the lead.
+
+**Stale-worktree consequence:** worktree
+`C:/dev/Updog_restore_lp_dashboard_runtime`
+(`codex/lp-dashboard-runtime-route-gap` @ `a15b6cbc`) shares its commit title
+with merged #889 — **superseded**, pruned in this milestone's hygiene **after**
+verifying containment (see hygiene step).
+
+### Roadmap tail (separate future milestones)
+- **M2** — operating objects `assumption` + `comment` (backend-first; red-team
+  JSONB-conflict / polymorphic-target first).
+- **M3** — generalized `data-provenance-v1.contract.ts` + `ProvenanceBoundary`
+  + reports/cashflow/forecast trust migration (PR-2/PR-4).
+- **M4** — route-mount parity CI guard: promote
+  `tests/unit/server/route-surface-inventory.test.ts` into a CI gate with an
+  `ALLOWED_UNMOUNTED` allowlist. **Pull-forward candidate** if investment-rounds
+  slips — it is cheap and prevents a known prod-bug class.
+
+(The standalone "supersede tranche" is no longer a tail item — it is folded into
+M1.)
+
+---
+
+## ADR amendment (decision 5)
+
+**Before:** append-only, NO update/delete and NO correction route in tranche 1;
+`enable_investment_rounds` MUST stay OFF in prod until a separate supersede
+tranche ships.
+
+**After (this spec):** append-only **with a supersede correction edge in tranche
+1** — a recorded round is still immutable, but an erroneous round is corrected by
+appending a *superseding* round (mirroring `cashFlowEvents.supersedesEventId`),
+never by mutation. Because a correction path now exists, the
+flag-off-until-separate-tranche guardrail is satisfied within M1;
+`enable_investment_rounds` still **defaults OFF** and enabling remains a
+soak/ops decision, but is no longer architecturally blocked.
+
+**Required before implementation:** record this as an amendment in ADR-023 with
+architect re-sign-off on decision 5. `phoenix-precision-guardian` §8 (money/
+precision) sign-off is **unaffected** — supersede adds a self-FK and reuses the
+existing `NUMERIC(20,6)` money columns; no new money semantics.
+
+---
+
+## Preconditions (verified on head `c27499f4`, 2026-06-21)
+
+- `investments.fund_id` **nullable** — `shared/schema/portfolio.ts:65`. Composite
+  FK target `UNIQUE (id, fund_id)` is valid even with nullable `fund_id` (`id` is
+  unique → the pair is always distinct); a NOT-NULL round `fund_id` can never
+  match a NULL-fund investment, so round-create also rejects NULL-fund parents
+  (400) as belt-and-suspenders.
+- 501 routes intact — `server/routes/investments.ts:143` (`/rounds`), `:181`
+  (`/cases`).
+- 501 asserted — `tests/integration/investment-scenario-capability.test.ts:15-25`
+  (rounds), `:27-37` (cases).
+- `enable_investment_rounds` flag absent; `useCreateRound` / `investment_rounds`
+  table / contract / service absent. Client scaffolding present
+  (`new-round-dialog.tsx` + `lib/investment-round-{defaults,utils}.ts` +
+  `types/investment-rounds.ts`).
+- Migration template — `server/migrations/20260616_operating_object_tasks_v1.{up,down}.sql`.
+
+---
+
+## PR-0 — Precondition migration (standalone precursor, tiny)
+
+Land and green **before** the feature PR. Journaled `up`/`down`.
+- Add `UNIQUE (id, fund_id)` on `investments` (cheap; `id` already unique).
+- **No** `fund_id NOT NULL` backfill — round-create rejects NULL-fund parents
+  with 400 instead (lower-risk than mutating existing rows).
+- `down` drops the unique constraint only.
+- Acceptance: migration applies + reverts clean against Testcontainers Postgres;
+  no existing investment delete path breaks.
+
+---
+
+## PR-1 — Feature PR (investment rounds + supersede + safe hygiene)
+
+### Step 1 — `investment_rounds` table (ADR decisions 2/3/7; findings B/C)
+Columns per the ADR column table: `NUMERIC(20,6)` money cols; `currency
+varchar(3) DEFAULT 'USD'`; `security_type varchar(32)` CHECK; `idempotency_key`,
+`request_hash varchar(64)`, `created_by` FK→`users.id` nullable, timestamps.
+**Plus (amendment):** `supersedes_round_id integer NULL REFERENCES
+investment_rounds(id) ON DELETE RESTRICT`.
+Constraints: indexes `(fund_id, investment_id)`, `(investment_id, round_date
+DESC)`; `UNIQUE (fund_id, idempotency_key)`; composite FK `(investment_id,
+fund_id) → investments(id, fund_id)` ON UPDATE/DELETE RESTRICT; **partial
+`UNIQUE (supersedes_round_id) WHERE supersedes_round_id IS NOT NULL`** (a round
+may be superseded at most once — no correction fork). `graduation_rate` +
+share-mechanics deferred (ADR 5a). Schema test proves
+delete-of-investment-with-rounds is blocked.
+
+### Step 2 — Shared Zod contract (ADR decision 8)
+`shared/contracts/investments/investment-round.contract.ts`. **Imports**
+`DecimalStringSchema`/`MoneyStringSchema` (never redeclares). Create body adds
+optional `supersedesRoundId: z.number().int().positive().optional()`.
+
+### Step 3 — Service seam (ADR decision 4; finding A)
+`server/services/investments/investment-round-service.ts` (route must not import
+`../db`/`../storage`). Idempotency: required `Idempotency-Key` → 428 if missing;
+on `UNIQUE (fund_id, idempotency_key)` conflict, compare stored `request_hash`
+(sha256 of canonical body via `import-reconciliation-service.ts`): equal →
+replay stored row; differ → 409. **Supersede:** when `supersedesRoundId` is set,
+load the referent → 404 if absent, 400 if different investment, 409 if already
+superseded (partial unique) → then insert the correction row pointing at it.
+"Current" rounds = rows not referenced by any `supersedes_round_id`.
+
+### Step 4 — Routes (ADR decision 6; finding D)
+`/api/investments/:investmentId/rounds` — **create + list + read** (create
+accepts `supersedesRoundId` for correction). Every route (read AND write):
+load investment → 404 → derive `investment.fund_id` →
+`enforceProvidedFundScope(req, res, fundId)` → 403 → act. Body-supplied
+`fund_id` (if any) must match derived or 400. List returns current
+(non-superseded) rounds by default. Mount on **both** `server/app.ts` +
+`server/routes.ts`.
+
+### Step 5 — Integration test rewrite (finding E)
+Rewrite `tests/integration/investment-scenario-capability.test.ts`: rounds
+501→**201** with FULL valid payload + `Idempotency-Key`; add **403** cross-fund,
+**404** unknown-investment, **428** missing-key, **409** key-reuse-different-body,
+and a **supersede** case (create → supersede → list shows corrected, second
+supersede of same round → 409). `cases` stays **501**.
+**Test isolation:** append-only rows have no delete route → truncate
+`investment_rounds` (or own-pool close) in teardown so rows don't accumulate
+across files (apply the #890 release-gate teardown lesson).
+
+### Step 6 — `useCreateRound` hook (ADR decision 8; finding F)
+Client hook + serializer (currency label→ISO-4217, number→`DecimalString`,
+mirror `cash-event-edit-model.ts`). Focused unit test. No live UI mount
+(deferred). Test-only hook usage is lint-tolerated (L2a precedent).
+
+### Step 7 — Flag (ADR Tier-3; R10)
+`enable_investment_rounds` via the registry/generation path, **default OFF**,
+with `expiresAt`. No longer architecturally blocked from enabling (correction
+path exists).
+
+### Step 8 — Folded hygiene (REVERSIBLE items only)
+- **Worktree prune** — only after verifying containment: `git -C <wt> status
+  --porcelain` is clean AND no commits ahead of the merged SHA. Prune
+  `lp_dashboard_runtime` (vs #889), `pr864-ci-fix`, `pr881_ci`.
+- **Delete merged local branches** (recoverable via reflog/remote).
+- **Archive the 3 loose planning docs** —
+  `docs/CRITICAL-REVIEW-secondary-surface-governance.md` + the two
+  `docs/superpowers/plans/2026-06-1{7,8}-secondary-surface-*.md` — **only after**
+  running the full CLAUDE.md Archive Gate **per file** (git-log landed/obsolete +
+  grep feature-gone + not-an-active-handoff) and citing the three checks for each
+  in the PR body. Apply the Derivability Test to CRITICAL-REVIEW specifically (it
+  is a non-derivable critique — keep if it fails the test).
+- **EXCLUDED:** the 136 stashes — left untouched (irreversible drop; no safe
+  automation; revisit as a separate human-reviewed pass if ever).
+
+---
+
+## Explicitly deferred (named, NOT in M1)
+- Live `/portfolio` round-dialog mounting behind `enable_investment_rounds`.
+- Performance cases, valuation/ownership/liq-pref, cap-table, bulk ops — stay
+  **501** with explicit unsupported tests.
+- `graduation_rate` + share-mechanics columns (additive nullable later, 0..1
+  ratio `numeric(5,4)`).
+- Stash-pile triage (separate human-reviewed pass).
+
+---
+
+## Acceptance criteria
+1. PR-0 lands first: `UNIQUE (id, fund_id)` on `investments`, applies+reverts clean.
+2. `POST .../rounds` → **201** with valid payload + `Idempotency-Key`; missing
+   key → **428**; conflicting reuse → **409**; benign retry replays stored row.
+3. Supersede: create→supersede→list shows the correction; a second supersede of
+   the same round → **409** (partial unique).
+4. GET list/read enforce fund scope: cross-fund → **403**, unknown investment →
+   **404** (no read-path IDOR).
+5. `cases` stays **501**; its test stays green.
+6. Schema test proves delete-of-investment-with-rounds is **blocked**.
+7. Money columns `NUMERIC(20,6)`; contract imports (not redeclares)
+   `DecimalStringSchema`; no JS-number money field.
+8. Route imports no `../db`/`../storage` (`guard:route-imports` green); logic in
+   the service.
+9. `enable_investment_rounds` exists, **off**, with `expiresAt`.
+10. `useCreateRound` + serializer unit-tested; integration teardown truncates
+    `investment_rounds`; `npm run check` + targeted vitest + `npm run lint` green.
+11. Hygiene: worktrees pruned **after** containment check; 3 docs archived **with
+    per-file Archive-Gate evidence in the PR body**; stashes untouched.
+12. ADR-023 amended (decision 5) with architect re-sign-off **before** merge.
+
+---
+
+## Process note
+The RedTeam parallel dispatch under-performed: 6 of 8 general-purpose agents
+narrated file reads without issuing tool calls, and one hallucinated a different
+spec/ADR entirely. Only the hygiene/reversibility agent (grounded in the real
+CLAUDE.md) produced usable output; the remaining adversarial angles were
+completed by the orchestrator directly. Recorded so the "red-teamed" label is
+not over-claimed.
+
+## Self-review
+- **Placeholders:** none — every step cites an ADR decision / verified file:line;
+  M2–M4 are scoped stubs (separate milestones).
+- **Consistency:** supersede fold is recorded as an explicit ADR amendment, not a
+  silent contradiction; money rules unchanged; hygiene scope matches the
+  reversible-only decision.
+- **Scope:** PR-0 (tiny migration) + PR-1 (feature incl. supersede + safe
+  hygiene). Larger than the first draft by the supersede edge — accepted to
+  deliver enable-able value.
+- **Userspace safety:** flag OFF by default; `cases` 501 preserved; no existing
+  route behaviour changes until the flag flips.

--- a/server/migrations/20260621_investments_id_fund_unique_v1.down.sql
+++ b/server/migrations/20260621_investments_id_fund_unique_v1.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE investments DROP CONSTRAINT IF EXISTS investments_id_fund_id_key;

--- a/server/migrations/20260621_investments_id_fund_unique_v1.up.sql
+++ b/server/migrations/20260621_investments_id_fund_unique_v1.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE investments ADD CONSTRAINT investments_id_fund_id_key UNIQUE (id, fund_id);

--- a/shared/schema/portfolio.ts
+++ b/shared/schema/portfolio.ts
@@ -16,6 +16,7 @@ import {
   serial,
   text,
   timestamp,
+  unique,
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
@@ -87,6 +88,7 @@ export const investments = pgTable(
       'investments_pricing_confidence_check',
       sql`${table.pricingConfidence} IN ('calculated', 'verified')`
     ),
+    idFundKey: unique('investments_id_fund_id_key').on(table.id, table.fundId),
   })
 );
 

--- a/tests/integration/migrations/investments-id-fund-unique.test.ts
+++ b/tests/integration/migrations/investments-id-fund-unique.test.ts
@@ -1,0 +1,56 @@
+import { execFileSync } from 'node:child_process';
+
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { setupTestDB } from '../../helpers/testcontainers';
+
+const STARTUP_TIMEOUT_MS = 90_000;
+const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
+
+let container: Awaited<ReturnType<typeof setupTestDB>> | undefined;
+let pool: Pool | undefined;
+
+function runDrizzlePush(connectionString: string): void {
+  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  execFileSync(npxCommand, ['drizzle-kit', 'push', '--force'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      DATABASE_URL: connectionString,
+    },
+    stdio: 'pipe',
+  });
+}
+
+describe.skipIf(skipIfNoDocker)('investments (id, fund_id) unique', () => {
+  beforeAll(async () => {
+    container = await setupTestDB();
+
+    const connectionString = container.getConnectionUri();
+    runDrizzlePush(connectionString);
+
+    pool = new Pool({ connectionString, max: 1 });
+  }, STARTUP_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await pool?.end();
+    await container?.stop();
+  });
+
+  it('has a unique constraint on (id, fund_id) so it can be a composite-FK target', async () => {
+    expect(pool).toBeDefined();
+    const db = drizzle(pool!);
+
+    const rows = await db.execute(sql`
+      SELECT 1
+      FROM pg_constraint
+      WHERE conname = 'investments_id_fund_id_key'
+        AND contype = 'u'
+    `);
+
+    expect(rows.rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## PR-0 of the ADR-023 L3b stack (precondition)

Splits the one row-affecting atom out of the feature PR so it lands and goes green independently.

### Changes
- **Schema**: add `UNIQUE (id, fund_id)` on `investments` (`investments_id_fund_id_key`) — the composite-FK target `investment_rounds` needs. `id` is already unique (PK) so it is satisfiable even where `fund_id` is NULL; round-create rejects NULL-fund parents at the service (no row backfill).
- **Migration**: journaled `20260621_investments_id_fund_unique_v1.{up,down}.sql`.
- **Test**: Testcontainers schema test asserting the constraint (CI; skips Windows-local without Docker).
- **Docs** (carried on this branch): the red-team-hardened L3b spec, the implementation plan, and **ADR-023 Amendment 1** (decision 5 → append-only *with* supersede; architect re-sign-off recorded).

### Test plan
- Local: `npm run check` green; the migration test runs in CI/Docker (Node-24 local can't run Testcontainers).
- CI: full-suite run dispatched to validate the migration apply/revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)