### PR TITLE
fix(schema): truncation-aware constraint checks — green main (follow-up to #948)

### DIFF
--- a/scripts/db-push-core.mjs
+++ b/scripts/db-push-core.mjs
@@ -254,13 +254,21 @@ function rowNames(rows, fieldName) {
   );
 }
 
+// PostgreSQL truncates identifiers to 63 bytes (NAMEDATALEN-1). Manifest/sentinel
+// names can exceed this; the stored conname/indexname is the truncated form, so
+// compare against the truncated name. Manifest identifiers are ASCII, so a 63-char
+// slice equals the 63-byte truncation PostgreSQL applies.
+export function pgIdentifier(name) {
+  return name.length > 63 ? name.slice(0, 63) : name;
+}
+
 export function findMissingSentinels({ sentinels, constraintRows, indexRows }) {
   const presentConstraints = rowNames(constraintRows, 'conname');
   const presentIndexes = rowNames(indexRows, 'indexname');
 
   return {
-    constraints: sentinels.constraints.filter((name) => !presentConstraints.has(name)),
-    indexes: sentinels.indexes.filter((name) => !presentIndexes.has(name)),
+    constraints: sentinels.constraints.filter((name) => !presentConstraints.has(pgIdentifier(name))),
+    indexes: sentinels.indexes.filter((name) => !presentIndexes.has(pgIdentifier(name))),
   };
 }
 

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -14,6 +14,7 @@ import {
   classifyDrizzlePushOutput,
   findMissingSentinels,
   matchesDbError,
+  pgIdentifier,
 } from './db-push-core.mjs';
 
 const { Client } = pg;
@@ -558,6 +559,7 @@ async function loadColumns(client, tableNames) {
 async function loadConstraints(client, tableNames, expectedTables) {
   const constraintNames = expectedTables.flatMap((table) => table.constraints ?? []);
   if (constraintNames.length === 0) return [];
+  const lookupNames = constraintNames.map(pgIdentifier);
 
   const result = await client.query(
     `
@@ -569,7 +571,7 @@ async function loadConstraints(client, tableNames, expectedTables) {
         AND rel.relname = ANY($1::text[])
         AND c.conname = ANY($2::text[])
     `,
-    [tableNames, constraintNames]
+    [tableNames, lookupNames]
   );
   return result.rows;
 }

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -2,6 +2,7 @@ import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testconta
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { pgIdentifier } from '../../scripts/db-push-core.mjs';
 import { loadManifests } from '../../scripts/reconcile-prod-schema.mjs';
 import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
 
@@ -72,11 +73,13 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     const expectedTables = manifests.flatMap((manifest) =>
       (manifest.expectedTables ?? []).map((table: { name: string }) => table.name)
     );
-    const expectedConstraints = manifests.flatMap((manifest) =>
-      (manifest.expectedTables ?? []).flatMap(
-        (table: { constraints?: string[] }) => table.constraints ?? []
+    const expectedConstraints = manifests
+      .flatMap((manifest) =>
+        (manifest.expectedTables ?? []).flatMap(
+          (table: { constraints?: string[] }) => table.constraints ?? []
+        )
       )
-    );
+      .map(pgIdentifier);
 
     expect(expectedTables).toHaveLength(16);
 

--- a/tests/unit/scripts/db-push.test.mjs
+++ b/tests/unit/scripts/db-push.test.mjs
@@ -14,6 +14,7 @@ import {
   findMissingSentinels,
   matchesDbError,
   parseDbPushArgs,
+  pgIdentifier,
   resolveLocalDrizzleBinary,
   resolveLocalDrizzleEntrypoint,
   shouldRefuseProdDbPush,
@@ -313,6 +314,11 @@ describe('db-push production URL guard', () => {
 });
 
 describe('db-push sentinel postcheck', () => {
+  it('normalizes PostgreSQL identifiers to the 63-byte stored form', () => {
+    expect(pgIdentifier('a'.repeat(75))).toHaveLength(63);
+    expect(pgIdentifier('short')).toBe('short');
+  });
+
   it('passes when all public-schema sentinels are present', async () => {
     const mockClient = createMockClient();
 
@@ -388,6 +394,20 @@ describe('db-push sentinel postcheck', () => {
     expect(INDEX_SENTINEL_QUERY).toContain("schemaname = 'public'");
     expect(missing.constraints).toEqual(sentinels.constraints);
     expect(missing.indexes).toEqual(sentinels.indexes);
+  });
+
+  it('treats a truncated PostgreSQL constraint name as present', () => {
+    const longConstraintName = 'a'.repeat(75);
+    const missing = findMissingSentinels({
+      sentinels: {
+        constraints: [longConstraintName],
+        indexes: [],
+      },
+      constraintRows: [{ conname: longConstraintName.slice(0, 63) }],
+      indexRows: [],
+    });
+
+    expect(missing.constraints).toEqual([]);
   });
 
   it('fails closed when DATABASE_URL is set but the database is unreachable', async () => {


### PR DESCRIPTION
## Why
`main` went red after #948 merged: `tests/integration/prod-schema-clone.test.ts` fails because 2 of 86 expected FK constraint names exceed PostgreSQL's 63-byte identifier limit. PG silently truncates them on creation, so the FKs exist under truncated names, but verification compared the **full** manifest name against `pg_constraint.conname` (already truncated) → false "missing".

- `fund_calculation_modes_last_reconciliation_run_id_reconciliation_runs_id_fk` (75)
- `lp_report_package_exports_report_package_id_lp_report_packages_id_fk` (68)

This is a verification bug, not a schema gap (prod has both under the truncated names via db:push). The same flaw lived in the runner's audit path (`loadConstraints` + `findMissingSentinels`), where it would never converge and an `--apply` would collide on the already-present truncated constraint.

## Fix
Add `pgIdentifier(name)` (truncate to 63) in `scripts/db-push-core.mjs` and apply it everywhere an expected name is compared to an actual `conname`:
- `findMissingSentinels` (constraints + indexes)
- `reconcile-prod-schema.mjs` `loadConstraints` query
- `prod-schema-clone.test.ts` `expectedConstraints`

Manifests keep their full human-readable names; renaming the FKs would diverge from what drizzle/db:push produce in prod.

## Verification
- Unit: `tests/unit/scripts/db-push.test.mjs` (+2 cases: `pgIdentifier` truncates >63; `findMissingSentinels` treats a truncated `conname` as present), `tests/unit/reconcile-prod-schema.test.ts` — 40 passed.
- Full suite (run_full_suite) on this branch: **green** (run 28338027384). `Test integration` success; `prod-schema-clone.test.ts (1 test) ✓`.

Scope: 4 files. No migration/manifest/schema content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)