### PR TITLE
feat(investment-rounds): ADR-023 L3b persistence backbone (rounds + supersede, flag OFF)

### DIFF
--- a/client/src/core/flags/unifiedClientFlags.ts
+++ b/client/src/core/flags/unifiedClientFlags.ts
@@ -33,6 +33,7 @@ const CANONICAL_TO_LEGACY_ALIASES: Record<ClientFlagKey, string[]> = {
   enable_cap_table_tabs: [],
   enable_modeling_wizard: [],
   enable_operations_hub: [],
+  enable_investment_rounds: [],
   enable_lp_reporting: [],
   enable_reserve_engine: [],
   enable_portfolio_table_v2: [],

--- a/client/src/hooks/useCreateRound.ts
+++ b/client/src/hooks/useCreateRound.ts
@@ -1,0 +1,40 @@
+import type { UseMutationResult } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  InvestmentRoundCreate,
+  InvestmentRoundResponse,
+} from '@shared/contracts/investments/investment-round.contract';
+import { apiRequest } from '@/lib/queryClient';
+
+export function investmentRoundsQueryKey(investmentId: string | number | undefined) {
+  return ['investment-rounds', investmentId] as const;
+}
+
+export function useCreateRound(
+  investmentId: string | number | undefined
+): UseMutationResult<InvestmentRoundResponse, Error, InvestmentRoundCreate> {
+  const queryClient = useQueryClient();
+
+  return useMutation<InvestmentRoundResponse, Error, InvestmentRoundCreate>({
+    mutationFn: async (payload) => {
+      if (!investmentId) {
+        throw new Error('No investment ID available');
+      }
+
+      return apiRequest<InvestmentRoundResponse>(
+        'POST',
+        `/api/investments/${investmentId}/rounds`,
+        payload,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'Idempotency-Key': crypto.randomUUID(),
+          },
+        }
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: investmentRoundsQueryKey(investmentId) });
+    },
+  });
+}

--- a/client/src/lib/investment-round-edit-model.ts
+++ b/client/src/lib/investment-round-edit-model.ts
@@ -1,0 +1,116 @@
+import type {
+  InvestmentRoundCreate,
+  SecurityType,
+} from '@shared/contracts/investments/investment-round.contract';
+
+type SecurityTypeLabel = 'Equity' | 'Convertible Note' | 'SAFE' | 'Warrant' | 'Other';
+
+export interface InvestmentRoundEditForm {
+  roundName: string;
+  securityType: SecurityType | SecurityTypeLabel;
+  /** Date portion only, 'YYYY-MM-DD'. */
+  roundDate: string;
+  currency: string;
+  investmentAmount: number;
+  roundSize?: number | null;
+  preMoneyValuation?: number | null;
+  supersedesRoundId?: number | null;
+}
+
+const CURRENCY_LABEL_TO_ISO: Record<string, string> = {
+  'United States Dollar ($)': 'USD',
+  'Canadian Dollar (CAD)': 'CAD',
+};
+
+const SECURITY_TYPE_TO_WIRE: Record<string, SecurityType> = {
+  equity: 'equity',
+  Equity: 'equity',
+  convertible_note: 'convertible_note',
+  'Convertible Note': 'convertible_note',
+  safe: 'safe',
+  SAFE: 'safe',
+  warrant: 'warrant',
+  Warrant: 'warrant',
+  other: 'other',
+  Other: 'other',
+};
+
+const DECIMAL_STRING_RE = /^-?\d+(\.\d{1,6})?$/;
+const ISO_CURRENCY_RE = /^[A-Z]{3}$/;
+
+function toIsoCurrency(currency: string): string {
+  const normalized = currency.trim();
+  if (ISO_CURRENCY_RE.test(normalized)) {
+    return normalized;
+  }
+
+  const parenthesizedCode = normalized.match(/\(([A-Z]{3})\)$/)?.[1];
+  if (parenthesizedCode) {
+    return parenthesizedCode;
+  }
+
+  if (normalized.startsWith('Euro')) {
+    return 'EUR';
+  }
+
+  if (normalized.startsWith('British Pound')) {
+    return 'GBP';
+  }
+
+  const mapped = CURRENCY_LABEL_TO_ISO[normalized];
+  if (mapped) {
+    return mapped;
+  }
+
+  throw new Error(`Unsupported investment round currency: ${currency}`);
+}
+
+function toSecurityType(securityType: InvestmentRoundEditForm['securityType']): SecurityType {
+  const mapped = SECURITY_TYPE_TO_WIRE[securityType];
+  if (mapped) {
+    return mapped;
+  }
+
+  throw new Error(`Unsupported investment round security type: ${securityType}`);
+}
+
+function toDecimalString(value: number): string {
+  if (!Number.isFinite(value)) {
+    throw new Error('Investment round money values must be finite numbers');
+  }
+
+  const normalized = value.toFixed(6).replace(/\.?0+$/, '');
+  const decimalString = normalized === '-0' ? '0' : normalized;
+
+  if (!DECIMAL_STRING_RE.test(decimalString)) {
+    throw new Error(`Investment round money value is not a decimal string: ${value}`);
+  }
+
+  return decimalString;
+}
+
+export function toInvestmentRoundCreatePayload(
+  form: InvestmentRoundEditForm,
+  fundId: number
+): InvestmentRoundCreate {
+  const payload: InvestmentRoundCreate = {
+    fundId,
+    roundName: form.roundName,
+    securityType: toSecurityType(form.securityType),
+    roundDate: form.roundDate,
+    currency: toIsoCurrency(form.currency),
+    investmentAmount: toDecimalString(form.investmentAmount),
+  };
+
+  if (form.roundSize != null) {
+    payload.roundSize = toDecimalString(form.roundSize);
+  }
+  if (form.preMoneyValuation != null) {
+    payload.preMoneyValuation = toDecimalString(form.preMoneyValuation);
+  }
+  if (form.supersedesRoundId != null) {
+    payload.supersedesRoundId = form.supersedesRoundId;
+  }
+
+  return payload;
+}

--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -99,6 +99,19 @@ flags:
     expiresAt: null
     aliases: ['ENABLE_OPERATIONS_HUB']
 
+  enable_investment_rounds:
+    default: false
+    description: 'Investment round persistence'
+    owner: 'gp-team'
+    risk: medium
+    exposeToClient: true
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: '2026-12-31'
+
   enable_lp_reporting:
     default: false
     description: 'LP reporting dashboard'

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "hermes:research": "node orchestrate.js --phase research",
     "hermes:production": "node orchestrate.js --phase production",
     "hermes:distribution": "node orchestrate.js --phase distribution",
+    "flags:generate": "npx tsx scripts/generate-flag-types.ts",
     "prepare": "husky install && node scripts/normalize-husky-shims.mjs",
     "pre-push": "node scripts/pre-push.mjs",
     "docs:lint": "remark docs/analysis --frail --quiet",

--- a/server/migrations/20260621_z_investment_rounds_v1.down.sql
+++ b/server/migrations/20260621_z_investment_rounds_v1.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS investment_rounds;

--- a/server/migrations/20260621_z_investment_rounds_v1.up.sql
+++ b/server/migrations/20260621_z_investment_rounds_v1.up.sql
@@ -1,0 +1,40 @@
+-- ADR-023 L3b: first-class investment financing rounds with fund-scoped
+-- idempotency and append-only supersede corrections.
+
+CREATE TABLE IF NOT EXISTS investment_rounds (
+  id SERIAL PRIMARY KEY,
+  investment_id INTEGER NOT NULL,
+  fund_id INTEGER NOT NULL REFERENCES funds(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  round_name VARCHAR(120) NOT NULL,
+  security_type VARCHAR(32) NOT NULL,
+  round_date DATE NOT NULL,
+  currency VARCHAR(3) NOT NULL DEFAULT 'USD',
+  investment_amount NUMERIC(20,6) NOT NULL,
+  round_size NUMERIC(20,6),
+  pre_money_valuation NUMERIC(20,6),
+  idempotency_key VARCHAR(255) NOT NULL,
+  request_hash VARCHAR(64) NOT NULL,
+  supersedes_round_id INTEGER REFERENCES investment_rounds(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  CONSTRAINT investment_rounds_security_type_check
+    CHECK (security_type IN ('equity', 'convertible_note', 'safe', 'warrant', 'other')),
+  CONSTRAINT investment_rounds_investment_fund_fk
+    FOREIGN KEY (investment_id, fund_id)
+    REFERENCES investments(id, fund_id)
+    ON UPDATE RESTRICT
+    ON DELETE RESTRICT,
+  CONSTRAINT investment_rounds_fund_idem_key
+    UNIQUE (fund_id, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS investment_rounds_fund_investment_idx
+  ON investment_rounds(fund_id, investment_id);
+
+CREATE INDEX IF NOT EXISTS investment_rounds_investment_round_date_idx
+  ON investment_rounds(investment_id, round_date DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS investment_rounds_supersedes_uq
+  ON investment_rounds(supersedes_round_id)
+  WHERE supersedes_round_id IS NOT NULL;

--- a/server/routes/investments.ts
+++ b/server/routes/investments.ts
@@ -1,12 +1,26 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
+import {
+  InvestmentRoundCreateSchema,
+  InvestmentRoundListResponseSchema,
+  InvestmentRoundResponseSchema,
+  type InvestmentRoundResponse,
+} from '@shared/contracts/investments/investment-round.contract';
 import { insertInvestmentSchema } from '@shared/schema';
+import type { InvestmentRound as PersistedInvestmentRound } from '@shared/schema/investment-rounds';
 import type { ApiError } from '@shared/types';
 import { toNumber } from '@shared/number';
 import { sendApiError } from '../lib/apiError';
 import { handleNumberParseError } from '../lib/number-parse-error';
 import { logger } from '../lib/logger.js';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { parseETag, rowVersionETag } from '../lib/http-preconditions';
+import { firstString } from '../lib/request-values';
+import {
+  createRound,
+  listRoundsForInvestment,
+  loadRound,
+} from '../services/investments/investment-round-service';
 import { storage, UnsupportedStorageOperationError } from '../storage';
 
 const router = Router();
@@ -140,31 +154,145 @@ async function handleUnsupportedScenarioWrite<T>(
   }
 }
 
+function numericIdentity(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return Number.parseInt(value, 10);
+  return null;
+}
+
+// Best-effort creator id. JWT subs are not guaranteed numeric and created_by is a
+// nullable users.id FK, so an unresolved identity stores NULL (never 401).
+// enforceProvidedFundScope populates req.user from a verified token.
+function resolveActorId(req: Request): number | null {
+  return numericIdentity(req.user?.id) ?? numericIdentity(req.user?.sub) ?? null;
+}
+
+function generatedRowEtag(xmin: string): string {
+  const etag = rowVersionETag(xmin);
+  if (!parseETag(etag)) {
+    throw new Error('Generated empty investment round ETag');
+  }
+  return etag;
+}
+
+function toRoundResponse(row: PersistedInvestmentRound, xmin: string): InvestmentRoundResponse {
+  return InvestmentRoundResponseSchema.parse({
+    id: row.id,
+    investmentId: row.investmentId,
+    fundId: row.fundId,
+    roundName: row.roundName,
+    securityType: row.securityType,
+    roundDate: row.roundDate,
+    currency: row.currency,
+    investmentAmount: row.investmentAmount,
+    roundSize: row.roundSize,
+    preMoneyValuation: row.preMoneyValuation,
+    supersedesRoundId: row.supersedesRoundId,
+    createdAt: (row.createdAt ?? new Date()).toISOString(),
+    updatedAt: (row.updatedAt ?? row.createdAt ?? new Date()).toISOString(),
+    etag: generatedRowEtag(xmin),
+  });
+}
+
+interface InvestmentRoundRouteScope {
+  investmentId: number;
+  fundId: number;
+}
+
+async function resolveInvestmentRoundRouteScope(
+  req: Request,
+  res: Response
+): Promise<InvestmentRoundRouteScope | undefined> {
+  const idParam = req.params['id'];
+  const investmentId = toNumber(idParam, 'investment ID');
+
+  if (investmentId <= 0) {
+    const error: ApiError = {
+      error: 'Invalid investment ID',
+      message: `Investment ID must be a positive integer, received: ${idParam}`,
+    };
+    res.status(400).json(error);
+    return undefined;
+  }
+
+  const investment = await storage.getInvestment(investmentId);
+  if (!investment) {
+    const error: ApiError = {
+      error: 'Investment not found',
+      message: `No investment exists with ID: ${investmentId}`,
+    };
+    res.status(404).json(error);
+    return undefined;
+  }
+
+  if (investment.fundId == null) {
+    res.status(400).json({
+      error: 'invalid_investment_fund_scope',
+      message: 'Cannot fund-scope a NULL-fund investment',
+    });
+    return undefined;
+  }
+
+  if (!(await enforceProvidedFundScope(req, res, investment.fundId))) {
+    return undefined;
+  }
+
+  return { investmentId, fundId: investment.fundId };
+}
+
 router.post('/investments/:id/rounds', async (req: Request, res: Response) => {
   try {
-    const idParam = req.params['id'];
-    const investmentId = toNumber(idParam, 'investment ID');
-
-    if (investmentId <= 0) {
-      const error: ApiError = {
-        error: 'Invalid investment ID',
-        message: `Investment ID must be a positive integer, received: ${idParam}`,
-      };
-      return res.status(400).json(error);
+    const scope = await resolveInvestmentRoundRouteScope(req, res);
+    if (!scope) {
+      return;
     }
 
-    const body = req.body as Record<string, unknown> | null;
-    if (!body || Object.keys(body).length === 0) {
-      const error: ApiError = {
-        error: 'Invalid round data',
-        message: 'Request body cannot be empty',
-      };
-      return res.status(400).json(error);
+    const idempotencyKey =
+      firstString(req.headers['idempotency-key']) ?? firstString(req.headers['x-idempotency-key']);
+    if (!idempotencyKey) {
+      return res.status(428).json({
+        error: 'precondition_required',
+        message: 'Idempotency-Key header is required',
+      });
     }
 
-    return await handleUnsupportedScenarioWrite(req, res, 'addInvestmentRound', () =>
-      storage.addInvestmentRound(investmentId, body)
-    );
+    const parsed = InvestmentRoundCreateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid request body', details: parsed.error.format() });
+    }
+    if (parsed.data.fundId !== scope.fundId) {
+      return res.status(400).json({
+        error: 'fundId mismatch',
+        message: 'Body fundId must match the investment fundId',
+      });
+    }
+
+    const result = await createRound({
+      ...parsed.data,
+      investmentId: scope.investmentId,
+      fundId: scope.fundId,
+      idempotencyKey,
+      createdBy: resolveActorId(req),
+    });
+
+    if (result.kind === 'created') {
+      return res.status(201).json(toRoundResponse(result.row, result.xmin));
+    }
+    if (result.kind === 'replayed') {
+      return res.status(200).json(toRoundResponse(result.row, result.xmin));
+    }
+    if (result.kind === 'key_reused') {
+      return res.status(409).json({ error: 'idempotency_key_reused' });
+    }
+    if (result.kind === 'already_superseded') {
+      return res.status(409).json({ error: 'round_already_superseded' });
+    }
+    if (result.kind === 'supersede_target_missing') {
+      return res.status(404).json({ error: 'supersede_target_missing' });
+    }
+    return res.status(400).json({ error: 'supersede_target_other_investment' });
   } catch (error) {
     if (handleNumberParseError(error, res, 'Invalid investment ID')) {
       return;
@@ -173,6 +301,71 @@ router.post('/investments/:id/rounds', async (req: Request, res: Response) => {
     const apiError: ApiError = {
       error: 'Database operation failed',
       message: error instanceof Error ? error.message : 'Failed to add investment round',
+    };
+    return res.status(500).json(apiError);
+  }
+});
+
+router.get('/investments/:id/rounds', async (req: Request, res: Response) => {
+  try {
+    const scope = await resolveInvestmentRoundRouteScope(req, res);
+    if (!scope) {
+      return;
+    }
+
+    const rows = await listRoundsForInvestment(scope.investmentId);
+    return res.status(200).json(
+      InvestmentRoundListResponseSchema.parse({
+        data: rows.map((row) => toRoundResponse(row.row, row.xmin)),
+      })
+    );
+  } catch (error) {
+    if (handleNumberParseError(error, res, 'Invalid investment ID')) {
+      return;
+    }
+
+    const apiError: ApiError = {
+      error: 'Database operation failed',
+      message: error instanceof Error ? error.message : 'Failed to list investment rounds',
+    };
+    return res.status(500).json(apiError);
+  }
+});
+
+router.get('/investments/:id/rounds/:roundId', async (req: Request, res: Response) => {
+  try {
+    const scope = await resolveInvestmentRoundRouteScope(req, res);
+    if (!scope) {
+      return;
+    }
+
+    const roundIdParam = req.params['roundId'];
+    const roundId = toNumber(roundIdParam, 'round ID');
+    if (roundId <= 0) {
+      const error: ApiError = {
+        error: 'Invalid round ID',
+        message: `Round ID must be a positive integer, received: ${roundIdParam}`,
+      };
+      return res.status(400).json(error);
+    }
+
+    const round = await loadRound(scope.investmentId, roundId);
+    if (!round) {
+      return res.status(404).json({ error: 'Investment round not found' });
+    }
+    return res.status(200).json(toRoundResponse(round.row, round.xmin));
+  } catch (error) {
+    if (
+      handleNumberParseError(error, res, (parseError) =>
+        parseError.message.includes('round ID') ? 'Invalid round ID' : 'Invalid investment ID'
+      )
+    ) {
+      return;
+    }
+
+    const apiError: ApiError = {
+      error: 'Database operation failed',
+      message: error instanceof Error ? error.message : 'Failed to fetch investment round',
     };
     return res.status(500).json(apiError);
   }

--- a/server/services/investments/investment-round-service.ts
+++ b/server/services/investments/investment-round-service.ts
@@ -1,0 +1,229 @@
+import { and, desc, eq, notExists, sql } from 'drizzle-orm';
+import { aliasedTable } from 'drizzle-orm/alias';
+
+import { db } from '../../db';
+import type { InvestmentRoundCreate } from '@shared/contracts/investments/investment-round.contract';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+import { investmentRounds, type InvestmentRound } from '@shared/schema/investment-rounds';
+
+type InvestmentRoundDatabase = typeof db;
+
+interface InvestmentRoundServiceOptions {
+  database?: InvestmentRoundDatabase;
+}
+
+export interface InvestmentRoundRow {
+  row: InvestmentRound;
+  /** Postgres xmin system column as text -- opaque per-row concurrency token. */
+  xmin: string;
+}
+
+export type CreateRoundResult =
+  | ({ kind: 'created' } & InvestmentRoundRow)
+  | ({ kind: 'replayed' } & InvestmentRoundRow)
+  | { kind: 'key_reused' }
+  | { kind: 'already_superseded' }
+  | { kind: 'supersede_target_missing' }
+  | { kind: 'supersede_target_other_investment' };
+
+interface CreateRoundArgs extends InvestmentRoundCreate {
+  investmentId: number;
+  idempotencyKey: string;
+  /** Best-effort creator id (nullable users.id FK); NULL when identity is not numeric. */
+  createdBy: number | null;
+}
+
+// Explicit column map + xmin::text (mirrors task-service). List the columns
+// rather than rely on an unproven getTableColumns import.
+const columnsWithXmin = {
+  id: investmentRounds.id,
+  investmentId: investmentRounds.investmentId,
+  fundId: investmentRounds.fundId,
+  roundName: investmentRounds.roundName,
+  securityType: investmentRounds.securityType,
+  roundDate: investmentRounds.roundDate,
+  currency: investmentRounds.currency,
+  investmentAmount: investmentRounds.investmentAmount,
+  roundSize: investmentRounds.roundSize,
+  preMoneyValuation: investmentRounds.preMoneyValuation,
+  idempotencyKey: investmentRounds.idempotencyKey,
+  requestHash: investmentRounds.requestHash,
+  supersedesRoundId: investmentRounds.supersedesRoundId,
+  createdBy: investmentRounds.createdBy,
+  createdAt: investmentRounds.createdAt,
+  updatedAt: investmentRounds.updatedAt,
+  rowXmin: sql<string>`xmin::text`,
+} as const;
+
+const supersedingRounds = aliasedTable(investmentRounds, 'superseding_rounds');
+
+function splitXmin(record: InvestmentRound & { rowXmin: string }): InvestmentRoundRow {
+  const { rowXmin, ...row } = record;
+  return { row: row as InvestmentRound, xmin: rowXmin };
+}
+
+function isUniqueConstraintViolation(error: unknown, constraintName: string): boolean {
+  const candidate = error as { code?: unknown; constraint?: unknown; message?: unknown };
+  return (
+    candidate.code === '23505' &&
+    (candidate.constraint === constraintName ||
+      (typeof candidate.message === 'string' && candidate.message.includes(constraintName)))
+  );
+}
+
+function requestHashFor(input: CreateRoundArgs): string {
+  return canonicalSha256({
+    investmentId: input.investmentId,
+    fundId: input.fundId,
+    roundName: input.roundName,
+    securityType: input.securityType,
+    roundDate: input.roundDate,
+    currency: input.currency,
+    investmentAmount: input.investmentAmount,
+    roundSize: input.roundSize,
+    preMoneyValuation: input.preMoneyValuation,
+    supersedesRoundId: input.supersedesRoundId,
+  });
+}
+
+async function loadRoundById(
+  roundId: number,
+  options: InvestmentRoundServiceOptions = {}
+): Promise<InvestmentRoundRow | undefined> {
+  const database = options.database ?? db;
+  const [record] = await database
+    .select(columnsWithXmin)
+    .from(investmentRounds)
+    .where(eq(investmentRounds.id, roundId))
+    .limit(1);
+  return record ? splitXmin(record) : undefined;
+}
+
+async function hasSupersedingRound(
+  roundId: number,
+  options: InvestmentRoundServiceOptions = {}
+): Promise<boolean> {
+  const database = options.database ?? db;
+  const [record] = await database
+    .select({ id: investmentRounds.id })
+    .from(investmentRounds)
+    .where(eq(investmentRounds.supersedesRoundId, roundId))
+    .limit(1);
+  return record !== undefined;
+}
+
+async function loadRoundByIdempotencyKey(
+  fundId: number,
+  idempotencyKey: string,
+  options: InvestmentRoundServiceOptions = {}
+): Promise<InvestmentRoundRow | undefined> {
+  const database = options.database ?? db;
+  const [record] = await database
+    .select(columnsWithXmin)
+    .from(investmentRounds)
+    .where(
+      and(eq(investmentRounds.fundId, fundId), eq(investmentRounds.idempotencyKey, idempotencyKey))
+    )
+    .limit(1);
+  return record ? splitXmin(record) : undefined;
+}
+
+export async function createRound(
+  input: CreateRoundArgs,
+  options: InvestmentRoundServiceOptions = {}
+): Promise<CreateRoundResult> {
+  const database = options.database ?? db;
+  const requestHash = requestHashFor(input);
+
+  if (input.supersedesRoundId !== undefined) {
+    const target = await loadRoundById(input.supersedesRoundId, options);
+    if (!target) {
+      return { kind: 'supersede_target_missing' };
+    }
+    if (target.row.investmentId !== input.investmentId) {
+      return { kind: 'supersede_target_other_investment' };
+    }
+    if (await hasSupersedingRound(input.supersedesRoundId, options)) {
+      return { kind: 'already_superseded' };
+    }
+  }
+
+  try {
+    const [record] = await database
+      .insert(investmentRounds)
+      .values({
+        investmentId: input.investmentId,
+        fundId: input.fundId,
+        roundName: input.roundName,
+        securityType: input.securityType,
+        roundDate: input.roundDate,
+        currency: input.currency,
+        investmentAmount: input.investmentAmount,
+        roundSize: input.roundSize ?? null,
+        preMoneyValuation: input.preMoneyValuation ?? null,
+        idempotencyKey: input.idempotencyKey,
+        requestHash,
+        supersedesRoundId: input.supersedesRoundId ?? null,
+        createdBy: input.createdBy,
+      })
+      .onConflictDoNothing({
+        target: [investmentRounds.fundId, investmentRounds.idempotencyKey],
+      })
+      .returning(columnsWithXmin);
+
+    if (record) {
+      return { kind: 'created', ...splitXmin(record) };
+    }
+  } catch (error) {
+    if (isUniqueConstraintViolation(error, 'investment_rounds_supersedes_uq')) {
+      return { kind: 'already_superseded' };
+    }
+    throw error;
+  }
+
+  const existing = await loadRoundByIdempotencyKey(input.fundId, input.idempotencyKey, options);
+  if (!existing) {
+    throw new Error('Idempotency conflict did not return an existing investment round');
+  }
+  if (existing.row.requestHash === requestHash) {
+    return { kind: 'replayed', ...existing };
+  }
+  return { kind: 'key_reused' };
+}
+
+export async function listRoundsForInvestment(
+  investmentId: number,
+  options: InvestmentRoundServiceOptions = {}
+): Promise<InvestmentRoundRow[]> {
+  const database = options.database ?? db;
+  const records = await database
+    .select(columnsWithXmin)
+    .from(investmentRounds)
+    .where(
+      and(
+        eq(investmentRounds.investmentId, investmentId),
+        notExists(
+          database
+            .select({ id: supersedingRounds.id })
+            .from(supersedingRounds)
+            .where(eq(supersedingRounds.supersedesRoundId, investmentRounds.id))
+        )
+      )
+    )
+    .orderBy(desc(investmentRounds.createdAt));
+  return records.map(splitXmin);
+}
+
+export async function loadRound(
+  investmentId: number,
+  roundId: number,
+  options: InvestmentRoundServiceOptions = {}
+): Promise<InvestmentRoundRow | undefined> {
+  const database = options.database ?? db;
+  const [record] = await database
+    .select(columnsWithXmin)
+    .from(investmentRounds)
+    .where(and(eq(investmentRounds.investmentId, investmentId), eq(investmentRounds.id, roundId)))
+    .limit(1);
+  return record ? splitXmin(record) : undefined;
+}

--- a/server/services/lp-reporting/import-reconciliation-service.ts
+++ b/server/services/lp-reporting/import-reconciliation-service.ts
@@ -12,9 +12,10 @@
  * @see docs/adr/ADR-011-decimal-string-api-convention.md
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
 import { Decimal } from '@shared/lib/decimal-config';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
 import type {
   ImportDryRunResponse,
   ImportError,
@@ -84,31 +85,6 @@ export interface ExistingFundState {
 
 export type ImportKind = 'ledger' | 'valuation-marks';
 
-function canonicalize(value: unknown): unknown {
-  if (value === null || typeof value !== 'object') {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map(canonicalize);
-  }
-
-  const record = value as Record<string, unknown>;
-  const canonical: Record<string, unknown> = {};
-  for (const key of Object.keys(record).sort()) {
-    const child = record[key];
-    if (child !== undefined) {
-      canonical[key] = canonicalize(child);
-    }
-  }
-  return canonical;
-}
-
-function sha256Hex(value: unknown): string {
-  return createHash('sha256')
-    .update(JSON.stringify(canonicalize(value)))
-    .digest('hex');
-}
-
 export function computeImportPreviewHash(input: {
   fundId: number;
   importKind: ImportKind;
@@ -122,7 +98,7 @@ export function computeImportPreviewHash(input: {
   reconciliation: ReconciliationSummary;
   preview: ImportPreviewRow[];
 }): string {
-  return sha256Hex(input);
+  return canonicalSha256(input);
 }
 
 export function computeSourceRowHash(input: {
@@ -131,7 +107,7 @@ export function computeSourceRowHash(input: {
   sourceType: SourceType;
   row: unknown;
 }): string {
-  return sha256Hex(input);
+  return canonicalSha256(input);
 }
 
 // ============================================================================

--- a/shared/contracts/investments/investment-round.contract.ts
+++ b/shared/contracts/investments/investment-round.contract.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+import {
+  DecimalStringSchema,
+  MoneyStringSchema,
+} from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+
+const CurrencySchema = z.string().regex(/^[A-Z]{3}$/);
+const NullableDecimalStringSchema = DecimalStringSchema.nullable();
+
+export const SecurityTypeSchema = z.enum([
+  'equity',
+  'convertible_note',
+  'safe',
+  'warrant',
+  'other',
+]);
+
+export const InvestmentRoundCreateSchema = z
+  .object({
+    fundId: z.number().int().positive(),
+    roundName: z.string().trim().min(1).max(120),
+    securityType: SecurityTypeSchema,
+    roundDate: z.string().date(),
+    currency: CurrencySchema.default('USD'),
+    investmentAmount: MoneyStringSchema,
+    roundSize: MoneyStringSchema.optional(),
+    preMoneyValuation: MoneyStringSchema.optional(),
+    supersedesRoundId: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const InvestmentRoundResponseSchema = z
+  .object({
+    id: z.number().int().positive(),
+    investmentId: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    roundName: z.string().min(1).max(120),
+    securityType: SecurityTypeSchema,
+    roundDate: z.string().date(),
+    currency: CurrencySchema,
+    investmentAmount: MoneyStringSchema,
+    roundSize: NullableDecimalStringSchema,
+    preMoneyValuation: NullableDecimalStringSchema,
+    supersedesRoundId: z.number().int().positive().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    etag: z.string().min(1),
+  })
+  .strict();
+
+export const InvestmentRoundListResponseSchema = z
+  .object({
+    data: z.array(InvestmentRoundResponseSchema),
+  })
+  .strict();
+
+export type SecurityType = z.infer<typeof SecurityTypeSchema>;
+export type InvestmentRoundCreate = z.infer<typeof InvestmentRoundCreateSchema>;
+export type InvestmentRoundResponse = z.infer<typeof InvestmentRoundResponseSchema>;
+export type InvestmentRoundListResponse = z.infer<typeof InvestmentRoundListResponseSchema>;

--- a/shared/generated/flag-defaults.ts
+++ b/shared/generated/flag-defaults.ts
@@ -1,7 +1,7 @@
 /**
  * AUTO-GENERATED FILE - DO NOT EDIT
  * Generated from: flags/registry.yaml
- * Generated at: 2026-05-08T03:13:17.920Z
+ * Generated at: 2026-06-21T13:04:18.724Z
  *
  * Run `npm run flags:generate` to regenerate
  */
@@ -105,6 +105,21 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     dependencies: ['enable_new_ia', 'enable_kpi_selectors'],
     expiresAt: null,
     aliases: ['ENABLE_OPERATIONS_HUB'],
+  },
+  enable_investment_rounds: {
+    default: false,
+    description: 'Investment round persistence',
+    owner: 'gp-team',
+    risk: 'medium',
+    exposeToClient: true,
+
+    environments: {
+      development: false,
+      staging: false,
+      production: false,
+    },
+    dependencies: [],
+    expiresAt: '2026-12-31',
   },
   enable_lp_reporting: {
     default: false,
@@ -541,6 +556,7 @@ export const FLAG_DEFAULTS: FlagRecord = {
   enable_cap_table_tabs: false,
   enable_modeling_wizard: false,
   enable_operations_hub: false,
+  enable_investment_rounds: false,
   enable_lp_reporting: false,
   enable_reserve_engine: false,
   enable_portfolio_table_v2: false,

--- a/shared/generated/flag-types.ts
+++ b/shared/generated/flag-types.ts
@@ -1,7 +1,7 @@
 /**
  * AUTO-GENERATED FILE - DO NOT EDIT
  * Generated from: flags/registry.yaml
- * Generated at: 2026-05-08T03:13:17.918Z
+ * Generated at: 2026-06-21T13:04:18.722Z
  *
  * Run `npm run flags:generate` to regenerate
  */
@@ -16,6 +16,7 @@ export type FlagKey =
   | 'enable_cap_table_tabs'
   | 'enable_modeling_wizard'
   | 'enable_operations_hub'
+  | 'enable_investment_rounds'
   | 'enable_lp_reporting'
   | 'enable_reserve_engine'
   | 'enable_portfolio_table_v2'
@@ -54,6 +55,7 @@ export type ClientFlagKey =
   | 'enable_cap_table_tabs'
   | 'enable_modeling_wizard'
   | 'enable_operations_hub'
+  | 'enable_investment_rounds'
   | 'enable_lp_reporting'
   | 'enable_reserve_engine'
   | 'enable_portfolio_table_v2'
@@ -135,6 +137,7 @@ export const ALL_FLAG_KEYS: readonly FlagKey[] = [
   'enable_cap_table_tabs',
   'enable_modeling_wizard',
   'enable_operations_hub',
+  'enable_investment_rounds',
   'enable_lp_reporting',
   'enable_reserve_engine',
   'enable_portfolio_table_v2',
@@ -174,6 +177,7 @@ export const CLIENT_FLAG_KEYS: readonly ClientFlagKey[] = [
   'enable_cap_table_tabs',
   'enable_modeling_wizard',
   'enable_operations_hub',
+  'enable_investment_rounds',
   'enable_lp_reporting',
   'enable_reserve_engine',
   'enable_portfolio_table_v2',

--- a/shared/lib/canonical-hash.ts
+++ b/shared/lib/canonical-hash.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto';
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  const record = value as Record<string, unknown>;
+  const canonical: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    const child = record[key];
+    if (child !== undefined) {
+      canonical[key] = canonicalize(child);
+    }
+  }
+  return canonical;
+}
+
+export function canonicalSha256(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalize(value)))
+    .digest('hex');
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -33,6 +33,7 @@ export * from './schema/shares';
 export * from './schema/user';
 export * from './schema/lp-reporting-evidence';
 export * from './schema/operating-objects';
+export * from './schema/investment-rounds';
 export * from './schemas/flags';
 export * from './schemas/reserve-approvals';
 

--- a/shared/schema/index.ts
+++ b/shared/schema/index.ts
@@ -20,3 +20,4 @@ export * from './shares';
 export * from './user';
 export * from './lp-reporting-evidence';
 export * from './operating-objects';
+export * from './investment-rounds';

--- a/shared/schema/investment-rounds.ts
+++ b/shared/schema/investment-rounds.ts
@@ -1,0 +1,91 @@
+/**
+ * Investment Rounds -- ADR-023 L3b persistence schema.
+ *
+ * First-class financing round records for investments. Fund scope is
+ * denormalized for indexed reads and enforced against the parent investment by
+ * a composite FK.
+ *
+ * Mirrors server/migrations/20260621_z_investment_rounds_v1.up.sql.
+ *
+ * @module shared/schema/investment-rounds
+ * @see docs/adr/ADR-023-investment-event-persistence.md
+ */
+
+import { sql } from 'drizzle-orm';
+import {
+  type AnyPgColumn,
+  check,
+  date,
+  foreignKey,
+  index,
+  integer,
+  numeric,
+  pgTable,
+  serial,
+  timestamp,
+  unique,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { funds } from './fund';
+import { investments } from './portfolio';
+import { users } from './user';
+
+export const investmentRounds = pgTable(
+  'investment_rounds',
+  {
+    id: serial('id').primaryKey(),
+    investmentId: integer('investment_id').notNull(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'restrict', onUpdate: 'restrict' }),
+    roundName: varchar('round_name', { length: 120 }).notNull(),
+    securityType: varchar('security_type', { length: 32 }).notNull(),
+    roundDate: date('round_date').notNull(),
+    currency: varchar('currency', { length: 3 }).notNull().default('USD'),
+    investmentAmount: numeric('investment_amount', { precision: 20, scale: 6 }).notNull(),
+    roundSize: numeric('round_size', { precision: 20, scale: 6 }),
+    preMoneyValuation: numeric('pre_money_valuation', { precision: 20, scale: 6 }),
+    idempotencyKey: varchar('idempotency_key', { length: 255 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    supersedesRoundId: integer('supersedes_round_id').references(
+      (): AnyPgColumn => investmentRounds.id,
+      { onDelete: 'restrict' }
+    ),
+    createdBy: integer('created_by').references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    securityTypeCheck: check(
+      'investment_rounds_security_type_check',
+      sql`${table.securityType} IN ('equity', 'convertible_note', 'safe', 'warrant', 'other')`
+    ),
+    investmentFundFk: foreignKey({
+      name: 'investment_rounds_investment_fund_fk',
+      columns: [table.investmentId, table.fundId],
+      foreignColumns: [investments.id, investments.fundId],
+    })
+      .onDelete('restrict')
+      .onUpdate('restrict'),
+    fundInvestmentIdx: index('investment_rounds_fund_investment_idx').on(
+      table.fundId,
+      table.investmentId
+    ),
+    investmentRoundDateIdx: index('investment_rounds_investment_round_date_idx').on(
+      table.investmentId,
+      table.roundDate.desc()
+    ),
+    fundIdempotencyKey: unique('investment_rounds_fund_idem_key').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    supersedesUniqueIdx: uniqueIndex('investment_rounds_supersedes_uq')
+      .on(table.supersedesRoundId)
+      .where(sql`supersedes_round_id IS NOT NULL`),
+  })
+);
+
+export type InvestmentRound = typeof investmentRounds.$inferSelect;
+export type InsertInvestmentRound = typeof investmentRounds.$inferInsert;

--- a/tests/helpers/apply-investment-round-constraints.ts
+++ b/tests/helpers/apply-investment-round-constraints.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { sql, type SQL } from 'drizzle-orm';
+import { Pool } from 'pg';
+
+const INVESTMENTS_UNIQUE_CONSTRAINT = 'investments_id_fund_id_key';
+const INVESTMENT_ROUNDS_FK_CONSTRAINT = 'investment_rounds_investment_fund_fk';
+
+interface QueryTarget {
+  query(queryText: string): Promise<unknown>;
+}
+
+interface ExecuteTarget {
+  execute(query: SQL): Promise<unknown>;
+}
+
+interface QueryResultShape {
+  rows?: unknown;
+}
+
+type ConstraintTarget = string | QueryTarget | ExecuteTarget;
+
+interface SqlRunner {
+  run(statement: string): Promise<unknown>;
+}
+
+function readMigration(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), 'utf8');
+}
+
+function extractStatement(migrationSql: string, pattern: RegExp, label: string): string {
+  const match = migrationSql.match(pattern);
+  if (!match?.[0]) {
+    throw new Error(`Unable to find ${label} in journaled migration SQL`);
+  }
+
+  return match[0];
+}
+
+function loadConstraintStatements(): {
+  investmentsUnique: string;
+  investmentRoundsFk: string;
+  investmentRoundsSupersedesIndex: string;
+} {
+  const investmentsUnique = readMigration(
+    'server/migrations/20260621_investments_id_fund_unique_v1.up.sql'
+  ).trim();
+  const investmentRoundsMigration = readMigration(
+    'server/migrations/20260621_z_investment_rounds_v1.up.sql'
+  );
+
+  const investmentRoundsFkClause = extractStatement(
+    investmentRoundsMigration,
+    /CONSTRAINT investment_rounds_investment_fund_fk\s+FOREIGN KEY \(investment_id, fund_id\)\s+REFERENCES investments\(id, fund_id\)\s+ON UPDATE RESTRICT\s+ON DELETE RESTRICT,/m,
+    INVESTMENT_ROUNDS_FK_CONSTRAINT
+  ).replace(/,\s*$/, '');
+  const investmentRoundsSupersedesIndex = extractStatement(
+    investmentRoundsMigration,
+    /CREATE UNIQUE INDEX IF NOT EXISTS investment_rounds_supersedes_uq\s+ON investment_rounds\(supersedes_round_id\)\s+WHERE supersedes_round_id IS NOT NULL;/m,
+    'investment_rounds_supersedes_uq'
+  );
+
+  return {
+    investmentsUnique,
+    investmentRoundsFk: `ALTER TABLE investment_rounds ADD ${investmentRoundsFkClause};`,
+    investmentRoundsSupersedesIndex,
+  };
+}
+
+function isQueryTarget(value: ConstraintTarget): value is QueryTarget {
+  if (typeof value !== 'object' || value === null) return false;
+  return typeof (value as { query?: unknown }).query === 'function';
+}
+
+function isExecuteTarget(value: ConstraintTarget): value is ExecuteTarget {
+  if (typeof value !== 'object' || value === null) return false;
+  return typeof (value as { execute?: unknown }).execute === 'function';
+}
+
+function resultRows(result: unknown): unknown[] {
+  if (typeof result !== 'object' || result === null) return [];
+
+  const rows = (result as QueryResultShape).rows;
+  return Array.isArray(rows) ? rows : [];
+}
+
+async function withSqlRunner<T>(
+  target: ConstraintTarget,
+  action: (runner: SqlRunner) => Promise<T>
+): Promise<T> {
+  if (typeof target === 'string') {
+    const pool = new Pool({ connectionString: target, max: 1 });
+    try {
+      return await action({ run: (statement) => pool.query(statement) });
+    } finally {
+      await pool.end();
+    }
+  }
+
+  if (isQueryTarget(target)) {
+    return action({ run: (statement) => target.query(statement) });
+  }
+
+  if (isExecuteTarget(target)) {
+    return action({ run: (statement) => target.execute(sql.raw(statement)) });
+  }
+
+  throw new Error('Unsupported database handle for investment round constraints');
+}
+
+async function constraintExists(runner: SqlRunner, constraintName: string): Promise<boolean> {
+  const result = await runner.run(`
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = '${constraintName}'
+    LIMIT 1
+  `);
+
+  return resultRows(result).length > 0;
+}
+
+export async function applyInvestmentRoundConstraints(target: ConstraintTarget): Promise<void> {
+  const statements = loadConstraintStatements();
+
+  await withSqlRunner(target, async (runner) => {
+    if (!(await constraintExists(runner, INVESTMENTS_UNIQUE_CONSTRAINT))) {
+      await runner.run(statements.investmentsUnique);
+    }
+
+    if (!(await constraintExists(runner, INVESTMENT_ROUNDS_FK_CONSTRAINT))) {
+      await runner.run(statements.investmentRoundsFk);
+    }
+
+    await runner.run(statements.investmentRoundsSupersedesIndex);
+  });
+}

--- a/tests/integration/investment-scenario-capability.test.ts
+++ b/tests/integration/investment-scenario-capability.test.ts
@@ -5,6 +5,7 @@ import express, { type NextFunction, type Request, type Response, type Router } 
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { applyInvestmentRoundConstraints } from '../helpers/apply-investment-round-constraints';
 import { setupTestDB } from '../helpers/testcontainers';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -182,6 +183,7 @@ describe.skipIf(!process.env.CI && process.platform === 'win32')(
       process.env._EXPLICIT_ALLOW_MEMORY_STORAGE = '0';
 
       runDrizzlePush(connectionString);
+      await applyInvestmentRoundConstraints(connectionString);
       vi.resetModules();
 
       const [{ default: investmentsRouter }, dbModule, schema] = await Promise.all([

--- a/tests/integration/investment-scenario-capability.test.ts
+++ b/tests/integration/investment-scenario-capability.test.ts
@@ -1,38 +1,347 @@
-import { beforeAll, describe, expect, it } from 'vitest';
-import express from 'express';
+import { execFileSync } from 'node:child_process';
+
+import { sql } from 'drizzle-orm';
+import express, { type NextFunction, type Request, type Response, type Router } from 'express';
 import request from 'supertest';
-import { registerRoutes } from '../../server/routes';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-describe('investment scenario capability routes', () => {
-  let app: express.Express;
+import { setupTestDB } from '../helpers/testcontainers';
 
-  beforeAll(async () => {
-    app = express();
-    app.use(express.json({ limit: '1mb' }));
-    await registerRoutes(app);
+const STARTUP_TIMEOUT_MS = 90_000;
+
+type DbModule = typeof import('../../server/db');
+type SchemaModule = typeof import('@shared/schema');
+
+interface Runtime {
+  app: express.Express;
+  otherFundApp: express.Express;
+  container: Awaited<ReturnType<typeof setupTestDB>>;
+  database: DbModule['db'];
+  closeDatabasePool: DbModule['closeDatabasePool'];
+  testFundId: number;
+  otherFundId: number;
+  testInvestmentId: number;
+}
+
+interface RoundResponseBody {
+  id: number;
+  etag: string;
+}
+
+interface RoundListResponseBody {
+  data: Array<{ id: number }>;
+}
+
+let runtime: Runtime | undefined;
+let startedContainer: Awaited<ReturnType<typeof setupTestDB>> | undefined;
+let teardownDatabase: DbModule['db'] | undefined;
+let closeTeardownDatabasePool: DbModule['closeDatabasePool'] | undefined;
+
+function runDrizzlePush(connectionString: string): void {
+  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  execFileSync(npxCommand, ['drizzle-kit', 'push', '--force'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      DATABASE_URL: connectionString,
+    },
+    stdio: 'pipe',
   });
+}
 
-  it('returns explicit 501 for unsupported investment round writes', async () => {
-    const response = await request(app)
-      .post('/api/investments/1/rounds')
-      .send({ name: 'Series A', amount: 1000000 })
-      .expect(501);
+function restoreEnv(snapshot: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
 
-    expect(response.body).toMatchObject({
-      error: 'Storage operation is not supported for this route',
-      code: 'UNSUPPORTED_STORAGE_OPERATION',
+function installTestUser(fundIds: number[]) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    req.user = {
+      id: 'test-user',
+      sub: '1',
+      fundIds,
+    } as Express.User;
+    next();
+  };
+}
+
+function buildApp(investmentsRouter: Router, fundIds: number[]): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(installTestUser(fundIds));
+  app.use('/api', investmentsRouter);
+  return app;
+}
+
+async function seedFixtures(
+  database: DbModule['db'],
+  schema: SchemaModule
+): Promise<{ testFundId: number; otherFundId: number; testInvestmentId: number }> {
+  await database
+    .insert(schema.users)
+    .values({ id: 1, username: 'test-user', password: 'not-used' })
+    .onConflictDoNothing();
+
+  const [testFund] = await database
+    .insert(schema.funds)
+    .values({
+      name: 'Investment Round Test Fund',
+      size: '100000000.00',
+      managementFee: '0.0200',
+      carryPercentage: '0.2000',
+      vintageYear: 2026,
+    })
+    .returning({ id: schema.funds.id });
+  const [otherFund] = await database
+    .insert(schema.funds)
+    .values({
+      name: 'Other Investment Round Fund',
+      size: '50000000.00',
+      managementFee: '0.0200',
+      carryPercentage: '0.2000',
+      vintageYear: 2026,
+    })
+    .returning({ id: schema.funds.id });
+
+  if (!testFund || !otherFund) {
+    throw new Error('Failed to seed test funds');
+  }
+
+  const [company] = await database
+    .insert(schema.portfolioCompanies)
+    .values({
+      fundId: testFund.id,
+      name: 'RoundCo',
+      sector: 'Software',
+      stage: 'Series A',
+      investmentAmount: '1000000.00',
+      investmentDate: new Date('2026-01-15T00:00:00.000Z'),
+      currentValuation: '10000000.00',
+      status: 'active',
+    })
+    .returning({ id: schema.portfolioCompanies.id });
+  if (!company) {
+    throw new Error('Failed to seed portfolio company');
+  }
+
+  const [investment] = await database
+    .insert(schema.investments)
+    .values({
+      fundId: testFund.id,
+      companyId: company.id,
+      investmentDate: new Date('2026-01-15T00:00:00.000Z'),
+      amount: '1000000.00',
+      round: 'Seed',
+      ownershipPercentage: '0.1000',
+      valuationAtInvestment: '10000000.00',
+    })
+    .returning({ id: schema.investments.id });
+  if (!investment) {
+    throw new Error('Failed to seed investment');
+  }
+
+  return {
+    testFundId: testFund.id,
+    otherFundId: otherFund.id,
+    testInvestmentId: investment.id,
+  };
+}
+
+function baseRoundBody(fundId: number) {
+  return {
+    fundId,
+    roundName: 'Series A',
+    securityType: 'equity',
+    roundDate: '2026-01-15',
+    currency: 'USD',
+    investmentAmount: '1000000',
+  } as const;
+}
+
+describe.skipIf(!process.env.CI && process.platform === 'win32')(
+  'investment scenario capability routes',
+  () => {
+    const originalEnv = { ...process.env };
+
+    beforeAll(async () => {
+      const container = await setupTestDB();
+      startedContainer = container;
+      const connectionString = container.getConnectionUri();
+
+      process.env.NODE_ENV = 'test';
+      process.env._EXPLICIT_NODE_ENV = 'test';
+      process.env.DATABASE_URL = connectionString;
+      process.env._EXPLICIT_DATABASE_URL = connectionString;
+      process.env.USE_REAL_DB_IN_VITEST = '1';
+      process.env.ALLOW_MEMORY_STORAGE = '0';
+      process.env._EXPLICIT_ALLOW_MEMORY_STORAGE = '0';
+
+      runDrizzlePush(connectionString);
+      vi.resetModules();
+
+      const [{ default: investmentsRouter }, dbModule, schema] = await Promise.all([
+        import('../../server/routes/investments'),
+        import('../../server/db'),
+        import('@shared/schema'),
+      ]);
+      teardownDatabase = dbModule.db;
+      closeTeardownDatabasePool = dbModule.closeDatabasePool;
+      const seeded = await seedFixtures(dbModule.db, schema);
+
+      runtime = {
+        app: buildApp(investmentsRouter, [seeded.testFundId]),
+        otherFundApp: buildApp(investmentsRouter, [seeded.otherFundId]),
+        container,
+        database: dbModule.db,
+        closeDatabasePool: dbModule.closeDatabasePool,
+        ...seeded,
+      };
+    }, STARTUP_TIMEOUT_MS * 2);
+
+    afterAll(async () => {
+      try {
+        await (runtime?.database ?? teardownDatabase)?.execute(
+          sql`TRUNCATE investment_rounds RESTART IDENTITY CASCADE`
+        );
+        await (runtime?.closeDatabasePool ?? closeTeardownDatabasePool)?.();
+        await (runtime?.container ?? startedContainer)?.stop();
+      } finally {
+        restoreEnv(originalEnv);
+        vi.resetModules();
+      }
     });
-  });
 
-  it('returns explicit 501 for unsupported performance case writes', async () => {
-    const response = await request(app)
-      .post('/api/investments/1/cases')
-      .send({ name: 'Base Case', probability: 0.5 })
-      .expect(501);
+    it('creates, replays, and rejects conflicting investment round idempotency keys', async () => {
+      expect(runtime).toBeDefined();
+      const active = runtime!;
+      const body = baseRoundBody(active.testFundId);
 
-    expect(response.body).toMatchObject({
-      error: 'Storage operation is not supported for this route',
-      code: 'UNSUPPORTED_STORAGE_OPERATION',
+      const created = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .set('Idempotency-Key', 'k1')
+        .send(body);
+
+      expect(created.status, JSON.stringify(created.body)).toBe(201);
+      expect(created.body).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          etag: expect.any(String),
+        })
+      );
+      expect(created.body).not.toHaveProperty('created_by');
+      expect(created.body).not.toHaveProperty('request_hash');
+      expect(created.body).not.toHaveProperty('idempotency_key');
+
+      const replayed = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .set('Idempotency-Key', 'k1')
+        .send(body);
+
+      expect(replayed.status, JSON.stringify(replayed.body)).toBe(200);
+      expect((replayed.body as RoundResponseBody).id).toBe((created.body as RoundResponseBody).id);
+
+      const conflicting = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .set('Idempotency-Key', 'k1')
+        .send({
+          ...body,
+          roundName: 'Series B',
+        });
+
+      expect(conflicting.status, JSON.stringify(conflicting.body)).toBe(409);
+      expect(conflicting.body).toEqual({ error: 'idempotency_key_reused' });
     });
-  });
-});
+
+    it('requires an Idempotency-Key header for round writes', async () => {
+      expect(runtime).toBeDefined();
+      const active = runtime!;
+
+      const response = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .send(baseRoundBody(active.testFundId));
+
+      expect(response.status, JSON.stringify(response.body)).toBe(428);
+    });
+
+    it('denies cross-fund round writes', async () => {
+      expect(runtime).toBeDefined();
+      const active = runtime!;
+
+      const response = await request(active.otherFundApp)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .set('Idempotency-Key', 'k2')
+        .send(baseRoundBody(active.testFundId));
+
+      expect(response.status, JSON.stringify(response.body)).toBe(403);
+    });
+
+    it('returns 404 when listing rounds for an unknown investment', async () => {
+      expect(runtime).toBeDefined();
+      const active = runtime!;
+
+      const response = await request(active.app).get('/api/investments/999999/rounds');
+
+      expect(response.status, JSON.stringify(response.body)).toBe(404);
+    });
+
+    it('supports append-only supersede and rejects double supersede', async () => {
+      expect(runtime).toBeDefined();
+      const active = runtime!;
+
+      const r1 = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .set('Idempotency-Key', 'k3')
+        .send({
+          ...baseRoundBody(active.testFundId),
+          roundName: 'Seed Correction Source',
+        });
+      expect(r1.status, JSON.stringify(r1.body)).toBe(201);
+
+      const superseder = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .set('Idempotency-Key', 'k4')
+        .send({
+          ...baseRoundBody(active.testFundId),
+          roundName: 'Seed Corrected',
+          supersedesRoundId: (r1.body as RoundResponseBody).id,
+        });
+      expect(superseder.status, JSON.stringify(superseder.body)).toBe(201);
+
+      const list = await request(active.app).get(
+        `/api/investments/${active.testInvestmentId}/rounds`
+      );
+      expect(list.status, JSON.stringify(list.body)).toBe(200);
+      const ids = (list.body as RoundListResponseBody).data.map((round) => round.id);
+      expect(ids).toContain((superseder.body as RoundResponseBody).id);
+      expect(ids).not.toContain((r1.body as RoundResponseBody).id);
+
+      const doubleSupersede = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/rounds`)
+        .set('Idempotency-Key', 'k5')
+        .send({
+          ...baseRoundBody(active.testFundId),
+          roundName: 'Second Correction',
+          supersedesRoundId: (r1.body as RoundResponseBody).id,
+        });
+
+      expect(doubleSupersede.status, JSON.stringify(doubleSupersede.body)).toBe(409);
+      expect(doubleSupersede.body).toEqual({ error: 'round_already_superseded' });
+    });
+
+    it('keeps performance case writes explicitly unsupported', async () => {
+      expect(runtime).toBeDefined();
+      const active = runtime!;
+
+      const response = await request(active.app)
+        .post(`/api/investments/${active.testInvestmentId}/cases`)
+        .send({ name: 'Base Case', probability: 0.5 });
+
+      expect(response.status, JSON.stringify(response.body)).toBe(501);
+    });
+  }
+);

--- a/tests/integration/migrations/investment-rounds-schema.test.ts
+++ b/tests/integration/migrations/investment-rounds-schema.test.ts
@@ -1,0 +1,189 @@
+import { execFileSync } from 'node:child_process';
+
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { setupTestDB } from '../../helpers/testcontainers';
+
+const STARTUP_TIMEOUT_MS = 90_000;
+const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
+
+let container: Awaited<ReturnType<typeof setupTestDB>> | undefined;
+let pool: Pool | undefined;
+
+function runDrizzlePush(connectionString: string): void {
+  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  execFileSync(npxCommand, ['drizzle-kit', 'push', '--force'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      DATABASE_URL: connectionString,
+    },
+    stdio: 'pipe',
+  });
+}
+
+function getPgErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const record = error as Record<string, unknown>;
+  if (typeof record.code === 'string') return record.code;
+
+  const cause = record.cause;
+  if (typeof cause === 'object' && cause !== null) {
+    const causeRecord = cause as Record<string, unknown>;
+    if (typeof causeRecord.code === 'string') return causeRecord.code;
+  }
+
+  return undefined;
+}
+
+async function expectPgRejection(action: () => Promise<unknown>, code: string): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    expect(getPgErrorCode(error)).toBe(code);
+    return;
+  }
+
+  throw new Error(`Expected PostgreSQL error ${code}`);
+}
+
+async function insertFundAndInvestment(): Promise<{ fundId: number; investmentId: number }> {
+  expect(pool).toBeDefined();
+  const db = drizzle(pool!);
+
+  const fund = await db.execute(sql`
+    INSERT INTO funds (name, size, management_fee, carry_percentage, vintage_year)
+    VALUES ('Round Schema Fund', '100000000.00', '0.0200', '0.2000', 2026)
+    RETURNING id
+  `);
+  const fundId = Number(fund.rows[0]?.id);
+
+  const investment = await db.execute(sql`
+    INSERT INTO investments (fund_id, investment_date, amount, round)
+    VALUES (${fundId}, '2026-01-15T00:00:00.000Z', '1000000.00', 'Seed')
+    RETURNING id
+  `);
+  const investmentId = Number(investment.rows[0]?.id);
+
+  return { fundId, investmentId };
+}
+
+async function insertRound(input: {
+  fundId: number;
+  investmentId: number;
+  idempotencyKey: string;
+  roundName: string;
+  supersedesRoundId?: number;
+}): Promise<number> {
+  expect(pool).toBeDefined();
+  const db = drizzle(pool!);
+
+  const result = await db.execute(sql`
+    INSERT INTO investment_rounds (
+      investment_id,
+      fund_id,
+      round_name,
+      security_type,
+      round_date,
+      investment_amount,
+      idempotency_key,
+      request_hash,
+      supersedes_round_id
+    )
+    VALUES (
+      ${input.investmentId},
+      ${input.fundId},
+      ${input.roundName},
+      'equity',
+      '2026-02-01',
+      '250000.000000',
+      ${input.idempotencyKey},
+      repeat('a', 64),
+      ${input.supersedesRoundId ?? null}
+    )
+    RETURNING id
+  `);
+
+  return Number(result.rows[0]?.id);
+}
+
+describe.skipIf(skipIfNoDocker)('investment_rounds schema', () => {
+  beforeAll(async () => {
+    container = await setupTestDB();
+
+    const connectionString = container.getConnectionUri();
+    runDrizzlePush(connectionString);
+
+    pool = new Pool({ connectionString, max: 1 });
+  }, STARTUP_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await pool?.end();
+    await container?.stop();
+  });
+
+  it('creates the investment_rounds table', async () => {
+    expect(pool).toBeDefined();
+    const db = drizzle(pool!);
+
+    const rows = await db.execute(sql`
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name = 'investment_rounds'
+    `);
+
+    expect(rows.rows).toHaveLength(1);
+  });
+
+  it('blocks deleting an investment that has a round', async () => {
+    expect(pool).toBeDefined();
+    const db = drizzle(pool!);
+    const { fundId, investmentId } = await insertFundAndInvestment();
+
+    await insertRound({
+      fundId,
+      investmentId,
+      idempotencyKey: 'delete-restrict',
+      roundName: 'Delete Restrict Seed',
+    });
+
+    await expectPgRejection(
+      () => db.execute(sql`DELETE FROM investments WHERE id = ${investmentId}`),
+      '23503'
+    );
+  });
+
+  it('rejects a second correction for the same superseded round', async () => {
+    const { fundId, investmentId } = await insertFundAndInvestment();
+    const originalRoundId = await insertRound({
+      fundId,
+      investmentId,
+      idempotencyKey: 'original-round',
+      roundName: 'Original Seed',
+    });
+
+    await insertRound({
+      fundId,
+      investmentId,
+      idempotencyKey: 'first-correction',
+      roundName: 'First Correction',
+      supersedesRoundId: originalRoundId,
+    });
+
+    await expectPgRejection(
+      () =>
+        insertRound({
+          fundId,
+          investmentId,
+          idempotencyKey: 'second-correction',
+          roundName: 'Second Correction',
+          supersedesRoundId: originalRoundId,
+        }),
+      '23505'
+    );
+  });
+});

--- a/tests/integration/migrations/investment-rounds-schema.test.ts
+++ b/tests/integration/migrations/investment-rounds-schema.test.ts
@@ -5,6 +5,7 @@ import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { applyInvestmentRoundConstraints } from '../../helpers/apply-investment-round-constraints';
 import { setupTestDB } from '../../helpers/testcontainers';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -116,6 +117,7 @@ describe.skipIf(skipIfNoDocker)('investment_rounds schema', () => {
 
     const connectionString = container.getConnectionUri();
     runDrizzlePush(connectionString);
+    await applyInvestmentRoundConstraints(connectionString);
 
     pool = new Pool({ connectionString, max: 1 });
   }, STARTUP_TIMEOUT_MS * 2);

--- a/tests/integration/migrations/investments-id-fund-unique.test.ts
+++ b/tests/integration/migrations/investments-id-fund-unique.test.ts
@@ -5,6 +5,7 @@ import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { applyInvestmentRoundConstraints } from '../../helpers/apply-investment-round-constraints';
 import { setupTestDB } from '../../helpers/testcontainers';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -31,6 +32,7 @@ describe.skipIf(skipIfNoDocker)('investments (id, fund_id) unique', () => {
 
     const connectionString = container.getConnectionUri();
     runDrizzlePush(connectionString);
+    await applyInvestmentRoundConstraints(connectionString);
 
     pool = new Pool({ connectionString, max: 1 });
   }, STARTUP_TIMEOUT_MS * 2);

--- a/tests/unit/contract/investments/investment-round.contract.test.ts
+++ b/tests/unit/contract/investments/investment-round.contract.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  InvestmentRoundCreateSchema,
+  InvestmentRoundResponseSchema,
+  SecurityTypeSchema,
+} from '@shared/contracts/investments/investment-round.contract';
+
+describe('InvestmentRoundCreateSchema', () => {
+  const validCreate = {
+    fundId: 1,
+    roundName: 'Series A',
+    securityType: 'equity',
+    roundDate: '2026-06-21',
+    currency: 'USD',
+    investmentAmount: '1250000.000000',
+    roundSize: '10000000.5',
+    preMoneyValuation: '50000000',
+  };
+
+  it('parses a valid create payload', () => {
+    const parsed = InvestmentRoundCreateSchema.safeParse(validCreate);
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it('defaults currency to USD', () => {
+    const parsed = InvestmentRoundCreateSchema.parse({
+      fundId: 1,
+      roundName: 'Seed',
+      securityType: 'safe',
+      roundDate: '2026-06-21',
+      investmentAmount: '250000',
+    });
+
+    expect(parsed.currency).toBe('USD');
+  });
+
+  it('rejects 7 decimal places for money fields', () => {
+    expect(
+      InvestmentRoundCreateSchema.safeParse({
+        ...validCreate,
+        investmentAmount: '1250000.0000001',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects unknown top-level keys (.strict)', () => {
+    expect(
+      InvestmentRoundCreateSchema.safeParse({
+        ...validCreate,
+        requestHash: 'x'.repeat(64),
+      }).success
+    ).toBe(false);
+  });
+
+  it('allows supersedesRoundId to be omitted or provided', () => {
+    expect(InvestmentRoundCreateSchema.safeParse(validCreate).success).toBe(true);
+    expect(
+      InvestmentRoundCreateSchema.safeParse({
+        ...validCreate,
+        supersedesRoundId: 10,
+      }).success
+    ).toBe(true);
+  });
+});
+
+describe('SecurityTypeSchema', () => {
+  it('covers the persisted security type set', () => {
+    expect(SecurityTypeSchema.options).toEqual([
+      'equity',
+      'convertible_note',
+      'safe',
+      'warrant',
+      'other',
+    ]);
+  });
+});
+
+describe('InvestmentRoundResponseSchema', () => {
+  const validResponse = {
+    id: 1,
+    investmentId: 11,
+    fundId: 1,
+    roundName: 'Series A',
+    securityType: 'equity',
+    roundDate: '2026-06-21',
+    currency: 'USD',
+    investmentAmount: '1250000.000000',
+    roundSize: null,
+    preMoneyValuation: '50000000.000000',
+    supersedesRoundId: null,
+    createdAt: '2026-06-21T12:00:00.000Z',
+    updatedAt: '2026-06-21T12:00:00.000Z',
+    etag: 'W/"abc123"',
+  };
+
+  it('parses a valid response payload', () => {
+    expect(InvestmentRoundResponseSchema.safeParse(validResponse).success).toBe(true);
+  });
+
+  it('rejects internal persistence fields', () => {
+    for (const internalField of ['created_by', 'request_hash', 'idempotency_key']) {
+      expect(
+        InvestmentRoundResponseSchema.safeParse({
+          ...validResponse,
+          [internalField]: 'internal',
+        }).success
+      ).toBe(false);
+    }
+  });
+
+  it('requires a non-empty etag', () => {
+    expect(InvestmentRoundResponseSchema.safeParse({ ...validResponse, etag: '' }).success).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/lib/canonical-hash.test.ts
+++ b/tests/unit/lib/canonical-hash.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+
+describe('canonicalSha256', () => {
+  it('is independent of object key order', () => {
+    expect(canonicalSha256({ a: 1, b: { c: 2, d: 3 } })).toBe(
+      canonicalSha256({ b: { d: 3, c: 2 }, a: 1 })
+    );
+  });
+
+  it('drops undefined object keys', () => {
+    expect(canonicalSha256({ a: 1, b: undefined })).toBe(canonicalSha256({ a: 1 }));
+  });
+});

--- a/tests/unit/lib/investment-round-edit-model.test.ts
+++ b/tests/unit/lib/investment-round-edit-model.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  toInvestmentRoundCreatePayload,
+  type InvestmentRoundEditForm,
+} from '@/lib/investment-round-edit-model';
+
+function baseForm(overrides: Partial<InvestmentRoundEditForm> = {}): InvestmentRoundEditForm {
+  return {
+    roundName: 'Series A',
+    securityType: 'Equity',
+    roundDate: '2026-06-21',
+    currency: 'United States Dollar ($)',
+    investmentAmount: 2.5,
+    roundSize: 1_000_000,
+    preMoneyValuation: 5_000_000,
+    ...overrides,
+  };
+}
+
+describe('toInvestmentRoundCreatePayload', () => {
+  it('maps the currency label to an ISO-4217 code', () => {
+    const payload = toInvestmentRoundCreatePayload(baseForm(), 7);
+
+    expect(payload.currency).toBe('USD');
+  });
+
+  it('serializes fractional money numbers to decimal strings without padded zeros', () => {
+    const payload = toInvestmentRoundCreatePayload(baseForm({ investmentAmount: 2.5 }), 7);
+
+    expect(payload.investmentAmount).toBe('2.5');
+  });
+
+  it('serializes integer money numbers to strings', () => {
+    const payload = toInvestmentRoundCreatePayload(baseForm({ investmentAmount: 1_000_000 }), 7);
+
+    expect(payload.investmentAmount).toBe('1000000');
+  });
+
+  it('preserves date-only roundDate verbatim', () => {
+    const payload = toInvestmentRoundCreatePayload(baseForm({ roundDate: '2026-01-15' }), 7);
+
+    expect(payload.roundDate).toBe('2026-01-15');
+  });
+
+  it('omits optional fields when absent', () => {
+    const payload = toInvestmentRoundCreatePayload(
+      baseForm({
+        roundSize: undefined,
+        preMoneyValuation: null,
+        supersedesRoundId: undefined,
+      }),
+      7
+    );
+
+    expect(payload).not.toHaveProperty('roundSize');
+    expect(payload).not.toHaveProperty('preMoneyValuation');
+    expect(payload).not.toHaveProperty('supersedesRoundId');
+  });
+});

--- a/tests/unit/services/investments/investment-round-service.test.ts
+++ b/tests/unit/services/investments/investment-round-service.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const captured = vi.hoisted(() => ({
+  insertedValues: undefined as Record<string, unknown> | undefined,
+  conflictConfig: undefined as unknown,
+  insertRows: [] as unknown[],
+  insertError: undefined as unknown,
+  limitQueue: [] as unknown[][],
+}));
+
+const dbMock = vi.hoisted(() => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        captured.insertedValues = values;
+        return {
+          onConflictDoNothing: vi.fn((config: unknown) => {
+            captured.conflictConfig = config;
+            return {
+              returning: vi.fn(async () => {
+                if (captured.insertError) throw captured.insertError;
+                return captured.insertRows;
+              }),
+            };
+          }),
+        };
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () =>
+            captured.limitQueue.length > 0 ? captured.limitQueue.shift() : []
+          ),
+          orderBy: vi.fn(async () =>
+            captured.limitQueue.length > 0 ? captured.limitQueue.shift() : []
+          ),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock('../../../../server/db', () => dbMock);
+
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+import { createRound } from '../../../../server/services/investments/investment-round-service';
+
+type CreateRoundInput = Parameters<typeof createRound>[0];
+type CreateRoundOptions = NonNullable<Parameters<typeof createRound>[1]>;
+
+function serviceOptions(): CreateRoundOptions {
+  return { database: dbMock.db as CreateRoundOptions['database'] };
+}
+
+function baseInput(overrides: Partial<CreateRoundInput> = {}): CreateRoundInput {
+  return {
+    investmentId: 11,
+    fundId: 1,
+    roundName: 'Series A',
+    securityType: 'equity',
+    roundDate: '2026-06-21',
+    currency: 'USD',
+    investmentAmount: '1250000.000000',
+    idempotencyKey: 'idem-1',
+    createdBy: 7,
+    ...overrides,
+  };
+}
+
+function expectedRequestHash(input: CreateRoundInput): string {
+  return canonicalSha256({
+    investmentId: input.investmentId,
+    fundId: input.fundId,
+    roundName: input.roundName,
+    securityType: input.securityType,
+    roundDate: input.roundDate,
+    currency: input.currency,
+    investmentAmount: input.investmentAmount,
+    roundSize: input.roundSize,
+    preMoneyValuation: input.preMoneyValuation,
+    supersedesRoundId: input.supersedesRoundId,
+  });
+}
+
+function roundRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const input = baseInput();
+  return {
+    id: 10,
+    investmentId: input.investmentId,
+    fundId: input.fundId,
+    roundName: input.roundName,
+    securityType: input.securityType,
+    roundDate: input.roundDate,
+    currency: input.currency,
+    investmentAmount: input.investmentAmount,
+    roundSize: null,
+    preMoneyValuation: null,
+    idempotencyKey: input.idempotencyKey,
+    requestHash: expectedRequestHash(input),
+    supersedesRoundId: null,
+    createdBy: input.createdBy,
+    createdAt: new Date('2026-06-21T12:00:00.000Z'),
+    updatedAt: new Date('2026-06-21T12:00:00.000Z'),
+    rowXmin: '5',
+    ...overrides,
+  };
+}
+
+describe('investment-round-service', () => {
+  beforeEach(() => {
+    captured.insertedValues = undefined;
+    captured.conflictConfig = undefined;
+    captured.insertRows = [];
+    captured.insertError = undefined;
+    captured.limitQueue = [];
+    dbMock.db.insert.mockClear();
+    dbMock.db.select.mockClear();
+  });
+
+  it('returns created with row/xmin and writes the canonical request hash', async () => {
+    const input = baseInput();
+    const requestHash = expectedRequestHash(input);
+    captured.insertRows = [roundRecord({ requestHash })];
+
+    const out = await createRound(input, serviceOptions());
+
+    expect(out.kind).toBe('created');
+    if (out.kind !== 'created') throw new Error('Expected created result');
+    expect(out.xmin).toBe('5');
+    expect(out.row).not.toHaveProperty('rowXmin');
+    expect(captured.insertedValues).toMatchObject({
+      investmentId: 11,
+      fundId: 1,
+      idempotencyKey: 'idem-1',
+      requestHash,
+      roundSize: null,
+      preMoneyValuation: null,
+      supersedesRoundId: null,
+      createdBy: 7,
+    });
+    expect(captured.conflictConfig).toBeDefined();
+  });
+
+  it('returns replayed when an idempotency conflict has the same request hash', async () => {
+    const input = baseInput();
+    captured.insertRows = [];
+    captured.limitQueue = [
+      [roundRecord({ requestHash: expectedRequestHash(input), rowXmin: '9' })],
+    ];
+
+    const out = await createRound(input, serviceOptions());
+
+    expect(out.kind).toBe('replayed');
+    if (out.kind !== 'replayed') throw new Error('Expected replayed result');
+    expect(out.xmin).toBe('9');
+    expect(out.row.id).toBe(10);
+  });
+
+  it('returns key_reused when an idempotency conflict has a different request hash', async () => {
+    captured.insertRows = [];
+    captured.limitQueue = [[roundRecord({ requestHash: '0'.repeat(64) })]];
+
+    await expect(createRound(baseInput(), serviceOptions())).resolves.toEqual({
+      kind: 'key_reused',
+    });
+  });
+
+  it('creates a superseding round when the target exists and is current', async () => {
+    const input = baseInput({ idempotencyKey: 'idem-2', supersedesRoundId: 20 });
+    captured.limitQueue = [[roundRecord({ id: 20 })], []];
+    captured.insertRows = [
+      roundRecord({
+        id: 21,
+        idempotencyKey: 'idem-2',
+        requestHash: expectedRequestHash(input),
+        supersedesRoundId: 20,
+      }),
+    ];
+
+    const out = await createRound(input, serviceOptions());
+
+    expect(out.kind).toBe('created');
+    if (out.kind !== 'created') throw new Error('Expected created result');
+    expect(out.row.id).toBe(21);
+    expect(captured.insertedValues).toMatchObject({ supersedesRoundId: 20 });
+  });
+
+  it('returns already_superseded when a row already references the target', async () => {
+    captured.limitQueue = [
+      [roundRecord({ id: 20 })],
+      [roundRecord({ id: 21, supersedesRoundId: 20 })],
+    ];
+
+    await expect(
+      createRound(baseInput({ supersedesRoundId: 20 }), serviceOptions())
+    ).resolves.toEqual({
+      kind: 'already_superseded',
+    });
+    expect(dbMock.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns already_superseded for the concurrent supersedes unique violation', async () => {
+    captured.limitQueue = [[roundRecord({ id: 20 })], []];
+    captured.insertError = Object.assign(
+      new Error('duplicate key value violates unique constraint "investment_rounds_supersedes_uq"'),
+      { code: '23505', constraint: 'investment_rounds_supersedes_uq' }
+    );
+
+    await expect(
+      createRound(baseInput({ supersedesRoundId: 20 }), serviceOptions())
+    ).resolves.toEqual({
+      kind: 'already_superseded',
+    });
+  });
+
+  it('returns supersede_target_missing when the target row is absent', async () => {
+    captured.limitQueue = [[]];
+
+    await expect(
+      createRound(baseInput({ supersedesRoundId: 999 }), serviceOptions())
+    ).resolves.toEqual({
+      kind: 'supersede_target_missing',
+    });
+    expect(dbMock.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns supersede_target_other_investment when the target belongs elsewhere', async () => {
+    captured.limitQueue = [[roundRecord({ id: 20, investmentId: 999 })]];
+
+    await expect(
+      createRound(baseInput({ supersedesRoundId: 20 }), serviceOptions())
+    ).resolves.toEqual({
+      kind: 'supersede_target_other_investment',
+    });
+    expect(dbMock.db.insert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PR-1 of the ADR-023 L3b stack (feature) — stacked on #PR-0

> Base is `feat/investment-rounds-precondition`; **retarget to `main` after PR-0 merges**. `enable_investment_rounds` ships **default OFF**.

Flips `POST /api/investments/:id/rounds` (501) into a backed, fund-scoped, idempotent create + list + read with an append-only supersede correction path.

### Changes (Tasks 1-8)
- **Table/migration** (`871d10eb`): `investment_rounds` (NUMERIC(20,6) money; composite FK `(investment_id,fund_id)->investments(id,fund_id)` RESTRICT; partial-unique `supersedes_round_id`; `UNIQUE(fund_id,idempotency_key)`) + journaled up/down. Extracted `shared/lib/canonical-hash.ts` (import-reconciliation delegates, 28 tests still green). Zod contract **imports** the money schema; response hides `created_by`/`request_hash`/`idempotency_key`.
- **Service + routes** (`e339095b`): `createRound` (Idempotency-Key `ON CONFLICT` → created/replayed/key_reused via `request_hash`; supersede pre-checks + partial-unique `23505` backstop → already_superseded), list (current only), read. Routes derive fund from the investment then `enforceProvidedFundScope` on **all three** (closes read-path IDOR); `/cases` stays 501.
- **Integration test** (`7c11ad6d`): real-Postgres 501→201, 200 replay, 409 key-reuse, 428 missing key, 403 cross-fund, 404 unknown investment, supersede + 409 double-supersede; teardown truncates.
- **Client + flag** (`d80eafd6`): `useCreateRound` hook + label→ISO / number→DecimalString serializer (5 tests); `enable_investment_rounds` flag (OFF). No live UI mount (deferred).

### Test plan
- Local: `npm run check` green ×5; **52 unit tests pass** (contract 9, service 8, serializer 5, hash 2, + 28 import-reconciliation).
- **CI (authoritative)**: integration test, `guard:route-imports`, full lint — can't run on the Node-24 local box.

### Deferred
Live `/portfolio` round-dialog mount behind the flag; performance cases / valuation / cap-table stay 501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)