### PR TITLE
Prevent masked Drizzle schema push success

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "guard:financial-placeholders:check": "node scripts/guardrails/no-portfolio-placeholder-financial-success.mjs",
     "guard:round-derived-financial-claims:check": "node scripts/guardrails/no-client-round-derived-financial-claims.mjs",
     "guardrails:check": "npm run guard:console:check && npm run guard:eslint-disable:check && npm run guard:scripts:check && npm run guard:route-imports:check && npm run guard:financial-placeholders:check && npm run guard:round-derived-financial-claims:check",
-    "db:push": "drizzle-kit push",
+    "db:push": "node scripts/db-push.mjs",
     "db:studio": "drizzle-kit studio",
     "db:seed:demo": "cross-env DEMO_SEED=1 npx tsx server/seed-demo-data.ts",
     "demo-profile:import": "npx tsx scripts/import-demo-profile.ts",

--- a/scripts/db-push-core.mjs
+++ b/scripts/db-push-core.mjs
@@ -1,0 +1,291 @@
+import path from 'node:path';
+
+export const DB_PUSH_POSTCHECK_SKIP_FLAG = '--skip-postcheck';
+export const DEFAULT_OUTPUT_CONTEXT_LIMIT = 16 * 1024;
+export const MISSING_DATABASE_URL_MESSAGE =
+  'DATABASE_URL is required for db:push postcheck; pass --skip-postcheck only for explicit offline inspection';
+
+export const UNIQUE_CONSTRAINT_SENTINELS = [
+  'investment_rounds_id_fund_uq',
+  'investment_round_model_overrides_id_fund_round_uq',
+];
+
+export const FOREIGN_KEY_SENTINELS = [
+  'investment_rounds_investment_fund_fk',
+  'investment_round_model_overrides_round_fund_fk',
+  'investment_round_model_overrides_supersedes_lineage_fk',
+];
+
+export const INDEX_SENTINELS = [
+  'investment_lots_investment_lot_type_idx',
+  'investment_lots_investment_idem_key_idx',
+  'investment_lots_investment_cursor_idx',
+  'forecast_snapshots_fund_time_idx',
+  'forecast_snapshots_source_hash_idx',
+  'forecast_snapshots_fund_idem_key_idx',
+  'forecast_snapshots_fund_cursor_idx',
+  'forecast_snapshots_source_hash_unique_idx',
+];
+
+export const CONSTRAINT_SENTINEL_QUERY = `
+SELECT c.conname
+FROM pg_constraint c
+JOIN pg_namespace n ON n.oid = c.connamespace
+WHERE n.nspname = 'public'
+  AND c.conname = ANY($1::text[])
+`;
+
+export const INDEX_SENTINEL_QUERY = `
+SELECT indexname
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname = ANY($1::text[])
+`;
+
+const DB_ERROR_PATTERNS = [
+  /\b42830\b/i,
+  /\bno unique constraint matching given keys\b/i,
+  /\bSQLSTATE\b/i,
+  /\bPostgresError\b/i,
+];
+
+export class DbPushPostcheckError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'DbPushPostcheckError';
+    this.details = details;
+  }
+}
+
+export function matchesDbError(text) {
+  if (typeof text !== 'string' || text.length === 0) {
+    return false;
+  }
+
+  return DB_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function classifyDrizzlePushOutput({ status, dbErrorDetected }) {
+  const exitStatus = typeof status === 'number' ? status : 1;
+
+  if (exitStatus !== 0) {
+    return {
+      ok: false,
+      reason: 'child-exit',
+      message: `drizzle-kit push exited with status ${exitStatus}`,
+    };
+  }
+
+  if (dbErrorDetected) {
+    return {
+      ok: false,
+      reason: 'database-error',
+      message: 'drizzle-kit push output contained a PostgreSQL database error signature',
+    };
+  }
+
+  return {
+    ok: true,
+    reason: 'ok',
+    message: 'drizzle-kit push completed cleanly',
+  };
+}
+
+export function buildDrizzleArgs(userArgs) {
+  return ['push', ...userArgs.filter((arg) => arg !== DB_PUSH_POSTCHECK_SKIP_FLAG)];
+}
+
+export function parseDbPushArgs(userArgs, env = process.env) {
+  const skipPostcheck =
+    userArgs.includes(DB_PUSH_POSTCHECK_SKIP_FLAG) || env.UPDOG_DB_PUSH_SKIP_POSTCHECK === '1';
+
+  return {
+    drizzleArgs: buildDrizzleArgs(userArgs),
+    skipPostcheck,
+  };
+}
+
+export function resolveLocalDrizzleBinary({
+  repoRoot = process.cwd(),
+  platform = process.platform,
+} = {}) {
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  const fileName = platform === 'win32' ? 'drizzle-kit.cmd' : 'drizzle-kit';
+  return pathApi.join(repoRoot, 'node_modules', '.bin', fileName);
+}
+
+export function resolveLocalDrizzleEntrypoint({
+  repoRoot = process.cwd(),
+  platform = process.platform,
+} = {}) {
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  return pathApi.join(repoRoot, 'node_modules', 'drizzle-kit', 'bin.cjs');
+}
+
+export function buildDrizzleSpawnCommand({
+  drizzleArgs,
+  nodePath = process.execPath,
+  platform = process.platform,
+  repoRoot = process.cwd(),
+}) {
+  return {
+    command: nodePath,
+    args: [resolveLocalDrizzleEntrypoint({ repoRoot, platform }), ...drizzleArgs],
+    localBinary: resolveLocalDrizzleBinary({ repoRoot, platform }),
+    localEntrypoint: resolveLocalDrizzleEntrypoint({ repoRoot, platform }),
+  };
+}
+
+export function buildSentinelChecks() {
+  return {
+    constraints: [...UNIQUE_CONSTRAINT_SENTINELS, ...FOREIGN_KEY_SENTINELS],
+    indexes: [...INDEX_SENTINELS],
+  };
+}
+
+export function shouldRunPostcheck({ skipPostcheck, databaseUrlPresent }) {
+  if (skipPostcheck) {
+    return {
+      run: false,
+      failure: false,
+      reason: 'explicit-skip',
+      message: 'postcheck skipped by explicit wrapper option',
+    };
+  }
+
+  if (!databaseUrlPresent) {
+    return {
+      run: false,
+      failure: true,
+      reason: 'missing-database-url',
+      message: MISSING_DATABASE_URL_MESSAGE,
+    };
+  }
+
+  return {
+    run: true,
+    failure: false,
+    reason: 'database-url-present',
+    message: 'postcheck will verify public-schema sentinels',
+  };
+}
+
+export function appendBoundedOutput(current, chunk, limit = DEFAULT_OUTPUT_CONTEXT_LIMIT) {
+  const next = `${current}${chunk}`;
+  if (next.length <= limit) {
+    return next;
+  }
+
+  return next.slice(next.length - limit);
+}
+
+function rowNames(rows, fieldName) {
+  return new Set(
+    rows
+      .map((row) => row?.[fieldName])
+      .filter((value) => typeof value === 'string' && value.length > 0)
+  );
+}
+
+export function findMissingSentinels({ sentinels, constraintRows, indexRows }) {
+  const presentConstraints = rowNames(constraintRows, 'conname');
+  const presentIndexes = rowNames(indexRows, 'indexname');
+
+  return {
+    constraints: sentinels.constraints.filter((name) => !presentConstraints.has(name)),
+    indexes: sentinels.indexes.filter((name) => !presentIndexes.has(name)),
+  };
+}
+
+export function formatMissingSentinels(missing) {
+  const lines = [];
+
+  if (missing.constraints.length > 0) {
+    lines.push(`missing constraints/FKs: ${missing.constraints.join(', ')}`);
+  }
+
+  if (missing.indexes.length > 0) {
+    lines.push(`missing indexes: ${missing.indexes.join(', ')}`);
+  }
+
+  return lines.join('; ');
+}
+
+function hasMissingSentinels(missing) {
+  return missing.constraints.length > 0 || missing.indexes.length > 0;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function verifyPostPushSentinels({
+  connectionString,
+  clientFactory,
+  sentinels = buildSentinelChecks(),
+}) {
+  if (!connectionString) {
+    throw new DbPushPostcheckError(
+      MISSING_DATABASE_URL_MESSAGE,
+      { kind: 'missing-database-url' }
+    );
+  }
+
+  const client = clientFactory({ connectionString });
+  let caughtError;
+
+  try {
+    await client.connect();
+    const constraintResult = await client.query(CONSTRAINT_SENTINEL_QUERY, [sentinels.constraints]);
+    const indexResult = await client.query(INDEX_SENTINEL_QUERY, [sentinels.indexes]);
+    const missing = findMissingSentinels({
+      sentinels,
+      constraintRows: constraintResult.rows,
+      indexRows: indexResult.rows,
+    });
+
+    if (hasMissingSentinels(missing)) {
+      throw new DbPushPostcheckError(
+        `db:push postcheck failed; ${formatMissingSentinels(missing)}`,
+        {
+          kind: 'missing-sentinels',
+          missing,
+        }
+      );
+    }
+  } catch (error) {
+    caughtError = error;
+  } finally {
+    if (typeof client.end === 'function') {
+      try {
+        await client.end();
+      } catch (error) {
+        caughtError ??= error;
+      }
+    }
+  }
+
+  if (caughtError) {
+    if (caughtError instanceof DbPushPostcheckError) {
+      throw caughtError;
+    }
+
+    throw new DbPushPostcheckError(
+      `db:push postcheck could not connect or query public-schema sentinels: ${errorMessage(
+        caughtError
+      )}`,
+      {
+        kind: 'postcheck-query-failed',
+        cause: caughtError,
+      }
+    );
+  }
+
+  return {
+    ok: true,
+    checked: {
+      constraints: sentinels.constraints.length,
+      indexes: sentinels.indexes.length,
+    },
+  };
+}

--- a/scripts/db-push.mjs
+++ b/scripts/db-push.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import console from 'node:console';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+import pg from 'pg';
+
+import {
+  appendBoundedOutput,
+  buildDrizzleSpawnCommand,
+  classifyDrizzlePushOutput,
+  matchesDbError,
+  parseDbPushArgs,
+  shouldRunPostcheck,
+  verifyPostPushSentinels,
+} from './db-push-core.mjs';
+
+const { Client } = pg;
+
+export function runDrizzlePushChild({
+  command,
+  args,
+  cwd = process.cwd(),
+  env = process.env,
+  stdout = process.stdout,
+  stderr = process.stderr,
+}) {
+  return new Promise((resolveResult) => {
+    let settled = false;
+    let dbErrorDetected = false;
+    let outputContext = '';
+
+    function settle(result) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolveResult({
+        dbErrorDetected,
+        outputContext,
+        ...result,
+      });
+    }
+
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ['inherit', 'pipe', 'pipe'],
+    });
+
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString('utf8');
+      dbErrorDetected ||= matchesDbError(text);
+      outputContext = appendBoundedOutput(outputContext, text);
+      stdout.write(chunk);
+    });
+
+    child.stderr.on('data', (chunk) => {
+      const text = chunk.toString('utf8');
+      dbErrorDetected ||= matchesDbError(text);
+      outputContext = appendBoundedOutput(outputContext, text);
+      stderr.write(chunk);
+    });
+
+    child.on('error', (error) => {
+      settle({
+        status: 1,
+        spawnError: error,
+      });
+    });
+
+    child.on('close', (status, signal) => {
+      settle({
+        status: status ?? 1,
+        signal,
+      });
+    });
+  });
+}
+
+export async function runDbPushCli({ argv = process.argv.slice(2), env = process.env } = {}) {
+  const { drizzleArgs, skipPostcheck } = parseDbPushArgs(argv, env);
+  const drizzleCommand = buildDrizzleSpawnCommand({
+    drizzleArgs,
+    repoRoot: process.cwd(),
+    platform: process.platform,
+  });
+
+  if (!existsSync(drizzleCommand.localBinary)) {
+    console.error(`[db:push] local drizzle-kit binary not found: ${drizzleCommand.localBinary}`);
+    console.error('[db:push] install dependencies before running db:push');
+    return 1;
+  }
+
+  if (!existsSync(drizzleCommand.localEntrypoint)) {
+    console.error(
+      `[db:push] local drizzle-kit entrypoint not found: ${drizzleCommand.localEntrypoint}`
+    );
+    console.error('[db:push] install dependencies before running db:push');
+    return 1;
+  }
+
+  const childResult = await runDrizzlePushChild({
+    command: drizzleCommand.command,
+    args: drizzleCommand.args,
+    env,
+  });
+
+  if (childResult.spawnError) {
+    console.error(`[db:push] failed to launch local drizzle-kit: ${childResult.spawnError.message}`);
+    return 1;
+  }
+
+  const classification = classifyDrizzlePushOutput({
+    status: childResult.status,
+    dbErrorDetected: childResult.dbErrorDetected,
+  });
+
+  if (!classification.ok) {
+    console.error(`[db:push] ${classification.message}`);
+    if (classification.reason === 'database-error' && childResult.outputContext.trim()) {
+      console.error('[db:push] recent drizzle-kit output:');
+      console.error(childResult.outputContext.trim());
+    }
+    return 1;
+  }
+
+  const postcheck = shouldRunPostcheck({
+    skipPostcheck,
+    databaseUrlPresent: Boolean(env.DATABASE_URL),
+  });
+
+  if (postcheck.failure) {
+    console.error(`[db:push] ${postcheck.message}`);
+    return 1;
+  }
+
+  if (!postcheck.run) {
+    return 0;
+  }
+
+  try {
+    await verifyPostPushSentinels({
+      connectionString: env.DATABASE_URL,
+      clientFactory: ({ connectionString }) => new Client({ connectionString }),
+    });
+  } catch (error) {
+    console.error(`[db:push] ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  return 0;
+}
+
+const isDirectExecution =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isDirectExecution) {
+  runDbPushCli().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -26,6 +26,7 @@ const serverSurfaceTests = [
   'tests/unit/queues/resolve-fund-id.test.ts',
   'tests/unit/routes/lp-api.contract.test.ts',
   'tests/regressions/ci-unified-playwright-install.test.ts',
+  'tests/unit/scripts/db-push.test.mjs',
 ];
 
 const releaseOwnedPaths = [
@@ -33,6 +34,8 @@ const releaseOwnedPaths = [
   'migrations',
   'shared/migrations',
   'scripts/release-check.mjs',
+  'scripts/db-push.mjs',
+  'scripts/db-push-core.mjs',
   'tests/integration/fund-lifecycle-db.test.ts',
   'tests/integration/migration-drift.test.ts',
   'vitest.config.testcontainers.ts',

--- a/tests/integration/helpers/run-drizzle-push.ts
+++ b/tests/integration/helpers/run-drizzle-push.ts
@@ -1,0 +1,13 @@
+import { execFileSync } from 'node:child_process';
+
+export function runDrizzlePush(connectionString: string): void {
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  execFileSync(npmCommand, ['run', 'db:push', '--', '--force'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      DATABASE_URL: connectionString,
+    },
+    stdio: 'pipe',
+  });
+}

--- a/tests/integration/investment-scenario-capability.test.ts
+++ b/tests/integration/investment-scenario-capability.test.ts
@@ -1,11 +1,10 @@
-import { execFileSync } from 'node:child_process';
-
 import { sql } from 'drizzle-orm';
 import express, { type NextFunction, type Request, type Response, type Router } from 'express';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { applyInvestmentRoundConstraints } from '../helpers/apply-investment-round-constraints';
+import { runDrizzlePush } from './helpers/run-drizzle-push';
 import { setupTestDB } from '../helpers/testcontainers';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -37,18 +36,6 @@ let runtime: Runtime | undefined;
 let startedContainer: Awaited<ReturnType<typeof setupTestDB>> | undefined;
 let teardownDatabase: DbModule['db'] | undefined;
 let closeTeardownDatabasePool: DbModule['closeDatabasePool'] | undefined;
-
-function runDrizzlePush(connectionString: string): void {
-  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-  execFileSync(npxCommand, ['drizzle-kit', 'push', '--force'], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      DATABASE_URL: connectionString,
-    },
-    stdio: 'pipe',
-  });
-}
 
 function restoreEnv(snapshot: Record<string, string | undefined>): void {
   for (const [key, value] of Object.entries(snapshot)) {

--- a/tests/integration/migrations/investment-rounds-schema.test.ts
+++ b/tests/integration/migrations/investment-rounds-schema.test.ts
@@ -1,10 +1,9 @@
-import { execFileSync } from 'node:child_process';
-
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { runDrizzlePush } from '../helpers/run-drizzle-push';
 import { applyInvestmentRoundConstraints } from '../../helpers/apply-investment-round-constraints';
 import { setupTestDB } from '../../helpers/testcontainers';
 import { createRound } from '../../../server/services/investments/investment-round-service';
@@ -14,18 +13,6 @@ const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
 
 let container: Awaited<ReturnType<typeof setupTestDB>> | undefined;
 let pool: Pool | undefined;
-
-function runDrizzlePush(connectionString: string): void {
-  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-  execFileSync(npxCommand, ['drizzle-kit', 'push', '--force'], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      DATABASE_URL: connectionString,
-    },
-    stdio: 'pipe',
-  });
-}
 
 function getPgErrorCode(error: unknown): string | undefined {
   if (typeof error !== 'object' || error === null) return undefined;

--- a/tests/integration/migrations/investments-id-fund-unique.test.ts
+++ b/tests/integration/migrations/investments-id-fund-unique.test.ts
@@ -1,10 +1,9 @@
-import { execFileSync } from 'node:child_process';
-
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { runDrizzlePush } from '../helpers/run-drizzle-push';
 import { applyInvestmentRoundConstraints } from '../../helpers/apply-investment-round-constraints';
 import { setupTestDB } from '../../helpers/testcontainers';
 
@@ -13,18 +12,6 @@ const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
 
 let container: Awaited<ReturnType<typeof setupTestDB>> | undefined;
 let pool: Pool | undefined;
-
-function runDrizzlePush(connectionString: string): void {
-  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-  execFileSync(npxCommand, ['drizzle-kit', 'push', '--force'], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      DATABASE_URL: connectionString,
-    },
-    stdio: 'pipe',
-  });
-}
 
 describe.skipIf(skipIfNoDocker)('investments (id, fund_id) unique', () => {
   beforeAll(async () => {

--- a/tests/unit/scripts/db-push.test.mjs
+++ b/tests/unit/scripts/db-push.test.mjs
@@ -1,0 +1,371 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONSTRAINT_SENTINEL_QUERY,
+  DB_PUSH_POSTCHECK_SKIP_FLAG,
+  INDEX_SENTINEL_QUERY,
+  MISSING_DATABASE_URL_MESSAGE,
+  appendBoundedOutput,
+  buildDrizzleArgs,
+  buildDrizzleSpawnCommand,
+  buildSentinelChecks,
+  classifyDrizzlePushOutput,
+  findMissingSentinels,
+  matchesDbError,
+  parseDbPushArgs,
+  resolveLocalDrizzleBinary,
+  resolveLocalDrizzleEntrypoint,
+  shouldRunPostcheck,
+  verifyPostPushSentinels,
+} from '../../../scripts/db-push-core.mjs';
+
+const connectionString = 'postgres://user:pass@localhost:5432/updog_test';
+
+function allConstraintRows() {
+  return buildSentinelChecks().constraints.map((conname) => ({ conname }));
+}
+
+function allIndexRows() {
+  return buildSentinelChecks().indexes.map((indexname) => ({ indexname }));
+}
+
+function createMockClient({ constraintRows = allConstraintRows(), indexRows = allIndexRows() } = {}) {
+  const queries = [];
+  const client = {
+    async connect() {},
+    async query(queryText, params) {
+      queries.push({ queryText, params });
+      if (queryText === CONSTRAINT_SENTINEL_QUERY) {
+        return { rows: constraintRows };
+      }
+      if (queryText === INDEX_SENTINEL_QUERY) {
+        return { rows: indexRows };
+      }
+      throw new Error(`Unexpected query: ${queryText}`);
+    },
+    async end() {},
+  };
+
+  return { client, queries };
+}
+
+async function verifyWithMockClient(mockClient) {
+  return verifyPostPushSentinels({
+    connectionString,
+    clientFactory: () => mockClient.client,
+  });
+}
+
+async function expectPostcheckMissing(mockClient, expectedNames) {
+  let rejection;
+
+  try {
+    await verifyWithMockClient(mockClient);
+  } catch (error) {
+    rejection = error;
+  }
+
+  expect(rejection).toBeInstanceOf(Error);
+  const message = rejection instanceof Error ? rejection.message : '';
+  for (const expectedName of expectedNames) {
+    expect(message).toContain(expectedName);
+  }
+}
+
+describe('db-push output classification', () => {
+  it('fails false-success 42830 output', () => {
+    expect(matchesDbError("error: code: '42830'")).toBe(true);
+    expect(matchesDbError('no unique constraint matching given keys')).toBe(true);
+
+    const result = classifyDrizzlePushOutput({
+      status: 0,
+      dbErrorDetected: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'database-error',
+    });
+    expect(result.message).toContain('PostgreSQL database error');
+  });
+
+  it('fails SQLSTATE and PostgresError output', () => {
+    expect(matchesDbError('SQLSTATE 42830')).toBe(true);
+    expect(matchesDbError('PostgresError: constraint lookup failed')).toBe(true);
+  });
+
+  it('does not fail benign warnings', () => {
+    expect(matchesDbError('Warning: using experimental drizzle-kit feature')).toBe(false);
+    expect(
+      classifyDrizzlePushOutput({
+        status: 0,
+        dbErrorDetected: false,
+      })
+    ).toMatchObject({ ok: true });
+  });
+
+  it('does not fail unrelated error text', () => {
+    expect(matchesDbError('note: previous error: count was already reported')).toBe(false);
+  });
+
+  it('fails child nonzero status', () => {
+    expect(
+      classifyDrizzlePushOutput({
+        status: 1,
+        dbErrorDetected: false,
+      })
+    ).toMatchObject({
+      ok: false,
+      reason: 'child-exit',
+    });
+  });
+
+  it('keeps early DB-error detection sticky outside the bounded output buffer', () => {
+    let outputContext = '';
+    let dbErrorDetected = false;
+
+    for (const chunk of ["error: code: '42830'", 'x'.repeat(128)]) {
+      dbErrorDetected ||= matchesDbError(chunk);
+      outputContext = appendBoundedOutput(outputContext, chunk, 32);
+    }
+
+    expect(outputContext).not.toContain('42830');
+    expect(dbErrorDetected).toBe(true);
+    expect(
+      classifyDrizzlePushOutput({
+        status: 0,
+        dbErrorDetected,
+      })
+    ).toMatchObject({
+      ok: false,
+      reason: 'database-error',
+    });
+  });
+});
+
+describe('db-push argument and binary helpers', () => {
+  it('forwards Drizzle args and strips wrapper-only flags', () => {
+    expect(buildDrizzleArgs(['--force'])).toEqual(['push', '--force']);
+    expect(buildDrizzleArgs([DB_PUSH_POSTCHECK_SKIP_FLAG, '--force'])).toEqual([
+      'push',
+      '--force',
+    ]);
+  });
+
+  it('parses postcheck skip without dropping child classification args', () => {
+    expect(
+      parseDbPushArgs([DB_PUSH_POSTCHECK_SKIP_FLAG, '--force'], {
+        UPDOG_DB_PUSH_SKIP_POSTCHECK: '0',
+      })
+    ).toEqual({
+      drizzleArgs: ['push', '--force'],
+      skipPostcheck: true,
+    });
+
+    expect(
+      parseDbPushArgs(['--force'], {
+        UPDOG_DB_PUSH_SKIP_POSTCHECK: '1',
+      })
+    ).toEqual({
+      drizzleArgs: ['push', '--force'],
+      skipPostcheck: true,
+    });
+  });
+
+  it('resolves the repository-local Drizzle binary without npx', () => {
+    expect(
+      resolveLocalDrizzleBinary({
+        repoRoot: 'C:\\dev\\Updog_restore',
+        platform: 'win32',
+      })
+    ).toBe('C:\\dev\\Updog_restore\\node_modules\\.bin\\drizzle-kit.cmd');
+
+    expect(
+      resolveLocalDrizzleBinary({
+        repoRoot: '/repo',
+        platform: 'linux',
+      })
+    ).toBe('/repo/node_modules/.bin/drizzle-kit');
+  });
+
+  it('builds a Windows-safe local Drizzle spawn command', () => {
+    const spawnCommand = buildDrizzleSpawnCommand({
+      drizzleArgs: ['push', '--force'],
+      nodePath: 'C:\\Program Files\\nodejs\\node.exe',
+      repoRoot: 'C:\\dev\\Updog_restore',
+      platform: 'win32',
+    });
+
+    expect(spawnCommand.command).toBe('C:\\Program Files\\nodejs\\node.exe');
+    expect(spawnCommand.localBinary).toBe(
+      'C:\\dev\\Updog_restore\\node_modules\\.bin\\drizzle-kit.cmd'
+    );
+    expect(spawnCommand.localEntrypoint).toBe(
+      'C:\\dev\\Updog_restore\\node_modules\\drizzle-kit\\bin.cjs'
+    );
+    expect(spawnCommand.args).toEqual([
+      'C:\\dev\\Updog_restore\\node_modules\\drizzle-kit\\bin.cjs',
+      'push',
+      '--force',
+    ]);
+    expect(spawnCommand.command).not.toContain('npx');
+    expect(spawnCommand.args.join(' ')).not.toContain('drizzle-kit.cmd');
+  });
+
+  it('resolves the local package entrypoint used for direct Node spawning', () => {
+    expect(
+      resolveLocalDrizzleEntrypoint({
+        repoRoot: '/repo',
+        platform: 'linux',
+      })
+    ).toBe('/repo/node_modules/drizzle-kit/bin.cjs');
+  });
+});
+
+describe('db-push postcheck decisions', () => {
+  it('fails closed when DATABASE_URL is missing by default', () => {
+    expect(
+      shouldRunPostcheck({
+        skipPostcheck: false,
+        databaseUrlPresent: false,
+      })
+    ).toMatchObject({
+      run: false,
+      failure: true,
+      reason: 'missing-database-url',
+    });
+    expect(
+      shouldRunPostcheck({
+        skipPostcheck: false,
+        databaseUrlPresent: false,
+      }).message
+    ).toBe(MISSING_DATABASE_URL_MESSAGE);
+  });
+
+  it('allows explicit postcheck skip only after clean child classification', () => {
+    expect(
+      shouldRunPostcheck({
+        skipPostcheck: true,
+        databaseUrlPresent: false,
+      })
+    ).toMatchObject({
+      run: false,
+      failure: false,
+      reason: 'explicit-skip',
+    });
+
+    expect(
+      classifyDrizzlePushOutput({
+        status: 0,
+        dbErrorDetected: true,
+      })
+    ).toMatchObject({
+      ok: false,
+      reason: 'database-error',
+    });
+  });
+});
+
+describe('db-push sentinel postcheck', () => {
+  it('passes when all public-schema sentinels are present', async () => {
+    const mockClient = createMockClient();
+
+    await expect(verifyWithMockClient(mockClient)).resolves.toMatchObject({
+      ok: true,
+      checked: {
+        constraints: 5,
+        indexes: 8,
+      },
+    });
+    expect(mockClient.queries).toHaveLength(2);
+  });
+
+  it('uses two batched public-schema catalog queries', async () => {
+    const mockClient = createMockClient();
+
+    await verifyWithMockClient(mockClient);
+
+    expect(mockClient.queries[0].queryText).toContain("n.nspname = 'public'");
+    expect(mockClient.queries[0].queryText).toContain('c.conname = ANY($1::text[])');
+    expect(mockClient.queries[0].params[0]).toHaveLength(5);
+    expect(mockClient.queries[1].queryText).toContain("schemaname = 'public'");
+    expect(mockClient.queries[1].queryText).toContain('indexname = ANY($1::text[])');
+    expect(mockClient.queries[1].params[0]).toHaveLength(8);
+  });
+
+  it('fails missing unique constraint sentinels with names', async () => {
+    const missing = [
+      'investment_rounds_id_fund_uq',
+      'investment_round_model_overrides_id_fund_round_uq',
+    ];
+    const mockClient = createMockClient({
+      constraintRows: allConstraintRows().filter((row) => !missing.includes(row.conname)),
+    });
+
+    await expectPostcheckMissing(mockClient, missing);
+  });
+
+  it('fails missing foreign-key sentinels with names', async () => {
+    const missing = [
+      'investment_rounds_investment_fund_fk',
+      'investment_round_model_overrides_round_fund_fk',
+      'investment_round_model_overrides_supersedes_lineage_fk',
+    ];
+    const mockClient = createMockClient({
+      constraintRows: allConstraintRows().filter((row) => !missing.includes(row.conname)),
+    });
+
+    await expectPostcheckMissing(mockClient, missing);
+  });
+
+  it('fails missing index sentinels with names', async () => {
+    const missing = [
+      'investment_lots_investment_lot_type_idx',
+      'forecast_snapshots_source_hash_unique_idx',
+    ];
+    const mockClient = createMockClient({
+      indexRows: allIndexRows().filter((row) => !missing.includes(row.indexname)),
+    });
+
+    await expectPostcheckMissing(mockClient, missing);
+  });
+
+  it('does not satisfy sentinels with same-named non-public objects', () => {
+    const sentinels = buildSentinelChecks();
+    const missing = findMissingSentinels({
+      sentinels,
+      constraintRows: [],
+      indexRows: [],
+    });
+
+    expect(CONSTRAINT_SENTINEL_QUERY).toContain("n.nspname = 'public'");
+    expect(INDEX_SENTINEL_QUERY).toContain("schemaname = 'public'");
+    expect(missing.constraints).toEqual(sentinels.constraints);
+    expect(missing.indexes).toEqual(sentinels.indexes);
+  });
+
+  it('fails closed when DATABASE_URL is set but the database is unreachable', async () => {
+    const client = {
+      async connect() {
+        throw new Error('ECONNREFUSED');
+      },
+      async query() {
+        throw new Error('query should not run');
+      },
+      async end() {},
+    };
+
+    await expect(
+      verifyPostPushSentinels({
+        connectionString,
+        clientFactory: () => client,
+      })
+    ).rejects.toThrow(/could not connect or query.*ECONNREFUSED/);
+  });
+
+  it('imports core helpers without running CLI work', async () => {
+    const imported = await import('../../../scripts/db-push-core.mjs');
+
+    expect(imported.buildDrizzleArgs(['--force'])).toEqual(['push', '--force']);
+  });
+});

--- a/vitest.config.testcontainers.ts
+++ b/vitest.config.testcontainers.ts
@@ -31,6 +31,9 @@ export default defineConfig({
       'tests/integration/migration-runner.test.ts',
       'tests/integration/fund-lifecycle-db.test.ts',
       'tests/integration/migration-drift.test.ts',
+      'tests/integration/migrations/investment-rounds-schema.test.ts',
+      'tests/integration/migrations/investments-id-fund-unique.test.ts',
+      'tests/integration/investment-scenario-capability.test.ts',
       // DISABLED: Pre-existing issues - fix in separate PRs
       // 'tests/integration/ScenarioMatrixCache.integration.test.ts', // bucket allocation validation
       // 'tests/integration/cache-monitoring.integration.test.ts', // server/db.ts imports database-mock


### PR DESCRIPTION
Drizzle can exit cleanly even after PostgreSQL rejects part of a push, so db:push now runs through a repository-owned wrapper that preserves the CLI path while classifying database error output and verifying public-schema sentinels. The Testcontainers setup path now uses the same wrapper instead of raw npx resolution, and release-check owns the wrapper unit coverage without adding a new database stage.

Constraint: drizzle-kit push has no dry-run mode, and Windows cannot safely spawn the .cmd shim directly from Node

Rejected: Keep using raw npx drizzle-kit push in Testcontainers | preserves the false-success path and version-resolution drift

Rejected: Add a release-check DB postcheck stage | broader and slower than the approved wrapper unit surface

Confidence: high

Scope-risk: narrow

Directive: Do not add --skip-postcheck to the Testcontainers helper without replacing the live sentinel proof elsewhere

Tested: TZ=UTC vitest run tests/unit/scripts/db-push.test.mjs --project=server

Tested: npm run check

Tested: npm run lint

Tested: release server surface Vitest command including tests/unit/scripts/db-push.test.mjs

Not-tested: Docker-backed Testcontainers sentinel proof in this Windows shell; Testcontainers reported no working container runtime strategy