### PR TITLE
docs: preserve untracked workstream plans + reviews

### DIFF
--- a/docs/CRITICAL-REVIEW-secondary-surface-governance.md
+++ b/docs/CRITICAL-REVIEW-secondary-surface-governance.md
@@ -1,0 +1,1434 @@
+# Critical Review: Latest Strategy Proposal for Secondary Surface Governance
+
+**Date:** 2026-06-17 **Reviewer:** Orchestrator **Scope:** Updog_restore route
+governance, production safety, mock-data quarantine, provenance contracts, and
+build-time exclusion **Validation method:** Live codebase exploration with
+parallel agent investigation **Status:** Claims validated against
+`C:\dev\Updog_restore`
+
+---
+
+## 1. Executive Summary of the Review
+
+The latest strategy proposal is **directionally sound** and makes four genuine
+improvements over prior iterations: it tightens Vite/Rollup build-exclusion
+mechanics, pushes provenance from UI labels into server/shared contracts,
+clarifies that client route gates are not security boundaries, and adds
+operational governance concerns (telemetry schemas, CODEOWNERS, source-map
+policy, health-gate thresholds). Most of these should be adopted.
+
+However, the strategy still contains **unvalidated claims, severity
+misclassifications, and gaps in codebase awareness** that would produce an
+incorrect implementation order if followed verbatim. The following sections
+distinguish **code facts**, **decision-doc claims**, **inferences**, and
+**future policy choices** for every major surface.
+
+---
+
+## 2. Claims That Are Correctly Validated
+
+### 2.1 `/reserves-demo` is mounted without `isProtected`
+
+**Code fact:** `client/src/app/app-routes.tsx:103` registers
+`{ path: '/reserves-demo', component: ReservesDemo }` with no `isProtected`
+flag. The `ReservesDemo` lazy import is declared at line 20 in the same
+production-reachable module.
+
+**Decision-doc claim:**
+`docs/plans/2026-03-27-secondary-surface-decisions.md:13-15` documents it as
+"intentional direct route mount" and "retire only with an explicit demo
+deprecation decision."
+
+**Verdict:** Both validated. The strategy correctly treats this as a
+ratification-required branch.
+
+### 2.2 `isProtected` is a fund-context guard, not an auth boundary
+
+**Code fact:** `client/src/app/app-router.tsx:51-99` defines `ProtectedRoute`.
+It imports `useFundContext()` and checks `needsSetup`, `isLoading`, and
+`fundLoadError`. It does **not** check JWT, session, role, or identity. The
+`renderAppRoute` function (lines 101-114) wraps `isProtected` routes in
+`<ProtectedRoute>`.
+
+**Verdict:** Validated. The strategy's rename to `fundContextGuard` in
+governance is appropriate.
+
+### 2.3 Tear Sheet mock export is client-side and hardcodes fund name
+
+**Code fact:** `client/src/components/reports/tear-sheet-dashboard.tsx:343`
+contains `fundName: 'Press On Ventures II', // Could come from context`. The PDF
+template `client/src/utils/pdf/templates/TearSheetTemplate.tsx` uses
+`@react-pdf/renderer`. The dashboard initializes state from `MOCK_TEAR_SHEETS`
+(line 130) and `MOCK_AUDIT_LOG` (line 219).
+
+**Verdict:** Validated. The strategy correctly identifies this as a P0A
+production-safety risk.
+
+### 2.4 Mock data arrays are present in production-reachable pages
+
+| Symbol                       | File                                                                  | Line | Production-Reachable |
+| ---------------------------- | --------------------------------------------------------------------- | ---- | -------------------- |
+| `MOCK_TEAR_SHEETS`           | `client/src/components/reports/tear-sheet-dashboard.tsx`              | 130  | YES                  |
+| `MOCK_AUDIT_LOG`             | same                                                                  | 219  | YES                  |
+| `SAMPLE_COMPANIES`           | `client/src/components/portfolio/portfolio-analytics-dashboard.tsx`   | 137  | YES                  |
+| `SAMPLE_CAP_TABLE_SCENARIOS` | `client/src/pages/CapTables.tsx`                                      | 41   | YES                  |
+| `SAMPLE_TRANSACTIONS`        | `client/src/components/cash-management/cash-management-dashboard.tsx` | 79   | YES                  |
+| `moicData`                   | `client/src/pages/moic-analysis.tsx`                                  | 51   | YES                  |
+| `$55M`                       | `client/src/pages/allocation-manager.tsx`                             | 43   | YES                  |
+
+**Verdict:** All validated. The quarantine list in Phase 4 is correct.
+
+### 2.5 Vite `sourcemap` is always `true` regardless of environment
+
+**Code fact:** `vite.config.ts:345` contains
+`sourcemap: process.env['VITE_SOURCEMAP'] === 'true' ? true : true`. The ternary
+is dead code; both branches return `true`.
+
+**Verdict:** Validated. Strategy correctly flags this as needing an explicit
+production source-map policy.
+
+### 2.6 ADR numbering conflict exists
+
+**Code fact:**
+
+- `DECISIONS.md:330` has `ADR-010: PowerLawDistribution API Design`
+- `docs/adr/ADR-010-xirr-day-count-and-bounds.md` has
+  `ADR-010: XIRR Day-Count and Bounds Reconciliation`
+- `DECISIONS.md:1543` has `ADR-011: Anti-Pattern Prevention Strategy`
+- `docs/adr/ADR-011-decimal-string-api-convention.md` has
+  `ADR-011: Decimal-String API Convention`
+- `DECISIONS.md:3560` has `ADR-012: Mandatory Evidence-Based Document Reviews`
+- `docs/adr/` has **no ADR-012 file**
+
+**Verdict:** Validated. The conflict is **worse than the strategy describes**:
+not only is ADR-012 missing from `docs/adr/`, but ADR-010 and ADR-011 have
+**completely different topics** in `DECISIONS.md` versus `docs/adr/`. This is
+not a simple duplication; it is a namespace collision.
+
+### 2.7 `portfolio/snapshots` is implemented but unmounted
+
+**Code fact:** `server/routes/portfolio/snapshots.ts` is 262 lines with full
+POST/GET/GET/PUT handlers. `server/routes.ts:67` mounts `portfolio/lots.js` but
+never mounts `portfolio/snapshots`.
+
+**Verdict:** Validated. The strategy correctly calls for a server-surface
+governance audit.
+
+### 2.8 LP Reporting middleware uses `requireLPAccess`, not `requireRole`
+
+**Code fact:** `server/routes/lp-api.ts:22-23` imports `requireLPAccess` and
+`requireLPFundAccess`. No LP Reporting route uses `requireRole`.
+`requireLPAccess` (defined in `server/middleware/requireLPAccess.ts:51`) checks
+`req.user.roles?.includes('lp') || req.user.role === 'lp'`.
+
+**Verdict:** Validated. The strategy's claim that LP Reporting uses
+`requireRole` is **incorrect**; it uses LP-specific middleware. The role audit
+should target `requireLPAccess` specifically, not generic `requireRole`.
+
+### 2.9 `ExpandableSidebar` and `client/src/config/navigation.ts` have zero production importers
+
+**Code fact:** Grep for `import.*ExpandableSidebar` and
+`from.*expandable-sidebar` returned zero matches. Grep for
+`from '@/config/navigation'` returned zero matches. Active layout
+`app-layout.tsx` uses `Sidebar` from `@/components/layout/sidebar`.
+
+**Verdict:** Validated. Both are dead artifacts. The strategy correctly
+schedules deletion after structural guards.
+
+---
+
+## 3. Claims That Are Mischaracterized or Under-Specified
+
+### 3.1 The `moicData` problem is more severe than described
+
+**Strategy claim:** "The current page has a live hook and server endpoint, but
+still defines static `moicData`."
+
+**Code fact:** `client/src/pages/moic-analysis.tsx:51-180` defines
+`const moicData: MOICMetric[] = [...]` with 8 hardcoded companies. This static
+array is used for **the main table, cards, and ranking UI** at lines 189, 208,
+321, 345, and 369. The live API (`useFundMoicRankings`) is only used for a
+conditional "Follow-on Rankings" section at the bottom of the page (line 406:
+`parsedFundId !== null && ...`).
+
+**Gap:** The strategy implies deleting `moicData` and adding provenance will fix
+the page. But the real problem is that the **primary UI is unconditionally
+fake** even when a `fundId` is present. The page should render the API response
+as the primary content when `fundId` is available, and show `UNAVAILABLE` or
+`NO_DATA` when it is not. Deleting `moicData` without a primary-data replacement
+path would break the page entirely. The PR 6 spec must include:
+
+1. Delete `moicData`.
+2. Make `useFundMoicRankings` the primary data source.
+3. Add `ProvenanceBoundary` wrapper.
+4. Render `Access Denied` for 401/403.
+5. Render `No Data` for empty live rankings.
+
+**Severity:** P0B (misleading production rendering) because a user with `fundId`
+in the query string sees a mix of fake primary data and real secondary data.
+
+### 3.2 `totalActiveAlerts` uses `|| 0`, not `?? 0`
+
+**Strategy claim:** "Current code uses
+`dashboardData?.data?.summary.totalActiveAlerts ?? 0`."
+
+**Code fact:** `client/src/pages/variance-tracking.tsx:278` uses
+`const totalActiveAlerts = dashboardData?.data?.summary?.totalActiveAlerts || 0;`
+(note `||` not `??`, and optional chaining on `summary`).
+
+**Gap:** The `||` operator makes `0` (a valid live zero) indistinguishable from
+`undefined`/`null` (missing/error). The `??` operator would at least preserve
+`0` as a valid value. However, the deeper issue is the same: the code collapses
+API failure into a falsy value. The proposed `AlertSummaryState` union type is
+the correct fix, but the strategy should cite the actual `||` operator, not
+`??`.
+
+**Severity:** P0B. The proposed state model is correct regardless of the
+operator detail.
+
+### 3.3 Cashflow demo fallback is already properly gated
+
+**Strategy claim:** "CashflowDashboard passes `allowDemoFallback: isDemoMode()`.
+... This is now P1 guardrail if the current fix is stable."
+
+**Code fact:** `client/src/core/demo/persona.ts:18` defines `isDemoMode()` to
+return `false` unconditionally in production unless `VITE_E2E_DEMO_ENABLED` is
+set or `?demo` query param is present.
+`client/src/hooks/useLiquidityAnalytics.ts:281-297` checks
+`options.allowDemoFallback` before returning mock data.
+
+**Gap:** The strategy's P0A/P0B split is directionally right, but cashflow
+should be **P1B or lower**, not P0B. The existing gate is structurally sound:
+production without explicit flags cannot reach mock data. The regression lock is
+appropriate, but the strategy should not group it with ungated mock surfaces
+like Tear Sheets.
+
+### 3.4 Tear Sheet PDF is lazy-loaded, not build-excluded
+
+**Strategy claim:** "Delete the mock export code path from production. Do not
+preserve a dormant client-side PDF function."
+
+**Code fact:** `client/src/components/reports/tear-sheet-dashboard.tsx:116-127`
+lazy-loads the PDF runtime via `loadTearSheetPdfRuntime()`. This is a
+**performance optimization**, not a conditional exclusion. The code path is
+still in the production bundle (just in a separate chunk).
+
+**Gap:** The strategy is correct about deleting the export path, but it should
+not confuse lazy-loading with build-exclusion. The PDF generation function is
+still reachable in production if the user triggers the export button. The
+server-side replacement rule is correct.
+
+### 3.5 `fund-moic-v1.contract.ts` has no provenance field
+
+**Strategy claim:** "Add provenance to shared MOIC response contract."
+
+**Code fact:** `shared/contracts/fund-moic-v1.contract.ts:16-20` defines
+`FundMoicRankingsResponseV1Schema` with `fundId`, `rankings`, and `generatedAt`
+only. No provenance field exists.
+
+**Gap:** Validated, but the strategy should also note that the codebase
+**already has a mature provenance pattern**
+(`shared/contracts/reserve-ic-decision-v1.contract.ts:28-102` defines
+`ReserveIcDecisionProvenanceSchema` with `sourceScenarioId`,
+`sourceAllocationVersion`, `liveAllocationVersion`, etc.). The new
+`DataProvenanceSchema` should be designed to be **compatible with** or
+**extend** this existing pattern, not reinvent it in a separate namespace. The
+`shared/contracts/` directory is the correct placement.
+
+### 3.6 `AirChair` leaks into benchmarking dashboard too
+
+**Strategy claim:** The quarantine list focuses on `/allocation-manager`,
+`/cap-tables`, `/portfolio-analytics`, `/cash-management`, and `/reserves-demo`.
+
+**Code fact:** `client/src/components/portfolio/benchmarking-dashboard.tsx:95`
+contains a hardcoded benchmark entry with `AirChair`.
+
+**Gap:** The strategy misses this additional leak. Any production bundle
+sentinel scan must include `AirChair` and other fake names, but also the
+**benchmarking dashboard** should be quarantined or rebuilt if it contains
+hardcoded sample data.
+
+### 3.7 LP Reporting Playwright tests bypass auth
+
+**Code fact:** `playwright.lp-reporting.config.ts` runs with `REQUIRE_AUTH: '0'`
+and `ALLOW_MEMORY_STORAGE: '1'`.
+
+**Gap:** The strategy correctly says to use the existing E2E harness, but it
+should note that the **test harness disables auth**. This is a test concern, not
+a production concern, but it means the E2E tests do not validate the
+auth/fund-scope middleware that production will use. The strategy should add a
+requirement for **auth-enabled integration tests** before LP Reporting
+promotion.
+
+---
+
+## 4. Persistent Weaknesses in the Strategy
+
+### 4.1 The PR sequence front-loads policy work but delays structural fixes
+
+The strategy proposes:
+
+- PR 0: Decision authority, CODEOWNERS, boundary matrix, ADR dedup
+- PR 1: P0A/P0B production safety (mock export removal, reserves-demo branch)
+- PR 2: Governance execution layer
+- PR 3: Build-time quarantine
+
+**Weakness:** The mock data is **already in production-reachable modules**.
+Waiting until PR 3 to move dev-only lazy imports to excluded modules means
+mock-backed routes remain in the production bundle for at least two PRs. The
+correct order should be:
+
+1. **Immediate:** Build-exclude `/reserves-demo` and mock-backed routes (or
+   confirm they are already excluded by the route array, which they are not).
+2. **PR 0:** Decision ratification.
+3. **PR 1:** Production safety (Tear Sheet export, mock tab removal, Active
+   Alerts fix).
+4. **PR 2:** Governance tests and registry.
+
+Since `app-routes.tsx` currently includes all routes in a single `APP_ROUTES`
+array with no production/dev split, the build-time quarantine is the
+**highest-priority structural change**. The strategy should not treat it as
+PR 3.
+
+### 4.2 The `server-surface governance audit` (Phase 12) is treated as a late add-on
+
+**Weakness:** The unmounted `portfolio/snapshots` route (262 lines, fully
+implemented) is a **production-trust risk** because it is documented but not
+reachable. If it becomes mounted by accident (e.g., a merge conflict or
+copy-paste error in `routes.ts`), it exposes endpoints that have not been tested
+in production. The audit should be **PR 0 or PR 1**, not Phase 12. The strategy
+should require:
+
+- A CI check that every `.ts` file under `server/routes/` is either mounted in
+  `routes.ts` or explicitly listed in an `UNMOUNTED_ROUTES` allowlist with a
+  documented reason.
+
+### 4.3 The strategy does not address the `reports` page beyond Tear Sheet
+
+**Weakness:** `client/src/pages/reports.tsx` lazy-loads `TearSheetDashboard`.
+The strategy focuses on the Tear Sheet tab and mock export. But what about the
+other reports tabs? If the entire `/reports` page is mock-backed, the page
+itself should be quarantined, not just the Tear Sheet tab. The strategy should
+verify which tabs are live-backed versus mock-backed before deciding whether to
+hide the tab or the entire page.
+
+### 4.4 The `DataProvenanceSchema` is comprehensive but not versioned
+
+**Weakness:** The proposed `DataProvenanceSchema` has 18 fields. This is correct
+for a final contract, but the rollout strategy should include **versioning**.
+The existing `ReserveIcDecisionProvenanceSchema` does not use a `configVersion`
+or `schemaVersion` field. The new schema should include
+`schemaVersion: z.literal('1.0')` or similar so that future additions are
+additive and backward-compatible. The strategy should also specify that the
+schema is **additive** to existing contracts, not a breaking replacement.
+
+### 4.5 The strategy does not leverage the existing `ReserveIcDecisionProvenanceSchema`
+
+**Weakness:** The codebase already has a provenance schema with
+`sourceScenarioId`, `sourceAllocationVersion`, `liveAllocationVersion`, etc. The
+new `DataProvenanceSchema` is more general (applies to all material financial
+APIs). The strategy should explicitly map the two: `ReserveIcDecisionProvenance`
+can become a **specialization** of `DataProvenanceSchema` with additional
+fields, or the new schema can be a **superset** that replaces the old one in
+future refactors. Without this mapping, the codebase will have two parallel
+provenance systems.
+
+### 4.6 The `isProtected` rename is governance-only, with no code change plan
+
+**Weakness:** The strategy says: "In governance, rename `isProtected` to
+`fundContextGuard` or keep it only as `routeFundSetupGuard`." But it does not
+specify a code change. If the rename is governance-only (docs, comments,
+registry), the TypeScript property `isProtected` remains in `AppRouteEntry` and
+`app-routes.tsx`. The strategy should specify whether the code rename is in
+scope, and if so, which PR should do it. If the code rename is deferred, the CI
+rule must lint against `isProtected` being used in auth contexts.
+
+### 4.7 The `fund-moic-v1.contract.ts` is not checked for the `generatedAt` field usage
+
+**Weakness:** The strategy says MOIC should be fund-scoped under
+`/fund-model-results/:fundId`. The existing contract has
+`generatedAt: z.string().datetime()`. The new provenance should include
+`calculatedAt` and `asOfDate`. The strategy should specify whether `generatedAt`
+is **deprecated** in favor of `calculatedAt` or **retained as a compatibility
+alias**. Without this decision, the API will accumulate redundant timestamp
+fields.
+
+### 4.8 The `shared/contracts/provenance.contract.ts` path conflicts with existing convention
+
+**Weakness:** The codebase uses `shared/contracts/` for domain-specific
+contracts (`fund-moic-v1.contract.ts`, `lp-reporting/*.contract.ts`). The
+strategy proposes `shared/contracts/provenance.contract.ts`. This is fine, but
+it should also consider whether provenance is a **cross-cutting concern** that
+belongs in `shared/schemas/common.ts` or `shared/types/metrics.ts` (which
+already have `MetricSource` for provenance). A cross-cutting schema in
+`shared/contracts/provenance.contract.ts` is correct, but the strategy should
+explicitly deprecate or map the existing `MetricSource` type.
+
+---
+
+## 5. Overlooked Opportunities
+
+### 5.1 Use the existing `shared/contracts/` directory as a provenance template
+
+`shared/contracts/reserve-ic-decision-v1.contract.ts:28-102` already has
+`ReserveIcDecisionProvenanceSchema`. This proves the team knows how to write Zod
+provenance contracts. The new `DataProvenanceSchema` should follow the same
+pattern (Zod object, exported type, exported schema). The strategy should
+reference this file as the implementation template.
+
+### 5.2 Add a CI check for `routes.ts` completeness
+
+Since `portfolio/snapshots` is fully implemented but unmounted, the CI should
+enforce:
+
+- Every file in `server/routes/**/*.ts` (excluding `index.ts` or `routes.ts`
+  itself) must be either imported in `routes.ts` or listed in an
+  `ALLOWED_UNMOUNTED` array with a comment.
+
+This is a one-line check that prevents future accidental exposure of unmounted
+routes.
+
+### 5.3 Use the `shared/contracts/` naming convention for the new provenance schema
+
+The existing contracts use kebab-case with version suffixes
+(`fund-moic-v1.contract.ts`, `reserve-ic-decision-v1.contract.ts`). The new file
+should be `shared/contracts/data-provenance-v1.contract.ts` to match. The
+strategy's `provenance.contract.ts` is acceptable but inconsistent with the
+existing convention.
+
+### 5.4 The `app-routes.tsx` line 20 lazy import is a DCE risk even if the route is filtered
+
+**Code fact:**
+`const ReservesDemo = React.lazy(() => import('@/pages/reserves-demo'));` is
+evaluated at module load time. Even if `APP_ROUTES` is filtered to exclude
+`/reserves-demo`, the `import()` call may still be analyzed by the bundler and
+the chunk may be generated. The correct fix is to move the lazy declaration to a
+dev-only module, as the strategy proposes in Phase 4.1, but the strategy should
+note that **filtering the route array is not sufficient** if the import
+declaration is in the same module.
+
+### 5.5 The `MOICAnalysisPage` should use the existing `fund-moic-v1.contract.ts` for Zod parsing
+
+**Code fact:** `client/src/hooks/use-moic.ts` does not import or validate
+against `FundMoicRankingsResponseV1Schema`. It uses a generic
+`useQuery<FundMoicRankingsResponseV1>`. The strategy should require that the
+client hook import the shared schema and validate the response at the network
+boundary. This is a prerequisite for the "missing provenance maps to FAILED"
+rule.
+
+---
+
+## 6. Code Fact vs. Decision-Doc vs. Inference vs. Future Policy
+
+The strategy correctly aims to distinguish these categories. Here is the
+corrected mapping for the most contentious surfaces:
+
+| Surface               | Code Fact                                                                                                 | Decision-Doc Claim                                                    | Inference                                                | Future Policy                                                        |
+| --------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------- | ------------------------------ |
+| `/reserves-demo`      | Mounted at `app-routes.tsx:103` without `isProtected`                                                     | Secondary Surface Decisions doc says "intentional internal live demo" | If no branch is ratified, default to production-disabled | Branch A or B must be ratified in PR 0                               |
+| `portfolio/snapshots` | Implemented at `server/routes/portfolio/snapshots.ts` (262 lines), **not mounted** in `routes.ts`         | Architecture doc says "Ready for Implementation" (6-endpoint API)     | It may become mounted accidentally in a future merge     | CI check for unmounted route files                                   |
+| `isProtected`         | Checks fund context (`needsSetup`, `isLoading`, `fundLoadError`) at `app-router.tsx:58-96`                | Strategy renames to `fundContextGuard` in governance                  | It is sometimes confused with auth                       | CI lint: `isProtected` cannot be sole auth boundary                  |
+| Tear Sheet export     | Client-side `@react-pdf/renderer` with hardcoded `Press On Ventures II` at `tear-sheet-dashboard.tsx:343` | Strategy says server-side only                                        | Client-side PDF generation is not authoritative          | Server-side export with provenance/idempotency                       |
+| `totalActiveAlerts`   | Uses `                                                                                                    |                                                                       | 0`at`variance-tracking.tsx:278`                          | Strategy says `?? 0` (incorrect detail)                              | API failure coerces to `0` / `Stable` | `AlertSummaryState` union type |
+| `moicData`            | Static array at `moic-analysis.tsx:51-180` is **primary UI data**                                         | Strategy says "delete static moicData"                                | The page is mostly fake even with `fundId` query param   | Fund-scoped child route with provenance                              |
+| LP Reporting          | Uses `requireAuth` + `requireLPAccess`/`requireLPFundAccess` (not `requireRole`)                          | Strategy says "audit `requireRole` callers"                           | LP role is implicit in `requireLPAccess`                 | Audit `requireLPAccess` and add shared role schema                   |
+| `sourcemap`           | Always `true` at `vite.config.ts:345` (dead conditional)                                                  | Strategy says "explicit source-map policy"                            | Public source maps may leak mock literals                | Decide public vs. private source-map serving                         |
+| ADR numbering         | `DECISIONS.md` ADR-010/011/012 have different topics from `docs/adr/` ADR-010/011                         | Strategy says "duplicate ADR IDs"                                     | The two files are independent namespaces                 | Generate ADR index, detect collisions, decide single source of truth |
+
+---
+
+## 7. Fully Revised Development Spec
+
+The following is the corrected, codebase-validated development strategy. Each
+phase references validated file paths and line numbers. Claims are tagged as
+**[Code]**, **[Doc]**, **[Inference]**, or **[Policy]**.
+
+---
+
+# Revised Strategy: Secondary Surface Governance & Production Truthfulness
+
+## Executive Strategy
+
+Updog_restore should treat every mounted, externally reachable, or documented
+surface as a governed product contract with explicit placement, environment,
+security boundary, data authority, calculation lineage, export policy,
+telemetry, owner, and rollback path.
+
+The first priority is **production truthfulness**, not discoverability. Remove
+or build-exclude mock/demo financial surfaces from production, make evidence
+state explicit in shared server/client contracts, and only then qualify MOIC and
+LP Reporting for fund-scoped exposure consistent with the repo's canonical
+`/fund-model-results/:fundId` flow.
+
+This is aligned with the README's current product truth: canonical flow is
+`/fund-setup -> review -> publish -> /fund-model-results/:fundId`, and
+secondary-surface exposure is intentionally narrow.
+
+---
+
+# Phase 0 — Decision authority and surface-truth baseline
+
+## 0.1 Decision-doc authority
+
+Update `docs/plans/2026-03-27-secondary-surface-decisions.md` first. No route
+promotion or preservation of unsafe demo routes proceeds without a ratified
+decision row.
+
+Add CODEOWNERS coverage for:
+
+```txt
+docs/plans/2026-03-27-secondary-surface-decisions.md @nikhillinit
+```
+
+**[Code]** Existing CODEOWNERS (`CODEOWNERS` root and `.github/CODEOWNERS`)
+covers `docs/adr/**`, metrics docs, observability docs, workflows, and security
+tooling, but not this decision file.
+
+## 0.2 Required decision row fields
+
+Each governed surface must declare:
+
+- surface path or route family,
+- product state,
+- allowed environments,
+- runtime/build placement,
+- client placement,
+- security boundary,
+- fund-scope requirement,
+- role/workflow policy,
+- data source authority,
+- calculation mode,
+- export policy,
+- telemetry key,
+- owner,
+- rollback path,
+- decision date,
+- review cadence,
+- ratifying reviewer.
+
+## 0.3 Decision-tree rule for `/reserves-demo`
+
+**[Code]** `client/src/app/app-routes.tsx:103` mounts `/reserves-demo` without
+`isProtected`. `client/src/app/app-routes.tsx:20` lazy-imports it in a
+production-reachable module.
+
+**[Doc]** The Secondary Surface Decisions doc describes it as an intentionally
+mounted internal live demo.
+
+PR 0 must choose exactly one:
+
+### Branch A — production-disabled (default)
+
+`/reserves-demo` is excluded from production route arrays and chunks. If no
+branch is ratified, this is the default.
+
+### Branch B — production-preserved as internal demo
+
+Allowed only if all of these are true:
+
+- external gateway or server-side demo authorization is documented,
+- the route is not treated as public,
+- production bundle sentinel policy allows it by explicit reviewed exception,
+- route telemetry identifies direct hits,
+- rollback is defined.
+
+## 0.4 ADR/decision hygiene
+
+**[Code]** `DECISIONS.md` contains ADR-010 (PowerLawDistribution), ADR-011
+(Anti-Pattern Prevention), ADR-012 (Evidence-Based Reviews). `docs/adr/`
+contains ADR-010 (XIRR Day-Count), ADR-011 (Decimal-String API), and **no
+ADR-012**. The same IDs refer to **different topics**.
+
+Add a Phase 0 task:
+
+- generate ADR index,
+- detect duplicate ADR IDs across `DECISIONS.md` and `docs/adr/**`,
+- decide whether `DECISIONS.md` is historical index, active source, or umbrella
+  table,
+- add CI check preventing new duplicate ADR IDs.
+
+## 0.5 Server-surface governance audit (moved from Phase 12)
+
+**[Code]** `server/routes/portfolio/snapshots.ts` is 262 lines, fully
+implemented, but `server/routes.ts:67` mounts `portfolio/lots.js` and never
+mounts `portfolio/snapshots`.
+
+Generate a server route inventory covering:
+
+- mounted Express routes,
+- unmounted route files,
+- docs-declared endpoints,
+- implementation status,
+- auth/fund-scope middleware,
+- response contract,
+- 501/placeholder status if present,
+- governance row.
+
+**[Policy]** Add CI check: every file in `server/routes/**/*.ts` must be either
+mounted in `routes.ts` or listed in an `ALLOWED_UNMOUNTED` array with a
+documented reason.
+
+---
+
+# Phase 1 — P0A production safety: stop externalization of fabricated facts
+
+## 1.1 Remove Tear Sheet mock export
+
+**[Code]** `client/src/components/reports/tear-sheet-dashboard.tsx:343`
+hardcodes `fundName: 'Press On Ventures II'`. The component uses
+`@react-pdf/renderer` (`client/src/utils/pdf/templates/TearSheetTemplate.tsx`).
+The PDF runtime is lazy-loaded at `tear-sheet-dashboard.tsx:116-127`, but this
+is a **performance optimization**, not a build exclusion.
+
+### Required change
+
+Delete the mock export code path from production. Do not preserve a dormant
+client-side PDF function that can be re-enabled from local state.
+
+### Final export rule
+
+**[Policy]** Authoritative financial documents must be generated server-side.
+The client may only:
+
+- request an export,
+- receive a binary or signed artifact reference,
+- download the server-created artifact.
+
+The server must enforce:
+
+- `requireAuth`,
+- fund scope,
+- role/workflow policy,
+- data provenance,
+- idempotency/version,
+- audit logging.
+
+### Acceptance tests
+
+- No production client code can generate a Tear Sheet PDF from local state.
+- Production bundle does not include `Press On Ventures II` from Tear Sheet
+  export.
+- Export UI is absent unless server export contract exists.
+- Export attempt in non-authoritative state returns/records blocked policy.
+
+## 1.2 Production-disable Tear Sheet mock tab/grid unless live-backed
+
+**[Code]** `client/src/components/reports/tear-sheet-dashboard.tsx:130` defines
+`MOCK_TEAR_SHEETS` and `MOCK_AUDIT_LOG` (line 219). The component is lazy-loaded
+by `client/src/pages/reports.tsx:6` and rendered at line 38.
+
+**[Inference]** The entire `/reports` page should be audited, not just the Tear
+Sheet tab, to confirm which tabs are live-backed.
+
+### Required change
+
+In production, one of these must be true:
+
+1. Tear Sheets tab is absent; or
+2. Tab renders a non-data unavailable state and does not import mock dashboard;
+   or
+3. Tab is backed by live, fund-scoped, provenance-bearing API data.
+
+Mock-labeled Tear Sheets may exist only in explicit demo/non-production
+surfaces.
+
+## 1.3 Make `/reserves-demo` production-safe
+
+**[Code]** `client/src/app/app-routes.tsx:103` mounts the route.
+`client/src/app/app-routes.tsx:20` declares the lazy import in the same
+production-reachable module.
+
+### Required change
+
+Implement the branch ratified in Phase 0.
+
+For Branch A, production must exclude the route and chunk. This requires moving
+the lazy import out of `app-routes.tsx` into a dev-only module, because
+**filtering the route array is not sufficient** if the `import()` declaration is
+analyzed by the bundler.
+
+For Branch B, server/gateway security and telemetry must be validated.
+
+### Acceptance tests
+
+- Production manifest excludes `/reserves-demo` unless Branch B is ratified.
+- Direct production navigation is Not Found/safe redirect unless Branch B is
+  ratified.
+- If Branch B, test gateway/admin access behavior and denial path.
+
+## 1.4 Fix Reports Active Alerts error-to-zero coercion
+
+**[Code]** `client/src/pages/variance-tracking.tsx:278` uses
+`const totalActiveAlerts = dashboardData?.data?.summary?.totalActiveAlerts || 0;`.
+Note `||` (not `??` as the prior strategy claimed).
+
+### Required state model
+
+```ts
+type AlertSummaryState =
+  | { state: 'LIVE'; count: number }
+  | { state: 'LOADING' }
+  | { state: 'FAILED'; status?: number; message: string }
+  | { state: 'UNAVAILABLE'; reason: string };
+```
+
+### Acceptance tests
+
+- API failure never displays `0` or `Stable`.
+- Valid live zero still displays `0` and `Stable`.
+- Reports list and dashboard summary render independently in mixed-success
+  cases.
+
+## 1.5 Lock cashflow demo fallback (P1, not P0)
+
+**[Code]** `client/src/components/dashboard/CashflowDashboard.tsx:90` passes
+`allowDemoFallback: isDemoMode()`. `client/src/core/demo/persona.ts:18` returns
+`false` in production unless `VITE_E2E_DEMO_ENABLED` is set or `?demo` query
+param is present. `client/src/hooks/useLiquidityAnalytics.ts:281-297` checks
+`options.allowDemoFallback` before returning mock data.
+
+**[Inference]** The existing gate is structurally sound. This is a **P1
+regression lock**, not P0B.
+
+### Required tests
+
+- production + `?demo` without E2E flag does not generate mock cashflow,
+- production + no inputs renders unavailable/empty,
+- E2E demo mode remains explicit and scoped.
+
+---
+
+# Phase 2 — Security boundary matrix
+
+The previous spec correctly said client route gates are not security boundaries,
+but the final strategy must operationalize that.
+
+## 2.1 Boundary matrix
+
+Create `docs/security/surface-boundary-matrix.md`.
+
+Each surface must classify:
+
+| Layer              | Meaning                                          |
+| ------------------ | ------------------------------------------------ |
+| Static SPA route   | URL can render shell or not                      |
+| Client UX guard    | Fund context, feature flag, role hint            |
+| API auth           | `requireAuth` or equivalent                      |
+| Fund scope         | `requireFundAccess` / `enforceProvidedFundScope` |
+| Role/policy        | `requireRole` or policy engine                   |
+| Workflow state     | dry-run, draft, approved, locked, package-ready  |
+| Deployment gateway | static app protection if any                     |
+| Export authority   | server-side artifact generation                  |
+
+**[Code]** `server/lib/auth/jwt.ts:218` defines `requireAuth`.
+`server/lib/auth/jwt.ts:255` defines `requireFundAccess`.
+`server/lib/auth/jwt.ts:245` defines `requireRole`.
+`server/lib/auth/provided-fund-scope.ts:27-65` defines
+`enforceProvidedFundScope`.
+
+## 2.2 `isProtected` governance rename
+
+**[Code]** `client/src/app/app-router.tsx:51-99` shows `isProtected` wraps
+`ProtectedRoute` which checks fund context only.
+
+**[Policy]** In governance, rename `isProtected` to `fundContextGuard` or keep
+it only as `routeFundSetupGuard`. It must never satisfy auth.
+
+**[Policy]** CI rule:
+
+```txt
+If authBoundary !== 'public-contract' and authBoundary !== 'external-gateway',
+a server/API access policy or explicit "no server data" rationale is required.
+isProtected/fundContextGuard alone is never sufficient.
+```
+
+---
+
+# Phase 3 — Build-time quarantine and chunk ownership
+
+## 3.1 Correct Vite/DCE pattern
+
+**[Code]** `client/src/app/app-routes.tsx` currently declares all lazy imports
+at the top level (lines 4-65) and includes all routes in a single `APP_ROUTES`
+array (lines 73-104). There is no production/dev split.
+
+**[Inference]** The final rule:
+
+> A production-disabled route is excluded only when its component module, lazy
+> import declaration, route entry, and route chunk are absent from
+> production-reachable modules.
+
+Do not use top-level lazy imports in production-reachable `app-routes.tsx` for
+dev-only routes.
+
+### Preferred architecture
+
+```ts
+// app-routes.core.tsx
+export const CORE_APP_ROUTES = [
+  // production-safe routes only
+];
+
+// app-routes.dev.tsx
+const ReservesDemo = React.lazy(() => import('@/pages/reserves-demo'));
+const AllocationManager = React.lazy(
+  () => import('@/pages/allocation-manager')
+);
+const CapTables = React.lazy(() => import('@/pages/CapTables'));
+
+export const DEV_ONLY_APP_ROUTES = [
+  { path: '/reserves-demo', component: ReservesDemo },
+  {
+    path: '/allocation-manager',
+    component: AllocationManager,
+    isProtected: true,
+  },
+  { path: '/cap-tables', component: CapTables, isProtected: true },
+];
+
+// app-routes.tsx
+export const APP_ROUTES = import.meta.env.PROD
+  ? CORE_APP_ROUTES
+  : [...CORE_APP_ROUTES, ...DEV_ONLY_APP_ROUTES];
+```
+
+If importing `DEV_ONLY_APP_ROUTES` itself causes route chunks to appear, use one
+of:
+
+- Vite alias in production to an empty module,
+- separate prod/dev route entry modules,
+- build-time plugin stripping dev route module,
+- CI manifest enforcement as the source of truth.
+
+## 3.2 Quarantine list
+
+**[Code]** Production-disabled until rebuilt or ratified:
+
+- `/reserves-demo` — mounted without `isProtected`, lazy import in
+  production-reachable module.
+- `/allocation-manager` — `client/src/pages/allocation-manager.tsx:43` hardcodes
+  `const totalFundSize = 55000000; // $55M fund`.
+- `/cap-tables` — `client/src/pages/CapTables.tsx:41` uses
+  `SAMPLE_CAP_TABLE_SCENARIOS`.
+- `/portfolio-analytics` —
+  `client/src/components/portfolio/portfolio-analytics-dashboard.tsx:137` uses
+  `SAMPLE_COMPANIES`.
+- `/cash-management` —
+  `client/src/components/cash-management/cash-management-dashboard.tsx:79` uses
+  `SAMPLE_TRANSACTIONS`.
+- `/moic-analysis` — `client/src/pages/moic-analysis.tsx:51-180` uses static
+  `moicData` as primary UI.
+- Benchmarking dashboard —
+  `client/src/components/portfolio/benchmarking-dashboard.tsx:95` contains
+  hardcoded `AirChair` benchmark entry.
+
+## 3.3 Bundle sentinel policy
+
+### Hard-fail source guards
+
+Run on production-reachable source:
+
+- `MOCK_`,
+- `SAMPLE_`,
+- `generateMock`,
+- fake financial export payloads,
+- client PDF generation for authoritative reports,
+- dev-only route modules imported by prod route modules.
+
+### Hard-fail bundle literals
+
+Scan built production assets for high-signal strings likely to survive
+minification:
+
+- `Press On Ventures II`,
+- `AirChair`,
+- `Mock data - would come from actual investment data`,
+- `Cash flow projection modeling and scenario analysis coming soon`,
+- `Fund Capital Reserves` if route quarantined,
+- other route-specific proper nouns.
+
+### Review-only sentinels
+
+Company names such as `TechFlow`, `FinanceHub`, or `DataFlow Systems` may
+collide with legitimate future data. Treat as review warnings unless tied to a
+quarantined chunk.
+
+### Avoid brittle sentinels
+
+Do not hard-fail on numeric literals like `2.5` or `0.35` alone.
+
+## 3.4 Source-map policy
+
+**[Code]** `vite.config.ts:345` sets
+`sourcemap: process.env['VITE_SOURCEMAP'] === 'true' ? true : true` (always
+`true`).
+
+**[Policy]** Add explicit decision:
+
+- If production source maps are publicly served: disable public source maps or
+  scan public maps for high-signal literals.
+- If source maps are private/upload-only: exclude them from client-served
+  sentinel checks and protect upload/storage access.
+
+---
+
+# Phase 4 — Route governance without drift
+
+## 4.1 Use executable registry + generated governance inventory
+
+Split layers:
+
+### Runtime registry
+
+Executable concerns:
+
+- path,
+- component,
+- placement,
+- environment,
+- feature flag,
+- redirect target,
+- public/admin/dev/prod-disabled classification.
+
+### Policy registry
+
+Security/export concerns:
+
+- auth boundary,
+- fund scope,
+- role policy,
+- workflow policy,
+- data authority,
+- export policy.
+
+### Generated inventory
+
+Docs enrichment:
+
+- owner,
+- decision doc,
+- decision date,
+- review cadence,
+- rollback,
+- telemetry key.
+
+This avoids turning one TypeScript file into a false master record while still
+keeping CI-enforced consistency.
+
+## 4.2 Route tests must import compiled objects
+
+**[Code]** `client/src/app/route-governance-registry.ts` imports `APP_ROUTES`,
+`ARCHIVED_PLACEHOLDER_ROUTES`, `LP_ROUTES`, `PUBLIC_ENTRY_ROUTES`,
+`ADMIN_GATED_ROUTES`, `LEGACY_REDIRECT_ROUTES` from `@/App` (lines 1-8).
+
+Tests should import:
+
+- `APP_ROUTES`,
+- `ARCHIVED_PLACEHOLDER_ROUTES`,
+- `PUBLIC_ENTRY_ROUTES`,
+- `LP_ROUTES`,
+- active `getNavigationItems()`,
+- governance registry.
+
+Do not rely on regex.
+
+## 4.3 Conditional nav parity
+
+Corrected rule:
+
+- every active nav item must map to a governed route;
+- every governed `core-nav`/`footer-nav` route must be representable in active
+  nav **when its environment, flags, and role/workflow constraints allow it**;
+- feature-gated nav must have tests for on/off states.
+
+## 4.4 Structural guard moves earlier
+
+**[Code]** `client/src/app/app-layout.tsx` imports `Sidebar` from
+`@/components/layout/sidebar`.
+`client/src/components/layout/expandable-sidebar.tsx` has zero production
+importers. `client/src/config/navigation.ts` has zero production importers.
+
+Add this in PR 2, not PR 8:
+
+- `AppLayout` imports canonical `Sidebar`,
+- `client/src/config/navigation.ts` has no production importers,
+- `ExpandableSidebar` has no production importers,
+- active nav source is unique.
+
+Deletion can still occur later after test cleanup.
+
+---
+
+# Phase 5 — Shared provenance contracts
+
+## 5.1 Shared schema
+
+Add `shared/contracts/data-provenance-v1.contract.ts` (following existing
+kebab-case naming convention), not just a client type.
+
+**[Code]** The codebase already has
+`shared/contracts/reserve-ic-decision-v1.contract.ts:28-102`
+(`ReserveIcDecisionProvenanceSchema`) as a provenance template. The new schema
+should be compatible with or extend this pattern.
+
+```ts
+export const DataProvenanceSchema = z.object({
+  schemaVersion: z.literal('1.0'),
+  state: z.enum([
+    'LIVE',
+    'PARTIAL',
+    'FALLBACK',
+    'DEMO',
+    'UNAVAILABLE',
+    'FAILED',
+  ]),
+  sourceAuthority: z.enum([
+    'authoritative',
+    'non_authoritative',
+    'demo',
+    'unknown',
+  ]),
+  calculationMode: z.enum([
+    'complete',
+    'partial',
+    'fallback',
+    'not_applicable',
+  ]),
+  source: z.string(),
+  sourceLabel: z.string().optional(),
+  fundId: z.number().int().positive().optional(),
+  asOfDate: z.string().datetime().nullable().optional(),
+  calculatedAt: z.string().datetime().nullable().optional(),
+  generatedAt: z.string().datetime().nullable().optional(),
+  configVersion: z.string().optional(),
+  publishedAt: z.string().datetime().nullable().optional(),
+  warnings: z.array(z.string()).default([]),
+  fallbackReason: z.string().optional(),
+  freshness: z.enum(['fresh', 'stale', 'unknown']),
+  exportEligibility: z.enum([
+    'allowed',
+    'allowed_approved_partial',
+    'blocked_non_authoritative',
+    'blocked_demo',
+    'blocked_failed',
+    'blocked_unavailable',
+    'blocked_policy',
+  ]),
+  correlationId: z.string().optional(),
+});
+```
+
+**[Policy]** The `schemaVersion` field ensures future additions are additive.
+The existing `ReserveIcDecisionProvenanceSchema` can be migrated to include
+`schemaVersion` in a future refactor.
+
+## 5.2 Wire contract rule
+
+Every server endpoint feeding a material financial UI must include:
+
+```ts
+provenance: DataProvenanceSchema;
+```
+
+This must be additive and versioned where needed.
+
+## 5.3 Zod network boundary
+
+**[Code]** `client/src/hooks/use-moic.ts` does not currently validate against
+`FundMoicRankingsResponseV1Schema`. It uses
+`useQuery<FundMoicRankingsResponseV1>` with manual JSON parsing.
+
+Client hooks must parse responses with Zod. If provenance is missing or invalid:
+
+- parse fails,
+- UI renders `FAILED`,
+- telemetry emits `route_data_state` with `FAILED`,
+- UI does not silently infer `FALLBACK`.
+
+## 5.4 Centralized rendering wrapper
+
+To avoid rollout brittleness, PR 4 should ship a central component:
+
+```tsx
+<ProvenanceBoundary provenance={provenance}>
+  {liveOrPartialContent}
+</ProvenanceBoundary>
+```
+
+It centrally handles all six states. Individual components can become exhaustive
+later; the rollout does not need every component to switch on every state on day
+one.
+
+---
+
+# Phase 6 — Forecast, cashflow, and reports trust migration
+
+## 6.1 Forecast fallback semantics
+
+The server can catch projected metric failure and fall back to defaults. The
+response currently carries sources, config, and warnings.
+
+Final rule:
+
+- fallback must be explicit in shared response contract,
+- `state = FALLBACK`,
+- `calculationMode = fallback`,
+- `sourceAuthority = non_authoritative` or `authoritative` depending on policy,
+  but export blocked by default,
+- `asOfDate` and `calculatedAt` should be null/omitted if values are static
+  config defaults,
+- UI should say "Default values from configuration vN," not "freshly
+  calculated."
+
+This addresses the review's as-of-date concern.
+
+## 6.2 Cashflow server-sourced model
+
+The cashflow demo fallback fix is necessary but not sufficient. The trust
+register still says dashboard liquidity analysis and forecasts should use
+fund-scoped server endpoints instead of generated browser inputs.
+
+Final rule:
+
+- production material cashflow metrics come from server response with
+  provenance,
+- no client-generated material values in production,
+- empty source renders `UNAVAILABLE`,
+- failure renders `FAILED`.
+
+## 6.3 Reports cards
+
+Reports dashboard cards must independently track provenance for:
+
+- report list,
+- latest report,
+- active alerts,
+- default baseline.
+
+No shared "everything failed" collapse.
+
+---
+
+# Phase 7 — MOIC promotion as fund-scoped child surface
+
+## 7.1 Product rationale
+
+MOIC ranking is valuable because Tactyc's reserve ranking ranks each company by
+expected return on planned reserves, and Exit MOIC on Planned Reserves is the
+expected return on the next dollar into each company. Tactyc's MOIC content says
+planned-reserve MOIC is especially useful for optimizing reserves and comparing
+one company's reserves to another.
+
+## 7.2 Current risk
+
+**[Code]** `client/src/pages/moic-analysis.tsx:51-180` defines
+`const moicData: MOICMetric[] = [...]` with 8 hardcoded companies. This static
+array is used for the **primary table, cards, and ranking UI** (lines 189, 208,
+321, 345, 369). The live API (`useFundMoicRankings`) is only used for a
+conditional "Follow-on Rankings" section at the bottom (line 406).
+
+**[Inference]** This means the page is **mostly fake** even when a `fundId` is
+present. Deleting `moicData` without making the API the primary data source
+would break the page.
+
+## 7.3 Final route model
+
+Preferred promotion:
+
+- `/fund-model-results/:fundId/moic-analysis`, or
+- a tab/action inside `/fund-model-results/:fundId`.
+
+Keep `/moic-analysis?fundId=` only as compatibility/deep link if necessary.
+
+## 7.4 Prerequisites
+
+1. Delete static `moicData`.
+2. Make `useFundMoicRankings` the **primary** data source for the main UI.
+3. Add provenance to `shared/contracts/fund-moic-v1.contract.ts` (currently
+   lacks it).
+4. Parse response with Zod at client boundary (`client/src/hooks/use-moic.ts`
+   must import `FundMoicRankingsResponseV1Schema`).
+5. Render `Access Denied` for 401/403.
+6. Render `No Data` for empty live ranking.
+7. Add telemetry.
+8. Add production bundle sentinel for old sample names.
+
+---
+
+# Phase 8 — LP Reporting promotion with role and workflow policy
+
+## 8.1 Current state
+
+**[Code]** LP Reporting import routes use `requireAuth`
+(`server/lib/auth/jwt.ts:218`) and LP-specific middleware (`requireLPAccess`,
+`requireLPFundAccess` from `server/middleware/requireLPAccess.ts`). Metric-run
+routes cover dry-run, commit, approval, lock, report package, exports, evidence
+records, and narrative workflows (`server/routes/lp-reporting/metric-runs.ts`).
+
+## 8.2 Role vocabulary audit
+
+Before enforcing role policy:
+
+- audit all `requireLPAccess` callers (not generic `requireRole`),
+- enumerate existing JWT role vocabulary (`lp`, `gp`, `admin`),
+- decide LP/GP/Admin policies,
+- add shared role schema if missing,
+- update server middleware tests.
+
+**[Code]** `requireLPAccess` checks
+`req.user.roles?.includes('lp') || req.user.role === 'lp'` (line 51). Do not
+assume LP roles exist just because JWT supports `role` and `lpId`.
+
+## 8.3 Workflow-state gates
+
+Promotion requires policy for:
+
+- dry-run-only state,
+- draft metric run,
+- evidence-complete draft,
+- approved,
+- locked,
+- report package assembled,
+- export-ready,
+- export-blocked.
+
+## 8.4 E2E harness
+
+**[Code]** `playwright.lp-reporting.config.ts` already targets
+`lp-reporting-package-flow.spec.ts` and configures LP Reporting test output. It
+runs with `REQUIRE_AUTH: '0'` and `ALLOW_MEMORY_STORAGE: '1'`.
+
+**[Policy]** Use the existing Playwright config for functional coverage, but add
+**auth-enabled integration tests** before production promotion because the E2E
+harness does not validate the auth middleware.
+
+Do not create parallel E2E infrastructure unless existing configs are
+insufficient.
+
+---
+
+# Phase 9 — Telemetry with privacy and health gates
+
+## 9.1 Redacted event schemas
+
+### `archived_redirect_hit`
+
+Fields:
+
+- `fromPath`
+- `toPath`
+- `hadFundIdParam: boolean`
+- `routeFamily`
+- `clientSessionIdHash` if already approved
+- `userRoleClass` attached server-side if available
+- no raw referrer
+- no user email/id
+- no fund name
+- retention ≤ 90 days unless legal/compliance approves longer.
+
+### `route_viewed`
+
+Client fields:
+
+- route key,
+- surface key,
+- placement,
+- flag state,
+- fund ID present boolean or hashed scoped ID if approved.
+
+Role should be attached server-side on ingestion where possible.
+
+## 9.2 Default promotion health gates
+
+For MOIC/LP Reporting staging soak:
+
+- at least 7 days or agreed minimum test window,
+- route load error ≤ 0.5%,
+- failed data state ≤ 1% excluding planned outage tests,
+- zero unhandled 401/403-as-empty regressions,
+- zero server export from non-authoritative provenance,
+- no production bundle sentinel violations,
+- no auth/fund-scope failure spike attributable to the promoted surface,
+- rollback drill completed.
+
+For limited production:
+
+- kill switch tested,
+- telemetry dashboard live,
+- owner/on-call identified,
+- failure budget defined.
+
+---
+
+# Phase 10 — External public contracts and archived redirects
+
+README defines `/shared/:shareId` and `/portal/:rest*` as intentional public
+contracts. Archived placeholder routes preserve redirects in code.
+
+Final governance:
+
+- public contracts are externally supported unauthenticated product contracts,
+- archived redirects are compatibility contracts,
+- neither should be confused with arbitrary client route reachability.
+
+Each archived redirect needs:
+
+- owner,
+- reason,
+- target,
+- telemetry,
+- deprecation criteria,
+- retention review.
+
+---
+
+# Phase 11 — Canonical flow trust: XState/wizard persistence
+
+Accepted as a trust-adjacent gap. The README canonical flow depends on
+`/fund-setup -> review -> publish -> /fund-model-results/:fundId`. DECISIONS.md
+includes ADR-016 for XState Wizard Persistence.
+
+Final strategy:
+
+- keep this outside P0 route governance,
+- add it as P3 canonical-flow trust dependency,
+- ensure governance changes do not distract from wizard data-loss prevention,
+- add a readiness check for canonical flow persistence before broad surface
+  promotion.
+
+---
+
+# Phase 12 — Dead nav cleanup
+
+## 12.1 Current facts
+
+**[Code]** Active layout (`client/src/app/app-layout.tsx`) renders `Sidebar`,
+not `ExpandableSidebar`. `ExpandableSidebar`
+(`client/src/components/layout/expandable-sidebar.tsx`) includes links to
+mock-backed routes. The legacy nav file (`client/src/config/navigation.ts`)
+defines many stale routes. Neither has production importers.
+
+## 12.2 Final order
+
+1. PR 2: add structural guard against production imports.
+2. Replace tests importing `ExpandableSidebar`.
+3. PR 8: delete `client/src/config/navigation.ts`.
+4. PR 8: delete `expandable-sidebar.tsx`.
+5. Keep historical summary only in docs if needed.
+
+---
+
+# Revised PR Sequence
+
+## PR 0 — Decision authority and boundary baseline
+
+- Update Secondary Surface Decisions.
+- Add CODEOWNERS for Secondary Surface Decisions.
+- Add security boundary matrix.
+- Add `/reserves-demo` branch decision.
+- Add ADR index/dedup check.
+- Add external public-contract definitions.
+- Add server-surface governance audit (moved from Phase 12).
+- Add CI check for unmounted route files.
+
+## PR 1 — Build-time quarantine and P0A production safety
+
+- Move dev-only lazy imports to production-excluded modules.
+- Production-exclude mock-backed routes.
+- Remove client-side Tear Sheet mock export.
+- Production-disable Tear Sheet mock tab/grid.
+- Implement ratified `/reserves-demo` branch.
+- Fix Reports Active Alerts failure coercion.
+- Add prod manifest and chunk ownership checks.
+- Add source-level mock guard.
+- Add high-signal bundle sentinel scan.
+- Decide source-map serving policy.
+
+## PR 2 — Governance execution layer
+
+- Extend route governance with executable/policy/docs layers.
+- Add compiled-object route/nav/governance tests.
+- Add structural guard for active nav source.
+- Add external public-contract allowlist.
+- Add archived redirect redacted telemetry schema.
+- Lock cashflow demo fallback (P1 regression test).
+
+## PR 3 — Shared provenance contract
+
+- Add shared Zod provenance schema
+  (`shared/contracts/data-provenance-v1.contract.ts`).
+- Add central `ProvenanceBoundary`.
+- Add export eligibility primitive.
+- Require material financial APIs to carry provenance additively.
+- Missing provenance at network boundary maps to `FAILED`.
+- Update `client/src/hooks/use-moic.ts` to validate against
+  `FundMoicRankingsResponseV1Schema`.
+
+## PR 4 — Visible trust migration
+
+- Forecast fallback contract and UI.
+- Reports card provenance.
+- Cashflow server-read model or explicit unavailable state.
+- Scenario Modeling tab hidden or converted to real fund-scoped link.
+- Canonical flow persistence status noted.
+
+## PR 5 — MOIC fund-scoped qualification
+
+- Delete static `moicData` and make API the primary data source.
+- Add provenance to `shared/contracts/fund-moic-v1.contract.ts`.
+- Prefer `/fund-model-results/:fundId` tab/child placement.
+- Keep query-param route only as compatibility if needed.
+- Add 401/403 Access Denied state.
+- Add telemetry and health gates.
+- Add production bundle sentinel for old sample names.
+- Quarantine benchmarking dashboard if still mock-backed.
+
+## PR 6 — LP Reporting qualification
+
+- Audit `requireLPAccess` and LP role schema (not generic `requireRole`).
+- Define workflow-state gates.
+- Enforce server-side role/workflow policy.
+- Add provenance to report package/export states.
+- Use existing `playwright.lp-reporting.config.ts` for functional E2E.
+- Add auth-enabled integration tests.
+- Add telemetry and health gates.
+
+## PR 7 — Dead nav deletion
+
+- Delete stale nav file (`client/src/config/navigation.ts`).
+- Delete `ExpandableSidebar`
+  (`client/src/components/layout/expandable-sidebar.tsx`).
+- Update tests.
+- Keep single active nav source guard.
+
+---
+
+# Final Acceptance Criteria
+
+The strategy is complete only when:
+
+1. `/reserves-demo` follows its ratified branch and is not accidentally public.
+2. Tear Sheet mock export is gone from production.
+3. Mock Tear Sheets do not render in production unless live-backed or explicitly
+   non-production demo.
+4. Reports never converts dashboard failure into `0 / Stable`.
+5. Production build excludes quarantined route chunks, not just route entries.
+6. Bundle scans and source guards both pass.
+7. Public source-map policy is explicit.
+8. Governance tests import and validate executable route/nav objects.
+9. `isProtected`/fund context guard is not treated as auth.
+10. Material financial APIs return shared Zod provenance.
+11. Missing/invalid provenance maps to `FAILED`.
+12. Server exports are authoritative binary/artifact flows, not client-rendered
+    PDFs from JSON.
+13. MOIC is fund-scoped, static sample data removed, API is primary data source,
+    and provenance-backed.
+14. LP Reporting promotion has role and workflow-state policy.
+15. Telemetry is redacted and health gates are numeric.
+16. Archived redirects are treated as compatibility contracts.
+17. Server route inventory covers mounted, unmounted, docs-only, and placeholder
+    APIs.
+18. CI check prevents unmounted route files from being silently ignored.
+19. Dead nav artifacts are deleted after structural guards are in place.
+20. Canonical flow remains protected by regression tests and wizard persistence
+    status is tracked.

--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "generatedAt": "2026-06-29T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 180,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 92,
+      "staleDays": 94,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 70,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 70,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1179,7 +1179,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-rubric-v33.md",
-      "staleDays": 4,
+      "staleDays": 6,
       "status": "REFERENCE"
     },
     {
@@ -1197,7 +1197,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-synthesis-v33.md",
-      "staleDays": 4,
+      "staleDays": 6,
       "status": "REFERENCE"
     },
     {
@@ -1224,7 +1224,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1304,7 +1304,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1319,7 +1319,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1336,7 +1336,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1353,7 +1353,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 82,
+      "staleDays": 84,
       "status": "UNKNOWN"
     },
     {
@@ -1371,7 +1371,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1405,7 +1405,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1421,7 +1421,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1436,7 +1436,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1451,7 +1451,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1466,7 +1466,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -1482,7 +1482,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1497,7 +1497,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1512,7 +1512,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1527,7 +1527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1542,7 +1542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1570,7 +1570,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 180,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1586,7 +1586,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "UNKNOWN"
     },
     {
@@ -1613,7 +1613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -1628,7 +1628,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -1643,7 +1643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1658,7 +1658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1673,7 +1673,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1726,7 +1726,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 180,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1740,7 +1740,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1754,7 +1754,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1768,7 +1768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1782,7 +1782,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1796,7 +1796,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1810,7 +1810,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1824,7 +1824,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -1839,7 +1839,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1854,7 +1854,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1869,7 +1869,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -1884,7 +1884,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1899,7 +1899,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1914,7 +1914,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1929,7 +1929,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1944,7 +1944,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1959,7 +1959,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -1978,7 +1978,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ready"
     },
     {
@@ -1997,7 +1997,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ready"
     },
     {
@@ -2016,7 +2016,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ready"
     },
     {
@@ -2031,7 +2031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2046,7 +2046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2085,7 +2085,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -2100,7 +2100,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -2115,7 +2115,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2141,7 +2141,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 37,
+      "staleDays": 39,
       "status": "UNKNOWN"
     },
     {
@@ -2156,7 +2156,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2183,7 +2183,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2198,7 +2198,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2213,7 +2213,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2228,7 +2228,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2244,7 +2244,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -2260,7 +2260,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2275,7 +2275,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2290,7 +2290,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2305,7 +2305,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2320,7 +2320,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2336,7 +2336,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -2351,7 +2351,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2366,7 +2366,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2381,7 +2381,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2397,7 +2397,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2412,7 +2412,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2427,7 +2427,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2442,7 +2442,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2456,7 +2456,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2471,7 +2471,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2567,7 +2567,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2583,7 +2583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2599,7 +2599,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2614,7 +2614,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2630,7 +2630,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2645,7 +2645,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2660,7 +2660,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2675,7 +2675,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2691,7 +2691,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2722,7 +2722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2740,7 +2740,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2755,7 +2755,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2770,7 +2770,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2785,7 +2785,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2800,7 +2800,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2816,7 +2816,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -2831,7 +2831,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2846,7 +2846,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2861,7 +2861,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -2876,7 +2876,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2891,7 +2891,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2906,7 +2906,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2921,7 +2921,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2936,7 +2936,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2951,7 +2951,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2966,7 +2966,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "ACTIVE"
     },
     {
@@ -2981,7 +2981,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -2996,7 +2996,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3032,7 +3032,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 92,
+      "staleDays": 94,
       "status": "ACTIVE"
     },
     {
@@ -3049,7 +3049,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "ACTIVE"
     },
     {
@@ -3064,7 +3064,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "ACTIVE"
     },
     {
@@ -3079,7 +3079,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3094,7 +3094,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3123,7 +3123,7 @@
       "lastUpdated": "2026-05-21",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 37,
+      "staleDays": 39,
       "status": "ACTIVE"
     },
     {
@@ -3138,7 +3138,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 24,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -3153,7 +3153,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3168,7 +3168,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "ACTIVE"
     },
     {
@@ -3195,7 +3195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3210,7 +3210,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3225,7 +3225,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-QUICK-START.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3240,7 +3240,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3255,7 +3255,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3270,7 +3270,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3285,7 +3285,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3300,7 +3300,7 @@
       "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "README.md",
-      "staleDays": 5,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -3315,7 +3315,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3330,7 +3330,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3345,7 +3345,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3362,7 +3362,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 92,
+      "staleDays": 94,
       "status": "ACTIVE"
     },
     {
@@ -3377,7 +3377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3392,7 +3392,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -3407,7 +3407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3422,7 +3422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3437,7 +3437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3452,7 +3452,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3467,7 +3467,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -3482,7 +3482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3497,7 +3497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3512,7 +3512,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -3527,7 +3527,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3542,7 +3542,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3557,7 +3557,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3572,7 +3572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3587,7 +3587,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -3602,7 +3602,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3617,7 +3617,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -3632,7 +3632,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3647,7 +3647,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3662,7 +3662,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3677,7 +3677,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -3692,7 +3692,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3707,7 +3707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3722,7 +3722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3737,7 +3737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3753,7 +3753,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "active"
     },
     {
@@ -3768,7 +3768,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3783,7 +3783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3798,7 +3798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3813,7 +3813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3828,7 +3828,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 82,
+      "staleDays": 84,
       "status": "ACTIVE"
     },
     {
@@ -3843,7 +3843,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3858,7 +3858,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -3873,7 +3873,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3888,7 +3888,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -3903,7 +3903,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3918,7 +3918,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3933,7 +3933,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3948,7 +3948,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3963,7 +3963,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3978,7 +3978,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -3993,7 +3993,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4008,7 +4008,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4023,7 +4023,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4038,7 +4038,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 24,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -4053,7 +4053,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -4068,7 +4068,7 @@
       "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 5,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -4083,7 +4083,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4110,7 +4110,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4125,7 +4125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4140,8 +4140,20 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/CRITICAL-REVIEW-secondary-surface-governance.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
     },
     {
       "docType": "doc",
@@ -4155,7 +4167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4170,7 +4182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4185,7 +4197,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4200,7 +4212,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4239,7 +4251,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 70,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -4254,7 +4266,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4269,7 +4281,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4284,7 +4296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4320,7 +4332,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 30,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -4335,7 +4347,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4350,7 +4362,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 68,
+      "staleDays": 70,
       "status": "HISTORICAL"
     },
     {
@@ -4365,7 +4377,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4380,7 +4392,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4395,7 +4407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4410,7 +4422,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -4425,7 +4437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4440,7 +4452,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4455,7 +4467,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4470,7 +4482,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4485,7 +4497,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4500,7 +4512,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4541,7 +4553,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -4556,7 +4568,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4571,7 +4583,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4586,7 +4598,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 83,
+      "staleDays": 85,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4601,7 +4613,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4616,7 +4628,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4631,7 +4643,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4646,7 +4658,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4660,7 +4672,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -4675,7 +4687,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4690,7 +4702,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4705,7 +4717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4720,7 +4732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4735,7 +4747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -4750,7 +4762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4765,7 +4777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4780,7 +4792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4795,7 +4807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4810,7 +4822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4825,7 +4837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4840,7 +4852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4855,7 +4867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4884,7 +4896,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -4899,7 +4911,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4914,7 +4926,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4929,7 +4941,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4944,7 +4956,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4959,7 +4971,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4974,7 +4986,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -4989,7 +5001,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -5004,7 +5016,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5019,7 +5031,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5034,7 +5046,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5049,7 +5061,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5064,7 +5076,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5079,7 +5091,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -5094,7 +5106,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5109,7 +5121,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5124,7 +5136,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5139,7 +5151,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5154,7 +5166,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 50,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -5169,7 +5181,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 50,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -5184,7 +5196,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -5199,7 +5211,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 36,
+      "staleDays": 38,
       "status": "ACTIVE"
     },
     {
@@ -5214,7 +5226,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5229,7 +5241,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5244,7 +5256,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5259,7 +5271,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5285,7 +5297,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -5300,7 +5312,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "Implemented"
     },
     {
@@ -5315,7 +5327,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/adr/ADR-023-investment-event-persistence.md",
-      "staleDays": 6,
+      "staleDays": 8,
       "status": "ACCEPTED (amended 2026-06-21)"
     },
     {
@@ -5330,7 +5342,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 70,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -5345,7 +5357,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5396,7 +5408,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5411,7 +5423,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 102,
+      "staleDays": 104,
       "status": "ARCHIVED"
     },
     {
@@ -5426,7 +5438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5441,7 +5453,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5456,7 +5468,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -5471,7 +5483,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 31,
+      "staleDays": 33,
       "status": "HISTORICAL"
     },
     {
@@ -5486,7 +5498,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 31,
+      "staleDays": 33,
       "status": "HISTORICAL"
     },
     {
@@ -5501,7 +5513,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5516,7 +5528,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5531,7 +5543,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5546,7 +5558,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5561,7 +5573,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5576,7 +5588,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5591,7 +5603,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5606,7 +5618,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5621,7 +5633,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5636,7 +5648,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5651,7 +5663,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5666,7 +5678,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5681,7 +5693,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5696,7 +5708,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5711,7 +5723,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5726,7 +5738,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5741,7 +5753,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5756,7 +5768,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 89,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -5771,7 +5783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5786,7 +5798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5800,7 +5812,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -5814,7 +5826,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -5829,7 +5841,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -5844,7 +5856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5859,7 +5871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5874,7 +5886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5889,7 +5901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5904,7 +5916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5919,7 +5931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5934,7 +5946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5949,7 +5961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5964,7 +5976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5979,7 +5991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -5994,7 +6006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6009,7 +6021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6024,7 +6036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6039,7 +6051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6054,7 +6066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6069,7 +6081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -6084,7 +6096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6099,7 +6111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6141,7 +6153,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 25,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -6189,7 +6201,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 25,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -6234,7 +6246,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 24,
+      "staleDays": 26,
       "status": "ACTIVE"
     },
     {
@@ -6267,7 +6279,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-22-entity-access-boundary.md",
-      "staleDays": 5,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -6300,7 +6312,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-entity-access-boundary.md",
-      "staleDays": 4,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -6333,7 +6345,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-trust-audit.md",
-      "staleDays": 4,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -6364,7 +6376,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/client-derived-math-inventory.md",
-      "staleDays": 4,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -6395,7 +6407,7 @@
       "lastUpdated": "2026-06-15",
       "owner": "Platform Team",
       "path": "docs/design/audits/server-object-readiness.md",
-      "staleDays": 12,
+      "staleDays": 14,
       "status": "ACTIVE"
     },
     {
@@ -6434,7 +6446,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 70,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -6450,7 +6462,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -6465,7 +6477,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6480,7 +6492,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6495,7 +6507,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6510,7 +6522,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6524,7 +6536,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -6539,7 +6551,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6554,7 +6566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6569,7 +6581,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6584,7 +6596,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6598,7 +6610,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -6613,7 +6625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6628,7 +6640,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -6643,7 +6655,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6658,7 +6670,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6673,7 +6685,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6688,7 +6700,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6703,7 +6715,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6718,7 +6730,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6733,7 +6745,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6748,7 +6760,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6763,7 +6775,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -6778,7 +6790,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6811,7 +6823,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 30,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -6826,7 +6838,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6859,7 +6871,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 30,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -6874,7 +6886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6889,7 +6901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6904,7 +6916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6919,7 +6931,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 68,
+      "staleDays": 70,
       "status": "HISTORICAL"
     },
     {
@@ -6934,7 +6946,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 41,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -6949,7 +6961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6964,7 +6976,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6979,7 +6991,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -6994,7 +7006,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7009,7 +7021,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7024,7 +7036,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7039,7 +7051,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7054,7 +7066,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7069,7 +7081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7084,7 +7096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7099,7 +7111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7114,7 +7126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7129,7 +7141,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -7144,7 +7156,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7159,7 +7171,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7174,7 +7186,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7189,7 +7201,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7204,7 +7216,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7219,7 +7231,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -7234,7 +7246,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7249,7 +7261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7264,7 +7276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7285,7 +7297,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "active"
     },
     {
@@ -7299,7 +7311,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -7314,7 +7326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7329,7 +7341,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7344,7 +7356,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7359,7 +7371,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7374,7 +7386,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7389,7 +7401,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7404,7 +7416,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7419,7 +7431,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7434,7 +7446,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7449,7 +7461,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -7464,7 +7476,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -7479,7 +7491,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -7494,7 +7506,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -7509,7 +7521,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7524,7 +7536,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7539,7 +7551,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7554,7 +7566,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7569,7 +7581,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7584,7 +7596,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7599,7 +7611,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7614,7 +7626,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7629,7 +7641,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7644,7 +7656,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7659,7 +7671,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7674,7 +7686,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7689,7 +7701,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7704,7 +7716,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7719,7 +7731,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7734,7 +7746,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7749,7 +7761,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7764,7 +7776,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7779,7 +7791,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7794,7 +7806,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7828,7 +7840,7 @@
       "lastUpdated": "2026-06-16",
       "owner": "Platform Team",
       "path": "docs/parity/convention-matrix.md",
-      "staleDays": 11,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -7843,7 +7855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7858,7 +7870,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7874,7 +7886,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 83,
+      "staleDays": 85,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7889,7 +7901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7904,7 +7916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7919,7 +7931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7934,7 +7946,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7949,7 +7961,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7976,7 +7988,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -7991,7 +8003,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8006,7 +8018,7 @@
       "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 5,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -8023,7 +8035,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 81,
+      "staleDays": 83,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -8038,7 +8050,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 41,
+      "staleDays": 43,
       "status": "BACKLOG"
     },
     {
@@ -8052,7 +8064,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -8069,7 +8081,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 27,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -8089,7 +8101,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 25,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -8118,7 +8130,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-13-gp-trust-readiness-register.md",
-      "staleDays": 14,
+      "staleDays": 16,
       "status": "ACTIVE"
     },
     {
@@ -8152,7 +8164,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/plans/2026-06-22-current-state-steelman-roadmap.md",
-      "staleDays": 5,
+      "staleDays": 7,
       "status": "DRAFT"
     },
     {
@@ -8189,7 +8201,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -8204,7 +8216,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -8219,7 +8231,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8234,7 +8246,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -8249,7 +8261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8264,7 +8276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8279,7 +8291,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8294,7 +8306,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8309,7 +8321,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8324,7 +8336,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8339,7 +8351,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8354,7 +8366,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8369,7 +8381,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8384,7 +8396,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8399,7 +8411,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8414,7 +8426,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8429,7 +8441,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8444,7 +8456,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8459,7 +8471,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8474,7 +8486,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8489,7 +8501,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 37,
+      "staleDays": 39,
       "status": "ACTIVE"
     },
     {
@@ -8504,7 +8516,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8518,7 +8530,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -8545,7 +8557,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8560,7 +8572,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -8575,7 +8587,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8590,7 +8602,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8605,7 +8617,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8620,7 +8632,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8635,7 +8647,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8650,7 +8662,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8665,7 +8677,7 @@
       "lastUpdated": "2026-06-12",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 15,
+      "staleDays": 17,
       "status": "PROVEN"
     },
     {
@@ -8680,7 +8692,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8695,7 +8707,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8710,7 +8722,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8725,7 +8737,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8740,7 +8752,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8755,7 +8767,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8770,7 +8782,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8785,7 +8797,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8800,7 +8812,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8815,7 +8827,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -8850,7 +8862,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "COMPLETED"
     },
     {
@@ -8881,7 +8893,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "REFERENCE"
     },
     {
@@ -8912,7 +8924,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "REFERENCE"
     },
     {
@@ -8943,7 +8955,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "REFERENCE"
     },
     {
@@ -8976,7 +8988,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "REFERENCE"
     },
     {
@@ -9007,7 +9019,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 36,
+      "staleDays": 38,
       "status": "REFERENCE"
     },
     {
@@ -9039,7 +9051,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "REFERENCE"
     },
     {
@@ -9054,7 +9066,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "ACTIVE"
     },
     {
@@ -9069,7 +9081,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9084,7 +9096,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9099,7 +9111,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9114,7 +9126,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9129,7 +9141,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9157,7 +9169,44 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 89,
+      "staleDays": 91,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "both",
+        "categories": [
+          "development",
+          "testing"
+        ],
+        "keywords": [
+          "investment rounds",
+          "enable_investment_rounds",
+          "feature flag",
+          "VITE_ENABLE_INVESTMENT_ROUNDS",
+          "idempotency",
+          "soak"
+        ],
+        "last_updated": "2026-06-28",
+        "owner": "gp-team",
+        "related_code": [
+          "flags/registry.yaml",
+          "client/src/shared/useFlags.ts",
+          "shared/feature-flags/flag-definitions.ts",
+          "server/routes/investments.ts",
+          "tests/integration/investment-scenario-capability.test.ts"
+        ],
+        "review_cadence": "P180D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-28",
+      "owner": "gp-team",
+      "path": "docs/runbooks/investment-rounds-enablement.md",
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -9172,7 +9221,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9187,7 +9236,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9202,7 +9251,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9217,7 +9266,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9232,7 +9281,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9247,7 +9296,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9262,7 +9311,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9277,7 +9326,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9292,7 +9341,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9307,7 +9356,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9322,7 +9371,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9337,7 +9386,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9352,7 +9401,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9367,7 +9416,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9382,7 +9431,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9397,7 +9446,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9411,7 +9460,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -9425,7 +9474,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -9439,7 +9488,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -9453,7 +9502,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "UNKNOWN"
     },
     {
@@ -9467,7 +9516,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -9481,7 +9530,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "UNKNOWN"
     },
     {
@@ -9496,7 +9545,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9511,7 +9560,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9526,7 +9575,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -9567,7 +9616,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "VERIFIED"
     },
     {
@@ -9915,7 +9964,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "DRAFT"
     },
     {
@@ -10113,7 +10162,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10195,7 +10244,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "VERIFIED"
     },
     {
@@ -10268,7 +10317,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "DRAFT"
     },
     {
@@ -10312,7 +10361,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "DRAFT"
     },
     {
@@ -10442,7 +10491,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "DRAFT"
     },
     {
@@ -10489,7 +10538,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "DRAFT"
     },
     {
@@ -10531,7 +10580,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 85,
+      "staleDays": 87,
       "status": "DRAFT"
     },
     {
@@ -10680,7 +10729,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10706,7 +10755,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10737,7 +10786,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10766,7 +10815,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10795,7 +10844,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10825,7 +10874,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10855,7 +10904,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10885,7 +10934,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 47,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -10918,7 +10967,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 70,
+      "staleDays": 72,
       "status": "DRAFT"
     },
     {
@@ -10983,7 +11032,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -10998,7 +11047,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11013,7 +11062,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11040,7 +11089,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -11068,7 +11117,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -11097,7 +11146,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -11125,7 +11174,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -11153,7 +11202,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "ACTIVE"
     },
     {
@@ -11180,7 +11229,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 29,
+      "staleDays": 31,
       "status": "COMPLETE"
     },
     {
@@ -11221,7 +11270,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 20,
+      "staleDays": 22,
       "status": "ACTIVE"
     },
     {
@@ -11238,7 +11287,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 14,
+      "staleDays": 16,
       "status": "COMPLETE"
     },
     {
@@ -11267,7 +11316,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 19,
+      "staleDays": 21,
       "status": "ACTIVE"
     },
     {
@@ -11296,7 +11345,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 18,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -11326,6 +11375,30 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-17-secondary-surface-production-safety.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-18-secondary-surface-trust-slim.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {
         "audience": "agents",
         "authority": "docs/adr/ADR-023-investment-event-persistence.md",
@@ -11340,7 +11413,7 @@
       "lastUpdated": "2026-06-21",
       "owner": "Core Team",
       "path": "docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md",
-      "staleDays": 6,
+      "staleDays": 8,
       "status": "DRAFT"
     },
     {
@@ -11352,6 +11425,30 @@
       "lastUpdated": null,
       "owner": null,
       "path": "docs/superpowers/plans/2026-06-22-investment-rounds-ui-v2.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-23-financial-actionability-p0.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-23-part-b-investment-rounds-ramp.md",
       "staleDays": 999,
       "status": "UNKNOWN"
     },
@@ -11370,7 +11467,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.3.md",
-      "staleDays": 4,
+      "staleDays": 6,
       "status": "HISTORICAL"
     },
     {
@@ -11388,7 +11485,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.4.md",
-      "staleDays": 4,
+      "staleDays": 6,
       "status": "DRAFT"
     },
     {
@@ -11399,7 +11496,76 @@
       "isStale": true,
       "lastUpdated": null,
       "owner": null,
+      "path": "docs/superpowers/plans/2026-06-24-pr-d-provenance-envelope-rounds-evidence.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-24-pr-e-moic-shadow-recording-canonical-route.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
       "path": "docs/superpowers/plans/2026-06-25-h9-pr3-lp-package-export-revalidation.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
+        "audience": "both",
+        "categories": [
+          "testing"
+        ],
+        "keywords": [
+          "investment rounds",
+          "soak",
+          "idempotency",
+          "feature flag",
+          "enable_investment_rounds"
+        ],
+        "last_updated": "2026-06-28",
+        "owner": "gp-team",
+        "related_code": [
+          "server/routes/investments.ts",
+          "server/services/investments/investment-round-service.ts",
+          "tests/integration/investment-scenario-capability.test.ts",
+          "docs/runbooks/investment-rounds-enablement.md"
+        ],
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-06-28",
+      "owner": "gp-team",
+      "path": "docs/superpowers/plans/2026-06-28-investment-rounds-soak.md",
+      "staleDays": 1,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md",
       "staleDays": 999,
       "status": "UNKNOWN"
     },
@@ -11429,7 +11595,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 14,
+      "staleDays": 16,
       "status": "COMPLETE"
     },
     {
@@ -11458,7 +11624,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 19,
+      "staleDays": 21,
       "status": "ACTIVE"
     },
     {
@@ -11487,7 +11653,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 18,
+      "staleDays": 20,
       "status": "ACTIVE"
     },
     {
@@ -11534,7 +11700,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/superpowers/specs/2026-06-13-gp-trust-readiness-audit-design.md",
-      "staleDays": 14,
+      "staleDays": 16,
       "status": "ACTIVE"
     },
     {
@@ -11551,7 +11717,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md",
-      "staleDays": 6,
+      "staleDays": 8,
       "status": "DRAFT (red-team hardened 2026-06-21)"
     },
     {
@@ -11602,7 +11768,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 38,
+      "staleDays": 40,
       "status": "ACTIVE"
     },
     {
@@ -11617,7 +11783,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11632,7 +11798,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11647,7 +11813,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11662,7 +11828,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11689,7 +11855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11704,7 +11870,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11719,7 +11885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11734,7 +11900,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11749,7 +11915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11764,7 +11930,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11779,7 +11945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "HISTORICAL"
     },
     {
@@ -11794,7 +11960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11809,7 +11975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11824,7 +11990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11839,7 +12005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11854,7 +12020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11869,7 +12035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11884,7 +12050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11899,7 +12065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11914,7 +12080,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 30,
+      "staleDays": 32,
       "status": "ACTIVE"
     },
     {
@@ -11960,7 +12126,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 180,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11975,7 +12141,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     },
     {
@@ -11990,11 +12156,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 159,
+      "staleDays": 161,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "generatedAt": "2026-06-29T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -13161,7 +13327,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED (amended 2026-06-21)": 1,
-      "ACTIVE": 450,
+      "ACTIVE": 452,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 3,
@@ -13176,14 +13342,14 @@
       "REFERENCE": 8,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 119,
+      "UNKNOWN": 127,
       "VERIFIED": 9,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 24,
-    "stale_docs": 111,
-    "total_docs": 664
+    "missing_frontmatter": 32,
+    "stale_docs": 119,
+    "total_docs": 674
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,26 +1,26 @@
 ---
-last_updated: 2026-06-27
+last_updated: 2026-06-29
 ---
 
 # Staleness Report
 
-*Generated: 2026-06-27T00:00:00.000Z*
+*Generated: 2026-06-29T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 664 |
-| Stale Documents | 111 |
-| Missing Frontmatter | 24 |
+| Total Documents | 674 |
+| Stale Documents | 119 |
+| Missing Frontmatter | 32 |
 
 ### By Status
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 450 |
-| UNKNOWN | 119 |
+| ACTIVE | 452 |
+| UNKNOWN | 127 |
 | DRAFT | 33 |
 | HISTORICAL | 21 |
 | VERIFIED | 9 |
@@ -50,6 +50,7 @@ Documents that need review (older than their cadence threshold):
 | `CONTEXT.md` | Never | 999 | No | Unassigned |
 | `DIRECTORY_DELETION_INVESTIGATION.md` | Never | 999 | No | Unassigned |
 | `docs/CA-PACING-ORACLE.md` | Never | 999 | No | Unassigned |
+| `docs/CRITICAL-REVIEW-secondary-surface-governance.md` | Never | 999 | No | Unassigned |
 | `docs/adr/ADR-020-analysis-cohort-boundary.md` | Never | 999 | No | Unassigned |
 | `docs/agents/domain.md` | Never | 999 | No | Unassigned |
 | `docs/agents/issue-tracker.md` | Never | 999 | No | Unassigned |
@@ -85,38 +86,37 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md` | Never | 999 | YES - verify! | Unassigned |
 | `docs/superpowers/plans/2026-06-11-worker-prod-ops.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/plans/2026-06-13-gp-trust-readiness-audit.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-17-secondary-surface-production-safety.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-18-secondary-surface-trust-slim.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/plans/2026-06-22-investment-rounds-ui-v2.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-23-financial-actionability-p0.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-23-part-b-investment-rounds-ramp.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-24-pr-d-provenance-envelope-rounds-evidence.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-24-pr-e-moic-shadow-recording-canonical-route.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/plans/2026-06-25-h9-pr3-lp-package-export-revalidation.md` | Never | 999 | No | Unassigned |
+| `docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md` | Never | 999 | YES - verify! | Unassigned |
-| `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md` | Never | 999 | No | Unassigned |
-| `docs/superpowers/specs/2026-06-21-investment-rounds-ui-v2-design.md` | Never | 999 | No | Unassigned |
-| `docs/tooling-catalog.md` | Never | 999 | No | Unassigned |
-| `.claude/AGENT-DIRECTORY.md` | 2025-12-29 | 180 | No | Platform Team |
-| `.claude/docs/TEST-STRATEGY.md` | 2025-12-29 | 180 | No | Platform Team |
-| `.claude/plan.md` | 2025-12-29 | 180 | YES - verify! | Platform Developer |
-| `docs/xirr-consolidation-roadmap.md` | 2025-12-29 | 180 | YES - verify! | Platform Developer |
-| `cheatsheets/agent-architecture.md` | 2026-01-19 | 159 | No | Unassigned |
 
-*...and 61 more stale documents.*
+*...and 69 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **.claude/plan.md** (180 days old)
-- [ ] **CHANGELOG.md** (38 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (159 days old)
-- [ ] **cheatsheets/schema-alignment.md** (159 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (159 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (159 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (159 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (159 days old)
+- [ ] **.claude/plan.md** (182 days old)
+- [ ] **CHANGELOG.md** (40 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (161 days old)
+- [ ] **cheatsheets/schema-alignment.md** (161 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (161 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (161 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (161 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (161 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)
 - [ ] **docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md** (999 days old)
 - [ ] **docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md** (999 days old)
-- [ ] **docs/xirr-consolidation-roadmap.md** (180 days old)
+- [ ] **docs/xirr-consolidation-roadmap.md** (182 days old)
 
 ## Missing Frontmatter
 
@@ -126,6 +126,7 @@ Documents without proper YAML frontmatter:
 - [ ] `CONTEXT.md`
 - [ ] `DIRECTORY_DELETION_INVESTIGATION.md`
 - [ ] `docs/CA-PACING-ORACLE.md`
+- [ ] `docs/CRITICAL-REVIEW-secondary-surface-governance.md`
 - [ ] `docs/adr/ADR-020-analysis-cohort-boundary.md`
 - [ ] `docs/agents/domain.md`
 - [ ] `docs/agents/issue-tracker.md`
@@ -140,8 +141,15 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md`
 - [ ] `docs/superpowers/plans/2026-06-11-worker-prod-ops.md`
 - [ ] `docs/superpowers/plans/2026-06-13-gp-trust-readiness-audit.md`
+- [ ] `docs/superpowers/plans/2026-06-17-secondary-surface-production-safety.md`
+- [ ] `docs/superpowers/plans/2026-06-18-secondary-surface-trust-slim.md`
 - [ ] `docs/superpowers/plans/2026-06-22-investment-rounds-ui-v2.md`
+- [ ] `docs/superpowers/plans/2026-06-23-financial-actionability-p0.md`
+- [ ] `docs/superpowers/plans/2026-06-23-part-b-investment-rounds-ramp.md`
+- [ ] `docs/superpowers/plans/2026-06-24-pr-d-provenance-envelope-rounds-evidence.md`
+- [ ] `docs/superpowers/plans/2026-06-24-pr-e-moic-shadow-recording-canonical-route.md`
 - [ ] `docs/superpowers/plans/2026-06-25-h9-pr3-lp-package-export-revalidation.md`
+- [ ] `docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md`
 - [ ] `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md`
 - [ ] `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md`
 - [ ] `docs/superpowers/specs/2026-06-21-investment-rounds-ui-v2-design.md`

--- a/docs/superpowers/plans/2026-06-17-secondary-surface-production-safety.md
+++ b/docs/superpowers/plans/2026-06-17-secondary-surface-production-safety.md
@@ -1,0 +1,816 @@
+# Secondary-Surface Production Safety (P0A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. **Project note:** This repo's workflow
+> contract routes edits/tests through Hermes
+> (`npm run hermes:production -- --task "..."`). Either dispatch each task via
+> Hermes or use a superpowers sub-skill; the steps below are written to be
+> executable either way.
+
+**Goal:** Stop the variance dashboard and Tear Sheet surface from externalizing
+fabricated facts in production — show truthful alert states instead of a fake
+`0/Stable`, build-exclude the mock Tear Sheet dashboard (and its client-side PDF
+export) from the production bundle, and make production source maps opt-in.
+
+**Architecture:** Three independent, non-contentious P0A fixes plus one reusable
+build-verification primitive. Pure decision logic is lifted into framework-free
+modules (`client/src/lib`, `scripts/`) and unit-tested fast; the React/Vite
+wiring is verified by `tsc` + a post-build manifest scan. No route-governance or
+`secondary-surface-decisions.md` changes are required (those are deferred to a
+separate decision-gated plan — see Follow-on Plans).
+
+**Tech Stack:** React 18 + TypeScript (strict), Vite/Rollup, Vitest (projects:
+`server`=node, `client`=jsdom), Node ESM build scripts.
+
+---
+
+## Why this scope (context)
+
+An adversarial evaluation of
+`docs/CRITICAL-REVIEW-secondary-surface-governance.md` (run `wf_8c63987a-c13`,
+summary in `.claude/artifacts/secondary-surface-proposal-evaluation.md`)
+verified 28/33 code claims exact and concluded the 8-PR proposal is over-scoped
+for a solo-dev tool. Two findings shape this plan:
+
+1. The **clean, immediately-shippable** P0A wins are: truthful Active Alerts
+   state (`variance-tracking.tsx:278` uses `|| 0`, collapsing API failure into
+   `0/Stable`), and removing the client-side Tear Sheet mock PDF export
+   (`tear-sheet-dashboard.tsx:343` fabricates a fund, the only prod importer is
+   `reports.tsx:6`).
+2. The mock-backed **routes** (`/allocation-manager`, `/cash-management`,
+   `/portfolio-analytics`, `/cap-tables`, `/reserves-demo`) are deliberately
+   pinned `internal-live` in `tests/unit/app/route-governance-registry.test.tsx`
+   and ratified in `docs/plans/2026-03-27-secondary-surface-decisions.md`.
+   Build-excluding them is contended and blocked on re-ratifying that decision —
+   **out of scope here**, deferred to Plan B.
+
+Correctness catch baked in: `'Press On Ventures II'` is NOT a usable mock
+sentinel — but not because it is legitimate. `branding.ts:15` ships
+`legalName: 'Press On Ventures II L.P.'`, which is itself a fabricated value
+(the registered adviser per SEC IAPD CRD 334106 is "Press On Ventures GP, LLC";
+no "II L.P." is on record). The literal therefore appears across several modules
+(branding.ts, tear-sheet, a test, an ExportWrapper comment) and is an unreliable
+locator. The Tear Sheet is verified by **manifest module-path absence**
+(`tear-sheet-dashboard`), not literal scanning. (The `branding.ts` legal-name
+defect is tracked separately — see Follow-on Plans.)
+
+---
+
+## File Structure
+
+**Created:**
+
+- `client/src/lib/variance-alert-summary.ts` — pure `AlertSummaryState` union +
+  `deriveAlertSummaryState()`. Framework-free so it unit-tests in the node
+  project (mirrors the existing `client/src/lib/cash-event-edit-model.ts`
+  pattern).
+- `tests/unit/lib/variance-alert-summary.test.ts` — unit tests for the pure
+  function (server/node project: glob `tests/unit/**/*.test.ts`).
+- `scripts/check-prod-bundle.mjs` — reusable production-bundle verifier: pure
+  `findForbiddenModules()` + `findSourceMaps()` and a CLI. Extensible (Plan B
+  appends route modules).
+- `tests/unit/scripts/check-prod-bundle.test.mjs` — unit tests for the pure
+  scanner functions (server project: glob `tests/unit/scripts/**/*.test.mjs`).
+
+**Modified:**
+
+- `client/src/pages/variance-tracking.tsx` — wire `deriveAlertSummaryState` into
+  the alert count, `analysisStatus`, and the "Active Alerts" StatCard.
+- `client/src/pages/reports.tsx` — build-exclude the Tear Sheet dashboard + tab
+  from production.
+- `vite.config.ts:345` — fix the dead `sourcemap` ternary to an opt-in policy.
+- `package.json` — add `build:verify` script.
+
+---
+
+## Task 1: Truthful Active Alerts state
+
+**Files:**
+
+- Create: `client/src/lib/variance-alert-summary.ts`
+- Test: `tests/unit/lib/variance-alert-summary.test.ts`
+- Modify: `client/src/pages/variance-tracking.tsx` (import; line 278;
+  `analysisStatus` block lines 283-311; "Active Alerts" StatCard lines 660-668)
+
+- [ ] **Step 1: Write the pure module**
+
+Create `client/src/lib/variance-alert-summary.ts`:
+
+```ts
+/**
+ * Truthful alert-summary state for the variance dashboard.
+ *
+ * The page previously used `dashboardData?.data?.summary?.totalActiveAlerts || 0`,
+ * which collapses an API failure (undefined) into a valid-looking `0` and renders
+ * "Stable" / "No active alerts". For an LP/GP-facing surface that is a fabricated
+ * fact. This module makes the distinction explicit so the UI can render LOADING /
+ * FAILED / UNAVAILABLE instead of a fake zero.
+ */
+export type AlertSummaryState =
+  | { state: 'LOADING' }
+  | { state: 'FAILED'; message: string }
+  | { state: 'UNAVAILABLE'; reason: string }
+  | { state: 'LIVE'; count: number };
+
+export interface AlertSummaryInput {
+  isLoading: boolean;
+  isError: boolean;
+  totalActiveAlerts: number | null | undefined;
+}
+
+export function deriveAlertSummaryState(
+  input: AlertSummaryInput
+): AlertSummaryState {
+  if (input.isLoading) {
+    return { state: 'LOADING' };
+  }
+  if (input.isError) {
+    return { state: 'FAILED', message: 'Unable to load alert summary.' };
+  }
+  if (
+    typeof input.totalActiveAlerts !== 'number' ||
+    !Number.isFinite(input.totalActiveAlerts)
+  ) {
+    return { state: 'UNAVAILABLE', reason: 'No alert summary available yet.' };
+  }
+  return { state: 'LIVE', count: input.totalActiveAlerts };
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/lib/variance-alert-summary.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { deriveAlertSummaryState } from '@/lib/variance-alert-summary';
+
+describe('deriveAlertSummaryState', () => {
+  it('reports LOADING while the query is in flight', () => {
+    expect(
+      deriveAlertSummaryState({
+        isLoading: true,
+        isError: false,
+        totalActiveAlerts: undefined,
+      })
+    ).toEqual({ state: 'LOADING' });
+  });
+
+  it('reports FAILED on query error instead of a fake zero', () => {
+    expect(
+      deriveAlertSummaryState({
+        isLoading: false,
+        isError: true,
+        totalActiveAlerts: undefined,
+      })
+    ).toEqual({ state: 'FAILED', message: 'Unable to load alert summary.' });
+  });
+
+  it('reports UNAVAILABLE when the count is missing but there is no error', () => {
+    expect(
+      deriveAlertSummaryState({
+        isLoading: false,
+        isError: false,
+        totalActiveAlerts: undefined,
+      })
+    ).toEqual({
+      state: 'UNAVAILABLE',
+      reason: 'No alert summary available yet.',
+    });
+  });
+
+  it('preserves a real zero as a LIVE value (not collapsed away)', () => {
+    expect(
+      deriveAlertSummaryState({
+        isLoading: false,
+        isError: false,
+        totalActiveAlerts: 0,
+      })
+    ).toEqual({ state: 'LIVE', count: 0 });
+  });
+
+  it('returns the live count when present', () => {
+    expect(
+      deriveAlertSummaryState({
+        isLoading: false,
+        isError: false,
+        totalActiveAlerts: 3,
+      })
+    ).toEqual({ state: 'LIVE', count: 3 });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run:
+`npx vitest run tests/unit/lib/variance-alert-summary.test.ts --project=server`
+Expected: PASS, 5 tests. (Module already exists from Step 1, so this is green
+immediately — the failing-first signal here is the prior nonexistence of the
+file; if you prefer strict red-first, create the test before the module and
+observe the import error.)
+
+- [ ] **Step 4: Wire the import into variance-tracking.tsx**
+
+In `client/src/pages/variance-tracking.tsx`, add this import next to the other
+`@/lib` imports (the file already imports `@/lib/utils` at line 56):
+
+```ts
+import { deriveAlertSummaryState } from '@/lib/variance-alert-summary';
+```
+
+- [ ] **Step 5: Replace the `|| 0` alert count (line 278)**
+
+Replace exactly:
+
+```ts
+const totalActiveAlerts = dashboardData?.data?.summary?.totalActiveAlerts || 0;
+```
+
+with:
+
+```ts
+const alertSummary = deriveAlertSummaryState({
+  isLoading: dashboardLoading,
+  isError: Boolean(dashboardError),
+  totalActiveAlerts: dashboardData?.data?.summary?.totalActiveAlerts,
+});
+const totalActiveAlerts =
+  alertSummary.state === 'LIVE' ? alertSummary.count : 0;
+```
+
+(`dashboardLoading` and `dashboardError` are already destructured at lines
+213-214; `lastAnalysisDate` at line 279 and `alertCounts` at line 280 remain
+unchanged.)
+
+- [ ] **Step 6: Replace the `analysisStatus` block (lines 283-311)**
+
+Replace the entire existing
+`const analysisStatus = isAnalysisRunning ? {...} : ... ;` expression with:
+
+```ts
+const analysisStatus =
+  alertSummary.state === 'LOADING'
+    ? {
+        value: 'Loading',
+        description: 'Loading alert summary',
+        badgeText: 'Loading',
+        badgeVariant: 'secondary' as const,
+      }
+    : alertSummary.state === 'FAILED'
+      ? {
+          value: 'Unavailable',
+          description: 'Alert summary failed to load',
+          badgeText: 'Data error',
+          badgeVariant: 'destructive' as const,
+        }
+      : alertSummary.state === 'UNAVAILABLE'
+        ? {
+            value: 'Unavailable',
+            description: 'No alert summary available yet',
+            badgeText: 'No data',
+            badgeVariant: 'secondary' as const,
+          }
+        : isAnalysisRunning
+          ? {
+              value: 'Running',
+              description: 'Variance analysis is in progress',
+              badgeText: 'In progress',
+              badgeVariant: 'secondary' as const,
+            }
+          : !lastAnalysisDate
+            ? {
+                value: 'Not Run',
+                description: 'Run analysis to generate the first report',
+                badgeText: 'No report',
+                badgeVariant: 'secondary' as const,
+              }
+            : totalActiveAlerts > 0
+              ? {
+                  value: 'Attention',
+                  description: 'Active alerts need review',
+                  badgeText: `${totalActiveAlerts} active`,
+                  badgeVariant: 'destructive' as const,
+                }
+              : {
+                  value: 'Stable',
+                  description: hasReports
+                    ? 'Driven by latest variance report'
+                    : 'Most recent analysis completed',
+                  badgeText: 'No active alerts',
+                  badgeVariant: 'default' as const,
+                };
+
+const activeAlertsValue: string | number =
+  alertSummary.state === 'LIVE'
+    ? alertSummary.count
+    : alertSummary.state === 'LOADING'
+      ? '…'
+      : '—';
+const activeAlertsBadge =
+  alertSummary.state === 'LIVE'
+    ? {
+        text: `${alertCounts?.critical || 0} Critical`,
+        variant: ((alertCounts?.critical || 0) > 0
+          ? 'destructive'
+          : 'secondary') as 'destructive' | 'secondary',
+      }
+    : alertSummary.state === 'FAILED'
+      ? { text: 'Unavailable', variant: 'destructive' as const }
+      : { text: 'No data', variant: 'secondary' as const };
+```
+
+- [ ] **Step 7: Update the "Active Alerts" StatCard (lines 660-668)**
+
+Replace exactly:
+
+```tsx
+<StatCard
+  title="Active Alerts"
+  value={dashboardData?.data?.summary?.totalActiveAlerts || 0}
+  icon={AlertTriangle}
+  badge={{
+    text: `${alertCounts?.critical || 0} Critical`,
+    variant: (alertCounts?.critical || 0) > 0 ? 'destructive' : 'secondary',
+  }}
+/>
+```
+
+with:
+
+```tsx
+<StatCard
+  title="Active Alerts"
+  value={activeAlertsValue}
+  icon={AlertTriangle}
+  badge={activeAlertsBadge}
+/>
+```
+
+- [ ] **Step 8: Verify types, lint, and the unit test**
+
+Run: `npm run check` Expected: PASS (no type errors in `variance-tracking.tsx`
+or the new module).
+
+Run: `npm run lint` Expected: PASS (0 warnings; gate is `--max-warnings 0`).
+
+Run:
+`npx vitest run tests/unit/lib/variance-alert-summary.test.ts --project=server`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add client/src/lib/variance-alert-summary.ts tests/unit/lib/variance-alert-summary.test.ts client/src/pages/variance-tracking.tsx
+git commit -m "fix(variance): render truthful alert state instead of error-as-zero"
+```
+
+---
+
+## Task 2: Reusable production-bundle verifier
+
+**Files:**
+
+- Create: `scripts/check-prod-bundle.mjs`
+- Test: `tests/unit/scripts/check-prod-bundle.test.mjs`
+- Modify: `package.json` (scripts)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/scripts/check-prod-bundle.test.mjs`:
+
+```mjs
+import { describe, expect, it } from 'vitest';
+import {
+  findForbiddenModules,
+  findSourceMaps,
+} from '../../../scripts/check-prod-bundle.mjs';
+
+describe('findForbiddenModules', () => {
+  it('flags a manifest entry whose source path matches a forbidden substring', () => {
+    const manifest = {
+      'client/src/components/reports/tear-sheet-dashboard.tsx': {
+        file: 'assets/tear-sheet-dashboard-abc123.js',
+        src: 'client/src/components/reports/tear-sheet-dashboard.tsx',
+        isDynamicEntry: true,
+      },
+    };
+    const hits = findForbiddenModules(manifest, ['tear-sheet-dashboard']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].needle).toBe('tear-sheet-dashboard');
+  });
+
+  it('returns no hits when the forbidden module is absent', () => {
+    const manifest = {
+      'client/src/pages/reports.tsx': {
+        file: 'assets/reports-def456.js',
+        src: 'client/src/pages/reports.tsx',
+      },
+    };
+    expect(findForbiddenModules(manifest, ['tear-sheet-dashboard'])).toEqual(
+      []
+    );
+  });
+});
+
+describe('findSourceMaps', () => {
+  it('returns only .map files', () => {
+    expect(findSourceMaps(['a.js', 'a.js.map', 'b.css', 'b.css.map'])).toEqual([
+      'a.js.map',
+      'b.css.map',
+    ]);
+  });
+
+  it('returns empty when no maps present', () => {
+    expect(findSourceMaps(['a.js', 'b.css'])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+`npx vitest run tests/unit/scripts/check-prod-bundle.test.mjs --project=server`
+Expected: FAIL — cannot resolve `../../../scripts/check-prod-bundle.mjs` (module
+not created yet).
+
+- [ ] **Step 3: Write the scanner module + CLI**
+
+Create `scripts/check-prod-bundle.mjs`:
+
+```mjs
+// Production-bundle safety verifier.
+//
+// Asserts that quarantined source modules are NOT present in the built client
+// manifest, and that no source-map files were emitted unless explicitly enabled.
+// Reusable: extend QUARANTINED_MODULES as more surfaces are build-excluded.
+//
+// Run after `npm run build` via `npm run build:verify`.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST_DIR = resolve(process.cwd(), 'dist/public');
+const MANIFEST_PATH = join(DIST_DIR, '.vite/manifest.json');
+
+// Source-path substrings that must never appear in a production build manifest.
+export const QUARANTINED_MODULES = ['tear-sheet-dashboard'];
+
+/** Pure: return manifest entries whose key/src/file matches a forbidden substring. */
+export function findForbiddenModules(manifest, forbiddenSubstrings) {
+  const hits = [];
+  for (const key of Object.keys(manifest)) {
+    const entry = manifest[key] ?? {};
+    const haystacks = [key, entry.src ?? '', entry.file ?? ''];
+    for (const needle of forbiddenSubstrings) {
+      if (haystacks.some((h) => String(h).includes(needle))) {
+        hits.push({ needle, key, file: entry.file ?? '' });
+      }
+    }
+  }
+  return hits;
+}
+
+/** Pure: return the subset of file paths that are source maps. */
+export function findSourceMaps(filePaths) {
+  return filePaths.filter((p) => p.endsWith('.map'));
+}
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+function main() {
+  if (!existsSync(MANIFEST_PATH)) {
+    console.error(
+      `[check-prod-bundle] manifest not found at ${MANIFEST_PATH}. Run "npm run build" first.`
+    );
+    process.exit(1);
+  }
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+  const moduleHits = findForbiddenModules(manifest, QUARANTINED_MODULES);
+
+  const allowSourceMaps = process.env['VITE_SOURCEMAP'] === 'true';
+  const sourceMaps = allowSourceMaps ? [] : findSourceMaps(walk(DIST_DIR));
+
+  let failed = false;
+  if (moduleHits.length > 0) {
+    failed = true;
+    console.error(
+      '[check-prod-bundle] FAIL: quarantined modules present in production bundle:'
+    );
+    for (const hit of moduleHits)
+      console.error(`  - "${hit.needle}" via ${hit.key} -> ${hit.file}`);
+  }
+  if (sourceMaps.length > 0) {
+    failed = true;
+    console.error(
+      '[check-prod-bundle] FAIL: source maps emitted without VITE_SOURCEMAP=true:'
+    );
+    for (const map of sourceMaps) console.error(`  - ${map}`);
+  }
+  if (failed) process.exit(1);
+  console.log(
+    '[check-prod-bundle] OK: no quarantined modules or stray source maps.'
+  );
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  main();
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+`npx vitest run tests/unit/scripts/check-prod-bundle.test.mjs --project=server`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Add the `build:verify` npm script**
+
+In `package.json`, add this entry to the `"scripts"` object (place it next to
+the other `build*` scripts):
+
+```json
+    "build:verify": "node scripts/check-prod-bundle.mjs",
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/check-prod-bundle.mjs tests/unit/scripts/check-prod-bundle.test.mjs package.json
+git commit -m "test(build): add production-bundle verifier for quarantined modules + source maps"
+```
+
+---
+
+## Task 3: Build-exclude the Tear Sheet mock dashboard
+
+**Files:**
+
+- Modify: `client/src/pages/reports.tsx` (lines 5-6 import; lines 18-21
+  TabsList; lines 27-40 TabsContent)
+
+- [ ] **Step 1: Confirm the verifier currently FAILS (negative control)**
+
+Run: `npm run build` (≈1-3 min) Run: `npm run build:verify` Expected: FAIL —
+`"tear-sheet-dashboard"` is present in the manifest (the lazy chunk is still
+emitted by the current code). This proves the gate is load-bearing.
+
+- [ ] **Step 2: Replace the lazy import (lines 5-6)**
+
+Replace exactly:
+
+```tsx
+// Lazy-load PDF generation to reduce initial bundle size (saves ~430 KB gzipped)
+const TearSheetDashboard = lazy(
+  () => import('@/components/reports/tear-sheet-dashboard')
+);
+```
+
+with:
+
+```tsx
+// Tear Sheets are mock-backed and ship a client-side PDF export that fabricates fund
+// facts. Build-exclude the entire dashboard (and its chunk) from production:
+// `import.meta.env.DEV` is statically replaced with `false` in production builds, so the
+// dynamic import in the dead branch is dropped by Rollup and no chunk is emitted.
+const SHOW_TEAR_SHEETS = import.meta.env.DEV;
+const TearSheetDashboard = SHOW_TEAR_SHEETS
+  ? lazy(() => import('@/components/reports/tear-sheet-dashboard'))
+  : null;
+```
+
+- [ ] **Step 3: Gate the tab trigger (lines 18-21)**
+
+Replace exactly:
+
+```tsx
+<TabsList className="grid w-full grid-cols-2">
+  <TabsTrigger value="reports">Fund Reports</TabsTrigger>
+  <TabsTrigger value="tear-sheets">Tear Sheets</TabsTrigger>
+</TabsList>
+```
+
+with:
+
+```tsx
+<TabsList
+  className={`grid w-full ${SHOW_TEAR_SHEETS ? 'grid-cols-2' : 'grid-cols-1'}`}
+>
+  <TabsTrigger value="reports">Fund Reports</TabsTrigger>
+  {SHOW_TEAR_SHEETS && (
+    <TabsTrigger value="tear-sheets">Tear Sheets</TabsTrigger>
+  )}
+</TabsList>
+```
+
+- [ ] **Step 4: Gate the tab content (lines 27-40)**
+
+Replace exactly:
+
+```tsx
+<TabsContent value="tear-sheets" className="mt-6">
+  <Suspense
+    fallback={
+      <div className="flex items-center justify-center p-12" role="status">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pov-charcoal mx-auto mb-4"></div>
+          <p className="text-charcoal-600">Preparing tear sheet workspace...</p>
+        </div>
+      </div>
+    }
+  >
+    <TearSheetDashboard />
+  </Suspense>
+</TabsContent>
+```
+
+with:
+
+```tsx
+{
+  SHOW_TEAR_SHEETS && TearSheetDashboard && (
+    <TabsContent value="tear-sheets" className="mt-6">
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center p-12" role="status">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pov-charcoal mx-auto mb-4"></div>
+              <p className="text-charcoal-600">
+                Preparing tear sheet workspace...
+              </p>
+            </div>
+          </div>
+        }
+      >
+        <TearSheetDashboard />
+      </Suspense>
+    </TabsContent>
+  );
+}
+```
+
+- [ ] **Step 5: Reconcile any existing test that asserts the Tear Sheets tab**
+
+Run: `npx vitest run --project=client -t "tear" 2>&1 | head -40` (locate
+component tests touching the tab). Also: search for assertions on the literal
+`Tear Sheets` under `tests/`. Run (search): use the editor's grep for
+`Tear Sheets` and `tear-sheets` within `tests/`. Expected: If a `reports`/jsdom
+test asserts the tab is present, note that under vitest
+`import.meta.env.DEV === true`, so the tab IS rendered in tests — existing
+assertions remain valid. No change needed unless a test asserts production-mode
+absence (none expected).
+
+- [ ] **Step 6: Verify types and the production build/scan (now GREEN)**
+
+Run: `npm run check` Expected: PASS.
+
+Run: `npm run build` (≈1-3 min) Run: `npm run build:verify` Expected: PASS —
+`[check-prod-bundle] OK`. The tear-sheet chunk is no longer emitted.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/pages/reports.tsx
+git commit -m "fix(reports): build-exclude mock Tear Sheet dashboard + PDF export from production"
+```
+
+---
+
+## Task 4: Source-map production policy
+
+**Files:**
+
+- Modify: `vite.config.ts:345`
+
+- [ ] **Step 1: Replace the dead `sourcemap` ternary (line 345)**
+
+Replace exactly:
+
+```ts
+      sourcemap: process.env['VITE_SOURCEMAP'] === 'true' ? true : true, // Always enable source maps for profiling (keeping environment option)
+```
+
+with:
+
+```ts
+      sourcemap: process.env['VITE_SOURCEMAP'] === 'true', // Off by default in production; opt in with VITE_SOURCEMAP=true. Avoids publishing maps that ease extraction of source/mock literals.
+```
+
+- [ ] **Step 2: Verify build emits no source maps by default**
+
+Run: `npm run build` (without `VITE_SOURCEMAP`) Run: `npm run build:verify`
+Expected: PASS — no `.map` files under `dist/public` (the verifier's source-map
+check passes).
+
+- [ ] **Step 3: Verify opt-in still works**
+
+Run (PowerShell):
+`$env:VITE_SOURCEMAP="true"; npm run build; npm run build:verify; Remove-Item Env:VITE_SOURCEMAP`
+Expected: build emits `.map` files AND `build:verify` PASSES (source-map check
+skipped when `VITE_SOURCEMAP=true`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vite.config.ts
+git commit -m "fix(build): make production source maps opt-in via VITE_SOURCEMAP"
+```
+
+---
+
+## Task 5: Full-suite verification
+
+**Files:** none (verification + optional CI wiring note)
+
+- [ ] **Step 1: Run type check, lint, and the full unit suite**
+
+Run: `npm run check` Expected: PASS.
+
+Run: `npm run lint` Expected: PASS (0 warnings).
+
+Run: `npm test` Expected: PASS (both `server` and `client` projects; the two new
+unit files included).
+
+- [ ] **Step 2: Final production build + verify**
+
+Run: `npm run build && npm run build:verify` Expected: `[check-prod-bundle] OK`.
+
+- [ ] **Step 3 (optional, recommended): wire `build:verify` into CI**
+
+Per the evaluation's premortem/devex findings, the gate is only durable if it is
+a hard, always-run check. Add `npm run build:verify` immediately after the
+existing build step in the CI build job, and confirm that job feeds the required
+`CI Gate Status` aggregator (do NOT add it as a separate path-filtered job —
+those skip docs-only PRs). Because this touches branch-protection-adjacent CI,
+confirm the exact workflow file before editing rather than guessing.
+
+---
+
+## Follow-on Plans (separate, do not fold into PR-1)
+
+These are independent subsystems from the proposal + amendment, deliberately
+split out:
+
+- **Plan B — Mock-route build exclusion.** Re-ratify
+  `docs/plans/2026-03-27-secondary-surface-decisions.md` and
+  `tests/unit/app/route-governance-registry.test.tsx` FIRST (the 4 operational
+  pages + `/reserves-demo` are currently pinned `internal-live`), then split
+  `client/src/app/app-routes.tsx` into core + dev-only modules and add a
+  production Vite `resolve.alias` mapping the dev-routes module to an empty stub
+  (mirror the `@sentry`→noop alias at `vite.config.ts:401`). Extend
+  `QUARANTINED_MODULES` in `scripts/check-prod-bundle.mjs` with the route source
+  paths. Verification is the manifest scan (governance unit tests run under
+  vitest where the alias is not applied, so keep them asserting the
+  dev-inclusive array — see eng-arch finding (d)).
+- **Plan C — MOIC live-primary + provenance base.** Make `useFundMoicRankings`
+  the primary data source in `client/src/pages/moic-analysis.tsx`, delete static
+  `moicData`, add Zod parsing in `client/src/hooks/use-moic.ts`, and introduce a
+  `.strict()` `ProvenanceBaseSchema` reconciled with
+  `shared/contracts/reserve-ic-decision-v1.contract.ts`.
+- **Plan D — ADR/decision hygiene.** Trivial unique-ADR-number + broken-link
+  check folded into the existing `docs:routing:generate` pipeline (not a
+  semantic dedup detector).
+- **Plan E — Branding legal-name truthfulness.**
+  `client/src/config/branding.ts:15` ships a non-registered `legalName` ('Press
+  On Ventures II L.P.'); the registered adviser is "Press On Ventures GP, LLC"
+  (SEC IAPD CRD 334106). Correct or data-source the value (and the related
+  `demo.fundName` / `Carmasal Fund` placeholders) per the owner's decision. Low
+  live exposure (only dead `investments` components consume it), so this is a
+  small standalone cleanup, not a P0A blocker.
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Accepted P0A items from
+`.claude/artifacts/secondary-surface-proposal-evaluation.md`: Active Alerts
+error-not-zero (Task 1), Tear Sheet client-export removal (Task 3), source-map
+policy (Task 4). Build-exclusion _mechanism_ is established reusably (Task 2)
+and applied to the one non-contentious surface (Tear Sheet); contended routes
+explicitly deferred to Plan B. MOIC/ADR deferred to Plans C/D. No accepted PR-1
+item is unaddressed.
+
+**2. Placeholder scan.** No TBD/TODO/"handle edge cases"/"similar to" — every
+code step has complete code; every command has expected output.
+
+**3. Type consistency.**
+`AlertSummaryState`/`deriveAlertSummaryState`/`AlertSummaryInput` are used
+identically in Task 1's module, test, and wiring.
+`findForbiddenModules`/`findSourceMaps`/`QUARANTINED_MODULES` match across Task
+2's module, test, and CLI. `SHOW_TEAR_SHEETS`/`TearSheetDashboard` are
+consistent across Task 3. `build:verify` is defined in Task 2 and invoked in
+Tasks 3-5.

--- a/docs/superpowers/plans/2026-06-18-secondary-surface-trust-slim.md
+++ b/docs/superpowers/plans/2026-06-18-secondary-surface-trust-slim.md
@@ -1,0 +1,442 @@
+# Secondary-Surface Trust (Solo Slim) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the app from presenting mock/fallback/sample data as real fund
+data, and prevent recurrence — sized for a solo developer on an internal team
+tool, not a multi-team SaaS.
+
+**Architecture:** Reuse the production-safety primitives shipped in PR #879
+(build-time bundle verifier + `import.meta.env.DEV` build exclusion) and extend
+them to the remaining mock-backed surfaces. Then move financial trust from UI
+convention into a shared provenance contract. Governance ceremony (10-field
+policy registry, CODEOWNERS, security-matrix docs, telemetry gates, identifier
+renames) is intentionally **cut** as YAGNI for a single-owner internal tool.
+
+**Tech Stack:** React 18 + Vite/Rollup (build-time tree-shaking via
+`import.meta.env.DEV`), TypeScript strict, Vitest, Zod, Drizzle. Node 20.19+.
+Tests under `TZ=UTC`.
+
+---
+
+## Source & supersession
+
+- **Reviews / supersedes:** `~/Downloads/updated-dev-roadmap-2026-06-18.md` (the
+  full PR-A..PR-K governance proposal). That proposal's _facts_ were verified
+  accurate against the repo; this plan keeps its trust/correctness spine and
+  cuts the governance overhead.
+- **Original safety plan:**
+  `docs/superpowers/plans/2026-06-17-secondary-surface-production-safety.md` (PR
+  #879 — now landed, treated here as a regression baseline).
+
+## Current state (verified 2026-06-18, main `3a91709d`)
+
+Landed and locked:
+
+- **PR #879** — truthful Active Alerts (`deriveAlertSummaryState`),
+  `scripts/check-prod-bundle.mjs` + `npm run build:verify` (CI hard gate), Tear
+  Sheet build-excluded via `import.meta.env.DEV`, source maps opt-in
+  (`VITE_SOURCEMAP`).
+- **PR #880** — `closeDatabasePool()` in `server/db.ts`; `release:check` DB
+  proof now passes stages 1–6 non-skipped.
+
+Verified open facts that drive this plan (file:line):
+
+- `scripts/check-prod-bundle.mjs:17` —
+  `QUARANTINED_MODULES = ['tear-sheet-dashboard']` (single entry).
+- `client/src/app/app-routes.tsx:20-25,89-92,103` — 5 mock routes are top-level
+  lazy imports, registered unconditionally, no DEV gate. **They are
+  nav-orphaned** (absent from `navigation-config.ts`) — reachable only by typing
+  the URL, so exposure is lower than "P0," but they still ship in the bundle.
+- `client/src/pages/moic-analysis.tsx:51-180` — static `moicData` is the
+  **primary** render (not a fallback); `:42-45` reads `fundId` from the query
+  string. `shared/contracts/fund-moic-v1.contract.ts:16-22` — response has no
+  provenance field.
+- `server/app.ts:43` (`makeApp`) vs `server/routes.ts:36` (`registerRoutes`) —
+  two route surfaces; `server/routes/portfolio/snapshots.ts` is fully
+  implemented but mounted on neither.
+- `server/routes/investments.ts:128,143,181` — `/rounds` and `/cases` return
+  501; no `investment_rounds` table and no `enable_investment_rounds` flag exist
+  yet.
+- `docs/design/audits/server-object-readiness.md:31` (task = HAS_PERSISTENCE)
+  contradicts `:72` (task = NONE); line 72 is factually wrong
+  (`server/routes/operating-object-tasks.ts` + migration
+  `20260616_operating_object_tasks_v1.up.sql` exist and are mounted).
+- `client/src/components/layout/expandable-sidebar.tsx` and
+  `client/src/config/navigation.ts` — zero **production** importers; canonical
+  layout uses `Sidebar` + `navigation-config.ts`. One **test** still references
+  them: `tests/unit/components/layout/sidebar-navigation.test.tsx`.
+
+## What this plan CUTS from the source proposal (YAGNI for solo/internal)
+
+- 10-field policy registry
+  (`authBoundary`/`rolePolicy`/`workflowPolicy`/`dataAuthority`/`calculationMode`/`exportPolicy`/`telemetryKey`/`owner`/`rollback`).
+- CODEOWNERS entries (single owner).
+- `docs/security/surface-boundary-matrix.md`.
+- `isProtected` → `fundContextGuard` rename across docs/tests (pure churn, risks
+  breaking green tests).
+- PR-H's 8-state LP workflow FSM (keep the working draft→approved→locked).
+- Telemetry / health gates (Phase 10).
+- PR-J assumption/comment contracts.
+
+## Sequenced roadmap (solo order)
+
+| #   | PR                                  | Theme                                                                    | Detail level here | Effort      | Impact               |
+| --- | ----------------------------------- | ------------------------------------------------------------------------ | ----------------- | ----------- | -------------------- |
+| 1   | **Firebreaks**                      | quarantine mock routes + delete dead nav + record decision               | **FULL (below)**  | low (hours) | med-high             |
+| 2   | Provenance contract                 | `shared/contracts/provenance.contract.ts` + `ProvenanceBoundary`         | stub              | med         | high                 |
+| 3   | MOIC live-primary                   | delete static `moicData`, Zod-parse live data, provenance, access-denied | stub              | med         | high                 |
+| 4   | Reports/cashflow/forecast trust     | per-card provenance, fallback labels, no fabricated zeros                | stub              | med         | high                 |
+| 5   | Route-mount parity guard            | CI script over `app.ts`+`routes.ts`; fix `snapshots.ts` + task-doc       | stub              | low-med     | med                  |
+| 6   | Investment rounds backend (ADR-023) | migration + table + routes + idempotency, flag off                       | stub (own plan)   | high        | high (product)       |
+| —   | Release-gate hygiene                | scenario-release-gate teardown (#880 follow-up)                          | note below        | low         | med (unblocks proof) |
+
+Big bets deliberately **not** in this plan unless numbers are observed wrong:
+capital-allocation unit unification (6 engines), XIRR 4-impl consolidation.
+Compass route wiring is governance OFF-LIMITS until Phase 3C Track B reopens —
+excluded.
+
+---
+
+## PR-1: Firebreaks (FULLY DETAILED)
+
+One PR, four tasks. Each is independently revertible. No user-facing nav points
+at the quarantined routes (verified nav-orphaned), so this does not break
+userspace.
+
+### Task 1: Extend the bundle quarantine list (test-first)
+
+**Files:**
+
+- Modify: `scripts/check-prod-bundle.mjs:17`
+- Test: `tests/unit/scripts/check-prod-bundle.test.mjs`
+
+- [ ] **Step 1: Write the failing test** — append to
+      `tests/unit/scripts/check-prod-bundle.test.mjs`:
+
+```js
+import { describe, it, expect } from 'vitest';
+import {
+  QUARANTINED_MODULES,
+  findForbiddenModules,
+} from '../../../scripts/check-prod-bundle.mjs';
+
+describe('mock-route quarantine extension', () => {
+  const newlyQuarantined = [
+    'reserves-demo',
+    'allocation-manager',
+    'cash-management',
+    'portfolio-analytics',
+    'CapTables',
+  ];
+
+  it('lists every mock-backed route module', () => {
+    for (const mod of newlyQuarantined) {
+      expect(QUARANTINED_MODULES).toContain(mod);
+    }
+  });
+
+  it('flags a manifest entry for each quarantined mock route', () => {
+    const manifest = Object.fromEntries(
+      newlyQuarantined.map((m) => [
+        `pages/${m}.tsx`,
+        { file: `assets/${m}-abc123.js` },
+      ])
+    );
+    const hits = findForbiddenModules(manifest, QUARANTINED_MODULES);
+    expect(hits.map((h) => h.needle).sort()).toEqual(
+      [...newlyQuarantined].sort()
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+`npx cross-env TZ=UTC vitest run tests/unit/scripts/check-prod-bundle.test.mjs`
+Expected: FAIL —
+`expected [ 'tear-sheet-dashboard' ] to contain 'reserves-demo'`.
+
+- [ ] **Step 3: Extend `QUARANTINED_MODULES`** in
+      `scripts/check-prod-bundle.mjs` (replace line 17):
+
+```js
+// Source-path substrings that must never appear in a production build manifest.
+export const QUARANTINED_MODULES = [
+  'tear-sheet-dashboard',
+  'reserves-demo',
+  'allocation-manager',
+  'cash-management',
+  'portfolio-analytics',
+  'CapTables',
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+`npx cross-env TZ=UTC vitest run tests/unit/scripts/check-prod-bundle.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Do NOT commit yet** — `build:verify` will fail until Task 2
+      excludes these routes from the bundle. Commit Tasks 1+2 together (Task 2
+      Step 5).
+
+### Task 2: DEV-gate the mock routes (build exclusion) — mirrors `reports.tsx`
+
+**Files:**
+
+- Modify: `client/src/app/app-routes.tsx:20-25` (remove top-level lazy decls),
+  `:89-92` and `:103` (remove inline entries), add a dev-only group.
+
+- [ ] **Step 1: Remove the five top-level lazy declarations** at
+      `app-routes.tsx:20,22,23,24,25` (delete these lines):
+
+```ts
+const ReservesDemo = React.lazy(() => import('@/pages/reserves-demo'));
+const AllocationManager = React.lazy(
+  () => import('@/pages/allocation-manager')
+);
+const CashManagement = React.lazy(() => import('@/pages/cash-management'));
+const PortfolioAnalytics = React.lazy(
+  () => import('@/pages/portfolio-analytics')
+);
+const CapTables = React.lazy(() => import('@/pages/CapTables'));
+```
+
+Keep `MOICAnalysisPage` (line 21) — MOIC is real work in PR-3, not a quarantined
+mock.
+
+- [ ] **Step 2: Add a dev-only route group** immediately before
+      `export const APP_ROUTES` (before line 73):
+
+```ts
+// Internal/demo surfaces. `import.meta.env.DEV` is statically replaced with `false`
+// in production builds, so Rollup tree-shakes these dynamic imports out of the prod
+// bundle (same mechanism as the Tear Sheet dashboard in pages/reports.tsx).
+// Production decision for /reserves-demo: Branch A — production-disabled.
+// Guarded by scripts/check-prod-bundle.mjs (QUARANTINED_MODULES).
+const SHOW_INTERNAL_DEMOS = import.meta.env.DEV;
+
+const INTERNAL_DEMO_ROUTES: AppRouteEntry[] = SHOW_INTERNAL_DEMOS
+  ? [
+      {
+        path: '/allocation-manager',
+        component: React.lazy(() => import('@/pages/allocation-manager')),
+        isProtected: true,
+      },
+      {
+        path: '/cash-management',
+        component: React.lazy(() => import('@/pages/cash-management')),
+        isProtected: true,
+      },
+      {
+        path: '/portfolio-analytics',
+        component: React.lazy(() => import('@/pages/portfolio-analytics')),
+        isProtected: true,
+      },
+      {
+        path: '/cap-tables',
+        component: React.lazy(() => import('@/pages/CapTables')),
+        isProtected: true,
+      },
+      {
+        path: '/reserves-demo',
+        component: React.lazy(() => import('@/pages/reserves-demo')),
+      },
+    ]
+  : [];
+```
+
+- [ ] **Step 3: Remove the five inline `APP_ROUTES` entries**
+      (`app-routes.tsx:89,90,91,92,103`) and spread the group in instead. The
+      array should no longer contain `/allocation-manager`, `/cash-management`,
+      `/portfolio-analytics`, `/cap-tables`, `/reserves-demo` as literals; add
+      `...INTERNAL_DEMO_ROUTES,` as the final element before the closing `];`.
+
+- [ ] **Step 4: Build and verify exclusion**
+
+Run: `npm run build && npm run build:verify` Expected: `build:verify` prints
+`[check-prod-bundle] OK: no quarantined modules or stray source maps.` If it
+FAILS naming a legitimate module (e.g. a real module whose path contains
+`portfolio-analytics`), narrow that substring in `QUARANTINED_MODULES` to a more
+specific path fragment (e.g. `pages/portfolio-analytics`) and re-run both the
+Task 1 test and `build:verify`.
+
+- [ ] **Step 5: Type-check and commit Tasks 1+2**
+
+Run: `npm run check` Expected: no new errors.
+
+```bash
+git add scripts/check-prod-bundle.mjs tests/unit/scripts/check-prod-bundle.test.mjs client/src/app/app-routes.tsx
+git commit -m "fix: build-exclude mock-backed routes and extend bundle quarantine"
+```
+
+### Task 3: Delete dead navigation artifacts
+
+**Files:**
+
+- Delete: `client/src/components/layout/expandable-sidebar.tsx`,
+  `client/src/config/navigation.ts`
+- Inspect/Modify: `tests/unit/components/layout/sidebar-navigation.test.tsx`
+
+- [ ] **Step 1: Re-confirm zero production importers**
+
+Run:
+`npx rg -n "expandable-sidebar|ExpandableSidebar|config/navigation" client/src`
+Expected: no matches under `client/src` source (the canonical `Sidebar` +
+`navigation-config` are used by `app-layout.tsx`). If any non-test source file
+matches, STOP — the artifact is not dead; remove it from this task.
+
+- [ ] **Step 2: Resolve the test importer** — open
+      `tests/unit/components/layout/sidebar-navigation.test.tsx`. It references
+      a dead module. Apply whichever fits:
+  - If it tests `ExpandableSidebar` behavior that the canonical `Sidebar`
+    already covers elsewhere → delete the test file.
+  - If it imports `config/navigation` only for fixture data → repoint the import
+    to `@/components/layout/navigation-config` and keep the assertions that
+    still hold.
+
+- [ ] **Step 3: Delete the dead files**
+
+```bash
+git rm client/src/components/layout/expandable-sidebar.tsx client/src/config/navigation.ts
+```
+
+- [ ] **Step 4: Run the layout tests + type-check**
+
+Run:
+`npx cross-env TZ=UTC vitest run tests/unit/components/layout && npm run check`
+Expected: PASS, no new type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "chore: delete dead navigation artifacts (expandable-sidebar, config/navigation)"
+```
+
+### Task 4: Record the `/reserves-demo` production decision (no code)
+
+**Files:**
+
+- Modify: `docs/plans/2026-03-27-secondary-surface-decisions.md`
+
+- [ ] **Step 1: Update the decision doc** — bump `last_updated` to `2026-06-18`
+      and add a decision row recording **Branch A**: `/reserves-demo` is
+      production-disabled (dev-only via `INTERNAL_DEMO_ROUTES`) and guarded by
+      `check-prod-bundle.mjs`. Add the same line for the four mock operational
+      routes. Keep it to one short table/section — this replaces the source
+      proposal's PR-B policy-registry ceremony.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/plans/2026-03-27-secondary-surface-decisions.md
+git commit -m "docs: record Branch A production-disable decision for mock-backed routes"
+```
+
+### PR-1 acceptance
+
+- `npm run build:verify` passes and would fail if any of the 6 quarantined
+  modules reappear.
+- Production manifest contains none of: `tear-sheet-dashboard`, `reserves-demo`,
+  `allocation-manager`, `cash-management`, `portfolio-analytics`, `CapTables`.
+- Dead-nav files gone; layout tests green.
+- Decision doc current.
+
+---
+
+## PR-2..PR-6: scoped stubs (expand each into its own plan when picked up)
+
+These are intentionally **not** bite-sized yet (multi-subsystem; later scope
+shifts as earlier PRs land). Each becomes its own `docs/superpowers/plans/` doc
+at execution time.
+
+### PR-2 — Shared provenance contract
+
+- Create `shared/contracts/provenance.contract.ts` (Zod):
+  `{ source: 'live'|'fallback'|'sample'|'unavailable', state: 'OK'|'PARTIAL'|'FAILED'|'UNAVAILABLE', generatedAt }`.
+  Missing/invalid provenance maps to `FAILED`.
+- Create `ProvenanceBoundary` renderer (client) consuming that state. Reuse the
+  `deriveAlertSummaryState` precedent from PR #879.
+- Acceptance: contract + renderer unit-tested; no surface migrated yet.
+
+### PR-3 — MOIC live-primary (depends on PR-2)
+
+- `moic-analysis.tsx`: delete static `moicData` (`:51-180`); make
+  `useFundMoicRankings` the primary source; Zod-parse at the network boundary;
+  401/403 → Access Denied (not empty); empty live ranking state.
+- Add provenance to `shared/contracts/fund-moic-v1.contract.ts`.
+- Prefer mounting under `/fund-model-results/:fundId`; keep `?fundId=` as
+  compatibility only if needed.
+- Acceptance: no static sample data renders in prod; live + denied + empty
+  states tested.
+
+### PR-4 — Reports / cashflow / forecast trust (depends on PR-2)
+
+- Reports cards get independent provenance state. Cashflow material metrics are
+  server-sourced or explicitly `UNAVAILABLE`. Forecast fallback labels say
+  configuration/default/fallback, never "fresh calculation." No fabricated zeros
+  in production no-input states.
+- Acceptance: each card renders truthful state under live / fallback / failed.
+
+### PR-5 — Route-mount parity guard
+
+- Add a CI script that inventories routes mounted on `server/app.ts` vs
+  `server/routes.ts` and fails on unexpected divergence. Mount or explicitly
+  archive `server/routes/portfolio/snapshots.ts`. Fix
+  `server-object-readiness.md:72` (task = HAS_PERSISTENCE). Keep this a
+  **script + test**, not a governance program.
+- Acceptance: parity script in CI; snapshots resolved; doc contradiction gone.
+
+### PR-6 — Investment rounds backend, ADR-023 L3b (own plan)
+
+- Precondition migration first: `investments.fund_id` nullable → enforce
+  `UNIQUE (id, fund_id)` (composite-FK target). Then `investment_rounds` table
+  (`NUMERIC(20,6)` money cols), required `Idempotency-Key` + request hash,
+  append-only, mandatory fund enforcement. Delete-of-investment-with-rounds =
+  `RESTRICT`. Keep `/cases` etc. at 501. Add `enable_investment_rounds`, **off
+  in production** until a supersede/correction tranche exists. No live UI.
+- Acceptance: integration test flips `/rounds` 501→201/200 behind the flag;
+  `/cases` stays 501.
+
+## Parallel hygiene (not blocking the spine)
+
+- **Release-gate teardown (#880 follow-up):** `release:check` DB proof passes
+  stages 1–6 but blocks at the Scenario release gate — two unhandled teardown
+  errors in
+  `tests/integration/scenarios/scenario-release-gate.integration.test.ts`. Fix
+  by applying the #880 pattern: await `closeDatabasePool()` (and any route-owned
+  pools) in that test's teardown before containers stop. Low effort, unblocks
+  the full release proof.
+- Batch fill-ins: `shell-quote` npm override (Dependabot 215),
+  `vite.config.ts:345` `true ? true : true` dead ternary, prune stale worktrees
+  (`C:/tmp/updog-pr864-ci-fix`) and merged local branches.
+
+---
+
+## Self-Review
+
+**Spec coverage** (vs source proposal PR-A..PR-K): PR-A = #879 (locked,
+regression baseline). PR-B → collapsed to Task 4 decision row
+(registry/CODEOWNERS/matrix CUT, justified). PR-C → PR-1 Tasks 1–2. PR-D → PR-5.
+PR-E → PR-2. PR-F → PR-4. PR-G → PR-3. PR-I → PR-6. PR-K → PR-1 Task 3.
+PR-H/PR-J + telemetry → CUT (documented). No silent drops.
+
+**Placeholder scan:** PR-1 Tasks 1–4 contain exact paths, full code, exact
+commands with expected output. PR-2..6 are explicitly marked scoped stubs
+(legitimate per the multi-subsystem scope-check), each to expand into its own
+plan — not placeholders within an executable task.
+
+**Type consistency:** `AppRouteEntry` (defined `app-routes.tsx:67`) is reused
+for `INTERNAL_DEMO_ROUTES`. `QUARANTINED_MODULES` / `findForbiddenModules` names
+match `check-prod-bundle.mjs` exports. `SHOW_INTERNAL_DEMOS` mirrors the
+existing `SHOW_TEAR_SHEETS` idiom.
+
+**Userspace safety:** quarantined routes verified nav-orphaned; build exclusion
+changes no reachable navigation. Dead-nav deletion gated on a re-confirm grep.

--- a/docs/superpowers/plans/2026-06-23-financial-actionability-p0.md
+++ b/docs/superpowers/plans/2026-06-23-financial-actionability-p0.md
@@ -1,0 +1,1283 @@
+# Financial Actionability P0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Portfolio Intelligence from returning or persisting fabricated
+financial success outputs, while preserving existing auth, validation, and
+durable CRUD behavior.
+
+**Architecture:** Treat the current Portfolio Intelligence API as a default-off
+prototype surface. Keep durable CRUD routes working, add a shared financial
+provenance contract, make prototype financial computation routes fail closed
+with `501`, register the server-only feature flag in the canonical registry, and
+add executable route/placeholder guardrails. Persistence quarantine, KPI
+contract reconciliation, Monte Carlo facade wiring, and reserve/MOIC ownership
+are deliberately follow-up plans after this P0 lands.
+
+**Tech Stack:** TypeScript, Express, Zod, Vitest, Supertest, YAML flag registry
+plus `npm run flags:generate`, existing Node scripts. No new dependencies.
+
+---
+
+## Current State Refresh
+
+Verified on 2026-06-23:
+
+- Local branch: `main`.
+- Local HEAD: `a5b01482bb09181dd3dc7032a3bf9c228060a259`.
+- `origin/main`: `a5b01482bb09181dd3dc7032a3bf9c228060a259`.
+- GitHub commit statuses for that SHA: `worthy-integrity - Updog_restore`
+  success and `Vercel` success.
+- Local checkout has unrelated dirt: `.claude/settings.json`,
+  `.claude/artifacts/`, `.session-memory.json`, and existing untracked
+  plan/review docs. Preserve it.
+- `server/config/features.ts` still defines `portfolioIntelligence` from
+  `ENABLE_PORTFOLIO_INTELLIGENCE`, default false.
+- `server/routes.ts` mounts `server/routes/portfolio-intelligence.ts` only when
+  `FEATURES.portfolioIntelligence` is true.
+- `flags/registry.yaml` and generated flag files do not define
+  `enable_portfolio_intelligence`.
+- `shared/contracts/financial-provenance.contract.ts` does not exist.
+- `server/routes/portfolio-intelligence.ts` still contains placeholder financial
+  success responses for simulation, reserve optimization, backtest, forecast
+  generation, forecast validation, quick scenario, and metrics.
+- `client/src/pages/kpi-manager/KpiDefinitionModal.tsx` still closes on save
+  without persistence, and KPI contract contradictions remain. Those are not in
+  this P0.
+
+## Scope Cut
+
+This plan implements only the P0 false-success blockade.
+
+Out of scope for this plan:
+
+- DB provenance columns and quarantine scripts.
+- KPI raw-facts versus computed-summary reconciliation.
+- Monte Carlo facade ownership.
+- Reserve/MOIC canonical pure implementation.
+- UI honesty badges for every consuming page.
+- Dependency cleanup.
+
+Those require separate plans after this P0 passes because they touch independent
+subsystems and cannot be safely batched into the first financial firebreak.
+
+## File Structure
+
+| File                                                                 | Responsibility                                                                         | Action     |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ---------- |
+| `shared/contracts/financial-provenance.contract.ts`                  | Shared Zod provenance/actionability contract                                           | Create     |
+| `tests/unit/contract/financial-provenance.contract.test.ts`          | Contract invariants                                                                    | Create     |
+| `server/lib/portfolio-prototype-block.ts`                            | Response builder for blocked prototype financial routes                                | Create     |
+| `server/routes/portfolio-intelligence.ts`                            | Preserve CRUD, convert prototype computations to `501`, add static-template provenance | Modify     |
+| `tests/unit/api/portfolio-intelligence.test.ts`                      | Update existing route expectations from fake success to fail-closed behavior           | Modify     |
+| `tests/fixtures/portfolio-intelligence-route-classification.ts`      | Executable route classification registry for this API surface                          | Create     |
+| `tests/unit/contract/portfolio-intelligence-route-inventory.test.ts` | Route drift and classification guard                                                   | Create     |
+| `flags/registry.yaml`                                                | Canonical flag metadata                                                                | Modify     |
+| `shared/generated/flag-types.ts`                                     | Generated flag type surface                                                            | Regenerate |
+| `shared/generated/flag-defaults.ts`                                  | Generated flag defaults and aliases                                                    | Regenerate |
+| `tests/unit/flags/portfolio-intelligence-flag.test.ts`               | Flag registry/default regression                                                       | Create     |
+| `scripts/guardrails/no-portfolio-placeholder-financial-success.mjs`  | Text tripwire for known placeholder literals in the route file                         | Create     |
+| `package.json`                                                       | Add guardrail script and include it in `guardrails:check`                              | Modify     |
+
+## Task 1: Add The Financial Provenance Contract
+
+**Files:**
+
+- Create: `shared/contracts/financial-provenance.contract.ts`
+- Create: `tests/unit/contract/financial-provenance.contract.test.ts`
+
+- [ ] **Step 1: Write the failing contract tests**
+
+Create `tests/unit/contract/financial-provenance.contract.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { FinancialProvenanceSchema } from '../../../shared/contracts/financial-provenance.contract';
+
+const computedActionable = {
+  sourceKind: 'computed',
+  actionability: 'actionable',
+  sourceEngine: 'monte-carlo-facade',
+  engineVersion: '1.0.0',
+  inputHash: 'input_sha256_abc',
+  assumptionsHash: 'assumptions_sha256_def',
+  generatedAt: '2026-06-23T00:00:00.000Z',
+  isFinanciallyActionable: true,
+  warnings: [],
+};
+
+describe('FinancialProvenanceSchema', () => {
+  it('accepts computed actionable provenance with engine and hash evidence', () => {
+    expect(FinancialProvenanceSchema.parse(computedActionable)).toEqual(
+      computedActionable
+    );
+  });
+
+  it('rejects actionable static template provenance', () => {
+    const result = FinancialProvenanceSchema.safeParse({
+      ...computedActionable,
+      sourceKind: 'static_template',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects computed actionable provenance without required evidence', () => {
+    const result = FinancialProvenanceSchema.safeParse({
+      sourceKind: 'computed',
+      actionability: 'actionable',
+      generatedAt: '2026-06-23T00:00:00.000Z',
+      isFinanciallyActionable: true,
+      warnings: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts blocked prototype provenance as non-actionable', () => {
+    const result = FinancialProvenanceSchema.parse({
+      sourceKind: 'prototype_blocked',
+      actionability: 'non_actionable',
+      generatedAt: '2026-06-23T00:00:00.000Z',
+      sourceRoute: 'POST /api/portfolio/scenarios/:id/simulate',
+      isFinanciallyActionable: false,
+      quarantineReason: 'prototype_financial_output_blocked',
+      warnings: ['Prototype financial output route is disabled.'],
+    });
+
+    expect(result.isFinanciallyActionable).toBe(false);
+  });
+
+  it('rejects unknown keys so response contracts stay explicit', () => {
+    const result = FinancialProvenanceSchema.safeParse({
+      ...computedActionable,
+      sampleFallback: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/contract/financial-provenance.contract.test.ts --project=server
+```
+
+Expected: FAIL because `shared/contracts/financial-provenance.contract.ts` does
+not exist.
+
+- [ ] **Step 3: Add the contract**
+
+Create `shared/contracts/financial-provenance.contract.ts`:
+
+```ts
+import { z } from 'zod';
+
+export const FinancialSourceKindSchema = z.enum([
+  'computed',
+  'imported_actual',
+  'user_assumption',
+  'static_template',
+  'demo_seed',
+  'prototype_blocked',
+  'legacy_unknown',
+]);
+
+export const FinancialActionabilitySchema = z.enum([
+  'actionable',
+  'input_only',
+  'non_actionable',
+  'quarantined',
+  'unknown_legacy',
+]);
+
+export const FinancialProvenanceSchema = z
+  .object({
+    sourceKind: FinancialSourceKindSchema,
+    actionability: FinancialActionabilitySchema,
+    sourceEngine: z.string().min(1).optional(),
+    engineVersion: z.string().min(1).optional(),
+    calculationVersion: z.string().min(1).optional(),
+    inputHash: z.string().min(1).optional(),
+    assumptionsHash: z.string().min(1).optional(),
+    scenarioHash: z.string().min(1).optional(),
+    generatedAt: z.string().datetime(),
+    generatedBy: z.union([z.string().min(1), z.number()]).optional(),
+    sourceRoute: z.string().min(1).optional(),
+    sourceCommitSha: z.string().min(7).optional(),
+    isFinanciallyActionable: z.boolean(),
+    quarantineReason: z.string().min(1).optional(),
+    warnings: z.array(z.string()).default([]),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (
+      value.isFinanciallyActionable &&
+      value.sourceKind !== 'computed' &&
+      value.sourceKind !== 'imported_actual'
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['isFinanciallyActionable'],
+        message:
+          'Only computed or imported_actual results may be financially actionable',
+      });
+    }
+
+    if (value.isFinanciallyActionable && value.sourceKind === 'computed') {
+      for (const field of [
+        'sourceEngine',
+        'engineVersion',
+        'inputHash',
+        'assumptionsHash',
+      ]) {
+        if (!value[field as keyof typeof value]) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [field],
+            message: `Computed actionable result requires ${field}`,
+          });
+        }
+      }
+    }
+  });
+
+export type FinancialSourceKind = z.infer<typeof FinancialSourceKindSchema>;
+export type FinancialActionability = z.infer<
+  typeof FinancialActionabilitySchema
+>;
+export type FinancialProvenance = z.infer<typeof FinancialProvenanceSchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/contract/financial-provenance.contract.test.ts --project=server
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/contracts/financial-provenance.contract.ts tests/unit/contract/financial-provenance.contract.test.ts
+git commit -m "Define financial actionability provenance"
+```
+
+Use the repo's Lore trailer format in the real commit body.
+
+## Task 2: Add A Shared Prototype Block Response Builder
+
+**Files:**
+
+- Create: `server/lib/portfolio-prototype-block.ts`
+- Test: covered through route tests in Task 3
+
+- [ ] **Step 1: Add the route block helper**
+
+Create `server/lib/portfolio-prototype-block.ts`:
+
+```ts
+import type { FinancialProvenance } from '@shared/contracts/financial-provenance.contract';
+
+export type PortfolioPrototypeRouteId =
+  | 'portfolio.scenarios.compare'
+  | 'portfolio.scenario.simulate'
+  | 'portfolio.reserves.optimize'
+  | 'portfolio.reserves.backtest'
+  | 'portfolio.forecasts.create'
+  | 'portfolio.forecasts.validate'
+  | 'portfolio.quickScenario.create'
+  | 'portfolio.metrics.read';
+
+type BuildPrototypeBlockedInput = {
+  routeId: PortfolioPrototypeRouteId;
+  sourceRoute: string;
+  replacement?: string;
+};
+
+export function makePrototypeBlockedProvenance(
+  sourceRoute: string
+): FinancialProvenance {
+  return {
+    sourceKind: 'prototype_blocked',
+    actionability: 'non_actionable',
+    generatedAt: new Date().toISOString(),
+    sourceRoute,
+    isFinanciallyActionable: false,
+    quarantineReason: 'prototype_financial_output_blocked',
+    warnings: ['Prototype financial output route is disabled.'],
+  };
+}
+
+export function buildPrototypeFinancialBlockedError(
+  input: BuildPrototypeBlockedInput
+) {
+  return {
+    error: 'not_implemented',
+    code: 'PROTOTYPE_FINANCIAL_OUTPUT_BLOCKED',
+    routeId: input.routeId,
+    message:
+      'This route is disabled because it previously returned non-computed financial outputs.',
+    ...(input.replacement ? { replacement: input.replacement } : {}),
+    provenance: makePrototypeBlockedProvenance(input.sourceRoute),
+  };
+}
+
+export function makeStaticTemplateProvenance(
+  sourceRoute: string
+): FinancialProvenance {
+  return {
+    sourceKind: 'static_template',
+    actionability: 'non_actionable',
+    generatedAt: new Date().toISOString(),
+    sourceRoute,
+    isFinanciallyActionable: false,
+    warnings: ['Static template values are not computed from fund data.'],
+  };
+}
+```
+
+- [ ] **Step 2: Run TypeScript baseline**
+
+Run:
+
+```bash
+npm run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/lib/portfolio-prototype-block.ts
+git commit -m "Centralize prototype financial block responses"
+```
+
+Use the repo's Lore trailer format in the real commit body.
+
+## Task 3: Update Portfolio Intelligence Route Tests First
+
+**Files:**
+
+- Modify: `tests/unit/api/portfolio-intelligence.test.ts`
+
+- [ ] **Step 1: Import route block assertion helpers**
+
+In `tests/unit/api/portfolio-intelligence.test.ts`, add this helper near
+`createTestApp`:
+
+```ts
+const expectPrototypeBlocked = (
+  body: Record<string, unknown>,
+  routeId: string
+) => {
+  expect(body.error).toBe('not_implemented');
+  expect(body.code).toBe('PROTOTYPE_FINANCIAL_OUTPUT_BLOCKED');
+  expect(body.routeId).toBe(routeId);
+  expect(body.provenance).toMatchObject({
+    sourceKind: 'prototype_blocked',
+    actionability: 'non_actionable',
+    isFinanciallyActionable: false,
+    quarantineReason: 'prototype_financial_output_blocked',
+  });
+  expect(
+    Date.parse((body.provenance as { generatedAt: string }).generatedAt)
+  ).not.toBeNaN();
+};
+```
+
+- [ ] **Step 2: Replace scenario comparison success expectation**
+
+In the `POST /api/portfolio/scenarios/compare` happy-path test, replace the
+success assertions with:
+
+```ts
+const response = await request(app)
+  .post('/api/portfolio/scenarios/compare')
+  .send(validComparisonData)
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.scenarios.compare');
+expect(response.body.replacement).toBe('/api/funds/:fundId/scenarios/compare');
+```
+
+- [ ] **Step 3: Replace simulation success expectation and prove no write**
+
+In the `POST /api/portfolio/scenarios/:id/simulate` happy-path test, replace the
+success assertions with:
+
+```ts
+const createSimulation = vi.spyOn(
+  portfolioIntelligenceService.simulations,
+  'create'
+);
+
+const response = await request(app)
+  .post(`/api/portfolio/scenarios/${scenarioId}/simulate`)
+  .send(validSimulationData)
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.scenario.simulate');
+expect(response.body.replacement).toBe('/api/monte-carlo/simulate');
+expect(createSimulation).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 4: Replace reserve optimization success expectation and prove no
+      write**
+
+In the `POST /api/portfolio/reserves/optimize` happy-path test, replace the
+success assertions with:
+
+```ts
+const createReserveStrategy = vi.spyOn(
+  portfolioIntelligenceService.reserves,
+  'create'
+);
+
+const response = await request(app)
+  .post('/api/portfolio/reserves/optimize?fundId=1')
+  .send(validOptimizationData)
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.reserves.optimize');
+expect(response.body.replacement).toBe('/api/funds/:fundId/reserves/optimize');
+expect(createReserveStrategy).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 5: Replace reserve backtest success expectation**
+
+In the `POST /api/portfolio/reserves/backtest` happy-path test, replace the
+success assertions with:
+
+```ts
+const response = await request(app)
+  .post('/api/portfolio/reserves/backtest')
+  .send(validBacktestData)
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.reserves.backtest');
+expect(testStorage.backtests.size).toBe(0);
+```
+
+- [ ] **Step 6: Replace forecast generation success expectation**
+
+In the `POST /api/portfolio/forecasts` happy-path test, replace the success
+assertions with:
+
+```ts
+const response = await request(app)
+  .post('/api/portfolio/forecasts?fundId=1')
+  .send(validForecastData)
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.forecasts.create');
+expect(testStorage.forecasts.size).toBe(0);
+```
+
+- [ ] **Step 7: Replace forecast validation success expectation and prove no
+      update**
+
+In the `POST /api/portfolio/forecasts/validate` happy-path test, replace the
+success assertions with:
+
+```ts
+const updateForecast = vi.spyOn(
+  portfolioIntelligenceService.forecasts,
+  'update'
+);
+
+const response = await request(app)
+  .post('/api/portfolio/forecasts/validate')
+  .send(validValidationData)
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.forecasts.validate');
+expect(updateForecast).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 8: Replace quick scenario success expectation**
+
+In the `POST /api/portfolio/quick-scenario` happy-path test, replace the success
+assertions with:
+
+```ts
+const response = await request(app)
+  .post('/api/portfolio/quick-scenario')
+  .send(validQuickScenarioData)
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.quickScenario.create');
+expect(testStorage.quickScenarios.size).toBe(0);
+```
+
+- [ ] **Step 9: Replace quick scenario comparison test**
+
+Replace the test named
+`should generate different projections for different risk profiles` with:
+
+```ts
+it('blocks quick-scenario projection generation for every risk profile', async () => {
+  for (const riskProfile of ['aggressive', 'conservative', 'moderate']) {
+    const response = await request(app)
+      .post('/api/portfolio/quick-scenario')
+      .send({ ...validQuickScenarioData, riskProfile })
+      .expect(501);
+
+    expectPrototypeBlocked(response.body, 'portfolio.quickScenario.create');
+  }
+});
+```
+
+- [ ] **Step 10: Replace metrics success expectation**
+
+In the `GET /api/portfolio/metrics/:scenarioId` happy-path test, replace the
+success assertions with:
+
+```ts
+const response = await request(app)
+  .get('/api/portfolio/metrics/scenario_123')
+  .expect(501);
+
+expectPrototypeBlocked(response.body, 'portfolio.metrics.read');
+expect(response.body.replacement).toBe('/api/events/fund/:fundId');
+```
+
+- [ ] **Step 11: Update template test to assert non-actionable provenance**
+
+In the `GET /api/portfolio/templates` happy-path test, keep status `200` and
+add:
+
+```ts
+expect(response.body.provenance).toMatchObject({
+  sourceKind: 'static_template',
+  actionability: 'non_actionable',
+  isFinanciallyActionable: false,
+});
+
+for (const template of response.body.data) {
+  expect(template.provenance).toMatchObject({
+    sourceKind: 'static_template',
+    actionability: 'non_actionable',
+    isFinanciallyActionable: false,
+  });
+}
+```
+
+- [ ] **Step 12: Run test to verify it fails before route changes**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/api/portfolio-intelligence.test.ts --project=server
+```
+
+Expected: FAIL because routes still return `success: true` for prototype
+financial outputs.
+
+- [ ] **Step 13: Commit test changes after implementation passes**
+
+Do not commit this task until Task 4 is complete and the test passes.
+
+## Task 4: Make Prototype Financial Routes Fail Closed
+
+**Files:**
+
+- Modify: `server/routes/portfolio-intelligence.ts`
+
+- [ ] **Step 1: Import the helper**
+
+Add near existing imports:
+
+```ts
+import {
+  buildPrototypeFinancialBlockedError,
+  makeStaticTemplateProvenance,
+} from '../lib/portfolio-prototype-block';
+```
+
+- [ ] **Step 2: Block scenario comparison after auth/validation**
+
+In `POST /api/portfolio/scenarios/compare`, after validation and `userId` auth
+checks, replace comparison creation and `success: true` response with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.scenarios.compare',
+    sourceRoute: 'POST /api/portfolio/scenarios/compare',
+    replacement: '/api/funds/:fundId/scenarios/compare',
+  })
+);
+```
+
+- [ ] **Step 3: Block scenario simulation after scenario existence check**
+
+In `POST /api/portfolio/scenarios/:id/simulate`, keep scenario ID validation,
+request validation, auth, and scenario existence check. Replace hardcoded
+`simulationResults`, `riskMetrics`, persistence, and `success: true` response
+with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.scenario.simulate',
+    sourceRoute: 'POST /api/portfolio/scenarios/:id/simulate',
+    replacement: '/api/monte-carlo/simulate',
+  })
+);
+```
+
+- [ ] **Step 4: Block reserve optimization after auth/validation**
+
+In `POST /api/portfolio/reserves/optimize`, keep fund ID validation, request
+validation, and auth. Replace hardcoded `optimalAllocation`,
+`performanceProjection`, persistence, and `success: true` response with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.reserves.optimize',
+    sourceRoute: 'POST /api/portfolio/reserves/optimize',
+    replacement: '/api/funds/:fundId/reserves/optimize',
+  })
+);
+```
+
+- [ ] **Step 5: Block reserve backtest after auth/validation**
+
+In `POST /api/portfolio/reserves/backtest`, keep request validation and auth.
+Replace in-memory storage mutation and `success: true` response with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.reserves.backtest',
+    sourceRoute: 'POST /api/portfolio/reserves/backtest',
+    replacement: '/api/funds/:fundId/reserves/backtest',
+  })
+);
+```
+
+- [ ] **Step 6: Block forecast generation after auth/validation**
+
+In `POST /api/portfolio/forecasts`, keep fund ID validation, request validation,
+and auth. Replace in-memory storage mutation and `success: true` response with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.forecasts.create',
+    sourceRoute: 'POST /api/portfolio/forecasts',
+    replacement: '/api/funds/:fundId/forecast-runs',
+  })
+);
+```
+
+- [ ] **Step 7: Block forecast validation after forecast existence check**
+
+In `POST /api/portfolio/forecasts/validate`, keep request validation, auth, and
+forecast existence check. Replace hardcoded accuracy metrics, update call, and
+`success: true` response with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.forecasts.validate',
+    sourceRoute: 'POST /api/portfolio/forecasts/validate',
+    replacement: '/api/funds/:fundId/forecast-runs/:forecastRunId/validation',
+  })
+);
+```
+
+- [ ] **Step 8: Add template provenance**
+
+In `GET /api/portfolio/templates`, before `res.json`, add:
+
+```ts
+const routeProvenance = makeStaticTemplateProvenance(
+  'GET /api/portfolio/templates'
+);
+const templatesWithProvenance = filteredTemplates.map((template) => ({
+  ...template,
+  provenance: routeProvenance,
+}));
+```
+
+Replace the response body with:
+
+```ts
+res.json({
+  success: true,
+  data: templatesWithProvenance,
+  count: templatesWithProvenance.length,
+  provenance: routeProvenance,
+});
+```
+
+- [ ] **Step 9: Block quick scenario after auth/validation**
+
+In `POST /api/portfolio/quick-scenario`, keep request validation and auth.
+Replace in-memory storage mutation and `success: true` response with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.quickScenario.create',
+    sourceRoute: 'POST /api/portfolio/quick-scenario',
+    replacement: '/api/funds/:fundId/scenarios',
+  })
+);
+```
+
+- [ ] **Step 10: Block scenario metrics after scenario ID validation**
+
+In `GET /api/portfolio/metrics/:scenarioId`, keep scenario ID validation.
+Replace hardcoded metrics and `success: true` response with:
+
+```ts
+return res.status(501).json(
+  buildPrototypeFinancialBlockedError({
+    routeId: 'portfolio.metrics.read',
+    sourceRoute: 'GET /api/portfolio/metrics/:scenarioId',
+    replacement: '/api/events/fund/:fundId',
+  })
+);
+```
+
+- [ ] **Step 11: Run focused route tests**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/api/portfolio-intelligence.test.ts --project=server
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Commit route and route-test changes**
+
+```bash
+git add server/routes/portfolio-intelligence.ts server/lib/portfolio-prototype-block.ts tests/unit/api/portfolio-intelligence.test.ts
+git commit -m "Block prototype portfolio financial outputs"
+```
+
+Use the repo's Lore trailer format in the real commit body.
+
+## Task 5: Add Executable Route Classification
+
+**Files:**
+
+- Create: `tests/fixtures/portfolio-intelligence-route-classification.ts`
+- Create: `tests/unit/contract/portfolio-intelligence-route-inventory.test.ts`
+
+- [ ] **Step 1: Add route classification fixture**
+
+Create `tests/fixtures/portfolio-intelligence-route-classification.ts`:
+
+```ts
+export type PortfolioIntelligenceRouteClassification =
+  | 'durable_crud'
+  | 'durable_read'
+  | 'static_template'
+  | 'prototype_501';
+
+export const portfolioIntelligenceRouteClassifications = [
+  {
+    method: 'post',
+    path: '/api/portfolio/strategies',
+    classification: 'durable_crud',
+  },
+  {
+    method: 'get',
+    path: '/api/portfolio/strategies/:fundId',
+    classification: 'durable_read',
+  },
+  {
+    method: 'put',
+    path: '/api/portfolio/strategies/:id',
+    classification: 'durable_crud',
+  },
+  {
+    method: 'delete',
+    path: '/api/portfolio/strategies/:id',
+    classification: 'durable_crud',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/scenarios',
+    classification: 'durable_crud',
+  },
+  {
+    method: 'get',
+    path: '/api/portfolio/scenarios/:fundId',
+    classification: 'durable_read',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/scenarios/compare',
+    classification: 'prototype_501',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/scenarios/:id/simulate',
+    classification: 'prototype_501',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/reserves/optimize',
+    classification: 'prototype_501',
+  },
+  {
+    method: 'get',
+    path: '/api/portfolio/reserves/strategies/:fundId',
+    classification: 'durable_read',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/reserves/backtest',
+    classification: 'prototype_501',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/forecasts',
+    classification: 'prototype_501',
+  },
+  {
+    method: 'get',
+    path: '/api/portfolio/forecasts/:scenarioId',
+    classification: 'durable_read',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/forecasts/validate',
+    classification: 'prototype_501',
+  },
+  {
+    method: 'get',
+    path: '/api/portfolio/templates',
+    classification: 'static_template',
+  },
+  {
+    method: 'post',
+    path: '/api/portfolio/quick-scenario',
+    classification: 'prototype_501',
+  },
+  {
+    method: 'get',
+    path: '/api/portfolio/metrics/:scenarioId',
+    classification: 'prototype_501',
+  },
+] as const satisfies ReadonlyArray<{
+  method: string;
+  path: string;
+  classification: PortfolioIntelligenceRouteClassification;
+}>;
+```
+
+- [ ] **Step 2: Add route inventory drift test**
+
+Create `tests/unit/contract/portfolio-intelligence-route-inventory.test.ts`:
+
+```ts
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { portfolioIntelligenceRouteClassifications } from '../../fixtures/portfolio-intelligence-route-classification';
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), 'server/routes/portfolio-intelligence.ts'),
+  'utf8'
+);
+
+const routePattern =
+  /router\[['"`](get|post|put|delete)['"`]\]\(\s*['"`]([^'"`]+)['"`]/g;
+
+function routeKey(method: string, path: string) {
+  return `${method.toUpperCase()} ${path}`;
+}
+
+describe('Portfolio Intelligence route inventory', () => {
+  it('classifies every route in server/routes/portfolio-intelligence.ts', () => {
+    const actualRoutes = [...routeSource.matchAll(routePattern)].map((match) =>
+      routeKey(match[1], match[2])
+    );
+    const classifiedRoutes = portfolioIntelligenceRouteClassifications.map(
+      (route) => routeKey(route.method, route.path)
+    );
+
+    expect(new Set(actualRoutes)).toEqual(new Set(classifiedRoutes));
+  });
+
+  it('keeps every prototype financial route fail-closed', () => {
+    const prototypeRoutes = portfolioIntelligenceRouteClassifications.filter(
+      (route) => route.classification === 'prototype_501'
+    );
+
+    expect(
+      prototypeRoutes.map((route) => routeKey(route.method, route.path)).sort()
+    ).toEqual([
+      'GET /api/portfolio/metrics/:scenarioId',
+      'POST /api/portfolio/forecasts',
+      'POST /api/portfolio/forecasts/validate',
+      'POST /api/portfolio/quick-scenario',
+      'POST /api/portfolio/reserves/backtest',
+      'POST /api/portfolio/reserves/optimize',
+      'POST /api/portfolio/scenarios/:id/simulate',
+      'POST /api/portfolio/scenarios/compare',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the route inventory test**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/contract/portfolio-intelligence-route-inventory.test.ts --project=server
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/portfolio-intelligence-route-classification.ts tests/unit/contract/portfolio-intelligence-route-inventory.test.ts
+git commit -m "Classify portfolio intelligence routes"
+```
+
+Use the repo's Lore trailer format in the real commit body.
+
+## Task 6: Register The Portfolio Intelligence Feature Flag
+
+**Files:**
+
+- Modify: `flags/registry.yaml`
+- Modify: `shared/generated/flag-types.ts`
+- Modify: `shared/generated/flag-defaults.ts`
+- Create: `tests/unit/flags/portfolio-intelligence-flag.test.ts`
+
+- [ ] **Step 1: Add the flag test**
+
+Create `tests/unit/flags/portfolio-intelligence-flag.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_FLAG_KEYS,
+  CLIENT_FLAG_KEYS,
+  isClientFlag,
+  isFlagKey,
+} from '@shared/generated/flag-types';
+import {
+  FLAG_ALIASES,
+  FLAG_DEFINITIONS,
+  FLAG_DEFAULTS,
+} from '@shared/generated/flag-defaults';
+
+describe('enable_portfolio_intelligence flag registration', () => {
+  it('registers the server-only high-risk flag and keeps it default-off', () => {
+    expect(ALL_FLAG_KEYS).toContain('enable_portfolio_intelligence');
+    expect(isFlagKey('enable_portfolio_intelligence')).toBe(true);
+    expect(CLIENT_FLAG_KEYS).not.toContain('enable_portfolio_intelligence');
+    expect(isClientFlag('enable_portfolio_intelligence')).toBe(false);
+    expect(FLAG_DEFAULTS.enable_portfolio_intelligence).toBe(false);
+    expect(FLAG_DEFINITIONS.enable_portfolio_intelligence).toMatchObject({
+      default: false,
+      owner: 'analytics',
+      risk: 'high',
+      exposeToClient: false,
+    });
+    expect(FLAG_ALIASES.ENABLE_PORTFOLIO_INTELLIGENCE).toBe(
+      'enable_portfolio_intelligence'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/flags/portfolio-intelligence-flag.test.ts --project=server
+```
+
+Expected: FAIL because generated flag files do not contain
+`enable_portfolio_intelligence`.
+
+- [ ] **Step 3: Add flag to registry**
+
+Add this entry under the server-only or high-risk feature flags in
+`flags/registry.yaml`:
+
+```yaml
+enable_portfolio_intelligence:
+  default: false
+  description:
+    'Portfolio Intelligence API surface; disabled until financial actionability
+    and provenance remediation are complete'
+  owner: 'analytics'
+  risk: high
+  exposeToClient: false
+  environments:
+    development: false
+    staging: false
+    production: false
+  dependencies: []
+  expiresAt: null
+  aliases: ['ENABLE_PORTFOLIO_INTELLIGENCE']
+```
+
+- [ ] **Step 4: Regenerate flag files**
+
+Run:
+
+```bash
+npm run flags:generate
+```
+
+Expected output includes:
+
+```text
+Generating flag-types.ts...
+Generating flag-defaults.ts...
+```
+
+- [ ] **Step 5: Run flag test**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/flags/portfolio-intelligence-flag.test.ts --project=server
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flags/registry.yaml shared/generated/flag-types.ts shared/generated/flag-defaults.ts tests/unit/flags/portfolio-intelligence-flag.test.ts
+git commit -m "Register portfolio intelligence feature flag"
+```
+
+Use the repo's Lore trailer format in the real commit body.
+
+## Task 7: Add Placeholder Financial Success Guardrail
+
+**Files:**
+
+- Create: `scripts/guardrails/no-portfolio-placeholder-financial-success.mjs`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the guardrail script**
+
+Create `scripts/guardrails/no-portfolio-placeholder-financial-success.mjs`:
+
+```js
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import console from 'node:console';
+
+const routePath = 'server/routes/portfolio-intelligence.ts';
+const source = readFileSync(routePath, 'utf8');
+
+const bannedLiterals = [
+  'mean: { irr: 0.2, multiple: 2.5, dpi: 1.8 }',
+  'median: { irr: 0.18, multiple: 2.3, dpi: 1.6 }',
+  'percentiles: { p10: 0.12, p25: 0.15, p75: 0.25, p90: 0.3 }',
+  'expectedIrr: 0.22',
+  'expectedMultiple: 2.8',
+  'riskAdjustedReturn: 0.18',
+  'totalReturn: 0.22',
+  'annualizedReturn: 0.18',
+  'sharpeRatio: 1.5',
+  'forecastPeriods: [',
+  'confidenceIntervals: {',
+  'mape: 0.12',
+  'rmse: 0.08',
+  'currentIrr: 0.18',
+  'currentMultiple: 2.1',
+  "dataFreshness: 'real-time'",
+];
+
+const violations = bannedLiterals.filter((literal) => source.includes(literal));
+
+if (violations.length > 0) {
+  console.error('[portfolio-placeholder-financial-success] failed');
+  console.error(
+    `  ${routePath} still contains blocked placeholder financial literals:`
+  );
+  for (const literal of violations) {
+    console.error(`  - ${literal}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log('[portfolio-placeholder-financial-success] pass');
+}
+```
+
+- [ ] **Step 2: Add package scripts**
+
+In `package.json`, add:
+
+```json
+"guard:financial-placeholders:check": "node scripts/guardrails/no-portfolio-placeholder-financial-success.mjs"
+```
+
+Replace the existing `guardrails:check` value with:
+
+```json
+"guardrails:check": "npm run guard:console:check && npm run guard:eslint-disable:check && npm run guard:scripts:check && npm run guard:route-imports:check && npm run guard:financial-placeholders:check"
+```
+
+- [ ] **Step 3: Run the guardrail**
+
+Run:
+
+```bash
+npm run guard:financial-placeholders:check
+```
+
+Expected: PASS after Task 4 removed the placeholder literals from
+`server/routes/portfolio-intelligence.ts`.
+
+- [ ] **Step 4: Run all guardrails**
+
+Run:
+
+```bash
+npm run guardrails:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/guardrails/no-portfolio-placeholder-financial-success.mjs package.json
+git commit -m "Guard portfolio placeholder financial outputs"
+```
+
+Use the repo's Lore trailer format in the real commit body.
+
+## Task 8: Run P0 Verification
+
+**Files:**
+
+- No new files.
+
+- [ ] **Step 1: Run focused proof**
+
+Run:
+
+```bash
+cross-env TZ=UTC vitest run tests/unit/contract/financial-provenance.contract.test.ts tests/unit/contract/portfolio-intelligence-route-inventory.test.ts tests/unit/api/portfolio-intelligence.test.ts tests/unit/flags/portfolio-intelligence-flag.test.ts --project=server
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run generated flag command idempotence check**
+
+Run:
+
+```bash
+npm run flags:generate
+git diff -- shared/generated/flag-types.ts shared/generated/flag-defaults.ts
+```
+
+Expected: no diff after the generated files are committed.
+
+- [ ] **Step 3: Run core validation and guardrails**
+
+Run:
+
+```bash
+npm run guardrails:check
+npm run validate:core
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full release proof**
+
+Run:
+
+```bash
+npm run release:check
+```
+
+Expected: PASS.
+
+If Windows local proof is blocked by Docker/Testcontainers or memory limits,
+rerun in native WSL with supported Node 20 and:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=4096
+npm run release:check
+```
+
+Expected: PASS or an exact failing release-check stage and error text.
+
+- [ ] **Step 5: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check HEAD --
+git status --short
+```
+
+Expected: no whitespace errors. `git status --short` shows only files owned by
+this P0 plus pre-existing unrelated dirt.
+
+- [ ] **Step 6: Final commit if verification changed generated files**
+
+If Task 8 produced any generated-file changes, commit them:
+
+```bash
+git add shared/generated/flag-types.ts shared/generated/flag-defaults.ts
+git commit -m "Refresh generated flag outputs"
+```
+
+Use the repo's Lore trailer format in the real commit body.
+
+## Acceptance Criteria
+
+- `server/routes/portfolio-intelligence.ts` no longer contains the known
+  hardcoded financial success literals.
+- Durable CRUD routes in Portfolio Intelligence still return their existing
+  success responses.
+- Prototype financial computation routes return `501` after existing
+  auth/validation checks.
+- Prototype financial routes do not write to DB services or `app.locals` maps.
+- `GET /api/portfolio/templates` remains available but returns non-actionable
+  static-template provenance.
+- `enable_portfolio_intelligence` exists in `flags/registry.yaml`, generated
+  flag files, and stays default false in every environment.
+- `guardrails:check` includes the new financial placeholder tripwire.
+- `npm run release:check` is either green or has an exact reported blocking
+  stage.
+
+## Follow-Up Plan Boundaries
+
+After this P0 merges, write separate plans in this order:
+
+1. Persistence provenance and quarantine for existing placeholder rows.
+2. KPI endpoint contract reconciliation and KPI Manager honest-save behavior.
+3. Monte Carlo public facade and Portfolio Intelligence simulation delegation.
+4. Reserve/MOIC canonical planned-reserves implementation.
+5. UI actionability badges and quarantined-result hiding across client surfaces.

--- a/docs/superpowers/plans/2026-06-23-part-b-investment-rounds-ramp.md
+++ b/docs/superpowers/plans/2026-06-23-part-b-investment-rounds-ramp.md
@@ -1,0 +1,395 @@
+# Part B — `enable_investment_rounds` Dev→Staging Ramp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ramp the `enable_investment_rounds` feature flag through dev and
+staging only (config + one regression test + manual smoke), leaving production
+OFF, so the investment-rounds vertical is proven on real data before the prod
+gate.
+
+**Architecture:** Config-only ramp. The backend rounds API + supersede are
+already mounted (`server/app.ts:215`) and fund-scoped by PR-H1. The live UI
+(`portfolio-company-summary.tsx:75`) gates on
+`useFlag('enable_investment_rounds')`, which resolves through
+`client/src/shared/useFlags.ts` in priority order: runtime override
+(`?ff_…`/localStorage) → `VITE_ENABLE_INVESTMENT_ROUNDS` build env →
+`ALL_FLAGS[key].enabled` (static `false`) → `false`. **The live UI never reads
+`flags/registry.yaml` or the generated defaults.** Therefore the per-environment
+client lever is the `VITE_*` build env, NOT the registry and NOT the global
+`ALL_FLAGS.enabled` bit.
+
+**Tech Stack:** Vite + React client, YAML flag registry + codegen
+(`npx tsx scripts/generate-flag-types.ts`), Vitest (jsdom client project),
+Drizzle/Postgres, `npx tsx scripts/seed-db.ts` for investment seed data.
+
+**Source of corrections:** This plan supersedes
+`.claude/artifacts/part-b-handoff.md` where the two diverge. Corrections
+verified in the Hermes debate (`.claude/artifacts/part-b-debate.md`): (1) the
+live UI lever is `VITE_*`, not a per-env branch in `flag-definitions.ts` (that
+branch does not exist); (2) the investment seeder is `scripts/seed-db.ts`, NOT
+the handoff's non-existent `server/seed-db.ts`, and NOT
+`server/seed-demo-data.ts` (which seeds no investments).
+
+---
+
+## File Structure
+
+| File                                                                  | Responsibility                                                                                       | Action                                                                             |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `tests/unit/flags/enable-investment-rounds.test.tsx`                  | Pin the corrected resolver model: dev-on via `VITE_*`, prod-off, global-default-stays-false tripwire | Modify (extend)                                                                    |
+| `flags/registry.yaml`                                                 | Declared per-env source of truth + server/generated surface                                          | Modify (dev, later staging → true; prod stays false)                               |
+| `shared/generated/flag-defaults.ts`, `shared/generated/flag-types.ts` | Generated server/default surface                                                                     | Regenerate via `npm run flags:generate`                                            |
+| `.env.development`                                                    | Dev build env — the live-UI lever for dev                                                            | Modify (add `VITE_ENABLE_INVESTMENT_ROUNDS=true`)                                  |
+| `.env.production`                                                     | Prod build env — explicit prod-off, matches existing `VITE_ENABLE_*=false` rows                      | Modify (add `VITE_ENABLE_INVESTMENT_ROUNDS=false`)                                 |
+| Staging deploy env (`.env.staging`/Vercel staging)                    | Staging build env — staging lever                                                                    | Modify in Task 5 only (gated on PR-H2 in flight)                                   |
+| `shared/feature-flags/flag-definitions.ts`                            | Client `ALL_FLAGS` registry                                                                          | **DO NOT EDIT** — `enabled` MUST stay `false`. Flipping it is the prod-leak NO-GO. |
+
+**Do NOT in this PR:** add new `docs/**/*.md` (triggers `router-index` regen /
+"Validate Discovery Routing"); add new `tests/integration/**` (won't auto-run on
+the PR — needs
+`gh workflow run ci-unified.yml --ref <branch> -f run_full_suite=true`). This
+plan doc itself is a working artifact; if you commit it, regenerate
+`docs/_generated/router-index.json` in a separate commit, or keep it out of the
+feature PR.
+
+---
+
+## Task 1: Pin the corrected resolver model with regression tests
+
+The existing test already guards `ALL_FLAGS.enabled===false` (line 18 — the
+prod-leak tripwire) and the localStorage override. Extend it to pin the `VITE_*`
+env lever, which is the actual dev/staging mechanism the rest of this plan
+relies on. These are regression guards: they assert existing behavior so it
+cannot silently break.
+
+**Files:**
+
+- Modify: `tests/unit/flags/enable-investment-rounds.test.tsx`
+
+- [ ] **Step 1: Replace the test file with the extended guard suite**
+
+```tsx
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ALL_FLAGS } from '@shared/feature-flags/flag-definitions';
+import { useFlag } from '@/shared/useFlags';
+
+// Regression guards for the Part B ramp. The live UI resolves the flag via
+// client/src/shared/useFlags.ts in priority order:
+//   runtime (?ff_/localStorage) ?? VITE_ENABLE_INVESTMENT_ROUNDS ?? ALL_FLAGS.enabled ?? false
+// The per-environment lever is the VITE_* build env, NOT a per-env branch in
+// flag-definitions.ts (none exists) and NOT the global ALL_FLAGS.enabled bit
+// (flipping that enables prod too — the NO-GO tripwire below).
+describe('enable_investment_rounds flag registration', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllEnvs();
+  });
+
+  it('is registered in ALL_FLAGS and the global default stays OFF (prod-leak tripwire)', () => {
+    expect(Object.keys(ALL_FLAGS)).toContain('enable_investment_rounds');
+    expect(ALL_FLAGS['enable_investment_rounds']?.enabled).toBe(false);
+  });
+
+  it('defaults OFF but is runtime-overridable (manual dev verification)', () => {
+    const off = renderHook(() => useFlag('enable_investment_rounds'));
+    expect(off.result.current).toBe(false);
+
+    window.localStorage.setItem('ff_enable_investment_rounds', '1');
+    const on = renderHook(() => useFlag('enable_investment_rounds'));
+    expect(on.result.current).toBe(true);
+  });
+
+  it('VITE_ENABLE_INVESTMENT_ROUNDS=true is the per-environment ON lever (dev/staging)', () => {
+    vi.stubEnv('VITE_ENABLE_INVESTMENT_ROUNDS', 'true');
+    const { result } = renderHook(() => useFlag('enable_investment_rounds'));
+    expect(result.current).toBe(true);
+  });
+
+  it('VITE_ENABLE_INVESTMENT_ROUNDS=false takes precedence over the default (prod build resolves OFF)', () => {
+    vi.stubEnv('VITE_ENABLE_INVESTMENT_ROUNDS', 'false');
+    const { result } = renderHook(() => useFlag('enable_investment_rounds'));
+    expect(result.current).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the suite to verify it passes (pins existing behavior)**
+
+Run:
+`npx vitest run tests/unit/flags/enable-investment-rounds.test.tsx --project=client`
+Expected: PASS, 4 tests. (If the two `vi.stubEnv` cases fail, the resolver does
+not read `import.meta.env` as documented — STOP and re-verify
+`client/src/shared/useFlags.ts:58-75` before proceeding; the whole ramp depends
+on this lever.)
+
+- [ ] **Step 3: Confirm the tripwire bites (negative control)**
+
+Temporarily edit `shared/feature-flags/flag-definitions.ts:263` `enabled: false`
+→ `enabled: true`, re-run the command from Step 2. Expected: the first test
+FAILS (`enabled` to be false). Revert the edit immediately and re-run — back to
+PASS. This proves the prod-leak guard is live.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/flags/enable-investment-rounds.test.tsx
+git commit -m "test(flags): pin enable_investment_rounds VITE env lever + prod-leak tripwire"
+```
+
+---
+
+## Task 2: Flip the dev registry surface and regenerate
+
+This updates the declared source-of-truth and the generated server/default
+surface so they don't drift. It does NOT, by itself, render the live UI (that's
+Task 3) — but keeping it consistent avoids a later mismatch and matches the
+roadmap's non-prod-eligibility posture.
+
+**Files:**
+
+- Modify: `flags/registry.yaml:108-111`
+- Regenerate: `shared/generated/flag-defaults.ts`,
+  `shared/generated/flag-types.ts`
+
+- [ ] **Step 1: Set development true, staging/production false**
+
+In `flags/registry.yaml`, change the `enable_investment_rounds` environments
+block (currently `:108-111`):
+
+```yaml
+environments:
+  development: true
+  staging: false
+  production: false
+```
+
+(Only `development` flips in this task. `staging` is Task 5; `production` must
+remain `false`.)
+
+- [ ] **Step 2: Regenerate the flag surfaces**
+
+Run: `npm run flags:generate` Expected: console logs
+`Generating flag-types.ts...`, `Generating flag-defaults.ts...`, and a flag
+count line (e.g. `Found 34 flags, Found 0 deprecated flags`).
+
+- [ ] **Step 3: Verify the generated diff is scoped and prod stays false**
+
+Run:
+`git diff --stat shared/generated/ && git grep -n "enable_investment_rounds" -- shared/generated/flag-defaults.ts`
+Expected: only `shared/generated/flag-defaults.ts` (and possibly
+`flag-types.ts`) changed; the `enable_investment_rounds` defaults reflect
+`development: true`, `production: false`. No other flag changed.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run check` Expected: PASS (0 errors). If the local node_modules is
+degraded and this false-fails, rely on the PR-event CI typecheck (per memory
+`feedback_local_typecheck_false_green_trust_ci`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flags/registry.yaml shared/generated/flag-defaults.ts shared/generated/flag-types.ts
+git commit -m "feat(flags): enable enable_investment_rounds in development registry surface"
+```
+
+---
+
+## Task 3: Wire the dev VITE lever and the explicit prod-off lever
+
+This is the change that actually renders the live UI in dev builds, and
+explicitly pins prod OFF.
+
+**Files:**
+
+- Modify: `.env.development`
+- Modify: `.env.production`
+
+- [ ] **Step 1: Add the dev ON lever**
+
+Append to `.env.development`:
+
+```
+VITE_ENABLE_INVESTMENT_ROUNDS=true
+```
+
+- [ ] **Step 2: Add the explicit prod OFF lever (mirrors existing
+      `VITE_ENABLE_*=false` rows)**
+
+Append to `.env.production` (next to the existing
+`VITE_ENABLE_OPERATIONS_HUB=false` / `VITE_ENABLE_LP_REPORTING=false` lines):
+
+```
+VITE_ENABLE_INVESTMENT_ROUNDS=false
+```
+
+- [ ] **Step 3: Verify the env lever resolves in a dev-mode build**
+
+Run:
+`npx vitest run tests/unit/flags/enable-investment-rounds.test.tsx --project=client`
+Expected: PASS, 4 tests (the env-lever cases from Task 1 already cover the
+resolver; this re-confirms nothing regressed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.development .env.production
+git commit -m "feat(flags): VITE_ENABLE_INVESTMENT_ROUNDS=true dev / =false prod"
+```
+
+---
+
+## Task 4: Dev smoke against real Postgres + seeded investments
+
+Verification task — proves the create→list→supersede→flag-off vertical on real
+data. Not committed code. **Memory mode seeds zero investments →
+empty-state-only false-green; this MUST run on Postgres.**
+
+**Files:** none (manual verification).
+
+- [ ] **Step 1: Bring up a Postgres dev DB and apply schema**
+
+Ensure `DATABASE_URL` in `.env.development`/`.env.local` points at a running
+Postgres (not memory mode), then: Run: `npm run db:push` Expected: schema sync
+completes without error.
+
+- [ ] **Step 2: Seed investments with the verified seeder**
+
+Run: `npx tsx scripts/seed-db.ts` Expected: console logs
+`[DONE] Created investments: N` (N ≥ 3) — these are companies[0,1,2]. (Do NOT
+use `server/seed-demo-data.ts` — it seeds funds/metrics but no investment rows.)
+
+- [ ] **Step 3: Confirm investment rows exist for a known fundId**
+
+Start the app (`npm run dev`) and run:
+`curl "http://localhost:5000/api/investments?fundId=<seededFundId>" -H "Authorization: Bearer <dev-token>"`
+Expected: a non-empty JSON array. Record the `fundId` and a `companyId` for the
+next step. (PR-H1 makes `fundId` REQUIRED — a bare `/api/investments` returns
+`400 fund_scope_required`.)
+
+- [ ] **Step 4: Smoke the lifecycle on the live page**
+
+Navigate to `/portfolio/company/<companyId>` for a seeded company. Verify in
+order:
+
+1. The Investment Rounds section renders (dev build →
+   `VITE_ENABLE_INVESTMENT_ROUNDS=true`).
+2. CREATE a round (new-round dialog → `useCreateRound`; an `Idempotency-Key` is
+   sent automatically).
+3. LIST shows it (current-only).
+4. SUPERSEDE it (create a correcting round with `supersedesRoundId`) → old row
+   drops from the list, new row shows the "corrected" badge.
+5. Append `?ff_enable_investment_rounds=0` to the URL → the entire section
+   disappears (no UI, no calls).
+
+- [ ] **Step 5: Capture the dev-ramp proof**
+
+Save the `fundId`, `companyId`, and the create/supersede transcript (curl output
+or screenshots) to `.claude/artifacts/part-b-dev-smoke.md`. This is the evidence
+input for the staging decision and the eventual PR-H3 posture proof. (Artifacts
+under `.claude/artifacts/**` are not docs-routing-tracked.)
+
+---
+
+## Task 5: Staging ramp — GATED on PR-H2 in flight
+
+Do NOT start this task unless PR-H2 is actually in progress. A staging flag with
+no prod line-of-sight goes stale (Claude-lane shelf-life finding). If H2 is not
+in flight, STOP after Task 4 and report.
+
+**Files:**
+
+- Modify: `flags/registry.yaml:108-111` (staging → true)
+- Regenerate: `shared/generated/*`
+- Modify: staging deploy env (`.env.staging` or Vercel staging project) —
+  `VITE_ENABLE_INVESTMENT_ROUNDS=true`
+
+- [ ] **Step 1: Flip staging in the registry**
+
+In `flags/registry.yaml`, set:
+
+```yaml
+environments:
+  development: true
+  staging: true
+  production: false
+```
+
+- [ ] **Step 2: Regenerate and verify prod still false**
+
+Run: `npm run flags:generate` Then:
+`git grep -n "enable_investment_rounds" -- shared/generated/flag-defaults.ts`
+Expected: staging now reflects true, `production: false` unchanged.
+
+- [ ] **Step 3: Set the staging build env lever**
+
+Add `VITE_ENABLE_INVESTMENT_ROUNDS=true` to the staging deployment environment
+(staging `.env`/Vercel staging env vars). Leave prod unset/false.
+
+- [ ] **Step 4: Typecheck + commit the registry change**
+
+Run: `npm run check` Expected: PASS.
+
+```bash
+git add flags/registry.yaml shared/generated/flag-defaults.ts shared/generated/flag-types.ts
+git commit -m "feat(flags): enable enable_investment_rounds in staging registry surface"
+```
+
+- [ ] **Step 5: Deploy to staging and re-run the lifecycle smoke**
+
+Deploy the branch to staging. Confirm the staging fund has investment rows first
+(`scripts/seed-db.ts` against the staging DB, or an existing seeded fund), then
+repeat Task 4 Step 4 on staging. Soak.
+
+- [ ] **Step 6: Report prod preconditions (do NOT flip prod)**
+
+In the PR description / handoff, list the prod-ramp preconditions and STOP:
+
+- PR-H1, PR-H2, PR-H3 merged.
+- PR-H3 production-flag-posture test green.
+- Target prod fund confirmed to have investment rows.
+- `flags/registry.yaml` `production: true` + regenerate, AND
+  `VITE_ENABLE_INVESTMENT_ROUNDS=true` in the prod build env.
+
+---
+
+## CI / Merge notes
+
+- `flags/**` and `shared/**` are classified `code` in
+  `.github/path-filters.yml`, so the PR triggers `check` + `test-affected` (the
+  Task 1 tests run). Required merge check: **CI Gate Status**.
+- Do not flip the global `ALL_FLAGS.enabled` bit in
+  `shared/feature-flags/flag-definitions.ts` — the Task 1 tripwire reds if you
+  do, and it would enable prod.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (vs the debate synthesis GO conditions):
+
+- registry dev/staging flip + regenerate → Task 2 / Task 5. ✓
+- `VITE_*` per-env lever, prod-off → Task 3 / Task 5 Step 3. ✓
+- keep `ALL_FLAGS.enabled=false` → enforced by Task 1 tripwire + File Structure
+  DO-NOT-EDIT. ✓
+- Postgres + `scripts/seed-db.ts`, confirm rows before asserting → Task 4 Steps
+  1-3. ✓
+- prove the live UI renders (not just metadata) → Task 4 Step 4. ✓
+- capture smoke evidence → Task 4 Step 5. ✓
+- stop at staging, gate staging on H2, report prod preconditions → Task 5 gate +
+  Step 6. ✓
+- avoid new docs / new integration tests on the PR → File Structure note. ✓
+
+**2. Placeholder scan:** No TBD/"handle edge cases"/"similar to".
+`<seededFundId>`/`<companyId>`/`<dev-token>` are runtime values produced by Task
+4 Steps 2-3, not unfilled plan content.
+
+**3. Type consistency:** `useFlag('enable_investment_rounds')`,
+`VITE_ENABLE_INVESTMENT_ROUNDS`, `ff_enable_investment_rounds`,
+`supersedesRoundId`, and the generated paths
+`shared/generated/flag-defaults.ts`/`flag-types.ts` are used identically across
+tasks and match the verified source.

--- a/docs/superpowers/plans/2026-06-24-pr-d-provenance-envelope-rounds-evidence.md
+++ b/docs/superpowers/plans/2026-06-24-pr-d-provenance-envelope-rounds-evidence.md
@@ -1,0 +1,2485 @@
+# PR-D Provenance Envelope + Rounds Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a strict, hash-bound dataset provenance envelope and read-only
+rounds-to-model evidence adapter over all non-superseded investment rounds.
+
+**Architecture:** PR-D adds contracts, provenance factories, override
+persistence, and a server-side read adapter. It deliberately does not add
+routes, render blocking, candidate/shadow payloads, or live MOIC ranking
+changes; PR-E owns those. The adapter emits strict parsed evidence with
+deterministic hashes so later work can safely promote it into route/render
+policy.
+
+**Tech Stack:** TypeScript, Zod, Drizzle ORM, PostgreSQL SQL migrations,
+Decimal.js via existing decimal utilities, Vitest server project, existing npm
+guardrail scripts.
+
+## Global Constraints
+
+- Baseline commit: `e8113431`, PR #916 "H3 investment-round operational
+  readiness + base currency".
+- Scope statement for PR: "PR-D introduces a strict, hash-bound dataset
+  provenance envelope and a read-only rounds-to-model evidence adapter over all
+  non-superseded investment rounds, with override-aware currency blocking and
+  amount-only non-equity handling; it does not alter live MOIC rankings, add
+  routes, expose shadow/candidate responses, or enforce render blocking."
+- Preserve unrelated checkout dirt. Do not reset, clean, stage, or commit
+  unrelated files from the root checkout.
+- Execution branch: `claude/beautiful-heisenberg-btcsmw`.
+- Reuse `shared/lib/canonical-hash.ts`; do not create a new hashing module.
+- Reuse `shared/contracts/financial-provenance.contract.ts`; do not redefine
+  provenance core enums or fields.
+- Active rounds are all non-superseded rows. Never collapse to one "latest"
+  round per investment.
+- Keep tests under `tests/unit/**` so `vitest.config.mjs` discovers them.
+- Hand-written migrations live under
+  `server/migrations/<YYYYMMDD>_..._v1.{up,down}.sql`.
+- `npm run check` runs `baseline:check`; `npm run lint` already runs
+  `guardrails:check`.
+- Final release proof is `npm run release:check`; CI green alone is not release
+  proof.
+
+---
+
+## File Structure
+
+- Create `shared/contracts/provenance-envelope.contract.ts`
+  - Owns `DatasetTrustStateSchema`, `WarningCodeSchema`,
+    `StructuredWarningSchema`, `ProvenanceEnvelopeSchema`, and exported types.
+  - Composes `FinancialProvenanceSchema` as `core`.
+
+- Create `shared/contracts/rounds-to-model-evidence.contract.ts`
+  - Owns strict evidence payload schema, per-company evidence schema, coverage
+    schema, warning-code record schema, and
+    `serializeRoundsToModelEvidence(value: unknown)`.
+  - Reuses `SecurityTypeSchema` from
+    `shared/contracts/investments/investment-round.contract.ts`.
+
+- Create `server/lib/rounds-provenance.ts`
+  - Owns provenance factory functions and canonical hash input construction.
+  - Depends on `canonicalSha256()` and the new provenance contract.
+
+- Create `shared/schema/investment-round-model-overrides.ts`
+  - Owns Drizzle table for read-only model role overrides.
+  - Mirrors investment-round integrity patterns.
+
+- Create `server/migrations/20260624_investment_round_model_overrides_v1.up.sql`
+  - Creates override table, composite FK target, FK, lineage indexes, and read
+    indexes.
+
+- Create
+  `server/migrations/20260624_investment_round_model_overrides_v1.down.sql`
+  - Drops constraints, indexes, and table in reverse order.
+
+- Modify `shared/schema.ts`
+  - Export `./schema/investment-round-model-overrides` because
+    `drizzle.config.ts` reads this barrel.
+
+- Modify `shared/schema/index.ts`
+  - Export `./investment-round-model-overrides` for compatibility imports.
+
+- Create `server/services/rounds-to-model-evidence-service.ts`
+  - Owns the read-only adapter.
+  - Loads fund base currency, companies, investments, active rounds, active
+    overrides.
+  - Aggregates per-company evidence and returns through strict serialization.
+
+- Create `tests/unit/contract/provenance-envelope.contract.test.ts`
+  - Contract tests for envelope trust-state mapping, strictness, hash binding,
+    and warning collision prevention.
+
+- Create `tests/unit/contract/rounds-to-model-evidence.contract.test.ts`
+  - Contract tests for evidence shape, strict leak rejection, decimal strings,
+    coverage, and warning code maps.
+
+- Create `tests/unit/services/rounds-to-model-evidence-service.test.ts`
+  - Service tests with injected/seeded database doubles.
+
+- Modify `tests/unit/services/fund-moic-ranking-service.test.ts`
+  - Adds regression around `getFundMoicRankings` so live MOIC rankings stay
+    sourced from `portfolioCompanies` and ignore `investmentRounds`.
+
+- Create `scripts/guardrails/no-client-round-derived-financial-claims.mjs`
+  - Narrow ratchet for new client-side round-aware financial derivation claims.
+
+- Modify `package.json`
+  - Add `guard:round-derived-financial-claims:check`.
+  - Append to `guardrails:check` only after the guardrail passes current code.
+
+---
+
+### Task 1: Preflight + Isolation
+
+**Files:**
+
+- No source files created or modified.
+
+**Interfaces:**
+
+- Consumes: current Git state, `origin/main`, desired branch name
+  `claude/beautiful-heisenberg-btcsmw`.
+- Produces: a clean implementation checkout at baseline `e8113431`.
+
+- [ ] **Step 1: Record current git state**
+
+Run:
+
+```powershell
+git status --short --branch
+git rev-parse --short HEAD
+git rev-parse --short origin/main
+git branch --show-current
+git branch --list claude/beautiful-heisenberg-btcsmw
+git ls-remote origin refs/heads/claude/beautiful-heisenberg-btcsmw
+```
+
+Expected:
+
+- `HEAD` and `origin/main` are `e8113431`.
+- If current checkout is dirty or not already on a clean
+  `claude/beautiful-heisenberg-btcsmw`, do not work in root checkout.
+
+- [ ] **Step 2: Create isolated worktree when required**
+
+Run only if the current checkout is dirty or not already on a clean designated
+branch:
+
+```powershell
+git worktree add .worktrees\pr-d-provenance-envelope-rounds-evidence origin/main
+Set-Location .worktrees\pr-d-provenance-envelope-rounds-evidence
+git switch -c claude/beautiful-heisenberg-btcsmw
+git rev-parse --short HEAD
+git status --short --branch
+```
+
+Expected:
+
+- `HEAD` is `e8113431`.
+- Worktree branch is `claude/beautiful-heisenberg-btcsmw`.
+- Worktree status is clean.
+
+- [ ] **Step 3: Capture active-round rule evidence**
+
+If Postgres is reachable, run a redacted count/shape/query-plan spike. Do not
+print monetary values.
+
+```sql
+EXPLAIN
+SELECT r.id, r.fund_id, r.investment_id, r.round_date, r.created_at
+FROM investment_rounds r
+WHERE r.fund_id = $1
+  AND NOT EXISTS (
+    SELECT 1
+    FROM investment_rounds newer
+    WHERE newer.supersedes_round_id = r.id
+  )
+ORDER BY r.investment_id ASC, r.round_date ASC, r.created_at ASC, r.id ASC;
+```
+
+If Postgres is not reachable, record that service tests will prove the same rule
+with injected rows.
+
+- [ ] **Step 4: Commit nothing**
+
+No commit is expected for Task 1. The deliverable is a clean implementation
+checkout and recorded preflight evidence.
+
+---
+
+### Task 2: Provenance Envelope Contract
+
+**Files:**
+
+- Create: `shared/contracts/provenance-envelope.contract.ts`
+- Test: `tests/unit/contract/provenance-envelope.contract.test.ts`
+
+**Interfaces:**
+
+- Consumes: `FinancialProvenanceSchema` from
+  `shared/contracts/financial-provenance.contract.ts`.
+- Produces:
+  - `DatasetTrustStateSchema`
+  - `WarningCodeSchema`
+  - `StructuredWarningSchema`
+  - `ProvenanceEnvelopeSchema`
+  - Types `DatasetTrustState`, `WarningCode`, `StructuredWarning`,
+    `ProvenanceEnvelope`
+
+- [ ] **Step 1: Write failing contract tests**
+
+Create `tests/unit/contract/provenance-envelope.contract.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  ProvenanceEnvelopeSchema,
+  type ProvenanceEnvelope,
+} from '../../../shared/contracts/provenance-envelope.contract';
+
+const computedCore = {
+  sourceKind: 'computed',
+  actionability: 'actionable',
+  sourceEngine: 'rounds-to-model',
+  engineVersion: 'rounds-to-model-v1',
+  inputHash: 'input-hash',
+  assumptionsHash: 'assumptions-hash',
+  generatedAt: '2026-06-24T00:00:00.000Z',
+  isFinanciallyActionable: true,
+  warnings: [],
+} as const;
+
+describe('ProvenanceEnvelopeSchema', () => {
+  it('accepts hash-bound LIVE computed provenance', () => {
+    const value: ProvenanceEnvelope = {
+      trustState: 'LIVE',
+      core: computedCore,
+      structuredWarnings: [],
+      sourceAsOf: '2026-06-24T00:00:00.000Z',
+      staleAfterSeconds: 3600,
+    };
+
+    expect(ProvenanceEnvelopeSchema.parse(value)).toEqual(value);
+  });
+
+  it('accepts empty-fund LIVE provenance with hashes and EMPTY_FUND info warning', () => {
+    const value = {
+      trustState: 'LIVE',
+      core: computedCore,
+      structuredWarnings: [
+        {
+          code: 'EMPTY_FUND',
+          severity: 'info',
+          message: 'No active investment rounds were found for this fund.',
+        },
+      ],
+    };
+
+    expect(ProvenanceEnvelopeSchema.parse(value)).toEqual(value);
+  });
+
+  it('requires hash-bound PARTIAL computed provenance at the envelope layer', () => {
+    const result = ProvenanceEnvelopeSchema.safeParse({
+      trustState: 'PARTIAL',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'input_only',
+        generatedAt: '2026-06-24T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        warnings: [],
+      },
+      structuredWarnings: [
+        {
+          code: 'ROLE_CLASSIFICATION_AMBIGUOUS',
+          severity: 'warning',
+          message: 'Initial versus follow-on role could not be determined.',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.map((issue) => issue.path.join('.'))
+      ).toContain('core.inputHash');
+      expect(
+        result.error.issues.map((issue) => issue.path.join('.'))
+      ).toContain('core.assumptionsHash');
+    }
+  });
+
+  it('accepts hash-bound UNAVAILABLE currency block provenance', () => {
+    const value = {
+      trustState: 'UNAVAILABLE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'quarantined',
+        sourceEngine: 'rounds-to-model',
+        engineVersion: 'rounds-to-model-v1',
+        inputHash: 'input-hash',
+        assumptionsHash: 'assumptions-hash',
+        generatedAt: '2026-06-24T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        quarantineReason: 'currency_mismatch',
+        warnings: [],
+      },
+      structuredWarnings: [
+        {
+          code: 'CURRENCY_MISMATCH_BLOCK',
+          severity: 'blocking',
+          message:
+            'Round currency does not match fund base currency after overrides.',
+        },
+      ],
+    };
+
+    expect(ProvenanceEnvelopeSchema.parse(value)).toEqual(value);
+  });
+
+  it('accepts FAILED adapter provenance without dataset hashes', () => {
+    const value = {
+      trustState: 'FAILED',
+      core: {
+        sourceKind: 'prototype_blocked',
+        actionability: 'non_actionable',
+        generatedAt: '2026-06-24T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        quarantineReason: 'round_adapter_failed',
+        warnings: [
+          'Rounds-to-model adapter failed before evidence could be emitted.',
+        ],
+      },
+      structuredWarnings: [
+        {
+          code: 'ROUND_ADAPTER_FAILED',
+          severity: 'blocking',
+          message:
+            'Rounds-to-model adapter failed before evidence could be emitted.',
+        },
+      ],
+    };
+
+    expect(ProvenanceEnvelopeSchema.parse(value)).toEqual(value);
+  });
+
+  it('keeps core warnings separate from structured warnings', () => {
+    const value = {
+      trustState: 'PARTIAL',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'input_only',
+        sourceEngine: 'rounds-to-model',
+        engineVersion: 'rounds-to-model-v1',
+        inputHash: 'input-hash',
+        assumptionsHash: 'assumptions-hash',
+        generatedAt: '2026-06-24T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        warnings: ['legacy string warning'],
+      },
+      structuredWarnings: [
+        {
+          code: 'NON_EQUITY_AMOUNT_ONLY',
+          severity: 'warning',
+          message: 'A non-equity round can only contribute amount evidence.',
+        },
+      ],
+    };
+
+    const parsed = ProvenanceEnvelopeSchema.parse(value);
+
+    expect(parsed.core.warnings).toEqual(['legacy string warning']);
+    expect(parsed.structuredWarnings[0]?.code).toBe('NON_EQUITY_AMOUNT_ONLY');
+  });
+
+  it('rejects shadow or candidate leak fields', () => {
+    const result = ProvenanceEnvelopeSchema.safeParse({
+      trustState: 'LIVE',
+      core: computedCore,
+      structuredWarnings: [],
+      shadowDiff: {},
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/contract/provenance-envelope.contract.test.ts --project=server
+```
+
+Expected:
+
+- FAIL because `shared/contracts/provenance-envelope.contract.ts` does not
+  exist.
+
+- [ ] **Step 3: Implement contract**
+
+Create `shared/contracts/provenance-envelope.contract.ts`:
+
+```ts
+import { z } from 'zod';
+
+import { FinancialProvenanceSchema } from './financial-provenance.contract';
+
+export const DatasetTrustStateSchema = z.enum([
+  'LIVE',
+  'PARTIAL',
+  'UNAVAILABLE',
+  'FAILED',
+]);
+
+export const WarningCodeSchema = z.enum([
+  'ROUND_ADAPTER_FAILED',
+  'CURRENCY_MISMATCH_BLOCK',
+  'DATA_STALE',
+  'ROLE_CLASSIFICATION_AMBIGUOUS',
+  'ROLE_TOLERANCE_OVERRIDDEN',
+  'ROUND_MODEL_OVERRIDE_APPLIED',
+  'INVALID_ROUND_AMOUNT',
+  'NON_EQUITY_AMOUNT_ONLY',
+  'EMPTY_FUND',
+]);
+
+export const StructuredWarningSchema = z
+  .object({
+    code: WarningCodeSchema,
+    severity: z.enum(['info', 'warning', 'blocking']),
+    message: z.string().min(1),
+    source: z.string().min(1).optional(),
+  })
+  .strict();
+
+function hasWarningCode(
+  warnings: Array<z.infer<typeof StructuredWarningSchema>>,
+  code: z.infer<typeof WarningCodeSchema>
+): boolean {
+  return warnings.some((warning) => warning.code === code);
+}
+
+function requireHashBoundComputed(
+  value: z.infer<typeof FinancialProvenanceSchema>,
+  ctx: z.RefinementCtx
+): void {
+  for (const field of ['inputHash', 'assumptionsHash'] as const) {
+    if (!value[field]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['core', field],
+        message: `${field} is required for non-FAILED computed provenance envelopes`,
+      });
+    }
+  }
+}
+
+export const ProvenanceEnvelopeSchema = z
+  .object({
+    trustState: DatasetTrustStateSchema,
+    core: FinancialProvenanceSchema,
+    structuredWarnings: z.array(StructuredWarningSchema),
+    sourceAsOf: z.string().datetime().optional(),
+    staleAfterSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.trustState !== 'FAILED' && value.core.sourceKind === 'computed') {
+      requireHashBoundComputed(value.core, ctx);
+    }
+
+    if (value.trustState === 'LIVE') {
+      if (value.core.sourceKind !== 'computed') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['core', 'sourceKind'],
+          message:
+            'PR-D LIVE provenance must be computed; imported_actual LIVE is deferred to PR-E',
+        });
+      }
+      if (
+        !value.core.isFinanciallyActionable ||
+        value.core.actionability !== 'actionable'
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['core', 'actionability'],
+          message: 'LIVE provenance must be financially actionable',
+        });
+      }
+      if (value.core.quarantineReason) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['core', 'quarantineReason'],
+          message: 'LIVE provenance cannot include quarantineReason',
+        });
+      }
+    }
+
+    if (value.trustState === 'PARTIAL') {
+      if (value.core.sourceKind !== 'computed') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['core', 'sourceKind'],
+          message: 'PARTIAL provenance must be computed',
+        });
+      }
+      if (
+        value.core.isFinanciallyActionable ||
+        value.core.actionability !== 'input_only'
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['core', 'actionability'],
+          message:
+            'PARTIAL provenance must be non-actionable input_only computed evidence',
+        });
+      }
+      if (value.core.quarantineReason) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['core', 'quarantineReason'],
+          message: 'PARTIAL provenance cannot include quarantineReason',
+        });
+      }
+      if (value.structuredWarnings.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['structuredWarnings'],
+          message:
+            'PARTIAL provenance requires at least one structured warning',
+        });
+      }
+    }
+
+    if (value.trustState === 'UNAVAILABLE') {
+      if (
+        value.core.sourceKind !== 'computed' ||
+        value.core.actionability !== 'quarantined' ||
+        value.core.quarantineReason !== 'currency_mismatch' ||
+        !hasWarningCode(value.structuredWarnings, 'CURRENCY_MISMATCH_BLOCK')
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['trustState'],
+          message:
+            'UNAVAILABLE PR-D provenance is reserved for computed currency_mismatch quarantine',
+        });
+      }
+    }
+
+    if (value.trustState === 'FAILED') {
+      if (
+        value.core.sourceKind !== 'prototype_blocked' ||
+        value.core.actionability !== 'non_actionable' ||
+        value.core.quarantineReason !== 'round_adapter_failed' ||
+        !hasWarningCode(value.structuredWarnings, 'ROUND_ADAPTER_FAILED')
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['trustState'],
+          message:
+            'FAILED provenance must be prototype_blocked round_adapter_failed provenance',
+        });
+      }
+    }
+  });
+
+export type DatasetTrustState = z.infer<typeof DatasetTrustStateSchema>;
+export type WarningCode = z.infer<typeof WarningCodeSchema>;
+export type StructuredWarning = z.infer<typeof StructuredWarningSchema>;
+export type ProvenanceEnvelope = z.infer<typeof ProvenanceEnvelopeSchema>;
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/contract/provenance-envelope.contract.test.ts --project=server
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 5: Commit**
+
+Use a Lore-style commit message:
+
+```powershell
+git add shared/contracts/provenance-envelope.contract.ts tests/unit/contract/provenance-envelope.contract.test.ts
+git commit -m @"
+Define strict dataset provenance envelopes
+
+PR-D needs a reusable trust envelope around existing financial provenance
+without redefining the core provenance schema. The envelope composes the
+existing strict schema and adds PR-D-specific trust-state consistency.
+
+Constraint: PR-D must not expose routes or shadow/candidate payloads
+Rejected: Redefine provenance core enums | existing FinancialProvenanceSchema already owns them
+Confidence: high
+Scope-risk: narrow
+Tested: cross-env TZ=UTC vitest run tests/unit/contract/provenance-envelope.contract.test.ts --project=server
+Not-tested: Full release gate
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+"@
+```
+
+---
+
+### Task 3: Rounds-to-Model Evidence Contract
+
+**Files:**
+
+- Create: `shared/contracts/rounds-to-model-evidence.contract.ts`
+- Test: `tests/unit/contract/rounds-to-model-evidence.contract.test.ts`
+
+**Interfaces:**
+
+- Consumes:
+  - `ProvenanceEnvelopeSchema`
+  - `WarningCodeSchema`
+  - `SecurityTypeSchema`
+  - `DecimalStringSchema`
+- Produces:
+  - `RoundsToModelEvidenceSchema`
+  - `serializeRoundsToModelEvidence(value: unknown): RoundsToModelEvidence`
+
+- [ ] **Step 1: Write failing contract tests**
+
+Create `tests/unit/contract/rounds-to-model-evidence.contract.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  RoundsToModelEvidenceSchema,
+  serializeRoundsToModelEvidence,
+} from '../../../shared/contracts/rounds-to-model-evidence.contract';
+
+const provenance = {
+  trustState: 'LIVE',
+  core: {
+    sourceKind: 'computed',
+    actionability: 'actionable',
+    sourceEngine: 'rounds-to-model',
+    engineVersion: 'rounds-to-model-v1',
+    inputHash: 'input-hash',
+    assumptionsHash: 'assumptions-hash',
+    generatedAt: '2026-06-24T00:00:00.000Z',
+    isFinanciallyActionable: true,
+    warnings: [],
+  },
+  structuredWarnings: [],
+};
+
+const validEvidence = {
+  fundId: 10,
+  baseCurrency: 'USD',
+  generatedAt: '2026-06-24T00:00:00.000Z',
+  companies: [
+    {
+      companyId: 101,
+      companyName: 'Acme',
+      investmentIds: [201],
+      initialAmount: '500000.000000',
+      followOnAmount: '125000.000000',
+      amountOnlyNonEquityAmount: '0.000000',
+      roundCount: 2,
+      rounds: [
+        {
+          roundId: 1,
+          investmentId: 201,
+          companyId: 101,
+          roundDate: '2024-01-15',
+          securityType: 'equity',
+          role: 'initial',
+          currency: 'USD',
+          investmentAmount: '500000.000000',
+          amountOnly: false,
+          overrideApplied: false,
+        },
+        {
+          roundId: 2,
+          investmentId: 201,
+          companyId: 101,
+          roundDate: '2025-02-01',
+          securityType: 'safe',
+          role: 'follow_on',
+          currency: 'USD',
+          investmentAmount: '125000.000000',
+          amountOnly: true,
+          overrideApplied: false,
+        },
+      ],
+      warnings: [],
+    },
+  ],
+  coverage: {
+    companyCount: 1,
+    investmentCount: 1,
+    activeRoundCount: 2,
+    activeOverrideCount: 0,
+    warningsByCode: {},
+  },
+  provenance,
+};
+
+describe('RoundsToModelEvidenceSchema', () => {
+  it('accepts strict evidence with decimal strings and provenance', () => {
+    expect(RoundsToModelEvidenceSchema.parse(validEvidence)).toEqual(
+      validEvidence
+    );
+  });
+
+  it('rejects numeric money fields', () => {
+    const result = RoundsToModelEvidenceSchema.safeParse({
+      ...validEvidence,
+      companies: [{ ...validEvidence.companies[0], initialAmount: 500000 }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects shadow and candidate leaks at serialization boundary', () => {
+    expect(() =>
+      serializeRoundsToModelEvidence({
+        ...validEvidence,
+        shadowDiff: {},
+        candidateResponse: {},
+        exportEligibility: { enabled: true },
+      })
+    ).toThrow();
+  });
+
+  it('requires warningsByCode keys to be warning codes', () => {
+    const result = RoundsToModelEvidenceSchema.safeParse({
+      ...validEvidence,
+      coverage: {
+        ...validEvidence.coverage,
+        warningsByCode: {
+          NOT_A_WARNING: 1,
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/contract/rounds-to-model-evidence.contract.test.ts --project=server
+```
+
+Expected:
+
+- FAIL because contract does not exist.
+
+- [ ] **Step 3: Implement evidence contract**
+
+Create `shared/contracts/rounds-to-model-evidence.contract.ts`:
+
+```ts
+import { z } from 'zod';
+
+import { DecimalStringSchema } from './lp-reporting/cash-flow-event.contract';
+import { SecurityTypeSchema } from './investments/investment-round.contract';
+import {
+  ProvenanceEnvelopeSchema,
+  WarningCodeSchema,
+  StructuredWarningSchema,
+} from './provenance-envelope.contract';
+
+const CurrencySchema = z.string().regex(/^[A-Z]{3}$/);
+
+export const RoundModelRoleSchema = z.enum([
+  'initial',
+  'follow_on',
+  'ambiguous',
+  'amount_only',
+]);
+
+export const RoundEvidenceSchema = z
+  .object({
+    roundId: z.number().int().positive(),
+    investmentId: z.number().int().positive(),
+    companyId: z.number().int().positive(),
+    roundDate: z.string().date(),
+    securityType: SecurityTypeSchema,
+    role: RoundModelRoleSchema,
+    currency: CurrencySchema,
+    investmentAmount: DecimalStringSchema,
+    amountOnly: z.boolean(),
+    overrideApplied: z.boolean(),
+  })
+  .strict();
+
+export const CompanyRoundsEvidenceSchema = z
+  .object({
+    companyId: z.number().int().positive(),
+    companyName: z.string().min(1),
+    investmentIds: z.array(z.number().int().positive()),
+    initialAmount: DecimalStringSchema,
+    followOnAmount: DecimalStringSchema,
+    amountOnlyNonEquityAmount: DecimalStringSchema,
+    roundCount: z.number().int().nonnegative(),
+    rounds: z.array(RoundEvidenceSchema),
+    warnings: z.array(StructuredWarningSchema),
+  })
+  .strict();
+
+export const RoundsEvidenceCoverageSchema = z
+  .object({
+    companyCount: z.number().int().nonnegative(),
+    investmentCount: z.number().int().nonnegative(),
+    activeRoundCount: z.number().int().nonnegative(),
+    activeOverrideCount: z.number().int().nonnegative(),
+    warningsByCode: z.record(WarningCodeSchema, z.number().int().nonnegative()),
+  })
+  .strict();
+
+export const RoundsToModelEvidenceSchema = z
+  .object({
+    fundId: z.number().int().positive(),
+    baseCurrency: CurrencySchema,
+    generatedAt: z.string().datetime(),
+    companies: z.array(CompanyRoundsEvidenceSchema),
+    coverage: RoundsEvidenceCoverageSchema,
+    provenance: ProvenanceEnvelopeSchema,
+  })
+  .strict();
+
+export type RoundModelRole = z.infer<typeof RoundModelRoleSchema>;
+export type RoundEvidence = z.infer<typeof RoundEvidenceSchema>;
+export type CompanyRoundsEvidence = z.infer<typeof CompanyRoundsEvidenceSchema>;
+export type RoundsEvidenceCoverage = z.infer<
+  typeof RoundsEvidenceCoverageSchema
+>;
+export type RoundsToModelEvidence = z.infer<typeof RoundsToModelEvidenceSchema>;
+
+export function serializeRoundsToModelEvidence(
+  value: unknown
+): RoundsToModelEvidence {
+  return RoundsToModelEvidenceSchema.parse(value);
+}
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/contract/rounds-to-model-evidence.contract.test.ts --project=server
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add shared/contracts/rounds-to-model-evidence.contract.ts tests/unit/contract/rounds-to-model-evidence.contract.test.ts
+git commit -m @"
+Constrain rounds-to-model evidence before routing
+
+PR-D needs a strict read-only evidence payload that can be trusted before PR-E
+adds routes or render policy. The contract rejects shadow and candidate fields
+at the serialization boundary.
+
+Constraint: PR-D has no HTTP route or export surface
+Rejected: Add shared/contracts/modeling namespace | no such namespace exists in repo today
+Confidence: high
+Scope-risk: narrow
+Tested: cross-env TZ=UTC vitest run tests/unit/contract/rounds-to-model-evidence.contract.test.ts --project=server
+Not-tested: Adapter integration
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+"@
+```
+
+---
+
+### Task 4: Provenance Factories
+
+**Files:**
+
+- Create: `server/lib/rounds-provenance.ts`
+- Test: extend `tests/unit/contract/provenance-envelope.contract.test.ts`
+
+**Interfaces:**
+
+- Consumes:
+  - `canonicalSha256(value: unknown): string`
+  - `ProvenanceEnvelopeSchema`
+- Produces:
+  - `buildRoundsInputHashInput(params): object`
+  - `buildRoundsAssumptionsHashInput(): object`
+  - `makeLiveRoundsProvenance(params): ProvenanceEnvelope`
+  - `makePartialRoundsProvenance(params): ProvenanceEnvelope`
+  - `makeCurrencyBlockedProvenance(params): ProvenanceEnvelope`
+  - `makeAdapterFailedProvenance(params): ProvenanceEnvelope`
+
+- [ ] **Step 1: Add failing factory tests**
+
+Append to `tests/unit/contract/provenance-envelope.contract.test.ts`:
+
+```ts
+import {
+  buildRoundsAssumptionsHashInput,
+  buildRoundsInputHashInput,
+  makeCurrencyBlockedProvenance,
+  makeLiveRoundsProvenance,
+  makePartialRoundsProvenance,
+} from '../../../server/lib/rounds-provenance';
+
+describe('rounds provenance factories', () => {
+  const now = new Date('2026-06-24T00:00:00.000Z');
+  const hashParams = {
+    fundId: 10,
+    baseCurrency: 'USD',
+    activeRounds: [{ id: 2 }, { id: 1 }],
+    activeOverrides: [],
+    parentInvestments: [{ id: 20 }],
+    companies: [{ id: 30 }],
+  };
+
+  it('uses explicit stable input hash membership', () => {
+    expect(buildRoundsInputHashInput(hashParams)).toEqual({
+      fundId: 10,
+      baseCurrency: 'USD',
+      activeRounds: [{ id: 2 }, { id: 1 }],
+      activeOverrides: [],
+      parentInvestments: [{ id: 20 }],
+      companies: [{ id: 30 }],
+    });
+  });
+
+  it('uses explicit assumptions hash membership', () => {
+    expect(buildRoundsAssumptionsHashInput()).toEqual({
+      rulesVersion: 'rounds-to-model-v1',
+      amountTolerancePct: '0.01',
+      minRoundReconciliationToleranceUsd: '25000',
+      dateToleranceDays: 14,
+      unsupportedSecurityTypePolicy: 'amount_only_or_unavailable',
+      currencyPolicy: 'post_override_fund_base_currency',
+      roleClassificationPolicy:
+        'override_before_currency_decimal_initial_vs_followon',
+    });
+  });
+
+  it('creates LIVE provenance with hashes', () => {
+    const provenance = makeLiveRoundsProvenance({
+      now,
+      hashParams,
+      structuredWarnings: [],
+    });
+
+    expect(provenance.trustState).toBe('LIVE');
+    expect(provenance.core.inputHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(provenance.core.assumptionsHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('creates hash-bound PARTIAL provenance', () => {
+    const provenance = makePartialRoundsProvenance({
+      now,
+      hashParams,
+      structuredWarnings: [
+        {
+          code: 'ROLE_CLASSIFICATION_AMBIGUOUS',
+          severity: 'warning',
+          message: 'Role classification is ambiguous.',
+        },
+      ],
+    });
+
+    expect(provenance.trustState).toBe('PARTIAL');
+    expect(provenance.core.inputHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(provenance.core.assumptionsHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('creates hash-bound currency block provenance', () => {
+    const provenance = makeCurrencyBlockedProvenance({
+      now,
+      hashParams,
+      structuredWarnings: [
+        {
+          code: 'CURRENCY_MISMATCH_BLOCK',
+          severity: 'blocking',
+          message: 'Round currency does not match fund base currency.',
+        },
+      ],
+    });
+
+    expect(provenance.trustState).toBe('UNAVAILABLE');
+    expect(provenance.core.quarantineReason).toBe('currency_mismatch');
+    expect(provenance.core.inputHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/contract/provenance-envelope.contract.test.ts --project=server
+```
+
+Expected:
+
+- FAIL because `server/lib/rounds-provenance.ts` does not exist.
+
+- [ ] **Step 3: Implement factories**
+
+Create `server/lib/rounds-provenance.ts`:
+
+```ts
+import { canonicalSha256 } from '../../shared/lib/canonical-hash';
+import type {
+  ProvenanceEnvelope,
+  StructuredWarning,
+} from '../../shared/contracts/provenance-envelope.contract';
+import { ProvenanceEnvelopeSchema } from '../../shared/contracts/provenance-envelope.contract';
+
+type HashParams = {
+  fundId: number;
+  baseCurrency: string;
+  activeRounds: unknown[];
+  activeOverrides: unknown[];
+  parentInvestments: unknown[];
+  companies: unknown[];
+};
+
+type FactoryParams = {
+  now: Date;
+  hashParams: HashParams;
+  structuredWarnings: StructuredWarning[];
+  sourceAsOf?: string;
+  staleAfterSeconds?: number;
+};
+
+export function buildRoundsInputHashInput(params: HashParams): HashParams {
+  return {
+    fundId: params.fundId,
+    baseCurrency: params.baseCurrency,
+    activeRounds: params.activeRounds,
+    activeOverrides: params.activeOverrides,
+    parentInvestments: params.parentInvestments,
+    companies: params.companies,
+  };
+}
+
+export function buildRoundsAssumptionsHashInput(): Record<
+  string,
+  string | number
+> {
+  return {
+    rulesVersion: 'rounds-to-model-v1',
+    amountTolerancePct: '0.01',
+    minRoundReconciliationToleranceUsd: '25000',
+    dateToleranceDays: 14,
+    unsupportedSecurityTypePolicy: 'amount_only_or_unavailable',
+    currencyPolicy: 'post_override_fund_base_currency',
+    roleClassificationPolicy:
+      'override_before_currency_decimal_initial_vs_followon',
+  };
+}
+
+function hashes(
+  hashParams: HashParams
+): Pick<ProvenanceEnvelope['core'], 'inputHash' | 'assumptionsHash'> {
+  return {
+    inputHash: canonicalSha256(buildRoundsInputHashInput(hashParams)),
+    assumptionsHash: canonicalSha256(buildRoundsAssumptionsHashInput()),
+  };
+}
+
+export function makeLiveRoundsProvenance(
+  params: FactoryParams
+): ProvenanceEnvelope {
+  return ProvenanceEnvelopeSchema.parse({
+    trustState: 'LIVE',
+    core: {
+      sourceKind: 'computed',
+      actionability: 'actionable',
+      sourceEngine: 'rounds-to-model',
+      engineVersion: 'rounds-to-model-v1',
+      ...hashes(params.hashParams),
+      generatedAt: params.now.toISOString(),
+      isFinanciallyActionable: true,
+      warnings: [],
+    },
+    structuredWarnings: params.structuredWarnings,
+    sourceAsOf: params.sourceAsOf,
+    staleAfterSeconds: params.staleAfterSeconds,
+  });
+}
+
+export function makePartialRoundsProvenance(
+  params: FactoryParams
+): ProvenanceEnvelope {
+  return ProvenanceEnvelopeSchema.parse({
+    trustState: 'PARTIAL',
+    core: {
+      sourceKind: 'computed',
+      actionability: 'input_only',
+      sourceEngine: 'rounds-to-model',
+      engineVersion: 'rounds-to-model-v1',
+      ...hashes(params.hashParams),
+      generatedAt: params.now.toISOString(),
+      isFinanciallyActionable: false,
+      warnings: [],
+    },
+    structuredWarnings: params.structuredWarnings,
+    sourceAsOf: params.sourceAsOf,
+    staleAfterSeconds: params.staleAfterSeconds,
+  });
+}
+
+export function makeCurrencyBlockedProvenance(
+  params: FactoryParams
+): ProvenanceEnvelope {
+  return ProvenanceEnvelopeSchema.parse({
+    trustState: 'UNAVAILABLE',
+    core: {
+      sourceKind: 'computed',
+      actionability: 'quarantined',
+      sourceEngine: 'rounds-to-model',
+      engineVersion: 'rounds-to-model-v1',
+      ...hashes(params.hashParams),
+      generatedAt: params.now.toISOString(),
+      isFinanciallyActionable: false,
+      quarantineReason: 'currency_mismatch',
+      warnings: [],
+    },
+    structuredWarnings: params.structuredWarnings,
+    sourceAsOf: params.sourceAsOf,
+    staleAfterSeconds: params.staleAfterSeconds,
+  });
+}
+
+export function makeAdapterFailedProvenance(params: {
+  now: Date;
+  message: string;
+}): ProvenanceEnvelope {
+  return ProvenanceEnvelopeSchema.parse({
+    trustState: 'FAILED',
+    core: {
+      sourceKind: 'prototype_blocked',
+      actionability: 'non_actionable',
+      generatedAt: params.now.toISOString(),
+      isFinanciallyActionable: false,
+      quarantineReason: 'round_adapter_failed',
+      warnings: [params.message],
+    },
+    structuredWarnings: [
+      {
+        code: 'ROUND_ADAPTER_FAILED',
+        severity: 'blocking',
+        message: params.message,
+      },
+    ],
+  });
+}
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/contract/provenance-envelope.contract.test.ts tests/unit/contract/rounds-to-model-evidence.contract.test.ts --project=server
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add server/lib/rounds-provenance.ts tests/unit/contract/provenance-envelope.contract.test.ts
+git commit -m @"
+Bind rounds provenance to explicit dataset hashes
+
+The rounds evidence adapter needs hashes that describe real input and
+assumption membership. Factory tests pin the exact objects so future changes
+cannot silently make hashes decorative.
+
+Constraint: PARTIAL and UNAVAILABLE computed envelopes must be hash-bound in PR-D
+Rejected: Rely only on FinancialProvenanceSchema hash requirements | core only requires hashes for actionable computed results
+Confidence: high
+Scope-risk: narrow
+Tested: cross-env TZ=UTC vitest run tests/unit/contract/provenance-envelope.contract.test.ts tests/unit/contract/rounds-to-model-evidence.contract.test.ts --project=server
+Not-tested: Adapter integration
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+"@
+```
+
+---
+
+### Task 5: Override Schema + Migration
+
+**Files:**
+
+- Create: `shared/schema/investment-round-model-overrides.ts`
+- Create:
+  `server/migrations/20260624_investment_round_model_overrides_v1.up.sql`
+- Create:
+  `server/migrations/20260624_investment_round_model_overrides_v1.down.sql`
+- Modify: `shared/schema.ts`
+- Modify: `shared/schema/index.ts`
+
+**Interfaces:**
+
+- Consumes: `investmentRounds`, `funds`, `users`.
+- Produces: `investmentRoundModelOverrides`, `InvestmentRoundModelOverride`,
+  `InsertInvestmentRoundModelOverride`.
+
+- [ ] **Step 1: Create migration up SQL**
+
+Create `server/migrations/20260624_investment_round_model_overrides_v1.up.sql`:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS investment_rounds_id_fund_uq
+  ON investment_rounds(id, fund_id);
+
+CREATE TABLE IF NOT EXISTS investment_round_model_overrides (
+  id SERIAL PRIMARY KEY,
+  fund_id INTEGER NOT NULL REFERENCES funds(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  round_id INTEGER NOT NULL,
+  override_role VARCHAR(32) NOT NULL,
+  reason TEXT NOT NULL,
+  created_by INTEGER REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  supersedes_override_id INTEGER REFERENCES investment_round_model_overrides(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  idempotency_key VARCHAR(255),
+  request_hash VARCHAR(64),
+  CONSTRAINT investment_round_model_overrides_role_check
+    CHECK (override_role IN ('initial', 'follow_on', 'amount_only'))
+);
+
+ALTER TABLE investment_round_model_overrides
+  ADD CONSTRAINT investment_round_model_overrides_round_fund_fk
+  FOREIGN KEY (round_id, fund_id) REFERENCES investment_rounds(id, fund_id)
+  ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS investment_round_model_overrides_supersedes_uq
+  ON investment_round_model_overrides(supersedes_override_id)
+  WHERE supersedes_override_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS investment_round_model_overrides_root_lineage_uq
+  ON investment_round_model_overrides(fund_id, round_id)
+  WHERE supersedes_override_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS investment_round_model_overrides_fund_round_idx
+  ON investment_round_model_overrides(fund_id, round_id, created_at, id);
+```
+
+- [ ] **Step 2: Create migration down SQL**
+
+Create
+`server/migrations/20260624_investment_round_model_overrides_v1.down.sql`:
+
+```sql
+ALTER TABLE IF EXISTS investment_round_model_overrides
+  DROP CONSTRAINT IF EXISTS investment_round_model_overrides_round_fund_fk;
+
+DROP INDEX IF EXISTS investment_round_model_overrides_fund_round_idx;
+DROP INDEX IF EXISTS investment_round_model_overrides_root_lineage_uq;
+DROP INDEX IF EXISTS investment_round_model_overrides_supersedes_uq;
+
+DROP TABLE IF EXISTS investment_round_model_overrides;
+
+DROP INDEX IF EXISTS investment_rounds_id_fund_uq;
+```
+
+- [ ] **Step 3: Create Drizzle schema**
+
+Create `shared/schema/investment-round-model-overrides.ts`:
+
+```ts
+import { sql } from 'drizzle-orm';
+import {
+  type AnyPgColumn,
+  check,
+  foreignKey,
+  index,
+  integer,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { funds } from './fund';
+import { investmentRounds } from './investment-rounds';
+import { users } from './user';
+
+export const investmentRoundModelOverrides = pgTable(
+  'investment_round_model_overrides',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, {
+        onDelete: 'restrict',
+        onUpdate: 'restrict',
+      }),
+    roundId: integer('round_id').notNull(),
+    overrideRole: varchar('override_role', { length: 32 }).notNull(),
+    reason: text('reason').notNull(),
+    createdBy: integer('created_by').references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    supersedesOverrideId: integer('supersedes_override_id').references(
+      (): AnyPgColumn => investmentRoundModelOverrides.id,
+      { onDelete: 'restrict', onUpdate: 'restrict' }
+    ),
+    idempotencyKey: varchar('idempotency_key', { length: 255 }),
+    requestHash: varchar('request_hash', { length: 64 }),
+  },
+  (table) => ({
+    overrideRoleCheck: check(
+      'investment_round_model_overrides_role_check',
+      sql`${table.overrideRole} IN ('initial', 'follow_on', 'amount_only')`
+    ),
+    roundFundFk: foreignKey({
+      name: 'investment_round_model_overrides_round_fund_fk',
+      columns: [table.roundId, table.fundId],
+      foreignColumns: [investmentRounds.id, investmentRounds.fundId],
+    })
+      .onUpdate('restrict')
+      .onDelete('restrict'),
+    supersedesUniqueIdx: uniqueIndex(
+      'investment_round_model_overrides_supersedes_uq'
+    )
+      .on(table.supersedesOverrideId)
+      .where(sql`supersedes_override_id IS NOT NULL`),
+    rootLineageUniqueIdx: uniqueIndex(
+      'investment_round_model_overrides_root_lineage_uq'
+    )
+      .on(table.fundId, table.roundId)
+      .where(sql`supersedes_override_id IS NULL`),
+    fundRoundIdx: index('investment_round_model_overrides_fund_round_idx').on(
+      table.fundId,
+      table.roundId,
+      table.createdAt,
+      table.id
+    ),
+  })
+);
+
+export type InvestmentRoundModelOverride =
+  typeof investmentRoundModelOverrides.$inferSelect;
+export type InsertInvestmentRoundModelOverride =
+  typeof investmentRoundModelOverrides.$inferInsert;
+```
+
+- [ ] **Step 4: Export schema**
+
+Modify `shared/schema.ts` by adding:
+
+```ts
+export * from './schema/investment-round-model-overrides';
+```
+
+Modify `shared/schema/index.ts` by adding:
+
+```ts
+export * from './investment-round-model-overrides';
+```
+
+- [ ] **Step 5: Run focused checks**
+
+Run:
+
+```powershell
+npm run check
+```
+
+Expected:
+
+- PASS, or fail only on unrelated pre-existing baseline debt. If it fails,
+  record exact output and do not widen the task without a direct schema-related
+  cause.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add shared/schema/investment-round-model-overrides.ts shared/schema.ts shared/schema/index.ts server/migrations/20260624_investment_round_model_overrides_v1.up.sql server/migrations/20260624_investment_round_model_overrides_v1.down.sql
+git commit -m @"
+Persist round model override lineage for evidence reads
+
+PR-D reads seeded override rows to classify round roles without adding admin
+write routes. The schema constrains overrides to a single supersession lineage
+per fund round so the adapter can fail closed on corrupt chains.
+
+Constraint: PR-E owns override write routes and idempotency enforcement
+Rejected: Defer idempotency columns | adding nullable columns now avoids a future table rewrite
+Confidence: medium
+Scope-risk: moderate
+Tested: npm run check
+Not-tested: Real database migration application
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+"@
+```
+
+---
+
+### Task 6: Rounds-to-Model Adapter
+
+**Files:**
+
+- Create: `server/services/rounds-to-model-evidence-service.ts`
+- Test: `tests/unit/services/rounds-to-model-evidence-service.test.ts`
+
+**Interfaces:**
+
+- Consumes:
+  - `db` by default, injectable database for tests.
+  - `investmentRounds`, `investmentRoundModelOverrides`, `funds`, `investments`,
+    `portfolioCompanies`.
+  - `serializeRoundsToModelEvidence`.
+  - `makeLiveRoundsProvenance`, `makePartialRoundsProvenance`,
+    `makeCurrencyBlockedProvenance`, `makeAdapterFailedProvenance`.
+- Produces:
+  - `buildRoundsToModelEvidence(params): Promise<RoundsToModelEvidence>`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Create `tests/unit/services/rounds-to-model-evidence-service.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  buildRoundsToModelEvidenceFromRows,
+  type RoundsEvidenceRows,
+} from '../../../server/services/rounds-to-model-evidence-service';
+
+const now = new Date('2026-06-24T00:00:00.000Z');
+
+const baseRows: RoundsEvidenceRows = {
+  fund: { id: 10, baseCurrency: 'USD' },
+  companies: [{ id: 101, name: 'Acme' }],
+  investments: [{ id: 201, fundId: 10, companyId: 101 }],
+  activeRounds: [
+    {
+      id: 1,
+      fundId: 10,
+      investmentId: 201,
+      roundDate: '2024-01-15',
+      createdAt: new Date('2024-01-16T00:00:00.000Z'),
+      securityType: 'equity',
+      currency: 'USD',
+      investmentAmount: '500000.000000',
+    },
+    {
+      id: 2,
+      fundId: 10,
+      investmentId: 201,
+      roundDate: '2025-02-01',
+      createdAt: new Date('2025-02-02T00:00:00.000Z'),
+      securityType: 'safe',
+      currency: 'USD',
+      investmentAmount: '125000.000000',
+    },
+  ],
+  activeOverrides: [],
+};
+
+describe('buildRoundsToModelEvidenceFromRows', () => {
+  it('aggregates all active rounds without latest-only collapse', () => {
+    const evidence = buildRoundsToModelEvidenceFromRows({
+      fundId: 10,
+      now,
+      rows: baseRows,
+    });
+
+    expect(evidence.companies).toHaveLength(1);
+    expect(evidence.companies[0]?.roundCount).toBe(2);
+    expect(evidence.companies[0]?.initialAmount).toBe('500000.000000');
+    expect(evidence.companies[0]?.followOnAmount).toBe('125000.000000');
+    expect(evidence.coverage.activeRoundCount).toBe(2);
+  });
+
+  it('treats non-equity rounds as amount-only evidence', () => {
+    const evidence = buildRoundsToModelEvidenceFromRows({
+      fundId: 10,
+      now,
+      rows: baseRows,
+    });
+
+    const safeRound = evidence.companies[0]?.rounds.find(
+      (round) => round.securityType === 'safe'
+    );
+    expect(safeRound?.amountOnly).toBe(true);
+    expect(evidence.companies[0]?.amountOnlyNonEquityAmount).toBe(
+      '125000.000000'
+    );
+    expect(evidence.coverage.warningsByCode.NON_EQUITY_AMOUNT_ONLY).toBe(1);
+  });
+
+  it('blocks mismatched currency after override classification', () => {
+    const evidence = buildRoundsToModelEvidenceFromRows({
+      fundId: 10,
+      now,
+      rows: {
+        ...baseRows,
+        activeRounds: [
+          {
+            ...baseRows.activeRounds[0],
+            currency: 'EUR',
+          },
+        ],
+      },
+    });
+
+    expect(evidence.provenance.trustState).toBe('UNAVAILABLE');
+    expect(evidence.provenance.core.quarantineReason).toBe('currency_mismatch');
+  });
+
+  it('fails closed on override lineage crossing fund-round boundaries', () => {
+    expect(() =>
+      buildRoundsToModelEvidenceFromRows({
+        fundId: 10,
+        now,
+        rows: {
+          ...baseRows,
+          activeOverrides: [
+            {
+              id: 1,
+              fundId: 10,
+              roundId: 1,
+              overrideRole: 'initial',
+              supersedesOverrideId: null,
+              createdAt: new Date('2024-01-16T00:00:00.000Z'),
+            },
+            {
+              id: 2,
+              fundId: 10,
+              roundId: 2,
+              overrideRole: 'follow_on',
+              supersedesOverrideId: 1,
+              createdAt: new Date('2024-01-17T00:00:00.000Z'),
+            },
+          ],
+        },
+      })
+    ).toThrow('Override lineage crosses fund-round boundaries');
+  });
+
+  it('serializes through the strict evidence boundary', () => {
+    const evidence = buildRoundsToModelEvidenceFromRows({
+      fundId: 10,
+      now,
+      rows: baseRows,
+    });
+
+    expect(evidence).not.toHaveProperty('shadowDiff');
+    expect(evidence).not.toHaveProperty('candidateResponse');
+    expect(evidence).not.toHaveProperty('exportEligibility');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/services/rounds-to-model-evidence-service.test.ts --project=server
+```
+
+Expected:
+
+- FAIL because service does not exist.
+
+- [ ] **Step 3: Implement row adapter and service boundary**
+
+Create `server/services/rounds-to-model-evidence-service.ts`:
+
+```ts
+import { and, asc, eq, notExists } from 'drizzle-orm';
+
+import { db } from '../db';
+import { funds } from '../../shared/schema/fund';
+import { investments, portfolioCompanies } from '../../shared/schema/portfolio';
+import { investmentRounds } from '../../shared/schema/investment-rounds';
+import { investmentRoundModelOverrides } from '../../shared/schema/investment-round-model-overrides';
+import {
+  serializeRoundsToModelEvidence,
+  type RoundsToModelEvidence,
+  type RoundModelRole,
+} from '../../shared/contracts/rounds-to-model-evidence.contract';
+import type { StructuredWarning } from '../../shared/contracts/provenance-envelope.contract';
+import {
+  makeCurrencyBlockedProvenance,
+  makeLiveRoundsProvenance,
+  makePartialRoundsProvenance,
+} from '../lib/rounds-provenance';
+
+type FundRow = { id: number; baseCurrency: string };
+type CompanyRow = { id: number; name: string };
+type InvestmentRow = { id: number; fundId: number; companyId: number | null };
+type ActiveRoundRow = {
+  id: number;
+  fundId: number;
+  investmentId: number;
+  roundDate: string;
+  createdAt: Date | null;
+  securityType: 'equity' | 'convertible_note' | 'safe' | 'warrant' | 'other';
+  currency: string;
+  investmentAmount: string;
+};
+type ActiveOverrideRow = {
+  id: number;
+  fundId: number;
+  roundId: number;
+  overrideRole: 'initial' | 'follow_on' | 'amount_only';
+  supersedesOverrideId: number | null;
+  createdAt: Date;
+};
+
+export type RoundsEvidenceRows = {
+  fund: FundRow;
+  companies: CompanyRow[];
+  investments: InvestmentRow[];
+  activeRounds: ActiveRoundRow[];
+  activeOverrides: ActiveOverrideRow[];
+};
+
+type BuildParams = {
+  fundId: number;
+  now: Date;
+  rows: RoundsEvidenceRows;
+};
+
+function decimalAdd(left: string, right: string): string {
+  const [leftWhole, leftFraction = ''] = left.split('.');
+  const [rightWhole, rightFraction = ''] = right.split('.');
+  const scale = 6;
+  const leftUnits =
+    BigInt(leftWhole) * 1_000_000n + BigInt(leftFraction.padEnd(scale, '0'));
+  const rightUnits =
+    BigInt(rightWhole) * 1_000_000n + BigInt(rightFraction.padEnd(scale, '0'));
+  const sum = leftUnits + rightUnits;
+  return `${sum / 1_000_000n}.${(sum % 1_000_000n).toString().padStart(scale, '0')}`;
+}
+
+function zeroDecimal(): string {
+  return '0.000000';
+}
+
+function validateOverrideLineage(overrides: ActiveOverrideRow[]): void {
+  const byId = new Map(overrides.map((override) => [override.id, override]));
+  for (const override of overrides) {
+    if (override.supersedesOverrideId === null) {
+      continue;
+    }
+    const parent = byId.get(override.supersedesOverrideId);
+    if (!parent) {
+      continue;
+    }
+    if (
+      parent.fundId !== override.fundId ||
+      parent.roundId !== override.roundId
+    ) {
+      throw new Error('Override lineage crosses fund-round boundaries');
+    }
+  }
+}
+
+function latestOverrideByRound(
+  overrides: ActiveOverrideRow[]
+): Map<number, ActiveOverrideRow> {
+  validateOverrideLineage(overrides);
+  const superseded = new Set(
+    overrides
+      .map((override) => override.supersedesOverrideId)
+      .filter((id): id is number => id !== null)
+  );
+  const active = overrides.filter((override) => !superseded.has(override.id));
+  const byRound = new Map<number, ActiveOverrideRow>();
+  for (const override of active) {
+    if (byRound.has(override.roundId)) {
+      throw new Error(
+        `Multiple active overrides for round ${override.roundId}`
+      );
+    }
+    byRound.set(override.roundId, override);
+  }
+  return byRound;
+}
+
+function roleForRound(params: {
+  round: ActiveRoundRow;
+  indexWithinInvestment: number;
+  override?: ActiveOverrideRow;
+}): RoundModelRole {
+  if (params.override) {
+    return params.override.overrideRole;
+  }
+  if (params.round.securityType !== 'equity') {
+    return 'amount_only';
+  }
+  return params.indexWithinInvestment === 0 ? 'initial' : 'follow_on';
+}
+
+function addWarning(
+  warnings: StructuredWarning[],
+  code: StructuredWarning['code'],
+  severity: StructuredWarning['severity'],
+  message: string,
+  source?: string
+): void {
+  warnings.push(
+    source ? { code, severity, message, source } : { code, severity, message }
+  );
+}
+
+export function buildRoundsToModelEvidenceFromRows(
+  params: BuildParams
+): RoundsToModelEvidence {
+  const warnings: StructuredWarning[] = [];
+  const byCompany = new Map(
+    params.rows.companies.map((company) => [company.id, company])
+  );
+  const byInvestment = new Map(
+    params.rows.investments.map((investment) => [investment.id, investment])
+  );
+  const overridesByRound = latestOverrideByRound(params.rows.activeOverrides);
+  const roundsByInvestment = new Map<number, ActiveRoundRow[]>();
+
+  for (const round of params.rows.activeRounds) {
+    const rounds = roundsByInvestment.get(round.investmentId) ?? [];
+    rounds.push(round);
+    roundsByInvestment.set(round.investmentId, rounds);
+  }
+
+  const companyEvidence = new Map<
+    number,
+    {
+      companyId: number;
+      companyName: string;
+      investmentIds: Set<number>;
+      initialAmount: string;
+      followOnAmount: string;
+      amountOnlyNonEquityAmount: string;
+      rounds: RoundsToModelEvidence['companies'][number]['rounds'];
+      warnings: StructuredWarning[];
+    }
+  >();
+  let currencyBlocked = false;
+
+  for (const [
+    investmentId,
+    investmentRoundsForInvestment,
+  ] of roundsByInvestment) {
+    investmentRoundsForInvestment.sort((left, right) => {
+      const byDate = left.roundDate.localeCompare(right.roundDate);
+      if (byDate !== 0) return byDate;
+      const byCreated = String(left.createdAt ?? '').localeCompare(
+        String(right.createdAt ?? '')
+      );
+      if (byCreated !== 0) return byCreated;
+      return left.id - right.id;
+    });
+
+    const investment = byInvestment.get(investmentId);
+    if (!investment?.companyId) {
+      addWarning(
+        warnings,
+        'ROLE_CLASSIFICATION_AMBIGUOUS',
+        'warning',
+        `Investment ${investmentId} has no parent company.`,
+        `investment:${investmentId}`
+      );
+      continue;
+    }
+    const company = byCompany.get(investment.companyId);
+    if (!company) {
+      addWarning(
+        warnings,
+        'ROLE_CLASSIFICATION_AMBIGUOUS',
+        'warning',
+        `Company ${investment.companyId} was not loaded for investment ${investmentId}.`,
+        `investment:${investmentId}`
+      );
+      continue;
+    }
+
+    const evidence = companyEvidence.get(company.id) ?? {
+      companyId: company.id,
+      companyName: company.name,
+      investmentIds: new Set<number>(),
+      initialAmount: zeroDecimal(),
+      followOnAmount: zeroDecimal(),
+      amountOnlyNonEquityAmount: zeroDecimal(),
+      rounds: [],
+      warnings: [],
+    };
+    evidence.investmentIds.add(investmentId);
+
+    investmentRoundsForInvestment.forEach((round, indexWithinInvestment) => {
+      const override = overridesByRound.get(round.id);
+      const role = roleForRound({ round, indexWithinInvestment, override });
+      const amountOnly =
+        role === 'amount_only' || round.securityType !== 'equity';
+      const roundWarnings: StructuredWarning[] = [];
+
+      if (round.currency !== params.rows.fund.baseCurrency) {
+        currencyBlocked = true;
+        addWarning(
+          warnings,
+          'CURRENCY_MISMATCH_BLOCK',
+          'blocking',
+          `Round ${round.id} currency ${round.currency} does not match fund base currency ${params.rows.fund.baseCurrency}.`,
+          `round:${round.id}`
+        );
+      }
+
+      if (override) {
+        addWarning(
+          warnings,
+          'ROUND_MODEL_OVERRIDE_APPLIED',
+          'info',
+          `Override ${override.id} applied to round ${round.id}.`,
+          `round:${round.id}`
+        );
+      }
+
+      if (amountOnly) {
+        const warning = {
+          code: 'NON_EQUITY_AMOUNT_ONLY' as const,
+          severity: 'warning' as const,
+          message: `Round ${round.id} is ${round.securityType} and contributes amount-only evidence.`,
+          source: `round:${round.id}`,
+        };
+        warnings.push(warning);
+        roundWarnings.push(warning);
+        evidence.amountOnlyNonEquityAmount = decimalAdd(
+          evidence.amountOnlyNonEquityAmount,
+          round.investmentAmount
+        );
+      } else if (role === 'initial') {
+        evidence.initialAmount = decimalAdd(
+          evidence.initialAmount,
+          round.investmentAmount
+        );
+      } else if (role === 'follow_on') {
+        evidence.followOnAmount = decimalAdd(
+          evidence.followOnAmount,
+          round.investmentAmount
+        );
+      }
+
+      evidence.rounds.push({
+        roundId: round.id,
+        investmentId: round.investmentId,
+        companyId: company.id,
+        roundDate: round.roundDate,
+        securityType: round.securityType,
+        role,
+        currency: round.currency,
+        investmentAmount: round.investmentAmount,
+        amountOnly,
+        overrideApplied: Boolean(override),
+      });
+      evidence.warnings.push(...roundWarnings);
+    });
+
+    companyEvidence.set(company.id, evidence);
+  }
+
+  if (params.rows.activeRounds.length === 0) {
+    addWarning(
+      warnings,
+      'EMPTY_FUND',
+      'info',
+      'No active investment rounds were found.'
+    );
+  }
+
+  const warningsByCode = warnings.reduce<Record<string, number>>(
+    (record, warning) => {
+      record[warning.code] = (record[warning.code] ?? 0) + 1;
+      return record;
+    },
+    {}
+  );
+  const hashParams = {
+    fundId: params.fundId,
+    baseCurrency: params.rows.fund.baseCurrency,
+    activeRounds: params.rows.activeRounds,
+    activeOverrides: params.rows.activeOverrides,
+    parentInvestments: params.rows.investments,
+    companies: params.rows.companies,
+  };
+  const provenance = currencyBlocked
+    ? makeCurrencyBlockedProvenance({
+        now: params.now,
+        hashParams,
+        structuredWarnings: warnings,
+      })
+    : warnings.some(
+          (warning) =>
+            warning.severity === 'warning' || warning.severity === 'blocking'
+        )
+      ? makePartialRoundsProvenance({
+          now: params.now,
+          hashParams,
+          structuredWarnings: warnings,
+        })
+      : makeLiveRoundsProvenance({
+          now: params.now,
+          hashParams,
+          structuredWarnings: warnings,
+        });
+
+  return serializeRoundsToModelEvidence({
+    fundId: params.fundId,
+    baseCurrency: params.rows.fund.baseCurrency,
+    generatedAt: params.now.toISOString(),
+    companies: Array.from(companyEvidence.values()).map((company) => ({
+      ...company,
+      investmentIds: Array.from(company.investmentIds).sort(
+        (left, right) => left - right
+      ),
+      roundCount: company.rounds.length,
+    })),
+    coverage: {
+      companyCount: companyEvidence.size,
+      investmentCount: params.rows.investments.length,
+      activeRoundCount: params.rows.activeRounds.length,
+      activeOverrideCount: params.rows.activeOverrides.length,
+      warningsByCode,
+    },
+    provenance,
+  });
+}
+
+export async function buildRoundsToModelEvidence(params: {
+  fundId: number;
+  now?: Date;
+  database?: typeof db;
+}): Promise<RoundsToModelEvidence> {
+  const database = params.database ?? db;
+  const now = params.now ?? new Date();
+  const [fund] = await database
+    .select({ id: funds.id, baseCurrency: funds.baseCurrency })
+    .from(funds)
+    .where(eq(funds.id, params.fundId))
+    .limit(1);
+  if (!fund) {
+    throw new Error(`Fund ${params.fundId} was not found`);
+  }
+
+  const companies = await database
+    .select({ id: portfolioCompanies.id, name: portfolioCompanies.name })
+    .from(portfolioCompanies)
+    .where(eq(portfolioCompanies.fundId, params.fundId))
+    .orderBy(asc(portfolioCompanies.id));
+  const parentInvestments = await database
+    .select({
+      id: investments.id,
+      fundId: investments.fundId,
+      companyId: investments.companyId,
+    })
+    .from(investments)
+    .where(eq(investments.fundId, params.fundId))
+    .orderBy(asc(investments.id));
+  const supersedingRounds = investmentRounds;
+  const activeRounds = await database
+    .select({
+      id: investmentRounds.id,
+      fundId: investmentRounds.fundId,
+      investmentId: investmentRounds.investmentId,
+      roundDate: investmentRounds.roundDate,
+      createdAt: investmentRounds.createdAt,
+      securityType: investmentRounds.securityType,
+      currency: investmentRounds.currency,
+      investmentAmount: investmentRounds.investmentAmount,
+    })
+    .from(investmentRounds)
+    .where(
+      and(
+        eq(investmentRounds.fundId, params.fundId),
+        notExists(
+          database
+            .select({ id: supersedingRounds.id })
+            .from(supersedingRounds)
+            .where(eq(supersedingRounds.supersedesRoundId, investmentRounds.id))
+        )
+      )
+    )
+    .orderBy(
+      asc(investmentRounds.investmentId),
+      asc(investmentRounds.roundDate),
+      asc(investmentRounds.createdAt),
+      asc(investmentRounds.id)
+    );
+  const activeOverrides = await database
+    .select({
+      id: investmentRoundModelOverrides.id,
+      fundId: investmentRoundModelOverrides.fundId,
+      roundId: investmentRoundModelOverrides.roundId,
+      overrideRole: investmentRoundModelOverrides.overrideRole,
+      supersedesOverrideId: investmentRoundModelOverrides.supersedesOverrideId,
+      createdAt: investmentRoundModelOverrides.createdAt,
+    })
+    .from(investmentRoundModelOverrides)
+    .where(eq(investmentRoundModelOverrides.fundId, params.fundId))
+    .orderBy(
+      asc(investmentRoundModelOverrides.roundId),
+      asc(investmentRoundModelOverrides.createdAt),
+      asc(investmentRoundModelOverrides.id)
+    );
+
+  return buildRoundsToModelEvidenceFromRows({
+    fundId: params.fundId,
+    now,
+    rows: {
+      fund,
+      companies,
+      investments: parentInvestments,
+      activeRounds: activeRounds as ActiveRoundRow[],
+      activeOverrides: activeOverrides as ActiveOverrideRow[],
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run adapter tests**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/services/rounds-to-model-evidence-service.test.ts --project=server
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add server/services/rounds-to-model-evidence-service.ts tests/unit/services/rounds-to-model-evidence-service.test.ts
+git commit -m @"
+Adapt active rounds into strict model evidence
+
+The adapter reads every non-superseded round and emits strict evidence without
+changing live ranking behavior. Currency and override corruption fail closed
+through provenance instead of leaking ambiguous model inputs.
+
+Constraint: PR-D must remain read-only and route-free
+Rejected: Latest-only round selection | follow-on rounds are active evidence, not superseded history
+Confidence: medium
+Scope-risk: moderate
+Tested: cross-env TZ=UTC vitest run tests/unit/services/rounds-to-model-evidence-service.test.ts --project=server
+Not-tested: Full server test project
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+"@
+```
+
+---
+
+### Task 7: Live MOIC Freeze Regression
+
+**Files:**
+
+- Modify: `tests/unit/services/fund-moic-ranking-service.test.ts`
+
+**Interfaces:**
+
+- Consumes: `getFundMoicRankings(fundId: number)`.
+- Produces: a regression proving the service reads `portfolioCompanies`, not
+  `investmentRounds`, and passes `followOnAmount: null`.
+
+- [ ] **Step 1: Add DB-path regression test**
+
+Modify `tests/unit/services/fund-moic-ranking-service.test.ts` by adding a
+module mock before importing the service:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const findMany = vi.fn();
+const investmentRoundsFindMany = vi.fn();
+
+vi.mock('../../../server/db', () => ({
+  db: {
+    query: {
+      portfolioCompanies: { findMany },
+      investmentRounds: { findMany: investmentRoundsFindMany },
+    },
+  },
+}));
+```
+
+Add this test:
+
+```ts
+it('keeps live rankings sourced from portfolioCompanies and ignores investment_rounds', async () => {
+  findMany.mockResolvedValue([
+    {
+      id: 101,
+      name: 'Acme',
+      investmentAmount: 500_000,
+      currentValuation: 1_500_000,
+      plannedReservesCents: 300_000_00,
+      exitMoicBps: 35000,
+      investmentDate: new Date('2022-01-01T00:00:00.000Z'),
+    },
+  ]);
+
+  const { getFundMoicRankings } =
+    await import('../../../server/services/fund-moic-ranking-service');
+  const result = await getFundMoicRankings(10);
+
+  expect(findMany).toHaveBeenCalledOnce();
+  expect(investmentRoundsFindMany).not.toHaveBeenCalled();
+  expect(result.provenance.source).toBe('portfolio_companies');
+  expect(result.provenance.metricBasis).toBe('planned_reserves');
+  expect(result.rankings).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run focused test**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/services/fund-moic-ranking-service.test.ts --project=server
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add tests/unit/services/fund-moic-ranking-service.test.ts
+git commit -m @"
+Freeze live MOIC rankings away from rounds evidence
+
+PR-D adds a read-only evidence adapter but live MOIC rankings must continue to
+use portfolio company planned reserves until a later explicit promotion PR.
+
+Constraint: PR-D must not alter live MOIC ranking behavior
+Rejected: Wire rounds evidence into getFundMoicRankings | route/render promotion is PR-E scope
+Confidence: high
+Scope-risk: narrow
+Tested: cross-env TZ=UTC vitest run tests/unit/services/fund-moic-ranking-service.test.ts --project=server
+Not-tested: Full server test project
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+"@
+```
+
+---
+
+### Task 8: Client Financial-Claim Guardrail
+
+**Files:**
+
+- Create: `scripts/guardrails/no-client-round-derived-financial-claims.mjs`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Consumes: client files under `client/src`.
+- Produces: npm script `guard:round-derived-financial-claims:check`.
+
+- [ ] **Step 1: Create guardrail script**
+
+Create `scripts/guardrails/no-client-round-derived-financial-claims.mjs`:
+
+```js
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const root = process.cwd();
+const tracked = execFileSync('git', ['ls-files', 'client/src'], {
+  cwd: root,
+  encoding: 'utf8',
+})
+  .split('\n')
+  .filter(Boolean);
+
+const bannedPatterns = [
+  /investmentRounds.*(moic|irr|tvpi|dpi|valuation|reserve)/i,
+  /(moic|irr|tvpi|dpi|valuation|reserve).*investmentRounds/i,
+  /roundsToModel.*(ranking|financial|metric|moic)/i,
+];
+
+const allowlist = new Set([
+  'client/src/components/investments/InvestmentRoundsSection.tsx',
+  'client/src/hooks/useInvestmentRounds.ts',
+]);
+
+const violations = [];
+
+for (const file of tracked) {
+  if (allowlist.has(file)) {
+    continue;
+  }
+  const absolute = resolve(root, file);
+  const content = readFileSync(absolute, 'utf8');
+  for (const pattern of bannedPatterns) {
+    if (pattern.test(content)) {
+      violations.push(relative(root, absolute));
+      break;
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('Client round-derived financial claim guardrail failed:');
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log('Client round-derived financial claim guardrail passed.');
+```
+
+- [ ] **Step 2: Run guardrail before wiring**
+
+Run:
+
+```powershell
+node scripts/guardrails/no-client-round-derived-financial-claims.mjs
+```
+
+Expected:
+
+- PASS. If it fails on existing legitimate display files, add those exact files
+  to the allowlist and rerun.
+
+- [ ] **Step 3: Wire guardrail only after it passes**
+
+Modify `package.json` scripts:
+
+```json
+"guard:round-derived-financial-claims:check": "node scripts/guardrails/no-client-round-derived-financial-claims.mjs",
+"guardrails:check": "npm run guard:console:check && npm run guard:eslint-disable:check && npm run guard:scripts:check && npm run guard:route-imports:check && npm run guard:financial-placeholders:check && npm run guard:round-derived-financial-claims:check"
+```
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```powershell
+npm run lint
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/guardrails/no-client-round-derived-financial-claims.mjs package.json
+git commit -m @"
+Guard against premature client round-derived metrics
+
+PR-D keeps rounds evidence read-only and server-side. A narrow guardrail blocks
+new client claims that derive financial metrics directly from investment rounds
+before PR-E promotes the evidence surface.
+
+Constraint: Existing client round display remains allowed
+Rejected: Ban all investmentRounds client usage | current UI legitimately displays rounds
+Confidence: medium
+Scope-risk: narrow
+Tested: npm run lint
+Not-tested: Full release gate
+Co-authored-by: OmX <omx@oh-my-codex.dev>
+"@
+```
+
+---
+
+### Task 9: Final Verification + PR Description
+
+**Files:**
+
+- No required source changes.
+- Optional create: `.claude/artifacts/pr-d-provenance-envelope-pr-body.md` only
+  if the implementation lane uses `.claude/artifacts` for PR bodies and keeps it
+  out of commit unless explicitly requested.
+
+**Interfaces:**
+
+- Consumes all prior task commits.
+- Produces verified branch and PR-ready evidence.
+
+- [ ] **Step 1: Run contract tests**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/contract/provenance-envelope.contract.test.ts tests/unit/contract/rounds-to-model-evidence.contract.test.ts --project=server
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 2: Run service tests**
+
+Run:
+
+```powershell
+cross-env TZ=UTC vitest run tests/unit/services/rounds-to-model-evidence-service.test.ts tests/unit/services/fund-moic-ranking-service.test.ts --project=server
+```
+
+Expected:
+
+- PASS.
+
+- [ ] **Step 3: Run final gates**
+
+Run:
+
+```powershell
+npm run policy:verify
+npm run lint
+npm run check
+npm run test -- --project=server
+npm run release:check
+```
+
+Expected:
+
+- PASS for each command.
+- If Windows local proof is unreliable, rerun `npm run release:check` in a
+  supported native WSL Node 20 environment and report the environment boundary
+  explicitly.
+
+- [ ] **Step 4: Verify migration path wording**
+
+Do not claim `npm run db:push` ran the hand-written migration. Use this wording
+in PR notes:
+
+```md
+Hand-written SQL lives under
+`server/migrations/20260624_investment_round_model_overrides_v1.{up,down}.sql`.
+Drizzle schema exports are kept in sync. `npm run db:push` is only a
+disposable-database schema compatibility check, not proof that the hand-written
+migration path ran.
+```
+
+- [ ] **Step 5: Draft PR body**
+
+Use this PR body structure:
+
+```md
+## Scope
+
+PR-D introduces a strict, hash-bound dataset provenance envelope and a read-only
+rounds-to-model evidence adapter over all non-superseded investment rounds, with
+override-aware currency blocking and amount-only non-equity handling; it does
+not alter live MOIC rankings, add routes, expose shadow/candidate responses, or
+enforce render blocking.
+
+## Baseline
+
+- Baseline: `e8113431`
+- Branch: `claude/beautiful-heisenberg-btcsmw`
+- Checkout isolation: [state whether direct clean branch or isolated worktree
+  was used]
+
+## What Changed
+
+- Added strict provenance envelope contract around existing
+  `FinancialProvenanceSchema`.
+- Added strict rounds-to-model evidence contract and serialization boundary.
+- Added read-only override persistence schema and SQL migration.
+- Added read-only rounds evidence adapter over all non-superseded rounds.
+- Added MOIC regression proving live rankings still ignore `investment_rounds`.
+- Added narrow guardrail against premature client financial derivation from
+  rounds.
+
+## Out of Scope
+
+- Routes and render enforcement.
+- `DATA_STALE` route-policy promotion.
+- Shadow controller.
+- Reconciliation persistence.
+- Canonical MOIC route.
+- `fund_calculation_modes`.
+- Override write/admin routes and write-path idempotency.
+
+## Verification
+
+- [paste exact commands and pass/fail results]
+
+## Migration Notes
+
+[paste Task 9 Step 4 wording]
+```
+
+- [ ] **Step 6: Final status check**
+
+Run:
+
+```powershell
+git status --short
+git log --oneline --max-count=8
+```
+
+Expected:
+
+- Only intentional PR-D files are modified or committed.
+- Unrelated root checkout dirt remains untouched if execution used a worktree.
+
+---
+
+## Migration Proof Boundary
+
+The implementation must distinguish three different checks:
+
+1. `server/migrations/20260624_investment_round_model_overrides_v1.up.sql` and
+   `.down.sql` exist and are internally reversible.
+2. Drizzle schema exports compile and stay aligned with SQL intent.
+3. `npm run db:push`, if run, proves disposable-database schema compatibility
+   only. It does not prove the hand-written migration runner applied the SQL
+   file.
+
+Do not collapse these into one generic "migration applied" claim.
+
+## Out of Scope for PR-E
+
+- HTTP route for rounds-to-model evidence.
+- Render blocking via `staleBlocksRender`.
+- `DATA_STALE` promotion into route policy.
+- Shadow/candidate response controller.
+- Reconciliation persistence.
+- Canonical MOIC route.
+- `fund_calculation_modes`.
+- `LIVE imported_actual` promotion.
+- Override write/admin routes.
+- Override write-path idempotency enforcement.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Provenance envelope: Task 2 and Task 4.
+  - Evidence contract: Task 3.
+  - Override persistence: Task 5.
+  - Active all-round adapter: Task 6.
+  - MOIC unchanged: Task 7.
+  - Guardrail: Task 8.
+  - Verification and PR body: Task 9.
+- Placeholder scan:
+  - No placeholder markers or unconstrained generic edge-case instructions
+    remain.
+- Type consistency:
+  - `ProvenanceEnvelope` is produced by Task 2 and consumed by Tasks 3 and 4.
+  - `RoundsToModelEvidence` is produced by Task 3 and returned by Task 6.
+  - `RoundModelRole` values match override roles: `initial`, `follow_on`,
+    `amount_only`.
+- Execution safety:
+  - Dirty checkout handling is explicit.
+  - Migration proof boundary is explicit.
+  - Live MOIC remains frozen.

--- a/docs/superpowers/plans/2026-06-24-pr-e-moic-shadow-recording-canonical-route.md
+++ b/docs/superpowers/plans/2026-06-24-pr-e-moic-shadow-recording-canonical-route.md
@@ -1,0 +1,218 @@
+# PR-E MOIC Shadow Recording And Canonical Route Implementation Plan
+
+> Status: in execution on branch `feat/pr-e-moic-shadow-recording` (2026-06-24).
+> Dispatch model: Hermes production lane (codex worker) per workflow contract;
+> Claude does intake / context / planning / verification. Each chunk is verified
+> with targeted Vitest (the `npm run check` postflight does NOT run vitest nor
+> typecheck test files).
+
+**Goal:** Extend the existing fund MOIC V1 surface with explicit
+no-op/materiality proof, opt-in V2 metadata, admin-triggered reconciliation
+recording, and canonical routing without shipping `on` mode activation.
+
+**Architecture:** Default V1 stays exact and side-effect free. V2 GET is
+side-effect free and reads the latest completed reconciliation only.
+Reconciliation recording happens through an idempotent admin POST.
+`fund_calculation_modes`, residency, kill switch, and `on` mode are deferred
+until a candidate can actually move `reservesMoic`.
+
+**Tech Stack:** TypeScript, Express, React/Wouter, TanStack Query, Zod strict
+contracts, Drizzle migrations, Vitest, `canonicalSha256`.
+
+---
+
+## Scope
+
+- PR-E includes: materiality/no-op characterization,
+  `exitProbability = null -> 0` defect pinning, strict V2 read shape, idempotent
+  admin reconciliation POST, canonical route, route-policy classifier fix,
+  dual-surface proof.
+- PR-E excludes: `fund_calculation_modes`, `modePreview`, seven-day residency,
+  kill switch, `on`, visible "round-aware ranking" claims.
+- Candidate stance: PR-E's candidate is a no-op candidate for reserves MOIC
+  unless a future `exitProbability`, `plannedReserves`, or `reserveExitMultiple`
+  source is introduced. The materiality service must detect such future changes.
+
+## Key Interfaces
+
+- `GET /api/funds/:fundId/moic/rankings`
+  - Default / `?contract=v1`: existing strict V1.
+  - `?contract=v2`: strict V2, no persistence.
+  - Unknown contract: 400.
+
+- `POST /api/admin/funds/:fundId/moic/reconciliations`
+  - Implement inside `server/routes/fund-moic.ts` as router path
+    `/admin/funds/:fundId/moic/reconciliations` (router mounted at `/api` in
+    both active surfaces).
+  - Missing `Idempotency-Key`: 428.
+  - Same key + same `request_hash`: replay existing run.
+  - Same key + different `request_hash`: 409.
+  - Requires auth, fund access, and `admin` role.
+
+- V2 schema (see plan body for full Zod). Reuses `FundMoicRankingItemV1Schema`.
+
+## Data Model — `reconciliation_runs` only
+
+- `id`, `fund_id`, `idempotency_key`, `request_hash`, `requested_by`,
+  `requested_at`, `status`.
+- `legacy_input_hash`, `candidate_input_hash`, `evidence_input_hash`,
+  `assumptions_hash`.
+- `legacy_output_hash`, `candidate_output_hash`.
+- `candidate_material` boolean, fixed false in PR-E unless a material candidate
+  is introduced.
+- `materiality_epsilon`, fixed `1e-8`.
+- `diff_summary jsonb`: counts only (`comparedInvestmentCount`,
+  `rankChangeCount`, `reservesMoicValueChangeCount`, `materialChangeCount`).
+- `round_evidence_summary jsonb`: counts and warning codes only.
+- Do NOT persist raw ranking arrays, ranking values, monetary values, raw diffs,
+  per-investment shadow comparisons, or per-round MOIC figures.
+
+Use `canonicalSha256` for ranked-array hashes and evidence hashes. Evidence hash
+uses the existing round-evidence snapshot path and live override enum values:
+`initial`, `follow_on`, `amount_only`.
+
+---
+
+## Execution Refinements (verified against `main` @ 2026-06-24)
+
+Ground-truth file map (all verified to exist unless noted):
+
+| Concern                          | Location                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| MOIC route                       | `server/routes/fund-moic.ts` — GET `/funds/:fundId/moic/rankings`, mounted `/api` in `server/app.ts:225` (makeApp) AND `server/routes.ts:87` (registerRoutes)                                                                                                                                                                                                      |
+| Ranking service                  | `server/services/fund-moic-ranking-service.ts` — `getFundMoicRankings(fundId)`, `buildMoicRankingsFromInvestments(fundId, investments)`                                                                                                                                                                                                                            |
+| MOIC calculator                  | `shared/core/moic/MOICCalculator.ts` — `rankByReservesMOIC` / `calculateReservesMOIC`                                                                                                                                                                                                                                                                              |
+| `exitProbability` null->0 defect | `server/routes/moic.ts` `dbToMOICInvestment()` — `toNumber(null) => 0`, so `reservesMOIC.value` collapses to 0 for null `exitProbability`. PIN, do not fix.                                                                                                                                                                                                        |
+| V1 contract                      | `shared/contracts/fund-moic-v1.contract.ts` — exports `FundMoicRankingItemV1Schema`, `FundMoicRankingsResponseV1Schema`                                                                                                                                                                                                                                            |
+| Route-policy classifier          | `server/route-policy/api-route-policy-registry.ts` — `getFinancialSurfaceForGovernanceEntry` (the `moic_reserves` branch is at ~line 74, BEFORE the `startsWith('/fund-model-results')` -> `fund_modeling` branch at ~line 85). Registry stores paths as LITERAL templates (e.g. `'/fund-model-results/:fundId/scenarios'` line 248, `'/moic-analysis'` line 300). |
+| `canonicalSha256`                | `shared/lib/canonical-hash.ts`                                                                                                                                                                                                                                                                                                                                     |
+| `requireRole`                    | `server/lib/auth/jwt.ts:245` — `requireRole('admin')`, 403 on mismatch. `requireAuth()`, `requireFundAccess` also here.                                                                                                                                                                                                                                            |
+| V1 hook                          | `client/src/hooks/use-moic.ts` — `useFundMoicRankings`, query key `['fund-moic-rankings', fundId]`                                                                                                                                                                                                                                                                 |
+| `/moic-analysis` page            | `client/src/pages/moic-analysis.tsx`; route in `client/src/app/app-route-definitions.ts:21` + `client/src/app/app-routes.tsx:36,98`                                                                                                                                                                                                                                |
+| Fund-model-results route family  | already present: `/fund-model-results/:fundId`, `/fund-model-results/:fundId/scenarios`                                                                                                                                                                                                                                                                            |
+| `OLD_TO_NEW_REDIRECTS`           | `client/src/core/routes/ia.ts` — do NOT edit; `/moic-analysis` is asserted absent in `tests/unit/app/legacy-route-map.test.ts`                                                                                                                                                                                                                                     |
+| Round-evidence enum              | `shared/contracts/rounds-to-model-evidence.contract.ts:13` — `RoundModelRoleSchema = z.enum(['initial','follow_on','ambiguous','amount_only'])`                                                                                                                                                                                                                    |
+| Round-evidence snapshot          | `server/services/rounds-to-model-evidence-service.ts`                                                                                                                                                                                                                                                                                                              |
+| Drizzle schema dir               | `shared/schema/` (canonical, `db:push` source); barrel `shared/schema.ts`; new table -> `shared/schema/reconciliation-runs.ts` + `export * from './schema/reconciliation-runs';`                                                                                                                                                                                   |
+| Migration dir                    | `migrations/` (drizzle `out`); latest `0015_funds_base_currency.sql`; add `0016_reconciliation_runs.sql`                                                                                                                                                                                                                                                           |
+
+Decisions locked in (resolve plan ambiguities flagged in review):
+
+1. **`request_hash` composition:**
+   `canonicalSha256({ kind: 'moic_reconciliation', fundId, contractVersion: '2.0.0' })`.
+   With no request body, the natural 409 test is "same Idempotency-Key reused
+   against a different `:fundId`" (different `request_hash`). Replay test = same
+   key + same fundId.
+2. **Missing Idempotency-Key -> 428** explicitly (NOT 400). Pin in test.
+3. **Materiality service is a PURE injectable comparator**:
+   `assessMoicMateriality(legacy: FundMoicRankingItemV1[], candidate: FundMoicRankingItemV1[], epsilon = MOIC_MATERIALITY_EPSILON)`.
+   It does NOT read the live adapter. `candidateMaterial` true iff any rank
+   changed OR any `reservesMoic.value` delta `> epsilon`. This makes the "future
+   positive `exitProbability` candidate is material" test constructible.
+4. **Route-policy needs BOTH edits** (plan only named the classifier): add the
+   `getFinancialSurfaceForGovernanceEntry` exact-string branch for
+   `/fund-model-results/:fundId/moic-analysis` -> `moic_reserves`, AND add a
+   governance REGISTRY entry for that literal path (else `policy:verify` has no
+   entry to classify). Keep both in the server chunk; gate with
+   `npm run policy:verify`.
+5. **Admin role:** POST uses `requireAuth()`, `requireFundAccess`,
+   `requireRole('admin')`. No invented middleware.
+6. **Migration is hand-written** `CREATE TABLE IF NOT EXISTS` (replay-safe). Do
+   NOT `drizzle-kit generate` against the drifted journal. Drizzle schema
+   columns and the SQL must agree exactly.
+7. **V2 GET reads latest COMPLETED reconciliation** by
+   `requested_at DESC, id DESC`; returns `latestReconciliation: null` +
+   `materiality.status: "not_run"` when none exists.
+
+Per-chunk verification protocol (because Hermes postflight = `npm run check`
+only):
+
+- After each codex dispatch: `git diff --name-only` to catch out-of-scope strays
+  before committing.
+- Run the chunk's targeted Vitest suites with
+  `npx vitest run --config vitest.config.mjs --configLoader native --project=<server|client> <files>`.
+- Review allowlist / idempotency / materiality tests line-by-line — they are the
+  ones a vacuous pass defeats.
+- Commit per chunk with a conventional message.
+
+## Implementation Tasks (chunked dispatch order)
+
+- **Chunk 1:** V2 contract (`shared/contracts/fund-moic-v2.contract.ts`, reuse
+  `FundMoicRankingItemV1Schema`), `reconciliation_runs` Drizzle schema + barrel
+  export + `0016` migration, structural allowlist tests
+  (`tests/unit/contract/fund-moic-v2.contract.test.ts`) enumerating every V2
+  object key set AND asserting `.strict()` rejects an injected forbidden field.
+- **Chunk 2:** `server/services/fund-moic-materiality.ts`
+  (`MOIC_MATERIALITY_EPSILON = 1e-8`), characterization tests appended to
+  `tests/unit/services/fund-moic-ranking-service.test.ts`,
+  `tests/unit/services/fund-moic-materiality.test.ts` (epsilon + future-material
+  proof).
+- **Chunk 3:** `reconciliation_runs` service (idempotent replay), V2 GET
+  branch + admin POST branch in `server/routes/fund-moic.ts`, dual-surface tests
+  through `registerRoutes()` and `makeApp()`.
+- **Chunk 4 (client):** `useFundMoicRankingsV2` (distinct query key + V2
+  `safeParse`, V1 hook unchanged), canonical page
+  `/fund-model-results/:fundId/moic-analysis` (V2 hook, shows materiality
+  status/warnings), thin `/moic-analysis?fundId=` redirect page, route
+  registration, hook/page/legacy-route-map tests.
+- **Chunk 4b (server route-policy):** classifier edit + registry entry + policy
+  assertion that canonical MOIC route returns `moic_reserves`;
+  `npm run policy:verify`.
+
+## V2 Schema (strict)
+
+```ts
+export const FundMoicRankingsResponseV2Schema = z
+  .object({
+    contractVersion: z.literal('2.0.0'),
+    fundId: z.number().int().positive(),
+    rankings: z.array(FundMoicRankingItemV1Schema),
+    provenance: z
+      .object({ mode: z.literal('legacy'), warnings: z.array(z.string()) })
+      .strict(),
+    latestReconciliation: z
+      .object({
+        runId: z.string().nullable(),
+        createdAt: z.string().datetime().nullable(),
+      })
+      .strict()
+      .nullable(),
+    materiality: z
+      .object({
+        status: z.enum(['not_run', 'recorded']),
+        candidateMaterial: z.literal(false),
+        epsilon: z.literal(1e-8),
+      })
+      .strict(),
+    roundEvidenceSummary: z
+      .object({
+        activeRoundCount: z.number().int().nonnegative(),
+        activeOverrideCount: z.number().int().nonnegative(),
+        warningCodes: z.array(z.string()),
+      })
+      .strict(),
+    generatedAt: z.string().datetime(),
+  })
+  .strict();
+```
+
+## Test Plan
+
+- Targeted server:
+  `npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/services/fund-moic-ranking-service.test.ts tests/unit/services/fund-moic-materiality.test.ts tests/unit/contract/fund-moic-v2.contract.test.ts`
+- Targeted client:
+  `npx vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/hooks/use-moic.test.tsx tests/unit/app/legacy-route-map.test.ts tests/unit/pages/moic-analysis.test.tsx`
+- Policy + surfaces: assert canonical MOIC route returns `moic_reserves`;
+  `npm run policy:verify`.
+- Broad gates: `npx vitest run ... --project=server`, `... --project=client`,
+  `npm run test:unit`, `npm run guard:round-derived-financial-claims:check`,
+  `npm run release:check`.
+
+## Assumptions
+
+- `npm run check` is informational only for this work (does not run vitest, does
+  not typecheck test files).
+- V2 returns `latestReconciliation: null` and `materiality.status: "not_run"`
+  when no completed reconciliation exists.
+- The newest completed reconciliation is selected by
+  `requested_at DESC, id DESC`.

--- a/docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md
+++ b/docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md
@@ -1,0 +1,210 @@
+# Debate synthesis — Prod schema-drift reconciliation: the 6 contested questions
+
+Run inline (Claude acting as the three comparator voices + synthesis) rather
+than via the Hermes CLI debate. Each position is grounded in code read this
+session (file:line cited). Voices: **A** = correctness/systems lens, **B** =
+pragmatic/implementer lens, **C** = adversarial skeptic (defects from locked
+decisions). Brief: `.hermes-debate-brief.md`.
+
+Verified substrate (this session):
+
+- `fund-moic.ts:114-142,177` + `rounds-to-model-evidence-service.ts:506-524` +
+  `fund-calculation-mode-service.ts:304-324` — the rounds degrade path.
+- `scripts/db-push-core.mjs` — `findMissingSentinels` diffs constraint/index
+  NAMES vs `pg_constraint.conname` / `pg_indexes.indexname`.
+- `drizzle.config.ts:8-14` — `out: './migrations'`,
+  `schema: ['./shared/schema.ts', ...]` → `./migrations` is GENERATED FROM
+  `shared/schema`.
+
+---
+
+## M1 — Bundle vs split
+
+- **A:** Bundle defensible — the guardrails (mount-parity test,
+  `./migrations`-vs-schema differ) are what prevent recurrence; shipping the fix
+  without them re-opens the hole. But Lane E (`testcontainers-migration.ts`
+  rewire) must be an isolated commit with its own proof gate, never interleaved
+  with the fix.
+- **B:** Split. The prod-fix (runner + M1–M4 manifests + shape audit +
+  mount-parity test) is independently shippable and clone-verifiable. Lane E
+  touches the test-DB creation path for the WHOLE repo — different blast radius,
+  different reviewers (M4 domain-locked).
+- **C (defect from Decision-1):** "One PR" optimizes for narrative, not rollback
+  cost. The prod apply is the only irreversible step; bundling repo/CI churn
+  with it means a CI-only revert also reverts your guardrails. R11 already split
+  deletions out — the bundle is already not "one."
+- **VERDICT — SPLIT along the existing R11 seam:**
+  - **PR-1 (the fix + recurrence guard):** runner + 4 manifests + shape-aware
+    audit + mount-parity regression test + `./migrations`-vs-`shared/schema`
+    differ. Land GREEN. Prod apply happens OFF PR-1 (operator-gated step).
+  - **PR-2 (canonicalize):** fold `server/migrations`, Lane E rewire, `db:push`
+    prod-guard — after PR-1 is proven, Lane E as its own commit + independent
+    green-clone proof.
+  - Honors user intent (fix+guards still bundled — the recurrence-prevention
+    pair) while removing test-infra blast radius from the prod-fix critical
+    path. If user holds one PR: mandate Lane E as an isolated commit with its
+    own proof gate.
+
+## M2 — Exact shape-aware idempotency predicate
+
+- **A:** SHAPE = {table present} ∧ {all expected `conname` present} ∧ {all
+  expected `indexname` present} ∧ {all expected columns present,
+  type+nullability match}.
+- **B:** Don't gold-plate. The load-bearing failure is 42830 = a missing
+  FK/unique constraint and the CREATE INDEX silently skipped after it —
+  `findMissingSentinels` ALREADY catches exactly that by name. `CREATE TABLE` is
+  atomic; columns rarely partially-apply. Column diff is phase-2, not a blocker.
+- **C:** Both miss R13. "Populated" is NOT the refuse trigger — "missing DDL is
+  non-additive-safe" is. Missing index → `CREATE INDEX [CONCURRENTLY]` (safe on
+  populated). Missing FK → `ADD CONSTRAINT ... NOT VALID` then `VALIDATE`
+  (safe). Missing nullable column → `ADD COLUMN` (safe). Only type-change /
+  `NOT NULL`-with-violating-rows / drop-rename require refuse.
+- **VERDICT — implementable predicate, reuses `findMissingSentinels`:**
+  1. SHAPE = {table exists?} + {missing constraints/indexes via
+     `findMissingSentinels`} + {missing columns via `information_schema.columns`
+     diff}.
+  2. **SKIP** iff table exists ∧ no missing sentinels ∧ no missing columns.
+  3. **APPLY-MISSING-DDL** iff every delta is additive-safe (`CREATE INDEX`,
+     `ADD CONSTRAINT NOT VALID`+`VALIDATE`, `ADD` nullable column) — regardless
+     of row count.
+  4. **REFUSE-FOR-HUMAN** iff any delta is non-additive (type change, `NOT NULL`
+     on a column with violating rows, drop/rename) ∧ table is populated.
+  - Manifest "expected objects" must enumerate constraint names + index names +
+    column specs (R8). Makes R2's "absent-OR-malformed" concrete without a new
+    differ.
+
+## M3 — Is "`./migrations` canonical" coherent?
+
+- **A:** Reframe: `shared/schema` = declarative SHAPE target; `./migrations` =
+  imperative APPLY LEDGER to reach it on a drifted DB. Not competing sources.
+  Binding invariant: "apply all `./migrations` to empty ⇒ catalog ==
+  `shared/schema`."
+- **B:** As written, "canonical = ./migrations" will mislead the next operator.
+  Blessed PROD-APPLY artifact = `./migrations` (via runner); blessed AUTHORING
+  source = `shared/schema`; `db:push` FROZEN for prod (R9). Say exactly that in
+  the runbook.
+- **C:** The synthetic-clone test does NOT fully close it — `./migrations`
+  contains hand-authored drift files (0013/0014/0019) drizzle generate would
+  never emit, so file-equivalence fails forever. Need the WEAKER invariant
+  (shape-equivalence, not file-equivalence) + a header marker (`-- @generated`
+  vs `-- @drift-patch`) so the R3 differ and a "don't hand-edit generated files"
+  lint can both function.
+- **VERDICT:** `shared/schema` = SHAPE source of truth; `./migrations` =
+  applied-SQL ledger; runner = blessed prod-apply path; `db:push` frozen for
+  prod. Coherence enforced by a **shape-equivalence** clone test (apply
+  `./migrations` to empty ⇒ introspected catalog == `shared/schema` target), NOT
+  file-equivalence. Add `-- @generated` / `-- @drift-patch` header markers so
+  the R3 differ + a no-hand-edit-generated lint work. This is the one rule + one
+  command Decision-2/R3 were missing.
+
+## M4 — Rounds silent-degrade contract (DOMAIN-LOCKED: investment-rounds sign-off)
+
+- **EMPIRICAL CORRECTION to R1 (verified this session):** absent rounds tables
+  do NOT serve a wrong number. Catch (`rounds-to-model-evidence-service.ts:506`)
+  → degraded evidence → `resolveMoicActionability` = `non_actionable`
+  (`fund-calculation-mode-service.ts:322-324`) → `usingCandidateRankings=false`
+  (`fund-moic.ts:141`) → response serves `sources.legacy` (`fund-moic.ts:142`).
+  The response ALSO carries
+  `roundEvidenceSummary.warningCodes = ['ROUND_ADAPTER_FAILED']`
+  (`fund-moic.ts:94-102,177`). So it FAIL-SAFES to the conservative legacy
+  answer WITH a surfaced warning — not a fabricated candidate number.
+- **A:** Server contract is already correct and defensible (fail-safe +
+  warning). Keep the degraded-200; the runtime contract test pins
+  `provenance.mode='legacy'` + `warningCodes` contains `ROUND_ADAPTER_FAILED` on
+  empty DB.
+- **B:** The narrow real risk is CLIENT-side: does `use-moic.ts` read/display
+  `roundEvidenceSummary.warningCodes`, or drop it? If dropped, the user sees
+  legacy numbers with no signal the rounds feature degraded. Verify the client
+  consumes the warning — that is the actual silent surface, not the server 200.
+- **C:** Even fail-safe-to-legacy is wrong if the operator BELIEVES rounds are
+  live. A degraded-200 that the client ignores is operationally identical to a
+  silent failure. Argue for a loud typed error when `?contract=v2` is requested
+  but rounds tables are absent/malformed — "you asked for v2, v2 is unavailable"
+  — rather than a quiet downgrade.
+- **CLIENT CLOSED (verified this session):** the warning IS rendered end-to-end
+  — `client/src/pages/fund-model-results-moic-analysis.tsx:67` reads
+  `warningCodes`, and `:114-118` maps each (incl. `ROUND_ADAPTER_FAILED`) to a
+  visible `Badge`. So absent rounds tables → user sees LEGACY rankings + a
+  visible warning badge. NOT silent at any layer.
+- **VERDICT (advisory — needs investment-rounds specialist sign-off):** KEEP the
+  server's fail-safe-to-legacy + warning (correct, not a bug); the client
+  already surfaces it. R1's "live silent wrong answer" is REFUTED — it is
+  observable end-to-end. Residual is UX only: the badge shows the raw code
+  `ROUND_ADAPTER_FAILED`, not a plain-language "rounds feature unavailable;
+  showing legacy" — low severity. M4 work reduces to: (1) runtime contract test
+  pinning the degraded payload on empty DB; (2) optional friendlier badge copy.
+  Feed back to the handoff: **re-rank #17–18 from "C1-SILENT/LIVE" to "C2 —
+  observable graceful degrade"** (still domain-locked, but NOT a latent-failure
+  priority).
+
+## M5 — Prod-apply transaction & recovery model
+
+- **A:** Per-manifest txn beats single-mega-txn: one txn across M1–M4 holds DDL
+  locks on live `funds`/`investments`/`portfolio_companies` (R7) for the whole
+  run and rolls back ALL on any failure, discarding progress you'd want to keep.
+- **B:** Ledger is the resume source of truth: (manifest name, ordered file
+  checksums, per-statement hashes, started_at, committed_at, applied_by,
+  target_db identity). Resume: skip manifests with a matching committed row,
+  re-run from first uncommitted; M2 idempotency makes re-running a
+  never-committed manifest safe.
+- **C:** The FK topological order WITHIN M4 (vehicles →
+  cash_flow_events/valuation_marks → lp_metric_runs → ...) means a mid-M4
+  partial leaves a broken LP graph — UNLESS each manifest is ONE atomic txn
+  (failure rolls the whole manifest back). Then forward-only resume = manifest
+  granularity; no partial graph possible.
+- **VERDICT:** ONE txn PER MANIFEST (atomic; FK order lives inside the txn so
+  failure rolls the whole manifest back — no partial LP graph). Ledger records
+  the fields above. `pg_advisory_lock` around the run +
+  `lock_timeout`/`statement_timeout`, fail-fast on contention. Forward-only
+  resume skips committed manifests, resumes from first uncommitted. No rollback
+  after a manifest commits. Low-traffic window (R7). "Reversible-by-design"
+  becomes honest: forward-recoverable, not reversible.
+
+## M6 — Open completeness (adversarial sweep)
+
+1. **OBSERVABILITY GAP (biggest miss):** no evidence anyone can tell a
+   latent-500 fired in prod today — triage is static (reading `makeApp`), not
+   "we saw N 5xx on /api/cohorts." Pull prod/Vercel 5xx logs for the 14 affected
+   routes as a PRE-apply baseline, re-query POST-apply. Without it you prove
+   pg_catalog, never the symptom.
+2. **M4 client-consumption** (above): verify `use-moic.ts` surfaces the warning.
+3. **R12 extension privilege:** confirm precheck covers `CREATE EXTENSION` —
+   Neon restricts extensions; a manifest needing pgcrypto/uuid fails at apply
+   with no precheck signal.
+4. **Post-apply smoke must use a fund WITH rounds data** + `?contract=v2`; an
+   empty fund takes the same degraded branch whether tables exist or not (tests
+   nothing).
+5. **Re-validate FK graph AFTER the R2 shape-shrink:** if the shape audit drops
+   already-present tables from a manifest, re-check that no later statement
+   depends on a skipped table's missing index/constraint.
+
+### Strongest single objection per voice
+
+- **A:** The plan proves the fix in `pg_catalog` but never proves the SYMPTOM
+  existed or cleared in prod — instrument first.
+- **B:** Lane E's test-infra rewire can turn the suite green against a migration
+  world prod doesn't use — false confidence worse than the original bug. Isolate
+  it.
+- **C:** "Reversible-by-design" and "`./migrations` canonical" are asserted, not
+  enforced; until a failing CI command backs each, they are documentation, not
+  guarantees.
+
+---
+
+## Net deltas to the locked plan
+
+1. **SPLIT** into PR-1 (fix+recurrence-guard) / PR-2 (canonicalize+Lane E) along
+   the R11 seam.
+2. **M2 predicate** keyed on additive-safe-vs-not (not populated-vs-empty),
+   reusing `findMissingSentinels`.
+3. **M3** reframed: `shared/schema` = shape source; `./migrations` = ledger;
+   enforce shape-equivalence (not file-equivalence) +
+   `@generated`/`@drift-patch` markers.
+4. **M4** R1 REFUTED: degrade is observable end-to-end (server fail-safes to
+   legacy + warning; `fund-model-results-moic-analysis.tsx:67,114-118` renders
+   it as a Badge). Re-rank #17–18 from C1-SILENT/LIVE to **C2 — observable
+   graceful degrade** (still domain-locked). Residual is UX-copy only.
+5. **M5** one-txn-per-manifest with FK order inside the txn; ledger-driven
+   forward-only resume.
+6. **M6** add a prod 5xx log baseline/post-check; fix the smoke to use a
+   rounds-populated fund.


### PR DESCRIPTION
## Why
8 substantive planning/review docs were authored but **never committed** — no git history, so they were one `rm` away from permanent loss. Several are active workstreams referenced in agent memory: the part-b rounds ramp, PR-D, PR-E, and the **prod schema-drift debate synthesis (M1–M6)** that drove the PR-1 reconcile work (#948/#949/#950).

## What
- Commit the 8 docs under `docs/` (CRITICAL-REVIEW + 7 `docs/superpowers/plans/`).
- Regenerated `docs/_generated/router-*` + staleness-report via `npm run docs:routing:generate` so **Validate Discovery Routing** passes.

Docs-only; no code paths touched. Surfaced + chosen over deletion because these are non-derivable institutional memory with no git fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)