### PR TITLE
fix(h9): deterministic round-evidence assumptions hash (PR2 Lane A)

### DIFF
--- a/server/services/fund-calculation-mode-service.ts
+++ b/server/services/fund-calculation-mode-service.ts
@@ -264,10 +264,9 @@ async function loadAcceptedMoicReconciliation(params: {
   throw new Error('MOIC actionability resolver requires a reconciliation lookup database');
 }
 
-function buildRoundEvidenceAssumptionsHash(now: Date): string {
+function buildRoundEvidenceAssumptionsHash(): string {
   return canonicalSha256({
     policyVersion: ACTIONABILITY_POLICY_VERSION,
-    generatedAt: now.toISOString(),
   });
 }
 
@@ -311,7 +310,7 @@ export function createMoicActionabilityResolver(params: { database?: unknown; no
     const sourceFingerprint = buildH9SourceFingerprint({
       moicSourceInputHash: sources.moicSourceInputHash,
       roundEvidenceInputHash: canonicalSha256(evidence.coverage),
-      roundEvidenceAssumptionsHash: buildRoundEvidenceAssumptionsHash(now),
+      roundEvidenceAssumptionsHash: buildRoundEvidenceAssumptionsHash(),
     });
     const accepted = await loadAcceptedMoicReconciliation({ database, fundId: input.fundId });
     const sourceFingerprintMatches = Boolean(

--- a/tests/unit/services/fund-moic-actionability-service.test.ts
+++ b/tests/unit/services/fund-moic-actionability-service.test.ts
@@ -41,6 +41,10 @@ type MoicActionabilityResult = {
   actionability?: unknown;
   actionabilityStatus?: unknown;
   status?: unknown;
+  sourceFingerprint?: {
+    roundEvidenceAssumptionsHash?: unknown;
+    fingerprintHash?: unknown;
+  };
 };
 
 type ResolveByParams = (input: { fundId: number }) => Promise<MoicActionabilityResult>;
@@ -188,5 +192,24 @@ describe('fund MOIC actionability resolver', () => {
 
     expect(result.sourceFingerprintMatches).toBe(false);
     expect(actionabilityStatus(result)).toBe('non_actionable');
+  });
+
+  it('produces a now-independent fingerprint so cache keys and snapshot stamps stay stable', async () => {
+    const database = makeDatabase([reconciliationRow()]);
+    const early = await resolveForFund(
+      createMoicActionabilityResolver({ database, now: new Date('2020-01-01T00:00:00.000Z') }),
+      7
+    );
+    const late = await resolveForFund(
+      createMoicActionabilityResolver({ database, now: new Date('2023-06-15T12:00:00.000Z') }),
+      7
+    );
+
+    expect(early.sourceFingerprint?.roundEvidenceAssumptionsHash).toBe(
+      late.sourceFingerprint?.roundEvidenceAssumptionsHash
+    );
+    expect(early.sourceFingerprint?.fingerprintHash).toBe(
+      late.sourceFingerprint?.fingerprintHash
+    );
   });
 });


### PR DESCRIPTION
## What

`buildRoundEvidenceAssumptionsHash` folded `generatedAt: now.toISOString()` into the hash, so `roundEvidenceAssumptionsHash` — and therefore the composite `fingerprintHash` — changed on every `resolve()`. This is the [HIGH] carried-over finding from PR1 (#931).

This drops the wall-clock field; the helper now hashes deterministic assumptions only (`{ policyVersion }`).

## Why now (blocks PR2/PR3)

- PR1's binary gate **survived** the nonce: it compares only `moicSourceInputHash` + `roundEvidenceInputHash`, not the composite.
- PR2 puts `h9SourceFingerprintHash` in reserve/pacing/metrics **cache keys** and stamps it on snapshots → every request would miss and every stamp would differ.
- PR3 recomputes the fingerprint in-transaction and aborts on drift → it would **always** drift.

So Lane A must land before the cache-key/stamp work.

## Determinism scope verified

The only fingerprint nonce was this helper. `evidence.coverage` — the sole evidence field hashed into `roundEvidenceInputHash` — is `now`-free (counts + `warningsByCode`); `generatedAt`/`provenance` live outside `coverage`. So removing `generatedAt` here makes the full fingerprint deterministic.

## Test

Adds a discriminating regression in `fund-moic-actionability-service.test.ts`: two resolvers constructed with **different** `now` (`2020-01-01` vs `2023-06-15`), same injected sources/evidence, must yield identical `roundEvidenceAssumptionsHash` and `fingerprintHash`. (Two calls on one resolver would false-pass, since `now` is captured once at construction.) RED before the fix, GREEN after. Full local: 32/32 in resolver + mode-service + h9-contract suites; `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)