### PR TITLE
fix(cors): allow Idempotency-Key preflight; prove MOIC admin surfaces

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -99,7 +99,7 @@ export function makeApp() {
       res.setHeader('Access-Control-Allow-Credentials', 'true');
       res.setHeader(
         'Access-Control-Allow-Headers',
-        'content-type, authorization, x-request-id, if-match'
+        'content-type, authorization, x-request-id, if-match, idempotency-key'
       );
       res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
     }

--- a/tests/unit/routes/fund-moic-admin-inputs.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-admin-inputs.behavior.test.ts
@@ -1,0 +1,264 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  user: null as null | { id: number | string; sub?: string; role: string; fundIds: number[] },
+}));
+const svc = vi.hoisted(() => ({ updateFundMoicInputs: vi.fn() }));
+
+vi.mock('../../../server/services/fund-moic-input-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-moic-input-service')>();
+  return { ...actual, updateFundMoicInputs: svc.updateFundMoicInputs };
+});
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
+      if (!authState.user) return res.sendStatus(401);
+      (req as Request & { user: unknown }).user = { ...authState.user };
+      next();
+    },
+  };
+});
+
+import fundMoicRouter from '../../../server/routes/fund-moic';
+import {
+  FundMoicInputIdempotencyConflictError,
+  FundMoicInputInProgressError,
+  FundMoicInputNotFoundError,
+  FundMoicInputVersionConflictError,
+} from '../../../server/services/fund-moic-input-service';
+
+const validBody = { expectedVersion: 3, exitProbability: 0.8, exitMoicBps: 35000 };
+const successResult = {
+  response: {
+    fundId: 1,
+    companyId: 12,
+    allocationVersion: 4,
+    exitProbability: 0.8,
+    exitMoicBps: 35000,
+  },
+  replayed: false,
+};
+const ADMIN = { id: 101, role: 'admin', fundIds: [1] };
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', fundMoicRouter);
+  app.use((_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
+    res.status(500).json({ error: 'internal_error' })
+  );
+  return app;
+}
+
+function put(
+  fundId: number | string,
+  companyId: number | string,
+  options: { key?: string; body?: unknown } = {}
+) {
+  const req = request(buildApp()).put(
+    `/api/admin/funds/${fundId}/moic-inputs/portfolio-companies/${companyId}`
+  );
+  if (options.key !== undefined) req.set('Idempotency-Key', options.key);
+  return req.send(options.body ?? validBody);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = null;
+  svc.updateFundMoicInputs.mockResolvedValue(successResult);
+});
+
+describe('fund MOIC admin input route - behavioral state machine', () => {
+  it('401 when unauthenticated, with zero service work', async () => {
+    authState.user = null;
+    const res = await put(1, 12, { key: 'k-401' });
+
+    expect(res.status).toBe(401);
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('400 on non-numeric fundId via requireFundAccess, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put('abc', 12, { key: 'k-fund' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Bad Request', message: 'Invalid fund ID' });
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('400 on invalid company id, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, 'abc', { key: 'k-company' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: 'invalid_company_id',
+      message: 'Company ID must be a positive integer',
+    });
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('428 when Idempotency-Key header is missing, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, 12);
+
+    expect(res.status).toBe(428);
+    expect(res.body).toEqual({
+      error: 'idempotency_key_required',
+      message: 'Idempotency-Key header is required',
+    });
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('428 when Idempotency-Key is whitespace only, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, 12, { key: '   ' });
+
+    expect(res.status).toBe(428);
+    expect(res.body).toEqual({
+      error: 'idempotency_key_required',
+      message: 'Idempotency-Key header is required',
+    });
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('400 on invalid body, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, 12, {
+      key: 'k-invalid-body',
+      body: { expectedVersion: 3, exitProbability: 1.5, exitMoicBps: 35000 },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_moic_input_update' });
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('400 on unknown body field, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, 12, {
+      key: 'k-unknown-body',
+      body: { ...validBody, surprise: true },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_moic_input_update' });
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('403 for a non-admin who has fund access, with zero service work', async () => {
+    authState.user = { id: 102, role: 'analyst', fundIds: [1] };
+    const res = await put(1, 12, { key: 'k-role' });
+
+    expect(res.status).toBe(403);
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('403 for an admin without fund access, with zero service work', async () => {
+    authState.user = { id: 101, role: 'admin', fundIds: [999] };
+    const res = await put(1, 12, { key: 'k-access' });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden', message: 'You do not have access to fund 1' });
+    expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
+  });
+
+  it('404 when the service reports a missing MOIC input row', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicInputs.mockRejectedValue(new FundMoicInputNotFoundError(1, 12));
+    const res = await put(1, 12, { key: 'k-404' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: 'moic_input_not_found' });
+  });
+
+  it('409 when the service reports a stale expected version', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicInputs.mockRejectedValue(new FundMoicInputVersionConflictError(3, 5));
+    const res = await put(1, 12, { key: 'k-version' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: 'stale_expected_version',
+      expectedVersion: 3,
+      actualVersion: 5,
+    });
+  });
+
+  it('409 when the service reports an idempotency conflict', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicInputs.mockRejectedValue(new FundMoicInputIdempotencyConflictError('reused'));
+    const res = await put(1, 12, { key: 'k-conflict' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: 'idempotency_conflict' });
+  });
+
+  it('409 when the service reports an in-progress idempotency request', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicInputs.mockRejectedValue(new FundMoicInputInProgressError());
+    const res = await put(1, 12, { key: 'k-progress' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: 'idempotency_request_in_progress' });
+  });
+
+  it('200 on successful update', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, 12, { key: 'k-success' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      fundId: 1,
+      companyId: 12,
+      allocationVersion: 4,
+      exitProbability: 0.8,
+      exitMoicBps: 35000,
+      replayed: false,
+    });
+  });
+
+  it('200 propagates service replay status', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicInputs.mockResolvedValue({ ...successResult, replayed: true });
+    const res = await put(1, 12, { key: 'k-replay' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+  });
+
+  it('passes trimmed idempotency key, body fields, fund, company, and actor to the service', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, 12, { key: '  k-args  ' });
+
+    expect(res.status).toBe(200);
+    expect(svc.updateFundMoicInputs).toHaveBeenCalledTimes(1);
+    expect(svc.updateFundMoicInputs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fundId: 1,
+        companyId: 12,
+        expectedVersion: 3,
+        exitProbability: 0.8,
+        exitMoicBps: 35000,
+        idempotencyKey: 'k-args',
+        actorId: 101,
+      })
+    );
+  });
+
+  it('normalizes string identity claims to numeric actorId', async () => {
+    authState.user = { id: '101', sub: '101', role: 'admin', fundIds: [1] };
+    const res = await put(1, 12, { key: 'k-actor' });
+
+    expect(res.status).toBe(200);
+    expect(svc.updateFundMoicInputs).toHaveBeenCalledWith(
+      expect.objectContaining({ actorId: 101 })
+    );
+  });
+});

--- a/tests/unit/routes/fund-moic-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/fund-moic-makeapp-surface.contract.test.ts
@@ -1,0 +1,128 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function authorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '1',
+    email: 'moic-surface-test@example.com',
+    role: 'admin',
+    fundIds: [],
+  })}`;
+}
+
+describe('fund MOIC makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('allows idempotency-key in CORS preflight headers', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .options('/api/admin/funds/1/moic/reconciliations')
+      .set('Origin', 'http://localhost:5173')
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Headers', 'content-type, idempotency-key');
+
+    expect(res.status).toBe(200);
+    const allowHeaders = String(res.headers['access-control-allow-headers'] ?? '').toLowerCase();
+    expect(allowHeaders).toContain('idempotency-key');
+  }, 30_000);
+
+  it('mounts the fund MOIC router on the production makeApp API surface', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/funds/abc/moic/rankings')
+      .set('Authorization', await authorizationHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Bad Request', message: 'Invalid fund ID' });
+  }, 30_000);
+});

--- a/tests/unit/routes/fund-moic-mode.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-mode.behavior.test.ts
@@ -1,0 +1,287 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  user: null as null | { id: number | string; sub?: string; role: string; fundIds: number[] },
+}));
+const svc = vi.hoisted(() => ({ updateFundMoicCalculationMode: vi.fn() }));
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
+  return { ...actual, updateFundMoicCalculationMode: svc.updateFundMoicCalculationMode };
+});
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
+      if (!authState.user) return res.sendStatus(401);
+      (req as Request & { user: unknown }).user = { ...authState.user };
+      next();
+    },
+  };
+});
+
+import fundMoicRouter from '../../../server/routes/fund-moic';
+import {
+  FundCalculationModeBlockedError,
+  FundCalculationModeIdempotencyConflictError,
+  FundCalculationModeInProgressError,
+  FundCalculationModeVersionConflictError,
+} from '../../../server/services/fund-calculation-mode-service';
+
+const preview = {
+  calculationKey: 'fund_moic_rankings_exit_probability',
+  configuredMode: 'shadow',
+  effectiveMode: 'shadow',
+  killSwitchActive: false,
+  shadowStartedAt: '2026-06-24T00:00:00.000Z',
+  eligibleAt: '2026-07-01T00:00:00.000Z',
+  residencyDaysRequired: 7,
+  residencyStatus: 'pending',
+  currentSourceMatchesAccepted: true,
+  unreconciledEditsPresent: false,
+  blockers: [],
+  version: 1,
+};
+const successResult = { response: preview, replayed: false };
+const validBody = { expectedVersion: 0, configuredMode: 'shadow', acceptedReconciliationRunId: 55 };
+const ADMIN = { id: 101, role: 'admin', fundIds: [1] };
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', fundMoicRouter);
+  app.use((_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
+    res.status(500).json({ error: 'internal_error' })
+  );
+  return app;
+}
+
+function put(fundId: number | string, options: { key?: string; body?: unknown } = {}) {
+  const req = request(buildApp()).put(
+    `/api/admin/funds/${fundId}/calculation-modes/fund-moic-rankings`
+  );
+  if (options.key !== undefined) req.set('Idempotency-Key', options.key);
+  return req.send(options.body ?? validBody);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = null;
+  svc.updateFundMoicCalculationMode.mockResolvedValue(successResult);
+});
+
+describe('fund MOIC calculation mode route - behavioral state machine', () => {
+  it('401 when unauthenticated, with zero service work', async () => {
+    authState.user = null;
+    const res = await put(1, { key: 'm-401' });
+
+    expect(res.status).toBe(401);
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('400 on non-numeric fundId via requireFundAccess, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put('abc', { key: 'm-fund' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Bad Request', message: 'Invalid fund ID' });
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('428 when Idempotency-Key header is missing, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1);
+
+    expect(res.status).toBe(428);
+    expect(res.body).toEqual({
+      error: 'idempotency_key_required',
+      message: 'Idempotency-Key header is required',
+    });
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('428 when Idempotency-Key is whitespace only, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, { key: '   ' });
+
+    expect(res.status).toBe(428);
+    expect(res.body).toEqual({
+      error: 'idempotency_key_required',
+      message: 'Idempotency-Key header is required',
+    });
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('400 on invalid configuredMode enum, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, {
+      key: 'm-invalid-enum',
+      body: { expectedVersion: 0, configuredMode: 'maybe' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_mode_update' });
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('400 on unknown body field, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, {
+      key: 'm-unknown-body',
+      body: { ...validBody, surprise: true },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_mode_update' });
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('400 on negative expectedVersion, with zero service work', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, {
+      key: 'm-negative-version',
+      body: { expectedVersion: -1, configuredMode: 'off' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_mode_update' });
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('403 for a non-admin who has fund access, with zero service work', async () => {
+    authState.user = { id: 102, role: 'analyst', fundIds: [1] };
+    const res = await put(1, { key: 'm-role' });
+
+    expect(res.status).toBe(403);
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('403 for an admin without fund access, with zero service work', async () => {
+    authState.user = { id: 101, role: 'admin', fundIds: [999] };
+    const res = await put(1, { key: 'm-access' });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden', message: 'You do not have access to fund 1' });
+    expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('409 when the service reports a stale expected version', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicCalculationMode.mockRejectedValue(
+      new FundCalculationModeVersionConflictError(1, 2)
+    );
+    const res = await put(1, { key: 'm-version' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: 'stale_expected_version',
+      expectedVersion: 1,
+      actualVersion: 2,
+    });
+  });
+
+  it('409 when the service reports blocked activation', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicCalculationMode.mockRejectedValue(
+      new FundCalculationModeBlockedError(['shadow_residency_pending'])
+    );
+    const res = await put(1, { key: 'm-blocked' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: 'mode_activation_blocked',
+      blockers: ['shadow_residency_pending'],
+    });
+  });
+
+  it('409 when the service reports an idempotency conflict', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicCalculationMode.mockRejectedValue(
+      new FundCalculationModeIdempotencyConflictError('reused')
+    );
+    const res = await put(1, { key: 'm-conflict' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: 'idempotency_conflict' });
+  });
+
+  it('409 when the service reports an in-progress idempotency request', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicCalculationMode.mockRejectedValue(new FundCalculationModeInProgressError());
+    const res = await put(1, { key: 'm-progress' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: 'idempotency_request_in_progress' });
+  });
+
+  it('200 on successful update', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, { key: 'm-success' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ...preview, replayed: false });
+  });
+
+  it('200 propagates service replay status', async () => {
+    authState.user = ADMIN;
+    svc.updateFundMoicCalculationMode.mockResolvedValue({ ...successResult, replayed: true });
+    const res = await put(1, { key: 'm-replay' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+  });
+
+  it('passes trimmed idempotency key, optionals, fund, mode, and actor to the service', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, {
+      key: '  m-args  ',
+      body: {
+        expectedVersion: 0,
+        configuredMode: 'shadow',
+        killSwitchActive: true,
+        acceptedReconciliationRunId: 55,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(svc.updateFundMoicCalculationMode).toHaveBeenCalledTimes(1);
+    expect(svc.updateFundMoicCalculationMode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fundId: 1,
+        expectedVersion: 0,
+        configuredMode: 'shadow',
+        killSwitchActive: true,
+        acceptedReconciliationRunId: 55,
+        idempotencyKey: 'm-args',
+        actorId: 101,
+      })
+    );
+  });
+
+  it('omits optional service args when optional body fields are omitted', async () => {
+    authState.user = ADMIN;
+    const res = await put(1, {
+      key: 'm-omitted',
+      body: { expectedVersion: 0, configuredMode: 'off' },
+    });
+
+    expect(res.status).toBe(200);
+    const arg = svc.updateFundMoicCalculationMode.mock.calls[0]?.[0];
+    expect(arg).toEqual(
+      expect.objectContaining({
+        fundId: 1,
+        expectedVersion: 0,
+        configuredMode: 'off',
+        idempotencyKey: 'm-omitted',
+        actorId: 101,
+      })
+    );
+    expect(arg).not.toHaveProperty('killSwitchActive');
+    expect(arg).not.toHaveProperty('acceptedReconciliationRunId');
+  });
+});

--- a/tests/unit/services/fund-calculation-mode-service.test.ts
+++ b/tests/unit/services/fund-calculation-mode-service.test.ts
@@ -244,6 +244,31 @@ describe('fund calculation mode service', () => {
     });
   });
 
+  it('rolls back from on to off with kill switch without requiring a fresh reconciliation', async () => {
+    const { database } = makeDatabase([
+      [{ id: 100 }],
+      [modeRow({ configured_mode: 'on', version: 2 })],
+      [modeRow({ configured_mode: 'off', kill_switch_active: true, version: 3 })],
+      [],
+    ]);
+
+    const result = await updateFundMoicCalculationMode({
+      ...baseUpdate,
+      expectedVersion: 2,
+      configuredMode: 'off',
+      killSwitchActive: true,
+      database: database as never,
+    });
+
+    expect(result.response).toMatchObject({
+      configuredMode: 'off',
+      effectiveMode: 'off',
+      killSwitchActive: true,
+      version: 3,
+    });
+    expect(result.replayed).toBe(false);
+  });
+
   it('keeps configured on effective candidate after source drift while marking stale', async () => {
     const { database } = makeDatabase([
       [

--- a/tests/unit/services/fund-moic-input-service.test.ts
+++ b/tests/unit/services/fund-moic-input-service.test.ts
@@ -83,6 +83,38 @@ describe('fund MOIC input service', () => {
     expect(tx.execute).toHaveBeenCalledTimes(5);
   });
 
+  it('treats the same idempotency key on a different company as an independent update', async () => {
+    expect(requestHashFor({ ...baseParams, companyId: 12 })).not.toBe(
+      requestHashFor({ ...baseParams, companyId: 13 })
+    );
+
+    const { database, tx } = makeDatabase([
+      [{ id: 2 }],
+      [{ allocation_version: 3 }],
+      [{ allocation_version: 4, exit_probability: '0.800000', exit_moic_bps: 35000 }],
+      [],
+      [],
+    ]);
+
+    const result = await updateFundMoicInputs({
+      ...baseParams,
+      companyId: 13,
+      database: database as never,
+    });
+
+    expect(result).toEqual({
+      response: {
+        fundId: 7,
+        companyId: 13,
+        allocationVersion: 4,
+        exitProbability: 0.8,
+        exitMoicBps: 35000,
+      },
+      replayed: false,
+    });
+    expect(tx.execute).toHaveBeenCalledTimes(5);
+  });
+
   it('replays a completed idempotency ledger response without updating again', async () => {
     const response: FundMoicInputUpdateResponse = {
       fundId: 7,


### PR DESCRIPTION
## Summary

One additive production change — `makeApp()` CORS now allows `Idempotency-Key` in the preflight `Access-Control-Allow-Headers` — plus proof-only test coverage for the admin MOIC PUT surfaces. No calculation semantics, JSON response shapes, V2 contract schemas, or migrations changed.

The CORS gap was real: the admin MOIC idempotent mutations (reconciliation `POST`, moic-input `PUT`, calculation-mode `PUT`) all require an `Idempotency-Key` header, but the browser preflight rejected it, so those calls would fail from the SPA.

## Changed files

| File | Change |
| --- | --- |
| `server/app.ts` | +`idempotency-key` in `Access-Control-Allow-Headers` (1 line, additive) |
| `tests/unit/routes/fund-moic-admin-inputs.behavior.test.ts` | NEW — 17 cases, PUT moic-inputs state machine |
| `tests/unit/routes/fund-moic-mode.behavior.test.ts` | NEW — 17 cases, PUT calculation-modes state machine |
| `tests/unit/routes/fund-moic-makeapp-surface.contract.test.ts` | NEW — 2 cases, CORS preflight + DB-free mount smoke |
| `tests/unit/services/fund-moic-input-service.test.ts` | +1 — same-key/different-company independence |
| `tests/unit/services/fund-calculation-mode-service.test.ts` | +1 — on→off rollback w/ kill switch, no fresh reconciliation |

## Commands run + results

| Command | Result |
| --- | --- |
| Route proof (4 suites) | **50 passed** (17 + 17 + 2 + 14) |
| Service proof (3 suites) | **24 passed** (input 8, mode 13, reconciliation 3) |
| Red-before-green CORS | header stripped → CORS case **fails**, mount-smoke **passes** → assertion has teeth (restored via Edit) |
| `git diff --check` | clean |
| `npm run check` (strict baseline, client/server/shared) | **0 new TS errors** |
| `npx eslint` (6 changed files) | clean |
| `npm run policy:verify` | PASS — 47 route-policy entries |
| `npm run guard:round-derived-financial-claims:check` | PASS |
| Cross-module integration grep | **zero** imports of fund-moic/rounds/calculation-mode into reserve/pacing/forecast/LP-export |

## Proof boundaries

- Full `npm run test:unit` deferred to CI — change is additive + isolated; confirmed **no unit test pins** the exact `Access-Control-Allow-Headers` string (only the new contract test reads it, asserting *contains* not equality).
- Migration test `tests/integration/migrations/moic-pr-e2-journal.test.ts` is `skipIf(noDocker)` → **did not execute locally** (Windows-without-Docker). The three schema-scope tuples (`reconciliation_runs_fund_id_idempotency_key_unique`, `fund_calculation_mode_requests_scope_unique`, `fund_moic_input_update_requests_scope_unique`) are asserted there and run structurally via the service-layer `ON CONFLICT` targets; CI/WSL executes the migration test.
- `release:check` env-blocked (Docker/Testcontainers); not run.

## Route-policy / migration / journal state

- Route-policy: no deltas — `policy:verify` PASS at 47 entries (still the non-enforcing scaffold; no new hand-declared auth).
- Migrations / Drizzle journal: unchanged. `migrations/meta/_journal.json` still ends at `0017_moic_exit_probability_modes` after `0016_reconciliation_runs`. No schema change, no `db:push`.

## V2 fields operators rely on

`latestReconciliation.{runId,createdAt,currentInputMatches}` · `modePreview.{shadowStartedAt,eligibleAt,residencyDaysRequired,residencyStatus,currentSourceMatchesAccepted,unreconciledEditsPresent,blockers,killSwitchActive,configuredMode,effectiveMode,version}` · `moicInputSummary` defaulted/blocking counts.

## Stale-claim corrections

- `moic_consumes_rounds` is **stale** for this lane.
- Current calculation key is **`fund_moic_rankings_exit_probability`**.
- **#926** was a schema-constraint repair (FK → `unique()`), not substantive MOIC behavior expansion.
- Global "idempotency" language is **stale** after fund-scoped ledgers (same key on a different fund = independent run).

## PR ledger + baseline

MOIC/trust evidence: #910, #912, #918, #919, #922, #924, #926, #927. Baseline advance only: #928. Built on `927420f6` (origin/main).

## H9 Go/No-Go packet

Decision rule: no-go unless every relevant row is `PASS`. **Zero PASS rows.** The cross-module integration row was verified by command; per-row file:line citations are a read-only code audit (statuses kept conservative).

| Criterion | Status | Code path (audit) | Proof command | Evidence | Decision impact |
| --- | --- | --- | --- | --- | --- |
| Cross-module integration | **FAIL** (verified) | reserve/pacing/forecast/lp-reporting | `grep "from.*(fund-moic\|rounds-to-model\|investment-round\|fund-calculation-mode)"` | **zero matches** | Decisive — no-go |
| Ownership/dilution source | FAIL | `reserve-input-builder.ts` defaults ownership 0.15 | `grep ownershipPercentage server/services/reserve*` | hardcoded fallback | no-go |
| Share price source | FAIL | `investments.sharePriceCents` unread in reserve flow | `grep sharePriceCents server/services/reserve*` | not consumed | no-go |
| Round source | UNPROVEN | `investmentRounds` read only by fund-moic/evidence | `grep investmentRounds server/services/reserve* pacing*` | no actionable consumer | no-go |
| Security type | FAIL | `securityType` → evidence audit only | `grep securityType` ranking svc | not in calc | no-go |
| Conversion (SAFE→equity) | BLOCKED | none in reserve/pacing/forecast | `grep conversion server/services/reserve*` | absent | no-go |
| Initial vs follow-on | UNPROVEN | `RoundModelRole` in evidence svc | `grep RoundModelRole reserve* pacing*` | audit only | no-go |
| Multi follow-on / weighted px | FAIL | no weighted-avg in reserve/pacing | `grep weighted reserve* pacing*` | absent | no-go |
| Partial realization/proceeds | BLOCKED | evidence schema only | `grep proceeds reserve* pacing*` | not integrated | no-go |
| SAFE/convertible price | FAIL | reserve engine ignores `preMoneyValuation` | `grep preMoneyValuation reserve*` | uses stage/sector mult | no-go |
| Planned vs deployed reserves | FAIL | `plannedReservesCents` → fund-moic only | `grep plannedReserves reserve-calculation*` | reserve engine ignores | no-go |
| Deal-level forecasts | FAIL | not in construction/dual-forecast | `grep futureRound construction* dual*` | audit only | no-go |
| Remaining-capital roll-forward | FAIL | pacing uses committedCapital | `grep resolvePacingFundSize` | no depletion tracking | no-go |
| Fund-life / terminal FMV | FAIL | none tied to rounds | `grep terminal\|liquidation reserve*` | absent | no-go |
| FX / base currency | BLOCKED | `currency` checked in evidence only | `grep CURRENCY_MISMATCH reserve* pacing*` | not in actionable | no-go |
| Missing-history behavior | FAIL | reserve fallback stage 'seed'/0.15 | `grep reserve-input-builder.ts` defaults | silent fallback | no-go |
| Hidden fallback into outputs | FAIL | reserve-input-builder 0.15 → fundSnapshots | `grep 0.15 reserve-input-builder.ts` | silent default ships | no-go |
| Route/actionability gates | BLOCKED | `VITE_ENABLE_INVESTMENT_ROUNDS` gates UI/route, not engines | grep flag in server routes | gate incomplete | no-go |
| Export staleness blocking | FAIL | LP export ignores reconciliation status | `grep staleness lp-reporting/report-package*` | no block | no-go |
| LP review / audit trail | UNPROVEN | `reconciliationRuns` ⟂ `evidenceRecords` (unlinked) | grep joins in lp-reporting | no lineage | no-go |

**H9 DECISION: NO-GO.** Rounds/MOIC are *feature-isolated, not feature-integrated*. The MOIC admin surface is now reliable, but no actionable output (reserves, forecast, LP export) consumes it; actionable outputs still run on hardcoded fallbacks. To flip GO: rewire `buildReservePortfolioInput()` / `resolvePacingFundSize()` / forecast builders onto rounds data, add reconciliation-staleness blockers to LP export, and link reconciliation runs → evidence_records.

## Activation runbook

Read state from `GET /api/funds/:fundId/moic/rankings?contract=v2`. Every admin mutation needs a **fresh** `Idempotency-Key` + an `expectedVersion`. Keys are **fund-scoped**; reuse a key only to retry the *exact same* request.

1. **Reconcile** — `POST /admin/funds/:fundId/moic/reconciliations` (fresh key). Note `runId`.
2. **Clear blockers** — if `moicInputSummary.activationBlocking*Count > 0`, `PUT /admin/funds/:fundId/moic-inputs/portfolio-companies/:companyId` (fresh key per edit), then re-reconcile.
3. **Shadow** — `PUT /admin/funds/:fundId/calculation-modes/fund-moic-rankings` `{ expectedVersion, configuredMode:"shadow", acceptedReconciliationRunId:<latestReconciliation.runId> }` (fresh key). Residency = 7 days.
4. **Wait** — `residencyStatus` → `eligible`, `blockers` empty.
5. **On** — same endpoint `{ expectedVersion, configuredMode:"on" }`. 409 `mode_activation_blocked` if residency/source/inputs not ready.
6. **Drift** — if `currentSourceMatchesAccepted` false / `unreconciledEditsPresent` true: re-reconcile + repeat, or roll back.

**Rollback** (always allowed, no fresh reconciliation): `{ "configuredMode":"off", "killSwitchActive":true, "expectedVersion":"<current version>" }`.

**Error map:** 400 invalid fund/company/body · 403 not-admin/no-access · 409 `stale_expected_version`/`mode_activation_blocked`/`idempotency_conflict`/`idempotency_request_in_progress` · 428 missing/blank key.

## Remaining risks

- CI is the real gate for full `test:unit` + `release:check` (deferred here).
- Migration schema-scopes asserted, not executed locally (Docker-gated) — CI/WSL runs them.
- H9 stays no-go until rounds→actionable-output wiring lands; this lane does not change that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
