### PR TITLE
test(wizard): unit-cover fee/exit-recycling step auto-save

### DIFF
--- a/client/src/components/modeling-wizard/steps/FeesExpensesStep.tsx
+++ b/client/src/components/modeling-wizard/steps/FeesExpensesStep.tsx
@@ -17,7 +17,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { feesExpensesSchema, type FeesExpensesInput } from '@/schemas/modeling-wizard.schemas';
-import { useDebounceDeep } from '@/hooks/useDebounceDeep';
 
 export interface FeesExpensesStepProps {
   initialData?: Partial<FeesExpensesInput>;
@@ -54,19 +53,32 @@ export function FeesExpensesStep({ initialData, onSave }: FeesExpensesStepProps)
 
   const stepDownEnabled = watch('managementFee.stepDown.enabled');
 
-  // Watch all form values and debounce to prevent infinite save loop
-  // watch() returns new object every render, defeating memoization
-  // useDebounceDeep uses JSON-based deep equality to stabilize references
-  const formValues = watch();
-  const debouncedFormValues = useDebounceDeep(formValues, 250);
-
-  // Auto-save when valid (uses debounced value to prevent 460+ saves/sec)
+  // Auto-save valid edits without depending on watch() object identity across renders.
   React.useEffect(() => {
-    const result = feesExpensesSchema.safeParse(debouncedFormValues);
-    if (result.success) {
-      onSave(result.data);
-    }
-  }, [debouncedFormValues, onSave]);
+    let saveTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    const subscription = watch((value) => {
+      if (saveTimeout) {
+        clearTimeout(saveTimeout);
+        saveTimeout = null;
+      }
+
+      const result = feesExpensesSchema.safeParse(value);
+      if (result.success) {
+        saveTimeout = setTimeout(() => {
+          onSave(result.data);
+          saveTimeout = null;
+        }, 250);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+      if (saveTimeout) {
+        clearTimeout(saveTimeout);
+      }
+    };
+  }, [watch, onSave]);
 
   // Toggle handler with preservation pattern
   const handleStepDownToggle = (enabled: boolean) => {

--- a/tests/unit/exit-recycling-step.test.tsx
+++ b/tests/unit/exit-recycling-step.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { act } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ExitRecyclingStep } from '@/components/modeling-wizard/steps/ExitRecyclingStep';
+import type {
+  ExitRecyclingInput,
+  FundFinancialsOutput,
+} from '@/schemas/modeling-wizard.schemas';
+
+const fundFinancials: FundFinancialsOutput = {
+  fundSize: 100,
+  orgExpenses: 0,
+  additionalExpenses: [],
+  investmentPeriod: 5,
+  gpCommitment: 1,
+  cashlessSplit: 50,
+  managementFee: { rate: 2, stepDown: { enabled: false } },
+};
+
+const enabledExitRecycling: ExitRecyclingInput = {
+  enabled: true,
+  recyclingCap: 15,
+  recyclingPeriod: 5,
+  exitRecyclingRate: 75,
+  mgmtFeeRecyclingRate: 0,
+};
+
+function getInput(label: RegExp): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
+}
+
+async function advanceTimers(ms: number) {
+  await act(async () => {
+    await Promise.resolve();
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+}
+
+describe('ExitRecyclingStep', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('auto-saves valid recycling inputs after the debounce window', async () => {
+    const onSave = vi.fn<(data: ExitRecyclingInput) => void>();
+    render(
+      <ExitRecyclingStep
+        initialData={enabledExitRecycling}
+        onSave={onSave}
+        fundFinancials={fundFinancials}
+      />
+    );
+
+    fireEvent.change(getInput(/^Recycling Period \(years\)/i), {
+      target: { value: '7' },
+    });
+
+    await advanceTimers(499);
+    expect(onSave).not.toHaveBeenCalled();
+
+    await advanceTimers(1);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    const saved = onSave.mock.calls.at(-1)?.[0];
+    expect(saved?.enabled).toBe(true);
+    expect(saved?.recyclingPeriod).toBe(7);
+    expect(saved?.recyclingCap).toBe(15);
+    expect(saved?.exitRecyclingRate).toBe(75);
+  });
+
+  it('flushes the last valid recycling data on unmount before the debounce fires', async () => {
+    const onSave = vi.fn<(data: ExitRecyclingInput) => void>();
+    const { unmount } = render(
+      <ExitRecyclingStep
+        initialData={enabledExitRecycling}
+        onSave={onSave}
+        fundFinancials={fundFinancials}
+      />
+    );
+
+    fireEvent.change(getInput(/^Recycling Period \(years\)/i), {
+      target: { value: '6' },
+    });
+
+    expect(onSave).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls.at(-1)?.[0].recyclingPeriod).toBe(6);
+
+    await advanceTimers(500);
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves all recycling fields while recycling is disabled', async () => {
+    const onSave = vi.fn<(data: ExitRecyclingInput) => void>();
+    render(
+      <ExitRecyclingStep
+        initialData={{
+          enabled: true,
+          recyclingCap: 20,
+          recyclingPeriod: 6,
+          exitRecyclingRate: 80,
+          mgmtFeeRecyclingRate: 35,
+        }}
+        onSave={onSave}
+        fundFinancials={fundFinancials}
+      />
+    );
+
+    expect(Number(getInput(/^Recycling Cap/i).value)).toBe(20);
+    expect(getInput(/^Recycling Period \(years\)/i)).toHaveValue(6);
+    expect(Number(getInput(/^Exit Recycling Rate/i).value)).toBe(80);
+    expect(getInput(/^Management Fee Recycling Rate/i)).toHaveValue(35);
+
+    const recyclingSwitch = screen.getByRole('switch', { name: /enable exit recycling/i });
+    fireEvent.click(recyclingSwitch);
+
+    expect(screen.queryByLabelText(/^Recycling Cap/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Recycling Period \(years\)/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Exit Recycling Rate/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Management Fee Recycling Rate/i)).not.toBeInTheDocument();
+
+    fireEvent.click(recyclingSwitch);
+
+    expect(Number(getInput(/^Recycling Cap/i).value)).toBe(20);
+    expect(getInput(/^Recycling Period \(years\)/i)).toHaveValue(6);
+    expect(Number(getInput(/^Exit Recycling Rate/i).value)).toBe(80);
+    expect(getInput(/^Management Fee Recycling Rate/i)).toHaveValue(35);
+  });
+});

--- a/tests/unit/fees-expenses-step.test.tsx
+++ b/tests/unit/fees-expenses-step.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { act } from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeesExpensesStep } from '@/components/modeling-wizard/steps/FeesExpensesStep';
+import type { FeesExpensesInput } from '@/schemas/modeling-wizard.schemas';
+
+const baseFeesExpenses: FeesExpensesInput = {
+  managementFee: {
+    rate: 2,
+    basis: 'committed',
+    stepDown: { enabled: false },
+  },
+  adminExpenses: {
+    annualAmount: 0.5,
+    growthRate: 3,
+  },
+};
+
+function getInput(label: RegExp): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
+}
+
+async function waitForRealTimers(ms: number) {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+}
+
+function setupUser() {
+  return userEvent.setup();
+}
+
+describe('FeesExpensesStep', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('auto-saves valid fee and admin inputs after the debounce window', async () => {
+    const user = setupUser();
+    const onSave = vi.fn<(data: FeesExpensesInput) => void>();
+    render(<FeesExpensesStep initialData={baseFeesExpenses} onSave={onSave} />);
+
+    onSave.mockClear();
+
+    await user.clear(getInput(/^Rate \(%\)/i));
+    await user.type(getInput(/^Rate \(%\)/i), '2.5');
+    await user.clear(getInput(/^Annual Amount/i));
+    await user.type(getInput(/^Annual Amount/i), '0.75');
+
+    expect(getInput(/^Rate \(%\)/i)).toHaveValue(2.5);
+    expect(getInput(/^Annual Amount/i)).toHaveValue(0.75);
+    expect(onSave).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+
+    const saved = onSave.mock.calls.at(-1)?.[0];
+    expect(saved?.managementFee.rate).toBe(2.5);
+    expect(saved?.managementFee.basis).toBe('committed');
+    expect(saved?.adminExpenses.annualAmount).toBe(0.75);
+    expect(saved?.adminExpenses.growthRate).toBe(3);
+  });
+
+  it('does not save invalid management-fee values', async () => {
+    const user = setupUser();
+    const onSave = vi.fn<(data: FeesExpensesInput) => void>();
+    render(<FeesExpensesStep initialData={baseFeesExpenses} onSave={onSave} />);
+
+    onSave.mockClear();
+
+    await user.clear(getInput(/^Rate \(%\)/i));
+    await user.type(getInput(/^Rate \(%\)/i), '6');
+    await waitForRealTimers(350);
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('preserves step-down fields while the section is toggled off', async () => {
+    const onSave = vi.fn<(data: FeesExpensesInput) => void>();
+    render(
+      <FeesExpensesStep
+        initialData={{
+          ...baseFeesExpenses,
+          managementFee: {
+            ...baseFeesExpenses.managementFee,
+            rate: 2.5,
+            stepDown: { enabled: true, afterYear: 5, newRate: 1.5 },
+          },
+        }}
+        onSave={onSave}
+      />
+    );
+
+    expect(getInput(/^After Year$/i)).toHaveValue(5);
+    expect(getInput(/^New Rate/i)).toHaveValue(1.5);
+
+    const stepDownSwitch = screen.getByRole('switch', { name: /enable fee step-down/i });
+    fireEvent.click(stepDownSwitch);
+
+    expect(screen.queryByLabelText(/^After Year$/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^New Rate/i)).not.toBeInTheDocument();
+
+    fireEvent.click(stepDownSwitch);
+
+    expect(getInput(/^After Year$/i)).toHaveValue(5);
+    expect(getInput(/^New Rate/i)).toHaveValue(1.5);
+
+    await waitFor(() => {
+      const saved = onSave.mock.calls.at(-1)?.[0];
+      expect(saved?.managementFee.stepDown).toMatchObject({
+        enabled: true,
+        afterYear: 5,
+        newRate: 1.5,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds jsdom unit coverage for two modeling-wizard steps that had none, plus a small auto-save refactor in `FeesExpensesStep`.

- **New:** `tests/unit/fees-expenses-step.test.tsx` (3 tests), `tests/unit/exit-recycling-step.test.tsx` (3 tests)
- **Modified:** `client/src/components/modeling-wizard/steps/FeesExpensesStep.tsx`

## Why
`FeesExpensesStep` / `ExitRecyclingStep` had no co-located unit coverage — only an e2e nav spec and calculation-level tests. These exercise the behavior directly: debounced auto-save, validation gating (invalid management-fee values don't save), and field preservation across a section toggle.

The source change replaces `useDebounceDeep(watch(), 250)` with RHF's `watch(callback)` subscription + a manual 250ms debounce: it fires on value changes only (no new object every render) and clears its timer on unmount. Behavior (250ms debounce, save-when-valid) is preserved; the tests pin it.

## Verification
- `tests/unit/fees-expenses-step.test.tsx` + `tests/unit/exit-recycling-step.test.tsx`: **6/6 pass** (`--project=client`)
- `npm run check`: 0 new TypeScript errors
- targeted ESLint (`--max-warnings 0`) on all 3 files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
