### PR TITLE
chore(lint): ignore .remember/** agent runtime scratch in eslint.config.js

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,7 @@ export default [
       '.claude/**',
       '.tmp/**',
       '.omx/**',
+      '.remember/**',
       '.worktrees/**',
       'node_modules/**',
       'build/**',


### PR DESCRIPTION
## Summary

One-line ESLint fix unblocking the release gate's lint step. ESLint flat config does **not** read `.gitignore`, so `eslint .` scanned the gitignored `.remember/` agent runtime dir and tripped on `.remember/tmp/last-ndc.ts` with a typescript-eslint *"file not found by the project service"* parse error (the file matches `**/*.ts` → TS parser with `parserOptions.project: tsconfig.eslint.json`, but isn't in any tsconfig include). This failed `npm run release:check` at step 2/11 (lint).

Fix mirrors `.remember/**` into the global `ignores` array alongside the other runtime-cache dirs already there (`.omx`, `.claude`, `.a5c`, `.tmp`, `.worktrees`, `.artifacts`). No lint-rule, release-semantics, or domain-code change.

```diff
       '.omx/**',
+      '.remember/**',
       '.worktrees/**',
```

## Proof

| Check | Before | After |
|-------|--------|-------|
| `eslint .remember/tmp/last-ndc.ts` | exit 1 (parse error) | ignored |
| `npm run lint` (eslint + 6 guardrails) | fail | **exit 0** |
| `release:check` steps 1–4 (TS baseline, **lint**, client surface, server/CI surface) | blocked at 2/11 | **all PASS** |

## Out of scope (next blocker, not this PR)

Full non-skipped `npm run release:check` stops at **step 5/11 (Fund lifecycle DB proof)** with `Could not find a working container runtime strategy` — no local Docker daemon. Environmental, unrelated to this change. Needs Docker Desktop (or the WSL release-check recipe) for the complete release proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
