### PR TITLE
feat(h9): stamp actionability fingerprint on reserve snapshot writes (PR2 Lane B)

### DIFF
--- a/server/services/fund-calculation-mode-service.ts
+++ b/server/services/fund-calculation-mode-service.ts
@@ -345,6 +345,17 @@ export function resolveMoicActionability(
   return defaultMoicActionabilityResolver.resolve(input);
 }
 
+export function toH9SnapshotColumns(result: MoicActionabilityResult) {
+  return {
+    h9MoicSourceInputHash: result.sourceFingerprint.moicSourceInputHash,
+    h9RoundEvidenceInputHash: result.sourceFingerprint.roundEvidenceInputHash,
+    h9RoundEvidenceAssumptionsHash: result.sourceFingerprint.roundEvidenceAssumptionsHash,
+    h9FingerprintHash: result.sourceFingerprint.fingerprintHash,
+    h9PolicyVersion: result.sourceFingerprint.policyVersion,
+    h9ActionabilityStatus: result.actionability,
+  };
+}
+
 function requestHashFor(params: {
   fundId: number;
   expectedVersion: number;

--- a/server/services/reserve-calculation-service.ts
+++ b/server/services/reserve-calculation-service.ts
@@ -1,6 +1,7 @@
 import { db } from '../db';
 import { fundSnapshots } from '@shared/schema';
 import { generateReserveSummary } from '@shared/core/reserves/ReserveEngine';
+import { resolveMoicActionability, toH9SnapshotColumns } from './fund-calculation-mode-service';
 import { markCalcRunCompletedIfReady } from './calc-run-tracking';
 import { buildReservePortfolioInput } from './reserve-input-builder';
 
@@ -59,6 +60,9 @@ export async function runReserveCalculation({
   const portfolio = await retryWithBackoff(() => buildReservePortfolioInput(fundId));
 
   const reserves = generateReserveSummary(fundId, portfolio);
+  // H9: stamp the actionability fingerprint onto the authoritative snapshot so
+  // downstream reuse/cache/export can gate on it. Display reads are unaffected.
+  const actionability = await resolveMoicActionability({ fundId });
 
   // ADR-022: authoritative-only writer. scenario_set_id intentionally omitted (defaults to NULL).
   const insertedSnapshots = await db
@@ -73,6 +77,7 @@ export async function runReserveCalculation({
       ...(runId != null && { runId }),
       ...(configId != null && { configId }),
       ...(configVersion != null && { configVersion }),
+      ...toH9SnapshotColumns(actionability),
       metadata: {
         portfolioCount: portfolio.length,
         engineRuntime: performance.now() - startTime,

--- a/tests/unit/services/reserve-calculation-h9-stamp.test.ts
+++ b/tests/unit/services/reserve-calculation-h9-stamp.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MoicActionabilityResult } from '../../../server/services/fund-calculation-mode-service';
+
+// Mock only resolveMoicActionability; keep the real toH9SnapshotColumns (pure mapper under test).
+const { resolveMoicActionability } = vi.hoisted(() => ({
+  resolveMoicActionability: vi.fn(),
+}));
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
+  return {
+    ...actual,
+    resolveMoicActionability,
+  };
+});
+
+// Capture the values handed to db.insert(...).values(...).
+const captured: { values?: Record<string, unknown> } = {};
+
+vi.mock('../../../server/db', () => ({
+  db: {
+    query: {
+      fundConfigs: { findFirst: vi.fn(async () => ({ version: 3, isPublished: true })) },
+      funds: { findFirst: vi.fn(async () => ({ id: 7, size: '100000000' })) },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        captured.values = values;
+        return {
+          returning: vi.fn(async () => [
+            { id: 101, createdAt: new Date('2026-06-25T00:00:00.000Z'), calcVersion: '1.0.0' },
+          ]),
+        };
+      }),
+    })),
+  },
+}));
+
+vi.mock('../../../server/services/reserve-input-builder', () => ({
+  buildReservePortfolioInput: vi.fn(async () => []),
+}));
+
+vi.mock('@shared/core/reserves/ReserveEngine', () => ({
+  generateReserveSummary: vi.fn(() => ({ ok: true })),
+}));
+
+vi.mock('../../../server/services/calc-run-tracking', () => ({
+  markCalcRunCompletedIfReady: vi.fn(async () => undefined),
+}));
+
+import { runReserveCalculation } from '../../../server/services/reserve-calculation-service';
+import { toH9SnapshotColumns } from '../../../server/services/fund-calculation-mode-service';
+
+function actionabilityResult(
+  status: 'actionable' | 'non_actionable'
+): MoicActionabilityResult {
+  return {
+    sourceFingerprintMatches: status === 'actionable',
+    actionability: status,
+    actionabilityStatus: status,
+    sourceFingerprint: {
+      moicSourceInputHash: 'moic-src-hash',
+      roundEvidenceInputHash: 'round-evidence-hash',
+      roundEvidenceAssumptionsHash: 'assumptions-hash',
+      fingerprintHash: 'fingerprint-hash',
+      policyVersion: 'h9-policy-v1',
+    },
+    acceptedReconciliationRunId: status === 'actionable' ? 42 : null,
+  } as MoicActionabilityResult;
+}
+
+describe('toH9SnapshotColumns', () => {
+  it('maps an actionable resolver result to all six stamp columns', () => {
+    const cols = toH9SnapshotColumns(actionabilityResult('actionable'));
+    expect(cols).toEqual({
+      h9MoicSourceInputHash: 'moic-src-hash',
+      h9RoundEvidenceInputHash: 'round-evidence-hash',
+      h9RoundEvidenceAssumptionsHash: 'assumptions-hash',
+      h9FingerprintHash: 'fingerprint-hash',
+      h9PolicyVersion: 'h9-policy-v1',
+      h9ActionabilityStatus: 'actionable',
+    });
+  });
+
+  it('stamps the full fingerprint even when non-actionable (satisfies the actionable-requires-non-null CHECK and feeds PR3 drift detection)', () => {
+    const cols = toH9SnapshotColumns(actionabilityResult('non_actionable'));
+    expect(cols.h9ActionabilityStatus).toBe('non_actionable');
+    expect(cols.h9FingerprintHash).toBe('fingerprint-hash');
+    expect(cols.h9MoicSourceInputHash).toBe('moic-src-hash');
+  });
+});
+
+describe('runReserveCalculation H9 stamp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete captured.values;
+  });
+
+  it('stamps the resolved H9 fingerprint columns onto the authoritative reserve snapshot insert', async () => {
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('actionable'));
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-1' });
+
+    expect(resolveMoicActionability).toHaveBeenCalledWith({ fundId: 7 });
+    expect(captured.values).toMatchObject({
+      type: 'RESERVE',
+      h9MoicSourceInputHash: 'moic-src-hash',
+      h9RoundEvidenceInputHash: 'round-evidence-hash',
+      h9RoundEvidenceAssumptionsHash: 'assumptions-hash',
+      h9FingerprintHash: 'fingerprint-hash',
+      h9PolicyVersion: 'h9-policy-v1',
+      h9ActionabilityStatus: 'actionable',
+    });
+  });
+
+  it('stamps non_actionable status when the fund is not actionable', async () => {
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('non_actionable'));
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-2' });
+
+    expect(captured.values?.h9ActionabilityStatus).toBe('non_actionable');
+  });
+});


### PR DESCRIPTION
## What

`runReserveCalculation` now resolves H9 actionability and stamps the six `h9_*` fingerprint columns onto the authoritative (`scenario_set_id` NULL) reserve snapshot. Adds `toH9SnapshotColumns` — a pure resolver-result -> column mapper.

## Governing decision (resolves a plan contradiction)

**H9 gates persistence/reuse/export semantics, not read-model computation.** Non-actionable funds (the default — no accepted MOIC reconciliation) still compute and **display** fresh dashboard reserve output; H9 only gates reuse-as-current, cache-as-authoritative, and PR3 export. This matches the Tactyc continuously-computed-forecast model and avoids dark-screening the dashboard for most funds.

Consequences:
- The dashboard read (`GET /api/funds/:id/results` -> `FundResultsReadService.loadSection`) is **unchanged**.
- No reserve cache / reuse-as-current path exists today, so the **stamp is the entire reserve-side change**. PR3 export gating consumes the stamp.

## Test (RED -> GREEN)

`tests/unit/services/reserve-calculation-h9-stamp.test.ts`:
- `toH9SnapshotColumns` maps actionable/non-actionable results to all six columns (fingerprint always populated, satisfying the `actionable`-requires-non-null CHECK and feeding PR3 drift detection).
- `runReserveCalculation` calls the resolver and the insert `.values()` carry the stamped columns.

4/4 green; `npm run check` clean.

## Stacking

Stacked on #932 (Lane A — deterministic fingerprint, which the stamp depends on). Base will auto-retarget to `main` when #932 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)