### PR TITLE
test(investment-rounds): add idempotency-key soak stability proof

### DIFF
--- a/tests/integration/investment-scenario-capability.test.ts
+++ b/tests/integration/investment-scenario-capability.test.ts
@@ -1,8 +1,9 @@
-import { sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import express, { type NextFunction, type Request, type Response, type Router } from 'express';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { investmentRounds } from '@shared/schema';
 import { applyInvestmentRoundConstraints } from '../helpers/apply-investment-round-constraints';
 import { runDrizzlePush } from './helpers/run-drizzle-push';
 import { setupTestDB } from '../helpers/testcontainers';
@@ -244,6 +245,51 @@ describe.skipIf(!process.env.CI && process.platform === 'win32')(
 
       expect(conflicting.status, JSON.stringify(conflicting.body)).toBe(409);
       expect(conflicting.body).toEqual({ error: 'idempotency_key_reused' });
+    });
+
+    it('holds idempotency-key stability across a repeated create soak', async () => {
+      expect(runtime).toBeDefined();
+      const active = runtime!;
+      const body = baseRoundBody(active.testFundId);
+      const idempotencyKey = 'soak-k1';
+      let firstBody: RoundResponseBody | undefined;
+
+      for (let attempt = 0; attempt < 25; attempt += 1) {
+        const response = await request(active.app)
+          .post(`/api/investments/${active.testInvestmentId}/rounds`)
+          .set('Idempotency-Key', idempotencyKey)
+          .send(body);
+
+        expect(response.status, JSON.stringify(response.body)).toBe(attempt === 0 ? 201 : 200);
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            id: expect.any(Number),
+            etag: expect.any(String),
+          })
+        );
+
+        const responseBody = response.body as RoundResponseBody;
+        if (attempt === 0) {
+          firstBody = responseBody;
+        } else {
+          expect(firstBody).toBeDefined();
+          expect(responseBody.id).toBe(firstBody?.id);
+          expect(responseBody.etag).toBe(firstBody?.etag);
+        }
+      }
+
+      expect(firstBody).toBeDefined();
+      const [roundCount] = await active.database
+        .select({ count: sql<number>`count(*)::int` })
+        .from(investmentRounds)
+        .where(
+          and(
+            eq(investmentRounds.investmentId, active.testInvestmentId),
+            eq(investmentRounds.idempotencyKey, idempotencyKey)
+          )
+        );
+
+      expect(roundCount?.count).toBe(1);
     });
 
     it('requires an Idempotency-Key header for round writes', async () => {


### PR DESCRIPTION
## What

Adds a controlled-soak stability proof to the existing
`tests/integration/investment-scenario-capability.test.ts` suite: a new
`it('holds idempotency-key stability across a repeated create soak')` that POSTs
the same investment-round body under a single `Idempotency-Key` 25 times and
asserts the contract holds under repetition, not just on a single replay:

- first response `201`, every subsequent response `200` (replay);
- stable `id` and `etag` across all 25 attempts (no row churn, no etag drift);
- exactly **one** persisted `investment_rounds` row for that investment + key.

## Why

The suite already covered single-shot create/replay/conflict, missing-key (428),
cross-fund denial (403), 404 listing, append-only supersede + double-supersede
(409), and performance-unsupported (501). It did **not** prove idempotency is
stable under *sustained repetition* — the "soak" gap. This closes it.

## Scope / safety

- **Test-only.** No production source, schema, route, or flag-default changes.
- `enable_investment_rounds` stays **default-OFF globally and OFF in prod** — this
  PR does not touch the flag.
- Mount parity is already correct on `main`: the rounds route is mounted on the
  prod `makeApp` surface (`server/app.ts`, `app.use('/api', investmentsRouter)`),
  so there is no prod-404 gap to close here.

## Enable levers (local/staging only — never flip on for prod)

Resolution order in `client/src/shared/useFlags.ts`:

1. runtime override — `?ff_enable_investment_rounds=1` query param **or**
   `localStorage['ff_enable_investment_rounds'] = '1'`;
2. build-time env — `VITE_ENABLE_INVESTMENT_ROUNDS=true`;
3. else the `ALL_FLAGS` default, which is **OFF** (the prod-leak tripwire guarded
   by `tests/unit/flags/enable-investment-rounds.test.tsx`).

`scripts/seed-db.ts` is **not** an enable lever — it only seeds sample
fund/company/investment data so the enabled UI has something to render.

## Verification

- `npm run check` (TypeScript baseline): PASS.
- `npx eslint` on the changed file: clean.
- The integration test is `skipIf(!CI && win32)` + testcontainers, so it is proven
  by a **full** `ci-unified` run (dispatched with `run_full_suite=true`), not on a
  local Windows box. Do not read a ~1m docs-only run as proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
