### PR TITLE
fix(investments): enforce fund scope on direct entity reads (PR-H1)

### DIFF
--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -6287,6 +6287,39 @@
         "categories": [
           "design",
           "audits",
+          "security",
+          "access-control"
+        ],
+        "keywords": [
+          "entity-access",
+          "fund-scope",
+          "investments",
+          "rls",
+          "idor",
+          "bola",
+          "pr-h1"
+        ],
+        "last_updated": "2026-06-22",
+        "owner": "Platform Team",
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-22",
+      "owner": "Platform Team",
+      "path": "docs/design/audits/2026-06-22-entity-access-boundary.md",
+      "staleDays": 1,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "both",
+        "categories": [
+          "design",
+          "audits",
           "backend-readiness",
           "persistence"
         ],
@@ -13070,7 +13103,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED (amended 2026-06-21)": 1,
-      "ACTIVE": 446,
+      "ACTIVE": 447,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 3,
@@ -13092,7 +13125,7 @@
     },
     "missing_frontmatter": 22,
     "stale_docs": 104,
-    "total_docs": 663
+    "total_docs": 664
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-06-23
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 663 |
+| Total Documents | 664 |
 | Stale Documents | 104 |
 | Missing Frontmatter | 22 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-06-23
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 446 |
+| ACTIVE | 447 |
 | UNKNOWN | 117 |
 | DRAFT | 32 |
 | HISTORICAL | 29 |

--- a/docs/design/audits/2026-06-22-entity-access-boundary.md
+++ b/docs/design/audits/2026-06-22-entity-access-boundary.md
@@ -1,0 +1,116 @@
+---
+status: ACTIVE
+audience: both
+last_updated: 2026-06-22
+owner: 'Platform Team'
+review_cadence: P90D
+categories: [design, audits, security, access-control]
+keywords: [entity-access, fund-scope, investments, rls, idor, bola, pr-h1]
+---
+
+# Direct entity access-boundary audit (PR-H1)
+
+**Purpose:** raw audit artifact for the roadmap's PR-H1
+(`docs/plans/2026-06-22-current-state-steelman-roadmap.md`). Records which
+direct investment read paths enforced fund scope before this PR, the empirical
+state of Postgres RLS on `investments` in production, and the exact fix applied.
+Intended for PR-H2 (route-policy registry) ingestion.
+
+**Method:** code trace against `main` at `10f38987` plus the prod build/deploy
+topology recorded in session memory (Vercel build runs `db:push`, not the raw
+SQL policy migrations). No production data was read; the RLS conclusion is a
+code-level proof, with a narrow user-runnable confirmation query provided below.
+
+## Scope audited
+
+`server/routes/investments.ts` mounted on `makeApp` (`server/app.ts:215`), the
+canonical production (Vercel) surface, behind the global `/api` auth guard
+(`server/app.ts:184`, `requireAuth`). `/api/investments` and
+`/api/investments/:id` are **not** in `isPublicApiPath`
+(`server/lib/public-api-boundary.ts`), so both require a valid bearer token.
+
+## Findings (pre-PR-H1)
+
+| Path                                        | Pre-PR-H1 behavior                                                                                                                  | Verdict |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `GET /api/investments/:id`                  | `storage.getInvestment(id)` returned the row with **no fund-scope check**.                                                          | **GAP** |
+| `GET /api/investments` (no `fundId`)        | Skipped `enforceProvidedFundScope`; `storage.getInvestments(undefined)` (`storage.ts:582`) returned **all rows** across funds/orgs. | **GAP** |
+| `GET /api/investments?fundId=`              | Parsed `fundId`, called `enforceProvidedFundScope`. Already scoped.                                                                 | OK      |
+| `POST /api/investments`                     | Enforces scope on body `fundId` when numeric.                                                                                       | OK      |
+| `POST/GET /api/investments/:id/rounds[...]` | `resolveInvestmentRoundRouteScope` (`:236`) loads the investment and enforces scope on its `fundId`.                                | OK      |
+| `POST /api/investments/:id/cases`           | Returns 501 (unsupported); no data read.                                                                                            | N/A     |
+
+Net: any authenticated principal — including a lower-trust LP viewer scoped to a
+single fund — could read **any** fund's/org's investment detail by id, or dump
+the entire `investments` table via the bare list. This is a cross-fund /
+cross-org broken-object-level-authorization (BOLA) gap at the application layer.
+
+## Is RLS a mitigating control in production?
+
+**No.** Severity is therefore a live gap, not defense-in-depth.
+
+Proof (code-level):
+
+1. **Production schema is built by `db:push` from the Drizzle schema
+   (`shared/schema`).** `shared/**` contains **zero** `org_id` /
+   `organization_id` columns, so production `investments` has no org column and
+   `db:push` never emits RLS policies. The two raw-SQL RLS migrations are
+   mutually incompatible — `migrations/0002_add_organizations.sql` uses INTEGER
+   `org_id` + GUC `app.current_org_id`;
+   `migrations/0002_multi_tenant_rls_setup.sql` uses UUID `organization_id` +
+   GUC `app.current_org` and redefines `current_org_id()` with a different
+   return type (a `CREATE OR REPLACE` cannot change INTEGER↔UUID). They cannot
+   both have applied, and **neither runs in the Vercel build**.
+2. **The production surface (`makeApp`) does not mount `withRLSTransaction`**
+   (referenced only by `server/server.ts`, the Docker path). The investment read
+   handlers use the global `db` pool and never call
+   `set_config('app.current_org', …)`.
+3. **Decisive step:** if `FORCE ROW LEVEL SECURITY` were active on `investments`
+   for the app role, then — because the GUC is never set on this connection —
+   the fail-closed policy would return **0 rows for every** investments query,
+   including the scoped `GET /api/investments?fundId=` that the live
+   investment-rounds UI (`client/src/hooks/useCompanyInvestments.ts:21`) depends
+   on. That feature returns real rows in production. Therefore RLS is not
+   enforcing on this path. ∎
+
+### Narrow production confirmation (optional, read-only)
+
+```sql
+SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE relname = 'investments';
+SELECT polname FROM pg_policies WHERE tablename = 'investments';
+SELECT column_name FROM information_schema.columns
+  WHERE table_name = 'investments' AND column_name IN ('org_id','organization_id');
+```
+
+Expected if the proof holds: `relrowsecurity = false` (or no policies) and
+**no** org column. If this ever returns enforcing RLS + an org column + an app
+role without `BYPASSRLS`, re-rate the residual app-layer fix as
+defense-in-depth, but keep it — the app layer must not depend on an out-of-band
+policy migration.
+
+## Fix applied in this PR
+
+- `GET /api/investments/:id`: after load + 404, reject `NULL`-fund rows
+  (`invalid_investment_fund_scope`, 400) and enforce
+  `enforceProvidedFundScope(req, res, investment.fundId)` (mirrors
+  `resolveInvestmentRoundRouteScope`). Cross-fund → 403 `FUND_ACCESS_DENIED`.
+- `GET /api/investments`: require an explicit `fundId`
+  (`fund_scope_required`, 400) before any data read, closing the unscoped list.
+  The only caller (`useCompanyInvestments`) already passes `?fundId=`, so this
+  is behavior-preserving. An admin/service token with unrestricted scope can
+  still query any specific fund via `?fundId=`.
+- Regression tests: `tests/unit/routes/investments-access-boundary.test.ts`
+  exercise the **real** `enforceProvidedFundScope` with signed bearer tokens and
+  assert: cross-fund `:id` → 403 (no detail leak), in-scope `:id` → 200, missing
+  → 404, NULL-fund → 400, unscoped list → 400, cross-fund list → 403, scoped
+  list → 200.
+
+## Residual / handoff to PR-H2
+
+- The app layer is now the enforcement point. RLS reconciliation against prod
+  (apply a single coherent policy set, or formally drop RLS as the control and
+  document the app layer as authoritative) remains a separate, tracked decision
+  — it is not required for this fix to hold.
+- The 403-vs-404 distinction for an existing-but-out-of-scope `:id` is an
+  existence oracle, but it matches the established round-route convention. PR-H2
+  may standardize this across `financial: true` routes.

--- a/server/routes/investments.ts
+++ b/server/routes/investments.ts
@@ -29,21 +29,31 @@ const log = logger.child({ route: 'investments' });
 router['get']('/investments', async (req: Request, res: Response) => {
   try {
     const fundIdQuery = req.query['fundId'];
-    let fundId: number | undefined;
 
-    if (fundIdQuery) {
-      const parsedId = toNumber(fundIdQuery as string, 'fund ID');
-      if (parsedId <= 0) {
-        const error: ApiError = {
-          error: 'Invalid fund ID query',
-          message: `Fund ID must be a positive integer, received: ${fundIdQuery}`,
-        };
-        return res.status(400).json(error);
-      }
-      fundId = parsedId;
+    // PR-H1: close the unscoped list path. Without an explicit fundId the prior
+    // handler issued a query with no fund predicate (storage.getInvestments(undefined)
+    // returns every row), letting any authenticated caller enumerate investments
+    // across funds/orgs. Require an explicit fund scope; the only caller
+    // (useCompanyInvestments) already passes ?fundId=.
+    if (fundIdQuery === undefined || fundIdQuery === '') {
+      const error: ApiError = {
+        error: 'fund_scope_required',
+        message: 'A fundId query parameter is required to list investments',
+      };
+      return res.status(400).json(error);
     }
 
-    if (fundId !== undefined && !(await enforceProvidedFundScope(req, res, fundId))) {
+    const parsedId = toNumber(fundIdQuery as string, 'fund ID');
+    if (parsedId <= 0) {
+      const error: ApiError = {
+        error: 'Invalid fund ID query',
+        message: `Fund ID must be a positive integer, received: ${fundIdQuery}`,
+      };
+      return res.status(400).json(error);
+    }
+    const fundId = parsedId;
+
+    if (!(await enforceProvidedFundScope(req, res, fundId))) {
       return;
     }
 
@@ -83,6 +93,21 @@ router['get']('/investments/:id', async (req: Request, res: Response) => {
       };
       return res.status(404).json(error);
     }
+
+    // PR-H1: a direct entity read must enforce the same fund scope as the round
+    // routes (resolveInvestmentRoundRouteScope), or any authenticated caller can
+    // read another fund's/org's investment detail by id.
+    if (investment.fundId == null) {
+      const error: ApiError = {
+        error: 'invalid_investment_fund_scope',
+        message: 'Cannot fund-scope a NULL-fund investment',
+      };
+      return res.status(400).json(error);
+    }
+    if (!(await enforceProvidedFundScope(req, res, investment.fundId))) {
+      return;
+    }
+
     return res.json(investment);
   } catch (error) {
     if (handleNumberParseError(error, res, 'Invalid investment ID')) {

--- a/tests/unit/routes/investments-access-boundary.test.ts
+++ b/tests/unit/routes/investments-access-boundary.test.ts
@@ -1,0 +1,209 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+
+// PR-H1: direct investment reads must enforce the same fund scope as the round
+// routes. These tests exercise the REAL enforceProvidedFundScope helper (signed
+// bearer tokens) while mocking storage so we control which fund an investment
+// belongs to. Cross-fund/cross-org reads must be denied; the unscoped list path
+// must be closed; the scoped ?fundId= behavior must be preserved.
+
+const TEST_SECRET = 'investments-route-auth-test-secret-minimum-32-chars';
+const TEST_ISSUER = 'updog-test';
+const TEST_AUDIENCE = 'updog-app-test';
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'REQUIRE_AUTH',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+] as const;
+
+type EnvKey = (typeof ENV_KEYS)[number];
+
+const storageState = vi.hoisted(() => ({
+  getInvestment: vi.fn(),
+  getInvestments: vi.fn(),
+}));
+
+vi.mock('../../../server/storage', () => ({
+  storage: {
+    getInvestment: storageState.getInvestment,
+    getInvestments: storageState.getInvestments,
+  },
+  UnsupportedStorageOperationError: class UnsupportedStorageOperationError extends Error {
+    code = 'unsupported_storage_operation';
+  },
+}));
+
+function setJwtEnv(): void {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.REQUIRE_AUTH = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = TEST_SECRET;
+  process.env._EXPLICIT_JWT_SECRET = TEST_SECRET;
+  process.env.JWT_ISSUER = TEST_ISSUER;
+  process.env._EXPLICIT_JWT_ISSUER = TEST_ISSUER;
+  process.env.JWT_AUDIENCE = TEST_AUDIENCE;
+  process.env._EXPLICIT_JWT_AUDIENCE = TEST_AUDIENCE;
+}
+
+function signToken(payload: Record<string, unknown>): string {
+  return jwt.sign(
+    {
+      sub: 'investments-route-user',
+      email: 'investments-route@example.com',
+      role: 'user',
+      ...payload,
+    },
+    TEST_SECRET,
+    {
+      algorithm: 'HS256',
+      issuer: TEST_ISSUER,
+      audience: TEST_AUDIENCE,
+      expiresIn: '1h',
+    }
+  );
+}
+
+async function makeApp() {
+  const { default: investmentsRouter } = await import('../../../server/routes/investments');
+  const app = express();
+  app.use(express.json());
+  app.use('/api', investmentsRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+describe('investments direct-read fund-scope boundary (PR-H1)', () => {
+  const originalEnv = new Map<EnvKey, string | undefined>();
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    setJwtEnv();
+    storageState.getInvestment.mockReset();
+    storageState.getInvestments.mockReset();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  describe('GET /api/investments/:id', () => {
+    it('denies a cross-fund direct read (investment belongs to a fund the caller cannot access)', async () => {
+      storageState.getInvestment.mockResolvedValue({ id: 5, fundId: 2, name: 'Secret Co' });
+      const app = await makeApp();
+      const token = signToken({ fundIds: [1] });
+
+      const response = await request(app)
+        .get('/api/investments/5')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      // No investment detail leaks in a denied response.
+      expect(JSON.stringify(response.body)).not.toContain('Secret Co');
+    });
+
+    it('returns the investment when it belongs to a fund in the caller scope', async () => {
+      storageState.getInvestment.mockResolvedValue({ id: 5, fundId: 1, name: 'My Co' });
+      const app = await makeApp();
+      const token = signToken({ fundIds: [1] });
+
+      const response = await request(app)
+        .get('/api/investments/5')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({ id: 5, fundId: 1, name: 'My Co' });
+    });
+
+    it('returns 404 for a missing investment without leaking existence via scope checks', async () => {
+      storageState.getInvestment.mockResolvedValue(undefined);
+      const app = await makeApp();
+      const token = signToken({ fundIds: [1] });
+
+      const response = await request(app)
+        .get('/api/investments/999')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({ error: 'Investment not found' });
+    });
+
+    it('rejects a NULL-fund investment as unscopeable', async () => {
+      storageState.getInvestment.mockResolvedValue({ id: 7, fundId: null, name: 'Orphan' });
+      const app = await makeApp();
+      const token = signToken({ fundIds: [1] });
+
+      const response = await request(app)
+        .get('/api/investments/7')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({ error: 'invalid_investment_fund_scope' });
+    });
+  });
+
+  describe('GET /api/investments (list)', () => {
+    it('closes the unscoped list path: requires an explicit fundId', async () => {
+      const app = await makeApp();
+      const token = signToken({ fundIds: [1] });
+
+      const response = await request(app)
+        .get('/api/investments')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({ error: 'fund_scope_required' });
+      expect(storageState.getInvestments).not.toHaveBeenCalled();
+    });
+
+    it('denies a cross-fund list (?fundId= for a fund outside the caller scope)', async () => {
+      const app = await makeApp();
+      const token = signToken({ fundIds: [1] });
+
+      const response = await request(app)
+        .get('/api/investments?fundId=2')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+      expect(storageState.getInvestments).not.toHaveBeenCalled();
+    });
+
+    it('preserves the scoped list for ?fundId= within the caller scope', async () => {
+      storageState.getInvestments.mockResolvedValue([{ id: 9, fundId: 1, name: 'In Scope' }]);
+      const app = await makeApp();
+      const token = signToken({ fundIds: [1] });
+
+      const response = await request(app)
+        .get('/api/investments?fundId=1')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([{ id: 9, fundId: 1, name: 'In Scope' }]);
+      expect(storageState.getInvestments).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
GET /api/investments/:id returned storage.getInvestment(id) with no fund-scope check, and GET /api/investments without fundId skipped enforceProvidedFundScope and returned all rows across funds/orgs. Any authenticated caller (incl. a single-fund LP viewer) could read another fund's/org's investment detail.

RLS does not mitigate in prod: shared/schema has no org column (db:push builds prod and never emits the raw-SQL RLS policies), makeApp does not mount withRLSTransaction, and the GET path never sets app.current_org -- so FORCE RLS, if active, would zero out the scoped ?fundId= read the live UI depends on.

Fix: :id now enforces enforceProvidedFundScope on the loaded investment's fundId (mirrors resolveInvestmentRoundRouteScope; cross-fund 403, NULL-fund 400); bare list now requires fundId (fund_scope_required 400). ?fundId= and 404 behavior preserved; the only callers already pass fundId. Adds 7 real-bearer cross-fund regression tests and docs/design/audits/2026-06-22-entity-access-boundary.md.
