### PR TITLE
feat(h9): stamp actionability fingerprint on pacing snapshot writes

### DIFF
--- a/server/services/pacing-calculation-service.ts
+++ b/server/services/pacing-calculation-service.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { generatePacingSummary } from '@shared/core/pacing/PacingEngine';
 import type { PacingInput } from '@shared/types';
 import { markCalcRunCompletedIfReady } from './calc-run-tracking';
+import { resolveMoicActionability, toH9SnapshotColumns } from './fund-calculation-mode-service';
 import { resolvePacingFundSize } from './pacing-fund-size';
 
 export interface PacingCalculationInput {
@@ -50,12 +51,15 @@ export async function runPacingCalculation({
   };
 
   const pacingSummary = generatePacingSummary(pacingInput);
+  const actionability = await resolveMoicActionability({ fundId });
+  const h9Columns = toH9SnapshotColumns(actionability);
 
   const historyInserts = pacingSummary.deployments.map((deployment) => ({
     fundId,
     quarter: `Q${deployment.quarter}`,
     deploymentAmount: deployment.deployment.toString(),
     marketCondition,
+    ...h9Columns,
   }));
 
   for (const history of historyInserts) {
@@ -67,6 +71,7 @@ export async function runPacingCalculation({
         set: {
           deploymentAmount: history.deploymentAmount,
           marketCondition: history.marketCondition,
+          ...h9Columns,
         },
       });
   }
@@ -84,6 +89,7 @@ export async function runPacingCalculation({
       ...(runId != null && { runId }),
       ...(configId != null && { configId }),
       ...(configVersion != null && { configVersion }),
+      ...h9Columns,
       metadata: {
         totalQuarters: pacingSummary.totalQuarters,
         avgQuarterlyDeployment: pacingSummary.avgQuarterlyDeployment,

--- a/tests/unit/services/pacing-calculation-h9-stamp.test.ts
+++ b/tests/unit/services/pacing-calculation-h9-stamp.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MoicActionabilityResult } from '../../../server/services/fund-calculation-mode-service';
+
+// Mock only resolveMoicActionability; keep the real toH9SnapshotColumns (pure mapper under test).
+const { resolveMoicActionability } = vi.hoisted(() => ({
+  resolveMoicActionability: vi.fn(),
+}));
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
+  return {
+    ...actual,
+    resolveMoicActionability,
+  };
+});
+
+// Capture every db.insert(...).values(...) payload and every onConflictDoUpdate(...) config.
+// runPacingCalculation writes two authoritative tables: pacing_history (upsert loop, no
+// .returning()) and fund_snapshots type PACING (.returning()). The mocked .values() must
+// expose BOTH chains or the pacing_history insert throws and RED errors instead of failing
+// on the h9 assertion.
+const capturedValues: Array<Record<string, unknown>> = [];
+const capturedConflicts: Array<{ set?: Record<string, unknown> }> = [];
+
+vi.mock('../../../server/db', () => ({
+  db: {
+    query: {
+      funds: { findFirst: vi.fn(async () => ({ id: 7, size: '100000000' })) },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        capturedValues.push(values);
+        return {
+          onConflictDoUpdate: vi.fn(async (config: { set?: Record<string, unknown> }) => {
+            capturedConflicts.push(config);
+          }),
+          returning: vi.fn(async () => [
+            { id: 101, createdAt: new Date('2026-06-25T00:00:00.000Z'), calcVersion: '1.0.0' },
+          ]),
+        };
+      }),
+    })),
+  },
+}));
+
+vi.mock('../../../server/services/pacing-fund-size', () => ({
+  resolvePacingFundSize: vi.fn(async () => 100_000_000),
+}));
+
+vi.mock('@shared/core/pacing/PacingEngine', () => ({
+  generatePacingSummary: vi.fn(() => ({
+    deployments: [
+      { quarter: 1, deployment: 1_000_000 },
+      { quarter: 2, deployment: 2_000_000 },
+    ],
+    totalQuarters: 2,
+    avgQuarterlyDeployment: 1_500_000,
+    marketCondition: 'neutral',
+  })),
+}));
+
+vi.mock('../../../server/services/calc-run-tracking', () => ({
+  markCalcRunCompletedIfReady: vi.fn(async () => undefined),
+}));
+
+import { runPacingCalculation } from '../../../server/services/pacing-calculation-service';
+
+function actionabilityResult(status: 'actionable' | 'non_actionable'): MoicActionabilityResult {
+  return {
+    sourceFingerprintMatches: status === 'actionable',
+    actionability: status,
+    actionabilityStatus: status,
+    sourceFingerprint: {
+      moicSourceInputHash: 'moic-src-hash',
+      roundEvidenceInputHash: 'round-evidence-hash',
+      roundEvidenceAssumptionsHash: 'assumptions-hash',
+      fingerprintHash: 'fingerprint-hash',
+      policyVersion: 'h9-policy-v1',
+    },
+    acceptedReconciliationRunId: status === 'actionable' ? 42 : null,
+  } as MoicActionabilityResult;
+}
+
+const H9_STAMP = {
+  h9MoicSourceInputHash: 'moic-src-hash',
+  h9RoundEvidenceInputHash: 'round-evidence-hash',
+  h9RoundEvidenceAssumptionsHash: 'assumptions-hash',
+  h9FingerprintHash: 'fingerprint-hash',
+  h9PolicyVersion: 'h9-policy-v1',
+  h9ActionabilityStatus: 'actionable',
+};
+
+function pacingHistoryValues(): Array<Record<string, unknown>> {
+  return capturedValues.filter((v) => v['quarter'] !== undefined);
+}
+
+function pacingSnapshotValues(): Record<string, unknown> | undefined {
+  return capturedValues.find((v) => v['type'] === 'PACING');
+}
+
+describe('runPacingCalculation H9 stamp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedValues.length = 0;
+    capturedConflicts.length = 0;
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('actionable'));
+  });
+
+  it('stamps the resolved H9 fingerprint onto every pacing_history upsert value', async () => {
+    await runPacingCalculation({ fundId: 7, correlationId: 'corr-1' });
+
+    const rows = pacingHistoryValues();
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row).toMatchObject(H9_STAMP);
+    }
+  });
+
+  it('stamps the H9 fingerprint onto the pacing_history conflict set so re-runs refresh provenance', async () => {
+    await runPacingCalculation({ fundId: 7, correlationId: 'corr-2' });
+
+    expect(capturedConflicts).toHaveLength(2);
+    for (const conflict of capturedConflicts) {
+      expect(conflict.set).toMatchObject(H9_STAMP);
+    }
+  });
+
+  it('stamps the H9 fingerprint onto the authoritative PACING fund_snapshots insert', async () => {
+    await runPacingCalculation({ fundId: 7, correlationId: 'corr-3' });
+
+    expect(pacingSnapshotValues()).toMatchObject({ type: 'PACING', ...H9_STAMP });
+  });
+
+  it('resolves actionability exactly once per run with the fund id', async () => {
+    await runPacingCalculation({ fundId: 7, correlationId: 'corr-4' });
+
+    expect(resolveMoicActionability).toHaveBeenCalledTimes(1);
+    expect(resolveMoicActionability).toHaveBeenCalledWith({ fundId: 7 });
+  });
+
+  it('stamps non_actionable status (full fingerprint retained) when the fund is not actionable', async () => {
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('non_actionable'));
+
+    await runPacingCalculation({ fundId: 7, correlationId: 'corr-5' });
+
+    const snapshot = pacingSnapshotValues();
+    expect(snapshot?.['h9ActionabilityStatus']).toBe('non_actionable');
+    expect(snapshot?.['h9FingerprintHash']).toBe('fingerprint-hash');
+    expect(pacingHistoryValues()[0]).toMatchObject({ h9ActionabilityStatus: 'non_actionable' });
+  });
+});


### PR DESCRIPTION
## Summary
- Stamp H9 actionability columns on pacing_history insert values.
- Stamp the same H9 columns in onConflictDoUpdate.set so pacing re-runs refresh provenance instead of preserving stale fingerprints.
- Stamp the authoritative PACING fund_snapshots insert.
- Add focused server coverage for history insert values, conflict update sets, snapshot insert values, resolver call shape, and non_actionable status.

## Verification
- npm run check
- TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/services/pacing-calculation-h9-stamp.test.ts
- npx eslint --no-cache --max-warnings 0 server/services/pacing-calculation-service.ts tests/unit/services/pacing-calculation-h9-stamp.test.ts
- git diff --check origin/main..HEAD