### PR TITLE
fix(schema): journal tasks CREATE + prod-schema reconcile runner (PR-1)

### DIFF
--- a/migrations/0012_sector_variance_drift.sql
+++ b/migrations/0012_sector_variance_drift.sql
@@ -1,3 +1,4 @@
+-- @drift-patch
 -- Migration: 0012_sector_variance_drift
 -- Purpose: Sector, cohort, and variance schema drift; closes journal drift for issue #781.
 -- Source of truth: drizzle-kit export from shared/schema.ts, shared/schema-lp-reporting.ts, and shared/schema-lp-sprint3.ts.

--- a/migrations/0014_lp_evidence_sprint3_drift.sql
+++ b/migrations/0014_lp_evidence_sprint3_drift.sql
@@ -1,3 +1,4 @@
+-- @drift-patch
 -- Migration: 0014_lp_evidence_sprint3_drift
 -- Purpose: LP evidence and Sprint 3 schema drift; closes journal drift for issue #781.
 -- Source of truth: drizzle-kit export from shared/schema.ts, shared/schema-lp-reporting.ts, and shared/schema-lp-sprint3.ts.

--- a/migrations/0016_reconciliation_runs.sql
+++ b/migrations/0016_reconciliation_runs.sql
@@ -1,3 +1,4 @@
+-- @drift-patch
 -- Migration: 0016_reconciliation_runs
 -- Purpose: Persist MOIC reconciliation run metadata and evidence summaries.
 -- Replay safety: CREATE TABLE/INDEX IF NOT EXISTS plus guarded constraints.

--- a/migrations/0017_moic_exit_probability_modes.sql
+++ b/migrations/0017_moic_exit_probability_modes.sql
@@ -1,3 +1,4 @@
+-- @drift-patch
 -- Migration: 0017_moic_exit_probability_modes
 -- Purpose: Add source-backed MOIC exit probability inputs and fund-scoped mode state.
 -- Replay safety: guarded ALTERs, CREATE TABLE IF NOT EXISTS, guarded constraints/indexes.

--- a/migrations/0020_operating_tasks_drift.sql
+++ b/migrations/0020_operating_tasks_drift.sql
@@ -1,0 +1,67 @@
+-- @drift-patch
+-- Operating-object tasks drift patch for the production makeApp surface.
+-- Mirrors shared/schema/operating-objects.ts and replaces the legacy
+-- server/migrations/20260616_operating_object_tasks_v1.up.sql path for PR-1.
+
+CREATE TABLE IF NOT EXISTS "tasks" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "title" varchar(200) NOT NULL,
+  "status" varchar(16) DEFAULT 'open' NOT NULL,
+  "owner_id" integer,
+  "due_date" date,
+  "description" text,
+  "created_by" integer,
+  "created_at" timestamp with time zone DEFAULT now(),
+  "updated_at" timestamp with time zone DEFAULT now(),
+  CONSTRAINT "tasks_status_check" CHECK ("status" IN ('open', 'in_progress', 'done')),
+  CONSTRAINT "tasks_title_nonempty_check" CHECK (length(btrim("title")) > 0)
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.tasks') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.tasks'::regclass
+         AND conname = 'tasks_fund_id_funds_id_fk'
+     ) THEN
+    ALTER TABLE "tasks"
+      ADD CONSTRAINT "tasks_fund_id_funds_id_fk"
+      FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.tasks') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.tasks'::regclass
+         AND conname = 'tasks_owner_id_users_id_fk'
+     ) THEN
+    ALTER TABLE "tasks"
+      ADD CONSTRAINT "tasks_owner_id_users_id_fk"
+      FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.tasks') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.tasks'::regclass
+         AND conname = 'tasks_created_by_users_id_fk'
+     ) THEN
+    ALTER TABLE "tasks"
+      ADD CONSTRAINT "tasks_created_by_users_id_fk"
+      FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_tasks_fund_created"
+  ON "tasks" USING btree ("fund_id", "created_at" DESC);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1782345602000,
       "tag": "0019_investments_id_fund_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1782691200000,
+      "tag": "0020_operating_tasks_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/db-push-core.mjs
+++ b/scripts/db-push-core.mjs
@@ -4,6 +4,9 @@ export const DB_PUSH_POSTCHECK_SKIP_FLAG = '--skip-postcheck';
 export const DEFAULT_OUTPUT_CONTEXT_LIMIT = 16 * 1024;
 export const MISSING_DATABASE_URL_MESSAGE =
   'DATABASE_URL is required for db:push postcheck; pass --skip-postcheck only for explicit offline inspection';
+export const PROD_DB_PUSH_REFUSAL_MESSAGE =
+  'Refusing db:push against the production database; use scripts/reconcile-prod-schema.mjs for operator-gated prod DDL';
+export const KNOWN_PRODUCTION_DB_HOST_PREFIXES = ['ep-snowy-boat-ad1z3h07'];
 
 export const UNIQUE_CONSTRAINT_SENTINELS = [
   'investment_rounds_id_fund_uq',
@@ -170,6 +173,70 @@ export function shouldRunPostcheck({ skipPostcheck, databaseUrlPresent }) {
   };
 }
 
+export function databaseUrlSignature(connectionString) {
+  if (!connectionString || connectionString === 'memory://') {
+    return null;
+  }
+
+  try {
+    const url = new URL(connectionString);
+    return `${url.protocol}//${url.username}@${url.hostname}${url.pathname}`.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function shouldRefuseProdDbPush({ databaseUrl, env = process.env } = {}) {
+  const signature = databaseUrlSignature(databaseUrl);
+  if (!signature) {
+    return {
+      refuse: false,
+      reason: 'no-database-url',
+      message: 'no database URL to classify',
+    };
+  }
+
+  const productionUrlKeys = [
+    'UPDOG_PRODUCTION_DATABASE_URL',
+    'PRODUCTION_DATABASE_URL',
+    'PROD_DATABASE_URL',
+  ];
+  const productionSignatures = productionUrlKeys
+    .map((key) => databaseUrlSignature(env[key]))
+    .filter((value) => typeof value === 'string');
+
+  if (productionSignatures.includes(signature)) {
+    return {
+      refuse: true,
+      reason: 'explicit-production-url-match',
+      message: PROD_DB_PUSH_REFUSAL_MESSAGE,
+    };
+  }
+
+  if (env.VERCEL_ENV === 'production') {
+    return {
+      refuse: true,
+      reason: 'vercel-production-env',
+      message: PROD_DB_PUSH_REFUSAL_MESSAGE,
+    };
+  }
+
+  const host = hostFromDatabaseUrl(databaseUrl);
+  if (host && KNOWN_PRODUCTION_DB_HOST_PREFIXES.some((prefix) => host.startsWith(prefix))) {
+    return {
+      refuse: true,
+      reason: 'known-production-host',
+      message: PROD_DB_PUSH_REFUSAL_MESSAGE,
+    };
+  }
+
+  return {
+    refuse: false,
+    reason: 'not-production',
+    message: 'database URL is not classified as production',
+  };
+}
+
 export function appendBoundedOutput(current, chunk, limit = DEFAULT_OUTPUT_CONTEXT_LIMIT) {
   const next = `${current}${chunk}`;
   if (next.length <= limit) {
@@ -217,6 +284,14 @@ function hasMissingSentinels(missing) {
 
 function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
+}
+
+function hostFromDatabaseUrl(connectionString) {
+  try {
+    return new URL(connectionString).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
 }
 
 export async function verifyPostPushSentinels({

--- a/scripts/db-push.mjs
+++ b/scripts/db-push.mjs
@@ -14,6 +14,7 @@ import {
   classifyDrizzlePushOutput,
   matchesDbError,
   parseDbPushArgs,
+  shouldRefuseProdDbPush,
   shouldRunPostcheck,
   verifyPostPushSentinels,
 } from './db-push-core.mjs';
@@ -84,6 +85,12 @@ export function runDrizzlePushChild({
 
 export async function runDbPushCli({ argv = process.argv.slice(2), env = process.env } = {}) {
   const { drizzleArgs, skipPostcheck } = parseDbPushArgs(argv, env);
+  const prodGuard = shouldRefuseProdDbPush({ databaseUrl: env.DATABASE_URL, env });
+  if (prodGuard.refuse) {
+    console.error(`[db:push] ${prodGuard.message}`);
+    return 1;
+  }
+
   const drizzleCommand = buildDrizzleSpawnCommand({
     drizzleArgs,
     repoRoot: process.cwd(),

--- a/scripts/prod-schema-manifests/01-cohort.json
+++ b/scripts/prod-schema-manifests/01-cohort.json
@@ -1,0 +1,119 @@
+{
+  "name": "M1-cohort",
+  "order": 1,
+  "description": "Cohort and sector analysis tables mounted through makeApp /api/cohorts.",
+  "sqlFiles": ["migrations/0012_sector_variance_drift.sql"],
+  "allowedCreateTables": [
+    "sector_taxonomy",
+    "sector_mappings",
+    "company_overrides",
+    "investment_overrides",
+    "cohort_definitions",
+    "variance_planner_leader"
+  ],
+  "expectedTables": [
+    {
+      "name": "sector_taxonomy",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "taxonomy_version", "nullable": false },
+        { "name": "slug", "nullable": false }
+      ],
+      "constraints": [
+        "sector_taxonomy_fund_version_slug_unique",
+        "sector_taxonomy_fund_id_funds_id_fk",
+        "sector_taxonomy_parent_sector_id_sector_taxonomy_id_fk",
+        "sector_taxonomy_created_by_user_id_users_id_fk",
+        "sector_taxonomy_updated_by_user_id_users_id_fk"
+      ],
+      "indexes": [
+        "sector_taxonomy_fund_version_idx",
+        "sector_taxonomy_parent_idx"
+      ]
+    },
+    {
+      "name": "sector_mappings",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "taxonomy_version", "nullable": false },
+        { "name": "raw_value_normalized", "nullable": false },
+        { "name": "canonical_sector_id", "nullable": false }
+      ],
+      "constraints": [
+        "sector_mappings_fund_version_normalized_unique",
+        "sector_mappings_fund_id_funds_id_fk",
+        "sector_mappings_canonical_sector_id_sector_taxonomy_id_fk",
+        "sector_mappings_created_by_user_id_users_id_fk",
+        "sector_mappings_updated_by_user_id_users_id_fk"
+      ],
+      "indexes": [
+        "sector_mappings_fund_version_idx",
+        "sector_mappings_canonical_sector_idx"
+      ]
+    },
+    {
+      "name": "company_overrides",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "taxonomy_version", "nullable": false },
+        { "name": "company_id", "nullable": false },
+        { "name": "canonical_sector_id", "nullable": false }
+      ],
+      "constraints": [
+        "company_overrides_fund_version_company_unique",
+        "company_overrides_fund_id_funds_id_fk",
+        "company_overrides_company_id_portfoliocompanies_id_fk",
+        "company_overrides_canonical_sector_id_sector_taxonomy_id_fk",
+        "company_overrides_created_by_user_id_users_id_fk",
+        "company_overrides_updated_by_user_id_users_id_fk"
+      ],
+      "indexes": [
+        "company_overrides_fund_version_idx",
+        "company_overrides_company_idx"
+      ]
+    },
+    {
+      "name": "investment_overrides",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "investment_id", "nullable": false }
+      ],
+      "constraints": [
+        "investment_overrides_fund_investment_unique",
+        "investment_overrides_vintage_quarter_check",
+        "investment_overrides_vintage_year_check",
+        "investment_overrides_fund_id_funds_id_fk",
+        "investment_overrides_investment_id_investments_id_fk",
+        "investment_overrides_created_by_user_id_users_id_fk",
+        "investment_overrides_updated_by_user_id_users_id_fk"
+      ],
+      "indexes": [
+        "investment_overrides_fund_idx",
+        "investment_overrides_investment_idx"
+      ]
+    },
+    {
+      "name": "cohort_definitions",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "name", "nullable": false },
+        { "name": "is_default", "nullable": false }
+      ],
+      "constraints": [
+        "cohort_definitions_fund_name_unique",
+        "cohort_definitions_fund_id_funds_id_fk",
+        "cohort_definitions_created_by_user_id_users_id_fk",
+        "cohort_definitions_updated_by_user_id_users_id_fk"
+      ],
+      "indexes": [
+        "cohort_definitions_fund_idx",
+        "cohort_definitions_default_idx"
+      ]
+    }
+  ]
+}

--- a/scripts/prod-schema-manifests/02-fund-moic.json
+++ b/scripts/prod-schema-manifests/02-fund-moic.json
@@ -1,0 +1,53 @@
+{
+  "name": "M2-fund-moic",
+  "order": 2,
+  "description": "Fund MOIC reconciliation and calculation-mode tables mounted through makeApp.",
+  "sqlFiles": [
+    "migrations/0016_reconciliation_runs.sql",
+    "migrations/0017_moic_exit_probability_modes.sql"
+  ],
+  "allowedCreateTables": [
+    "reconciliation_runs",
+    "fund_calculation_modes",
+    "fund_calculation_mode_requests",
+    "fund_moic_input_update_requests"
+  ],
+  "expectedTables": [
+    {
+      "name": "reconciliation_runs",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "idempotency_key", "nullable": false },
+        { "name": "status", "nullable": false }
+      ],
+      "constraints": [
+        "reconciliation_runs_fund_id_funds_id_fk",
+        "reconciliation_runs_requested_by_users_id_fk",
+        "reconciliation_runs_fund_id_idempotency_key_unique",
+        "reconciliation_runs_status_check"
+      ],
+      "indexes": ["idx_reconciliation_runs_fund_requested"]
+    },
+    {
+      "name": "fund_calculation_modes",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "calculation_key", "nullable": false },
+        { "name": "configured_mode", "nullable": false },
+        { "name": "kill_switch_active", "nullable": false },
+        { "name": "version", "nullable": false }
+      ],
+      "constraints": [
+        "fund_calculation_modes_fund_calculation_key_unique",
+        "fund_calculation_modes_configured_mode_check",
+        "fund_calculation_modes_version_check",
+        "fund_calculation_modes_fund_id_funds_id_fk",
+        "fund_calculation_modes_last_reconciliation_run_id_reconciliation_runs_id_fk",
+        "fund_calculation_modes_updated_by_users_id_fk"
+      ],
+      "indexes": ["idx_fund_calculation_modes_fund_updated"]
+    }
+  ]
+}

--- a/scripts/prod-schema-manifests/03-operating-tasks.json
+++ b/scripts/prod-schema-manifests/03-operating-tasks.json
@@ -1,0 +1,32 @@
+{
+  "name": "M3-operating-tasks",
+  "order": 3,
+  "description": "Operating-object tasks table mounted through makeApp /api/funds/:fundId/tasks.",
+  "sqlFiles": ["migrations/0020_operating_tasks_drift.sql"],
+  "allowedCreateTables": ["tasks"],
+  "expectedTables": [
+    {
+      "name": "tasks",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "title", "type": "varchar", "nullable": false },
+        { "name": "status", "type": "varchar", "nullable": false },
+        { "name": "owner_id", "type": "integer", "nullable": true },
+        { "name": "due_date", "type": "date", "nullable": true },
+        { "name": "description", "type": "text", "nullable": true },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": true },
+        { "name": "updated_at", "type": "timestamptz", "nullable": true }
+      ],
+      "constraints": [
+        "tasks_status_check",
+        "tasks_title_nonempty_check",
+        "tasks_fund_id_funds_id_fk",
+        "tasks_owner_id_users_id_fk",
+        "tasks_created_by_users_id_fk"
+      ],
+      "indexes": ["idx_tasks_fund_created"]
+    }
+  ]
+}

--- a/scripts/prod-schema-manifests/04-lp-reporting.json
+++ b/scripts/prod-schema-manifests/04-lp-reporting.json
@@ -1,0 +1,217 @@
+{
+  "name": "M4-lp-reporting",
+  "order": 4,
+  "description": "LP reporting evidence tables mounted through makeApp LP reporting routes.",
+  "sqlFiles": ["migrations/0014_lp_evidence_sprint3_drift.sql"],
+  "allowedCreateTables": [
+    "vehicles",
+    "cash_flow_events",
+    "valuation_marks",
+    "lp_metric_runs",
+    "narrative_runs",
+    "evidence_records",
+    "lp_report_packages",
+    "lp_report_package_exports",
+    "lp_vehicle_participation",
+    "lp_vehicle_participation_history",
+    "lp_capital_calls",
+    "lp_payment_submissions",
+    "lp_distribution_details",
+    "lp_documents",
+    "lp_notifications",
+    "lp_notification_preferences"
+  ],
+  "expectedTables": [
+    {
+      "name": "vehicles",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "vehicle_slug", "nullable": false },
+        { "name": "vehicle_type", "nullable": false },
+        { "name": "name", "nullable": false }
+      ],
+      "constraints": [
+        "vehicles_fund_slug_unique",
+        "vehicles_type_check",
+        "vehicles_status_check",
+        "vehicles_admin_score_check",
+        "vehicles_fund_id_funds_id_fk"
+      ],
+      "indexes": ["idx_vehicles_fund_type"]
+    },
+    {
+      "name": "cash_flow_events",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "event_type", "nullable": false },
+        { "name": "amount", "nullable": false },
+        { "name": "event_date", "nullable": false },
+        { "name": "perspective", "nullable": false }
+      ],
+      "constraints": [
+        "cash_flow_event_type_check",
+        "cash_flow_perspective_check",
+        "cash_flow_status_check",
+        "cash_flow_locked_not_mutable",
+        "cash_flow_events_fund_id_funds_id_fk",
+        "cash_flow_events_vehicle_id_vehicles_id_fk",
+        "cash_flow_events_company_id_portfoliocompanies_id_fk",
+        "cash_flow_events_lp_id_limited_partners_id_fk"
+      ],
+      "indexes": [
+        "idx_cash_flow_fund_date",
+        "idx_cash_flow_vehicle_date",
+        "idx_cash_flow_company_date",
+        "idx_cash_flow_event_type",
+        "idx_cash_flow_import_batch",
+        "cash_flow_events_fund_source_hash_unique"
+      ]
+    },
+    {
+      "name": "valuation_marks",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "company_id", "nullable": false },
+        { "name": "mark_date", "nullable": false },
+        { "name": "as_of_date", "nullable": false },
+        { "name": "fair_value", "nullable": false }
+      ],
+      "constraints": [
+        "valuation_mark_source_check",
+        "valuation_confidence_check",
+        "valuation_status_check",
+        "valuation_marks_fund_id_funds_id_fk",
+        "valuation_marks_vehicle_id_vehicles_id_fk",
+        "valuation_marks_company_id_portfoliocompanies_id_fk"
+      ],
+      "indexes": [
+        "idx_valuation_marks_fund_asof",
+        "idx_valuation_marks_company_asof",
+        "idx_valuation_marks_vehicle_asof",
+        "idx_valuation_marks_import_batch",
+        "valuation_marks_fund_source_hash_unique"
+      ]
+    },
+    {
+      "name": "lp_metric_runs",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "run_type", "nullable": false },
+        { "name": "perspective", "nullable": false },
+        { "name": "as_of_date", "nullable": false },
+        { "name": "status", "nullable": false }
+      ],
+      "constraints": [
+        "lp_metric_run_type_check",
+        "lp_metric_run_perspective_check",
+        "lp_metric_run_status_check",
+        "lp_metric_runs_fund_id_funds_id_fk",
+        "lp_metric_runs_vehicle_id_vehicles_id_fk"
+      ],
+      "indexes": [
+        "idx_lp_metric_runs_fund_asof",
+        "idx_lp_metric_runs_vehicle_asof",
+        "idx_lp_metric_runs_status",
+        "lp_metric_runs_fund_run_inputs_unique"
+      ]
+    },
+    {
+      "name": "evidence_records",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "evidence_source", "nullable": false },
+        { "name": "confidence_level", "nullable": false },
+        { "name": "materiality_level", "nullable": false },
+        { "name": "confidentiality", "nullable": false }
+      ],
+      "constraints": [
+        "evidence_one_target_check",
+        "evidence_source_check",
+        "evidence_confidence_check",
+        "evidence_materiality_check",
+        "evidence_confidentiality_check",
+        "evidence_records_fund_id_funds_id_fk"
+      ],
+      "indexes": [
+        "idx_evidence_fund",
+        "idx_evidence_valuation_mark",
+        "idx_evidence_company",
+        "idx_evidence_metric_run",
+        "evidence_records_metric_run_idempotency_unique",
+        "idx_evidence_narrative_run",
+        "idx_evidence_expiration_date",
+        "idx_evidence_confidence",
+        "idx_evidence_confidentiality"
+      ]
+    },
+    {
+      "name": "narrative_runs",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "metric_run_id", "nullable": false },
+        { "name": "narrative_type", "nullable": false },
+        { "name": "status", "nullable": false }
+      ],
+      "constraints": [
+        "narrative_type_check",
+        "narrative_status_check",
+        "narrative_runs_metric_run_id_lp_metric_runs_id_fk"
+      ],
+      "indexes": [
+        "idx_narrative_runs_metric_run",
+        "narrative_runs_metric_run_type_unique"
+      ]
+    },
+    {
+      "name": "lp_report_packages",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "metric_run_id", "nullable": false },
+        { "name": "status", "nullable": false }
+      ],
+      "constraints": [
+        "lp_report_package_status_check",
+        "lp_report_packages_fund_id_funds_id_fk",
+        "lp_report_packages_metric_run_id_lp_metric_runs_id_fk"
+      ],
+      "indexes": [
+        "lp_report_packages_metric_run_unique",
+        "idx_lp_report_packages_fund_metric",
+        "idx_lp_report_packages_fund_assembled_at"
+      ]
+    },
+    {
+      "name": "lp_report_package_exports",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "report_package_id", "nullable": false },
+        { "name": "format", "nullable": false },
+        { "name": "status", "nullable": false }
+      ],
+      "constraints": [
+        "lp_report_package_export_format_check",
+        "lp_report_package_export_version_check",
+        "lp_report_package_export_status_check",
+        "lp_report_package_export_hash_algorithm_check",
+        "lp_report_package_export_hash_check",
+        "lp_report_package_export_artifact_size_check",
+        "lp_report_package_exports_fund_id_funds_id_fk",
+        "lp_report_package_exports_report_package_id_lp_report_packages_id_fk"
+      ],
+      "indexes": [
+        "lp_report_package_exports_package_format_version_unique",
+        "idx_lp_report_package_exports_fund_metric",
+        "idx_lp_report_package_exports_fund_metric_package",
+        "idx_lp_report_package_exports_fund_ready_at"
+      ]
+    }
+  ]
+}

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -1,0 +1,763 @@
+#!/usr/bin/env node
+
+import { config } from 'dotenv';
+config({ quiet: true });
+
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+import {
+  classifyDrizzlePushOutput,
+  findMissingSentinels,
+  matchesDbError,
+} from './db-push-core.mjs';
+
+const { Client } = pg;
+
+export const DEFAULT_MANIFEST_DIR = 'scripts/prod-schema-manifests';
+export const LEDGER_TABLE = 'prod_schema_reconcile_ledger';
+export const RECONCILE_LOCK_ID = 20260628;
+export const ACTION_SKIP = 'SKIP';
+export const ACTION_APPLY_MISSING_DDL = 'APPLY-MISSING-DDL';
+export const ACTION_REFUSE_FOR_HUMAN = 'REFUSE-FOR-HUMAN';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SAFE_IDENTIFIER_PATTERN = /^[a-z_][a-z0-9_]*$/;
+const FORBIDDEN_SQL_PATTERN = /\b(?:neon_auth|drizzle_migrations)\b/i;
+const MIGRATION_MARKER_PATTERN = /^\s*--\s*@(generated|drift-patch)\b/m;
+
+export class ReconcileError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'ReconcileError';
+    this.details = details;
+  }
+}
+
+export function parseReconcileArgs(argv, env = process.env) {
+  const args = [...argv];
+  const apply = args.includes('--apply');
+  const yes = args.includes('--yes');
+  const manifestDir = valueAfter(args, '--manifest-dir') ?? env.UPDOG_SCHEMA_MANIFEST_DIR ?? DEFAULT_MANIFEST_DIR;
+  const expectedDatabase =
+    valueAfter(args, '--expect-db') ?? env.UPDOG_EXPECTED_DATABASE ?? env.PGDATABASE ?? null;
+
+  return {
+    apply,
+    yes,
+    manifestDir,
+    expectedDatabase,
+  };
+}
+
+export function assertApplyConfirmation({ apply, yes }) {
+  if (apply && !yes) {
+    throw new ReconcileError('--apply requires --yes to confirm a schema mutation', {
+      kind: 'missing-apply-confirmation',
+    });
+  }
+}
+
+export function isPoolerUrl(connectionString) {
+  try {
+    const url = new URL(connectionString);
+    return /(?:^|-|[.])pooler(?:-|[.]|$)/i.test(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function assertDirectDatabaseUrl(connectionString) {
+  if (!connectionString || connectionString === 'memory://') {
+    throw new ReconcileError('DATABASE_URL is missing or memory://; set it to the target database', {
+      kind: 'missing-database-url',
+    });
+  }
+
+  if (isPoolerUrl(connectionString)) {
+    throw new ReconcileError('Refusing pooled database URL; DDL requires the direct Neon endpoint', {
+      kind: 'pooler-url-refused',
+    });
+  }
+}
+
+export async function loadManifests(manifestDir = DEFAULT_MANIFEST_DIR, rootDir = repoRoot) {
+  const absoluteDir = path.resolve(rootDir, manifestDir);
+  const files = (await fs.readdir(absoluteDir))
+    .filter((fileName) => fileName.endsWith('.json'))
+    .sort();
+
+  const manifests = [];
+  for (const fileName of files) {
+    const manifestPath = path.join(absoluteDir, fileName);
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+    manifests.push({
+      ...manifest,
+      manifestPath: path.relative(rootDir, manifestPath).replace(/\\/g, '/'),
+    });
+  }
+
+  return manifests.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
+export async function readManifestSql(manifest, rootDir = repoRoot) {
+  const files = [];
+  for (const relPath of manifest.sqlFiles ?? []) {
+    const absolutePath = path.resolve(rootDir, relPath);
+    const sql = await fs.readFile(absolutePath, 'utf8');
+    files.push({
+      path: relPath,
+      sql,
+      checksum: sha256(sql),
+      statements: splitSqlStatements(sql),
+    });
+  }
+  return files;
+}
+
+export function splitSqlStatements(sql) {
+  return sql
+    .split('--> statement-breakpoint')
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
+export function manifestChecksum(manifest, sqlFiles) {
+  return sha256(
+    JSON.stringify({
+      name: manifest.name,
+      sqlFiles: sqlFiles.map((file) => ({ path: file.path, checksum: file.checksum })),
+      expectedTables: manifest.expectedTables ?? [],
+    })
+  );
+}
+
+export function statementHashes(sqlFiles) {
+  return sqlFiles.flatMap((file) =>
+    file.statements.map((statement, index) => ({
+      file: file.path,
+      index,
+      hash: sha256(statement),
+    }))
+  );
+}
+
+export function validateManifestSql(manifest, sqlFiles) {
+  const allowedCreates = new Set([
+    ...(manifest.allowedCreateTables ?? []),
+    ...(manifest.expectedTables ?? []).map((table) => table.name),
+  ]);
+
+  for (const file of sqlFiles) {
+    if (!MIGRATION_MARKER_PATTERN.test(file.sql)) {
+      throw new ReconcileError(`${file.path} is missing -- @generated or -- @drift-patch marker`, {
+        kind: 'missing-migration-marker',
+        file: file.path,
+      });
+    }
+
+    if (FORBIDDEN_SQL_PATTERN.test(file.sql)) {
+      throw new ReconcileError(`${file.path} references a forbidden schema-management table`, {
+        kind: 'forbidden-sql-target',
+        file: file.path,
+      });
+    }
+
+    for (const tableName of extractCreateTableNames(file.sql)) {
+      if (!allowedCreates.has(tableName)) {
+        throw new ReconcileError(
+          `${file.path} creates ${tableName}, which is not declared in manifest ${manifest.name}`,
+          {
+            kind: 'undeclared-create',
+            file: file.path,
+            tableName,
+            manifest: manifest.name,
+          }
+        );
+      }
+    }
+  }
+}
+
+export function extractCreateTableNames(sql) {
+  const withoutLineComments = sql.replace(/--.*$/gm, '');
+  return Array.from(
+    withoutLineComments.matchAll(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z_][a-z0-9_]*)"?/gi
+    ),
+    (match) => match[1]
+  ).filter((tableName) => typeof tableName === 'string');
+}
+
+export async function auditManifest(client, manifest) {
+  const expectedTables = manifest.expectedTables ?? [];
+  const tableNames = expectedTables.map((table) => table.name);
+  if (tableNames.length === 0) {
+    return {
+      manifest: manifest.name,
+      action: ACTION_SKIP,
+      objects: [],
+    };
+  }
+
+  const presentTables = await loadPresentTables(client, tableNames);
+  const columns = await loadColumns(client, tableNames);
+  const constraints = await loadConstraints(client, tableNames, expectedTables);
+  const indexes = await loadIndexes(client, expectedTables);
+  const objects = [];
+
+  for (const expectedTable of expectedTables) {
+    objects.push(
+      await auditTable({
+        client,
+        expectedTable,
+        tablePresent: presentTables.has(expectedTable.name),
+        columns: columns.get(expectedTable.name) ?? new Map(),
+        constraints,
+        indexes,
+      })
+    );
+  }
+
+  return {
+    manifest: manifest.name,
+    action: summarizeAction(objects.map((object) => object.action)),
+    objects,
+  };
+}
+
+export function decideObjectAction({ tablePresent, deltas, populated }) {
+  if (!tablePresent) {
+    return ACTION_APPLY_MISSING_DDL;
+  }
+
+  if (deltas.length === 0) {
+    return ACTION_SKIP;
+  }
+
+  const hasNonAdditiveDelta = deltas.some((delta) => delta.additiveSafe === false);
+  if (hasNonAdditiveDelta && populated) {
+    return ACTION_REFUSE_FOR_HUMAN;
+  }
+
+  return ACTION_APPLY_MISSING_DDL;
+}
+
+export function formatAuditReport({ identity, privilegePrecheck, audits, apply }) {
+  const lines = [
+    `Target database: ${identity.database} user=${identity.user}`,
+    `Mode: ${apply ? 'apply' : 'audit-only'}`,
+    `Privilege precheck: database_create=${privilegePrecheck.canCreateDatabaseObjects} schema_create=${privilegePrecheck.canCreatePublicSchemaObjects} extension_create=${privilegePrecheck.canCreateExtension}`,
+    '',
+  ];
+
+  for (const audit of audits) {
+    lines.push(`${audit.manifest}: ${audit.action}`);
+    for (const object of audit.objects) {
+      const deltaSummary =
+        object.deltas.length === 0
+          ? 'shape-ok'
+          : object.deltas.map((delta) => delta.name).join(', ');
+      lines.push(`  ${object.table}: ${object.action} (${deltaSummary})`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export async function readDatabaseIdentity(client) {
+  const result = await client.query(
+    `SELECT current_database() AS database, current_user AS "user", inet_server_addr()::text AS host`
+  );
+  const row = result.rows[0] ?? {};
+  return {
+    database: String(row.database ?? ''),
+    user: String(row.user ?? ''),
+    host: row.host === null || row.host === undefined ? null : String(row.host),
+  };
+}
+
+export function assertExpectedDatabase(identity, expectedDatabase) {
+  if (!expectedDatabase) return;
+  if (identity.database !== expectedDatabase) {
+    throw new ReconcileError(
+      `Target database identity mismatch: expected ${expectedDatabase}, got ${identity.database}`,
+      {
+        kind: 'database-identity-mismatch',
+        expectedDatabase,
+        actualDatabase: identity.database,
+      }
+    );
+  }
+}
+
+export async function precheckPrivileges(client) {
+  const result = await client.query(`
+    SELECT
+      has_database_privilege(current_database(), 'CREATE') AS "canCreateDatabaseObjects",
+      has_schema_privilege('public', 'CREATE') AS "canCreatePublicSchemaObjects",
+      has_database_privilege(current_database(), 'CREATE') AS "canCreateExtension"
+  `);
+  const row = result.rows[0] ?? {};
+  return {
+    canCreateDatabaseObjects: row.canCreateDatabaseObjects === true,
+    canCreatePublicSchemaObjects: row.canCreatePublicSchemaObjects === true,
+    canCreateExtension: row.canCreateExtension === true,
+  };
+}
+
+export function assertApplyPrivileges(privilegePrecheck) {
+  const missing = Object.entries(privilegePrecheck)
+    .filter(([, value]) => value !== true)
+    .map(([key]) => key);
+  if (missing.length > 0) {
+    throw new ReconcileError(`Target role lacks required DDL privileges: ${missing.join(', ')}`, {
+      kind: 'missing-privileges',
+      missing,
+    });
+  }
+}
+
+export async function runReconciliation({
+  client,
+  manifests,
+  rootDir = repoRoot,
+  apply = false,
+  expectedDatabase = null,
+  stdout = process.stdout,
+}) {
+  const identity = await readDatabaseIdentity(client);
+  assertExpectedDatabase(identity, expectedDatabase);
+  const privilegePrecheck = await precheckPrivileges(client);
+  if (apply) {
+    assertApplyPrivileges(privilegePrecheck);
+  }
+
+  const preparedManifests = [];
+  for (const manifest of manifests) {
+    const sqlFiles = await readManifestSql(manifest, rootDir);
+    validateManifestSql(manifest, sqlFiles);
+    preparedManifests.push({
+      manifest,
+      sqlFiles,
+      checksum: manifestChecksum(manifest, sqlFiles),
+      statementHashes: statementHashes(sqlFiles),
+    });
+  }
+
+  const audits = [];
+  for (const prepared of preparedManifests) {
+    audits.push(await auditManifest(client, prepared.manifest));
+  }
+
+  stdout.write(`${formatAuditReport({ identity, privilegePrecheck, audits, apply })}\n`);
+
+  if (!apply) {
+    stdout.write('\nAudit-only mode. Re-run with --apply --yes to apply the manifests.\n');
+    return { ok: true, applied: [], audits };
+  }
+
+  const auditByManifest = new Map(audits.map((audit) => [audit.manifest, audit]));
+  const refused = audits.filter((audit) => audit.action === ACTION_REFUSE_FOR_HUMAN);
+  if (refused.length > 0) {
+    throw new ReconcileError(
+      `Refusing apply; ${refused.map((audit) => audit.manifest).join(', ')} need human review`,
+      {
+        kind: 'human-review-required',
+        audits: refused,
+      }
+    );
+  }
+
+  const manifestsNeedingApply = preparedManifests.filter(
+    (prepared) => auditByManifest.get(prepared.manifest.name)?.action === ACTION_APPLY_MISSING_DDL
+  );
+  if (manifestsNeedingApply.length === 0) {
+    stdout.write('\nAll manifest shapes already match; no DDL applied.\n');
+    return { ok: true, applied: [], audits };
+  }
+
+  await acquireAdvisoryLock(client);
+  const applied = [];
+  try {
+    await setApplyTimeouts(client);
+    await ensureLedger(client);
+
+    for (const prepared of manifestsNeedingApply) {
+      if (await hasCommittedLedger(client, prepared.manifest.name, prepared.checksum)) {
+        stdout.write(`\nSkipping ${prepared.manifest.name}: committed ledger row already exists.\n`);
+        continue;
+      }
+
+      await applyPreparedManifest({ client, prepared, identity, stdout });
+      applied.push(prepared.manifest.name);
+    }
+  } finally {
+    await releaseAdvisoryLock(client);
+  }
+
+  return { ok: true, applied, audits };
+}
+
+export async function runReconcileCli({ argv = process.argv.slice(2), env = process.env } = {}) {
+  const options = parseReconcileArgs(argv, env);
+  assertApplyConfirmation(options);
+  assertDirectDatabaseUrl(env.DATABASE_URL);
+
+  const client = new Client({ connectionString: env.DATABASE_URL });
+  try {
+    await client.connect();
+    const manifests = await loadManifests(options.manifestDir);
+    await runReconciliation({
+      client,
+      manifests,
+      apply: options.apply,
+      expectedDatabase: options.expectedDatabase,
+    });
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const classification = classifyDrizzlePushOutput({
+      status: 0,
+      dbErrorDetected: matchesDbError(message),
+    });
+    console.error(`[reconcile-prod-schema] ${message}`);
+    if (!classification.ok) {
+      console.error(`[reconcile-prod-schema] ${classification.message}`);
+    }
+    return 1;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+async function auditTable({ client, expectedTable, tablePresent, columns, constraints, indexes }) {
+  const deltas = [];
+
+  if (!tablePresent) {
+    deltas.push({ kind: 'missing-table', name: expectedTable.name, additiveSafe: true });
+    return {
+      table: expectedTable.name,
+      present: false,
+      populated: false,
+      deltas,
+      action: ACTION_APPLY_MISSING_DDL,
+    };
+  }
+
+  for (const expectedColumn of expectedTable.columns ?? []) {
+    const actualColumn = columns.get(expectedColumn.name);
+    if (!actualColumn) {
+      deltas.push({
+        kind: 'missing-column',
+        name: `${expectedTable.name}.${expectedColumn.name}`,
+        additiveSafe: expectedColumn.nullable !== false,
+      });
+      continue;
+    }
+
+    if (
+      expectedColumn.type &&
+      normalizeColumnType(actualColumn) !== normalizeExpectedType(expectedColumn.type)
+    ) {
+      deltas.push({
+        kind: 'column-type-mismatch',
+        name: `${expectedTable.name}.${expectedColumn.name}`,
+        expected: expectedColumn.type,
+        actual: normalizeColumnType(actualColumn),
+        additiveSafe: false,
+      });
+    }
+
+    if (
+      typeof expectedColumn.nullable === 'boolean' &&
+      actualColumn.nullable !== expectedColumn.nullable
+    ) {
+      deltas.push({
+        kind: 'column-nullability-mismatch',
+        name: `${expectedTable.name}.${expectedColumn.name}`,
+        expected: expectedColumn.nullable,
+        actual: actualColumn.nullable,
+        additiveSafe: false,
+      });
+    }
+  }
+
+  const missingSentinels = findMissingSentinels({
+    sentinels: {
+      constraints: expectedTable.constraints ?? [],
+      indexes: expectedTable.indexes ?? [],
+    },
+    constraintRows: constraints,
+    indexRows: indexes,
+  });
+
+  for (const name of missingSentinels.constraints) {
+    deltas.push({ kind: 'missing-constraint', name, additiveSafe: true });
+  }
+
+  for (const name of missingSentinels.indexes) {
+    deltas.push({ kind: 'missing-index', name, additiveSafe: true });
+  }
+
+  const populated =
+    deltas.some((delta) => delta.additiveSafe === false) &&
+    (await hasRows(client, expectedTable.name));
+  const action = decideObjectAction({ tablePresent, deltas, populated });
+
+  return {
+    table: expectedTable.name,
+    present: true,
+    populated,
+    deltas,
+    action,
+  };
+}
+
+async function loadPresentTables(client, tableNames) {
+  const result = await client.query(
+    `
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+        AND table_name = ANY($1::text[])
+    `,
+    [tableNames]
+  );
+  return new Set(result.rows.map((row) => row.table_name));
+}
+
+async function loadColumns(client, tableNames) {
+  const result = await client.query(
+    `
+      SELECT table_name, column_name, data_type, udt_name, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = ANY($1::text[])
+    `,
+    [tableNames]
+  );
+  const columns = new Map();
+  for (const row of result.rows) {
+    const tableColumns = columns.get(row.table_name) ?? new Map();
+    tableColumns.set(row.column_name, {
+      dataType: row.data_type,
+      udtName: row.udt_name,
+      nullable: row.is_nullable === 'YES',
+    });
+    columns.set(row.table_name, tableColumns);
+  }
+  return columns;
+}
+
+async function loadConstraints(client, tableNames, expectedTables) {
+  const constraintNames = expectedTables.flatMap((table) => table.constraints ?? []);
+  if (constraintNames.length === 0) return [];
+
+  const result = await client.query(
+    `
+      SELECT c.conname
+      FROM pg_constraint c
+      JOIN pg_class rel ON rel.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = c.connamespace
+      WHERE n.nspname = 'public'
+        AND rel.relname = ANY($1::text[])
+        AND c.conname = ANY($2::text[])
+    `,
+    [tableNames, constraintNames]
+  );
+  return result.rows;
+}
+
+async function loadIndexes(client, expectedTables) {
+  const indexNames = expectedTables.flatMap((table) => table.indexes ?? []);
+  if (indexNames.length === 0) return [];
+
+  const result = await client.query(
+    `
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = ANY($1::text[])
+    `,
+    [indexNames]
+  );
+  return result.rows;
+}
+
+async function hasRows(client, tableName) {
+  assertSafeIdentifier(tableName);
+  const result = await client.query(`SELECT EXISTS (SELECT 1 FROM "${tableName}" LIMIT 1) AS populated`);
+  return result.rows[0]?.populated === true;
+}
+
+function summarizeAction(actions) {
+  if (actions.includes(ACTION_REFUSE_FOR_HUMAN)) return ACTION_REFUSE_FOR_HUMAN;
+  if (actions.includes(ACTION_APPLY_MISSING_DDL)) return ACTION_APPLY_MISSING_DDL;
+  return ACTION_SKIP;
+}
+
+async function acquireAdvisoryLock(client) {
+  const result = await client.query('SELECT pg_try_advisory_lock($1) AS acquired', [
+    RECONCILE_LOCK_ID,
+  ]);
+  if (result.rows[0]?.acquired !== true) {
+    throw new ReconcileError('Another prod-schema reconciliation run holds the advisory lock', {
+      kind: 'advisory-lock-contended',
+    });
+  }
+}
+
+async function releaseAdvisoryLock(client) {
+  await client.query('SELECT pg_advisory_unlock($1)', [RECONCILE_LOCK_ID]);
+}
+
+async function setApplyTimeouts(client) {
+  await client.query("SET lock_timeout = '5s'");
+  await client.query("SET statement_timeout = '5min'");
+}
+
+async function ensureLedger(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "${LEDGER_TABLE}" (
+      "id" bigserial PRIMARY KEY,
+      "manifest_name" text NOT NULL,
+      "manifest_checksum" text NOT NULL,
+      "file_checksums" jsonb NOT NULL,
+      "statement_hashes" jsonb NOT NULL,
+      "target_database" text NOT NULL,
+      "target_user" text NOT NULL,
+      "applied_by" text NOT NULL,
+      "started_at" timestamp with time zone NOT NULL DEFAULT now(),
+      "committed_at" timestamp with time zone,
+      "status" text NOT NULL,
+      CONSTRAINT "${LEDGER_TABLE}_status_check" CHECK ("status" IN ('started','committed'))
+    )
+  `);
+  await client.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS "${LEDGER_TABLE}_manifest_committed_idx"
+    ON "${LEDGER_TABLE}" ("manifest_name", "manifest_checksum")
+    WHERE "committed_at" IS NOT NULL
+  `);
+}
+
+async function hasCommittedLedger(client, manifestName, checksum) {
+  const result = await client.query(
+    `
+      SELECT 1
+      FROM "${LEDGER_TABLE}"
+      WHERE "manifest_name" = $1
+        AND "manifest_checksum" = $2
+        AND "committed_at" IS NOT NULL
+      LIMIT 1
+    `,
+    [manifestName, checksum]
+  );
+  return result.rowCount > 0;
+}
+
+async function applyPreparedManifest({ client, prepared, identity, stdout }) {
+  const fileChecksums = prepared.sqlFiles.map((file) => ({ path: file.path, checksum: file.checksum }));
+  const appliedBy = process.env.USER || process.env.USERNAME || 'unknown';
+  let ledgerId;
+
+  await client.query('BEGIN');
+  try {
+    const ledger = await client.query(
+      `
+        INSERT INTO "${LEDGER_TABLE}"
+          ("manifest_name", "manifest_checksum", "file_checksums", "statement_hashes",
+           "target_database", "target_user", "applied_by", "status")
+        VALUES ($1, $2, $3::jsonb, $4::jsonb, $5, $6, $7, 'started')
+        RETURNING "id"
+      `,
+      [
+        prepared.manifest.name,
+        prepared.checksum,
+        JSON.stringify(fileChecksums),
+        JSON.stringify(prepared.statementHashes),
+        identity.database,
+        identity.user,
+        appliedBy,
+      ]
+    );
+    ledgerId = ledger.rows[0].id;
+
+    for (const file of prepared.sqlFiles) {
+      stdout.write(`\nApplying ${file.path} (${file.statements.length} statements)\n`);
+      for (const statement of file.statements) {
+        await client.query(statement);
+      }
+    }
+
+    const after = await auditManifest(client, prepared.manifest);
+    if (after.action !== ACTION_SKIP) {
+      throw new ReconcileError(`Post-apply shape audit failed for ${prepared.manifest.name}`, {
+        kind: 'post-apply-audit-failed',
+        audit: after,
+      });
+    }
+
+    await client.query(
+      `
+        UPDATE "${LEDGER_TABLE}"
+        SET "committed_at" = now(), "status" = 'committed'
+        WHERE "id" = $1
+      `,
+      [ledgerId]
+    );
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  }
+}
+
+function normalizeColumnType(column) {
+  const dataType = String(column.dataType ?? '').toLowerCase();
+  const udtName = String(column.udtName ?? '').toLowerCase();
+  if (dataType === 'user-defined') return udtName;
+  if (dataType === 'character varying') return 'varchar';
+  if (dataType === 'timestamp with time zone') return 'timestamptz';
+  if (dataType === 'timestamp without time zone') return 'timestamp';
+  if (dataType === 'integer') return 'integer';
+  if (dataType === 'numeric') return 'numeric';
+  return dataType;
+}
+
+function normalizeExpectedType(type) {
+  return String(type).toLowerCase();
+}
+
+function assertSafeIdentifier(identifier) {
+  if (!SAFE_IDENTIFIER_PATTERN.test(identifier)) {
+    throw new ReconcileError(`Unsafe SQL identifier: ${identifier}`, {
+      kind: 'unsafe-identifier',
+      identifier,
+    });
+  }
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function valueAfter(args, flag) {
+  const index = args.indexOf(flag);
+  if (index === -1) return null;
+  return args[index + 1] ?? null;
+}
+
+const isDirectExecution =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isDirectExecution) {
+  runReconcileCli().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/scripts/schema-drift-active-surfaces.ts
+++ b/scripts/schema-drift-active-surfaces.ts
@@ -10,6 +10,7 @@ export const ACTIVE_SURFACE_IDS = [
   'shares',
   'sensitivity',
   'snapshots',
+  'prod-schema-reconcile',
 ] as const;
 
 export type ActiveSurfaceId = (typeof ACTIVE_SURFACE_IDS)[number];
@@ -370,6 +371,38 @@ export const ACTIVE_SCHEMA_SURFACES: readonly ActiveSchemaSurface[] = [
       'tests/unit/phase2b/fund-state-contract.test.ts',
     ],
     notes: 'The fund-state route contract is covered, but migration evidence is fragmented.',
+  },
+  {
+    id: 'prod-schema-reconcile',
+    label: 'Production schema reconciliation PR-1 guardrails',
+    requiredFiles: [
+      {
+        path: 'scripts/reconcile-prod-schema.mjs',
+        layer: 'test',
+        description: 'audit-first manifest runner for operator-gated prod schema reconciliation',
+      },
+      {
+        path: 'scripts/prod-schema-manifests/03-operating-tasks.json',
+        layer: 'test',
+        description: 'manifest that binds the makeApp tasks surface to journaled SQL',
+      },
+    ],
+    requiredExports: [],
+    migrationEvidence: [
+      {
+        pattern: 'migrations/0020_operating_tasks_drift.sql',
+        required: true,
+        description: 'journaled tasks CREATE for makeApp mount parity',
+      },
+    ],
+    tests: [
+      'tests/unit/mount-parity-migrations.test.ts',
+      'tests/unit/reconcile-prod-schema.test.ts',
+      'tests/integration/prod-schema-clone.test.ts',
+      'tests/integration/prod-schema-contract.test.ts',
+    ],
+    notes:
+      'shared/schema remains the shape source; migrations are the applied-SQL ledger for the runner.',
   },
 ];
 

--- a/shared/schema/operating-objects.ts
+++ b/shared/schema/operating-objects.ts
@@ -6,7 +6,7 @@
  * (fund-scoped work items, minimal create/list). assumption/comment follow in
  * later PRs and slot in beside `tasks` here.
  *
- * Mirrors server/migrations/20260616_operating_object_tasks_v1.up.sql. Use the
+ * Mirrors migrations/0020_operating_tasks_drift.sql. Use the
  * exported $inferSelect / $inferInsert types in services/contracts; never
  * hand-declare a column type in a consumer.
  *

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -1,0 +1,91 @@
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { loadManifests } from '../../scripts/reconcile-prod-schema.mjs';
+import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
+
+const STARTUP_TIMEOUT_MS = 90_000;
+const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
+
+let postgres: StartedPostgreSqlContainer | undefined;
+let pool: Pool | undefined;
+
+async function publicTables(activePool: Pool, tableNames: readonly string[]) {
+  const result = await activePool.query<{ table_name: string }>(
+    `
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+        AND table_name = ANY($1::text[])
+    `,
+    [tableNames]
+  );
+
+  return new Set(result.rows.map((row) => row.table_name));
+}
+
+async function publicConstraints(activePool: Pool, constraintNames: readonly string[]) {
+  const result = await activePool.query<{ conname: string }>(
+    `
+      SELECT c.conname
+      FROM pg_constraint c
+      JOIN pg_namespace n ON n.oid = c.connamespace
+      WHERE n.nspname = 'public'
+        AND c.conname = ANY($1::text[])
+    `,
+    [constraintNames]
+  );
+
+  return new Set(result.rows.map((row) => row.conname));
+}
+
+describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
+  beforeAll(async () => {
+    postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+      .withDatabase('test_db')
+      .withUsername('test_user')
+      .withPassword('test_password')
+      .withStartupTimeout(STARTUP_TIMEOUT_MS)
+      .start();
+
+    const connectionString = postgres.getConnectionUri();
+    await runMigrationsWithConnectionString(connectionString);
+    pool = new Pool({ connectionString, max: 1 });
+  }, STARTUP_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await pool?.end();
+    if (process.env.CI === 'true') {
+      console.warn(
+        '[prod-schema-clone] Postgres container left for CI cleanup after pg pool close'
+      );
+      return;
+    }
+    await postgres?.stop();
+  });
+
+  it('applies the PR-1 manifest tables and FK sentinels to an empty clone', async () => {
+    expect(pool).toBeDefined();
+    const manifests = await loadManifests();
+    const expectedTables = manifests.flatMap((manifest) =>
+      (manifest.expectedTables ?? []).map((table: { name: string }) => table.name)
+    );
+    const expectedConstraints = manifests.flatMap((manifest) =>
+      (manifest.expectedTables ?? []).flatMap(
+        (table: { constraints?: string[] }) => table.constraints ?? []
+      )
+    );
+
+    expect(expectedTables).toHaveLength(16);
+
+    const migratedTables = await publicTables(pool!, expectedTables);
+    const migratedConstraints = await publicConstraints(pool!, expectedConstraints);
+
+    expect(expectedTables.filter((tableName) => !migratedTables.has(tableName))).toEqual([]);
+    expect(
+      expectedConstraints.filter((constraintName) => !migratedConstraints.has(constraintName))
+    ).toEqual([]);
+  });
+});

--- a/tests/integration/prod-schema-contract.test.ts
+++ b/tests/integration/prod-schema-contract.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const LATENT_500_TABLES = [
+  'cohort_definitions',
+  'sector_taxonomy',
+  'sector_mappings',
+  'company_overrides',
+  'investment_overrides',
+  'reconciliation_runs',
+  'fund_calculation_modes',
+  'tasks',
+  'cash_flow_events',
+  'valuation_marks',
+  'vehicles',
+  'lp_metric_runs',
+  'evidence_records',
+  'narrative_runs',
+] as const;
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.resolve(process.cwd(), relativePath), 'utf8');
+}
+
+describe('prod schema empty-DB contract surface', () => {
+  it('keeps the C1 latent-500 contract matrix explicit', () => {
+    expect(LATENT_500_TABLES).toHaveLength(14);
+    expect(LATENT_500_TABLES).toContain('tasks');
+    expect(LATENT_500_TABLES).toContain('lp_metric_runs');
+  });
+
+  it('pins rounds v2 as observable graceful degradation, not silent success', () => {
+    const fundMoicRoute = readRepoFile('server/routes/fund-moic.ts');
+    const evidenceService = readRepoFile('server/services/rounds-to-model-evidence-service.ts');
+    const moicPage = readRepoFile('client/src/pages/fund-model-results-moic-analysis.tsx');
+
+    expect(fundMoicRoute).toContain("contract !== 'v2'");
+    expect(fundMoicRoute).toContain('provenance');
+    expect(fundMoicRoute).toContain('legacy');
+    expect(evidenceService).toContain('ROUND_ADAPTER_FAILED');
+    expect(moicPage).toContain('warningCodes');
+    expect(moicPage).toContain('Badge');
+  });
+});

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const MIGRATIONS_DIR = path.resolve(process.cwd(), 'migrations');
+
+const C1_MOUNTED_TABLES = [
+  'cohort_definitions',
+  'sector_taxonomy',
+  'sector_mappings',
+  'company_overrides',
+  'investment_overrides',
+  'reconciliation_runs',
+  'fund_calculation_modes',
+  'tasks',
+  'vehicles',
+  'cash_flow_events',
+  'valuation_marks',
+  'lp_metric_runs',
+  'evidence_records',
+  'narrative_runs',
+  'lp_report_packages',
+  'lp_report_package_exports',
+] as const;
+
+const DEFERRED_DOMAIN_LOCKED_TABLES = [
+  // Decision-3 / Debate D4 defer rounds storage to the investment-rounds rollout.
+  'investment_rounds',
+  'investment_round_model_overrides',
+] as const;
+
+function migrationSql(): string {
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((fileName) => fileName.endsWith('.sql'))
+    .sort()
+    .map((fileName) => fs.readFileSync(path.join(MIGRATIONS_DIR, fileName), 'utf8'))
+    .join('\n');
+}
+
+function hasCreateTable(sql: string, tableName: string): boolean {
+  const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    String.raw`CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+"?${escaped}"?\b`,
+    'i'
+  ).test(sql);
+}
+
+describe('makeApp mount parity with journaled migrations', () => {
+  it('has CREATE TABLE coverage for every C1 mounted table except deferred rounds tables', () => {
+    const sql = migrationSql();
+    const missingCreateTables = C1_MOUNTED_TABLES.filter(
+      (tableName) => !hasCreateTable(sql, tableName)
+    );
+
+    expect(missingCreateTables).toEqual([]);
+  });
+
+  it('keeps deferred rounds tables documented outside the C1 migration parity assertion', () => {
+    expect(DEFERRED_DOMAIN_LOCKED_TABLES).toEqual([
+      'investment_rounds',
+      'investment_round_model_overrides',
+    ]);
+  });
+});

--- a/tests/unit/reconcile-prod-schema.test.ts
+++ b/tests/unit/reconcile-prod-schema.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACTION_APPLY_MISSING_DDL,
+  ACTION_REFUSE_FOR_HUMAN,
+  ACTION_SKIP,
+  ReconcileError,
+  assertApplyConfirmation,
+  assertDirectDatabaseUrl,
+  assertExpectedDatabase,
+  auditManifest,
+  decideObjectAction,
+  parseReconcileArgs,
+  runReconciliation,
+  validateManifestSql,
+  extractCreateTableNames,
+} from '../../scripts/reconcile-prod-schema.mjs';
+
+interface QueryCall {
+  readonly text: string;
+  readonly params?: readonly unknown[];
+}
+
+interface MockClientOptions {
+  readonly database?: string;
+  readonly presentTables?: readonly string[];
+  readonly columns?: readonly {
+    table_name: string;
+    column_name: string;
+    data_type: string;
+    udt_name?: string;
+    is_nullable: 'YES' | 'NO';
+  }[];
+  readonly constraints?: readonly string[];
+  readonly indexes?: readonly string[];
+  readonly populatedTables?: readonly string[];
+}
+
+function createMockClient(options: MockClientOptions = {}) {
+  const calls: QueryCall[] = [];
+  const presentTables = new Set(options.presentTables ?? []);
+  const constraints = new Set(options.constraints ?? []);
+  const indexes = new Set(options.indexes ?? []);
+  const populatedTables = new Set(options.populatedTables ?? []);
+
+  return {
+    calls,
+    async query(text: string, params?: readonly unknown[]) {
+      calls.push({ text, params });
+
+      if (text.includes('has_database_privilege')) {
+        return {
+          rows: [
+            {
+              canCreateDatabaseObjects: true,
+              canCreatePublicSchemaObjects: true,
+              canCreateExtension: true,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+
+      if (text.includes('current_database()')) {
+        return {
+          rows: [
+            {
+              database: options.database ?? 'updog_test',
+              user: 'tester',
+              host: '127.0.0.1',
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+
+      if (text.includes('information_schema.tables')) {
+        const names = params?.[0] as string[];
+        return {
+          rows: names
+            .filter((name) => presentTables.has(name))
+            .map((table_name) => ({ table_name })),
+          rowCount: names.length,
+        };
+      }
+
+      if (text.includes('information_schema.columns')) {
+        return {
+          rows: [...(options.columns ?? [])],
+          rowCount: options.columns?.length ?? 0,
+        };
+      }
+
+      if (text.includes('FROM pg_constraint')) {
+        const names = params?.[1] as string[];
+        return {
+          rows: names.filter((conname) => constraints.has(conname)).map((conname) => ({ conname })),
+          rowCount: names.length,
+        };
+      }
+
+      if (text.includes('FROM pg_indexes')) {
+        const names = params?.[0] as string[];
+        return {
+          rows: names
+            .filter((indexname) => indexes.has(indexname))
+            .map((indexname) => ({ indexname })),
+          rowCount: names.length,
+        };
+      }
+
+      if (text.includes('SELECT EXISTS')) {
+        const match = text.match(/FROM "([^"]+)"/);
+        const tableName = match?.[1] ?? '';
+        return {
+          rows: [{ populated: populatedTables.has(tableName) }],
+          rowCount: 1,
+        };
+      }
+
+      if (text === 'SELECT pg_try_advisory_lock($1) AS acquired') {
+        return { rows: [{ acquired: true }], rowCount: 1 };
+      }
+
+      if (text === 'SELECT pg_advisory_unlock($1)') {
+        return { rows: [{ pg_advisory_unlock: true }], rowCount: 1 };
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+}
+
+const manifest = {
+  name: 'fixture',
+  expectedTables: [
+    {
+      name: 'tasks',
+      columns: [
+        { name: 'id', type: 'integer', nullable: false },
+        { name: 'fund_id', type: 'integer', nullable: false },
+        { name: 'title', type: 'varchar', nullable: false },
+      ],
+      constraints: ['tasks_fund_id_funds_id_fk'],
+      indexes: ['idx_tasks_fund_created'],
+    },
+  ],
+};
+
+function fullShapeClient() {
+  return createMockClient({
+    presentTables: ['tasks'],
+    columns: [
+      {
+        table_name: 'tasks',
+        column_name: 'id',
+        data_type: 'integer',
+        udt_name: 'int4',
+        is_nullable: 'NO',
+      },
+      {
+        table_name: 'tasks',
+        column_name: 'fund_id',
+        data_type: 'integer',
+        udt_name: 'int4',
+        is_nullable: 'NO',
+      },
+      {
+        table_name: 'tasks',
+        column_name: 'title',
+        data_type: 'character varying',
+        udt_name: 'varchar',
+        is_nullable: 'NO',
+      },
+    ],
+    constraints: ['tasks_fund_id_funds_id_fk'],
+    indexes: ['idx_tasks_fund_created'],
+  });
+}
+
+describe('reconcile-prod-schema runner helpers', () => {
+  it('defaults to audit-only mode', () => {
+    expect(parseReconcileArgs([])).toMatchObject({
+      apply: false,
+      yes: false,
+      manifestDir: 'scripts/prod-schema-manifests',
+    });
+  });
+
+  it('requires --yes for apply mode', () => {
+    expect(() => assertApplyConfirmation({ apply: true, yes: false })).toThrow(ReconcileError);
+    expect(() => assertApplyConfirmation({ apply: true, yes: true })).not.toThrow();
+  });
+
+  it('refuses pooled database URLs', () => {
+    expect(() =>
+      assertDirectDatabaseUrl(
+        'postgres://u:p@ep-snowy-boat-ad1z3h07-pooler.us-east-1.aws.neon.tech/db'
+      )
+    ).toThrow(/pooled database URL/);
+  });
+
+  it('asserts the expected database identity before apply', () => {
+    expect(() =>
+      assertExpectedDatabase({ database: 'wrong', user: 'u', host: null }, 'expected')
+    ).toThrow(/identity mismatch/);
+  });
+
+  it('blocks undeclared CREATE TABLE statements in manifest SQL', () => {
+    expect(() =>
+      validateManifestSql({ name: 'fixture', allowedCreateTables: ['tasks'], expectedTables: [] }, [
+        {
+          path: 'fixture.sql',
+          sql: '-- @drift-patch\nCREATE TABLE IF NOT EXISTS "unexpected_table" (id serial primary key);',
+        },
+      ])
+    ).toThrow(/not declared/);
+  });
+
+  it('extracts CREATE TABLE IF NOT EXISTS names without treating IF as the table', () => {
+    expect(
+      extractCreateTableNames(
+        '-- Replay safety: CREATE TABLE IF NOT EXISTS.\n-- @drift-patch\nCREATE TABLE IF NOT EXISTS "fund_calculation_modes" (id serial);'
+      )
+    ).toEqual(['fund_calculation_modes']);
+  });
+
+  it('blocks forbidden schema-management targets in manifest SQL', () => {
+    expect(() =>
+      validateManifestSql({ name: 'fixture', allowedCreateTables: ['tasks'], expectedTables: [] }, [
+        { path: 'fixture.sql', sql: '-- @drift-patch\nSELECT * FROM drizzle_migrations;' },
+      ])
+    ).toThrow(/forbidden/);
+  });
+
+  it('requires generated or drift-patch markers on manifest SQL', () => {
+    expect(() =>
+      validateManifestSql({ name: 'fixture', allowedCreateTables: ['tasks'], expectedTables: [] }, [
+        { path: 'fixture.sql', sql: 'CREATE TABLE IF NOT EXISTS "tasks" (id serial primary key);' },
+      ])
+    ).toThrow(/missing -- @generated or -- @drift-patch marker/);
+  });
+});
+
+describe('reconcile-prod-schema shape decisions', () => {
+  it('skips objects with full table, column, constraint, and index shape', async () => {
+    const client = fullShapeClient();
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_SKIP);
+    expect(audit.objects[0]?.deltas).toEqual([]);
+  });
+
+  it('applies missing DDL when the table is absent', async () => {
+    const client = createMockClient();
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_APPLY_MISSING_DDL);
+    expect(audit.objects[0]?.deltas.map((delta) => delta.kind)).toContain('missing-table');
+  });
+
+  it('applies additive-safe missing constraints and indexes regardless of row count', async () => {
+    const client = createMockClient({
+      presentTables: ['tasks'],
+      populatedTables: ['tasks'],
+      columns: [
+        {
+          table_name: 'tasks',
+          column_name: 'id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+        },
+        {
+          table_name: 'tasks',
+          column_name: 'fund_id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+        },
+        {
+          table_name: 'tasks',
+          column_name: 'title',
+          data_type: 'character varying',
+          udt_name: 'varchar',
+          is_nullable: 'NO',
+        },
+      ],
+    });
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_APPLY_MISSING_DDL);
+    expect(audit.objects[0]?.deltas.map((delta) => delta.kind)).toEqual([
+      'missing-constraint',
+      'missing-index',
+    ]);
+  });
+
+  it('refuses non-additive deltas on populated tables', () => {
+    expect(
+      decideObjectAction({
+        tablePresent: true,
+        populated: true,
+        deltas: [{ kind: 'column-type-mismatch', name: 'tasks.title', additiveSafe: false }],
+      })
+    ).toBe(ACTION_REFUSE_FOR_HUMAN);
+  });
+
+  it('audit-only mode does not issue mutation queries', async () => {
+    const client = fullShapeClient();
+    const output: string[] = [];
+
+    await runReconciliation({
+      client,
+      manifests: [manifest],
+      apply: false,
+      stdout: { write: (chunk: string) => output.push(chunk) },
+    });
+
+    expect(output.join('')).toContain('Audit-only mode');
+    expect(
+      client.calls.some((call) => /\bBEGIN\b|INSERT INTO|CREATE TABLE|COMMIT/.test(call.text))
+    ).toBe(false);
+  });
+
+  it('apply mode performs no mutation when all manifest shapes already match', async () => {
+    const client = fullShapeClient();
+    const output: string[] = [];
+
+    await runReconciliation({
+      client,
+      manifests: [manifest],
+      apply: true,
+      stdout: { write: (chunk: string) => output.push(chunk) },
+    });
+
+    expect(output.join('')).toContain('no DDL applied');
+    expect(
+      client.calls.some((call) => /\bBEGIN\b|INSERT INTO|CREATE TABLE|COMMIT/.test(call.text))
+    ).toBe(false);
+  });
+});

--- a/tests/unit/schema/schema-drift-active-surfaces.test.ts
+++ b/tests/unit/schema/schema-drift-active-surfaces.test.ts
@@ -31,9 +31,7 @@ describe('active schema drift surface manifest', () => {
     expect(referencedPaths).toContain('shared/schema.ts');
     expect(referencedPaths).toContain('shared/schema/lp-reporting-evidence.ts');
     expect(referencedPaths).toContain('shared/contracts/fund-state-read-v1.contract.ts');
-    expect(
-      referencedPaths.some((entry) => entry === 'migrations' || entry.startsWith('migrations/'))
-    ).toBe(false);
+    expect(referencedPaths).toContain('migrations/0020_operating_tasks_drift.sql');
     expect(
       referencedPaths.some(
         (entry) => entry === 'server/db/schema' || entry.startsWith('server/db/schema/')

--- a/tests/unit/scripts/db-push.test.mjs
+++ b/tests/unit/scripts/db-push.test.mjs
@@ -5,6 +5,7 @@ import {
   DB_PUSH_POSTCHECK_SKIP_FLAG,
   INDEX_SENTINEL_QUERY,
   MISSING_DATABASE_URL_MESSAGE,
+  PROD_DB_PUSH_REFUSAL_MESSAGE,
   appendBoundedOutput,
   buildDrizzleArgs,
   buildDrizzleSpawnCommand,
@@ -15,6 +16,7 @@ import {
   parseDbPushArgs,
   resolveLocalDrizzleBinary,
   resolveLocalDrizzleEntrypoint,
+  shouldRefuseProdDbPush,
   shouldRunPostcheck,
   verifyPostPushSentinels,
 } from '../../../scripts/db-push-core.mjs';
@@ -262,6 +264,50 @@ describe('db-push postcheck decisions', () => {
     ).toMatchObject({
       ok: false,
       reason: 'database-error',
+    });
+  });
+});
+
+describe('db-push production URL guard', () => {
+  it('refuses an explicit production database URL match without comparing secrets', () => {
+    const prodUrl = 'postgres://user:secret@prod.example.com:5432/updog?sslmode=require';
+    const sameTargetDifferentSecret =
+      'postgres://user:different@prod.example.com:5432/updog?sslmode=require';
+
+    expect(
+      shouldRefuseProdDbPush({
+        databaseUrl: sameTargetDifferentSecret,
+        env: { UPDOG_PRODUCTION_DATABASE_URL: prodUrl },
+      })
+    ).toMatchObject({
+      refuse: true,
+      reason: 'explicit-production-url-match',
+      message: PROD_DB_PUSH_REFUSAL_MESSAGE,
+    });
+  });
+
+  it('refuses the known Neon production host from the drift handoff', () => {
+    expect(
+      shouldRefuseProdDbPush({
+        databaseUrl:
+          'postgres://user:secret@ep-snowy-boat-ad1z3h07-pooler.us-east-1.aws.neon.tech/updog',
+        env: {},
+      })
+    ).toMatchObject({
+      refuse: true,
+      reason: 'known-production-host',
+    });
+  });
+
+  it('refuses Vercel production environments', () => {
+    expect(
+      shouldRefuseProdDbPush({
+        databaseUrl: 'postgres://user:secret@db.example.com/updog',
+        env: { VERCEL_ENV: 'production' },
+      })
+    ).toMatchObject({
+      refuse: true,
+      reason: 'vercel-production-env',
     });
   });
 });

--- a/vitest.config.testcontainers.ts
+++ b/vitest.config.testcontainers.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'tests/integration/migration-runner.test.ts',
       'tests/integration/fund-lifecycle-db.test.ts',
       'tests/integration/migration-drift.test.ts',
+      'tests/integration/prod-schema-clone.test.ts',
       'tests/integration/migrations/investment-rounds-schema.test.ts',
       'tests/integration/migrations/investments-id-fund-unique.test.ts',
       'tests/integration/investment-scenario-capability.test.ts',


### PR DESCRIPTION
Close the canonical-migration drift behind makeApp-reachable routes without touching prod. The only C1 mounted table missing a journaled CREATE was `tasks` (it lived only in non-journaled server/migrations/) -> add journaled 0020_operating_tasks_drift.sql + journal entry; the other 15 C1 tables already had CREATEs in 0012/0014/0016/0017.

- Add audit-first reconcile runner (scripts/reconcile-prod-schema.mjs) with shape-aware SKIP/APPLY/REFUSE, SQL marker (@drift-patch) enforcement, advisory-lock + apply-ledger, no-op when shapes already match.
- Add PR-1 manifests M1-M4 (cohort, fund-moic, operating-tasks, lp-reporting); M1/M2/M4 REFERENCE existing journaled SQL, only `tasks` is net-new.
- Add db:push prod-URL refusal guard (exit 1, not silent 0).
- Register PR-1 surface in schema-drift validation.
- TDD: mount-parity unit test (RED on missing `tasks`, GREEN after 0020) with a documented allowlist exempting deferred domain-locked rounds tables (Decision-3 / Debate D4); plus reconcile unit + prod-schema contract/clone integration tests.

Out of scope (deferred): rounds tables #17-18, prod apply, PR-2 canonicalize.