### PR TITLE
fix(schema): use unique() constraints for FK-referenced composite keys

### DIFF
--- a/shared/schema/investment-round-model-overrides.ts
+++ b/shared/schema/investment-round-model-overrides.ts
@@ -9,6 +9,7 @@ import {
   serial,
   text,
   timestamp,
+  unique,
   uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
@@ -61,7 +62,10 @@ export const investmentRoundModelOverrides = pgTable(
     supersedesUniqueIdx: uniqueIndex('investment_round_model_overrides_supersedes_uq')
       .on(table.supersedesOverrideId)
       .where(sql`supersedes_override_id IS NOT NULL`),
-    idFundRoundUniqueIdx: uniqueIndex('investment_round_model_overrides_id_fund_round_uq').on(
+    // FK target for supersedes_lineage_fk (self-reference). Must be a UNIQUE
+    // CONSTRAINT (not a unique index) so drizzle-kit push creates it before the
+    // FK phase; a uniqueIndex is created after FKs -> PG 42830 aborts the push.
+    idFundRoundUnique: unique('investment_round_model_overrides_id_fund_round_uq').on(
       table.id,
       table.fundId,
       table.roundId

--- a/shared/schema/investment-rounds.ts
+++ b/shared/schema/investment-rounds.ts
@@ -92,7 +92,11 @@ export const investmentRounds = pgTable(
       table.fundId,
       table.idempotencyKey
     ),
-    idFundUniqueIdx: uniqueIndex('investment_rounds_id_fund_uq').on(table.id, table.fundId),
+    // FK target for investment_round_model_overrides.round_fund_fk. Must be a
+    // UNIQUE CONSTRAINT (not a unique index): drizzle-kit push creates table
+    // constraints before the cross-table FK phase, whereas uniqueIndex is
+    // created after FKs -> PG 42830 aborts the push (see investments.id_fund_id_key).
+    idFundUnique: unique('investment_rounds_id_fund_uq').on(table.id, table.fundId),
     supersedesUniqueIdx: uniqueIndex('investment_rounds_supersedes_uq')
       .on(table.supersedesRoundId)
       .where(sql`supersedes_round_id IS NOT NULL`),


### PR DESCRIPTION
drizzle-kit push creates table UNIQUE constraints before the cross-table FK phase but creates uniqueIndex objects after it. investment_rounds(id, fund_id) and investment_round_model_overrides(id, fund_id, round_id) were declared as uniqueIndex yet are FK targets, so push aborted with PG 42830 ("no unique constraint matching given keys for referenced table") before any CREATE INDEX ran -- leaving investment_lots and forecast_snapshots without their secondary indexes and failing 3 portfolio-schema integration tests.

The failure was masked on main because drizzle-kit push exits 0 on error.

Convert the two FK-referenced uniqueIndexes to unique() constraints (matching the working investments.id_fund_id_key precedent). Partial uniqueIndexes (WHERE clauses, not FK targets) are unchanged. Index names are preserved. Prod migrations already create these via CREATE UNIQUE INDEX before the FK, so prod is unaffected (db:push is never run against prod).

Verified locally against a fresh db:push: completes with no 42830 and all previously-missing indexes present on both tables.