### PR TITLE
docs: corrected current-state steelman v2 roadmap, readiness, governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,9 @@
 # Feature flags governance
 /flags/ @nikhillinit
 /flags/* @nikhillinit
+/shared/feature-flags/ @nikhillinit
 
 # Security-sensitive paths
-/server/auth/ @nikhillinit
 /server/rum/ @nikhillinit
 /migrations/ @nikhillinit
 
@@ -34,8 +34,8 @@
 
 # Infrastructure and observability
 /client/src/metrics/ @nikhillinit
-/client/src/lib/feature-flags.ts @nikhillinit
 /client/src/engines/ @nikhillinit
+/scripts/check-prod-bundle.mjs @nikhillinit
 
 # Testing
 /tests/unit/reserves-*.test.ts @nikhillinit
@@ -43,14 +43,15 @@
 /tests/integration/ @nikhillinit
 
 # CI/CD
-/.github/workflows/ci-reserves-v11.yml @nikhillinit
-/.github/workflows/canary-gate.yml @nikhillinit
+/.github/workflows/ci-unified.yml @nikhillinit
 
 # Documentation
-/docs/reserves/ @nikhillinit
+/README.md @nikhillinit
+/docs/BUILD_READINESS.md @nikhillinit
 /docs/ROLLBACK_TRIGGERS.md @nikhillinit
 /docs/INCIDENT_RESPONSE.md @nikhillinit
+/docs/plans/2026-03-27-secondary-surface-decisions.md @nikhillinit
+/docs/plans/2026-06-22-current-state-steelman-roadmap.md @nikhillinit
 
-# Server-side implementation
-/server/routes/reserves.ts @nikhillinit
-/server/plugins/reserves-metrics.plugin.ts @nikhillinit
+# Route governance (policy registry)
+/client/src/app/route-governance-registry.ts @nikhillinit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-03-28
+last_updated: 2026-06-22
 ---
 
 # POVC Fund-Modeling Platform
@@ -17,10 +17,24 @@ Current secondary-surface exposure is intentionally narrow:
   `/portfolio?tab=reserve-planning`
 - `kpi-manager` and `kpi-submission` are archived entrypoints and permanently
   redirect to `/dashboard`
+- `/reserves-demo`, `/allocation-manager`, `/cash-management`,
+  `/portfolio-analytics`, and `/cap-tables` are deleted;
+  `scripts/check-prod-bundle.mjs` (`QUARANTINED_MODULES`) guards reintroduction
+  by source-path substring (the cap-tables token is the module name `CapTables`,
+  not the `/cap-tables` route)
 - `/shared/:shareId` is an intentional public shared-link contract
 - `/portal/:rest*` is an intentional public entrypoint that currently resolves
   to access denied
 - Compass remains experimental and unmounted on the server
+- MOIC rankings must come from the live fund-scoped contract with provenance;
+  sample rankings are not a production fallback
+- Investment round routes enforce fund scope on create, list, and read; the
+  `enable_investment_rounds` flag remains off for production until explicit
+  readiness gates are accepted
+- LP dashboard/profile widget routes are mounted in both active server surfaces.
+  LP Reporting export/download routes already exist and are authenticated, but
+  are not yet admin-only or watermarked, so they remain subject to
+  role/workflow/provenance qualification before production trust claims
 
 ## Development
 
@@ -32,16 +46,20 @@ npm run dev
 ## Validation
 
 ```bash
+npm run check
 npm run validate:core
+npm run build && npm run build:verify
+npm run release:check   # canonical end-to-end release gate (Docker/WSL2)
 ```
 
 ## Authoritative Docs
 
 - [Build Readiness](docs/BUILD_READINESS.md)
 - [Secondary-Surface Decisions](docs/plans/2026-03-27-secondary-surface-decisions.md)
+- [Current-State Steelman Roadmap](docs/plans/2026-06-22-current-state-steelman-roadmap.md)
 
 ## Historical Note
 
 Older roadmap and audit material elsewhere in the repo should be treated as
-historical context unless it matches the documents above and the live app
-routing/navigation behavior.
+historical context unless it matches the documents above and the live app,
+route-policy, feature-flag, and API-contract behavior.

--- a/docs/BUILD_READINESS.md
+++ b/docs/BUILD_READINESS.md
@@ -1,14 +1,15 @@
 ---
 status: ACTIVE
-last_updated: 2026-03-28
+last_updated: 2026-06-22
 ---
 
 # Build Readiness Verification Report
 
 ## Current Readiness
 
-The repo is currently judged by the live lifecycle and active validation lanes,
-not by older roadmap checkpoints.
+The repo is judged by live lifecycle, active validation lanes, production-bundle
+verification, route policy, and current API contracts — not by older roadmap
+checkpoints.
 
 Authoritative product surface:
 
@@ -17,33 +18,72 @@ Authoritative product surface:
 - model results is the post-publish destination
 - `planning`, `kpi-manager`, and `kpi-submission` are archived redirect-only
   entrypoints, not live product surfaces
+- `/reserves-demo`, `/allocation-manager`, `/cash-management`,
+  `/portfolio-analytics`, and `/cap-tables` are deleted;
+  `scripts/check-prod-bundle.mjs` (`QUARANTINED_MODULES`) guards reintroduction
+  by matching source-path substrings (`reserves-demo`, `allocation-manager`,
+  `cash-management`, `portfolio-analytics`, `CapTables`) — a re-added surface is
+  caught only if its module path contains one of those tokens (note `CapTables`,
+  the module name, not the `/cap-tables` route)
 - `/shared/:shareId` remains an intentional public shared-link contract
 - `/portal/:rest*` remains an intentional public entrypoint that currently
   resolves to access denied
 - Compass is unmounted and experimental, not part of build readiness
+- Investment round create/list/read routes enforce fund scope through the parent
+  investment before returning round data
+- LP dashboard/profile widget routes are mounted in both active server surfaces
+- LP Reporting export and report-download routes already exist and are mounted
+  (`server/routes/lp-reporting/metric-runs.ts` JSON/CSV exports behind
+  `requireAuth`+`requireFundAccess`; `server/routes/lp-api.ts` report download
+  behind `requireAuth`+`requireLPAccess`, filtered by `lpId`). They are
+  authenticated but not yet admin-only or watermarked, so they are not
+  production-trust-qualified until role, workflow-state, provenance, and
+  export-eligibility gates are accepted
 
 ## Required Validation Commands
 
 ```bash
+npm run check
 npm run validate:core
+npm run build && npm run build:verify
+npm run release:check   # canonical release gate (Docker/WSL2; --skip-db for a fast subset)
 ```
+
+`npm run build:verify` executes `scripts/check-prod-bundle.mjs`; it must fail if
+any quarantined module appears in the production bundle or if source maps are
+emitted without `VITE_SOURCEMAP=true`.
+
+`npm run release:check` (`scripts/release-check.mjs`) is the authoritative
+end-to-end release gate — build, typecheck, prod-bundle verifier, and a
+Testcontainers Postgres proof. CI green is baseline health, not release proof;
+it needs Docker (WSL2 on Windows), and `--skip-db` runs the non-DB subset.
 
 ## Surface Status
 
 - `planning`: archived route that redirects to `/portfolio?tab=reserve-planning`
 - `kpi-manager`: archived route that redirects to `/dashboard`
 - `kpi-submission`: archived route that redirects to `/dashboard`
+- `/reserves-demo`: deleted; restore requires a new owned implementation and
+  route decision
+- `/allocation-manager`, `/cash-management`, `/portfolio-analytics`,
+  `/cap-tables`: deleted; restore requires owned implementations and route
+  decisions
+- `/moic-analysis`: compatibility route only; canonical fund-context placement
+  is tracked in the current-state roadmap
 - `/shared/:shareId`: public contract preserved for shared dashboard links
-- `/portal/:rest*`: public contract preserved as the access-denied portal entrypoint
+- `/portal/:rest*`: public contract preserved as the access-denied portal
+  entrypoint
 - `server/compass/routes.ts`: explicit experimental/unmounted status
 
 ## Authoritative References
 
 - [README](../README.md)
 - [Secondary-Surface Decisions](plans/2026-03-27-secondary-surface-decisions.md)
+- [Current-State Steelman Roadmap](plans/2026-06-22-current-state-steelman-roadmap.md)
 
 ## Historical Note
 
-Earlier build-readiness audit content has been superseded by the commands and
-surface-status rules above. Treat older references as historical unless they
-align with the current docs and live route behavior.
+Earlier build-readiness audit content has been superseded by the commands,
+surface-status rules, route-policy work, and production-bundle verifier above.
+Treat older references as historical unless they align with the current docs and
+live route behavior.

--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-06-22T00:00:00.000Z",
+  "generatedAt": "2026-06-23T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 175,
+      "staleDays": 176,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 87,
+      "staleDays": 88,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1176,7 +1176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1192,7 +1192,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1208,7 +1208,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1223,7 +1223,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1305,7 +1305,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 77,
+      "staleDays": 78,
       "status": "UNKNOWN"
     },
     {
@@ -1323,7 +1323,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1340,7 +1340,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1357,7 +1357,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1373,7 +1373,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1403,7 +1403,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1418,7 +1418,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -1434,7 +1434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1449,7 +1449,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1464,7 +1464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1479,7 +1479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1494,7 +1494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1522,7 +1522,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 175,
+      "staleDays": 176,
       "status": "ACTIVE"
     },
     {
@@ -1538,7 +1538,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "UNKNOWN"
     },
     {
@@ -1565,7 +1565,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -1580,7 +1580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -1595,7 +1595,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1610,7 +1610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1625,7 +1625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1678,7 +1678,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 175,
+      "staleDays": 176,
       "status": "ACTIVE"
     },
     {
@@ -1692,7 +1692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1706,7 +1706,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1720,7 +1720,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1791,7 +1791,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1806,7 +1806,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1821,7 +1821,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -1836,7 +1836,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1851,7 +1851,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1866,7 +1866,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1881,7 +1881,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1896,7 +1896,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1911,7 +1911,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1930,7 +1930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ready"
     },
     {
@@ -1949,7 +1949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ready"
     },
     {
@@ -1968,7 +1968,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ready"
     },
     {
@@ -1983,7 +1983,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -1998,7 +1998,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2037,7 +2037,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -2052,7 +2052,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -2067,7 +2067,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 32,
+      "staleDays": 33,
       "status": "UNKNOWN"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2135,7 +2135,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2150,7 +2150,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2165,7 +2165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2180,7 +2180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2196,7 +2196,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -2212,7 +2212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2227,7 +2227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2242,7 +2242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2257,7 +2257,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2272,7 +2272,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2288,7 +2288,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -2303,7 +2303,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2318,7 +2318,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2333,7 +2333,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2349,7 +2349,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2364,7 +2364,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2379,7 +2379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2394,7 +2394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2408,7 +2408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2423,7 +2423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2439,7 +2439,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2455,7 +2455,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2471,7 +2471,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2566,7 +2566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2582,7 +2582,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2597,7 +2597,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2612,7 +2612,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2627,7 +2627,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2643,7 +2643,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2659,7 +2659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2674,7 +2674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2692,7 +2692,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2722,7 +2722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2737,7 +2737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2752,7 +2752,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2768,7 +2768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2783,7 +2783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2798,7 +2798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO-v2.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -2813,7 +2813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/HANDOFF-MEMO.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -2828,7 +2828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/immediate-actions-summary.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -2843,7 +2843,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2858,7 +2858,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -2873,7 +2873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2888,7 +2888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2903,7 +2903,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2918,7 +2918,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2933,7 +2933,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2948,7 +2948,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -2963,7 +2963,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-baseline-report-2025-12-23.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -2978,7 +2978,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/test-remediation-summary.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -2993,7 +2993,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/week2-execution-report.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -3008,7 +3008,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "ACTIVE"
     },
     {
@@ -3023,7 +3023,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3038,7 +3038,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3074,7 +3074,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 87,
+      "staleDays": 88,
       "status": "ACTIVE"
     },
     {
@@ -3091,7 +3091,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "ACTIVE"
     },
     {
@@ -3106,7 +3106,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "ACTIVE"
     },
     {
@@ -3121,7 +3121,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3136,7 +3136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3165,7 +3165,7 @@
       "lastUpdated": "2026-05-21",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 32,
+      "staleDays": 33,
       "status": "ACTIVE"
     },
     {
@@ -3180,7 +3180,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -3195,7 +3195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3210,7 +3210,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "ACTIVE"
     },
     {
@@ -3237,7 +3237,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3252,7 +3252,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3267,7 +3267,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-QUICK-START.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3282,7 +3282,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3297,7 +3297,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3312,7 +3312,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3327,22 +3327,22 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-03-28",
+        "last_updated": "2026-06-22",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
       "isStale": false,
-      "lastUpdated": "2026-03-28",
+      "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "README.md",
-      "staleDays": 86,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -3357,7 +3357,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3372,7 +3372,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3387,7 +3387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3404,7 +3404,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 87,
+      "staleDays": 88,
       "status": "ACTIVE"
     },
     {
@@ -3419,7 +3419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3434,7 +3434,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3449,7 +3449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3464,7 +3464,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3479,7 +3479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3494,7 +3494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3509,7 +3509,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -3524,7 +3524,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3539,7 +3539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3554,7 +3554,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3569,7 +3569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3584,7 +3584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3599,7 +3599,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3614,7 +3614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3629,7 +3629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -3644,7 +3644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3659,7 +3659,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3674,7 +3674,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3689,7 +3689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3704,7 +3704,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3719,7 +3719,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3734,7 +3734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3749,7 +3749,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3764,7 +3764,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3779,7 +3779,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3795,7 +3795,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "active"
     },
     {
@@ -3810,7 +3810,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3825,7 +3825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3840,7 +3840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3855,7 +3855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3870,7 +3870,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 77,
+      "staleDays": 78,
       "status": "ACTIVE"
     },
     {
@@ -3885,7 +3885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3900,7 +3900,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -3915,7 +3915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3930,7 +3930,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3945,7 +3945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3960,7 +3960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3975,7 +3975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -3990,7 +3990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4005,7 +4005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4020,7 +4020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4035,7 +4035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4050,7 +4050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4065,7 +4065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4080,7 +4080,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -4095,22 +4095,22 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-03-28",
+        "last_updated": "2026-06-22",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
       "isStale": false,
-      "lastUpdated": "2026-03-28",
+      "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 86,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -4125,7 +4125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4152,7 +4152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4167,7 +4167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4182,7 +4182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4197,7 +4197,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4212,7 +4212,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4227,7 +4227,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4242,7 +4242,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4281,7 +4281,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "ACTIVE"
     },
     {
@@ -4296,7 +4296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4311,7 +4311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4326,7 +4326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4362,7 +4362,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 25,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -4377,7 +4377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4392,7 +4392,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 63,
+      "staleDays": 64,
       "status": "HISTORICAL"
     },
     {
@@ -4407,7 +4407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4422,7 +4422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4437,7 +4437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4452,7 +4452,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -4467,7 +4467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4482,7 +4482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4497,7 +4497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4512,7 +4512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4527,7 +4527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4542,7 +4542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4583,7 +4583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -4598,7 +4598,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4613,7 +4613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4628,7 +4628,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 78,
+      "staleDays": 79,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4643,7 +4643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4658,7 +4658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4673,7 +4673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4688,7 +4688,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4702,7 +4702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -4717,7 +4717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4732,7 +4732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4747,7 +4747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4762,7 +4762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4777,7 +4777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -4792,7 +4792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4807,7 +4807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4822,7 +4822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4837,7 +4837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4852,7 +4852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4867,7 +4867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4882,7 +4882,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4897,7 +4897,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4926,7 +4926,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -4941,7 +4941,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4956,7 +4956,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4971,7 +4971,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -4986,7 +4986,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5001,7 +5001,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5016,7 +5016,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5031,7 +5031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -5046,7 +5046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5061,7 +5061,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5076,7 +5076,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5091,7 +5091,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5106,7 +5106,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5121,7 +5121,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -5136,7 +5136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5151,7 +5151,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5166,7 +5166,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5181,7 +5181,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5196,7 +5196,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 45,
+      "staleDays": 46,
       "status": "ACTIVE"
     },
     {
@@ -5211,7 +5211,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 45,
+      "staleDays": 46,
       "status": "ACTIVE"
     },
     {
@@ -5226,7 +5226,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -5241,7 +5241,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 31,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -5256,7 +5256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5271,7 +5271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5286,7 +5286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5301,7 +5301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5327,7 +5327,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -5342,7 +5342,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "Implemented"
     },
     {
@@ -5357,7 +5357,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/adr/ADR-023-investment-event-persistence.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACCEPTED (amended 2026-06-21)"
     },
     {
@@ -5372,7 +5372,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "ACTIVE"
     },
     {
@@ -5387,7 +5387,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5438,7 +5438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5453,7 +5453,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 97,
+      "staleDays": 98,
       "status": "ARCHIVED"
     },
     {
@@ -5468,7 +5468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5483,7 +5483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5498,7 +5498,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -5513,7 +5513,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "HISTORICAL"
     },
     {
@@ -5528,7 +5528,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 26,
+      "staleDays": 27,
       "status": "HISTORICAL"
     },
     {
@@ -5543,7 +5543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5558,7 +5558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5573,7 +5573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5588,7 +5588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5603,7 +5603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5618,7 +5618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5633,7 +5633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5648,7 +5648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5663,7 +5663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5678,7 +5678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5693,7 +5693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5708,7 +5708,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5723,7 +5723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5738,7 +5738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5753,7 +5753,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5768,7 +5768,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5783,7 +5783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5798,7 +5798,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 84,
+      "staleDays": 85,
       "status": "ACTIVE"
     },
     {
@@ -5813,7 +5813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5828,7 +5828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5842,7 +5842,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -5856,7 +5856,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -5871,7 +5871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -5886,7 +5886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5901,7 +5901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5916,7 +5916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5931,7 +5931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5946,7 +5946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5961,7 +5961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5976,7 +5976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -5991,7 +5991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6006,7 +6006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6021,7 +6021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6036,7 +6036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6051,7 +6051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6066,7 +6066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6081,7 +6081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6096,7 +6096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6111,7 +6111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -6126,7 +6126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6141,7 +6141,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6183,7 +6183,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 20,
+      "staleDays": 21,
       "status": "ACTIVE"
     },
     {
@@ -6231,7 +6231,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 20,
+      "staleDays": 21,
       "status": "ACTIVE"
     },
     {
@@ -6276,7 +6276,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 19,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -6307,7 +6307,7 @@
       "lastUpdated": "2026-06-15",
       "owner": "Platform Team",
       "path": "docs/design/audits/server-object-readiness.md",
-      "staleDays": 7,
+      "staleDays": 8,
       "status": "ACTIVE"
     },
     {
@@ -6346,7 +6346,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "ACTIVE"
     },
     {
@@ -6362,7 +6362,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -6377,7 +6377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6392,7 +6392,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6407,7 +6407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6422,7 +6422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6436,7 +6436,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -6451,7 +6451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6466,7 +6466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6481,7 +6481,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6496,7 +6496,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6510,7 +6510,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -6525,7 +6525,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6540,7 +6540,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -6555,7 +6555,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6570,7 +6570,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6585,7 +6585,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6600,7 +6600,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6615,7 +6615,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6630,7 +6630,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6645,7 +6645,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6660,7 +6660,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6675,7 +6675,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -6690,7 +6690,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6723,7 +6723,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 25,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -6738,7 +6738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6771,7 +6771,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 25,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -6786,7 +6786,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6801,7 +6801,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6816,7 +6816,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6831,7 +6831,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 63,
+      "staleDays": 64,
       "status": "HISTORICAL"
     },
     {
@@ -6846,7 +6846,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 36,
+      "staleDays": 37,
       "status": "ACTIVE"
     },
     {
@@ -6861,7 +6861,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6876,7 +6876,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6891,7 +6891,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6906,7 +6906,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6921,7 +6921,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6936,7 +6936,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6951,7 +6951,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6966,7 +6966,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6981,7 +6981,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -6996,7 +6996,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7011,7 +7011,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7026,7 +7026,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7041,7 +7041,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -7056,7 +7056,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7071,7 +7071,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7086,7 +7086,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7101,7 +7101,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7116,7 +7116,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7131,7 +7131,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -7146,7 +7146,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7161,7 +7161,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7176,7 +7176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7197,7 +7197,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "active"
     },
     {
@@ -7211,7 +7211,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -7226,7 +7226,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7241,7 +7241,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7256,7 +7256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7271,7 +7271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7286,7 +7286,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7301,7 +7301,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7316,7 +7316,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7331,7 +7331,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7346,7 +7346,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7361,7 +7361,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -7376,7 +7376,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -7391,7 +7391,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -7406,7 +7406,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -7421,7 +7421,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7436,7 +7436,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7451,7 +7451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7466,7 +7466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7481,7 +7481,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7496,7 +7496,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7511,7 +7511,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7526,7 +7526,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7541,7 +7541,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7556,7 +7556,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7571,7 +7571,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7586,7 +7586,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7601,7 +7601,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7616,7 +7616,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7631,7 +7631,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7646,7 +7646,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7661,7 +7661,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7676,7 +7676,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7691,7 +7691,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7706,7 +7706,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7740,7 +7740,7 @@
       "lastUpdated": "2026-06-16",
       "owner": "Platform Team",
       "path": "docs/parity/convention-matrix.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -7755,7 +7755,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7770,7 +7770,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7786,7 +7786,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 78,
+      "staleDays": 79,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7801,7 +7801,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7816,7 +7816,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7831,7 +7831,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7846,7 +7846,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7861,7 +7861,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7888,7 +7888,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -7903,22 +7903,22 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-06-19",
+        "last_updated": "2026-06-22",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
       "isStale": false,
-      "lastUpdated": "2026-06-19",
+      "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 3,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -7935,7 +7935,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 76,
+      "staleDays": 77,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -7950,7 +7950,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 36,
+      "staleDays": 37,
       "status": "BACKLOG"
     },
     {
@@ -7964,7 +7964,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -7981,7 +7981,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 22,
+      "staleDays": 23,
       "status": "ACTIVE"
     },
     {
@@ -8001,7 +8001,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 20,
+      "staleDays": 21,
       "status": "ACTIVE"
     },
     {
@@ -8030,8 +8030,42 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-13-gp-trust-readiness-register.md",
-      "staleDays": 9,
+      "staleDays": 10,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "both",
+        "categories": [
+          "roadmap",
+          "governance",
+          "trust",
+          "product-strategy"
+        ],
+        "keywords": [
+          "current-state",
+          "steelman",
+          "secondary-surface",
+          "investment-rounds",
+          "moic",
+          "lp-reporting",
+          "provenance"
+        ],
+        "last_updated": "2026-06-22",
+        "owner": "Platform Team",
+        "review_cadence": "P14D",
+        "reviewed_sha": "20eef5c9",
+        "status": "DRAFT"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-22",
+      "owner": "Platform Team",
+      "path": "docs/plans/2026-06-22-current-state-steelman-roadmap.md",
+      "staleDays": 1,
+      "status": "DRAFT"
     },
     {
       "docType": "doc",
@@ -8067,7 +8101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -8082,7 +8116,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "ACTIVE"
     },
     {
@@ -8097,7 +8131,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8112,7 +8146,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -8127,7 +8161,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8142,7 +8176,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8157,7 +8191,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8172,7 +8206,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8187,7 +8221,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8202,7 +8236,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8217,7 +8251,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8232,7 +8266,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8247,7 +8281,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8262,7 +8296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8277,7 +8311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8292,7 +8326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8307,7 +8341,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8322,7 +8356,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8337,7 +8371,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8352,7 +8386,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8367,7 +8401,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 32,
+      "staleDays": 33,
       "status": "ACTIVE"
     },
     {
@@ -8382,7 +8416,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8396,7 +8430,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -8423,7 +8457,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8438,7 +8472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -8453,7 +8487,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8468,7 +8502,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8483,7 +8517,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8498,7 +8532,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8513,7 +8547,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8528,7 +8562,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8543,7 +8577,7 @@
       "lastUpdated": "2026-06-12",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "PROVEN"
     },
     {
@@ -8558,7 +8592,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8573,7 +8607,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8588,7 +8622,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8603,7 +8637,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8618,7 +8652,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8633,7 +8667,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8648,7 +8682,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8663,7 +8697,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8678,7 +8712,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8693,7 +8727,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8728,7 +8762,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "COMPLETED"
     },
     {
@@ -8759,7 +8793,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "REFERENCE"
     },
     {
@@ -8790,7 +8824,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "REFERENCE"
     },
     {
@@ -8821,7 +8855,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "REFERENCE"
     },
     {
@@ -8854,7 +8888,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "REFERENCE"
     },
     {
@@ -8885,7 +8919,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 31,
+      "staleDays": 32,
       "status": "REFERENCE"
     },
     {
@@ -8917,7 +8951,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "REFERENCE"
     },
     {
@@ -8932,7 +8966,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -8947,7 +8981,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8962,7 +8996,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8977,7 +9011,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -8992,7 +9026,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9007,7 +9041,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9035,7 +9069,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 84,
+      "staleDays": 85,
       "status": "ACTIVE"
     },
     {
@@ -9050,7 +9084,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9065,7 +9099,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9080,7 +9114,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9095,7 +9129,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9110,7 +9144,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9125,7 +9159,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9140,7 +9174,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9155,7 +9189,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9170,7 +9204,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9185,7 +9219,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9200,7 +9234,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9215,7 +9249,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9230,7 +9264,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9245,7 +9279,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9260,7 +9294,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9275,7 +9309,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9290,7 +9324,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-01-to-01-07-extraction.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -9305,7 +9339,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-08-to-01-18-extraction.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -9320,7 +9354,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-18-extraction.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -9334,7 +9368,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -9348,7 +9382,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -9362,7 +9396,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -9376,7 +9410,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -9390,7 +9424,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -9404,7 +9438,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "UNKNOWN"
     },
     {
@@ -9419,7 +9453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9434,7 +9468,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9449,7 +9483,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -9490,7 +9524,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "VERIFIED"
     },
     {
@@ -9838,7 +9872,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "DRAFT"
     },
     {
@@ -10036,7 +10070,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10118,7 +10152,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "VERIFIED"
     },
     {
@@ -10191,7 +10225,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "DRAFT"
     },
     {
@@ -10235,7 +10269,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "DRAFT"
     },
     {
@@ -10365,7 +10399,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "DRAFT"
     },
     {
@@ -10412,7 +10446,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "DRAFT"
     },
     {
@@ -10454,7 +10488,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "DRAFT"
     },
     {
@@ -10603,7 +10637,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10629,7 +10663,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10660,7 +10694,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10689,7 +10723,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10718,7 +10752,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10748,7 +10782,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10778,7 +10812,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10808,7 +10842,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "DRAFT"
     },
     {
@@ -10841,7 +10875,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 65,
+      "staleDays": 66,
       "status": "DRAFT"
     },
     {
@@ -10906,7 +10940,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -10921,7 +10955,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -10936,7 +10970,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -10963,7 +10997,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "ACTIVE"
     },
     {
@@ -10991,7 +11025,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "ACTIVE"
     },
     {
@@ -11020,7 +11054,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "ACTIVE"
     },
     {
@@ -11048,7 +11082,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "ACTIVE"
     },
     {
@@ -11076,7 +11110,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "ACTIVE"
     },
     {
@@ -11103,7 +11137,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 24,
+      "staleDays": 25,
       "status": "COMPLETE"
     },
     {
@@ -11144,7 +11178,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 15,
+      "staleDays": 16,
       "status": "ACTIVE"
     },
     {
@@ -11161,7 +11195,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 9,
+      "staleDays": 10,
       "status": "COMPLETE"
     },
     {
@@ -11190,7 +11224,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -11219,7 +11253,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -11263,7 +11297,7 @@
       "lastUpdated": "2026-06-21",
       "owner": "Core Team",
       "path": "docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "DRAFT"
     },
     {
@@ -11304,7 +11338,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 9,
+      "staleDays": 10,
       "status": "COMPLETE"
     },
     {
@@ -11333,7 +11367,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 14,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -11362,7 +11396,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 13,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -11409,7 +11443,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/superpowers/specs/2026-06-13-gp-trust-readiness-audit-design.md",
-      "staleDays": 9,
+      "staleDays": 10,
       "status": "ACTIVE"
     },
     {
@@ -11426,7 +11460,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "DRAFT (red-team hardened 2026-06-21)"
     },
     {
@@ -11477,7 +11511,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 33,
+      "staleDays": 34,
       "status": "ACTIVE"
     },
     {
@@ -11492,7 +11526,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11507,7 +11541,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11522,7 +11556,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11537,7 +11571,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11564,7 +11598,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11579,7 +11613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11594,7 +11628,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11609,7 +11643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11624,7 +11658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11639,7 +11673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11654,7 +11688,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "HISTORICAL"
     },
     {
@@ -11669,7 +11703,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11684,7 +11718,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11699,7 +11733,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11714,7 +11748,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11729,7 +11763,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11744,7 +11778,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11759,7 +11793,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11774,7 +11808,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11789,7 +11823,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 25,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -11835,7 +11869,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 175,
+      "staleDays": 176,
       "status": "ACTIVE"
     },
     {
@@ -11850,7 +11884,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     },
     {
@@ -11865,11 +11899,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 154,
+      "staleDays": 155,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-06-22T00:00:00.000Z",
+  "generatedAt": "2026-06-23T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -13041,7 +13075,7 @@
       "BACKLOG": 1,
       "COMPLETE": 3,
       "COMPLETED": 1,
-      "DRAFT": 31,
+      "DRAFT": 32,
       "DRAFT (red-team hardened 2026-06-21)": 1,
       "HISTORICAL": 29,
       "HISTORICAL-SNAPSHOT": 1,
@@ -13058,7 +13092,7 @@
     },
     "missing_frontmatter": 22,
     "stale_docs": 104,
-    "total_docs": 662
+    "total_docs": 663
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,17 +1,17 @@
 ---
-last_updated: 2026-06-22
+last_updated: 2026-06-23
 ---
 
 # Staleness Report
 
-*Generated: 2026-06-22T00:00:00.000Z*
+*Generated: 2026-06-23T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 662 |
+| Total Documents | 663 |
 | Stale Documents | 104 |
 | Missing Frontmatter | 22 |
 
@@ -21,7 +21,7 @@ last_updated: 2026-06-22
 |--------|-------|
 | ACTIVE | 446 |
 | UNKNOWN | 117 |
-| DRAFT | 31 |
+| DRAFT | 32 |
 | HISTORICAL | 29 |
 | VERIFIED | 9 |
 | INDEXED | 6 |
@@ -89,13 +89,13 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/specs/2026-06-21-investment-rounds-ui-v2-design.md` | Never | 999 | No | Unassigned |
 | `docs/tooling-catalog.md` | Never | 999 | No | Unassigned |
-| `cheatsheets/agent-architecture.md` | 2026-01-19 | 154 | No | Unassigned |
-| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 154 | No | Unassigned |
-| `cheatsheets/ai-code-review.md` | 2026-01-19 | 154 | No | Unassigned |
-| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 154 | No | Unassigned |
-| `cheatsheets/api.md` | 2026-01-19 | 154 | No | Unassigned |
-| `cheatsheets/capability-checklist.md` | 2026-01-19 | 154 | No | Unassigned |
-| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 154 | No | Unassigned |
+| `cheatsheets/agent-architecture.md` | 2026-01-19 | 155 | No | Unassigned |
+| `cheatsheets/agent-memory/database-expert-schema-tdd.md` | 2026-01-19 | 155 | No | Unassigned |
+| `cheatsheets/ai-code-review.md` | 2026-01-19 | 155 | No | Unassigned |
+| `cheatsheets/anti-pattern-prevention.md` | 2026-01-19 | 155 | No | Unassigned |
+| `cheatsheets/api.md` | 2026-01-19 | 155 | No | Unassigned |
+| `cheatsheets/capability-checklist.md` | 2026-01-19 | 155 | No | Unassigned |
+| `cheatsheets/ci-validator-guide.md` | 2026-01-19 | 155 | No | Unassigned |
 
 *...and 54 more stale documents.*
 
@@ -103,13 +103,13 @@ Documents that need review (older than their cadence threshold):
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **CHANGELOG.md** (33 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (154 days old)
-- [ ] **cheatsheets/schema-alignment.md** (154 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (154 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (154 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (154 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (154 days old)
+- [ ] **CHANGELOG.md** (34 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (155 days old)
+- [ ] **cheatsheets/schema-alignment.md** (155 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (155 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (155 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (155 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (155 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)

--- a/docs/plans/2026-03-27-secondary-surface-decisions.md
+++ b/docs/plans/2026-03-27-secondary-surface-decisions.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-06-19
+last_updated: 2026-06-22
 ---
 
 # Secondary Surface Decisions
@@ -12,8 +12,8 @@ last_updated: 2026-06-19
 | `planning`                                                                                                         | Archived redirect                       | `client/src/App.tsx`, `client/src/app/route-governance-registry.ts` | explicit route redirect                                                                                                                    | restore only via a new owned implementation and route decision                               |
 | `kpi-manager`                                                                                                      | Archived redirect                       | `client/src/App.tsx`, `client/src/app/route-governance-registry.ts` | explicit route redirect                                                                                                                    | restore only via a new owned implementation and route decision                               |
 | `kpi-submission`                                                                                                   | Archived redirect                       | `client/src/App.tsx`, `client/src/app/route-governance-registry.ts` | explicit route redirect                                                                                                                    | restore only via a new owned implementation and route decision                               |
-| `/reserves-demo`                                                                                                   | Deleted (Branch B)                      | removed in branch chore/remove-mock-surface-pages                   | not mounted in any environment; bundle verifier guards reintroduction                                                                      | re-create only via an owned implementation and a fresh route decision                        |
-| `/allocation-manager`, `/cash-management`, `/portfolio-analytics`, `/cap-tables`                                   | Deleted (Branch B)                      | removed in branch chore/remove-mock-surface-pages                   | not mounted in any environment; bundle verifier guards reintroduction                                                                      | re-create only via owned implementations                                                     |
+| `/reserves-demo`                                                                                                   | Deleted (Branch B)                      | removed in branch chore/remove-mock-surface-pages                   | not mounted in any environment; `scripts/check-prod-bundle.mjs` guards reintroduction                                                      | re-create only via an owned implementation and a fresh route decision                        |
+| `/allocation-manager`, `/cash-management`, `/portfolio-analytics`, `/cap-tables`                                   | Deleted (Branch B)                      | removed in branch chore/remove-mock-surface-pages                   | not mounted in any environment; `scripts/check-prod-bundle.mjs` guards reintroduction                                                      | re-create only via owned implementations and fresh route decisions                           |
 | `/shared/:shareId`                                                                                                 | Public contract                         | `client/src/App.tsx`, `client/src/app/route-governance-registry.ts` | intentional public mount                                                                                                                   | remove only with an explicit external-link migration                                         |
 | `/portal/:rest*`                                                                                                   | Public contract                         | `client/src/App.tsx`, `client/src/app/route-governance-registry.ts` | intentional public mount to access denied                                                                                                  | change only with an explicit portal activation or deprecation plan                           |
 | Compass                                                                                                            | Experimental and unmounted              | `server/compass/routes.ts` plus future server mount gate            | no server mount                                                                                                                            | mount only behind an explicit activation decision                                            |
@@ -60,33 +60,34 @@ future reactivation path in source control. Trade-off: KPI pages are no longer
 recoverable through client-side flags. Rollback requires a new owned
 implementation and route decision.
 
-## Reserves Demo
+## Deleted Mock Operational Surfaces
 
-> Supersession (2026-06-18, Branch B): /reserves-demo and the four mock
-> operational surfaces (/allocation-manager, /cash-management,
-> /portfolio-analytics, /cap-tables) plus their transitively-dead component
-> closure have been DELETED entirely. PR-1 (the firebreak) first build-excluded
-> them as dev-only; this follow-up removes the page modules and 12 dead
-> components outright. They are no longer mounted in any environment.
-> scripts/check-prod-bundle.mjs (QUARANTINED_MODULES) remains as a permanent
-> guard against reintroduction into the production bundle.
+Supersession (2026-06-18/19, Branch B): `/reserves-demo` and the four mock
+operational surfaces (`/allocation-manager`, `/cash-management`,
+`/portfolio-analytics`, `/cap-tables`) plus their transitively-dead component
+closure have been **deleted entirely**. The firebreak first build-excluded them
+as dev-only; the follow-up removed the page modules and their exclusive
+components outright. They are no longer mounted in any environment.
+`scripts/check-prod-bundle.mjs` (`QUARANTINED_MODULES`) remains as a permanent
+guard against reintroduction into the production bundle.
 
-- White: `/reserves-demo` is a direct smoke-tested surface backed by a real page
-  component, but it was missing from the mounted app route list.
-- Red: leaving the page file unmounted makes CI pass depend on implementation
-  luck instead of route truth.
-- Yellow: it is not a core workflow destination or sidebar item, but it is still
-  a deliberate demo surface that should remain directly reachable.
-- Black: treating the demo as an accidental page guarantees future regressions
-  in build-only and smoke lanes.
-- Green: keep it mounted as an intentional internal-live route and cover it in
-  route-perimeter tests.
-- Blue: final decision is to preserve `/reserves-demo` as an intentionally
-  mounted demo surface, separate from the core workflow perimeter.
+- White: the pages existed, but they were mock/sample-backed or nav-orphaned and
+  implied product capabilities the platform could not truthfully support.
+- Red: leaving them mounted or bundled let users, QA, and future agents mistake
+  sample-backed surfaces for product commitments.
+- Yellow: each concept may return later, but only as an owned implementation
+  with live contracts and a fresh route decision.
+- Black: preserving dev-only route exceptions after deletion would keep stale
+  documentation and tests alive.
+- Green: delete the route/page/component closure and keep bundle quarantine as
+  the anti-regression guard.
+- Blue: final decision is Branch B deletion. Reintroduction requires a new owned
+  implementation, route-policy entry, tests, and production-bundle verification.
 
-Benefits: keeps the smoke target honest and makes the mounted route explicit in
-governance. Trade-off: one non-core demo route remains directly reachable by
-design. Rollback: remove only with an explicit demo retirement decision.
+Benefits: removes false product promises and shrinks the production trust
+surface. Trade-off: these surfaces are no longer recoverable at runtime without
+re-implementation. Rollback: revert the deletion branch or rebuild behind a new
+owned route decision.
 
 ## Public Contracts
 
@@ -173,9 +174,10 @@ Playwright testMatch across all configs, server mount, worker registration):
   with hub-specific named exports; currently unimported but retained by decision
   for future integration.
 
-Deferred (separate decisions, not in this PR): LP-sibling routes
-(`lp-{capital-calls,distributions,documents,notifications}.ts`) are unmounted
-but called by live `/lp/dashboard` widgets (a 404 bug) — decision: MOUNT the
-routes (tracked as follow-up). `NotionIntegrationHub` + `notion-integration.tsx`
-remain dormant per the keep-registry. The other nine `@deprecated` symbols have
-live callers and are retained.
+Follow-up completed: LP-sibling routes
+(`lp-{capital-calls,distributions,documents,notifications}.ts`) are now mounted
+for the live `/lp/dashboard` widgets in both active server surfaces. Keep them
+covered by mount-parity tests so the 404 regression does not return.
+`NotionIntegrationHub` + `notion-integration.tsx` remain dormant per the
+keep-registry. The other nine `@deprecated` symbols have live callers and are
+retained.

--- a/docs/plans/2026-06-22-current-state-steelman-roadmap.md
+++ b/docs/plans/2026-06-22-current-state-steelman-roadmap.md
@@ -1,0 +1,482 @@
+---
+status: DRAFT
+last_updated: 2026-06-22
+reviewed_sha: 20eef5c9
+owner: Platform Team
+review_cadence: P14D
+audience: both
+categories: [roadmap, governance, trust, product-strategy]
+keywords:
+  [
+    current-state,
+    steelman,
+    secondary-surface,
+    investment-rounds,
+    moic,
+    lp-reporting,
+    provenance,
+  ]
+---
+
+# Current-State Steelman Roadmap v2
+
+**DRAFT** — pending the enforcement PRs (PR-H0 through PR-H8) below; not yet
+authoritative. Reviewed against `main` at `20eef5c9`. This document consolidates
+stale roadmap snapshots and replaces the first current-state steelman draft,
+anchored to the June 18-22 secondary-surface, MOIC, LP-dashboard, and
+investment-rounds work, and incorporates the synthesized review comments from
+2026-06-22. Where it disagrees with current `main` code, the code wins (see
+Decision rule).
+
+## What changed from v1
+
+The first roadmap had the right strategic spine but overstated readiness in a
+few places. This revision accepts the material review objections:
+
+- **Route-policy registry must precede LP Reporting qualification.** LP
+  role/workflow/export policy should not be invented ad hoc inside an LP-only
+  PR.
+- **Investment-round flag readiness is blocked by access-boundary proof.**
+  `GET /api/investments/:id` and similar entity reads must be audited before any
+  non-prod flag ramp.
+- **MOIC compatibility routing must not become a bypass.** A query-param
+  compatibility route may remain only if active references are documented and
+  API-level fund access is regression-tested.
+- **LP Reporting is not fully trust-qualified yet.** Until
+  role/workflow/provenance/export gates are accepted, any LP export path must be
+  admin-only and watermarked `PRE-PRODUCTION / NOT AUDITED`; if no export path
+  exists, a test or grep proof must say so.
+- **Governance claims need enforcement.** The roadmap now assigns CI/lint/script
+  owners for bundle quarantine, route policy, LP mount parity, stale-doc
+  hygiene, and production flag posture.
+- **Weasel words were removed.** Scope and acceptance criteria now use testable
+  outcomes rather than “consider,” “if needed,” or “where possible.”
+
+## Review method
+
+The review used a structured multi-pass method:
+
+1. **Literal pass:** what the current code, flags, routes, and merged PRs
+   actually say.
+2. **Stakeholder pass:** what GPs, LP viewers, operators, maintainers, and
+   future agents need protected.
+3. **Failure pass:** what could externalize fabricated data, bypass fund scope,
+   or create false confidence.
+4. **Temporal pass:** what became stale after the recent PR stack.
+5. **Product-domain pass:** what the Tactyc reference model implies about
+   reserves, rounds, MOIC, actuals, and reporting.
+6. **Adversarial pass:** the strongest case for the repo’s current architecture,
+   followed by the strongest objections.
+7. **Integration pass:** accepted, modified, or rejected each review comment and
+   rewrote the execution sequence accordingly.
+
+## Steelman thesis
+
+The strongest version of `Updog_restore` is a **trust-first venture fund
+platform**. The repo has already made the key product-trust pivot: mock/sample
+financial surfaces were deleted, production bundle verification guards
+reintroduction, MOIC no longer renders static sample rankings as primary
+content, LP dashboard widgets no longer depend on fixture-only routes, and
+investment rounds now have a real persistence backbone plus a flag-gated UI.
+
+The next best path is **not** a broad rewrite. The next best path is to harden
+the new spine:
+
+- keep the canonical modeling flow truthful;
+- close direct entity access-boundary gaps;
+- convert route governance into policy governance;
+- promote investment rounds only after access, flag, workflow, and support
+  proof;
+- define how persisted rounds feed reserve/MOIC calculations before changing
+  engines;
+- generalize provenance beyond MOIC;
+- place MOIC/reserve ranking where fund context is canonical;
+- qualify LP Reporting with role, workflow, provenance, export, and watermark
+  policy.
+
+## Current state map
+
+| Area                        | Current state                                                                                                                                                                                      | Strongest interpretation                                                                          | Remaining pressure                                                                                                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Production mock surfaces    | `/reserves-demo`, `/allocation-manager`, `/cash-management`, `/portfolio-analytics`, and `/cap-tables` are deleted; `scripts/check-prod-bundle.mjs` (`QUARANTINED_MODULES`) guards reintroduction. | The repo chose deletion over dev-only ambiguity, which is the cleanest trust posture.             | Keep decision docs and build docs aligned; add a negative test that proves a renamed mock surface is caught by the governance layer, not just by substring coincidence. |
+| Tear Sheet / Reports        | Mock Tear Sheet production chunk was build-excluded; Active Alerts no longer collapses failure into fake zero.                                                                                     | The first false-financial-fact class is now guarded by build and UI logic.                        | Authoritative exports still need a server-side artifact policy before any replacement Tear Sheet returns.                                                               |
+| MOIC                        | `/moic-analysis` is live-primary, fund-id driven, Zod-parsed, and provenance-gated.                                                                                                                | The page now fails closed instead of showing sample companies.                                    | The route is still compatibility-shaped; canonical placement should be fund-results-native, and compatibility must be API-access tested or removed.                     |
+| Investment rounds           | ADR-023 L3b persistence landed with `investment_rounds`, idempotent create, list/read, fund enforcement on round routes, supersede correction, and UI v2 behind `enable_investment_rounds`.        | This is the first real investment-event persistence backbone needed for reserve/MOIC correctness. | The flag remains off in every environment; direct investment reads still require access-boundary audit before any flag ramp.                                            |
+| LP dashboard / LP Reporting | LP dashboard/profile widget routers are mounted in both `makeApp` and `registerRoutes`; dashboard hooks use runtime contracts.                                                                     | The fixture-only dashboard gap was closed without a new aggregate API.                            | LP Reporting remains unqualified until role, workflow, provenance, export, and watermark gates land.                                                                    |
+| Route governance            | The registry imports executable route objects and guards path/exposure coverage.                                                                                                                   | The route perimeter is no longer regex-only or doc-only.                                          | The registry still needs policy fields: financial tag, API auth boundary, fund-scope mode, role/workflow requirements, export eligibility, telemetry key, and owner.    |
+| Server dead surfaces        | Portfolio snapshot/version-history dead code was archived; verified orphans were removed.                                                                                                          | The repo is deleting implied capabilities that were never mounted.                                | Continue distinguishing docs-only, unmounted, mounted-placeholder, and live-mounted states.                                                                             |
+| Tasks operating object      | Backend/list hook landed; readiness audit was partially corrected.                                                                                                                                 | Useful precedent for backend-first operating objects.                                             | It is not on the immediate product spine; do not displace investment rounds, MOIC, or LP Reporting.                                                                     |
+
+## Product-domain anchor
+
+The domain logic reinforces the sequence:
+
+- Capital-allocation-first construction is more stable than fixed deal-count
+  construction because changing check sizes, follow-ons, fees, expenses, or
+  recycling otherwise breaks the model.
+- Current Forecast should account for actual investments and remaining capital,
+  while Construction Forecast is the original plan before investments.
+- Follow-on reserves depend on round sizes, valuations, graduation rates, exit
+  rates, failure rates, and later-stage assumptions.
+- Exit MOIC on Planned Reserves is the reserve-ranking metric: expected return
+  on the next dollar into each company.
+- Therefore, **investment rounds and actuals are upstream of durable
+  reserve/MOIC/reporting trust**.
+
+## Temporary trust measures
+
+These measures apply until the relevant hardening PR lands:
+
+1. **LP exports:** any active LP export route before PR-H7b completion must be
+   admin-only and include `WATERMARK: PRE-PRODUCTION / NOT AUDITED` in the
+   generated artifact and UI preview. If no LP export route exists, PR-H0 must
+   add a grep/test proof that no export path is active.
+2. **Investment rounds:** `enable_investment_rounds` remains `false` in
+   production until PR-H1, PR-H2, PR-H3, and the support playbook are accepted.
+3. **MOIC compatibility:** `/moic-analysis?fundId=` remains compatibility-only.
+   It may survive PR-H6 only if active references are documented and API-level
+   cross-fund denial is covered by tests.
+4. **Deleted mock surfaces:** reintroducing a deleted surface requires a new
+   owned implementation, route decision, and production-bundle negative test.
+
+## Enforcement baseline
+
+The roadmap is executable only if enforcement moves from documentation to
+checks:
+
+- **Bundle quarantine:** CI must run `npm run build:verify` after
+  `npm run build`; `scripts/check-prod-bundle.mjs` and its `QUARANTINED_MODULES`
+  list must be CODEOWNERS-protected.
+- **Route policy:** PR-H2 adds policy-registry tests that fail if a route tagged
+  `financial: true` lacks auth boundary, fund-scope mode, owner, and export
+  policy.
+- **`isProtected` guard:** PR-H2 adds a lint/test assertion that `isProtected`
+  alone never counts as API auth or fund-scope enforcement.
+- **LP mount parity:** PR-H2 adds a regression test proving LP dashboard/widget
+  routes are mounted in both `makeApp` and `registerRoutes`.
+- **Flag posture:** PR-H3 adds a production-like flag test proving
+  `enable_investment_rounds` cannot be on in production until the acceptance
+  gate is updated.
+- **Doc cadence:** PR-H8 adds or wires the existing discovery/staleness
+  generator so active docs past cadence fail a scheduled hygiene check or
+  generate a review artifact.
+
+## What to stop doing
+
+- Do not recreate deleted mock/demo pages to solve navigation gaps.
+- Do not promote a client-only report/export path for authoritative financial
+  documents.
+- Do not treat `isProtected` as identity auth or fund access.
+- Do not promote investment rounds to production because the UI exists behind a
+  flag.
+- Do not add performance cases, valuation events, ownership, or cap-table events
+  until their persistence and correction models are explicit.
+- Do not rebuild auth from scratch inside route-policy work.
+- Do not implement reserve/MOIC calculation engine changes inside the
+  rounds-to-model contract bridge.
+- Do not let old docs with execution claims guide work unless they are marked
+  `ACTIVE`, current by cadence, and consistent with current code.
+
+## Revised PR sequence
+
+### PR-H0 — Adversarial trust audit
+
+**Goal:** add failing or proving checks for the highest-risk assumptions before
+implementation PRs begin.
+
+Scope:
+
+- attempt cross-fund access through `GET /api/investments/:id` and record the
+  result;
+- attempt round list/read across fund boundaries and prove current denial
+  remains intact;
+- attempt to reintroduce a deleted mock surface under a new page name and
+  document whether bundle/policy checks catch it;
+- attempt to flip `enable_investment_rounds` in a production-like flag
+  environment and record the result;
+- detect whether LP export routes exist; if they exist, prove admin-only +
+  watermark or open a blocker for PR-H7b.
+
+Acceptance:
+
+- creates `docs/design/audits/2026-06-22-trust-adversarial-audit.md` with
+  pass/fail findings and exact follow-up owners;
+- no production behavior changes except tests/audit artifacts;
+- findings are linked from PR-H1 and PR-H2 implementation plans.
+
+### PR-H1 — Direct entity access-boundary hardening
+
+**Goal:** make direct investment read paths match the rigor already applied to
+round routes.
+
+Scope:
+
+- audit `GET /api/investments/:id` and other direct entity reads for fund-scope
+  enforcement;
+- close the unscoped `GET /api/investments` list path: with no `fundId` it skips
+  `enforceProvidedFundScope` and `storage.getInvestments(undefined)` issues a
+  query with no fund predicate — require an explicit fund scope or scope to the
+  caller's funds;
+- confirm whether Postgres RLS (`investments_isolation_policy`, org-keyed on
+  `app.current_org`) actually enforces on the non-transactional GET path in
+  production before rating severity — the app-layer query is unscoped, but under
+  FORCE RLS with an unset GUC the policy fails closed; fix the app layer
+  regardless as defense-in-depth;
+- add route tests proving cross-fund reads cannot leak investment detail;
+- preserve list-by-fund behavior for `GET /api/investments?fundId=...`;
+- produce `docs/design/audits/2026-06-22-entity-access-boundary.md` as a raw
+  audit artifact for PR-H2 ingestion;
+- keep this PR independent of the future route-policy registry.
+
+Acceptance:
+
+- direct investment reads are fund-scoped or explicitly return no sensitive fund
+  data;
+- regression tests fail if cross-fund investment detail is returned;
+- round routes keep investment-derived fund enforcement on create/list/read;
+- no UI relies on an unscoped direct investment read.
+
+### PR-H2 — Route policy registry and governance enforcement
+
+**Goal:** extend route governance from path/exposure coverage into
+product-policy coverage.
+
+Scope:
+
+- add route-policy metadata for auth boundary, fund-scope mode, role/workflow
+  policy, export policy, telemetry key, owner, and `financial: true` tag;
+- ingest PR-H1 raw access-boundary findings;
+- add tests that every `financial: true` route has policy coverage;
+- add tests that `isProtected` does not satisfy API auth or fund scope;
+- add CI assertion that `npm run build:verify` fails on quarantined module
+  reintroduction;
+- add LP mount parity tests for `makeApp` and `registerRoutes`;
+- CODEOWNERS-protect `scripts/check-prod-bundle.mjs`, active route-policy files,
+  and current-state docs.
+
+Acceptance:
+
+- every mounted SPA route has route/exposure coverage;
+- every route tagged `financial: true` has policy coverage;
+- public contracts and archived redirects remain explicitly classified;
+- LP dashboard/widget route removal fails tests;
+- `scripts/check-prod-bundle.mjs` remains a blocking build-verification
+  primitive.
+
+### PR-H3 — Investment rounds flag-readiness proof
+
+**Goal:** make `enable_investment_rounds` eligible for non-prod proof without
+production exposure.
+
+Prerequisites:
+
+- blocked until PR-H1 and PR-H2 are accepted and merged.
+
+Scope:
+
+- keep production default off;
+- enable development only after route access, flag-off invisibility, and
+  production-off checks pass;
+- add a feature-flag readiness checklist covering create, replay, key reuse,
+  supersede, double-supersede, empty state, access denial, and flag-off
+  invisibility;
+- add flag-on route-rendering telemetry/test hooks;
+- draft `docs/runbooks/investment-round-supersede-support.md` for
+  supersede/correction edge cases;
+- keep cases, valuation, ownership, and cap-table events outside scope.
+
+Acceptance:
+
+- flag-on behavior is demonstrably safe in development/non-prod tests;
+- flag-off behavior is invisible in UI and route tests;
+- production flag remains false;
+- support playbook exists and covers idempotency conflict, missing supersede
+  target, double supersede, and rollback communication.
+
+### PR-H4 — Rounds-to-model contract bridge
+
+**Goal:** define how persisted rounds feed reserve/MOIC calculations before
+building more event types.
+
+Scope:
+
+- document whether `investment_rounds` are source-of-truth, evidence inputs, or
+  UI-only event records for current calculations;
+- define field-level mapping from rounds to planned reserves, valuation,
+  ownership, and MOIC inputs;
+- reserve a provenance hook in the contract shape so PR-H5 can populate it
+  without structural change;
+- keep `/cases` 501 until performance-case persistence has its own ADR;
+- define migration sequencing for future valuation/ownership/cap-table tranches;
+- do not implement calculation engine changes in this PR.
+
+Acceptance:
+
+- produces a contract/spec with explicit enum references and docstrings for each
+  mapping state;
+- every calculation consumer is classified as `uses_rounds`, `ignores_rounds`,
+  or `blocked_until_modeling_pr`;
+- no UI copy claims that rounds affect calculations unless the consumer is
+  `uses_rounds`;
+- future event types have a sequenced dependency map.
+
+### PR-H5 — Shared provenance envelope
+
+**Goal:** generalize the MOIC provenance win without forcing an all-endpoints
+rewrite.
+
+Scope:
+
+- introduce `shared/contracts/provenance.contract.ts` with source authority,
+  calculation mode, freshness, warnings, and export eligibility;
+- adapt MOIC as the mandatory phase-one consumer;
+- if MOIC adaptation is blocked, document the exact blocker and open a named
+  follow-up ticket before merging;
+- make missing/invalid provenance fail closed for phase-one material financial
+  responses;
+- define `LIVE`, `PARTIAL`, `FALLBACK`, `DEMO`, `UNAVAILABLE`, and `FAILED`
+  semantics.
+
+Acceptance:
+
+- MOIC parses the shared provenance envelope or has a documented blocker and
+  follow-up;
+- financial UI can distinguish provenance states without inference;
+- export eligibility is contract-level, not component convention;
+- contract parse failure never renders stale/sample values.
+
+### PR-H6 — MOIC canonical placement and compatibility hardening
+
+**Goal:** move MOIC from query-param compatibility to fund-context-native
+product placement.
+
+Scope:
+
+- add a fund-results child route or tab such as
+  `/fund-model-results/:fundId/moic-analysis`;
+- keep `/moic-analysis?fundId=` only if an active integration/bookmark reference
+  is documented; otherwise remove it;
+- if compatibility remains, add API-level fund-scope regression tests proving
+  the route cannot access another fund’s MOIC data;
+- render 401/403 as auth/access denied, not generic unavailable;
+- add no-data and stale/provenance states;
+- preserve planned-reserves MOIC as the reserve deployment ranking metric.
+
+Acceptance:
+
+- MOIC has canonical fund context without query dependency;
+- retained compatibility route has documented callers and access-denial tests;
+- empty live ranking is a valid no-data state;
+- stale/missing provenance fails closed.
+
+### PR-H7a — LP Reporting role and access qualification
+
+**Goal:** qualify LP surfaces at the role/access layer using the route-policy
+registry.
+
+Prerequisites:
+
+- blocked until PR-H2 is accepted and merged.
+
+Scope:
+
+- audit role vocabulary and `requireRole` callers;
+- define GP/LP/admin access for ledger, valuations, metrics, imports, reports,
+  exports, and evidence;
+- implement basic access gates for the highest-risk LP surfaces first: reports,
+  exports, imports, and evidence;
+- keep workflow-state machine and export provenance for PR-H7b;
+- add at least one route or component test per new access gate.
+
+Acceptance:
+
+- LP access failures render explicit role/access states;
+- admin-only pre-qualification export posture is enforced if export routes
+  exist;
+- no LP surface relies on route mount alone as qualification.
+
+### PR-H7b — LP Reporting workflow, provenance, and export qualification
+
+**Goal:** qualify LP reporting outputs with workflow state, provenance, and
+export policy.
+
+Prerequisites:
+
+- blocked until PR-H5 and PR-H7a are accepted and merged.
+
+Scope:
+
+- add workflow-state gates for draft, approved, locked, report-package-ready,
+  export-ready, and export-blocked states;
+- attach shared provenance/export eligibility to report package and export
+  paths;
+- add watermark behavior for any pre-production or not-audited export path;
+- use existing LP Reporting Playwright infrastructure and add at least one test
+  per new workflow-state gate;
+- update route-policy metadata for each qualified LP surface.
+
+Acceptance:
+
+- LP exports cannot be produced from `DEMO`, `FALLBACK`, `UNAVAILABLE`, or
+  `FAILED` provenance;
+- role, workflow, and provenance failures render explicit UI states;
+- every active LP export artifact is either qualified or visibly watermarked and
+  admin-only;
+- dashboard widgets and route mounts no longer hide missing policy.
+
+### PR-H8 — Mechanical documentation hygiene
+
+**Goal:** prevent old execution claims from misleading future agents.
+
+Scope:
+
+- add frontmatter to high-priority active superpowers plans/specs;
+- mark superseded execution plans `HISTORICAL` and add `superseded_by` links;
+- regenerate discovery/staleness artifacts through the repo generator;
+- add or document the scheduled review mechanism for P14D docs.
+
+Acceptance:
+
+- H8 does not replace documentation acceptance criteria in H1, H2, H4, H7a, or
+  H7b;
+- product-policy documentation remains in the PR that changes policy;
+- generated staleness report lists zero active stale docs for the
+  roadmap-critical set;
+- README and Build Readiness point to current-state references.
+
+## Roadmap acceptance criteria
+
+The roadmap remains current only while all of the following are true:
+
+1. Deleted mock surfaces stay absent from routes and production bundles.
+2. `scripts/check-prod-bundle.mjs` remains a hard production-build verifier in
+   CI.
+3. MOIC uses live Zod-parsed data and does not render sample rankings.
+4. Investment rounds stay flag-gated until access, route-policy, flag, workflow,
+   and support proof are complete.
+5. Round routes enforce fund scope on create/list/read.
+6. Direct investment read paths are audited and hardened.
+7. LP dashboard/widget routes stay mounted in both active server surfaces.
+8. LP Reporting promotion has role, workflow, provenance, export, and watermark
+   gates.
+9. Route governance distinguishes client fund-context guards from API auth and
+   fund scope.
+10. Older execution-claim docs are marked historical or revalidated.
+
+## Decision rule
+
+When code facts, merged PR descriptions, and old roadmap docs disagree, trust in
+this order:
+
+1. current `main` code and generated artifacts;
+2. accepted ADRs and active decision docs updated after the code landed;
+3. merged PR descriptions from the relevant feature/fix;
+4. old plans/specs only as historical context.
+
+## Decision-rule enforcement
+
+- PR-H2 adds route-policy tests and `isProtected` guardrails.
+- PR-H2 protects bundle quarantine and LP mount parity in CI.
+- PR-H8 adds the doc-cadence/staleness mechanism.
+- Every future roadmap PR must state whether it changes one of the ten
+  acceptance criteria above.


### PR DESCRIPTION
## Summary

Applies the steelman-v2 doc/governance package with the "do not apply wholesale" review corrections folded in (independent review + codex challenge + red-team). Docs/governance only; no product code changes.

## Corrections folded in
- **README / BUILD_READINESS**: add `npm run release:check` (canonical end-to-end release gate); correct the `QUARANTINED_MODULES` claim (matches the `CapTables` module substring, not the `/cap-tables` route); state LP export/download routes already exist and are authenticated (`requireAuth`+`requireFundAccess`/`requireLPAccess`) but not admin-only/watermarked.
- **CODEOWNERS**: prune 7 dead paths (`server/auth`, `client/src/lib/feature-flags.ts`, `docs/reserves`, `server/routes/reserves.ts`, `server/plugins/reserves-metrics.plugin.ts`, `ci-reserves-v11.yml`, `canary-gate.yml`); add `shared/feature-flags/` and `client/src/app/route-governance-registry.ts`.
- **Roadmap**: marked `DRAFT`, pinned `reviewed_sha: 20eef5c9`; PR-H1 sharpened to cover the unscoped `GET /api/investments` (no `fundId`) list path plus a prod-RLS-enforcement check before rating severity.
- **Routing index regenerated** (663 docs) so the Documentation Routing Check passes on the added doc.

## Verification
- `git apply --check` clean against `20eef5c9`.
- Documentation Routing Check sync logic run locally: structural + `docPaths` + `stats.total_docs` consistent; post-prettier regen produced zero diff.
- Pre-commit + commit-msg hooks passed.

## Deferred (not in this PR)
App-layer investments fund-scope hardening is tracked as **PR-H1 code work**, pending prod-RLS confirmation (`investments_isolation_policy` may already fail closed). This PR is docs/governance only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)