### PR TITLE
feat(moic): V2 read contract, idempotent reconciliation recording, canonical route (PR-E)

### DIFF
--- a/client/src/app/app-route-definitions.ts
+++ b/client/src/app/app-route-definitions.ts
@@ -15,6 +15,7 @@ export const APP_ROUTE_DEFINITIONS = [
   { path: '/financial-modeling', isProtected: true },
   { path: '/model-results', isProtected: true },
   { path: '/fund-model-results/:fundId/scenarios', isProtected: true },
+  { path: '/fund-model-results/:fundId/moic-analysis', isProtected: true },
   { path: '/fund-model-results/:fundId', isProtected: true },
   { path: '/sensitivity-analysis', isProtected: true },
   { path: '/reports', isProtected: true },

--- a/client/src/app/app-routes.tsx
+++ b/client/src/app/app-routes.tsx
@@ -29,10 +29,14 @@ export const NotFound = React.lazy(() => import('@/pages/not-found'));
 // Fund Model Results (post-wizard output)
 const FundModelResults = React.lazy(() => import('@/pages/fund-model-results'));
 const FundScenarioWorkspace = React.lazy(() => import('@/pages/fund-scenario-workspace'));
+const FundModelResultsMoicAnalysis = React.lazy(
+  () => import('@/pages/fund-model-results-moic-analysis')
+);
 const FinancialModelingPage = React.lazy(() => import('@/pages/financial-modeling'));
 const ForecastingPage = React.lazy(() => import('@/pages/forecasting'));
 const ModelResultsPage = React.lazy(() => import('@/pages/model-results'));
 const SensitivityAnalysisPage = React.lazy(() => import('@/pages/sensitivity-analysis'));
+// Keep /moic-analysis on the existing live page; the redirect page is not registered here.
 const MOICAnalysisPage = React.lazy(() => import('@/pages/moic-analysis'));
 // LP Sharing
 export const SharedDashboard = React.lazy(() => import('@/pages/shared-dashboard'));
@@ -92,6 +96,7 @@ const APP_ROUTE_COMPONENTS: Record<
   '/financial-modeling': FinancialModelingPage,
   '/model-results': ModelResultsPage,
   '/fund-model-results/:fundId/scenarios': FundScenarioWorkspace,
+  '/fund-model-results/:fundId/moic-analysis': FundModelResultsMoicAnalysis,
   '/fund-model-results/:fundId': FundModelResults,
   '/sensitivity-analysis': SensitivityAnalysisPage,
   '/reports': Reports,

--- a/client/src/hooks/use-moic.ts
+++ b/client/src/hooks/use-moic.ts
@@ -10,6 +10,10 @@ import {
   FundMoicRankingsResponseV1Schema,
   type FundMoicRankingsResponseV1,
 } from '@shared/contracts/fund-moic-v1.contract';
+import {
+  FundMoicRankingsResponseV2Schema,
+  type FundMoicRankingsResponseV2,
+} from '@shared/contracts/fund-moic-v2.contract';
 
 interface RankedInvestment {
   investment: Investment;
@@ -114,6 +118,44 @@ export function useFundMoicRankings(fundId: number | null) {
         throw buildFundMoicContractError(res.status);
       });
       const parsed = FundMoicRankingsResponseV1Schema.safeParse(raw);
+
+      if (!parsed.success) {
+        throw buildFundMoicContractError(res.status);
+      }
+
+      return parsed.data;
+    },
+    enabled: validFundId !== null,
+  });
+}
+
+export function useFundMoicRankingsV2(fundId: number | null) {
+  const validFundId = fundId !== null && Number.isInteger(fundId) && fundId > 0 ? fundId : null;
+
+  return useQuery<FundMoicRankingsResponseV2, FundMoicRankingsHookError>({
+    queryKey: ['fund-moic-rankings-v2', validFundId],
+    queryFn: async () => {
+      if (validFundId === null) {
+        throw new Error('A positive fund ID is required') as FundMoicRankingsHookError;
+      }
+
+      const res = await fetch(`/api/funds/${validFundId}/moic/rankings?contract=v2`, {
+        credentials: 'include',
+      });
+
+      if (!res.ok) {
+        const errorBody: unknown = await res.json().catch(() => ({}));
+        const error = new Error(
+          getErrorMessage(errorBody, 'Failed to load live MOIC rankings')
+        ) as FundMoicRankingsHookError;
+        error.status = res.status;
+        throw error;
+      }
+
+      const raw: unknown = await res.json().catch(() => {
+        throw buildFundMoicContractError(res.status);
+      });
+      const parsed = FundMoicRankingsResponseV2Schema.safeParse(raw);
 
       if (!parsed.success) {
         throw buildFundMoicContractError(res.status);

--- a/client/src/pages/fund-model-results-moic-analysis.tsx
+++ b/client/src/pages/fund-model-results-moic-analysis.tsx
@@ -1,0 +1,210 @@
+import { AlertTriangle, Info, Loader2 } from 'lucide-react';
+import { useRoute } from 'wouter';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useFundMoicRankingsV2 } from '@/hooks/use-moic';
+import type { FundMoicRankingsResponseV2 } from '@shared/contracts/fund-moic-v2.contract';
+
+type FundIdParseResult =
+  | { status: 'missing'; fundId: null }
+  | { status: 'invalid'; fundId: null }
+  | { status: 'valid'; fundId: number };
+
+type FundMoicRankingV2 = FundMoicRankingsResponseV2['rankings'][number];
+
+function parseFundIdParam(rawValue: string | undefined): FundIdParseResult {
+  if (rawValue === undefined) {
+    return { status: 'missing', fundId: null };
+  }
+
+  const trimmed = rawValue.trim();
+  const parsed = Number(trimmed);
+
+  if (!/^\d+$/.test(trimmed) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    return { status: 'invalid', fundId: null };
+  }
+
+  return { status: 'valid', fundId: parsed };
+}
+
+function formatMoicValue(value: number | null): string {
+  return value === null ? 'Unavailable' : `${value.toFixed(2)}x`;
+}
+
+function StateCard({
+  title,
+  description,
+  icon = 'warning',
+}: {
+  title: string;
+  description: string;
+  icon?: 'loading' | 'info' | 'warning';
+}) {
+  const Icon = icon === 'loading' ? Loader2 : icon === 'info' ? Info : AlertTriangle;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-pov-charcoal">
+          <Icon className={`h-5 w-5 ${icon === 'loading' ? 'animate-spin' : ''}`} />
+          <span>{title}</span>
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+function ProvenanceStrip({ data }: { data: FundMoicRankingsResponseV2 }) {
+  const warningCodes = data.roundEvidenceSummary.warningCodes;
+
+  return (
+    <Card className="border-presson-info/20 bg-presson-info/10">
+      <CardContent className="grid gap-3 p-4 text-sm md:grid-cols-3">
+        <div>
+          <p className="text-muted-foreground">Materiality</p>
+          <p className="font-medium text-pov-charcoal">{data.materiality.status}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Provenance</p>
+          <p className="font-medium text-pov-charcoal">{data.provenance.mode}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Warning codes</p>
+          <div className="mt-1 flex flex-wrap gap-2">
+            {warningCodes.length > 0 ? (
+              warningCodes.map((code) => (
+                <Badge
+                  key={code}
+                  variant="outline"
+                  className="border-beige-200 text-charcoal-700"
+                >
+                  {code}
+                </Badge>
+              ))
+            ) : (
+              <span className="font-medium text-pov-charcoal">None</span>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RankingsTable({ rankings }: { rankings: FundMoicRankingV2[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>MOIC Rankings</CardTitle>
+        <CardDescription>Fund-scoped V2 rankings payload.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Rank</TableHead>
+              <TableHead>Investment</TableHead>
+              <TableHead className="text-right">Reserves MOIC</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rankings.map((item) => (
+              <TableRow key={item.investmentId}>
+                <TableCell className="font-semibold text-charcoal-600">#{item.rank}</TableCell>
+                <TableCell className="font-medium text-pov-charcoal">
+                  {item.investmentName}
+                </TableCell>
+                <TableCell className="text-right font-bold tabular-nums text-pov-charcoal">
+                  {formatMoicValue(item.reservesMoic.value)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function FundModelResultsMoicAnalysisPage() {
+  const [, params] = useRoute('/fund-model-results/:fundId/moic-analysis');
+  const fundIdResult = parseFundIdParam(params?.fundId);
+  const { data, error, isLoading } = useFundMoicRankingsV2(fundIdResult.fundId);
+  const hasParsedResponse = fundIdResult.status === 'valid' && !error && data;
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <header>
+        <h1 className="text-3xl font-bold text-pov-charcoal">MOIC Analysis</h1>
+        <p className="text-muted-foreground">
+          {fundIdResult.status === 'valid' ? `Fund ${fundIdResult.fundId}` : 'Fund-scoped results'}
+        </p>
+      </header>
+
+      {fundIdResult.status === 'missing' ? (
+        <StateCard
+          title="Fund ID required"
+          description="MOIC rankings are unavailable because the route did not include a fund ID."
+          icon="info"
+        />
+      ) : null}
+
+      {fundIdResult.status === 'invalid' ? (
+        <StateCard
+          title="Invalid fund ID"
+          description="MOIC rankings are unavailable because the fund ID is not a positive integer."
+        />
+      ) : null}
+
+      {fundIdResult.status === 'valid' && isLoading ? (
+        <StateCard
+          title="Loading MOIC rankings"
+          description="Fetching the fund-scoped MOIC rankings response."
+          icon="loading"
+        />
+      ) : null}
+
+      {fundIdResult.status === 'valid' && error ? (
+        <StateCard
+          title={
+            error.code === 'CONTRACT_PARSE_ERROR'
+              ? 'MOIC contract mismatch'
+              : 'Unable to load MOIC rankings'
+          }
+          description={
+            error.code === 'CONTRACT_PARSE_ERROR'
+              ? 'The response did not match the required V2 contract, so rankings are not shown.'
+              : 'The rankings endpoint returned a load error, so rankings are not shown.'
+          }
+        />
+      ) : null}
+
+      {hasParsedResponse && data.rankings.length === 0 ? (
+        <>
+          <ProvenanceStrip data={data} />
+          <StateCard
+            title="No rankings available"
+            description="The V2 response returned zero reserves MOIC ranking rows for this fund."
+            icon="info"
+          />
+        </>
+      ) : null}
+
+      {hasParsedResponse && data.rankings.length > 0 ? (
+        <>
+          <ProvenanceStrip data={data} />
+          <RankingsTable rankings={data.rankings} />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/migrations/0016_reconciliation_runs.sql
+++ b/migrations/0016_reconciliation_runs.sql
@@ -1,0 +1,90 @@
+-- Migration: 0016_reconciliation_runs
+-- Purpose: Persist MOIC reconciliation run metadata and evidence summaries.
+-- Replay safety: CREATE TABLE/INDEX IF NOT EXISTS plus guarded constraints.
+
+CREATE TABLE IF NOT EXISTS "reconciliation_runs" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "request_hash" text NOT NULL,
+  "requested_by" integer,
+  "requested_at" timestamptz DEFAULT now() NOT NULL,
+  "status" varchar(16) DEFAULT 'completed' NOT NULL,
+  "legacy_input_hash" text NOT NULL,
+  "candidate_input_hash" text NOT NULL,
+  "evidence_input_hash" text NOT NULL,
+  "assumptions_hash" text NOT NULL,
+  "legacy_output_hash" text NOT NULL,
+  "candidate_output_hash" text NOT NULL,
+  "candidate_material" boolean DEFAULT false NOT NULL,
+  "materiality_epsilon" double precision NOT NULL,
+  "diff_summary" jsonb NOT NULL,
+  "round_evidence_summary" jsonb NOT NULL,
+  CONSTRAINT "reconciliation_runs_idempotency_key_unique" UNIQUE ("idempotency_key"),
+  CONSTRAINT "reconciliation_runs_status_check" CHECK ("status" IN ('pending','completed','failed'))
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.reconciliation_runs') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.reconciliation_runs'::regclass
+         AND conname = 'reconciliation_runs_fund_id_funds_id_fk'
+     ) THEN
+    ALTER TABLE "reconciliation_runs"
+      ADD CONSTRAINT "reconciliation_runs_fund_id_funds_id_fk"
+      FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.reconciliation_runs') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.reconciliation_runs'::regclass
+         AND conname = 'reconciliation_runs_requested_by_users_id_fk'
+     ) THEN
+    ALTER TABLE "reconciliation_runs"
+      ADD CONSTRAINT "reconciliation_runs_requested_by_users_id_fk"
+      FOREIGN KEY ("requested_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.reconciliation_runs') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.reconciliation_runs'::regclass
+         AND conname = 'reconciliation_runs_idempotency_key_unique'
+     ) THEN
+    ALTER TABLE "reconciliation_runs"
+      ADD CONSTRAINT "reconciliation_runs_idempotency_key_unique" UNIQUE ("idempotency_key");
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.reconciliation_runs') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.reconciliation_runs'::regclass
+         AND conname = 'reconciliation_runs_status_check'
+     ) THEN
+    ALTER TABLE "reconciliation_runs"
+      ADD CONSTRAINT "reconciliation_runs_status_check" CHECK ("status" IN ('pending','completed','failed'));
+  END IF;
+END
+$$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_reconciliation_runs_fund_requested"
+  ON "reconciliation_runs" USING btree ("fund_id", "requested_at" DESC);

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -71,7 +71,11 @@ export function getFinancialSurfaceForGovernanceEntry(
     return 'export_artifact';
   }
 
-  if (entry.path === '/performance' || entry.path === '/moic-analysis') {
+  if (
+    entry.path === '/performance' ||
+    entry.path === '/moic-analysis' ||
+    entry.path === '/fund-model-results/:fundId/moic-analysis'
+  ) {
     return 'moic_reserves';
   }
 
@@ -261,6 +265,19 @@ const GOVERNANCE_ROUTE_POLICY_DECISIONS: Readonly<Record<string, RoutePolicyDeci
   '/fund-model-results/:fundId': {
     lifecycle: 'durable_crud',
     financialSurface: 'fund_modeling',
+    apiAuthBoundary: 'require_auth_and_fund_access',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'fund_scope_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: false,
+    staleBlocksExport: false,
+    staleBlocksRender: true,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+  },
+  '/fund-model-results/:fundId/moic-analysis': {
+    lifecycle: 'durable_crud',
+    financialSurface: 'moic_reserves',
     apiAuthBoundary: 'require_auth_and_fund_access',
     fundScopeMode: 'route_param_fund_id',
     workflowRequirement: 'fund_scope_verified',

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -67,7 +67,7 @@ router.get(
     const fundId = parseFundId(req, res);
     if (fundId === null) return;
 
-    const contract = req.query.contract;
+    const contract = req.query['contract'];
     if (contract === undefined || contract === 'v1') {
       const rankings = await getFundMoicRankings(fundId);
       return res.json(rankings);

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -1,8 +1,19 @@
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import { requireAuth, requireFundAccess } from '../lib/auth/jwt.js';
+import { requireAuth, requireFundAccess, requireRole } from '../lib/auth/jwt.js';
+import {
+  FundMoicRankingsResponseV2Schema,
+  type FundMoicRankingsResponseV2,
+} from '../../shared/contracts/fund-moic-v2.contract.js';
 import { FundIdParamSchema } from '../../shared/schemas/portfolio-route.js';
+import { MOIC_MATERIALITY_EPSILON } from '../services/fund-moic-materiality.js';
 import { getFundMoicRankings } from '../services/fund-moic-ranking-service.js';
+import {
+  getLatestCompletedMoicReconciliation,
+  MoicReconciliationConflictError,
+  recordMoicReconciliation,
+} from '../services/fund-moic-reconciliation-service.js';
+import { buildRoundsToModelEvidence } from '../services/rounds-to-model-evidence-service.js';
 
 const router = Router();
 
@@ -26,6 +37,28 @@ function parseFundId(req: Request, res: Response): number | null {
   return parsed.data.fundId;
 }
 
+function numericIdentity(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return Number.parseInt(value, 10);
+  return null;
+}
+
+function resolveActorId(req: Request): number | null {
+  return numericIdentity(req.user?.id) ?? numericIdentity(req.user?.sub) ?? null;
+}
+
+function roundEvidenceSummary(coverage: {
+  activeRoundCount: number;
+  activeOverrideCount: number;
+  warningsByCode: Record<string, number>;
+}) {
+  return {
+    activeRoundCount: coverage.activeRoundCount,
+    activeOverrideCount: coverage.activeOverrideCount,
+    warningCodes: Object.keys(coverage.warningsByCode).sort(),
+  };
+}
+
 router.get(
   '/funds/:fundId/moic/rankings',
   requireAuth(),
@@ -34,8 +67,81 @@ router.get(
     const fundId = parseFundId(req, res);
     if (fundId === null) return;
 
-    const rankings = await getFundMoicRankings(fundId);
-    return res.json(rankings);
+    const contract = req.query.contract;
+    if (contract === undefined || contract === 'v1') {
+      const rankings = await getFundMoicRankings(fundId);
+      return res.json(rankings);
+    }
+
+    if (contract !== 'v2') {
+      return res.status(400).json({
+        error: 'invalid_contract',
+        message: 'contract must be v1 or v2',
+      });
+    }
+
+    const [rankings, latestReconciliation, evidence] = await Promise.all([
+      getFundMoicRankings(fundId),
+      getLatestCompletedMoicReconciliation(fundId),
+      buildRoundsToModelEvidence({ fundId }),
+    ]);
+
+    const response: FundMoicRankingsResponseV2 = {
+      contractVersion: '2.0.0',
+      fundId,
+      rankings: rankings.rankings,
+      provenance: { mode: 'legacy', warnings: [] },
+      latestReconciliation,
+      materiality: {
+        status: latestReconciliation ? 'recorded' : 'not_run',
+        candidateMaterial: false,
+        epsilon: MOIC_MATERIALITY_EPSILON,
+      },
+      roundEvidenceSummary: roundEvidenceSummary(evidence.coverage),
+      generatedAt: new Date().toISOString(),
+    };
+
+    return res.json(FundMoicRankingsResponseV2Schema.parse(response));
+  })
+);
+
+router.post(
+  '/admin/funds/:fundId/moic/reconciliations',
+  requireAuth(),
+  requireFundAccess,
+  requireRole('admin'),
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseFundId(req, res);
+    if (fundId === null) return;
+
+    const idempotencyKey = req.header('Idempotency-Key')?.trim();
+    if (!idempotencyKey) {
+      return res.status(428).json({
+        error: 'idempotency_key_required',
+        message: 'Idempotency-Key header is required',
+      });
+    }
+
+    try {
+      const { run, replayed } = await recordMoicReconciliation({
+        fundId,
+        idempotencyKey,
+        requestedBy: resolveActorId(req),
+      });
+      return res.status(replayed ? 200 : 201).json({
+        runId: run.runId,
+        createdAt: run.createdAt,
+        replayed,
+      });
+    } catch (error) {
+      if (error instanceof MoicReconciliationConflictError) {
+        return res.status(409).json({
+          error: 'idempotency_conflict',
+          message: error.message,
+        });
+      }
+      throw error;
+    }
   })
 );
 

--- a/server/services/fund-moic-materiality.ts
+++ b/server/services/fund-moic-materiality.ts
@@ -1,0 +1,77 @@
+/** No-op/materiality detector for MOIC reconciliation using epsilon-based rank-or-value sensitivity. */
+import type { FundMoicRankingItemV1 } from '../../shared/contracts/fund-moic-v1.contract';
+
+export const MOIC_MATERIALITY_EPSILON = 1e-8;
+
+export interface MoicMaterialityResult {
+  candidateMaterial: boolean;
+  comparedInvestmentCount: number;
+  rankChangeCount: number;
+  reservesMoicValueChangeCount: number;
+  materialChangeCount: number;
+}
+
+export function assessMoicMateriality(
+  legacy: readonly FundMoicRankingItemV1[],
+  candidate: readonly FundMoicRankingItemV1[],
+  epsilon: number = MOIC_MATERIALITY_EPSILON
+): MoicMaterialityResult {
+  const candidateById = new Map(candidate.map((item) => [item.investmentId, item]));
+  const legacyIds = new Set(legacy.map((item) => item.investmentId));
+  const comparedLegacyIds = new Set<string>();
+
+  let comparedInvestmentCount = 0;
+  let rankChangeCount = 0;
+  let reservesMoicValueChangeCount = 0;
+  let materialChangeCount = 0;
+
+  for (const legacyItem of legacy) {
+    const investmentId = legacyItem.investmentId;
+
+    if (comparedLegacyIds.has(investmentId)) {
+      continue;
+    }
+
+    comparedLegacyIds.add(investmentId);
+
+    const candidateItem = candidateById.get(investmentId);
+
+    if (!candidateItem) {
+      materialChangeCount += 1;
+      continue;
+    }
+
+    comparedInvestmentCount += 1;
+
+    const rankChanged = legacyItem.rank !== candidateItem.rank;
+    const legacyValue = legacyItem.reservesMoic.value ?? 0;
+    const candidateValue = candidateItem.reservesMoic.value ?? 0;
+    const valueChanged = Math.abs(legacyValue - candidateValue) > epsilon;
+
+    if (rankChanged) {
+      rankChangeCount += 1;
+    }
+
+    if (valueChanged) {
+      reservesMoicValueChangeCount += 1;
+    }
+
+    if (rankChanged || valueChanged) {
+      materialChangeCount += 1;
+    }
+  }
+
+  for (const candidateId of candidateById.keys()) {
+    if (!legacyIds.has(candidateId)) {
+      materialChangeCount += 1;
+    }
+  }
+
+  return {
+    candidateMaterial: materialChangeCount > 0,
+    comparedInvestmentCount,
+    rankChangeCount,
+    reservesMoicValueChangeCount,
+    materialChangeCount,
+  };
+}

--- a/server/services/fund-moic-reconciliation-service.ts
+++ b/server/services/fund-moic-reconciliation-service.ts
@@ -1,0 +1,165 @@
+import { and, desc, eq } from 'drizzle-orm';
+
+import { db } from '../db';
+import { canonicalSha256 } from '../../shared/lib/canonical-hash';
+import {
+  reconciliationRuns,
+  type InsertReconciliationRun,
+  type ReconciliationRun,
+} from '../../shared/schema';
+import {
+  assessMoicMateriality,
+  MOIC_MATERIALITY_EPSILON,
+} from './fund-moic-materiality';
+import { getFundMoicRankings } from './fund-moic-ranking-service';
+import { buildRoundsToModelEvidence } from './rounds-to-model-evidence-service';
+
+const MOIC_RECONCILIATION_CONTRACT_VERSION = '2.0.0';
+
+type MoicReconciliationDatabase = typeof db;
+
+type RoundEvidenceSummary = {
+  activeRoundCount: number;
+  activeOverrideCount: number;
+  warningCodes: string[];
+};
+
+export class MoicReconciliationConflictError extends Error {
+  readonly code = 'idempotency_conflict';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'MoicReconciliationConflictError';
+  }
+}
+
+export interface MoicReconciliationRunRef {
+  runId: string;
+  createdAt: string;
+}
+
+function runRef(row: Pick<ReconciliationRun, 'id' | 'requestedAt'>): MoicReconciliationRunRef {
+  return {
+    runId: String(row.id),
+    createdAt: row.requestedAt.toISOString(),
+  };
+}
+
+function summarizeRoundEvidence(coverage: {
+  activeRoundCount: number;
+  activeOverrideCount: number;
+  warningsByCode: Record<string, number>;
+}): RoundEvidenceSummary {
+  return {
+    activeRoundCount: coverage.activeRoundCount,
+    activeOverrideCount: coverage.activeOverrideCount,
+    warningCodes: Object.keys(coverage.warningsByCode).sort(),
+  };
+}
+
+function requestHashFor(fundId: number): string {
+  return canonicalSha256({
+    kind: 'moic_reconciliation',
+    fundId,
+    contractVersion: MOIC_RECONCILIATION_CONTRACT_VERSION,
+  });
+}
+
+async function loadReconciliationByIdempotencyKey(
+  idempotencyKey: string,
+  database: MoicReconciliationDatabase
+): Promise<ReconciliationRun | undefined> {
+  const [existing] = await database
+    .select()
+    .from(reconciliationRuns)
+    .where(eq(reconciliationRuns.idempotencyKey, idempotencyKey))
+    .limit(1);
+  return existing;
+}
+
+function replayOrConflict(
+  existing: ReconciliationRun,
+  requestHash: string
+): { run: MoicReconciliationRunRef; replayed: true } {
+  if (existing.requestHash !== requestHash) {
+    throw new MoicReconciliationConflictError('Idempotency-Key reused with a different request');
+  }
+  return { run: runRef(existing), replayed: true };
+}
+
+export async function getLatestCompletedMoicReconciliation(
+  fundId: number,
+  database: MoicReconciliationDatabase = db
+): Promise<MoicReconciliationRunRef | null> {
+  const [row] = await database
+    .select()
+    .from(reconciliationRuns)
+    .where(and(eq(reconciliationRuns.fundId, fundId), eq(reconciliationRuns.status, 'completed')))
+    .orderBy(desc(reconciliationRuns.requestedAt), desc(reconciliationRuns.id))
+    .limit(1);
+
+  return row ? runRef(row) : null;
+}
+
+export async function recordMoicReconciliation(params: {
+  fundId: number;
+  idempotencyKey: string;
+  requestedBy: number | null;
+  database?: MoicReconciliationDatabase;
+}): Promise<{ run: MoicReconciliationRunRef; replayed: boolean }> {
+  const database = params.database ?? db;
+  const requestHash = requestHashFor(params.fundId);
+  const existing = await loadReconciliationByIdempotencyKey(params.idempotencyKey, database);
+  if (existing) {
+    return replayOrConflict(existing, requestHash);
+  }
+
+  const legacy = await getFundMoicRankings(params.fundId);
+  const candidate = legacy;
+  const materiality = assessMoicMateriality(legacy.rankings, candidate.rankings);
+  const evidence = await buildRoundsToModelEvidence({ fundId: params.fundId, database });
+  const rankingsHash = canonicalSha256(legacy.rankings);
+  const roundEvidenceSummary = summarizeRoundEvidence(evidence.coverage);
+
+  const insertValues: InsertReconciliationRun = {
+    fundId: params.fundId,
+    idempotencyKey: params.idempotencyKey,
+    requestHash,
+    requestedBy: params.requestedBy,
+    status: 'completed',
+    legacyInputHash: rankingsHash,
+    candidateInputHash: rankingsHash,
+    evidenceInputHash: canonicalSha256(evidence.coverage),
+    assumptionsHash: canonicalSha256({
+      epsilon: MOIC_MATERIALITY_EPSILON,
+      contractVersion: MOIC_RECONCILIATION_CONTRACT_VERSION,
+    }),
+    legacyOutputHash: rankingsHash,
+    candidateOutputHash: rankingsHash,
+    candidateMaterial: false,
+    materialityEpsilon: MOIC_MATERIALITY_EPSILON,
+    diffSummary: {
+      comparedInvestmentCount: materiality.comparedInvestmentCount,
+      rankChangeCount: materiality.rankChangeCount,
+      reservesMoicValueChangeCount: materiality.reservesMoicValueChangeCount,
+      materialChangeCount: materiality.materialChangeCount,
+    },
+    roundEvidenceSummary,
+  };
+
+  const [inserted] = await database
+    .insert(reconciliationRuns)
+    .values(insertValues)
+    .onConflictDoNothing({ target: reconciliationRuns.idempotencyKey })
+    .returning();
+
+  if (inserted) {
+    return { run: runRef(inserted), replayed: false };
+  }
+
+  const replayed = await loadReconciliationByIdempotencyKey(params.idempotencyKey, database);
+  if (!replayed) {
+    throw new Error('Idempotency conflict did not return an existing MOIC reconciliation run');
+  }
+  return replayOrConflict(replayed, requestHash);
+}

--- a/shared/contracts/fund-moic-v2.contract.ts
+++ b/shared/contracts/fund-moic-v2.contract.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { FundMoicRankingItemV1Schema } from './fund-moic-v1.contract';
+
+export const FundMoicRankingsResponseV2Schema = z
+  .object({
+    contractVersion: z.literal('2.0.0'),
+    fundId: z.number().int().positive(),
+    rankings: z.array(FundMoicRankingItemV1Schema),
+    provenance: z
+      .object({ mode: z.literal('legacy'), warnings: z.array(z.string()) })
+      .strict(),
+    latestReconciliation: z
+      .object({
+        runId: z.string().nullable(),
+        createdAt: z.string().datetime().nullable(),
+      })
+      .strict()
+      .nullable(),
+    materiality: z
+      .object({
+        status: z.enum(['not_run', 'recorded']),
+        candidateMaterial: z.literal(false),
+        epsilon: z.literal(1e-8),
+      })
+      .strict(),
+    roundEvidenceSummary: z
+      .object({
+        activeRoundCount: z.number().int().nonnegative(),
+        activeOverrideCount: z.number().int().nonnegative(),
+        warningCodes: z.array(z.string()),
+      })
+      .strict(),
+    generatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export type FundMoicRankingsResponseV2 = z.infer<typeof FundMoicRankingsResponseV2Schema>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -33,6 +33,7 @@ export * from './schema/shares';
 export * from './schema/user';
 export * from './schema/lp-reporting-evidence';
 export * from './schema/operating-objects';
+export * from './schema/reconciliation-runs';
 export * from './schema/investment-rounds';
 export * from './schema/investment-round-model-overrides';
 export * from './schemas/flags';

--- a/shared/schema/reconciliation-runs.ts
+++ b/shared/schema/reconciliation-runs.ts
@@ -1,0 +1,55 @@
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  check,
+  doublePrecision,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { funds } from './fund';
+import { users } from './user';
+
+export const reconciliationRuns = pgTable(
+  'reconciliation_runs',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    idempotencyKey: text('idempotency_key').notNull().unique(),
+    requestHash: text('request_hash').notNull(),
+    requestedBy: integer('requested_by').references(() => users.id),
+    requestedAt: timestamp('requested_at', { withTimezone: true }).notNull().defaultNow(),
+    status: varchar('status', { length: 16 }).notNull().default('completed'),
+    legacyInputHash: text('legacy_input_hash').notNull(),
+    candidateInputHash: text('candidate_input_hash').notNull(),
+    evidenceInputHash: text('evidence_input_hash').notNull(),
+    assumptionsHash: text('assumptions_hash').notNull(),
+    legacyOutputHash: text('legacy_output_hash').notNull(),
+    candidateOutputHash: text('candidate_output_hash').notNull(),
+    candidateMaterial: boolean('candidate_material').notNull().default(false),
+    materialityEpsilon: doublePrecision('materiality_epsilon').notNull(),
+    diffSummary: jsonb('diff_summary').notNull(),
+    roundEvidenceSummary: jsonb('round_evidence_summary').notNull(),
+  },
+  (table) => ({
+    statusCheck: check(
+      'reconciliation_runs_status_check',
+      sql`${table.status} IN ('pending','completed','failed')`
+    ),
+    fundRequestedIdx: index('idx_reconciliation_runs_fund_requested').on(
+      table.fundId,
+      table.requestedAt.desc()
+    ),
+  })
+);
+
+export type ReconciliationRun = typeof reconciliationRuns.$inferSelect;
+export type InsertReconciliationRun = typeof reconciliationRuns.$inferInsert;

--- a/tests/unit/contract/fund-moic-v2.contract.test.ts
+++ b/tests/unit/contract/fund-moic-v2.contract.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FundMoicRankingsResponseV2Schema,
+  type FundMoicRankingsResponseV2,
+} from '../../../shared/contracts/fund-moic-v2.contract';
+
+/**
+ * Structural allowlist tests for the V2 read contract.
+ *
+ * PR-E's whole point is that the V2 surface leaks NO ranking values, monetary
+ * amounts, raw diffs, or per-investment shadow comparisons. A test that only
+ * checks "a valid payload parses" is vacuous against that goal. So every object
+ * here is pinned to an EXACT allowed key set, and `.strict()` is proven to
+ * reject an injected forbidden field on each nested object.
+ */
+
+const makeValidV2 = (): FundMoicRankingsResponseV2 => ({
+  contractVersion: '2.0.0',
+  fundId: 7,
+  rankings: [
+    {
+      rank: 1,
+      investmentId: 'inv-a',
+      investmentName: 'Acme',
+      reservesMoic: { value: 1.5, description: 'desc', formula: 'formula' },
+    },
+  ],
+  provenance: { mode: 'legacy', warnings: [] },
+  latestReconciliation: null,
+  materiality: { status: 'not_run', candidateMaterial: false, epsilon: 1e-8 },
+  roundEvidenceSummary: { activeRoundCount: 0, activeOverrideCount: 0, warningCodes: [] },
+  generatedAt: '2026-06-24T00:00:00.000Z',
+});
+
+describe('FundMoicRankingsResponseV2 contract — allowlist', () => {
+  it('accepts a fully valid V2 payload', () => {
+    expect(FundMoicRankingsResponseV2Schema.safeParse(makeValidV2()).success).toBe(true);
+  });
+
+  it('pins the EXACT top-level key set', () => {
+    const parsed = FundMoicRankingsResponseV2Schema.parse(makeValidV2());
+    expect(Object.keys(parsed).sort()).toEqual(
+      [
+        'contractVersion',
+        'fundId',
+        'generatedAt',
+        'latestReconciliation',
+        'materiality',
+        'provenance',
+        'rankings',
+        'roundEvidenceSummary',
+      ].sort()
+    );
+  });
+
+  it('pins the EXACT provenance key set', () => {
+    const parsed = FundMoicRankingsResponseV2Schema.parse(makeValidV2());
+    expect(Object.keys(parsed.provenance).sort()).toEqual(['mode', 'warnings'].sort());
+  });
+
+  it('pins the EXACT materiality key set', () => {
+    const parsed = FundMoicRankingsResponseV2Schema.parse(makeValidV2());
+    expect(Object.keys(parsed.materiality).sort()).toEqual(
+      ['candidateMaterial', 'epsilon', 'status'].sort()
+    );
+  });
+
+  it('pins the EXACT latestReconciliation key set (when present)', () => {
+    const payload = makeValidV2();
+    payload.latestReconciliation = { runId: 'run-1', createdAt: '2026-06-24T00:00:00.000Z' };
+    const parsed = FundMoicRankingsResponseV2Schema.parse(payload);
+    expect(parsed.latestReconciliation).not.toBeNull();
+    expect(Object.keys(parsed.latestReconciliation ?? {}).sort()).toEqual(
+      ['createdAt', 'runId'].sort()
+    );
+  });
+
+  it('pins the EXACT roundEvidenceSummary key set', () => {
+    const parsed = FundMoicRankingsResponseV2Schema.parse(makeValidV2());
+    expect(Object.keys(parsed.roundEvidenceSummary).sort()).toEqual(
+      ['activeOverrideCount', 'activeRoundCount', 'warningCodes'].sort()
+    );
+  });
+});
+
+describe('FundMoicRankingsResponseV2 contract — forbidden-field rejection', () => {
+  it('rejects a forbidden top-level leakage field', () => {
+    const bad = { ...makeValidV2(), rawDiff: [{ a: 1 }] };
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects monetary leakage smuggled at top level', () => {
+    const bad = { ...makeValidV2(), totalReservesUsd: 1_000_000 };
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a forbidden field on provenance', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error injecting a forbidden key
+    bad.provenance.candidateValues = [1, 2, 3];
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a forbidden field on materiality', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error injecting a forbidden key
+    bad.materiality.rawDelta = 0.42;
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a forbidden field on roundEvidenceSummary (no round IDs)', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error injecting a forbidden key
+    bad.roundEvidenceSummary.roundIds = ['r1', 'r2'];
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a forbidden field on latestReconciliation', () => {
+    const bad = makeValidV2();
+    bad.latestReconciliation = {
+      runId: 'run-1',
+      createdAt: '2026-06-24T00:00:00.000Z',
+      // @ts-expect-error injecting a forbidden key
+      legacyOutputHash: 'deadbeef',
+    };
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects per-investment leakage on a ranking item', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error injecting a forbidden per-investment field
+    bad.rankings[0].shadowComparison = { legacy: 0, candidate: 1 };
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe('FundMoicRankingsResponseV2 contract — literal/enum pins', () => {
+  it('rejects a contractVersion other than 2.0.0', () => {
+    const bad = { ...makeValidV2(), contractVersion: '1.0.0' };
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects provenance.mode other than legacy', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error narrowing literal
+    bad.provenance.mode = 'on';
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects materiality.candidateMaterial === true (PR-E candidate is a no-op)', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error literal false only
+    bad.materiality.candidateMaterial = true;
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a materiality.epsilon other than 1e-8', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error literal epsilon only
+    bad.materiality.epsilon = 1e-6;
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a materiality.status outside the enum', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error enum only
+    bad.materiality.status = 'on';
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('accepts materiality.status === recorded', () => {
+    const ok = makeValidV2();
+    ok.materiality.status = 'recorded';
+    expect(FundMoicRankingsResponseV2Schema.safeParse(ok).success).toBe(true);
+  });
+
+  it('accepts a null runId/createdAt inside a present latestReconciliation', () => {
+    const ok = makeValidV2();
+    ok.latestReconciliation = { runId: null, createdAt: null };
+    expect(FundMoicRankingsResponseV2Schema.safeParse(ok).success).toBe(true);
+  });
+});

--- a/tests/unit/hooks/use-moic-v2.test.tsx
+++ b/tests/unit/hooks/use-moic-v2.test.tsx
@@ -1,0 +1,98 @@
+import React, { type PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useFundMoicRankingsV2 } from '../../../client/src/hooks/use-moic';
+import type { FundMoicRankingsResponseV2 } from '../../../shared/contracts/fund-moic-v2.contract';
+
+function makeV2Response(fundId: number): FundMoicRankingsResponseV2 {
+  return {
+    contractVersion: '2.0.0',
+    fundId,
+    rankings: [
+      {
+        rank: 1,
+        investmentId: '101',
+        investmentName: 'Acme Corp',
+        reservesMoic: {
+          value: 0,
+          description: 'Expected return on planned reserves',
+          formula: 'reserve exit value / planned reserves',
+        },
+      },
+    ],
+    provenance: { mode: 'legacy', warnings: [] },
+    latestReconciliation: null,
+    materiality: { status: 'not_run', candidateMaterial: false, epsilon: 1e-8 },
+    roundEvidenceSummary: { activeRoundCount: 0, activeOverrideCount: 0, warningCodes: [] },
+    generatedAt: '2026-06-24T00:00:00.000Z',
+  };
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useFundMoicRankingsV2', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves a valid V2 payload and requests the v2 contract', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse(makeV2Response(5)));
+
+    const { result } = renderHook(() => useFundMoicRankingsV2(5), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.contractVersion).toBe('2.0.0');
+    expect(result.current.data?.materiality.status).toBe('not_run');
+    expect(fetchSpy).toHaveBeenCalledWith('/api/funds/5/moic/rankings?contract=v2', {
+      credentials: 'include',
+    });
+  });
+
+  it('rejects a payload that violates the strict V2 allowlist with CONTRACT_PARSE_ERROR', async () => {
+    // A forbidden top-level leakage field must fail the strict safeParse — the
+    // hook is the client-side enforcement point for the no-leakage contract.
+    const leaky = { ...makeV2Response(5), rawDiff: [{ legacy: 0, candidate: 1 }] };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(leaky));
+
+    const { result } = renderHook(() => useFundMoicRankingsV2(5), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.code).toBe('CONTRACT_PARSE_ERROR');
+  });
+
+  it.each<number | null>([null, 0, -1, Number.NaN])(
+    'does not fetch for non-positive or missing fund ID %s',
+    (fundId) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      renderHook(() => useFundMoicRankingsV2(fundId), { wrapper: createWrapper() });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/tests/unit/route-policy/canonical-moic-route.policy.test.ts
+++ b/tests/unit/route-policy/canonical-moic-route.policy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  API_ROUTE_POLICY_REGISTRY,
+  EXPLICIT_GOVERNANCE_POLICY_KEYS,
+  getFinancialSurfaceForGovernanceEntry,
+} from '../../../server/route-policy/api-route-policy-registry';
+import type { RouteGovernanceEntry } from '../../../client/src/app/route-governance-registry';
+
+const CANONICAL = '/fund-model-results/:fundId/moic-analysis';
+
+const entry = (path: string): RouteGovernanceEntry => ({
+  path,
+  surface: 'app-route',
+  exposure: 'internal-live',
+  isProtected: false,
+});
+
+describe('route-policy: canonical fund-model-results MOIC route', () => {
+  it('classifies the canonical MOIC route as moic_reserves, not fund_modeling', () => {
+    // Regression guard for Chunk 4b: the path starts with `/fund-model-results`,
+    // which would otherwise fall through to the `fund_modeling` branch. The
+    // exact-string `moic_reserves` branch is evaluated FIRST and must win.
+    expect(getFinancialSurfaceForGovernanceEntry(entry(CANONICAL))).toBe('moic_reserves');
+  });
+
+  it('still classifies a plain fund-model-results route as fund_modeling', () => {
+    expect(getFinancialSurfaceForGovernanceEntry(entry('/fund-model-results/:fundId'))).toBe(
+      'fund_modeling'
+    );
+  });
+
+  it('registers a governance policy decision for the canonical MOIC route', () => {
+    // Without this decisions-map entry, buildGovernancePolicyEntry returns
+    // undefined and the route would silently get no policy entry once it lands
+    // in ROUTE_GOVERNANCE_REGISTRY (added by Chunk 4).
+    expect(EXPLICIT_GOVERNANCE_POLICY_KEYS.has(CANONICAL)).toBe(true);
+  });
+
+  it('surfaces the canonical MOIC route in the BUILT policy registry as moic_reserves', () => {
+    // End-to-end of the Chunk 4 + Chunk 4b coupling: the client route definition
+    // (APP_ROUTE_DEFINITIONS -> ROUTE_GOVERNANCE_REGISTRY), the classifier branch,
+    // and the decisions-map entry must all line up for the route to materialize
+    // in the built policy registry with the correct surface.
+    const entry = API_ROUTE_POLICY_REGISTRY.find((candidate) => candidate.path === CANONICAL);
+    expect(entry).toBeDefined();
+    expect(entry?.financialSurface).toBe('moic_reserves');
+  });
+});

--- a/tests/unit/routes/fund-moic-route-contract.test.ts
+++ b/tests/unit/routes/fund-moic-route-contract.test.ts
@@ -29,7 +29,7 @@ describe('fund-moic route contract', () => {
 
   it('branches the GET on a v1/v2 contract query and rejects unknown contracts', async () => {
     const source = await readRepoFile('server/routes/fund-moic.ts');
-    expect(source).toContain('req.query.contract');
+    expect(source).toContain("req.query['contract']");
     expect(source).toContain("'v2'");
     expect(source).toContain('invalid_contract');
     // V2 output is re-validated against the strict allowlist contract.

--- a/tests/unit/routes/fund-moic-route-contract.test.ts
+++ b/tests/unit/routes/fund-moic-route-contract.test.ts
@@ -26,4 +26,29 @@ describe('fund-moic route contract', () => {
     const source = await readRepoFile('server/routes/fund-moic.ts');
     expect(source).toContain('getFundMoicRankings');
   });
+
+  it('branches the GET on a v1/v2 contract query and rejects unknown contracts', async () => {
+    const source = await readRepoFile('server/routes/fund-moic.ts');
+    expect(source).toContain('req.query.contract');
+    expect(source).toContain("'v2'");
+    expect(source).toContain('invalid_contract');
+    // V2 output is re-validated against the strict allowlist contract.
+    expect(source).toContain('FundMoicRankingsResponseV2Schema.parse');
+  });
+
+  it('exposes the admin reconciliation POST with role + idempotency guards', async () => {
+    const source = await readRepoFile('server/routes/fund-moic.ts');
+    expect(source).toContain('/admin/funds/:fundId/moic/reconciliations');
+    expect(source).toContain("requireRole('admin')");
+    expect(source).toContain('Idempotency-Key');
+    expect(source).toContain('recordMoicReconciliation');
+  });
+
+  it('maps the idempotency lifecycle to 428 (missing key), 409 (conflict), 201/200 (new/replay)', async () => {
+    const source = await readRepoFile('server/routes/fund-moic.ts');
+    expect(source).toContain('428');
+    expect(source).toContain('MoicReconciliationConflictError');
+    expect(source).toContain('409');
+    expect(source).toContain('replayed ? 200 : 201');
+  });
 });

--- a/tests/unit/services/fund-moic-materiality.test.ts
+++ b/tests/unit/services/fund-moic-materiality.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assessMoicMateriality,
+  MOIC_MATERIALITY_EPSILON,
+} from '../../../server/services/fund-moic-materiality';
+import type { FundMoicRankingItemV1 } from '../../../shared/contracts/fund-moic-v1.contract';
+
+const item = (
+  investmentId: string,
+  rank: number,
+  value: number | null
+): FundMoicRankingItemV1 => ({
+  rank,
+  investmentId,
+  investmentName: investmentId,
+  reservesMoic: { value, description: 'd', formula: 'f' },
+});
+
+describe('assessMoicMateriality', () => {
+  it('exposes the fixed epsilon', () => {
+    expect(MOIC_MATERIALITY_EPSILON).toBe(1e-8);
+  });
+
+  it('treats identical legacy/candidate as immaterial', () => {
+    const legacy = [item('1', 1, 3.5), item('2', 2, 2.0)];
+    const candidate = [item('1', 1, 3.5), item('2', 2, 2.0)];
+    const result = assessMoicMateriality(legacy, candidate);
+    expect(result).toEqual({
+      candidateMaterial: false,
+      comparedInvestmentCount: 2,
+      rankChangeCount: 0,
+      reservesMoicValueChangeCount: 0,
+      materialChangeCount: 0,
+    });
+  });
+
+  it('treats a value delta strictly within epsilon as immaterial', () => {
+    const legacy = [item('1', 1, 1.0)];
+    const candidate = [item('1', 1, 1.0 + MOIC_MATERIALITY_EPSILON)];
+    const result = assessMoicMateriality(legacy, candidate);
+    // delta === epsilon is NOT > epsilon
+    expect(result.candidateMaterial).toBe(false);
+    expect(result.reservesMoicValueChangeCount).toBe(0);
+  });
+
+  it('treats a value delta exceeding epsilon as material', () => {
+    const legacy = [item('1', 1, 1.0)];
+    const candidate = [item('1', 1, 1.0 + 2 * MOIC_MATERIALITY_EPSILON)];
+    const result = assessMoicMateriality(legacy, candidate);
+    expect(result.candidateMaterial).toBe(true);
+    expect(result.reservesMoicValueChangeCount).toBe(1);
+    expect(result.materialChangeCount).toBe(1);
+    expect(result.rankChangeCount).toBe(0);
+  });
+
+  it('treats a rank change alone as material', () => {
+    const legacy = [item('1', 1, 3.5), item('2', 2, 2.0)];
+    const candidate = [item('1', 2, 3.5), item('2', 1, 2.0)];
+    const result = assessMoicMateriality(legacy, candidate);
+    expect(result.candidateMaterial).toBe(true);
+    expect(result.rankChangeCount).toBe(2);
+    expect(result.materialChangeCount).toBe(2);
+    expect(result.reservesMoicValueChangeCount).toBe(0);
+  });
+
+  it('counts an added/removed investment as a material change, not a comparison', () => {
+    const legacy = [item('1', 1, 3.5)];
+    const candidate = [item('1', 1, 3.5), item('2', 2, 2.0)];
+    const result = assessMoicMateriality(legacy, candidate);
+    expect(result.comparedInvestmentCount).toBe(1);
+    expect(result.materialChangeCount).toBe(1);
+    expect(result.candidateMaterial).toBe(true);
+  });
+
+  it('treats null reservesMoic.value as 0 for the delta', () => {
+    const legacy = [item('1', 1, null)];
+    const candidate = [item('1', 1, 0)];
+    const result = assessMoicMateriality(legacy, candidate);
+    expect(result.candidateMaterial).toBe(false);
+  });
+
+  it('detects a FUTURE positive exitProbability candidate as material', () => {
+    // Today the live adapter null-coerces exitProbability -> reservesMoic.value 0.
+    // The day a real exitProbability/plannedReserves/reserveExitMultiple source
+    // lands, the candidate values become positive. This proves the detector fires.
+    const legacyAllZero = [item('1', 1, 0), item('2', 2, 0)];
+    const candidateWithProbability = [item('1', 1, 2.45), item('2', 2, 1.4)];
+    const result = assessMoicMateriality(legacyAllZero, candidateWithProbability);
+    expect(result.candidateMaterial).toBe(true);
+    expect(result.reservesMoicValueChangeCount).toBe(2);
+  });
+
+  it('honors a caller-supplied epsilon override', () => {
+    const legacy = [item('1', 1, 1.0)];
+    const candidate = [item('1', 1, 1.5)];
+    expect(assessMoicMateriality(legacy, candidate, 1).candidateMaterial).toBe(false);
+    expect(assessMoicMateriality(legacy, candidate, 0.1).candidateMaterial).toBe(true);
+  });
+});

--- a/tests/unit/services/fund-moic-ranking-service.test.ts
+++ b/tests/unit/services/fund-moic-ranking-service.test.ts
@@ -143,4 +143,65 @@ describe('fund MOIC ranking service', () => {
     expect(result.provenance.metricBasis).toBe('planned_reserves');
     expect(result.rankings).toHaveLength(1);
   });
+
+  // --- PR-E characterization: pin current (defective) live behavior ---
+
+  it('pins the live defect: getFundMoicRankings hardcodes exitProbability=null, so probability-weighted reservesMoic collapses to 0 even when the source row carries a real exit probability', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Acme',
+        investmentAmount: 500_000,
+        currentValuation: 1_500_000,
+        plannedReservesCents: 300_000_00, // non-zero planned reserves
+        exitMoicBps: 35000, // non-zero reserve exit multiple (350x)
+        exitProbability: 0.8, // real, non-null probability in the source row
+        investmentDate: new Date('2022-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const { getFundMoicRankings } = await import(
+      '../../../server/services/fund-moic-ranking-service'
+    );
+    const result = await getFundMoicRankings(10);
+
+    // DEFECT pinned: getFundMoicRankings maps every company with a hardcoded
+    // exitProbability: null (it never reads the source column), so
+    // calculateReservesMOIC(applyProbability=true) multiplies by 0 -> the
+    // reservesMoic.value is 0 regardless of the real 0.8 above. The 0.8 is
+    // deliberately ignored here to prove the column is dropped, not just null.
+    // V2 shadow reconciliation exists to surface/correct this; pin V1 behavior.
+    expect(result.rankings[0]?.reservesMoic.value).toBe(0);
+  });
+
+  it('characterizes follow-on/initial-only changes as no-ops for reserves MOIC value and rank', () => {
+    const base: Investment[] = [
+      makeInvestment({ id: '1', name: 'A', reserveExitMultiple: 3.0 }),
+      makeInvestment({ id: '2', name: 'B', reserveExitMultiple: 2.0 }),
+    ];
+    const followOnAndInitialChanged: Investment[] = [
+      makeInvestment({
+        id: '1',
+        name: 'A',
+        reserveExitMultiple: 3.0,
+        followOnInvestment: 999_999,
+        initialInvestment: 12_345,
+      }),
+      makeInvestment({
+        id: '2',
+        name: 'B',
+        reserveExitMultiple: 2.0,
+        followOnInvestment: 5,
+        initialInvestment: 1,
+      }),
+    ];
+
+    const before = buildMoicRankingsFromInvestments(1, base);
+    const after = buildMoicRankingsFromInvestments(1, followOnAndInitialChanged);
+
+    const project = (r: typeof before) =>
+      r.rankings.map((x) => [x.investmentId, x.rank, x.reservesMoic.value]);
+
+    expect(project(after)).toEqual(project(before));
+  });
 });


### PR DESCRIPTION
## Summary

PR-E extends the fund MOIC V1 surface with an opt-in V2 read contract, admin-triggered idempotent reconciliation recording, and a canonical route — **without** activating `on` mode, `fund_calculation_modes`, residency, or a kill switch. Default V1 stays byte-for-byte identical and side-effect free.

The PR-E candidate is a deliberate **no-op** for reserves MOIC: `candidateMaterial` is hard-`false` until a future `exitProbability` / `plannedReserves` / `reserveExitMultiple` source is introduced. The materiality detector is built and tested now so that a future material candidate is provably caught.

### Defect this pins (does not fix)

`getFundMoicRankings` (`server/services/fund-moic-ranking-service.ts`) hardcodes `exitProbability: null` at the `dbToMOICInvestment` mapping site — the column is never read. `rankByReservesMOIC` applies probability, so live V1 `reservesMoic.value` collapses to `0` for every company with reserves. This is a dropped-column defect, not a null-data bug. A characterization test feeds a real `0.8` and still asserts `0`, pinning current behavior so the future fix is a deliberate, reviewed change.

## What's in scope

- **V2 read contract** (`shared/contracts/fund-moic-v2.contract.ts`, strict, reuses `FundMoicRankingItemV1Schema`).
- **`reconciliation_runs`** Drizzle schema + barrel export + hand-written replay-safe migration `0016_reconciliation_runs.sql` (`CREATE TABLE IF NOT EXISTS`). Persists **counts + hashes only** — no raw ranking arrays, monetary values, or per-investment diffs.
- **Materiality detector** (`server/services/fund-moic-materiality.ts`, `MOIC_MATERIALITY_EPSILON = 1e-8`) — pure injectable comparator.
- **Idempotent reconciliation service** (`server/services/fund-moic-reconciliation-service.ts`) — load→replay / 409 on hash mismatch; `onConflictDoNothing` + re-load for the insert race.
- **Route branches** in `server/routes/fund-moic.ts`:
  - `GET /api/funds/:fundId/moic/rankings?contract=v2` — strict V2 read, side-effect free, unknown `contract` → 400.
  - `POST /api/admin/funds/:fundId/moic/reconciliations` — `requireAuth` + `requireFundAccess` + `requireRole('admin')`; missing `Idempotency-Key` → 428, reuse-with-different-hash → 409, new → 201 / replay → 200.
- **Canonical route** `/fund-model-results/:fundId/moic-analysis` (client) using the V2 hook; legacy `/moic-analysis` left untouched (deprecation deferred).
- **Route-policy** classifier exact-string branch (ordered before the `/fund-model-results` → `fund_modeling` fallthrough) + governance registry entry → canonical route classifies as `moic_reserves`.

## Out of scope (deferred)

`fund_calculation_modes`, `modePreview`, seven-day residency, kill switch, `on` mode, visible round-aware ranking claims.

## Verification

- Local: `guard:round-derived-financial-claims:check` passes. (Local toolchain is degraded — no vitest/tsx — so CI is the verifier for `policy:verify`, `release:check`, and the targeted Vitest suites.)
- CI runs the full unit suite (`tests/unit/**`) on this PR, including: V2 contract strict-allowlist tests, materiality epsilon + future-material proof, ranking-service characterization (pins the `exitProbability` defect), route-contract test, V2 hook strict `safeParse` test, and the canonical-route policy classification test.

## Known follow-up (not in this PR)

Behavioral DB-mocked idempotency test exercising the POST through the Express app (replay / 409 / 428 / insert-race) and a canonical-page render test. Current coverage is source-contract + policy + hook level; the runtime replay/conflict path is the highest-risk code and warrants a behavioral test next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
