### PR TITLE
fix(ci): unblock integration suite (drizzle-push 42830 + source-map m…

### DIFF
--- a/migrations/0019_investments_id_fund_unique.sql
+++ b/migrations/0019_investments_id_fund_unique.sql
@@ -1,0 +1,31 @@
+-- Migration: 0019_investments_id_fund_unique
+-- Purpose: Add the (id, fund_id) UNIQUE constraint on investments so it can serve
+-- as a composite-FK target for the investment-rounds tables. This syncs the
+-- journaled ./migrations set with shared/schema (portfolio.ts:
+-- unique('investments_id_fund_id_key')), which db:push already creates on a fresh
+-- database.
+--
+-- Why this is needed: integration tests build the schema with migrate(./migrations)
+-- and THEN reconcile with `drizzle-kit push`. Without this constraint, push must
+-- ALTER the pre-existing investments table to add the unique key AND create the
+-- investment_rounds composite FK in the same pass; drizzle-kit orders the FK before
+-- the unique key, so PostgreSQL aborts with 42830 ("no unique constraint matching
+-- given keys for referenced table investments"). Creating the constraint up front
+-- lets push create the investment-rounds tables as a clean additive diff.
+--
+-- Replay safety: guarded ADD CONSTRAINT (skips if the table or constraint is absent
+-- or already present), matching applyInvestmentRoundConstraints' existence check.
+
+DO $$
+BEGIN
+  IF to_regclass('public.investments') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conname = 'investments_id_fund_id_key'
+         AND conrelid = 'public.investments'::regclass
+     ) THEN
+    ALTER TABLE "investments"
+      ADD CONSTRAINT "investments_id_fund_id_key" UNIQUE ("id", "fund_id");
+  END IF;
+END $$;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1782345601000,
       "tag": "0018_h9_actionability_snapshot_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1782345602000,
+      "tag": "0019_investments_id_fund_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "packageManager": "npm@10.9.2",
   "scripts": {
     "preinstall": "node scripts/check-package-manager.mjs",
+    "postinstall": "node scripts/patch-vitest-sourcemap.mjs",
     "doctor": "node scripts/doctor.mjs",
     "doctor:shell": "node scripts/doctor-shell.mjs",
     "doctor:quick": "node scripts/doctor-quick.mjs",

--- a/scripts/patch-vitest-sourcemap.mjs
+++ b/scripts/patch-vitest-sourcemap.mjs
@@ -1,0 +1,40 @@
+// Postinstall guard: make @vitest/utils' error-stack source-map reader resilient to a
+// malformed inline `sourceMappingURL=data:...base64,` marker bundled inside a dependency
+// (e.g. drizzle-kit/bin.cjs ships such a literal). Without this guard,
+// convertSourceMap.fromSource() throws "Unexpected end of JSON input" while vitest
+// symbolicates a failing test's stack; that throw escapes as an unhandled error and MASKS
+// the real failure (CI shows "0 failed + 1 unhandled error", exit 1).
+//
+// Idempotent, fail-safe, and version-resilient: no-ops if the target file is absent,
+// already guarded, or the upstream code shape changed; never throws (must not break install).
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const TARGET = 'node_modules/@vitest/utils/dist/source-map/node.js';
+const MARKER = '__updogSourcemapGuard';
+const NEEDLE =
+  'const map = (convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, createConvertSourceMapReadMap(filePath)))?.toObject();';
+
+try {
+  if (!existsSync(TARGET)) {
+    process.exit(0);
+  }
+  const original = readFileSync(TARGET, 'utf8');
+  if (original.includes(MARKER) || !original.includes(NEEDLE)) {
+    process.exit(0);
+  }
+  const guarded = [
+    `let map; // ${MARKER}`,
+    '\ttry {',
+    '\t\tmap = (convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, createConvertSourceMapReadMap(filePath)))?.toObject();',
+    '\t} catch {',
+    '\t\treturn undefined;',
+    '\t}',
+  ].join('\n');
+  writeFileSync(TARGET, original.replace(NEEDLE, guarded));
+  console.log('[patch-vitest-sourcemap] guarded @vitest/utils source-map reader');
+} catch (error) {
+  console.warn(
+    '[patch-vitest-sourcemap] skipped:',
+    error instanceof Error ? error.message : error
+  );
+}


### PR DESCRIPTION
Two stacked bugs made `ci-unified` "Test integration" deterministically red.

Layer B (real blocker): journaled ./migrations lacked the investments_id_fund_id_key UNIQUE(id, fund_id) constraint that shared/schema already defines. Integration tests build the schema with migrate(./migrations) then reconcile with `drizzle-kit push`; without the pre-existing constraint, push must ALTER the existing investments table AND create the investment_rounds composite FK in one pass, and drizzle-kit orders the FK before the unique key, so PostgreSQL aborts with 42830 ("no unique constraint matching given keys for referenced table investments"). Add replay-safe journaled migration 0019 so migrate() pre-creates the constraint and push becomes a clean additive diff.

Layer A (masking): vitest 4.1.8's error-stack symbolicator calls convertSourceMap.fromSource() on every stack frame; drizzle-kit/bin.cjs ships a literal `sourceMappingURL=data:...base64,` marker, so JSON.parse throws "Unexpected end of JSON input", which escaped as an unhandled error and MASKED the 42830 failures as "0 failed + 1 unhandled error" (exit 1). Add a fail-safe, idempotent postinstall guard (scripts/patch-vitest-sourcemap.mjs) so a malformed inline sourcemap degrades gracefully instead of crashing failure reporting.

Verified in WSL (Docker + pgvector; npm ci -> postinstall guard -> vitest): 42830 eliminated suite-wide, previously-failing migration tests pass, zero unhandled errors. Note: the 4.1.9 bump cannot fix Layer A (the source-map chain is byte-identical 4.1.8->4.1.9).