### PR TITLE
feat(trust): H3 investment-round operational readiness + base currency

### DIFF
--- a/.claude/artifacts/prC-storage-fund-investigation.md
+++ b/.claude/artifacts/prC-storage-fund-investigation.md
@@ -1,0 +1,50 @@
+# PR C Storage Fund Investigation
+
+Run ID: hermes-2026-06-23T23-06-10-372Z Phase: production Owner: codex Reviewer:
+claude
+
+## Finding
+
+`server/storage.ts` is part of `tsconfig.server.json` compilation. The reviewer
+claim that those two `: Fund` literals must fail the server typecheck was a
+false positive as stated: the file is not silently excluded. It passed because
+`server/storage.ts` imports `Fund` from `../schema/src/index.js`, which resolves
+to `schema/src/index.ts` and then `schema/src/tables.ts`. Before this fix, that
+legacy `funds` table did not define `baseCurrency`, so its `Fund` select shape
+did not require the field.
+
+Separately, `@shared/schema` resolves to `shared/schema.ts`, whose `Fund` type
+is select-inferred from `shared/schema/fund.ts`; that schema does define
+`baseCurrency: varchar('base_currency', { length: 3 }).notNull().default('USD')`.
+In Drizzle select inference, a not-null column with a default is still present
+and required in the selected row shape. The default only makes insert input
+optional.
+
+## Evidence
+
+- `tsconfig.server.json` includes `server/**/*`, `shared/**/*`, and
+  `schema/src/**/*`; it excludes tests via `**/*.test.ts` and `**/*.test.tsx`.
+- `npx tsc -p tsconfig.server.json --listFilesOnly --pretty false` listed
+  `server/storage.ts`, `schema/src/index.ts`, and `shared/schema/fund.ts`.
+- `npx tsc -p tsconfig.server.json --traceResolution --pretty false` resolved
+  `../schema/src/index.js` from `server/storage.ts` to `schema/src/index.ts`.
+- A TypeScript compiler API probe showed:
+  - `server/storage.ts` was in the server program.
+  - `server/storage.ts` `Fund` resolved to `schema/src/tables.ts` and did not
+    have `baseCurrency` before the fix.
+  - `tests/unit/services/projected-metrics-calculator.test.ts` was not in the
+    server program, but when added to a probe program its `@shared/schema`
+    `Fund` had `baseCurrency`.
+
+## Fix
+
+- Added `baseCurrency` to the legacy `schema/src/tables.ts` `funds` table.
+- Added `baseCurrency: 'USD'` to the two in-memory `Fund` literals in
+  `server/storage.ts`.
+- Added `baseCurrency: 'USD'` to the `Fund` literal in
+  `tests/unit/services/projected-metrics-calculator.test.ts`.
+
+## Verification
+
+- `npx tsc -p tsconfig.server.json --noEmit --pretty false`: pass.
+- `npm run check`: pass, 0 TypeScript errors.

--- a/migrations/0015_funds_base_currency.sql
+++ b/migrations/0015_funds_base_currency.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "funds" ADD COLUMN IF NOT EXISTS "base_currency" varchar(3) DEFAULT 'USD' NOT NULL;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1775952000000,
       "tag": "0014_lp_evidence_sprint3_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1782172800000,
+      "tag": "0015_funds_base_currency",
+      "breakpoints": true
     }
   ]
 }

--- a/schema/src/tables.ts
+++ b/schema/src/tables.ts
@@ -20,6 +20,7 @@ export const funds = pgTable('funds', {
   carryPercentage: decimal('carry_percentage', { precision: 5, scale: 4 }).notNull(),
   vintageYear: integer('vintage_year').notNull(),
   status: text('status').notNull().default('active'),
+  baseCurrency: varchar('base_currency', { length: 3 }).notNull().default('USD'),
   engineResults: jsonb('engine_results').$type<EngineResults>(),
   createdAt: timestamp('created_at').defaultNow(),
 });

--- a/server/migrations/20260623_funds_base_currency_v1.down.sql
+++ b/server/migrations/20260623_funds_base_currency_v1.down.sql
@@ -1,0 +1,9 @@
+DO $$
+DECLARE non_usd integer;
+BEGIN
+  SELECT count(*) INTO non_usd FROM funds WHERE base_currency <> 'USD';
+  IF non_usd > 0 THEN
+    RAISE EXCEPTION 'Cannot drop funds.base_currency: % funds have non-USD currency', non_usd;
+  END IF;
+END $$;
+ALTER TABLE funds DROP COLUMN IF EXISTS base_currency;

--- a/server/migrations/20260623_funds_base_currency_v1.up.sql
+++ b/server/migrations/20260623_funds_base_currency_v1.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE funds ADD COLUMN IF NOT EXISTS base_currency varchar(3) NOT NULL DEFAULT 'USD';

--- a/server/migrations/20260623_z_investment_rounds_operational_v1.down.sql
+++ b/server/migrations/20260623_z_investment_rounds_operational_v1.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS investment_rounds_fund_round_order_idx;
+ALTER TABLE investment_rounds DROP CONSTRAINT IF EXISTS investment_rounds_amount_positive;

--- a/server/migrations/20260623_z_investment_rounds_operational_v1.up.sql
+++ b/server/migrations/20260623_z_investment_rounds_operational_v1.up.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'investment_rounds_amount_positive') THEN
+    ALTER TABLE investment_rounds
+      ADD CONSTRAINT investment_rounds_amount_positive CHECK (investment_amount > 0);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS investment_rounds_fund_round_order_idx
+  ON investment_rounds (fund_id, investment_id, round_date, created_at, id);

--- a/server/routes/funds.ts
+++ b/server/routes/funds.ts
@@ -113,6 +113,7 @@ function normalizeStoredFund(fund: StoredFund): PersistedFund {
     ...fund,
     establishmentDate: (fund as Partial<PersistedFund>).establishmentDate ?? null,
     isActive: (fund as Partial<PersistedFund>).isActive ?? true,
+    baseCurrency: (fund as Partial<PersistedFund>).baseCurrency ?? 'USD',
   };
 }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -189,6 +189,7 @@ export class MemStorage implements IStorage {
       carryPercentage: '0.20',
       vintageYear: 2020,
       status: 'active',
+      baseCurrency: 'USD',
       engineResults: null,
       createdAt: new Date(),
     };
@@ -348,6 +349,7 @@ export class MemStorage implements IStorage {
       carryPercentage: String(insertFund.carryPercentage),
       vintageYear: insertFund.vintageYear,
       status: 'active', // Default value from schema
+      baseCurrency: 'USD',
       engineResults: insertFund.engineResults ?? null,
       createdAt: new Date(),
     };

--- a/shared/lib/telemetry-redaction.ts
+++ b/shared/lib/telemetry-redaction.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+export const MONETARY_FIELD_DENYLIST = Object.freeze([
+  'amount',
+  'investmentAmount',
+  'investment_amount',
+  'preMoneyValuation',
+  'pre_money_valuation',
+  'postMoneyValuation',
+  'post_money_valuation',
+  'roundSize',
+  'round_size',
+  'valuation',
+  'ownershipPercentage',
+  'ownership_percentage',
+] as const);
+
+const monetaryFields = new Set<string>(MONETARY_FIELD_DENYLIST);
+
+export const TelemetryEventSchema = z
+  .object({
+    event: z.string(),
+    fundId: z.number().optional(),
+    investmentId: z.number().optional(),
+    roundId: z.number().optional(),
+    eventKind: z.string().optional(),
+    count: z.number().optional(),
+    occurredAt: z.string().optional(),
+    outcome: z.string().optional(),
+  })
+  .strict();
+
+export type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function assertNoMonetaryFieldsInValue(value: unknown, path: string): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      assertNoMonetaryFieldsInValue(item, `${path}[${index}]`);
+    });
+    return;
+  }
+
+  if (!isPlainObject(value)) {
+    return;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const currentPath = path ? `${path}.${key}` : key;
+    if (monetaryFields.has(key)) {
+      throw new Error(`Telemetry event contains monetary field: ${currentPath}`);
+    }
+    assertNoMonetaryFieldsInValue(nestedValue, currentPath);
+  }
+}
+
+export function assertNoMonetaryFields(event: Record<string, unknown>): void {
+  assertNoMonetaryFieldsInValue(event, '');
+}
+
+export function redactTelemetryEvent(event: Record<string, unknown>): TelemetryEvent {
+  const parsed = TelemetryEventSchema.parse(event);
+  assertNoMonetaryFields(parsed);
+  return parsed;
+}

--- a/shared/schema/fund.ts
+++ b/shared/schema/fund.ts
@@ -43,6 +43,7 @@ export const funds = pgTable('funds', {
   establishmentDate: date('establishment_date'),
   status: text('status').notNull().default('active'),
   isActive: boolean('is_active').default(true),
+  baseCurrency: varchar('base_currency', { length: 3 }).notNull().default('USD'),
   engineResults: jsonb('engine_results').$type<EngineResults>(),
   createdAt: timestamp('created_at').defaultNow(),
 });

--- a/shared/schema/investment-rounds.ts
+++ b/shared/schema/investment-rounds.ts
@@ -62,6 +62,10 @@ export const investmentRounds = pgTable(
       'investment_rounds_security_type_check',
       sql`${table.securityType} IN ('equity', 'convertible_note', 'safe', 'warrant', 'other')`
     ),
+    amountPositiveCheck: check(
+      'investment_rounds_amount_positive',
+      sql`${table.investmentAmount} > 0`
+    ),
     investmentFundFk: foreignKey({
       name: 'investment_rounds_investment_fund_fk',
       columns: [table.investmentId, table.fundId],
@@ -76,6 +80,13 @@ export const investmentRounds = pgTable(
     investmentRoundDateIdx: index('investment_rounds_investment_round_date_idx').on(
       table.investmentId,
       table.roundDate.desc()
+    ),
+    fundRoundOrderIdx: index('investment_rounds_fund_round_order_idx').on(
+      table.fundId,
+      table.investmentId,
+      table.roundDate,
+      table.createdAt,
+      table.id
     ),
     fundIdempotencyKey: unique('investment_rounds_fund_idem_key').on(
       table.fundId,

--- a/tests/integration/migrations/investment-rounds-schema.test.ts
+++ b/tests/integration/migrations/investment-rounds-schema.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { applyInvestmentRoundConstraints } from '../../helpers/apply-investment-round-constraints';
 import { setupTestDB } from '../../helpers/testcontainers';
+import { createRound } from '../../../server/services/investments/investment-round-service';
 
 const STARTUP_TIMEOUT_MS = 90_000;
 const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
@@ -119,7 +120,7 @@ describe.skipIf(skipIfNoDocker)('investment_rounds schema', () => {
     runDrizzlePush(connectionString);
     await applyInvestmentRoundConstraints(connectionString);
 
-    pool = new Pool({ connectionString, max: 1 });
+    pool = new Pool({ connectionString, max: 4 });
   }, STARTUP_TIMEOUT_MS * 2);
 
   afterAll(async () => {
@@ -139,6 +140,28 @@ describe.skipIf(skipIfNoDocker)('investment_rounds schema', () => {
     `);
 
     expect(rows.rows).toHaveLength(1);
+  });
+
+  it('has the operational readiness schema additions', async () => {
+    expect(pool).toBeDefined();
+    const db = drizzle(pool!);
+
+    const fundsBaseCurrency = await db.execute(sql`
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'funds'
+        AND column_name = 'base_currency'
+    `);
+    expect(fundsBaseCurrency.rows).toHaveLength(1);
+
+    const positiveAmountConstraint = await db.execute(sql`
+      SELECT 1
+      FROM pg_constraint
+      WHERE conname = 'investment_rounds_amount_positive'
+        AND contype = 'c'
+    `);
+    expect(positiveAmountConstraint.rows).toHaveLength(1);
   });
 
   it('blocks deleting an investment that has a round', async () => {
@@ -187,5 +210,72 @@ describe.skipIf(skipIfNoDocker)('investment_rounds schema', () => {
         }),
       '23505'
     );
+  });
+
+  it('allows exactly one concurrent supersede for the same base round', async () => {
+    expect(pool).toBeDefined();
+    const db = drizzle(pool!);
+    const { fundId, investmentId } = await insertFundAndInvestment();
+
+    const base = await createRound(
+      {
+        fundId,
+        investmentId,
+        idempotencyKey: 'concurrent-base-round',
+        roundName: 'Concurrent Base Round',
+        securityType: 'equity',
+        roundDate: '2026-03-01',
+        currency: 'USD',
+        investmentAmount: '500000.000000',
+        createdBy: null,
+      },
+      { database: db }
+    );
+    expect(base.kind).toBe('created');
+    if (base.kind !== 'created') {
+      throw new Error(`Expected base round creation, received ${base.kind}`);
+    }
+
+    const results = await Promise.all([
+      createRound(
+        {
+          fundId,
+          investmentId,
+          idempotencyKey: 'concurrent-correction-a',
+          roundName: 'Concurrent Correction A',
+          securityType: 'equity',
+          roundDate: '2026-03-02',
+          currency: 'USD',
+          investmentAmount: '525000.000000',
+          supersedesRoundId: base.row.id,
+          createdBy: null,
+        },
+        { database: db }
+      ),
+      createRound(
+        {
+          fundId,
+          investmentId,
+          idempotencyKey: 'concurrent-correction-b',
+          roundName: 'Concurrent Correction B',
+          securityType: 'equity',
+          roundDate: '2026-03-03',
+          currency: 'USD',
+          investmentAmount: '550000.000000',
+          supersedesRoundId: base.row.id,
+          createdBy: null,
+        },
+        { database: db }
+      ),
+    ]);
+
+    expect(results.map((result) => result.kind).sort()).toEqual(['already_superseded', 'created']);
+
+    const supersedingRows = await db.execute(sql`
+      SELECT id
+      FROM investment_rounds
+      WHERE supersedes_round_id = ${base.row.id}
+    `);
+    expect(supersedingRows.rows).toHaveLength(1);
   });
 });

--- a/tests/unit/lib/telemetry-redaction.test.ts
+++ b/tests/unit/lib/telemetry-redaction.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertNoMonetaryFields,
+  MONETARY_FIELD_DENYLIST,
+  redactTelemetryEvent,
+  TelemetryEventSchema,
+} from '@shared/lib/telemetry-redaction';
+
+describe('telemetry-redaction', () => {
+  it('passes clean events through the denylist check and schema', () => {
+    const event = {
+      event: 'investment_round_created',
+      fundId: 1,
+      investmentId: 2,
+      roundId: 3,
+      eventKind: 'round',
+      count: 1,
+      occurredAt: '2026-06-23T00:00:00.000Z',
+      outcome: 'created',
+    };
+
+    expect(() => assertNoMonetaryFields(event)).not.toThrow();
+    expect(TelemetryEventSchema.parse(event)).toEqual(event);
+    expect(redactTelemetryEvent(event)).toEqual(event);
+  });
+
+  it('throws for every monetary field at top level and nested inside objects and arrays', () => {
+    for (const field of MONETARY_FIELD_DENYLIST) {
+      expect(() => assertNoMonetaryFields({ event: 'blocked', [field]: 1 })).toThrow(field);
+      expect(() => assertNoMonetaryFields({ event: 'blocked', nested: { [field]: 1 } })).toThrow(
+        field
+      );
+      expect(() =>
+        assertNoMonetaryFields({ event: 'blocked', nested: [{ safe: true }, { [field]: 1 }] })
+      ).toThrow(field);
+    }
+  });
+
+  it('rejects unknown monetary fields through the strict schema', () => {
+    expect(() =>
+      TelemetryEventSchema.parse({
+        event: 'investment_round_created',
+        investmentAmount: '1000000',
+      })
+    ).toThrow();
+  });
+
+  it('throws from redactTelemetryEvent on a monetary payload', () => {
+    expect(() =>
+      redactTelemetryEvent({
+        event: 'investment_round_created',
+        investmentAmount: '1000000',
+      })
+    ).toThrow();
+  });
+});

--- a/tests/unit/services/projected-metrics-calculator.test.ts
+++ b/tests/unit/services/projected-metrics-calculator.test.ts
@@ -25,6 +25,7 @@ const zeroTargetFund: Fund = {
   establishmentDate: '2026-01-15',
   status: 'active',
   isActive: true,
+  baseCurrency: 'USD',
   engineResults: null,
   createdAt: new Date('2026-01-15T00:00:00.000Z'),
 };


### PR DESCRIPTION
## Summary

PR-C / milestone H3 of the Trust-First Milestones v3.4 plan: investment-round
operational readiness plus a fund base-currency column.

## Deliverables

- **`funds.base_currency`** (`varchar(3) NOT NULL DEFAULT 'USD'`): migration
  pair + Drizzle column in `shared/schema/fund.ts`. The down-migration is
  rollback-safe ONLY while all funds are USD and RAISEs otherwise.
- **`investment_amount > 0` CHECK** + operational composite index
  `(fund_id, investment_id, round_date, created_at, id)`: idempotent/replay-safe
  migration pair, mirrored in the Drizzle schema (db:push schema-truth).
- **Telemetry monetary-field redaction** (`shared/lib/telemetry-redaction.ts`):
  a strict zod allowlist (primary) + a null-safe recursive `assertNoMonetaryFields`
  (secondary). Never logs `amount`/`investment_amount`/`valuation`/etc.
- **Deterministic double-supersede concurrency test** (real Postgres): two
  concurrent supersede inserts -> exactly one `created` + one
  `already_superseded`, order-independent multiset assertion, one superseding row.
- **Schema-existence test** for the new column + constraint.

## Schema-duplication fix (surfaced during review)

Review flagged the two `: Fund` literals in `server/storage.ts` as a possible
typecheck break. Investigation showed the build was genuinely green and
explained why: `server/storage.ts` imports `Fund` from a **second, legacy**
`funds` table definition at `schema/src/tables.ts` (distinct from
`shared/schema/fund.ts`), which lacked `base_currency`. To keep the two
definitions consistent, `base_currency` was added to the legacy schema and the
in-memory `Fund` literals (`server/storage.ts`) + a test fixture were made
schema-complete. `schema/src/` is not wired into `drizzle.config.ts`/db:push, so
this is a pure type-consistency change with no DB/migration side effect.

**Follow-up:** the `schema/src/` legacy duplicate should be removed/archived to
eliminate the drift risk entirely; tracked as a separate PR.

## Notes

- Same-fund / same-investment supersede checks already landed in PR #912; not
  re-added.
- `normalizeStoredFund` defaults `baseCurrency` to `'USD'` for in-memory rows.

## Test evidence

- `npm run check`: 0 TypeScript errors (rebased onto current main).
- Telemetry redaction unit tests + concurrency/schema integration tests (the
  integration suite runs under Docker in CI).

## Plan reference

`docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.4.md` sections 8.1,
8.2, 10 (H3), 15.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
