### PR TITLE
fix(investment-rounds): register client flag + relocate tests (merged gate was dead)

### DIFF
--- a/shared/feature-flags/flag-definitions.ts
+++ b/shared/feature-flags/flag-definitions.ts
@@ -255,6 +255,16 @@ export const POLISH_FLAGS: Record<string, FeatureFlag> = {
     dependencies: ['enable_cash_event_object'],
   },
 
+  enable_investment_rounds: {
+    key: 'enable_investment_rounds',
+    name: 'Investment Rounds',
+    description:
+      'Investment-rounds surface (list + add/supersede dialog, trajectory ribbon) on the live company detail page. Reads/writes /api/investments/:id/rounds. OFF by default.',
+    enabled: false,
+    rolloutPercentage: 0,
+    dependencies: [],
+  },
+
   enable_route_redirects: {
     key: 'enable_route_redirects',
     name: 'Legacy Route Redirects',

--- a/tests/unit/components/investments/investment-rounds-section.test.tsx
+++ b/tests/unit/components/investments/investment-rounds-section.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { InvestmentRoundsSection } from './investment-rounds-section';
+import { InvestmentRoundsSection } from '@/components/investments/investment-rounds-section';
 import { useCompanyInvestments } from '@/hooks/useCompanyInvestments';
 import { useInvestmentRounds } from '@/hooks/useInvestmentRounds';
 
 vi.mock('@/hooks/useCompanyInvestments', () => ({ useCompanyInvestments: vi.fn() }));
 vi.mock('@/hooks/useInvestmentRounds', () => ({ useInvestmentRounds: vi.fn() }));
-vi.mock('./new-round-dialog', () => ({ default: () => <div data-testid="round-dialog" /> }));
+vi.mock('@/components/investments/new-round-dialog', () => ({
+  default: () => <div data-testid="round-dialog" />,
+}));
 
 const mockInvestments = vi.mocked(useCompanyInvestments);
 const mockRounds = vi.mocked(useInvestmentRounds);

--- a/tests/unit/components/investments/new-round-dialog.test.tsx
+++ b/tests/unit/components/investments/new-round-dialog.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ApiError } from '@/lib/queryClient';
-import NewRoundDialog from './new-round-dialog';
+import NewRoundDialog from '@/components/investments/new-round-dialog';
 
 const { mutate } = vi.hoisted(() => ({ mutate: vi.fn() }));
 vi.mock('@/hooks/useCreateRound', async (orig) => {

--- a/tests/unit/components/investments/rounds-table.test.tsx
+++ b/tests/unit/components/investments/rounds-table.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import type { InvestmentRoundResponse } from '@shared/contracts/investments/investment-round.contract';
-import { RoundsTable } from './rounds-table';
+import { RoundsTable } from '@/components/investments/rounds-table';
 
 function round(over: Partial<InvestmentRoundResponse>): InvestmentRoundResponse {
   return {

--- a/tests/unit/components/investments/trajectory-ribbon.test.tsx
+++ b/tests/unit/components/investments/trajectory-ribbon.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import type { InvestmentRoundResponse } from '@shared/contracts/investments/investment-round.contract';
-import { TrajectoryRibbon } from './trajectory-ribbon';
+import { TrajectoryRibbon } from '@/components/investments/trajectory-ribbon';
 
 function round(over: Partial<InvestmentRoundResponse>): InvestmentRoundResponse {
   return {

--- a/tests/unit/flags/enable-investment-rounds.test.tsx
+++ b/tests/unit/flags/enable-investment-rounds.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ALL_FLAGS } from '@shared/feature-flags/flag-definitions';
+import { useFlag } from '@/shared/useFlags';
+
+// Regression guard: the flag groups are typed `Record<string, FeatureFlag>`, so
+// `FlagKey` collapses to `string` and `useFlag('enable_investment_rounds')`
+// compiles even when the key is NOT registered. If the key is missing from
+// ALL_FLAGS the gate is silently always-false AND not runtime-overridable, which
+// makes the whole investment-rounds surface dead. These runtime checks catch that.
+describe('enable_investment_rounds flag registration', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('is registered in ALL_FLAGS and defaults OFF', () => {
+    expect(Object.keys(ALL_FLAGS)).toContain('enable_investment_rounds');
+    expect(ALL_FLAGS['enable_investment_rounds']?.enabled).toBe(false);
+  });
+
+  it('defaults OFF but is runtime-overridable (so dev can enable it)', () => {
+    const off = renderHook(() => useFlag('enable_investment_rounds'));
+    expect(off.result.current).toBe(false);
+
+    window.localStorage.setItem('ff_enable_investment_rounds', '1');
+    const on = renderHook(() => useFlag('enable_investment_rounds'));
+    expect(on.result.current).toBe(true);
+  });
+});

--- a/tests/unit/hooks/useCompanyInvestments.test.tsx
+++ b/tests/unit/hooks/useCompanyInvestments.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useCompanyInvestments } from './useCompanyInvestments';
+import { useCompanyInvestments } from '@/hooks/useCompanyInvestments';
 import { apiRequest } from '@/lib/queryClient';
 
 vi.mock('@/lib/queryClient', async (orig) => {

--- a/tests/unit/hooks/useInvestmentRounds.test.tsx
+++ b/tests/unit/hooks/useInvestmentRounds.test.tsx
@@ -2,8 +2,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useInvestmentRounds } from './useInvestmentRounds';
-import { investmentRoundsQueryKey } from './useCreateRound';
+import { useInvestmentRounds } from '@/hooks/useInvestmentRounds';
+import { investmentRoundsQueryKey } from '@/hooks/useCreateRound';
 import { apiRequest } from '@/lib/queryClient';
 
 vi.mock('@/lib/queryClient', async (orig) => {

--- a/tests/unit/lib/investment-round-error.test.tsx
+++ b/tests/unit/lib/investment-round-error.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ApiError } from '@/lib/queryClient';
-import { roundErrorMessage } from './investment-round-error';
+import { roundErrorMessage } from '@/lib/investment-round-error';
 
 describe('roundErrorMessage', () => {
   it('distinguishes 409 sub-codes via errorCode', () => {

--- a/tests/unit/lib/investment-round-format.test.tsx
+++ b/tests/unit/lib/investment-round-format.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatRoundMoney, formatRoundDate } from './investment-round-format';
+import { formatRoundMoney, formatRoundDate } from '@/lib/investment-round-format';
 
 describe('investment-round-format', () => {
   it('formats ISO-currency decimal strings as whole money', () => {

--- a/tests/unit/pages/portfolio-company-summary.rounds.test.tsx
+++ b/tests/unit/pages/portfolio-company-summary.rounds.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import PortfolioCompanySummaryPage from './portfolio-company-summary';
+import PortfolioCompanySummaryPage from '@/pages/portfolio-company-summary';
 import { usePortfolioCompany } from '@/hooks/use-fund-data';
 import { useFlag } from '@/shared/useFlags';
 


### PR DESCRIPTION
## Why
Two defects in the merged Phase A (#903), both invisible to CI:

1. **Dead flag gate.** `enable_investment_rounds` was in `flags/registry.yaml` but **never added to the client `ALL_FLAGS`** (`shared/feature-flags/flag-definitions.ts`). The flag groups are typed `Record<string, FeatureFlag>`, so `FlagKey` collapses to `string` and `useFlag('enable_investment_rounds')` compiled — but at runtime the key was absent, so the gate was **always false and not even runtime-overridable**. `InvestmentRoundsSection` could never render. Registered it (`enabled: false`) in `POLISH_FLAGS`.

2. **Tests never ran.** The 9 Phase A test files were co-located under `client/src/**`, which the vitest config never collects (the `server`+`client` projects only include `tests/unit/**`). So CI's `unit-fast` passed without executing them. Relocated all to `tests/unit/**` as `.test.tsx` (jsdom client project, alias imports), plus a flag-registration regression test.

## Verification
All 10 files / **26 tests pass** locally via the real config (`--project=client`). `npm run check` clean. Flag stays **OFF** (no behavior change); dev can enable via `?ff_enable_investment_rounds=1` or localStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)