### PR TITLE
fix(schema): PR-2a prod schema canonicalization — validation + reconcile teeth, no deletions

### DIFF
--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -11736,6 +11736,23 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
+        "created": "2026-06-29",
+        "source": "docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md",
+        "status": "DRAFT",
+        "verified_head": "3524a1bfcc2ce05d3574430f92b39442c3df29d1"
+      },
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md",
+      "staleDays": 999,
+      "status": "DRAFT"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
         "categories": [
           "tech-debt",
           "type-safety"
@@ -13332,7 +13349,7 @@
       "BACKLOG": 1,
       "COMPLETE": 3,
       "COMPLETED": 1,
-      "DRAFT": 33,
+      "DRAFT": 34,
       "DRAFT (red-team hardened 2026-06-21)": 1,
       "HISTORICAL": 21,
       "HISTORICAL-SNAPSHOT": 1,
@@ -13348,8 +13365,8 @@
       "ready": 3
     },
     "missing_frontmatter": 32,
-    "stale_docs": 119,
-    "total_docs": 674
+    "stale_docs": 120,
+    "total_docs": 675
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,8 +11,8 @@ last_updated: 2026-06-29
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 674 |
-| Stale Documents | 119 |
+| Total Documents | 675 |
+| Stale Documents | 120 |
 | Missing Frontmatter | 32 |
 
 ### By Status
@@ -21,7 +21,7 @@ last_updated: 2026-06-29
 |--------|-------|
 | ACTIVE | 452 |
 | UNKNOWN | 127 |
-| DRAFT | 33 |
+| DRAFT | 34 |
 | HISTORICAL | 21 |
 | VERIFIED | 9 |
 | REFERENCE | 8 |
@@ -97,7 +97,7 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md` | Never | 999 | YES - verify! | Unassigned |
 
-*...and 69 more stale documents.*
+*...and 70 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 

--- a/docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md
+++ b/docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md
@@ -1,0 +1,1190 @@
+---
+status: DRAFT
+created: 2026-06-29
+source: docs/superpowers/plans/2026-06-28-prod-schema-drift-debate-synthesis.md
+verified_head: 3524a1bfcc2ce05d3574430f92b39442c3df29d1
+---
+
+# PR-2 Schema Canonicalization Design
+
+## Objective
+
+Design PR-2 so schema canonicalization removes false-green and false-red
+validation paths before any legacy migration surface is retired.
+
+The approved strategy is:
+
+- `shared/schema.ts`, `shared/schema-lp-reporting.ts`, and
+  `shared/schema-lp-sprint3.ts` are the Drizzle shape source.
+- `migrations/` plus `migrations/meta/_journal.json` is the journaled
+  applied-SQL ledger.
+- Production DDL is operator/reconcile-gated through
+  `scripts/reconcile-prod-schema.mjs`; normal `db:push` is not the production
+  apply path.
+- `server/migrations/` and `shared/migrations/` are not deleted or ignored until
+  PR-2 proves their active consumers and unique DDL content have been
+  classified.
+
+This spec approves PR-2a/PR-2b with amendments. It rejects the original four-way
+topology because that design undercounted `shared/migrations`, missed direct
+`server/migrations` consumers, and overstated production `db:push`.
+
+## Verified Baseline
+
+Live verification was refreshed on `main` at
+`3524a1bfcc2ce05d3574430f92b39442c3df29d1`. `git status --short --branch`
+reported `## main...origin/main` plus this spec as an untracked file:
+`?? docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md`.
+
+- `drizzle.config.ts:7-14` writes to `./migrations` and reads
+  `./shared/schema.ts`, `./shared/schema-lp-reporting.ts`, and
+  `./shared/schema-lp-sprint3.ts`.
+- `package.json:35-49` has `release:check`, `validate:schema-drift`, and
+  `db:push`; it has no `db:migrate` script.
+- Root `migrations/` has 37 `.sql` files. `migrations/meta/_journal.json` has 22
+  tags. All 22 tags have files, leaving 15 loose root SQL files:
+  `0001_create_portfolio_tables`, `0001_portfolio_schema_hardening`,
+  `0001_portfolio_schema_hardening_ROLLBACK`, `0002_add_organizations`,
+  `0002_multi_tenant_rls_setup`, `0002_multi_tenant_rls_setup_ROLLBACK`,
+  `0008_demo_profile_import_rows_rollback`, `001_lp_reporting_schema`,
+  `002_lp_reporting_indexes`, `003_lp_dashboard_materialized_view`,
+  `004_lp_sprint3_tables`, `20251030_stage_normalization_log`,
+  `20251031_add_agent_memories`, `999_fix_materialized_view`,
+  `manual-migration`.
+- Journaled root SQL marker status is mixed. Drift patches `0012`, `0014`,
+  `0016`, `0017`, and `0020` already carry `-- @drift-patch`, but existing
+  journaled files including `0011_scenario_share_sensitivity_drift`,
+  `0013_lp_reporting_core_drift`, and `0019_investments_id_fund_unique` have no
+  `-- @generated` or `-- @drift-patch` marker. PR-2a must avoid false-reding
+  these already-applied files as if they were new generated SQL.
+- `tests/unit/mount-parity-migrations.test.ts:32-38` claims journaled migrations
+  in the suite name at `:49`, but concatenates every root `migrations/*.sql`.
+  That is the current false-green path.
+- `tests/helpers/testcontainers.ts:81-103` applies Drizzle `./migrations` and
+  then applies raw SQL from `./shared/migrations`. Those five shared SQL files
+  are therefore live test setup until proven otherwise.
+- `tests/helpers/testcontainers-migration.ts:61-89` already contains a
+  journal-aware reader for one helper, but it falls back to sorted SQL files
+  when no journal exists. PR-2a needs a canonical journal-only helper for root
+  `migrations/`.
+- `scripts/db-push-core.mjs:7-9` names the production refusal message;
+  `:208-230` refuses explicit production URL matches, Vercel production, and a
+  known production host; `scripts/db-push.mjs:86-157` runs postcheck sentinels
+  after non-production `db:push`.
+- `scripts/reconcile-prod-schema.mjs:42-60` is audit-only unless `--apply --yes`
+  is present; `:75-87` requires a direct `DATABASE_URL` and refuses pooled URLs;
+  `:150-162` already requires `-- @generated` or `-- @drift-patch`; `:330-362`
+  prints an audit report and exits without DDL in audit-only mode; `:407-420`
+  reads the target from `DATABASE_URL` and supports expected identity through
+  `--expect-db` / `UPDOG_EXPECTED_DATABASE`.
+- `scripts/deploy-production.ts:300-302` and `scripts/ga-checklist.mjs:429-433`
+  still call `npm run db:migrate -- --dry-run`, which is stale because the
+  package has no `db:migrate` script.
+- `scripts/quality-gates.ts:455-470` prefers `server/migrations/` over
+  `migrations/` whenever both directories exist. That is a false-red or
+  false-green risk after root `migrations/` becomes canonical.
+- `scripts/schema-drift-active-surfaces.ts:106-112`, `:158-164`, `:210-215`,
+  `:257-262`, `:307-312`, and `:351-365` still use `server/migrations` patterns
+  as migration evidence.
+- Active tests/helpers still read `server/migrations` directly:
+  `tests/integration/allocation-scenario-apply.test.ts:77-84`,
+  `tests/helpers/apply-investment-round-constraints.ts:46-51`, and
+  `tests/integration/lp-reporting-foundation-migration.test.ts:15-24, 43-45`.
+- Shared schema comments still name exact `server/migrations` files, for example
+  `shared/schema/lp-reporting-evidence.ts:4-13` and
+  `shared/schema/investment-rounds.ts:1-9`.
+- `server/migrations/` currently contains 57 SQL files.
+- `shared/migrations/` currently contains five raw SQL files and is named in
+  `scripts/release-check.mjs:32-36` as release-owned.
+- `shared/migrations/` creates procedural objects, not only declarative shape:
+  `0001_create_job_outbox.sql` creates `update_job_outbox_updated_at()` and
+  `job_outbox_updated_at`; `0002_create_scenario_matrices.sql` creates
+  `update_scenario_matrices_updated_at()` and `scenario_matrices_updated_at`;
+  `0003_create_optimization_sessions.sql` creates
+  `update_optimization_sessions_updated_at()` and
+  `optimization_sessions_updated_at`.
+- `vitest.config.testcontainers.ts` has an explicit include list and does not
+  currently include `tests/integration/migration-shape-equivalence.test.ts`. A
+  new shape-equivalence file with that name will not be collected unless the
+  config is updated or the test reuses an already included path.
+
+## RALPLAN-DR Summary
+
+### Principles
+
+1. Validate the same ledger the runtime/test path actually applies.
+2. Do not retire or delete a legacy surface until all active consumers and
+   unique DDL content have been inventoried.
+3. Keep production DDL behind `scripts/reconcile-prod-schema.mjs`; use `db:push`
+   only as a non-production shape-build path.
+4. Prove catalog shape, not file identity: tables, columns, types, nullability,
+   constraints, foreign keys, indexes, and any in-scope procedural objects must
+   compare equal.
+5. Prefer one canonical helper and one reconcile framework over parallel
+   validators that can disagree.
+
+### Decision Drivers
+
+1. Eliminate false-green tests caused by loose root SQL files satisfying
+   assertions without being journaled.
+2. Eliminate false-red ops checks caused by stale `db:migrate` and
+   `server/migrations` assumptions.
+3. Preserve operator safety by deferring destructive cleanup until a green,
+   evidence-backed canonical path exists.
+
+### Options Considered
+
+#### Option A: Original four-way topology
+
+Approach: Treat root `migrations/`, shared schemas, `server/migrations/`, and
+production `db:push` as peer surfaces and canonicalize them together.
+
+Pros:
+
+- Single narrative for all schema surfaces.
+- Could reduce migration confusion in one pass.
+
+Cons:
+
+- Omits `shared/migrations`, even though Testcontainers applies it.
+- Understates direct `server/migrations` consumers in scripts, tests, helpers,
+  and comments.
+- Overstates production `db:push`; current code refuses production `db:push` and
+  points to reconcile.
+
+Verdict: rejected.
+
+#### Option B: Two-stage PR-2a/PR-2b
+
+Approach: PR-2a adds validation teeth and reconcile alignment without deletions.
+PR-2b folds and retires legacy surfaces only after PR-2a proves the canonical
+path.
+
+Pros:
+
+- Fixes false validation paths before removing any legacy files.
+- Keeps production mutation gated by the existing reconcile script.
+- Allows `shared/migrations` and `server/migrations` to be classified from
+  evidence instead of assumption.
+
+Cons:
+
+- Requires two PRs and two review passes.
+- Leaves legacy directories present for one PR longer.
+
+Verdict: selected.
+
+#### Option C: Big-bang retirement
+
+Approach: Move useful SQL to root `migrations/`, delete `server/migrations/`,
+delete `shared/migrations/`, and fix all consumers in one PR.
+
+Pros:
+
+- Fastest path to an apparently clean topology.
+
+Cons:
+
+- Highest rollback cost.
+- Can break active tests and helpers before proving the replacement path.
+- Makes per-file orphan classification easy to skip.
+
+Verdict: rejected.
+
+## Canonical Topology After PR-2a
+
+PR-2a should establish this truth model without deleting legacy directories:
+
+| Surface                                                                            | Role                                                         | PR-2a treatment                                                                                                                                 |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shared/schema.ts`, `shared/schema-lp-reporting.ts`, `shared/schema-lp-sprint3.ts` | Declarative Drizzle shape source                             | Keep as DB-B shape-build authority                                                                                                              |
+| `migrations/meta/_journal.json` + tagged root `migrations/<tag>.sql`               | Canonical applied-SQL ledger                                 | Use journal tags only for ledger readers                                                                                                        |
+| Loose root `migrations/*.sql`                                                      | Unclassified legacy SQL                                      | Detect and classify; do not use for parity proof                                                                                                |
+| `shared/migrations/*.sql`                                                          | Raw Testcontainers-applied SQL, including functions/triggers | Prove on a like-for-like track: separate apply/introspect proof under Resolution A, or symmetric apply to both DB-A and DB-B under Resolution B |
+| `server/migrations/*.sql`                                                          | Legacy direct-consumer ledger                                | Inventory and compare before any retirement                                                                                                     |
+| `scripts/reconcile-prod-schema.mjs`                                                | Production audit/apply path                                  | Reuse; do not build a parallel reconciler                                                                                                       |
+| `npm run db:push`                                                                  | Non-production Drizzle shape push                            | Keep production refusal/postcheck behavior                                                                                                      |
+
+## PR-2a: Teeth + Reconcile, No Deletions
+
+PR-2a must be a validation and alignment PR. It must not remove
+`server/migrations/`, `shared/migrations/`, or loose root SQL files.
+
+### 1. Add a Journal-Only Migration Reader Helper
+
+Add a reusable helper, for example `scripts/migration-ledger.ts`, with exports
+similar to:
+
+- `readDrizzleJournal(rootDir, migrationsDir = 'migrations')`
+- `readJournaledMigrationFiles(rootDir, migrationsDir = 'migrations')`
+- `findLooseMigrationSql(rootDir, migrationsDir = 'migrations')`
+- `classifyMigrationSqlFile(file, journalTags)`
+
+Hard requirements:
+
+- Root `migrations/` readers must use `_journal.json` order only.
+- Missing `_journal.json` is a failure for canonical root migrations.
+- A journal tag without a matching SQL file is a failure.
+- A loose SQL file is never silently included in the journaled SQL set.
+- The helper must preserve enough metadata for tests to print exact paths and
+  classifications.
+
+Do not reuse the fallback behavior from
+`tests/helpers/testcontainers-migration.ts:83-90` for canonical root validation.
+The fallback is useful for generic helper compatibility, but PR-2a needs a
+strict reader for the canonical ledger.
+
+### 2. Fix Mount-Parity to Read Journal Tags Only
+
+Update `tests/unit/mount-parity-migrations.test.ts` so `migrationSql()` reads
+only files named by `migrations/meta/_journal.json`.
+
+Acceptance criteria:
+
+- A loose root SQL file that creates a missing table does not make mount-parity
+  pass.
+- A missing journaled SQL file fails with the missing tag/path.
+- The test name can keep "journaled migrations" because it will finally match
+  the implementation.
+
+Expected outcome and failure rule (verified at this baseline):
+
+- The flip is expected to stay GREEN. At
+  `3524a1bfcc2ce05d3574430f92b39442c3df29d1`, every C1 mounted table has its
+  `CREATE TABLE` in a journaled file, not a loose one:
+  `cohort_definitions`/`sector_taxonomy`/`sector_mappings`/`company_overrides`/
+  `investment_overrides` in `0012_sector_variance_drift`; the seven LP/evidence
+  tables (`vehicles`, `cash_flow_events`, `valuation_marks`, `lp_metric_runs`,
+  `evidence_records`, `narrative_runs`, `lp_report_packages`,
+  `lp_report_package_exports`) in `0014_lp_evidence_sprint3_drift`;
+  `reconciliation_runs` in `0016_reconciliation_runs`; `fund_calculation_modes`
+  in `0017_moic_exit_probability_modes`; `tasks` in
+  `0020_operating_tasks_drift`. The implementer must re-verify this mapping
+  before landing, because a loose file currently masks any future regression.
+- If the flip turns RED for a mounted table, that is a real missing-journal
+  finding, not a test that needs loosening. Fix it by journaling the table's DDL
+  into the ledger with a marker (or a documented `-- @drift-patch`), never by
+  re-including loose `migrations/*.sql` files into `migrationSql()`.
+
+Recurrence guard for the mounted-table set itself (debate D6 — 3-voice
+consensus):
+
+- `C1_MOUNTED_TABLES` (`tests/unit/mount-parity-migrations.test.ts:7-24`) is a
+  HARDCODED list. The journal-only flip fixes WHERE DDL is read but not WHICH
+  tables must exist, so a newly mounted `makeApp` DB-backed route whose table
+  nobody adds to the list passes parity and re-opens the original latent-500
+  class. The hardcoded list is itself a latent false-green of the class this
+  effort targets.
+- PR-2a must add a cross-check between the mounted route surface
+  (`server/app.ts` `makeApp` route registration) and `C1_MOUNTED_TABLES`: fail
+  if a newly mounted DB-backed route is not classified as covered, deferred
+  (`DEFERRED_DOMAIN_LOCKED_TABLES`), or non-table-backed. Keep
+  `C1_MOUNTED_TABLES` as the enforcement set; full auto-derivation of tables
+  from route handlers is not required, but an unclassified new mount must not
+  pass silently.
+
+### 3. Add Loose/Orphan SQL Detector and Classifier
+
+Add a detector that reports every root SQL file not referenced by
+`migrations/meta/_journal.json`.
+
+Initial live loose list from this baseline:
+
+- `0001_create_portfolio_tables`
+- `0001_portfolio_schema_hardening`
+- `0001_portfolio_schema_hardening_ROLLBACK`
+- `0002_add_organizations`
+- `0002_multi_tenant_rls_setup`
+- `0002_multi_tenant_rls_setup_ROLLBACK`
+- `0008_demo_profile_import_rows_rollback`
+- `001_lp_reporting_schema`
+- `002_lp_reporting_indexes`
+- `003_lp_dashboard_materialized_view`
+- `004_lp_sprint3_tables`
+- `20251030_stage_normalization_log`
+- `20251031_add_agent_memories`
+- `999_fix_materialized_view`
+- `manual-migration`
+
+Classifier categories:
+
+- `journaled-generated`: file is in `_journal.json` and marked `-- @generated`.
+- `journaled-drift-patch`: file is in `_journal.json` and marked
+  `-- @drift-patch`.
+- `legacy-journaled-unmarked`: file is already in `_journal.json` at the PR-2a
+  baseline but lacks `-- @generated` / `-- @drift-patch`. This is a remediation
+  class, not a new-migration failure class. Known baseline examples include
+  `0011_scenario_share_sensitivity_drift`, `0013_lp_reporting_core_drift`, and
+  `0019_investments_id_fund_unique`.
+- `loose-rollback`: file name or content indicates rollback/down SQL.
+- `loose-legacy-drift`: file appears to be an older drift or manual repair.
+- `loose-shared-ledger-candidate`: file overlaps `shared/migrations` or
+  Testcontainers setup.
+- `loose-server-ledger-candidate`: file overlaps `server/migrations`.
+- `loose-materialized-view`: file creates/repairs a materialized view
+  (`003_lp_dashboard_materialized_view`, `999_fix_materialized_view`). Called
+  out because Drizzle shape push does not own materialized views, so these need
+  an explicit PR-2b decision rather than landing in `unknown-loose` by default.
+- `loose-rls`: file sets up row-level security or tenancy policy
+  (`0002_multi_tenant_rls_setup`, `0002_multi_tenant_rls_setup_ROLLBACK`). Same
+  rationale: RLS is not shape-source-emitted and needs a dedicated PR-2b call.
+- `unknown-loose`: insufficient evidence; must block deletion.
+
+PR-2a may mark files as unclassified or candidate classes, but it must not turn
+all 15 loose files into delete candidates without per-file evidence.
+
+### 4. Reuse Existing Marker Convention
+
+Extend the existing reconcile marker convention across canonical migration
+validation:
+
+- `-- @generated` for Drizzle-generated SQL.
+- `-- @drift-patch` for hand-authored, shape-preserving drift SQL.
+
+Existing precedent:
+
+- `scripts/reconcile-prod-schema.mjs:31-32` defines the marker regex.
+- `scripts/reconcile-prod-schema.mjs:156-162` rejects manifest SQL without one
+  of the markers.
+- Current root migration drift patches already use `-- @drift-patch` on `0012`,
+  `0014`, `0016`, `0017`, and `0020`.
+
+Grandfather/remediation rule (debate D5 — REVISED to allowlist, 3-voice
+consensus):
+
+- Do NOT add markers by editing the already-applied `legacy-journaled-unmarked`
+  files (`0011_scenario_share_sensitivity_drift`,
+  `0013_lp_reporting_core_drift`, `0019_investments_id_fund_unique`). Even a
+  comment-only edit changes the file's content, and Drizzle keys applied
+  migrations by a SHA-256 of file content
+  (`tests/helpers/testcontainers-migration.ts:127-133` `hashMigration()`;
+  drizzle-orm `pg-core/dialect.js` stores that hash in `drizzle_migrations`). A
+  content change perturbs the checksum surface and risks a mismatch in any
+  environment that already ran `migrate()` against the old hash. (Prod uses
+  `db:push`, not `migrate()`, and CI clones are fresh, so the practical risk is
+  low — but it is non-zero and avoidable.)
+- Instead, maintain a `LEGACY_JOURNALED_UNMARKED_ALLOWLIST` inside the validator
+  (e.g. `scripts/migration-ledger.ts`), keyed by
+  `{ tag, current content hash }`, listing the three tags above. The validator
+  treats allowlisted tags as satisfying the marker requirement without a marker
+  in the file.
+- Keying the allowlist on the current content hash makes it self-tightening: if
+  one of these files is later edited substantively, its hash no longer matches
+  the allowlist entry, so the validator stops grandfathering it and forces it
+  through the strict path below — exactly the desired behavior.
+- The marker validator should report each allowlisted file by tag and matched
+  hash so reviewers can see what is grandfathered versus newly marked.
+- Strict marker + journal + snapshot requirements apply to everything NOT on the
+  allowlist. New `-- @generated` files, or substantive edits to `-- @generated`
+  files, must carry the matching `_journal.json` tag and
+  `migrations/meta/*snapshot*` companion metadata.
+
+For legacy loose files, classification may record missing markers without
+editing them unless the file is promoted into the canonical ledger.
+
+### 5. Add No-Hand-Edit Guard for Generated SQL
+
+Add a guard in the migration validator, not a separate reconciliation framework.
+
+The guard should reject generated SQL changes when the change does not look like
+a Drizzle regeneration. A practical first version:
+
+- `-- @generated` SQL under root `migrations/` may be added or changed only when
+  the corresponding `_journal.json` tag and matching
+  `migrations/meta/*snapshot*` metadata are present in the same change.
+- `-- @drift-patch` SQL must be journaled and must include a short reason line
+  after the marker, for example `-- Reason: production drift patch for ...`.
+- New root SQL files without either marker fail validation.
+- `legacy-journaled-unmarked` files are handled by the
+  `LEGACY_JOURNALED_UNMARKED_ALLOWLIST` (see §4) and must NOT be edited to add a
+  marker. If PR-2a (or any later change) modifies the executable SQL of one of
+  those files, the content-hash key no longer matches the allowlist, the file
+  drops out of grandfathering, and it must pass the same strict guard as any
+  other journaled SQL change.
+- Existing loose SQL files remain reported as loose/unclassified until PR-2b or
+  a later cleanup PR classifies them.
+
+Unit tests must prove:
+
+- Missing marker fails.
+- `-- @generated` without matching journal/meta context fails.
+- `-- @drift-patch` without a reason fails.
+- Legacy loose files are reported, not deleted.
+
+### 6. Replace Stale `db:migrate --dry-run` References
+
+Replace active operational callsites that invoke the nonexistent script:
+
+- `scripts/deploy-production.ts:300-302`
+- `scripts/ga-checklist.mjs:429-433`
+
+Use the existing safe audit path:
+
+```bash
+node scripts/reconcile-prod-schema.mjs --manifest-dir scripts/prod-schema-manifests
+```
+
+The replacement command must run with a direct `DATABASE_URL`. The reconcile CLI
+refuses missing, `memory://`, and pooled URLs because DDL requires the direct
+database endpoint. When the target identity is known, pass `--expect-db <name>`
+or set `UPDOG_EXPECTED_DATABASE=<name>` so the audit confirms the expected
+database before reporting success.
+
+Do not include `--apply --yes` in deploy or GA check preflight. Audit-only mode
+is the intended dry-run equivalent because `scripts/reconcile-prod-schema.mjs`
+exits before DDL unless `--apply --yes` is supplied. `--apply --yes` remains an
+operator-only production mutation command outside PR-2a validation.
+
+The deploy/GA preflight must not hard-fail when no direct endpoint is reachable.
+Today `scripts/ga-checklist.mjs:429-436` always returns `false` because the
+`db:migrate` script is missing, and `scripts/deploy-production.ts:299-303` runs
+the check as `critical: false`. The replacement must preserve a non-blocking
+posture in environments without a direct `DATABASE_URL`: detect a missing,
+`memory://`, or pooled URL before invoking reconcile and SKIP with an explicit
+`schema audit skipped: no direct DATABASE_URL` message, rather than letting the
+reconcile CLI exit non-zero and re-introduce the false-red this section is
+trying to remove. Run the audit only when a direct endpoint and the manifest dir
+are both available. DECISION (2026-06-28 eng review): **the skip-guard is
+SELECTED** over removing the schema check entirely, so a real audit signal is
+preserved wherever a direct `DATABASE_URL` is available.
+
+Unit tests must prove the replacement does not silently regress to a new
+false-red or false-green:
+
+- With no/`memory://`/pooled `DATABASE_URL`, the deploy/GA check SKIPS with the
+  explicit message and returns a non-failing result (not a throw, not `false`).
+- With a direct `DATABASE_URL` and a manifest dir, the check invokes the
+  audit-only reconcile path (no `--apply --yes`) and surfaces its audit result.
+- The check never passes `--apply --yes` from deploy or GA preflight.
+
+Also update user-facing stale references in follow-up docs or console output
+when touched, but the blocking PR-2a scope is the active deploy/GA scripts.
+
+### 7. Add Shape-Equivalence Proof
+
+Add a Testcontainers proof that compares two clean databases. Build both in the
+same container as separate databases (`CREATE DATABASE`).
+
+Reuse the existing journaled-clone harness instead of building a parallel one
+(Principle 5). The journaled DB-A build mechanism already exists and is proven
+green-in-CI: `tests/integration/prod-schema-clone.test.ts` spins up
+`pgvector/pgvector:pg16`, applies the root journal in `_journal.json` order via
+`tests/helpers/testcontainers-migration.ts` `runMigrationsWithConnectionString`
+(Drizzle `migrate()` over journal tags only), and is already collected by
+`vitest.config.testcontainers.ts`. That existing test does a ONE-SIDED sentinel
+check (16 expected tables + constraints from the PR-1 manifests), not a
+two-sided shape diff. "Reuse" therefore means EXTEND it to a two-sided DB-A vs
+DB-B comparison, hosting the DB-B build and the catalog diff in or alongside
+that file so they inherit its container, its journal-aware helper, and its
+`skipIfNoDocker = !process.env.CI && process.platform === 'win32'` guard. A new
+filename is acceptable only if it reuses the same helper/container and the PR
+justifies the parallel validator against Principle 5; if used, it must be added
+to the `vitest.config.testcontainers.ts` include list (see below). Because of
+the `skipIfNoDocker` guard, a local Windows run of this gate SKIPS and proves
+nothing; real proof comes from CI or the supported Docker/Node environment, the
+same evidence tier as `release:check`.
+
+Extensions are defensive, not load-bearing on the current image. Keep a
+`CREATE EXTENSION IF NOT EXISTS pgcrypto` (and `vector` if a vector column ever
+enters scope) as cheap image-independent insurance, but do NOT justify it with
+"both builds fail to construct without it" — that is empirically false on the
+pg16 image. The journaled DB-A clone already builds with NO explicit extension
+creation (`prod-schema-clone.test.ts` is green in CI): `gen_random_uuid()` is a
+PostgreSQL 16 core function, and the only `CREATE EXTENSION vector` in root
+`migrations/` lives in the LOOSE, non-journaled
+`20251031_add_agent_memories.sql`, which the journaled path never applies. DB-B
+(built from the three Drizzle shape sources) needs no `vector` either: none of
+`shared/schema.ts`, `shared/schema-lp-reporting.ts`, or
+`shared/schema-lp-sprint3.ts` declares a vector column. Match whatever the
+chosen container image and shape source actually require, and confirm against
+the existing harness rather than asserting a failure that does not occur.
+
+- DB-A: journal-built path.
+  - Create required extensions, then apply root `migrations/` in `_journal.json`
+    order only. This is the equivalence assertion the M3 debate fixed: "apply
+    all journaled `migrations/` to empty ⇒ catalog == `shared/schema`." The root
+    journal, not `shared/migrations`, is the ledger being proven equivalent to
+    the shape source.
+- DB-B: shared-schema-built path.
+  - Create the same extensions, then build schema from the Drizzle shape source
+    used by `drizzle.config.ts`.
+  - Prefer programmatic `drizzle-kit/api` `pushSchema` for DB-B. The existing
+    non-production `db:push` wrapper is a fallback, but `scripts/db-push.mjs`
+    runs prod-shaped postcheck sentinels after the push (`:86-157`) that can
+    false-fail against a fresh shape-only DB-B and abort the build; if the
+    wrapper is used, the postcheck must be bypassed or scoped for the disposable
+    database. Either way, keep production refusal semantics intact.
+
+Handle `shared/migrations` explicitly, because it is the part the original
+design got wrong. It is FIVE files, not only the three procedural ones:
+`0001`/`0002`/`0003` create base tables that ARE in the shape source
+(`job_outbox`, `scenario_matrices`, and `optimization_sessions` are defined in
+`shared/schema.ts`) PLUS procedural objects (the `update_*_updated_at` functions
+and triggers) that a Drizzle `db:push` from the shape source structurally cannot
+emit; `0004_variance_alert_automation.sql` adds an `alert_evaluation_executions`
+table, a `job_outbox.dedupe_key` column, ordinary and partial unique indexes
+(including `performance_alerts_open_incident_unique`), and a one-time data
+`UPDATE`; `0005_backtest_scenario_comparison_summary.sql` adds a
+`backtest_results.scenario_comparison_summary` JSONB column. Two consequences:
+
+- The `shared/migrations` proof must introspect these non-procedural additions
+  (table, columns, ordinary/partial indexes), not only `pg_trigger`/`pg_proc`,
+  or it false-greens `0004`/`0005`. Under Resolution B the symmetric full-shape
+  diff covers them automatically; under Resolution A the separate track must
+  diff them explicitly.
+- `shared/migrations` must be applied AFTER the base tables it references exist
+  (`0004` carries FKs to `funds`, `fund_baselines`, `alert_rules`, `calc_runs`,
+  `performance_alerts`), mirroring the live helper order
+  (`tests/helpers/testcontainers.ts` applies Drizzle `./migrations` first, then
+  raw `shared/migrations`). The `0004` data `UPDATE` is a no-op on an empty
+  clone, so it is an ordering/dependency concern, not a data-correctness risk in
+  the proof.
+
+Therefore:
+
+- Do NOT apply `shared/migrations` to DB-A only and then assert DB-A == DB-B
+  including procedural objects. That comparison is red by construction: DB-A has
+  triggers/functions DB-B can never contain. Including `shared/migrations`
+  one-sidedly while also comparing `pg_trigger`/`pg_proc` (below) cannot go
+  green.
+- DECISION (2026-06-28 eng review): **Resolution A is SELECTED.** Resolution B
+  is retained below only as the considered alternative. The proof keeps the core
+  assertion root-journal vs `shared/schema` and proves the procedural-only
+  `shared/migrations` objects on a separate NAMED-PRESENCE track (not a vacuous
+  apply-and-introspect step — see the D2 hardening below).
+  - Resolution A (SELECTED, M3-aligned): keep the core assertion as root-journal
+    DB-A vs `shared/schema` DB-B. Put `shared/migrations` on a separate track.
+    CRITICAL (debate D2 — 3-voice consensus): the separate track must NOT be a
+    vacuous "apply-and-introspect" step. `shared/migrations` procedural objects
+    have no shape-source counterpart to diff against, so "introspect" collapses
+    into the existing apply-and-proceed
+    (`tests/helpers/testcontainers.ts:88-103` asserts nothing) and proves
+    nothing. Resolution A's track must instead be an explicit NAMED-PRESENCE
+    assertion that FAILS if any expected object is absent:
+    `update_job_outbox_updated_at()`, `update_scenario_matrices_updated_at()`,
+    `update_optimization_sessions_updated_at()` (functions);
+    `job_outbox_updated_at`, `scenario_matrices_updated_at`,
+    `optimization_sessions_updated_at` (triggers); `alert_evaluation_executions`
+    (table), `job_outbox.dedupe_key` (column),
+    `idx_job_outbox_job_type_dedupe` + `performance_alerts_open_incident_unique`
+    (indexes), `backtest_results.scenario_comparison_summary` (column).
+  - Required per-object matrix (debate STRONGEST OBJECTION — Codex, confidence
+    9/10): before scoping anything to the "no shape counterpart" track, PR-2a
+    must build a matrix with columns `shared/migrations object` |
+    `in shared/schema?` | `in root journal?` | `procedural-only?` |
+    `Resolution A assertion`. The base tables `job_outbox`/`scenario_matrices`/
+    `optimization_sessions` ARE in `shared/schema` (so they belong to the main
+    journal-vs-shape sentinel gate, NOT the separate track), and the `0004`
+    alert-automation objects may overlap the root-journal
+    `0005_phase1c2_alert_automation` ledger entry — verify with local proof.
+    Only objects that are genuinely procedural-only (the 3 functions + 3
+    triggers) have "no shape-source counterpart"; everything else is covered by
+    the sentinel gate and must not be double-counted or skipped. This matches
+    the PR-2b plan to classify `shared/migrations` from evidence.
+  - Resolution B: apply `shared/migrations/*.sql` symmetrically to BOTH DB-A and
+    DB-B after each is built, so the procedural objects exist on both sides and
+    the comparison is apples-to-apples. This proves the journaled ledger and the
+    shape source agree AND that `shared/migrations` applies cleanly on top of
+    both, at the cost of folding a raw-SQL surface into the equivalence proof.
+- Do not silently drop `shared/migrations` from the test setup; both resolutions
+  keep its DDL proven, just on a like-for-like footing.
+
+The proof must be executable under the current Testcontainers Vitest config.
+
+DECISION (2026-06-28 eng review): **Extend
+`tests/integration/prod-schema-clone.test.ts`.** It is already collected by
+`vitest.config.testcontainers.ts`, so NO include-list edit is required and there
+is no risk of the gate silently never collecting the comparator. Add the DB-B
+build and the two-sided catalog diff to that file (it does a one-sided 16-table
+sentinel check today). A separate
+`tests/integration/migration-shape-equivalence.test.ts` is the rejected
+alternative; if a future change still wants it, it MUST be added to the
+`vitest.config.testcontainers.ts` include list in the same change.
+
+The PR evidence must show Vitest collected and ran the DB-A/DB-B comparator. A
+source-only comparator that is never discovered by the configured gate is not
+acceptable.
+
+Two tiers: a deterministic GATING sentinel set, and a non-gating full-text
+DIAGNOSTIC (debate D1 — 3-voice consensus). The mandatory full `pg_get_*` text
+diff was demoted because raw catalog text (`int4` vs `integer`,
+default-expression formatting, FK-action wording, def whitespace/quoting,
+catalog-dependent ordering) is normalization-fragile and would false-RED — the
+exact trust-eroding failure mode this effort fights. But demoting it must NOT
+re-introduce a type-drift false-green, so the gating set below explicitly
+includes normalized column TYPE and nullability, not just presence.
+
+GATING sentinel set (a mismatch here FAILS the gate) — compared by normalized
+NAME + shape, never by raw definition text:
+
+- Tables in `public`.
+- Columns by table and column name.
+- Column type, normalized so equivalent spellings compare equal (`int4` ==
+  `integer`, `timestamptz` == `timestamp with time zone`, etc.) — derived from
+  catalog formatting, not only broad `information_schema.data_type`.
+- Nullability.
+- Primary keys, unique constraints, checks, and FKs, by `conname`.
+- FK referenced table/columns and update/delete actions.
+- Index names (`indexname`), uniqueness, and predicate (partial-index `WHERE`).
+
+DIAGNOSTIC tier (reported as info, does NOT fail the gate unless a GATING
+sentinel above also mismatches):
+
+- `pg_get_constraintdef` / `pg_get_indexdef` / `pg_get_triggerdef` /
+  `pg_get_functiondef` full text for in-scope objects, plus `pg_trigger` rows
+  for in-scope user triggers (excluding PostgreSQL internal triggers) and the
+  relevant `pg_proc` rows. Surface these for reviewer eyes; do not gate on their
+  byte-equality.
+
+Recommended catalog sources:
+
+- `pg_class`, `pg_namespace`, `pg_attribute`, `pg_type`, and `format_type` for
+  tables and column type details.
+- `pg_constraint` and `pg_get_constraintdef` for PK/unique/check/FK shape.
+- `pg_index`, `pg_class`, and `pg_get_indexdef` for indexes.
+- `pg_trigger`, `pg_proc`, `pg_get_triggerdef`, and `pg_get_functiondef` for
+  in-scope procedural shape.
+
+Normalize identifier quoting and type spelling for the GATING sentinels, but
+never drop constraint/FK/index names from the comparison — the prior bug class
+was name-and-shape sensitive (a missing FK/unique name caused the 42830 that
+silently skipped the following index). Reserve fragile whitespace/def-text
+normalization for the diagnostic tier, where a mismatch only informs.
+
+Exclude Drizzle's migration bookkeeping from the diff. If DB-A is built via the
+reuse path (Drizzle `migrate()` in `runMigrationsWithConnectionString`, which
+writes `migrationsTable: 'drizzle_migrations'`, `migrationsSchema: 'public'`),
+DB-A gets a `public.drizzle_migrations` table that DB-B does not — `db:push` /
+`drizzle-kit/api pushSchema` are stateless and create no migrations table. A
+full `public`-table diff would therefore false-RED on `drizzle_migrations`
+alone, the same red-by-construction class as the procedural-object asymmetry.
+The comparator must exclude the bookkeeping relation
+(`public.drizzle_migrations` under this config, or `__drizzle_migrations` if the
+default schema is ever used) from the table/column/index comparison.
+
+Procedural-object proof depends on composition. Under Resolution A (SELECTED),
+prove the procedural-only objects by NAMED-PRESENCE assertion (the function/
+trigger list above), NOT by a cross-DB `pg_trigger`/`pg_proc` diff — there is no
+procedural counterpart on the shape side, so a diff is a guaranteed false-red.
+Under Resolution B, a cross-DB `pg_trigger`/`pg_proc` diff is valid because both
+sides applied the same raw SQL. Either way, do not omit the procedural objects
+from their proof: `shared/migrations` carries executable behavior (the
+`update_*_updated_at` triggers) that a table/column-only comparison would
+false-green. Named-presence is the Resolution A escape from that false-green;
+one-sided diffing against the Drizzle shape source is not.
+
+### 8. Add Dual-Ledger Divergence Detector
+
+Before any `server/migrations` retirement, add a detector that compares
+`server/migrations/*.up.sql` to the canonical root journal ledger.
+
+The detector should answer:
+
+- Which server migration files create tables, columns, constraints, FKs, or
+  indexes not present in the root journal plus `shared/migrations` DB-A build?
+- Which server migration files are exact or shape-equivalent duplicates of root
+  journal entries?
+- Which server migration files are still read by tests/helpers/scripts?
+- Which comments/contracts name exact server migration files and must be
+  rewritten when the content moves?
+
+PR-2a may land the detector and report divergence. PR-2b is the first PR allowed
+to move or retire content based on that report.
+
+CI semantics (debate D4 — 3-voice consensus, with Codex's crash/finding split):
+
+- In PR-2a the detector is report-only: reported divergence ROWS are non-gating
+  reviewer data and MUST NOT fail `npm run validate:schema-drift` or any other
+  gate.
+- BUT detector execution/parse ERRORS (the script throws, can't read a file,
+  emits unparseable output) MUST fail CI — "report-only" must not silently
+  swallow a broken detector and present an empty report as "no divergence."
+- The divergence report MUST be attached to the PR description as a non-blocking
+  artifact. PR-2b is where unresolved divergence becomes blocking.
+
+### 9. Wire Validation Into Existing Gates
+
+Do not create a competing reconciliation framework.
+
+Preferred wiring:
+
+- Keep `npm run validate:schema-drift` as the top-level PR-2a schema gate.
+- Extend `scripts/schema-drift-active-surfaces.ts` or a helper it imports so the
+  command also runs journal/orphan/marker validation.
+- Keep `scripts/reconcile-prod-schema.mjs` responsible for production manifest
+  audit/apply behavior.
+
+## PR-2a Verification Gates
+
+Required commands, split into two lanes (debate D3 — 3-voice consensus). Even
+though PR-2a stays one PR (user decision), the gates must be split so the cheap
+deterministic guards cannot be hidden behind the Docker proof's reliability.
+
+Unit / deterministic lane (must pass INDEPENDENTLY of Docker; no skip):
+
+```bash
+npx cross-env TZ=UTC vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/mount-parity-migrations.test.ts
+npx cross-env TZ=UTC vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/migration-ledger*.test.ts tests/unit/migration-marker*.test.ts
+# deploy/GA skip-guard behavior (see PR-2a section 6)
+npm run check
+npm run lint
+npm run validate:schema-drift
+```
+
+Docker / Testcontainers lane (real proof only in CI or the supported Docker/Node
+environment):
+
+```bash
+npx cross-env TZ=UTC vitest run --config vitest.config.testcontainers.ts tests/integration/prod-schema-clone.test.ts
+npm run release:check
+```
+
+The shape-equivalence proof extends
+`tests/integration/prod-schema-clone.test.ts` (already in the include list — see
+§7), so no `vitest.config.testcontainers.ts` edit is needed. The comparator must
+actually instantiate DB-A and DB-B and compare catalog shape; a mock-only test
+is insufficient. On local Windows the Testcontainers lane SKIPS via
+`skipIfNoDocker` — a skip is NON-EVIDENCE, not a pass. Merge requires BOTH lanes
+green: the unit lane proven locally or in CI, and the Docker lane proven in CI /
+the supported environment. A flaky Docker proof must never be able to mask a red
+unit-lane guard.
+
+`npm run release:check` must run in the supported Docker/Node environment for
+this repo. If the local environment cannot run the supported gate, the PR must
+state that gap and include supported-environment release proof before merge.
+
+PR-2a is not complete unless the PR description includes:
+
+- Journal tag count, root SQL count, loose SQL count, and loose file list.
+- Which `shared/migrations` resolution was used (A: separate track, or B:
+  symmetric apply to both databases) and the like-for-like procedural-object
+  comparison evidence, including the non-procedural `0004`/`0005` additions.
+- Whether the comparator extended `tests/integration/prod-schema-clone.test.ts`
+  / its helper and container, or used a new file; if new, the Principle 5
+  justification and the `vitest.config.testcontainers.ts` include-list edit.
+- Confirmation that the comparator excludes `public.drizzle_migrations` from the
+  shape diff (the journaled DB-A build via `migrate()` creates it; DB-B does
+  not).
+- The extensions created (if any) and confirmation they match the image/shape
+  requirements — note that the pg16 journaled clone builds with none, so this is
+  defensive, not a precondition.
+- Confirmation that the DB-A/DB-B comparator was collected and run by
+  `vitest.config.testcontainers.ts` in CI or the supported environment (a local
+  Windows run SKIPS via `skipIfNoDocker` and is not proof).
+- The dual-ledger divergence report summary for `server/migrations`.
+- Confirmation that deploy/GA no longer call `db:migrate --dry-run`.
+- Confirmation that no production DDL was run.
+
+## PR-2b: Fold + Retire
+
+PR-2b can start only after PR-2a is green and reviewed. Its job is to remove the
+legacy topology after the canonical validation path has teeth.
+
+### 1. Inventory Every Direct `server/migrations` Consumer
+
+The initial live inventory includes:
+
+- `scripts/schema-drift-active-surfaces.ts`
+- `scripts/quality-gates.ts`
+- `scripts/run-migrations.ts`
+- `tests/integration/allocation-scenario-apply.test.ts`
+- `tests/helpers/apply-investment-round-constraints.ts`
+- `tests/helpers/testcontainers.ts`
+- `tests/integration/lp-reporting-foundation-migration.test.ts`
+- `tests/unit/schema/schema-drift-active-surfaces.test.ts`
+- `tests/unit/schema/lp-reporting-evidence-schema.test.ts`
+- `server/services/sensitivity-run-service.ts`
+- Shared schema comments under `shared/schema/*`, including
+  `shared/schema/lp-reporting-evidence.ts`,
+  `shared/schema/investment-rounds.ts`, and
+  `shared/schema/investment-round-model-overrides.ts`
+- Shared contract comments under `shared/contracts/lp-reporting/*`, including
+  `cash-flow-event.contract.ts`, `evidence-record.contract.ts`,
+  `lp-metric-run.contract.ts`, and `valuation-mark.contract.ts`
+- Active script references to stale `db:migrate`, including
+  `scripts/deploy-production.ts`, `scripts/ga-checklist.mjs`,
+  `scripts/fix-critical-issues.ts`, and `scripts/verify-fixes.ts`
+- Docs and historical plans that mention exact server migration paths, lower
+  priority unless they instruct active behavior
+
+PR-2b must refresh this list before editing with:
+
+```bash
+rg --line-number "server/migrations|shared/migrations|run-migrations|db:migrate" scripts tests shared server docs package.json
+```
+
+Treat active source, script, helper, and test references as blocking. Treat docs
+and historical references as lower priority unless they still instruct active
+operator or development behavior.
+
+### 2. Repoint Active Gates
+
+Update:
+
+- `scripts/schema-drift-active-surfaces.ts`
+- `tests/unit/schema/schema-drift-active-surfaces.test.ts`
+- `scripts/quality-gates.ts`
+
+Required behavior:
+
+- Active migration evidence points to the canonical root journal ledger or to a
+  documented drift patch.
+- `quality-gates.ts` no longer prefers `server/migrations/` over `migrations/`.
+- Missing canonical migration evidence fails with a path that points to the new
+  ledger.
+
+### 3. Update Tests, Helpers, and Schema Comments
+
+Update exact server migration file references in:
+
+- Test setup that reads server SQL directly.
+- Helpers that extract constraints from server migration text.
+- Shared schema and contract comments that say "mirrors
+  `server/migrations/...`".
+
+Where a test needs a small statement such as a constraint add, prefer importing
+or generating it from the canonical journal/drift helper rather than copying SQL
+into the test.
+
+### 4. Migrate Unique Server Content
+
+For each `server/migrations/*.up.sql` file:
+
+- If the shape is already present in DB-A, mark it as duplicate and eligible for
+  retirement.
+- If the shape is absent but belongs in the current app, migrate it into the
+  canonical root ledger as either Drizzle-generated SQL or a documented
+  `-- @drift-patch`.
+- If the shape is historical and no active code/tests require it, document the
+  evidence and retire it with the directory.
+
+Do not promote server `down.sql` files into the root canonical ledger unless a
+specific forward-only recovery need is proven. Production reconcile remains
+forward-only and ledgered.
+
+### 5. Retire `server/migrations/` With a Guard
+
+Only after active consumers are gone and unique content has been folded:
+
+- Remove `server/migrations/`.
+- Add a guard that rejects new files under `server/migrations/`.
+- Update documentation that previously instructed new schema work to add
+  `server/migrations` files.
+
+The guard can live in the existing schema-drift or guardrails infrastructure; do
+not add a standalone framework if an existing gate can own it.
+
+### 6. Remove `scripts/run-migrations.ts` Last
+
+`scripts/run-migrations.ts` reads `shared/migrations` and documents
+`npm run db:migrate`, but package scripts no longer expose `db:migrate`.
+
+Removal is allowed only after:
+
+- Active `db:migrate` callsites have been removed or replaced.
+- `shared/migrations` has been classified and either folded or intentionally
+  retained.
+- Docs/console output no longer direct operators to `npm run db:migrate`.
+
+## PR-2b Verification Gates
+
+PR-2b requires all PR-2a gates plus:
+
+```bash
+rg --line-number "server/migrations|db:migrate|run-migrations|shared/migrations" scripts tests shared server docs package.json
+npm run validate:schema-drift
+npm run release:check
+```
+
+`npm run release:check` must run in the supported Docker/Node environment for
+this repo. If run outside that environment, the PR must state the environment
+gap and include the supported-environment proof before merge.
+
+PR-2b is not complete unless:
+
+- The consumer inventory proves no active `server/migrations` dependency
+  remains.
+- Any retained `shared/migrations` usage is intentionally documented and covered
+  by DB-A/DB-B shape proof.
+- `scripts/run-migrations.ts` is removed only if no active callsite or retained
+  shared-ledger role depends on it.
+- The PR description names every server migration file with unique content and
+  where it moved.
+
+## Non-Goals
+
+- Do not mutate production.
+- Do not run production `db:push`.
+- Do not delete `server/migrations/` in PR-2a.
+- Do not delete or classify all 15 loose root SQL files as delete candidates
+  without per-file evidence.
+- Do not create a second production reconciliation framework parallel to
+  `scripts/reconcile-prod-schema.mjs`.
+- Do not weaken `db:push` production refusal or postcheck behavior.
+
+## Open Risks and Mitigations
+
+| Risk                                                                                        | Mitigation                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shared/migrations` may be real test setup, obsolete baggage, or a separate raw-SQL ledger. | PR-2a keeps its DDL proven on a like-for-like footing (Resolution A separate track or Resolution B symmetric apply), never one-sided in the journal-vs-shape assertion. PR-2b cannot remove it without consumer and shape evidence.                                                                                                                                                                           |
+| Clean DB-A/DB-B builds fail before any comparison.                                          | Reuse the proven `prod-schema-clone.test.ts` journaled-build path, which already constructs a green clone on pg16. Add `CREATE EXTENSION IF NOT EXISTS` defensively, but treat extensions as image-dependent insurance, not a precondition: `gen_random_uuid()` is pg16 core, `vector` is only used by the loose (out-of-scope) `agent_memories` file, and no in-scope shape source declares a vector column. |
+| Comparator false-REDs on Drizzle bookkeeping.                                               | If DB-A is built via `migrate()`, exclude `public.drizzle_migrations` (or `__drizzle_migrations`) from the table/column/index diff; DB-B via `db:push`/`pushSchema` is stateless and has no such table.                                                                                                                                                                                                       |
+| New comparator duplicates the existing journaled-clone gate.                                | Extend `prod-schema-clone.test.ts` (one-sided sentinel today) into the two-sided diff, reusing its container, helper, and `skipIfNoDocker` guard, rather than adding a parallel validator.                                                                                                                                                                                                                    |
+| Hidden `server/migrations` consumers exist.                                                 | PR-2b starts with a fresh `rg` inventory and updates active tests/helpers/scripts before retirement.                                                                                                                                                                                                                                                                                                          |
+| Shape-equivalence can be too weak.                                                          | Compare constraints, FKs, indexes, types, and nullability, not only tables and columns.                                                                                                                                                                                                                                                                                                                       |
+| Shape-equivalence false-greens procedural drift.                                            | Compare `pg_trigger`/`pg_proc` on a like-for-like composition (separate `shared/migrations` track, or symmetric apply to both DBs); never one-sided against the Drizzle shape source, which cannot emit triggers and would force a guaranteed false-red.                                                                                                                                                      |
+| Reconcile replacement stays red where no direct endpoint exists.                            | Guard the deploy/GA check to skip with an explicit message when no direct `DATABASE_URL` is present; run the audit only when a direct endpoint and manifests are available.                                                                                                                                                                                                                                   |
+| New Testcontainers comparator is never collected.                                           | Update `vitest.config.testcontainers.ts` include list or reuse an included test filename, and attach run evidence.                                                                                                                                                                                                                                                                                            |
+| Stale ops scripts keep deploy/GA red.                                                       | PR-2a replaces active `db:migrate --dry-run` calls with audit-only reconcile.                                                                                                                                                                                                                                                                                                                                 |
+| Generated SQL guard blocks legitimate Drizzle regeneration.                                 | Provide a documented regeneration path and tests for journal/meta companion changes.                                                                                                                                                                                                                                                                                                                          |
+| Baseline journaled files without markers are false-reded.                                   | Classify them as `legacy-journaled-unmarked` and allow marker-only remediation before strict future rules apply.                                                                                                                                                                                                                                                                                              |
+| Loose root files are silently relied on by tests.                                           | Mount-parity and ledger helpers must read journal tags only; loose files are reported separately.                                                                                                                                                                                                                                                                                                             |
+
+## ADR
+
+### Decision
+
+Adopt the two-stage PR-2a/PR-2b plan. PR-2a adds journal-only validation,
+orphan/marker guards, stale ops-script fixes, shape-equivalence proof, and
+dual-ledger divergence detection without deleting legacy migration surfaces.
+PR-2b folds and retires `server/migrations` only after PR-2a is green.
+
+### Drivers
+
+- Current mount-parity can pass from loose root SQL that Drizzle never applies.
+- Current ops scripts still call a nonexistent `db:migrate` script.
+- Current tests/helpers/scripts still consume `server/migrations` directly.
+- Production DDL already has a reconcile/audit path and must remain
+  operator-gated.
+
+### Alternatives Considered
+
+- Original four-way topology: rejected because it omits `shared/migrations`,
+  undercounts `server/migrations` consumers, and misstates production `db:push`.
+- Big-bang retirement: rejected because it raises rollback cost and can delete
+  useful SQL before proving equivalence.
+
+### Why Chosen
+
+The selected split first makes validation truthful, then lets retirement proceed
+from evidence. It keeps the production safety model intact and makes future
+schema work choose between Drizzle-generated shape and documented drift patch
+instead of ad hoc SQL surfaces.
+
+### Consequences
+
+- PR-2 takes two PRs instead of one.
+- Legacy directories remain briefly, but with explicit detector output.
+- The shape-equivalence Testcontainers proof is the main correctness bar for
+  schema canonicalization, but post-D1 the GATING half is the normalized
+  named-sentinel set (tables/columns/type/nullability/named constraints + FK
+  actions/named indexes); the full `pg_get_*` catalog diff is a non-gating
+  diagnostic. The bar is "named-shape equivalence," not byte-equal catalog text.
+
+### Follow-ups
+
+- After PR-2b, update any remaining historical docs that still teach
+  `server/migrations` as the migration destination.
+- Consider moving the shape comparator into a reusable release-check helper once
+  it has proven stable.
+- Consider adding a short `DECISIONS.md` entry if PR-2 changes the long-term
+  migration authoring policy.
+
+## Execution Handoff Guidance
+
+Recommended `$ralph` path:
+
+```bash
+$ralph docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md
+```
+
+Use one sequential owner for PR-2a because it touches validation flow, tests,
+and operational scripts that must stay coherent.
+
+Recommended `$team` path if parallel execution is needed:
+
+```bash
+$team docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md
+```
+
+### Available-Agent-Types Roster and Staffing
+
+- `explore`: refresh `server/migrations`, `shared/migrations`, and loose SQL
+  consumers before edits.
+- `executor`: implement helper, tests, and script rewires.
+- `test-engineer`: build the DB-A/DB-B Testcontainers proof.
+- `critic`: review the detector classifications and retirement preconditions.
+- `verifier`: run gates and confirm no production mutation path was used.
+
+Team verification path:
+
+- Team proves PR-2a gates before shutdown.
+- Ralph or a final verifier reruns `npm run validate:schema-drift` and the
+  shape-equivalence Testcontainers gate after integration.
+- PR-2b does not begin until PR-2a evidence is attached to the handoff.
+
+## Changed Sections and Residual Risks
+
+- Changed `Verified Baseline` to state the actual untracked spec status, mixed
+  journal-marker baseline, direct reconcile URL requirement, procedural objects
+  in `shared/migrations`, and explicit Testcontainers include-list behavior.
+- Changed PR-2a marker rules to introduce `legacy-journaled-unmarked` and allow
+  marker-only remediation for already-journaled SQL before strict future marker
+  and snapshot rules apply.
+- Changed DB-A/DB-B shape proof to keep `shared/migrations` procedural objects
+  on a like-for-like track instead of applying them to only DB-A.
+- Changed Testcontainers instructions so the comparator must be collected by
+  `vitest.config.testcontainers.ts`, not merely added to the tree.
+- Changed deploy/GA guidance to replace stale `db:migrate --dry-run` with
+  audit-only `scripts/reconcile-prod-schema.mjs` using direct `DATABASE_URL`, no
+  `--apply --yes`, and optional `--expect-db` / `UPDOG_EXPECTED_DATABASE`.
+- Changed PR-2a gates to include `npm run check`, `npm run lint`, and
+  supported-environment `npm run release:check` proof.
+- Changed PR-2b inventory to call out active source/script/test references such
+  as `server/services/sensitivity-run-service.ts`,
+  `shared/contracts/lp-reporting/*.contract.ts`, `scripts/run-migrations.ts`,
+  and current `rg` hits for migration surfaces.
+- Changed DB-A/DB-B composition so the shape-equivalence assertion is
+  root-journal vs `shared/schema` (M3-aligned), added required-extension
+  preconditions for both databases, and resolved the procedural-object
+  contradiction: a one-sided `shared/migrations` include plus `pg_trigger`/
+  `pg_proc` comparison is red by construction, so the spec now requires a
+  like-for-like composition (Resolution A separate track or Resolution B
+  symmetric apply).
+- Changed the deploy/GA reconcile replacement to require a
+  skip-when-no-direct-URL guard so it does not re-introduce a false-red, and
+  noted the skip-versus-remove open choice.
+
+Second review pass (verified against `3524a1bf`):
+
+- Changed §7 to reuse the existing green-in-CI journaled-clone harness
+  (`tests/integration/prod-schema-clone.test.ts` +
+  `runMigrationsWithConnectionString`) and extend it to a two-sided diff, rather
+  than building a parallel comparator (Principle 5). Noted its `skipIfNoDocker`
+  guard means a local Windows run SKIPS and is not proof.
+- Corrected the extension precondition: the "both builds fail to construct
+  without `pgcrypto`/`vector`" claim is empirically false on pg16. The journaled
+  clone builds with no explicit extensions (`gen_random_uuid()` is pg16 core;
+  the only `CREATE EXTENSION vector` is the loose, out-of-scope `agent_memories`
+  file; no in-scope shape source declares a vector column). Extensions are kept
+  as defensive insurance, not a precondition.
+- Added a `drizzle_migrations` exclusion to the comparator: the
+  `migrate()`-built DB-A creates `public.drizzle_migrations` that stateless DB-B
+  lacks, a red-by-construction asymmetry on the table diff.
+- Expanded the `shared/migrations` handling from three procedural files to all
+  five, requiring the proof to introspect the non-procedural `0004`/`0005`
+  additions and to apply `shared/migrations` after the base tables it
+  references.
+- Added §2 expected-outcome and failure-rule language: all 16 C1 tables are
+  journaled today (`0012`/`0014`/`0016`/`0017`/`0020`) so the flip stays green;
+  a red is a journaling gap to fix with a marker, never by re-including loose
+  files.
+- Updated the open-risks table and PR-2a checklist accordingly.
+
+Eng-review pass (2026-06-28, decisions locked by user):
+
+- PR-2a stays ONE PR (validation teeth bundled), not split — user decision over
+  the reviewer's split recommendation; matches the debate-synthesis scoping.
+- `shared/migrations` composition: Resolution A (separate track) SELECTED.
+- Shape-equivalence comparator: EXTEND `prod-schema-clone.test.ts` (no
+  include-list edit) SELECTED over a new file.
+- Deploy/GA preflight: skip-when-no-direct-URL guard SELECTED over removal.
+- Added a §6 unit-test requirement for the skip-guard (SKIP vs audit-run, never
+  `--apply --yes`) — closes a regression-class test gap.
+- Flagged the `db:push` wrapper postcheck-sentinel false-fail risk for the DB-B
+  build; spec now prefers `drizzle-kit/api` `pushSchema`.
+
+Hermes debate pass (2026-06-28, round 2 — Claude inline + Codex + Kimi
+comparators). Evidence-strength caveat: the D1-D6 prompts were framed by a
+Claude-authored brief that embedded Claude's own positions, so Codex/Kimi
+agreement on D1-D6 is partly an ECHO, not independent triangulation. The
+genuinely independent/additive findings came from the OPEN-ENDED prompt parts:
+Codex's per-object matrix (STRONGEST OBJECTION → D2) and Kimi's completeness
+sweep (§3 matview/RLS classes, the out-of-scope residual items). Treat D2/D6 as
+triangulated and D1/D5 as Claude judgment calls (see flags below), not as
+six-way validated consensus. No user-sovereign decision (one-PR, Resolution A,
+extend-clone, skip-guard) was reversed; D1 and D5 DO reverse prior spec-author
+positions and are flagged as such:
+
+- D1 (JUDGMENT CALL — reverses the ADR's "comprehensive diff is the bar"): §7
+  comparator split into a deterministic GATING sentinel set (tables, cols,
+  normalized type, nullability, named constraints + FK actions, named indexes +
+  predicate) and a non-gating full-text DIAGNOSTIC. Column TYPE stays in the
+  gate so demotion does not re-introduce a type-drift false-green, but column
+  DEFAULTS and CHECK-expression TEXT are now diagnostic-only — that is the cost
+  of the demotion. Justified by THEORIZED normalization flakiness
+  (`int4`/`integer`, def-text), NOT observed failures; the existing
+  `prod-schema-clone.test.ts` sentinel approach is the green-in-CI precedent.
+  User confirmed (2026-06-28): keep the sentinel gate + non-gating diagnostic.
+- D2 + Codex STRONGEST OBJECTION: §7 Resolution A is now an explicit
+  NAMED-PRESENCE assertion plus a required per-object matrix
+  (`in shared/schema?` / `in root journal?` / `procedural-only?`); only the 3
+  functions + 3 triggers are genuinely "no shape counterpart," the rest belong
+  to the sentinel gate.
+- D3: §PR-2a gates split into a unit/deterministic lane and a Docker lane; local
+  Windows skip = non-evidence; merge needs both lanes green. Fixed the stale
+  `migration-shape-equivalence.test.ts` gate reference to
+  `prod-schema-clone.test.ts` per the extend-clone decision.
+- D4: §8 detector CI semantics — divergence rows non-gating, but detector
+  crash/parse errors fail CI; report attached to the PR.
+- D5: §4/§5 marker remediation REVERSED from editing applied files to a
+  validator-side `LEGACY_JOURNALED_UNMARKED_ALLOWLIST` keyed by tag + content
+  hash, because a comment-only edit perturbs the Drizzle content-hash surface
+  (`hashMigration()` + drizzle `pg-core/dialect.js`). User confirmed
+  (2026-06-28): keep the allowlist; do not edit the applied files.
+- D6: §2 added a `makeApp`-route-vs-`C1_MOUNTED_TABLES` cross-check — the
+  hardcoded list was itself a latent false-green of the original latent-500
+  class.
+- §3 added `loose-materialized-view` and `loose-rls` classifier classes (Kimi
+  completeness sweep) so matview/RLS loose files do not silently fall to
+  `unknown-loose`.
+
+Residual risks:
+
+- `shared/migrations` may remain a valid raw-SQL test ledger; PR-2a must not
+  retire it by assumption.
+- Procedural-object comparison may require normalization beyond tables and
+  constraints; reviewers should inspect any trigger/function diff carefully.
+- Supported-environment `release:check` may be unavailable on a local Windows
+  shell; merge readiness still requires proof from the supported repo
+  environment.
+- PR-2b can still uncover hidden active consumers after PR-2a lands; deletion
+  remains blocked until the refreshed inventory is clean.
+- The `shared/migrations` resolution is DECIDED: Resolution A (separate track),
+  per the 2026-06-28 eng review. B remains documented as the considered
+  alternative only.
+- The reconcile audit in deploy/GA preflight depends on a direct endpoint; the
+  skip-guard is DECIDED (2026-06-28 eng review) over removing the check, so it
+  SKIPS with an explicit message in pooled-only or URL-less environments and
+  runs the audit only where a direct `DATABASE_URL` is available. The skip-guard
+  behavior must be unit-tested (see §6).
+- One active script outside the named PR-2b inventory,
+  `scripts/apply-scenario-drift-migrations.mjs`, contains only a "do NOT run
+  `db:migrate` against prod" warning comment (not a callsite); the PR-2b `rg`
+  refresh step already surfaces it, so it needs no special handling beyond the
+  standard pass.
+- The comparator's exclusion set (`drizzle_migrations` and any future Drizzle
+  bookkeeping) is build-mechanism-dependent. If the DB-A build path changes away
+  from Drizzle `migrate()`, re-check what bookkeeping relations exist on each
+  side before trusting a full `public` diff.
+- All 16 C1 tables are journaled at this baseline, so the §2 flip is green
+  today, but a loose file masks regressions; the implementer must re-verify the
+  table-to-tag mapping rather than assume it from this spec.
+- `.claude/settings.local.json` still allowlists a `npm run db:migrate:status`
+  command that no longer exists. This is a stale local permission entry, not
+  operator/dev behavior, so it is out of PR-2 scope; noted here only for
+  completeness alongside the other stale `db:migrate` references.
+- Kimi completeness sweep flagged three items that are OPERATOR/PROD-PROOF
+  concerns, explicitly OUT of PR-2a scope (PR-2a does not mutate prod and proves
+  shape in `pg_catalog`, not the live symptom): (1) prod 5xx-log baseline/
+  post-check for the affected routes (debate-synthesis M6); (2)
+  `CREATE EXTENSION` privilege precheck on the Neon target before an operator
+  apply; (3) post-apply smoke against a rounds-POPULATED fund (empty clones take
+  the degraded branch regardless). These belong to the PR-1/operator-apply
+  runbook, not PR-2a; listed so they are not lost.
+- §5's generated-SQL guard says `-- @generated` files need "matching"
+  `migrations/meta/*snapshot*` metadata but does not define what "matching"
+  verifies (hash? presence?). Low-severity vagueness for the implementer to pin.
+- The shape comparator is additive/presence-oriented and has no policy for
+  intentional renames (a column moving between shape files appears as drop+add).
+  Out of PR-2a scope (additive focus), flagged for future authoring policy.

--- a/docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md
+++ b/docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md
@@ -479,10 +479,12 @@ that file so they inherit its container, its journal-aware helper, and its
 `skipIfNoDocker = !process.env.CI && process.platform === 'win32'` guard. A new
 filename is acceptable only if it reuses the same helper/container and the PR
 justifies the parallel validator against Principle 5; if used, it must be added
-to the `vitest.config.testcontainers.ts` include list (see below). Because of
-the `skipIfNoDocker` guard, a local Windows run of this gate SKIPS and proves
-nothing; real proof comes from CI or the supported Docker/Node environment, the
-same evidence tier as `release:check`.
+to the `vitest.config.testcontainers.ts` include list (see below). The
+testcontainers global setup starts containers before the per-file
+`skipIfNoDocker` guard, so on a host with no container runtime this command
+HARD-FAILS in global setup, not as a clean skip; either way, local Windows is
+NON-EVIDENCE. Real proof comes from CI or the supported Docker/Node environment,
+the same evidence tier as `release:check`.
 
 Extensions are defensive, not load-bearing on the current image. Keep a
 `CREATE EXTENSION IF NOT EXISTS pgcrypto` (and `vector` if a vector column ever
@@ -743,11 +745,12 @@ The shape-equivalence proof extends
 `tests/integration/prod-schema-clone.test.ts` (already in the include list — see
 §7), so no `vitest.config.testcontainers.ts` edit is needed. The comparator must
 actually instantiate DB-A and DB-B and compare catalog shape; a mock-only test
-is insufficient. On local Windows the Testcontainers lane SKIPS via
-`skipIfNoDocker` — a skip is NON-EVIDENCE, not a pass. Merge requires BOTH lanes
-green: the unit lane proven locally or in CI, and the Docker lane proven in CI /
-the supported environment. A flaky Docker proof must never be able to mask a red
-unit-lane guard.
+is insufficient. On local Windows without a container runtime, the
+testcontainers global setup HARD-FAILS before the per-file `skipIfNoDocker`
+guard can produce a clean skip; either way, local Windows is NON-EVIDENCE.
+Merge requires BOTH lanes green: the unit lane proven locally or in CI, and the
+Docker lane proven in CI / the supported environment. A flaky Docker proof must
+never be able to mask a red unit-lane guard.
 
 `npm run release:check` must run in the supported Docker/Node environment for
 this repo. If the local environment cannot run the supported gate, the PR must
@@ -770,7 +773,8 @@ PR-2a is not complete unless the PR description includes:
   defensive, not a precondition.
 - Confirmation that the DB-A/DB-B comparator was collected and run by
   `vitest.config.testcontainers.ts` in CI or the supported environment (a local
-  Windows run SKIPS via `skipIfNoDocker` and is not proof).
+  Windows run is not proof, and without a container runtime HARD-FAILS in
+  global setup before `skipIfNoDocker` can produce a clean skip).
 - The dual-ledger divergence report summary for `server/migrations`.
 - Confirmation that deploy/GA no longer call `db:migrate --dry-run`.
 - Confirmation that no production DDL was run.
@@ -1060,8 +1064,9 @@ Second review pass (verified against `3524a1bf`):
 - Changed §7 to reuse the existing green-in-CI journaled-clone harness
   (`tests/integration/prod-schema-clone.test.ts` +
   `runMigrationsWithConnectionString`) and extend it to a two-sided diff, rather
-  than building a parallel comparator (Principle 5). Noted its `skipIfNoDocker`
-  guard means a local Windows run SKIPS and is not proof.
+  than building a parallel comparator (Principle 5). Noted local Windows is not
+  proof, and without a container runtime the testcontainers global setup
+  HARD-FAILS before `skipIfNoDocker` can produce a clean skip.
 - Corrected the extension precondition: the "both builds fail to construct
   without `pgcrypto`/`vector`" claim is empirically false on pg16. The journaled
   clone builds with no explicit extensions (`gen_random_uuid()` is pg16 core;

--- a/migrations/0021_version_columns_bigint_drift.sql
+++ b/migrations/0021_version_columns_bigint_drift.sql
@@ -1,0 +1,44 @@
+-- @drift-patch
+-- Reason: align optimistic-lock version columns with the shared/schema bigint shape source; journal 0001 created them as integer before the shape widened to bigint. Proven by tests/integration/prod-schema-clone.test.ts.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'forecast_snapshots'
+      AND column_name = 'version'
+      AND data_type = 'integer'
+  ) THEN
+    ALTER TABLE "forecast_snapshots" ALTER COLUMN "version" TYPE bigint;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'investment_lots'
+      AND column_name = 'version'
+      AND data_type = 'integer'
+  ) THEN
+    ALTER TABLE "investment_lots" ALTER COLUMN "version" TYPE bigint;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'reserve_allocations'
+      AND column_name = 'version'
+      AND data_type = 'integer'
+  ) THEN
+    ALTER TABLE "reserve_allocations" ALTER COLUMN "version" TYPE bigint;
+  END IF;
+END $$;

--- a/migrations/0021_version_columns_bigint_drift.sql
+++ b/migrations/0021_version_columns_bigint_drift.sql
@@ -1,5 +1,8 @@
 -- @drift-patch
 -- Reason: align optimistic-lock version columns with the shared/schema bigint shape source; journal 0001 created them as integer before the shape widened to bigint. Proven by tests/integration/prod-schema-clone.test.ts.
+-- NOTE: ALTER COLUMN TYPE bigint is a NON-additive in-place type change (table rewrite under ACCESS EXCLUSIVE lock on a populated table).
+-- Safe here because: replayed only on empty CI clones; prod is already bigint (built by db:push from the shape source); the reconcile M2 predicate refuses non-additive DDL on populated tables.
+-- If ever applied to a populated table, schedule a maintenance window.
 
 DO $$
 BEGIN

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1782691200000,
       "tag": "0020_operating_tasks_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1782777600000,
+      "tag": "0021_version_columns_bigint_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/deploy-production.ts
+++ b/scripts/deploy-production.ts
@@ -8,12 +8,12 @@ import { execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import * as crypto from 'crypto';
-import { 
-  DeploymentError, 
-  HealthCheckError, 
+import {
+  DeploymentError,
+  HealthCheckError,
   RolloutMetrics,
   createDeploymentError,
-  createHealthCheckError
+  createHealthCheckError,
 } from '../server/types/errors.js';
 import { DeploymentTracer, tracer } from '../server/lib/tracing.js';
 import { DeploymentCircuitBreaker } from './deployment-circuit-breaker.js';
@@ -47,7 +47,7 @@ function loadConfig(): DeploymentConfig {
       errorRate: Number(process.env.DEPLOY_ERROR_THRESHOLD || 0.01),
       p99Latency: Number(process.env.DEPLOY_P99_THRESHOLD || 1000),
       memoryUsage: Number(process.env.DEPLOY_MEMORY_THRESHOLD || 0.8),
-      cpuUsage: Number(process.env.DEPLOY_CPU_THRESHOLD || 0.7)
+      cpuUsage: Number(process.env.DEPLOY_CPU_THRESHOLD || 0.7),
     },
     stages: [
       { name: 'smoke', percentage: 0, duration: 120000, smoothing: 1 },
@@ -56,12 +56,12 @@ function loadConfig(): DeploymentConfig {
       { name: 'expanded', percentage: 25, duration: 900000, smoothing: 5 },
       { name: 'majority', percentage: 50, duration: 900000, smoothing: 5 },
       { name: 'nearly-full', percentage: 95, duration: 600000, smoothing: 3 },
-      { name: 'full', percentage: 100, duration: 300000, smoothing: 3 }
+      { name: 'full', percentage: 100, duration: 300000, smoothing: 3 },
     ],
     rollback: {
       automatic: true,
-      timeoutMs: 120000
-    }
+      timeoutMs: 120000,
+    },
   };
 
   // Override with config file if exists
@@ -75,22 +75,24 @@ function loadConfig(): DeploymentConfig {
 }
 
 // Execute command with proper error handling and specific types
-async function exec(command: string): Promise<{ success: boolean; output?: string; error?: string }> {
+async function exec(
+  command: string
+): Promise<{ success: boolean; output?: string; error?: string }> {
   try {
     const output = execSync(command, { encoding: 'utf-8', stdio: 'pipe' });
     return { success: true, output };
   } catch (error: unknown) {
     const execError = error as { message: string; stdout?: Buffer };
-    return { 
-      success: false, 
+    return {
+      success: false,
       error: execError.message,
-      output: execError.stdout?.toString() || ''
+      output: execError.stdout?.toString() || '',
     };
   }
 }
 
 // Sleep helper
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Statistical analysis for canary deployments
 interface StatisticalTest {
@@ -101,8 +103,10 @@ interface StatisticalTest {
 }
 
 function twoProportionZTest(
-  successes1: number, total1: number, 
-  successes2: number, total2: number,
+  successes1: number,
+  total1: number,
+  successes2: number,
+  total2: number,
   alpha: number = 0.05
 ): StatisticalTest {
   if (total1 === 0 || total2 === 0) {
@@ -112,32 +116,33 @@ function twoProportionZTest(
   const p1 = successes1 / total1;
   const p2 = successes2 / total2;
   const pooledP = (successes1 + successes2) / (total1 + total2);
-  
+
   if (pooledP === 0 || pooledP === 1) {
     return { pValue: 1.0, significant: false, confidenceLevel: 1 - alpha, effect: 'neutral' };
   }
 
-  const se = Math.sqrt(pooledP * (1 - pooledP) * (1/total1 + 1/total2));
+  const se = Math.sqrt(pooledP * (1 - pooledP) * (1 / total1 + 1 / total2));
   const z = Math.abs(p1 - p2) / se;
-  
+
   // Two-tailed p-value approximation
   const pValue = 2 * (1 - normalCDF(Math.abs(z)));
-  
+
   const effect = p1 > p2 ? 'positive' : p1 < p2 ? 'negative' : 'neutral';
-  
+
   return {
     pValue,
     significant: pValue < alpha,
     confidenceLevel: 1 - alpha,
-    effect
+    effect,
   };
 }
 
 function normalCDF(x: number): number {
   // Approximation of standard normal CDF
   const t = 1 / (1 + 0.2316419 * Math.abs(x));
-  const d = 0.3989423 * Math.exp(-x * x / 2);
-  const prob = d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+  const d = 0.3989423 * Math.exp((-x * x) / 2);
+  const prob =
+    d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
   return x > 0 ? 1 - prob : prob;
 }
 
@@ -148,7 +153,7 @@ class ProductionDeployment {
   private startTime: number;
   private confidence: number = 0.5;
   private tracer: DeploymentTracer;
-  private history: Array<{success: boolean; duration: number; version: string}> = [];
+  private history: Array<{ success: boolean; duration: number; version: string }> = [];
   private circuitBreaker: DeploymentCircuitBreaker;
   private sloValidator: SLOValidator;
   private statisticalGates: StatisticalGates;
@@ -161,27 +166,27 @@ class ProductionDeployment {
       version,
       startTime: this.startTime,
       stages: [],
-      metrics: []
+      metrics: [],
     };
-    
+
     // Initialize distributed tracing
     this.tracer = new DeploymentTracer(this.deployment.id, version);
-    
+
     // Initialize circuit breaker with Redis persistence
     this.circuitBreaker = new DeploymentCircuitBreaker({
       failureThreshold: Number(process.env.CIRCUIT_BREAKER_THRESHOLD || 3),
       resetTimeout: Number(process.env.CIRCUIT_BREAKER_RESET_TIMEOUT || 3600000),
       halfOpenTests: 1,
       redisUrl: process.env.REDIS_URL,
-      persistenceKey: 'deployment-circuit-breaker'
+      persistenceKey: 'deployment-circuit-breaker',
     });
-    
+
     // Initialize SLO validator
     this.sloValidator = new SLOValidator();
-    
+
     // Initialize statistical gates
     this.statisticalGates = new StatisticalGates();
-    
+
     // Load deployment history and adjust confidence
     this.loadDeploymentHistory();
     this.updateConfidenceFromHistory();
@@ -190,7 +195,7 @@ class ProductionDeployment {
   async execute() {
     // Check circuit breaker status first
     const circuitStatus = this.circuitBreaker.getStatus();
-    console.log(`🔌 Circuit Breaker Status: ${circuitStatus.state.toUpperCase()}`);
+    console.log(`Circuit Breaker Status: ${circuitStatus.state.toUpperCase()}`);
     if (!circuitStatus.healthy) {
       console.log(`   Will reset at: ${circuitStatus.willResetAt?.toISOString()}`);
     }
@@ -198,7 +203,7 @@ class ProductionDeployment {
     // Execute deployment with circuit breaker protection
     try {
       return await this.circuitBreaker.executeDeployment(async () => {
-        console.log('🚀 Production Deployment Starting');
+        console.log('Production Deployment Starting');
         console.log(`   Version: ${this.version}`);
         console.log(`   Deployment ID: ${this.deployment.id}`);
         console.log(`   Confidence: ${(this.confidence * 100).toFixed(1)}%\n`);
@@ -208,8 +213,10 @@ class ProductionDeployment {
 
         // Phase 2: Progressive deployment with adaptive stages
         const adaptiveStages = this.getAdaptiveStages();
-        console.log(`📈 Using ${adaptiveStages.length}-stage rollout based on confidence: ${(this.confidence * 100).toFixed(1)}%\n`);
-        
+        console.log(
+          `Using ${adaptiveStages.length}-stage rollout based on confidence: ${(this.confidence * 100).toFixed(1)}%\n`
+        );
+
         for (const stage of adaptiveStages) {
           await this.deployStage(stage);
         }
@@ -219,18 +226,18 @@ class ProductionDeployment {
 
         // Success!
         await this.recordSuccess();
-        
+
         // Finish tracing
         this.tracer.finishDeployment('success', {
           totalDuration: Date.now() - this.startTime,
           stagesCompleted: adaptiveStages.length,
-          finalConfidence: this.confidence
+          finalConfidence: this.confidence,
         });
-        
-        console.log('\n✅ Deployment successful!');
+
+        console.log('\nPASS: Deployment successful!');
         console.log(`   Total time: ${Math.round((Date.now() - this.startTime) / 60000)} minutes`);
         console.log(`   Trace ID: ${this.tracer.getRootSpanId()}`);
-        
+
         return this.deployment;
       }); // End of circuit breaker execution
     } catch (error) {
@@ -240,43 +247,44 @@ class ProductionDeployment {
   }
 
   async handleFailure(error: unknown) {
-    const deploymentError = error instanceof Error 
-      ? createDeploymentError(error.message, {
-          deploymentId: this.deployment.id,
-          version: this.version,
-          confidence: this.confidence
-        })
-      : createDeploymentError('Unknown deployment error', {
-          deploymentId: this.deployment.id,
-          version: this.version,
-          confidence: this.confidence
-        });
+    const deploymentError =
+      error instanceof Error
+        ? createDeploymentError(error.message, {
+            deploymentId: this.deployment.id,
+            version: this.version,
+            confidence: this.confidence,
+          })
+        : createDeploymentError('Unknown deployment error', {
+            deploymentId: this.deployment.id,
+            version: this.version,
+            confidence: this.confidence,
+          });
 
-    console.error(`\n❌ Deployment failed: ${deploymentError.message}`);
-    
+    console.error(`\nFAIL: Deployment failed: ${deploymentError.message}`);
+
     if (this.config.rollback.automatic) {
       deploymentError.rollbackTriggered = true;
       await this.rollback();
     }
-    
+
     // Finish tracing with failure
     this.tracer.finishDeployment('failed', {
       error: deploymentError.message,
       rollbackTriggered: deploymentError.rollbackTriggered,
-      failureStage: deploymentError.stage
+      failureStage: deploymentError.stage,
     });
-    
+
     await this.recordFailure(deploymentError);
     console.log(`   Trace ID: ${this.tracer.getRootSpanId()}`);
-    
+
     // Circuit breaker will handle the failure tracking
     throw deploymentError;
   }
 
   private async preflight() {
     const preflightSpan = this.tracer.startPreflight();
-    console.log('✈️  Preflight Checks\n');
-    
+    console.log('Preflight Checks\n');
+
     // Hard gates for external dependencies
     await this.validateExternalDependencies();
 
@@ -284,43 +292,45 @@ class ProductionDeployment {
       {
         name: 'Git tag exists',
         command: `git rev-parse ${this.version}`,
-        critical: true
+        critical: true,
       },
       {
         name: 'All tests passing',
         command: 'npm test -- --run',
-        critical: true
+        critical: true,
       },
       {
         name: 'TypeScript compilation',
         command: 'npm run check',
-        critical: true
+        critical: true,
       },
       {
-        name: 'Database migrations',
-        command: 'npm run db:migrate -- --dry-run',
-        critical: false
+        name: 'Schema audit (audit-only reconcile)',
+        command: 'node scripts/schema-audit-preflight.mjs',
+        critical: false,
       },
       {
         name: 'Security audit',
         command: 'npm audit --audit-level=high',
-        critical: false
-      }
+        critical: false,
+      },
     ];
 
     try {
       for (const check of checks) {
         process.stdout.write(`   ${check.name}... `);
         tracer.log(preflightSpan.id, 'info', `Running check: ${check.name}`);
-        
+
         const result = await exec(check.command);
-        
+
         if (result.success) {
-          console.log('✅');
+          console.log('PASS:');
           tracer.log(preflightSpan.id, 'info', `Check passed: ${check.name}`);
         } else {
-          console.log('❌');
-          tracer.log(preflightSpan.id, 'error', `Check failed: ${check.name}`, { error: result.error });
+          console.log('FAIL:');
+          tracer.log(preflightSpan.id, 'error', `Check failed: ${check.name}`, {
+            error: result.error,
+          });
           if (check.critical) {
             throw new Error(`Critical check failed: ${check.name}`);
           }
@@ -330,14 +340,16 @@ class ProductionDeployment {
       tracer.finishSpan(preflightSpan.id, 'completed', { checksCompleted: checks.length });
       console.log();
     } catch (error) {
-      tracer.finishSpan(preflightSpan.id, 'failed', { error: error instanceof Error ? error.message : 'Unknown error' });
+      tracer.finishSpan(preflightSpan.id, 'failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       throw error;
     }
   }
 
   private async validateExternalDependencies() {
-    console.log('🔍 Validating External Dependencies\n');
-    
+    console.log('Validating External Dependencies\n');
+
     const dependencies = [
       {
         name: 'Database Connection',
@@ -351,7 +363,7 @@ class ProductionDeployment {
           } else {
             throw new Error('DATABASE_URL environment variable not set');
           }
-        }
+        },
       },
       {
         name: 'Redis Connection',
@@ -365,7 +377,7 @@ class ProductionDeployment {
           } else {
             throw new Error('REDIS_URL environment variable not set');
           }
-        }
+        },
       },
       {
         name: 'Error Tracking DSN',
@@ -377,7 +389,7 @@ class ProductionDeployment {
               const url = new URL(process.env.ERROR_TRACKING_DSN);
               const response = await fetch(`${url.protocol}//${url.host}/api/0/`, {
                 method: 'HEAD',
-                timeout: 5000
+                timeout: 5000,
               });
               if (!response.ok) {
                 throw new Error(`Error tracking service returned ${response.status}`);
@@ -386,19 +398,19 @@ class ProductionDeployment {
               throw new Error(`Error tracking service unreachable: ${error}`);
             }
           } else {
-            console.warn('   ⚠️  ERROR_TRACKING_DSN not configured (optional)');
+            console.warn('   WARN: ERROR_TRACKING_DSN not configured (optional)');
           }
-        }
+        },
       },
       {
         name: 'Required Environment Variables',
         test: async () => {
           const required = ['NODE_ENV', 'CORS_ORIGIN', 'BODY_LIMIT'];
-          const missing = required.filter(env => !process.env[env]);
+          const missing = required.filter((env) => !process.env[env]);
           if (missing.length > 0) {
             throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
           }
-        }
+        },
       },
       {
         name: 'Prometheus Endpoint',
@@ -406,9 +418,12 @@ class ProductionDeployment {
           // Test Prometheus connectivity if configured
           if (process.env.PROMETHEUS_URL) {
             try {
-              const response = await fetch(`${process.env.PROMETHEUS_URL}/api/v1/label/__name__/values`, {
-                timeout: 5000
-              });
+              const response = await fetch(
+                `${process.env.PROMETHEUS_URL}/api/v1/label/__name__/values`,
+                {
+                  timeout: 5000,
+                }
+              );
               if (!response.ok) {
                 throw new Error(`Prometheus returned ${response.status}`);
               }
@@ -416,31 +431,31 @@ class ProductionDeployment {
               throw new Error(`Prometheus unreachable: ${error}`);
             }
           } else {
-            console.log('   ℹ️  PROMETHEUS_URL not configured (using simulation mode)');
+            console.log('   INFO: PROMETHEUS_URL not configured (using simulation mode)');
           }
-        }
-      }
+        },
+      },
     ];
 
     for (const dep of dependencies) {
       try {
         console.log(`   Testing ${dep.name}...`);
         await dep.test();
-        console.log(`   ✅ ${dep.name} - OK`);
+        console.log(`   PASS: ${dep.name} - OK`);
       } catch (error) {
-        console.error(`   ❌ ${dep.name} - FAILED: ${error}`);
+        console.error(`   FAIL: ${dep.name} - FAILED: ${error}`);
         throw new Error(`Dependency validation failed: ${dep.name} - ${error}`);
       }
     }
-    
-    console.log('\n✅ All external dependencies validated\n');
+
+    console.log('\nPASS: All external dependencies validated\n');
   }
 
-  private async deployStage(stage: typeof this.config.stages[0]) {
+  private async deployStage(stage: (typeof this.config.stages)[0]) {
     const stageStart = Date.now();
     const stageSpan = this.tracer.startStage(stage.name, stage.percentage, stage.duration);
-    console.log(`📦 Stage: ${stage.name} (${stage.percentage}%)`);
-    
+    console.log(`Stage: ${stage.name} (${stage.percentage}%)`);
+
     // Update traffic routing
     if (stage.percentage > 0) {
       console.log(`   Routing ${stage.percentage}% traffic to v${this.version}`);
@@ -457,9 +472,9 @@ class ProductionDeployment {
     const monitoring = await this.monitorWithSmoothing(stage.duration, stage.smoothing, stage.name);
 
     if (!monitoring.healthy) {
-      tracer.finishSpan(stageSpan.id, 'failed', { 
+      tracer.finishSpan(stageSpan.id, 'failed', {
         reason: monitoring.reason,
-        metrics: monitoring.metrics 
+        metrics: monitoring.metrics,
       });
       throw new Error(`Stage ${stage.name} failed: ${monitoring.reason}`);
     }
@@ -473,19 +488,23 @@ class ProductionDeployment {
       percentage: stage.percentage,
       duration: Date.now() - stageStart,
       metrics: monitoring.metrics,
-      completedAt: Date.now()
+      completedAt: Date.now(),
     });
 
     tracer.finishSpan(stageSpan.id, 'completed', {
       actualDuration: Date.now() - stageStart,
       confidence: this.confidence,
-      metricsCollected: monitoring.metrics?.length || 0
+      metricsCollected: monitoring.metrics?.length || 0,
     });
 
-    console.log(`   ✅ Stage completed successfully\n`);
+    console.log(`   PASS: Stage completed successfully\n`);
   }
 
-  private async monitorWithSmoothing(duration: number, intervals: number, stageName?: string): Promise<any> {
+  private async monitorWithSmoothing(
+    duration: number,
+    intervals: number,
+    stageName?: string
+  ): Promise<any> {
     const startTime = Date.now();
     const checkInterval = Math.min(10000, duration / intervals);
     const samples: any[] = [];
@@ -493,57 +512,70 @@ class ProductionDeployment {
 
     while (Date.now() - startTime < duration) {
       const metrics = await this.fetchMetrics(stageName);
-      
+
       // For canary stages, use statistical gates for authoritative decisions
       if (stageName && (stageName.includes('canary') || stageName.includes('small'))) {
         const canaryMetrics = await this.fetchCanarySpecificMetrics(stageName);
         const baselineMetrics = await this.fetchBaselineMetrics();
-        
+
         // Build statistical arms for comparison
         const canaryArm: StatisticalArm = {
           successes: Math.round(canaryMetrics.sampleSize * metrics.successRate),
           total: canaryMetrics.sampleSize,
-          latencySamples: this.generateLatencySamples(metrics.p99Latency, Math.min(canaryMetrics.sampleSize, 10000)),
+          latencySamples: this.generateLatencySamples(
+            metrics.p99Latency,
+            Math.min(canaryMetrics.sampleSize, 10000)
+          ),
           errorRate: metrics.errorRate,
-          p99Latency: metrics.p99Latency
+          p99Latency: metrics.p99Latency,
         };
-        
+
         const baselineArm: StatisticalArm = {
           successes: Math.round(canaryMetrics.sampleSize * baselineMetrics.successRate),
           total: canaryMetrics.sampleSize,
-          latencySamples: this.generateLatencySamples(baselineMetrics.p99Latency, Math.min(canaryMetrics.sampleSize, 10000)),
+          latencySamples: this.generateLatencySamples(
+            baselineMetrics.p99Latency,
+            Math.min(canaryMetrics.sampleSize, 10000)
+          ),
           errorRate: baselineMetrics.errorRate,
-          p99Latency: baselineMetrics.p99Latency
+          p99Latency: baselineMetrics.p99Latency,
         };
-        
+
         // Apply statistical gates
         const gateResult = this.statisticalGates.evaluateCanary(canaryArm, baselineArm);
-        
-        console.log(`\n   🧮 Statistical Gate Decision: ${gateResult.decision}`);
+
+        console.log(`\n   Statistical Gate Decision: ${gateResult.decision}`);
         console.log(`      Reason: ${gateResult.reason}`);
-        
+
         if (gateResult.decision === 'FAIL') {
           return {
             healthy: false,
             reason: `Statistical gate failed: ${gateResult.reason}`,
             metrics: samples,
-            statisticalResult: gateResult
+            statisticalResult: gateResult,
           };
         } else if (gateResult.decision === 'EXTEND') {
           console.log(`      Extending monitoring period for more samples...`);
           // Extend duration by 50% if we need more samples
           duration = Math.min(duration * 1.5, duration + 300000); // Max 5 min extension
         }
-        
+
         samples.push({ ...metrics, canary: canaryMetrics, statisticalGate: gateResult });
-        
+
         // Log canary-specific insights
-        if (samples.length % 3 === 0) { // Every 3rd sample
-          console.log(`\n   📊 Canary Analysis (${this.version}):`);
-          console.log(`      Error rate: ${canaryMetrics.comparison.errorRateDiff.toFixed(2)}% vs baseline`);
-          console.log(`      Latency: ${canaryMetrics.comparison.latencyDiff.toFixed(2)}% vs baseline`);
+        if (samples.length % 3 === 0) {
+          // Every 3rd sample
+          console.log(`\n   Canary Analysis (${this.version}):`);
+          console.log(
+            `      Error rate: ${canaryMetrics.comparison.errorRateDiff.toFixed(2)}% vs baseline`
+          );
+          console.log(
+            `      Latency: ${canaryMetrics.comparison.latencyDiff.toFixed(2)}% vs baseline`
+          );
           console.log(`      Sample size: ${canaryMetrics.sampleSize} requests`);
-          console.log(`      Required samples: ${gateResult.details.requiresSamples.errors} errors, ${gateResult.details.requiresSamples.latency} latency`);
+          console.log(
+            `      Required samples: ${gateResult.details.requiresSamples.errors} errors, ${gateResult.details.requiresSamples.latency} latency`
+          );
         }
       } else {
         samples.push(metrics);
@@ -554,13 +586,13 @@ class ProductionDeployment {
 
       if (!healthy) {
         failures++;
-        
+
         // N-of-M gating
         if (failures >= Math.ceil(intervals * 0.6)) {
           return {
             healthy: false,
             reason: `${failures}/${intervals} health checks failed`,
-            metrics: samples
+            metrics: samples,
           };
         }
       } else {
@@ -577,7 +609,7 @@ class ProductionDeployment {
     return {
       healthy: true,
       metrics: samples,
-      successRate: (intervals - failures) / intervals
+      successRate: (intervals - failures) / intervals,
     };
   }
 
@@ -586,7 +618,7 @@ class ProductionDeployment {
     // Example Prometheus queries:
     // - rate(http_requests_total{version="v1.3.2",stage="canary"}[5m])
     // - histogram_quantile(0.99, rate(http_request_duration_seconds_bucket{version="v1.3.2"}[5m]))
-    
+
     const baseMetrics = {
       timestamp: Date.now(),
       errorRate: Math.random() * 0.005, // 0-0.5% error rate
@@ -594,7 +626,7 @@ class ProductionDeployment {
       memoryUsage: 0.4 + Math.random() * 0.3, // 40-70%
       cpuUsage: 0.3 + Math.random() * 0.3, // 30-60%
       requestRate: 1000 + Math.random() * 500, // 1000-1500 RPS
-      successRate: 0.995 + Math.random() * 0.005 // 99.5-100% success
+      successRate: 0.995 + Math.random() * 0.005, // 99.5-100% success
     };
 
     // Add version-specific and stage-specific variations for realism
@@ -620,16 +652,23 @@ class ProductionDeployment {
     // Version-specific metrics comparison
     const currentMetrics = await this.fetchMetrics(stage);
     const baselineMetrics = await this.fetchBaselineMetrics();
-    
+
     return {
       version: this.version,
       stage,
       comparison: {
-        errorRateDiff: ((currentMetrics.errorRate - baselineMetrics.errorRate) / baselineMetrics.errorRate) * 100,
-        latencyDiff: ((currentMetrics.p99Latency - baselineMetrics.p99Latency) / baselineMetrics.p99Latency) * 100,
-        performanceDiff: ((currentMetrics.successRate - baselineMetrics.successRate) / baselineMetrics.successRate) * 100
+        errorRateDiff:
+          ((currentMetrics.errorRate - baselineMetrics.errorRate) / baselineMetrics.errorRate) *
+          100,
+        latencyDiff:
+          ((currentMetrics.p99Latency - baselineMetrics.p99Latency) / baselineMetrics.p99Latency) *
+          100,
+        performanceDiff:
+          ((currentMetrics.successRate - baselineMetrics.successRate) /
+            baselineMetrics.successRate) *
+          100,
       },
-      sampleSize: Math.floor(1000 * (stage === 'canary' ? 0.01 : 0.05)) // Realistic sample sizes
+      sampleSize: Math.floor(1000 * (stage === 'canary' ? 0.01 : 0.05)), // Realistic sample sizes
     };
   }
 
@@ -643,7 +682,7 @@ class ProductionDeployment {
       memoryUsage: 0.5,
       cpuUsage: 0.4,
       requestRate: 1200,
-      successRate: 0.998
+      successRate: 0.998,
     };
   }
 
@@ -652,17 +691,17 @@ class ProductionDeployment {
       metrics.errorRate < this.config.thresholds.errorRate,
       metrics.p99Latency < this.config.thresholds.p99Latency,
       metrics.memoryUsage < this.config.thresholds.memoryUsage,
-      metrics.cpuUsage < this.config.thresholds.cpuUsage
+      metrics.cpuUsage < this.config.thresholds.cpuUsage,
     ];
 
-    return checks.every(check => check);
+    return checks.every((check) => check);
   }
 
   private async updateTrafficSplit(percentage: number) {
     // In production, update load balancer/service mesh
     // Example: kubectl set image deployment/api api=myapp:${this.version}
     // Example: aws elbv2 modify-target-group-attributes
-    
+
     // For now, simulate
     await sleep(1000);
   }
@@ -671,10 +710,10 @@ class ProductionDeployment {
     // Bayesian confidence using Beta distribution
     const priorSuccesses = Math.max(1, this.confidence * 20); // Convert to beta parameters
     const priorFailures = Math.max(1, (1 - this.confidence) * 20);
-    
+
     const posteriorSuccesses = priorSuccesses + (score > 0.5 ? 1 : 0);
     const posteriorFailures = priorFailures + (score <= 0.5 ? 1 : 0);
-    
+
     // Update confidence as the mean of the posterior Beta distribution
     this.confidence = posteriorSuccesses / (posteriorSuccesses + posteriorFailures);
     this.confidence = Math.max(0.1, Math.min(0.95, this.confidence)); // Clamp between 10% and 95%
@@ -688,7 +727,7 @@ class ProductionDeployment {
         this.history = data.map((d: any) => ({
           success: d.status === 'success',
           duration: d.duration || 0,
-          version: d.version || 'unknown'
+          version: d.version || 'unknown',
         }));
       } catch (error) {
         console.warn('Failed to load deployment history:', error);
@@ -700,17 +739,23 @@ class ProductionDeployment {
     const recentDeployments = this.history.slice(-10);
     if (recentDeployments.length === 0) return;
 
-    const successRate = recentDeployments.filter(d => d.success).length / recentDeployments.length;
-    const avgDuration = recentDeployments.reduce((sum, d) => sum + d.duration, 0) / recentDeployments.length;
+    const successRate =
+      recentDeployments.filter((d) => d.success).length / recentDeployments.length;
+    const avgDuration =
+      recentDeployments.reduce((sum, d) => sum + d.duration, 0) / recentDeployments.length;
 
     // Adjust confidence based on history
-    if (successRate > 0.9 && avgDuration < 1800000) { // >90% success, <30min avg
+    if (successRate > 0.9 && avgDuration < 1800000) {
+      // >90% success, <30min avg
       this.confidence = Math.min(0.9, this.confidence * 1.1);
-    } else if (successRate < 0.5) { // <50% success
+    } else if (successRate < 0.5) {
+      // <50% success
       this.confidence = Math.max(0.2, this.confidence * 0.7);
     }
 
-    console.log(`📊 Confidence adjusted from history: ${(this.confidence * 100).toFixed(1)}% (${successRate * 100}% success rate)`);
+    console.log(
+      `Confidence adjusted from history: ${(this.confidence * 100).toFixed(1)}% (${successRate * 100}% success rate)`
+    );
   }
 
   private getAdaptiveStages() {
@@ -721,17 +766,17 @@ class ProductionDeployment {
         { name: 'smoke', percentage: 0, duration: 60000, smoothing: 1 },
         { name: 'canary', percentage: 10, duration: 120000, smoothing: 3 },
         { name: 'majority', percentage: 50, duration: 180000, smoothing: 5 },
-        { name: 'full', percentage: 100, duration: 300000, smoothing: 3 }
+        { name: 'full', percentage: 100, duration: 300000, smoothing: 3 },
       ];
     } else if (this.confidence > 0.7) {
-      // Medium confidence - standard rollout  
+      // Medium confidence - standard rollout
       return [
         { name: 'smoke', percentage: 0, duration: 120000, smoothing: 1 },
         { name: 'canary', percentage: 5, duration: 180000, smoothing: 3 },
         { name: 'early', percentage: 25, duration: 300000, smoothing: 5 },
         { name: 'majority', percentage: 50, duration: 300000, smoothing: 5 },
         { name: 'nearly-full', percentage: 95, duration: 180000, smoothing: 3 },
-        { name: 'full', percentage: 100, duration: 300000, smoothing: 3 }
+        { name: 'full', percentage: 100, duration: 300000, smoothing: 3 },
       ];
     } else {
       // Low confidence - cautious rollout
@@ -743,25 +788,25 @@ class ProductionDeployment {
         { name: 'quarter', percentage: 25, duration: 900000, smoothing: 5 },
         { name: 'half', percentage: 50, duration: 900000, smoothing: 5 },
         { name: 'most', percentage: 95, duration: 600000, smoothing: 3 },
-        { name: 'full', percentage: 100, duration: 600000, smoothing: 3 }
+        { name: 'full', percentage: 100, duration: 600000, smoothing: 3 },
       ];
     }
   }
 
   private async finalValidation() {
-    console.log('🔍 Final Validation\n');
+    console.log('Final Validation\n');
 
     const validations = [
       { name: 'SLO compliance', check: () => this.validateSLOs() },
       { name: 'Synthetic tests', check: () => this.runSyntheticTests() },
-      { name: 'Health endpoints', check: () => this.checkHealthEndpoints() }
+      { name: 'Health endpoints', check: () => this.checkHealthEndpoints() },
     ];
 
     for (const validation of validations) {
       process.stdout.write(`   ${validation.name}... `);
       const passed = await validation.check();
-      console.log(passed ? '✅' : '❌');
-      
+      console.log(passed ? 'PASS:' : 'FAIL:');
+
       if (!passed) {
         throw new Error(`Final validation failed: ${validation.name}`);
       }
@@ -771,14 +816,14 @@ class ProductionDeployment {
   private async validateSLOs(): Promise<boolean> {
     // Use comprehensive multi-window burn rate analysis
     const sloResult = await this.sloValidator.validate(this.version);
-    
+
     console.log(`   SLO Status: ${sloResult.overallSeverity.toUpperCase()}`);
     console.log(`   Recommendation: ${sloResult.recommendation}`);
-    
+
     // Log error budget status
     const budgetStatus = await this.sloValidator.getErrorBudgetStatus();
     console.log(`   Error Budget: ${(budgetStatus.remaining * 100).toFixed(1)}% remaining`);
-    
+
     return sloResult.passing;
   }
 
@@ -800,43 +845,43 @@ class ProductionDeployment {
     const samples: number[] = [];
     const mean = Math.log(p99 * 0.6); // Mean is lower than p99
     const stddev = 0.3;
-    
+
     for (let i = 0; i < count; i++) {
       // Box-Muller transform for normal distribution
       const u1 = Math.random();
       const u2 = Math.random();
       const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
-      
+
       // Convert to log-normal
       const sample = Math.exp(mean + stddev * z);
       samples.push(Math.max(10, Math.round(sample))); // Min 10ms
     }
-    
+
     return samples.sort((a, b) => a - b);
   }
 
   private async rollback() {
-    console.log('\n🔄 Rolling back deployment...');
-    
+    console.log('\nRolling back deployment...');
+
     const rollbackStart = Date.now();
-    
+
     // Get previous version
     const result = await exec('git describe --abbrev=0 --tags HEAD~1');
     const previousVersion = result.output?.trim() || 'previous';
-    
+
     console.log(`   Rolling back to ${previousVersion}`);
-    
+
     // Update traffic to previous version
     await this.updateTrafficSplit(0);
-    
+
     // Record rollback
     this.deployment.rollback = {
       triggeredAt: rollbackStart,
       duration: Date.now() - rollbackStart,
-      previousVersion
+      previousVersion,
     };
-    
-    console.log('   ✅ Rollback completed\n');
+
+    console.log('   PASS: Rollback completed\n');
   }
 
   private async recordSuccess() {
@@ -844,15 +889,13 @@ class ProductionDeployment {
       ...this.deployment,
       status: 'success',
       duration: Date.now() - this.startTime,
-      confidence: this.confidence
+      confidence: this.confidence,
     };
-    
+
     // Write to deployment history
     const historyPath = join(process.cwd(), 'deployments.json');
-    const history = existsSync(historyPath) 
-      ? JSON.parse(readFileSync(historyPath, 'utf-8'))
-      : [];
-    
+    const history = existsSync(historyPath) ? JSON.parse(readFileSync(historyPath, 'utf-8')) : [];
+
     history.push(record);
     writeFileSync(historyPath, JSON.stringify(history, null, 2));
   }
@@ -863,15 +906,13 @@ class ProductionDeployment {
       status: 'failed',
       error: error.message,
       duration: Date.now() - this.startTime,
-      confidence: this.confidence
+      confidence: this.confidence,
     };
-    
+
     // Write to deployment history
     const historyPath = join(process.cwd(), 'deployments.json');
-    const history = existsSync(historyPath)
-      ? JSON.parse(readFileSync(historyPath, 'utf-8'))
-      : [];
-    
+    const history = existsSync(historyPath) ? JSON.parse(readFileSync(historyPath, 'utf-8')) : [];
+
     history.push(record);
     writeFileSync(historyPath, JSON.stringify(history, null, 2));
   }
@@ -880,7 +921,7 @@ class ProductionDeployment {
 // Main execution
 async function main() {
   const version = process.argv[2] || process.env.DEPLOY_VERSION;
-  
+
   if (!version) {
     console.error('Usage: deploy-production.ts <version>');
     console.error('   or: DEPLOY_VERSION=v1.2.3 deploy-production.ts');
@@ -893,7 +934,7 @@ async function main() {
 
 // Run if called directly (ES module compatible)
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(error => {
+  main().catch((error) => {
     console.error('Fatal error:', error);
     process.exit(1);
   });

--- a/scripts/dual-ledger-divergence.ts
+++ b/scripts/dual-ledger-divergence.ts
@@ -1,0 +1,763 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { readJournaledMigrationFiles } from './migration-ledger';
+
+export type DdlObject = {
+  kind: 'table' | 'column' | 'constraint' | 'index';
+  name: string;
+  table?: string;
+};
+
+export interface DivergenceRow {
+  severity: 'info';
+  code: string;
+  file: string;
+  message: string;
+}
+
+export interface DetectorError {
+  severity: 'error';
+  code: string;
+  file?: string;
+  message: string;
+}
+
+export interface DualLedgerDivergenceResult {
+  ok: boolean;
+  divergences: DivergenceRow[];
+  errors: DetectorError[];
+  summary: {
+    serverForwardFiles: number;
+    uniqueObjectFiles: number;
+    duplicateFiles: number;
+    activeConsumerFiles: number;
+  };
+}
+
+type ParseDiagnostic = {
+  kind: 'note' | 'error';
+  message: string;
+};
+
+type ParsedDdlObjects = {
+  objects: DdlObject[];
+  diagnostics: ParseDiagnostic[];
+};
+
+const IDENTIFIER_PATTERN = String.raw`(?:(?:"(?:""|[^"])+"|[a-zA-Z_][a-zA-Z0-9_$]*)\s*\.\s*)?(?:"(?:""|[^"])+"|[a-zA-Z_][a-zA-Z0-9_$]*)`;
+
+const TABLE_PATTERN = new RegExp(
+  String.raw`\bcreate\s+table\s+(?:if\s+not\s+exists\s+)?(${IDENTIFIER_PATTERN})(?=\s|\()`,
+  'i'
+);
+
+const ALTER_ADD_COLUMN_PATTERN = new RegExp(
+  String.raw`\balter\s+table\s+(?:if\s+exists\s+)?(?:only\s+)?(${IDENTIFIER_PATTERN})\s+add\s+column\s+(?:if\s+not\s+exists\s+)?(${IDENTIFIER_PATTERN})(?=\s|,|;)`,
+  'i'
+);
+
+const CONSTRAINT_PATTERN = new RegExp(
+  String.raw`\b(?:add\s+)?constraint\s+(?:if\s+not\s+exists\s+)?(${IDENTIFIER_PATTERN})(?=\s)`,
+  'gi'
+);
+
+const INDEX_PATTERN = new RegExp(
+  String.raw`\bcreate\s+(?:unique\s+)?index\s+(?:concurrently\s+)?(?:if\s+not\s+exists\s+)?(${IDENTIFIER_PATTERN})\s+on\b`,
+  'i'
+);
+
+const ACTIVE_CONSUMER_FILES = [
+  'scripts/quality-gates.ts',
+  'scripts/schema-drift-active-surfaces.ts',
+  'tests/helpers/apply-investment-round-constraints.ts',
+  'tests/integration/allocation-scenario-apply.test.ts',
+  'tests/integration/lp-reporting-foundation-migration.test.ts',
+  'tests/unit/schema/lp-reporting-evidence-schema.test.ts',
+  'tests/unit/schema/schema-drift-active-surfaces.test.ts',
+  'server/services/sensitivity-run-service.ts',
+] as const;
+
+const ACTIVE_CONSUMER_GLOBS = [
+  { dir: 'shared/contracts/lp-reporting', suffix: '.contract.ts' },
+  { dir: 'shared/schema', suffix: '.ts' },
+] as const;
+
+export function extractDdlObjects(sql: string): DdlObject[] {
+  return parseDdlObjects(sql).objects;
+}
+
+export function detectDualLedgerDivergence(rootDir: string): DualLedgerDivergenceResult {
+  const resolvedRoot = path.resolve(rootDir);
+  const divergences: DivergenceRow[] = [];
+  const errors: DetectorError[] = [];
+  const journalObjects = new Map<string, DdlObject>();
+
+  try {
+    for (const migration of readJournaledMigrationFiles(resolvedRoot)) {
+      addObjectsToMap(journalObjects, parseDdlForDetector(migration.sql, migration.file, errors));
+    }
+  } catch (error) {
+    errors.push({
+      severity: 'error',
+      code: 'journal-read-error',
+      message: errorMessage(error, 'Failed to read journaled migration files.'),
+    });
+  }
+
+  for (const sharedFile of listSharedMigrationFiles(resolvedRoot, errors)) {
+    const relativePath = normalizePath(path.relative(resolvedRoot, sharedFile));
+    try {
+      const sql = fs.readFileSync(sharedFile, 'utf8');
+      addObjectsToMap(journalObjects, parseDdlForDetector(sql, relativePath, errors));
+    } catch (error) {
+      errors.push({
+        severity: 'error',
+        code: 'shared-file-read-error',
+        file: relativePath,
+        message: errorMessage(error, `Failed to read shared migration file ${relativePath}.`),
+      });
+    }
+  }
+
+  const serverForwardFiles = listServerMigrationFiles(resolvedRoot, errors).filter(
+    (file) => !file.endsWith('.down.sql')
+  );
+
+  for (const file of serverForwardFiles) {
+    const absolutePath = path.join(resolvedRoot, 'server', 'migrations', file);
+    const relativePath = normalizePath(path.relative(resolvedRoot, absolutePath));
+    let objects: DdlObject[];
+
+    try {
+      const sql = fs.readFileSync(absolutePath, 'utf8');
+      objects = parseDdlForDetector(sql, relativePath, errors);
+    } catch (error) {
+      errors.push({
+        severity: 'error',
+        code: 'server-file-read-error',
+        file: relativePath,
+        message: errorMessage(error, `Failed to read server migration file ${relativePath}.`),
+      });
+      continue;
+    }
+
+    const objectKeys = uniqueSorted(objects.map(objectKey));
+    const missingObjectKeys = objectKeys.filter((key) => !journalObjects.has(key));
+    if (missingObjectKeys.length > 0) {
+      divergences.push({
+        severity: 'info',
+        code: 'server-unique-content',
+        file: relativePath,
+        message: `Server forward migration creates objects absent from the journal/shared ledger: ${missingObjectKeys.join(', ')}`,
+      });
+    }
+
+    const tableObjectKeys = uniqueSorted(
+      objects.filter((object) => object.kind === 'table').map(objectKey)
+    );
+    if (tableObjectKeys.length > 0 && tableObjectKeys.every((key) => journalObjects.has(key))) {
+      divergences.push({
+        severity: 'info',
+        code: 'server-shape-duplicate',
+        file: relativePath,
+        message: `All server-created table objects are already present in the journal/shared ledger: ${tableObjectKeys.join(', ')}`,
+      });
+    }
+  }
+
+  const activeConsumerRows = detectActiveConsumerFiles(resolvedRoot, errors);
+  divergences.push(...activeConsumerRows);
+
+  return {
+    ok: errors.length === 0,
+    divergences,
+    errors,
+    summary: {
+      serverForwardFiles: serverForwardFiles.length,
+      uniqueObjectFiles: countRows(divergences, 'server-unique-content'),
+      duplicateFiles: countRows(divergences, 'server-shape-duplicate'),
+      activeConsumerFiles: activeConsumerRows.length,
+    },
+  };
+}
+
+export function formatDualLedgerReport(result: DualLedgerDivergenceResult): string {
+  const lines = [
+    '# Dual Ledger Divergence Report',
+    '',
+    `ok=${String(result.ok)}`,
+    `serverForwardFiles=${result.summary.serverForwardFiles}`,
+    `uniqueObjectFiles=${result.summary.uniqueObjectFiles}`,
+    `duplicateFiles=${result.summary.duplicateFiles}`,
+    `activeConsumerFiles=${result.summary.activeConsumerFiles}`,
+    `errors=${result.errors.length}`,
+    '',
+  ];
+
+  if (result.errors.length > 0) {
+    lines.push('## Detector Errors', '');
+    for (const error of result.errors) {
+      const file = error.file ? ` file=${error.file}` : '';
+      lines.push(`- ERROR code=${error.code}${file}`);
+      lines.push(`  ${error.message}`);
+    }
+    lines.push('');
+  }
+
+  if (result.divergences.length === 0) {
+    lines.push('## Divergences', '', 'No report-only divergence rows.');
+    return lines.join('\n');
+  }
+
+  lines.push('## Divergences', '');
+  for (const [code, rows] of groupRowsByCode(result.divergences)) {
+    lines.push(`### ${code}`, '');
+    for (const row of rows) {
+      lines.push(`- ${row.file}`);
+      lines.push(`  ${row.message}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+function parseDdlForDetector(sql: string, file: string, errors: DetectorError[]): DdlObject[] {
+  const parsed = parseDdlObjects(sql);
+  for (const diagnostic of parsed.diagnostics) {
+    if (diagnostic.kind === 'error') {
+      errors.push({
+        severity: 'error',
+        code: 'sql-parse-error',
+        file,
+        message: diagnostic.message,
+      });
+    }
+  }
+  return parsed.objects;
+}
+
+function parseDdlObjects(sql: string): ParsedDdlObjects {
+  const objects = new Map<string, DdlObject>();
+  const diagnostics: ParseDiagnostic[] = [];
+
+  for (const statement of splitSqlStatements(sql)) {
+    const normalizedStatement = stripSqlComments(statement).trim();
+    if (normalizedStatement.length === 0 || !shouldParseStatement(normalizedStatement)) {
+      continue;
+    }
+
+    if (hasUnclosedQuotedIdentifier(normalizedStatement)) {
+      diagnostics.push({
+        kind: 'error',
+        message: `Could not parse DDL statement with an unclosed quoted identifier: ${previewStatement(normalizedStatement)}`,
+      });
+      continue;
+    }
+
+    const objectsBefore = objects.size;
+    collectCreateTableObject(normalizedStatement, objects);
+    collectAlterAddColumnObject(normalizedStatement, objects);
+    collectConstraintObjects(normalizedStatement, objects);
+    collectCreateIndexObject(normalizedStatement, objects);
+
+    if (objects.size === objectsBefore) {
+      diagnostics.push({
+        kind: 'note',
+        message: `No supported DDL object was extracted from: ${previewStatement(normalizedStatement)}`,
+      });
+    }
+  }
+
+  return {
+    objects: Array.from(objects.values()).sort((left, right) =>
+      objectKey(left).localeCompare(objectKey(right))
+    ),
+    diagnostics,
+  };
+}
+
+function collectCreateTableObject(statement: string, objects: Map<string, DdlObject>): void {
+  const match = TABLE_PATTERN.exec(statement);
+  const identifier = match?.[1];
+  if (!identifier) return;
+  addObject(objects, { kind: 'table', name: normalizeIdentifier(identifier) });
+}
+
+function collectAlterAddColumnObject(statement: string, objects: Map<string, DdlObject>): void {
+  const match = ALTER_ADD_COLUMN_PATTERN.exec(statement);
+  const tableIdentifier = match?.[1];
+  const columnIdentifier = match?.[2];
+  if (!tableIdentifier || !columnIdentifier) return;
+
+  addObject(objects, {
+    kind: 'column',
+    table: normalizeIdentifier(tableIdentifier),
+    name: normalizeIdentifier(columnIdentifier),
+  });
+}
+
+function collectConstraintObjects(statement: string, objects: Map<string, DdlObject>): void {
+  for (const match of statement.matchAll(CONSTRAINT_PATTERN)) {
+    const identifier = match[1];
+    if (!identifier) continue;
+    addObject(objects, { kind: 'constraint', name: normalizeIdentifier(identifier) });
+  }
+}
+
+function collectCreateIndexObject(statement: string, objects: Map<string, DdlObject>): void {
+  const match = INDEX_PATTERN.exec(statement);
+  const identifier = match?.[1];
+  if (!identifier) return;
+  addObject(objects, { kind: 'index', name: normalizeIdentifier(identifier) });
+}
+
+function addObject(objects: Map<string, DdlObject>, object: DdlObject): void {
+  objects.set(objectKey(object), object);
+}
+
+function addObjectsToMap(target: Map<string, DdlObject>, objects: readonly DdlObject[]): void {
+  for (const object of objects) {
+    target.set(objectKey(object), object);
+  }
+}
+
+function objectKey(object: DdlObject): string {
+  if (object.kind === 'column') {
+    return `${object.kind}:${object.table ?? 'unknown'}.${object.name}`;
+  }
+  return `${object.kind}:${object.name}`;
+}
+
+function shouldParseStatement(statement: string): boolean {
+  return (
+    /\bcreate\s+table\b/i.test(statement) ||
+    /\bcreate\s+(?:unique\s+)?index\b/i.test(statement) ||
+    (/\balter\s+table\b/i.test(statement) && /\badd\s+(?:column|constraint)\b/i.test(statement))
+  );
+}
+
+function hasUnclosedQuotedIdentifier(statement: string): boolean {
+  let quoteCount = 0;
+  for (let index = 0; index < statement.length; index += 1) {
+    const char = statement[index];
+    if (char !== '"') continue;
+
+    if (statement[index + 1] === '"') {
+      index += 1;
+      continue;
+    }
+
+    quoteCount += 1;
+  }
+  return quoteCount % 2 !== 0;
+}
+
+function normalizeIdentifier(identifier: string): string {
+  const parts = splitIdentifierParts(identifier.trim());
+  const lastPart = parts.at(-1) ?? identifier;
+  return stripIdentifierQuotes(lastPart).toLowerCase();
+}
+
+function splitIdentifierParts(identifier: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let inQuotedIdentifier = false;
+
+  for (let index = 0; index < identifier.length; index += 1) {
+    const char = identifier[index];
+    if (char === '"') {
+      current += char;
+      if (identifier[index + 1] === '"') {
+        current += identifier[index + 1];
+        index += 1;
+      } else {
+        inQuotedIdentifier = !inQuotedIdentifier;
+      }
+      continue;
+    }
+
+    if (char === '.' && !inQuotedIdentifier) {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim().length > 0) {
+    parts.push(current.trim());
+  }
+
+  return parts;
+}
+
+function stripIdentifierQuotes(identifier: string): string {
+  const trimmed = identifier.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/""/g, '"');
+  }
+  return trimmed;
+}
+
+function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let current = '';
+  let state: 'normal' | 'single-quote' | 'double-quote' | 'line-comment' | 'block-comment' =
+    'normal';
+  let dollarQuoteTag: string | null = null;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index];
+    const next = sql[index + 1];
+
+    if (dollarQuoteTag) {
+      current += char;
+      if (sql.startsWith(dollarQuoteTag, index)) {
+        current += sql.slice(index + 1, index + dollarQuoteTag.length);
+        index += dollarQuoteTag.length - 1;
+        dollarQuoteTag = null;
+      }
+      continue;
+    }
+
+    if (state === 'line-comment') {
+      current += char;
+      if (char === '\n') state = 'normal';
+      continue;
+    }
+
+    if (state === 'block-comment') {
+      current += char;
+      if (char === '*' && next === '/') {
+        current += next;
+        index += 1;
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'single-quote') {
+      current += char;
+      if (char === "'" && next === "'") {
+        current += next;
+        index += 1;
+      } else if (char === "'") {
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'double-quote') {
+      current += char;
+      if (char === '"' && next === '"') {
+        current += next;
+        index += 1;
+      } else if (char === '"') {
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (char === '-' && next === '-') {
+      current += char + next;
+      index += 1;
+      state = 'line-comment';
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      current += char + next;
+      index += 1;
+      state = 'block-comment';
+      continue;
+    }
+
+    if (char === "'") {
+      current += char;
+      state = 'single-quote';
+      continue;
+    }
+
+    if (char === '"') {
+      current += char;
+      state = 'double-quote';
+      continue;
+    }
+
+    if (char === '$') {
+      const tag = readDollarQuoteTag(sql, index);
+      if (tag) {
+        current += tag;
+        index += tag.length - 1;
+        dollarQuoteTag = tag;
+        continue;
+      }
+    }
+
+    if (char === ';') {
+      if (current.trim().length > 0) {
+        statements.push(current);
+      }
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim().length > 0) {
+    statements.push(current);
+  }
+
+  return statements;
+}
+
+function stripSqlComments(sql: string): string {
+  let output = '';
+  let state: 'normal' | 'single-quote' | 'double-quote' | 'line-comment' | 'block-comment' =
+    'normal';
+  let dollarQuoteTag: string | null = null;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index];
+    const next = sql[index + 1];
+
+    if (dollarQuoteTag) {
+      output += char;
+      if (sql.startsWith(dollarQuoteTag, index)) {
+        output += sql.slice(index + 1, index + dollarQuoteTag.length);
+        index += dollarQuoteTag.length - 1;
+        dollarQuoteTag = null;
+      }
+      continue;
+    }
+
+    if (state === 'line-comment') {
+      if (char === '\n') {
+        output += char;
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'block-comment') {
+      if (char === '*' && next === '/') {
+        output += ' ';
+        index += 1;
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'single-quote') {
+      output += char;
+      if (char === "'" && next === "'") {
+        output += next;
+        index += 1;
+      } else if (char === "'") {
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (state === 'double-quote') {
+      output += char;
+      if (char === '"' && next === '"') {
+        output += next;
+        index += 1;
+      } else if (char === '"') {
+        state = 'normal';
+      }
+      continue;
+    }
+
+    if (char === '-' && next === '-') {
+      index += 1;
+      state = 'line-comment';
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      index += 1;
+      state = 'block-comment';
+      continue;
+    }
+
+    if (char === "'") {
+      output += char;
+      state = 'single-quote';
+      continue;
+    }
+
+    if (char === '"') {
+      output += char;
+      state = 'double-quote';
+      continue;
+    }
+
+    if (char === '$') {
+      const tag = readDollarQuoteTag(sql, index);
+      if (tag) {
+        output += tag;
+        index += tag.length - 1;
+        dollarQuoteTag = tag;
+        continue;
+      }
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+function readDollarQuoteTag(sql: string, startIndex: number): string | null {
+  const rest = sql.slice(startIndex);
+  const match = /^\$[a-zA-Z_][a-zA-Z0-9_]*\$|^\$\$/.exec(rest);
+  return match?.[0] ?? null;
+}
+
+function previewStatement(statement: string): string {
+  const compact = statement.replace(/\s+/g, ' ').trim();
+  return compact.length > 140 ? `${compact.slice(0, 137)}...` : compact;
+}
+
+function listSharedMigrationFiles(rootDir: string, errors: DetectorError[]): string[] {
+  const sharedDir = path.join(rootDir, 'shared', 'migrations');
+  if (!fs.existsSync(sharedDir)) {
+    return [];
+  }
+
+  try {
+    return fs
+      .readdirSync(sharedDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+      .map((entry) => path.join(sharedDir, entry.name))
+      .sort((left, right) => left.localeCompare(right));
+  } catch (error) {
+    errors.push({
+      severity: 'error',
+      code: 'shared-dir-read-error',
+      file: normalizePath(path.relative(rootDir, sharedDir)),
+      message: errorMessage(error, 'Failed to list shared migrations.'),
+    });
+    return [];
+  }
+}
+
+function listServerMigrationFiles(rootDir: string, errors: DetectorError[]): string[] {
+  const serverMigrationsDir = path.join(rootDir, 'server', 'migrations');
+  try {
+    return fs
+      .readdirSync(serverMigrationsDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+      .map((entry) => entry.name)
+      .sort((left, right) => left.localeCompare(right));
+  } catch (error) {
+    errors.push({
+      severity: 'error',
+      code: 'server-dir-read-error',
+      file: normalizePath(path.relative(rootDir, serverMigrationsDir)),
+      message: errorMessage(error, 'Failed to list server migrations.'),
+    });
+    return [];
+  }
+}
+
+function detectActiveConsumerFiles(rootDir: string, errors: DetectorError[]): DivergenceRow[] {
+  const rows: DivergenceRow[] = [];
+  const files = uniqueSorted([...ACTIVE_CONSUMER_FILES, ...expandConsumerGlobs(rootDir)]);
+
+  for (const file of files) {
+    const absolutePath = path.join(rootDir, ...file.split('/'));
+    if (!fs.existsSync(absolutePath)) {
+      continue;
+    }
+
+    try {
+      const contents = fs.readFileSync(absolutePath, 'utf8');
+      if (contents.includes('server/migrations')) {
+        rows.push({
+          severity: 'info',
+          code: 'server-migrations-active-consumer',
+          file,
+          message:
+            'Active code or tests still reference server/migrations; reviewer data for PR-2b, non-gating.',
+        });
+      }
+    } catch (error) {
+      errors.push({
+        severity: 'error',
+        code: 'consumer-file-read-error',
+        file,
+        message: errorMessage(error, `Failed to read active consumer file ${file}.`),
+      });
+    }
+  }
+
+  return rows;
+}
+
+function expandConsumerGlobs(rootDir: string): string[] {
+  const files: string[] = [];
+
+  for (const glob of ACTIVE_CONSUMER_GLOBS) {
+    const absoluteDir = path.join(rootDir, ...glob.dir.split('/'));
+    if (!fs.existsSync(absoluteDir)) {
+      continue;
+    }
+
+    for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith(glob.suffix)) {
+        files.push(`${glob.dir}/${entry.name}`);
+      }
+    }
+  }
+
+  return files;
+}
+
+function groupRowsByCode(rows: readonly DivergenceRow[]): [string, DivergenceRow[]][] {
+  const grouped = new Map<string, DivergenceRow[]>();
+  for (const row of rows) {
+    const existingRows = grouped.get(row.code) ?? [];
+    existingRows.push(row);
+    grouped.set(row.code, existingRows);
+  }
+
+  return Array.from(grouped.entries()).sort(([left], [right]) => left.localeCompare(right));
+}
+
+function countRows(rows: readonly DivergenceRow[], code: string): number {
+  return rows.filter((row) => row.code === code).length;
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function isCliInvocation(): boolean {
+  const invokedPath = process.argv[1];
+  return (
+    typeof invokedPath === 'string' && path.resolve(invokedPath) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isCliInvocation()) {
+  const result = detectDualLedgerDivergence(process.cwd());
+  console.log(formatDualLedgerReport(result));
+  process.exit(result.ok ? 0 : 1);
+}

--- a/scripts/dual-ledger-divergence.ts
+++ b/scripts/dual-ledger-divergence.ts
@@ -177,7 +177,7 @@ export function detectDualLedgerDivergence(rootDir: string): DualLedgerDivergenc
       });
     }
 
-    if (unparsedDdlKeywords.length > 0 && missingObjectKeys.length === 0) {
+    if (unparsedDdlKeywords.length > 0) {
       divergences.push({
         severity: 'info',
         code: 'server-unparsed-ddl',

--- a/scripts/dual-ledger-divergence.ts
+++ b/scripts/dual-ledger-divergence.ts
@@ -54,9 +54,14 @@ const TABLE_PATTERN = new RegExp(
   'i'
 );
 
-const ALTER_ADD_COLUMN_PATTERN = new RegExp(
-  String.raw`\balter\s+table\s+(?:if\s+exists\s+)?(?:only\s+)?(${IDENTIFIER_PATTERN})\s+add\s+column\s+(?:if\s+not\s+exists\s+)?(${IDENTIFIER_PATTERN})(?=\s|,|;)`,
+const ALTER_TABLE_PATTERN = new RegExp(
+  String.raw`\balter\s+table\s+(?:if\s+exists\s+)?(?:only\s+)?(${IDENTIFIER_PATTERN})(?=\s)`,
   'i'
+);
+
+const ADD_COLUMN_CLAUSE_PATTERN = new RegExp(
+  String.raw`\badd\s+column\s+(?:if\s+not\s+exists\s+)?(${IDENTIFIER_PATTERN})(?=\s|,|;)`,
+  'gi'
 );
 
 const CONSTRAINT_PATTERN = new RegExp(
@@ -83,6 +88,21 @@ const ACTIVE_CONSUMER_FILES = [
 const ACTIVE_CONSUMER_GLOBS = [
   { dir: 'shared/contracts/lp-reporting', suffix: '.contract.ts' },
   { dir: 'shared/schema', suffix: '.ts' },
+] as const;
+
+const UNPARSED_DDL_PATTERNS = [
+  {
+    label: 'ALTER COLUMN TYPE',
+    pattern: /^\s*alter\s+table\b[\s\S]*\balter\s+(?:column\s+)?[\s\S]*\btype\b/i,
+  },
+  { label: 'CREATE EXTENSION', pattern: /^\s*create\s+extension\b/i },
+  { label: 'CREATE FUNCTION', pattern: /^\s*create\s+(?:or\s+replace\s+)?function\b/i },
+  { label: 'CREATE MATERIALIZED VIEW', pattern: /^\s*create\s+materialized\s+view\b/i },
+  { label: 'CREATE POLICY', pattern: /^\s*create\s+(?:or\s+replace\s+)?policy\b/i },
+  { label: 'CREATE TRIGGER', pattern: /^\s*create\s+(?:or\s+replace\s+)?trigger\b/i },
+  { label: 'CREATE TYPE', pattern: /^\s*create\s+(?:or\s+replace\s+)?type\b/i },
+  { label: 'CREATE VIEW', pattern: /^\s*create\s+(?:or\s+replace\s+)?view\b/i },
+  { label: 'DROP', pattern: /^\s*drop\b/i },
 ] as const;
 
 export function extractDdlObjects(sql: string): DdlObject[] {
@@ -130,10 +150,12 @@ export function detectDualLedgerDivergence(rootDir: string): DualLedgerDivergenc
     const absolutePath = path.join(resolvedRoot, 'server', 'migrations', file);
     const relativePath = normalizePath(path.relative(resolvedRoot, absolutePath));
     let objects: DdlObject[];
+    let unparsedDdlKeywords: string[] = [];
 
     try {
       const sql = fs.readFileSync(absolutePath, 'utf8');
       objects = parseDdlForDetector(sql, relativePath, errors);
+      unparsedDdlKeywords = detectUnparsedDdlKeywords(sql);
     } catch (error) {
       errors.push({
         severity: 'error',
@@ -152,6 +174,17 @@ export function detectDualLedgerDivergence(rootDir: string): DualLedgerDivergenc
         code: 'server-unique-content',
         file: relativePath,
         message: `Server forward migration creates objects absent from the journal/shared ledger: ${missingObjectKeys.join(', ')}`,
+      });
+    }
+
+    if (unparsedDdlKeywords.length > 0 && missingObjectKeys.length === 0) {
+      divergences.push({
+        severity: 'info',
+        code: 'server-unparsed-ddl',
+        file: relativePath,
+        message: `Server forward migration contains unparsed DDL (${unparsedDdlKeywords.join(
+          ', '
+        )}); inspect manually before PR-2b deletion.`,
       });
     }
 
@@ -288,16 +321,20 @@ function collectCreateTableObject(statement: string, objects: Map<string, DdlObj
 }
 
 function collectAlterAddColumnObject(statement: string, objects: Map<string, DdlObject>): void {
-  const match = ALTER_ADD_COLUMN_PATTERN.exec(statement);
-  const tableIdentifier = match?.[1];
-  const columnIdentifier = match?.[2];
-  if (!tableIdentifier || !columnIdentifier) return;
+  const tableMatch = ALTER_TABLE_PATTERN.exec(statement);
+  const tableIdentifier = tableMatch?.[1];
+  if (!tableIdentifier) return;
 
-  addObject(objects, {
-    kind: 'column',
-    table: normalizeIdentifier(tableIdentifier),
-    name: normalizeIdentifier(columnIdentifier),
-  });
+  for (const match of statement.matchAll(ADD_COLUMN_CLAUSE_PATTERN)) {
+    const columnIdentifier = match[1];
+    if (!columnIdentifier) continue;
+
+    addObject(objects, {
+      kind: 'column',
+      table: normalizeIdentifier(tableIdentifier),
+      name: normalizeIdentifier(columnIdentifier),
+    });
+  }
 }
 
 function collectConstraintObjects(statement: string, objects: Map<string, DdlObject>): void {
@@ -338,6 +375,23 @@ function shouldParseStatement(statement: string): boolean {
     /\bcreate\s+(?:unique\s+)?index\b/i.test(statement) ||
     (/\balter\s+table\b/i.test(statement) && /\badd\s+(?:column|constraint)\b/i.test(statement))
   );
+}
+
+function detectUnparsedDdlKeywords(sql: string): string[] {
+  const keywords = new Set<string>();
+
+  for (const statement of splitSqlStatements(sql)) {
+    const normalizedStatement = stripSqlComments(statement).trim();
+    if (normalizedStatement.length === 0) continue;
+
+    for (const { label, pattern } of UNPARSED_DDL_PATTERNS) {
+      if (pattern.test(normalizedStatement)) {
+        keywords.add(label);
+      }
+    }
+  }
+
+  return Array.from(keywords).sort((left, right) => left.localeCompare(right));
 }
 
 function hasUnclosedQuotedIdentifier(statement: string): boolean {

--- a/scripts/ga-checklist.mjs
+++ b/scripts/ga-checklist.mjs
@@ -10,6 +10,8 @@ import fetch from 'node-fetch';
 import fs from 'fs/promises';
 import path from 'path';
 
+import { runSchemaAuditPreflight } from './schema-audit-preflight.mjs';
+
 const CHECKS = {
   // CI/CD checks
   ci: {
@@ -427,13 +429,12 @@ async function checkCanaryFlags() {
 }
 
 async function checkMigrations() {
-  try {
-    // Check if migrations can run successfully
-    const result = execSync('npm run db:migrate -- --dry-run', { encoding: 'utf-8' });
-    return !result.includes('error') && !result.includes('failed');
-  } catch {
-    return false;
-  }
+  const result = await runSchemaAuditPreflight({
+    databaseUrl: process.env.DATABASE_URL,
+    manifestDir: process.env.UPDOG_SCHEMA_MANIFEST_DIR ?? 'scripts/prod-schema-manifests',
+    expectedDb: process.env.UPDOG_EXPECTED_DATABASE ?? null,
+  });
+  return result.ok;
 }
 
 async function checkRollbackCapability() {
@@ -456,7 +457,7 @@ async function checkBackupStatus() {
 
 // Run checklist
 async function runChecklist() {
-  console.log('🚀 GA Pre-deployment Checklist');
+  console.log('GA Pre-deployment Checklist');
   console.log('=' .repeat(50));
   
   const results = {
@@ -467,7 +468,7 @@ async function runChecklist() {
   };
   
   for (const [categoryKey, category] of Object.entries(CHECKS)) {
-    console.log(`\n📋 ${category.name}`);
+    console.log(`\n${category.name}`);
     
     const categoryResult = {
       name: category.name,
@@ -480,7 +481,7 @@ async function runChecklist() {
       process.stdout.write(`  Checking ${check.name}...`);
       
       const result = await check.fn();
-      const status = result ? '✅' : check.critical ? '❌' : '⚠️';
+      const status = result ? 'PASS:' : check.critical ? 'FAIL:' : 'WARN:';
       
       console.log(` ${status}`);
       
@@ -502,13 +503,13 @@ async function runChecklist() {
   
   // Summary
   console.log('\n' + '=' .repeat(50));
-  console.log('📊 CHECKLIST SUMMARY');
+  console.log('CHECKLIST SUMMARY');
   console.log('=' .repeat(50));
   
   if (results.passed) {
-    console.log('✅ All checks passed - READY FOR GA');
+    console.log('PASS: All checks passed - READY FOR GA');
   } else {
-    console.log('❌ Critical failures detected - NOT READY FOR GA');
+    console.log('FAIL: Critical failures detected - NOT READY FOR GA');
     console.log('\nCritical failures:');
     results.criticalFailures.forEach(f => console.log(`  - ${f}`));
   }
@@ -519,7 +520,7 @@ async function runChecklist() {
     JSON.stringify(results, null, 2)
   );
   
-  console.log('\n📁 Results saved to ga-checklist-results.json');
+  console.log('\nResults saved to ga-checklist-results.json');
   
   return results.passed ? 0 : 1;
 }

--- a/scripts/ga-checklist.mjs
+++ b/scripts/ga-checklist.mjs
@@ -428,7 +428,7 @@ async function checkCanaryFlags() {
   return true;
 }
 
-async function checkMigrations() {
+export async function checkMigrations() {
   const result = await runSchemaAuditPreflight({
     databaseUrl: process.env.DATABASE_URL,
     manifestDir: process.env.UPDOG_SCHEMA_MANIFEST_DIR ?? 'scripts/prod-schema-manifests',
@@ -436,7 +436,7 @@ async function checkMigrations() {
   });
   if (result.status === 'skipped') {
     console.warn(result.message);
-    return false;
+    return result.ok;
   }
   return result.ok;
 }

--- a/scripts/ga-checklist.mjs
+++ b/scripts/ga-checklist.mjs
@@ -434,6 +434,10 @@ async function checkMigrations() {
     manifestDir: process.env.UPDOG_SCHEMA_MANIFEST_DIR ?? 'scripts/prod-schema-manifests',
     expectedDb: process.env.UPDOG_EXPECTED_DATABASE ?? null,
   });
+  if (result.status === 'skipped') {
+    console.warn(result.message);
+    return false;
+  }
   return result.ok;
 }
 

--- a/scripts/migration-ledger.ts
+++ b/scripts/migration-ledger.ts
@@ -1,0 +1,529 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface JournalFile {
+  version?: string;
+  dialect?: string;
+  entries: { idx: number; when: number; tag: string; breakpoints: boolean }[];
+}
+
+export interface JournaledMigrationFile {
+  tag: string;
+  file: string;
+  absPath: string;
+  sql: string;
+}
+
+export type MigrationClass =
+  | 'journaled-generated'
+  | 'journaled-drift-patch'
+  | 'legacy-journaled-unmarked'
+  | 'loose-rollback'
+  | 'loose-materialized-view'
+  | 'loose-rls'
+  | 'loose-shared-ledger-candidate'
+  | 'loose-server-ledger-candidate'
+  | 'loose-legacy-drift'
+  | 'unknown-loose';
+
+export interface LedgerFinding {
+  severity: 'error' | 'warning' | 'info';
+  code: string;
+  file?: string;
+  message: string;
+}
+
+export const MIGRATION_MARKER_PATTERN = /^\s*--\s*@(generated|drift-patch)\b/m;
+
+export const LEGACY_JOURNALED_UNMARKED_ALLOWLIST: { tag: string; sha256: string }[] = [
+  {
+    tag: '0000_quick_vivisector',
+    sha256: '6a7e7a6109cbaef773301ba939f899ee5f28362b142e84e9d1b3ae2e021b7b41',
+  },
+  {
+    tag: '0001_certain_miracleman',
+    sha256: '3092cab7d3eca160576cdd2f4a8b78a9f6c34148e53fae6443ae2a13abe59d6a',
+  },
+  {
+    tag: '0002_phase0_variance_automation',
+    sha256: '6510b66bba8bd57e58505422234c1835c472a6ac9725e0786515cf9dde7bea13',
+  },
+  {
+    tag: '0003_phase0_runtime_alignment',
+    sha256: 'f6d9f536f69cc1c61ff74cf07e93e0b837c57cb71b9e29d2f2a906d60b7291cf',
+  },
+  {
+    tag: '0004_phase1a1c_company_snapshots',
+    sha256: 'afd1bf394d94c2d426daf6a66e264499f0f917e6eea982f2b14badb07c669164',
+  },
+  {
+    tag: '0005_phase1c2_alert_automation',
+    sha256: '0ec2b6103b64f63d37e995d6b05d4343526008f9e762a62d8f2fc4b660eccce9',
+  },
+  {
+    tag: '0005b_create_backtest_results',
+    sha256: 'e4ae8a9f5f2695b82d61ba515ebc954f27c3751f46cfd4e9f55769fb19376c43',
+  },
+  {
+    tag: '0006_phase2_backtest_scenario_comparison_summary',
+    sha256: '70bf1de42bb322005ab71778d66d5e3cd109c5fc01a4b0ae444270086b1e6483',
+  },
+  {
+    tag: '0007_phase2_retire_dormant_saved_comparison_persistence',
+    sha256: '4f29f9b7329664c283954b9a92f461afd9a6b78b2c821fae1038519342612e92',
+  },
+  {
+    tag: '0008_demo_profile_import_rows',
+    sha256: '0493d1e7ea4eb2dd75257345255159856988599fe221cdc8c572c86b0c9e8772',
+  },
+  {
+    tag: '0009_fund_snapshots_scenario_set_id',
+    sha256: '6d4460542e249fedf963ce87d294c3a3bba9c407bf17e73efebc7130a88eade9',
+  },
+  {
+    tag: '0010_fund_scenario_sets',
+    sha256: '07965dc1d621e4bcda00eb599a6f308b4b594420576cfccabeaa33ecfcc1ae5a',
+  },
+  {
+    tag: '0011_scenario_share_sensitivity_drift',
+    sha256: '31aaacc07bcc9b070e109bf6b97fa30d5c86d268b8d6a37e2fc9f5cfa41b9054',
+  },
+  {
+    tag: '0013_lp_reporting_core_drift',
+    sha256: '22546f7bfc76fd4e3a2c9e50c6dccfde2f35cf416acb3d6a706979704e6e5149',
+  },
+  {
+    tag: '0015_funds_base_currency',
+    sha256: '82f989cbee1c5f36c00ac42668936bc7df842489b80af52cbde9aaab7b73adbd',
+  },
+  {
+    tag: '0018_h9_actionability_snapshot_columns',
+    sha256: '6be3b5e5afe7e328a98b7670baa0a62c20460572473f0d6cfbada57e3de69efc',
+  },
+  {
+    tag: '0019_investments_id_fund_unique',
+    sha256: 'c69d2a2498f48314d858922bbfd53c5896cfc9e64d55c662f3034c6cf3543879',
+  },
+];
+
+const LEGACY_DRIFT_PATCH_REASON_ALLOWLIST = new Set([
+  '0012_sector_variance_drift',
+  '0014_lp_evidence_sprint3_drift',
+  '0016_reconciliation_runs',
+  '0017_moic_exit_probability_modes',
+  '0020_operating_tasks_drift',
+]);
+
+const SHARED_LEDGER_TABLES = new Set([
+  'alert_evaluation_executions',
+  'backtest_results',
+  'job_outbox',
+  'optimization_sessions',
+  'scenario_matrices',
+]);
+
+const SERVER_LEDGER_TABLES = new Set([
+  'activities',
+  'agent_memories',
+  'allocation_scenario_decisions',
+  'allocation_scenario_events',
+  'allocation_scenario_ic_decisions',
+  'allocation_scenario_items',
+  'allocation_scenarios',
+  'audit_log',
+  'cash_flow_events',
+  'deal_opportunities',
+  'due_diligence_items',
+  'evidence_records',
+  'financial_projections',
+  'fund_configs',
+  'fund_events',
+  'fund_metrics',
+  'fund_models',
+  'fund_nav_snapshots',
+  'fund_snapshots',
+  'funds',
+  'investment_lots',
+  'investment_round_model_overrides',
+  'investment_rounds',
+  'investments',
+  'limited_partners',
+  'lp_capital_accounts',
+  'lp_capital_calls',
+  'lp_distribution_details',
+  'lp_documents',
+  'lp_fund_commitments',
+  'lp_metric_runs',
+  'lp_notifications',
+  'lp_notification_preferences',
+  'lp_payment_submissions',
+  'lp_performance_snapshots',
+  'lp_report_package_exports',
+  'lp_report_packages',
+  'lp_reports',
+  'lp_vehicle_participation',
+  'lp_vehicle_participation_history',
+  'market_research',
+  'narrative_runs',
+  'pipeline_activities',
+  'pipeline_stages',
+  'portfolio_companies',
+  'portfoliocompanies',
+  'reallocation_audit',
+  'reserve_allocations',
+  'scenario_audit_logs',
+  'scenario_cases',
+  'scenarios',
+  'scoring_models',
+  'sensitivity_runs',
+  'share_snapshots',
+  'stage_normalization_log',
+  'tasks',
+  'users',
+  'valuation_marks',
+]);
+
+export function readDrizzleJournal(rootDir: string, migrationsDir = 'migrations'): JournalFile {
+  const journalPath = path.join(rootDir, migrationsDir, 'meta', '_journal.json');
+  if (!fs.existsSync(journalPath)) {
+    throw new Error(`Drizzle journal missing at ${journalPath}`);
+  }
+
+  const raw = fs.readFileSync(journalPath, 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  return parseJournalFile(parsed, journalPath);
+}
+
+export function readJournaledMigrationFiles(
+  rootDir: string,
+  migrationsDir = 'migrations'
+): JournaledMigrationFile[] {
+  const journal = readDrizzleJournal(rootDir, migrationsDir);
+  return journal.entries.map((entry) => {
+    const file = `${entry.tag}.sql`;
+    const absPath = path.join(rootDir, migrationsDir, file);
+    if (!fs.existsSync(absPath)) {
+      throw new Error(`Journal tag ${entry.tag} has no matching migration file at ${absPath}`);
+    }
+
+    return {
+      tag: entry.tag,
+      file,
+      absPath,
+      sql: fs.readFileSync(absPath, 'utf-8'),
+    };
+  });
+}
+
+export function findLooseMigrationSql(
+  rootDir: string,
+  migrationsDir = 'migrations'
+): { file: string; absPath: string }[] {
+  const journalTags = new Set(
+    readDrizzleJournal(rootDir, migrationsDir).entries.map((entry) => entry.tag)
+  );
+  const migrationsPath = path.join(rootDir, migrationsDir);
+
+  return fs
+    .readdirSync(migrationsPath, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .filter((entry) => !journalTags.has(path.basename(entry.name, '.sql')))
+    .map((entry) => ({ file: entry.name, absPath: path.join(migrationsPath, entry.name) }))
+    .sort((left, right) => left.file.localeCompare(right.file));
+}
+
+export function classifyMigrationSqlFile(
+  fileName: string,
+  sql: string,
+  journalTags: ReadonlySet<string>
+): {
+  file: string;
+  class: MigrationClass;
+  marker: '@generated' | '@drift-patch' | null;
+  reasons: string[];
+} {
+  const tag = path.basename(fileName, '.sql');
+  const marker = readMigrationMarker(sql);
+  const reasons: string[] = [];
+
+  if (journalTags.has(tag)) {
+    if (marker === '@generated') {
+      reasons.push('journal tag is present and SQL is marked generated');
+      return { file: fileName, class: 'journaled-generated', marker, reasons };
+    }
+
+    if (marker === '@drift-patch') {
+      reasons.push('journal tag is present and SQL is marked drift patch');
+      return { file: fileName, class: 'journaled-drift-patch', marker, reasons };
+    }
+
+    reasons.push('journal tag is present with no marker');
+    return { file: fileName, class: 'legacy-journaled-unmarked', marker, reasons };
+  }
+
+  const normalizedFileName = fileName.toLowerCase();
+  const normalizedSql = sql.toLowerCase();
+  const tableNames = extractSqlTableNames(sql);
+
+  if (isRollbackLike(normalizedFileName, normalizedSql)) {
+    reasons.push('filename or SQL content is rollback/drop dominant');
+    return { file: fileName, class: 'loose-rollback', marker, reasons };
+  }
+
+  if (
+    /\b(?:create|refresh)\s+materialized\s+view\b/i.test(sql) ||
+    normalizedFileName.includes('materialized_view')
+  ) {
+    reasons.push('SQL creates or refreshes a materialized view');
+    return { file: fileName, class: 'loose-materialized-view', marker, reasons };
+  }
+
+  if (
+    /\benable\s+row\s+level\s+security\b/i.test(sql) ||
+    /\bcreate\s+policy\b/i.test(sql) ||
+    normalizedSql.includes('multi_tenant_rls')
+  ) {
+    reasons.push('SQL contains RLS setup');
+    return { file: fileName, class: 'loose-rls', marker, reasons };
+  }
+
+  if (hasOverlap(tableNames, SHARED_LEDGER_TABLES)) {
+    reasons.push('table names overlap shared/migrations');
+    return { file: fileName, class: 'loose-shared-ledger-candidate', marker, reasons };
+  }
+
+  if (hasOverlap(tableNames, SERVER_LEDGER_TABLES)) {
+    reasons.push('table names overlap server/migrations');
+    return { file: fileName, class: 'loose-server-ledger-candidate', marker, reasons };
+  }
+
+  if (isLegacyDriftLike(normalizedFileName, normalizedSql)) {
+    reasons.push('filename or SQL content indicates legacy manual drift');
+    return { file: fileName, class: 'loose-legacy-drift', marker, reasons };
+  }
+
+  reasons.push('no ledger, rollback, materialized-view, RLS, or legacy drift signal detected');
+  return { file: fileName, class: 'unknown-loose', marker, reasons };
+}
+
+export function sha256OfFile(absPath: string): string {
+  const contents = fs.readFileSync(absPath, 'utf-8');
+  return crypto.createHash('sha256').update(contents).digest('hex');
+}
+
+export function validateMigrationLedger(
+  rootDir: string,
+  migrationsDir = 'migrations'
+): { ok: boolean; findings: LedgerFinding[] } {
+  const findings: LedgerFinding[] = [];
+  let journal: JournalFile;
+
+  try {
+    journal = readDrizzleJournal(rootDir, migrationsDir);
+  } catch (error) {
+    return {
+      ok: false,
+      findings: [
+        {
+          severity: 'error',
+          code: 'drizzle-journal-missing',
+          message: error instanceof Error ? error.message : 'Drizzle journal missing',
+        },
+      ],
+    };
+  }
+
+  const journalTags = new Set(journal.entries.map((entry) => entry.tag));
+  const allowlist = new Map(
+    LEGACY_JOURNALED_UNMARKED_ALLOWLIST.map((entry) => [entry.tag, entry.sha256])
+  );
+
+  for (const entry of journal.entries) {
+    const file = `${entry.tag}.sql`;
+    const absPath = path.join(rootDir, migrationsDir, file);
+    if (!fs.existsSync(absPath)) {
+      findings.push({
+        severity: 'error',
+        code: 'journal-tag-missing-file',
+        file,
+        message: `Journal tag ${entry.tag} has no matching ${file} file.`,
+      });
+      continue;
+    }
+
+    const sql = fs.readFileSync(absPath, 'utf-8');
+    const classification = classifyMigrationSqlFile(file, sql, journalTags);
+    const currentHash = sha256OfFile(absPath);
+
+    if (classification.class === 'legacy-journaled-unmarked') {
+      const expectedHash = allowlist.get(entry.tag);
+      if (expectedHash === currentHash) {
+        findings.push({
+          severity: 'info',
+          code: 'legacy-journaled-unmarked-allowlisted',
+          file,
+          message: `Grandfathered journaled SQL ${entry.tag} matched allowlist hash ${currentHash}.`,
+        });
+      } else {
+        findings.push({
+          severity: 'error',
+          code: 'journaled-sql-missing-marker',
+          file,
+          message: `Journaled SQL ${entry.tag} is unmarked; new/edited journaled SQL needs -- @generated or -- @drift-patch marker.`,
+        });
+      }
+    }
+
+    if (classification.class === 'journaled-drift-patch' && !hasDriftPatchReason(sql, entry.tag)) {
+      findings.push({
+        severity: 'error',
+        code: 'drift-patch-missing-reason',
+        file,
+        message: `Journaled drift patch ${entry.tag} needs a -- Reason: line after the -- @drift-patch marker.`,
+      });
+    }
+
+    if (
+      classification.class === 'journaled-generated' &&
+      !hasAnySnapshotFile(rootDir, migrationsDir)
+    ) {
+      findings.push({
+        severity: 'error',
+        code: 'generated-migration-missing-snapshot',
+        file,
+        message: `Generated journaled SQL ${entry.tag} lacks a sibling ${migrationsDir}/meta/*snapshot* file.`,
+      });
+    }
+  }
+
+  for (const loose of findLooseMigrationSql(rootDir, migrationsDir)) {
+    const sql = fs.readFileSync(loose.absPath, 'utf-8');
+    const classification = classifyMigrationSqlFile(loose.file, sql, journalTags);
+    findings.push({
+      severity: classification.class === 'unknown-loose' ? 'warning' : 'info',
+      code: 'loose-migration-sql',
+      file: loose.file,
+      message: `Loose migration SQL ${loose.file} classified as ${classification.class}; report only, not deleted.`,
+    });
+  }
+
+  return {
+    ok: !findings.some((finding) => finding.severity === 'error'),
+    findings,
+  };
+}
+
+function parseJournalFile(value: unknown, journalPath: string): JournalFile {
+  if (!isRecord(value) || !Array.isArray(value.entries)) {
+    throw new Error(`Invalid Drizzle journal at ${journalPath}`);
+  }
+
+  return {
+    version: typeof value.version === 'string' ? value.version : undefined,
+    dialect: typeof value.dialect === 'string' ? value.dialect : undefined,
+    entries: value.entries.map((entry, index) => parseJournalEntry(entry, index, journalPath)),
+  };
+}
+
+function parseJournalEntry(
+  value: unknown,
+  index: number,
+  journalPath: string
+): JournalFile['entries'][number] {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid Drizzle journal entry ${index} at ${journalPath}`);
+  }
+
+  if (
+    typeof value.idx !== 'number' ||
+    typeof value.when !== 'number' ||
+    typeof value.tag !== 'string'
+  ) {
+    throw new Error(`Invalid Drizzle journal entry ${index} at ${journalPath}`);
+  }
+
+  return {
+    idx: value.idx,
+    when: value.when,
+    tag: value.tag,
+    breakpoints: typeof value.breakpoints === 'boolean' ? value.breakpoints : false,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readMigrationMarker(sql: string): '@generated' | '@drift-patch' | null {
+  const match = MIGRATION_MARKER_PATTERN.exec(sql);
+  if (!match) return null;
+  return match[1] === 'generated' ? '@generated' : '@drift-patch';
+}
+
+function isRollbackLike(fileName: string, sql: string): boolean {
+  if (fileName.includes('rollback') || fileName.endsWith('.down.sql')) return true;
+  const rollbackCount = countMatches(sql, /\brollback\b/g);
+  const dropCount = countMatches(
+    sql,
+    /\bdrop\s+(?:table|view|materialized\s+view|policy|index|trigger|function)\b/g
+  );
+  const createCount = countMatches(
+    sql,
+    /\bcreate\s+(?:table|view|materialized\s+view|policy|index|trigger|function)\b/g
+  );
+  return dropCount > createCount || (rollbackCount > 1 && dropCount > 0);
+}
+
+function isLegacyDriftLike(fileName: string, sql: string): boolean {
+  return (
+    /(?:manual|legacy|drift|hardening|normalization|agent_memories|portfolio|lp_reporting|sprint3|fix)/.test(
+      fileName
+    ) || /(?:manual|legacy|drift|hardening|normalization|agent_memories|portfolio)/.test(sql)
+  );
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+  return [...value.matchAll(pattern)].length;
+}
+
+function extractSqlTableNames(sql: string): Set<string> {
+  const names = new Set<string>();
+  const tablePattern =
+    /\b(?:create\s+table(?:\s+if\s+not\s+exists)?|alter\s+table(?:\s+if\s+exists)?|drop\s+table(?:\s+if\s+exists)?)\s+(?:"(?:public)"\.)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?/gi;
+
+  for (const match of sql.matchAll(tablePattern)) {
+    const tableName = match[1];
+    if (tableName) {
+      names.add(tableName.toLowerCase());
+    }
+  }
+
+  return names;
+}
+
+function hasOverlap(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  for (const value of left) {
+    if (right.has(value)) return true;
+  }
+
+  return false;
+}
+
+function hasDriftPatchReason(sql: string, tag: string): boolean {
+  const lines = sql.split(/\r?\n/);
+  const markerIndex = lines.findIndex((line) => /^\s*--\s*@drift-patch\b/.test(line));
+  if (markerIndex === -1) return false;
+
+  const hasReason = lines.slice(markerIndex + 1).some((line) => /^\s*--\s*Reason:\s*\S/.test(line));
+  return hasReason || LEGACY_DRIFT_PATCH_REASON_ALLOWLIST.has(tag);
+}
+
+function hasAnySnapshotFile(rootDir: string, migrationsDir: string): boolean {
+  const metaDir = path.join(rootDir, migrationsDir, 'meta');
+  if (!fs.existsSync(metaDir)) return false;
+
+  return fs
+    .readdirSync(metaDir, { withFileTypes: true })
+    .some((entry) => entry.isFile() && entry.name.includes('snapshot'));
+}

--- a/scripts/migration-ledger.ts
+++ b/scripts/migration-ledger.ts
@@ -166,7 +166,7 @@ export const LEGACY_LOOSE_MIGRATION_ALLOWLIST: { file: string; sha256: string }[
   },
   {
     file: 'manual-migration.sql',
-    sha256: '774a69d3a5ec66625542eab6dba462808cac2ab67afae9981f41239d998e1e9f',
+    sha256: '2b4ea3a8d8c06d24f6cd71119fa7b6e6e14e93b7fbe1de54e1382b6dee836558',
   },
 ];
 
@@ -375,6 +375,13 @@ export function sha256OfFile(absPath: string): string {
   return crypto.createHash('sha256').update(contents).digest('hex');
 }
 
+function sha256OfFileNormalized(absPath: string): string {
+  // Hashes are line-ending-normalized so grandfathering matches CRLF Windows
+  // worktrees and LF CI checkouts; .gitattributes stores .sql as LF.
+  const contents = fs.readFileSync(absPath, 'utf-8').replace(/\r\n/g, '\n');
+  return crypto.createHash('sha256').update(contents).digest('hex');
+}
+
 export function validateMigrationLedger(
   rootDir: string,
   migrationsDir = 'migrations'
@@ -420,7 +427,7 @@ export function validateMigrationLedger(
 
     const sql = fs.readFileSync(absPath, 'utf-8');
     const classification = classifyMigrationSqlFile(file, sql, journalTags);
-    const currentHash = sha256OfFile(absPath);
+    const currentHash = sha256OfFileNormalized(absPath);
 
     if (classification.class === 'legacy-journaled-unmarked') {
       const expectedHash = allowlist.get(entry.tag);
@@ -467,7 +474,7 @@ export function validateMigrationLedger(
     const sql = fs.readFileSync(loose.absPath, 'utf-8');
     const classification = classifyMigrationSqlFile(loose.file, sql, journalTags);
     const expectedHash = looseAllowlist.get(loose.file);
-    const isGrandfathered = expectedHash === sha256OfFile(loose.absPath);
+    const isGrandfathered = expectedHash === sha256OfFileNormalized(loose.absPath);
     const isMarked = classification.marker !== null;
 
     if (!isGrandfathered && !isMarked) {

--- a/scripts/migration-ledger.ts
+++ b/scripts/migration-ledger.ts
@@ -107,6 +107,69 @@ export const LEGACY_JOURNALED_UNMARKED_ALLOWLIST: { tag: string; sha256: string 
   },
 ];
 
+export const LEGACY_LOOSE_MIGRATION_ALLOWLIST: { file: string; sha256: string }[] = [
+  {
+    file: '0001_create_portfolio_tables.sql',
+    sha256: '151399cf65832c82b144eb1a84de1d18bd9e087dd52ca17900721eb288844789',
+  },
+  {
+    file: '0001_portfolio_schema_hardening.sql',
+    sha256: '54256efa95cacb7fd424cdc1295365590b0b39c35c726df5aeb354ffb2f5753c',
+  },
+  {
+    file: '0001_portfolio_schema_hardening_ROLLBACK.sql',
+    sha256: '7c3eae251749986b8a0e6019d232007419a676764eeb33936142945b8f3363ad',
+  },
+  {
+    file: '0002_add_organizations.sql',
+    sha256: 'b585d5d690cf41bad3ed285a488cb781b644a16a2a1e7fefcdf4e8009dcd1dc5',
+  },
+  {
+    file: '0002_multi_tenant_rls_setup.sql',
+    sha256: '2b2da5c7021a6db5afd8f49b8cc469adfeac4d396b721ac198fa78b30176be67',
+  },
+  {
+    file: '0002_multi_tenant_rls_setup_ROLLBACK.sql',
+    sha256: '34f17ba26f568835ffbbc50069ef444ef0c615e3504db2a0d912f06da3627343',
+  },
+  {
+    file: '0008_demo_profile_import_rows_rollback.sql',
+    sha256: '94480995d55bace16808cb09945e7e6f1e52b963bb348a3f537bba069c392ad1',
+  },
+  {
+    file: '001_lp_reporting_schema.sql',
+    sha256: '37aec6891e791a502169e2f65fab5b973adb2fe2abcfef75fba43485a2d16384',
+  },
+  {
+    file: '002_lp_reporting_indexes.sql',
+    sha256: '8c0d99a94f25c370e876ef67b60362298b08d76b5301b051ccb12333cb9a61ff',
+  },
+  {
+    file: '003_lp_dashboard_materialized_view.sql',
+    sha256: '9aad80209c3504e6a0150f46befeea7a9824cbd8ad293411296777648e703218',
+  },
+  {
+    file: '004_lp_sprint3_tables.sql',
+    sha256: '6cb2f94270775c72abe6bc4812e1f3a829e8311f17b4cb9fe98615a9bc600185',
+  },
+  {
+    file: '20251030_stage_normalization_log.sql',
+    sha256: '83da5c19d242be44e94b02ba26fa3a37090a754f5ff3c9b69bc3f1f8f4b07bd9',
+  },
+  {
+    file: '20251031_add_agent_memories.sql',
+    sha256: '60d0c3580adfbfae8e0352361c20543d528f64de48f622ab7836da8706582491',
+  },
+  {
+    file: '999_fix_materialized_view.sql',
+    sha256: 'fa75fe753dbd03009871c6f4936bd5b4cfd5462ce5b76e0b33092701c2f69b7d',
+  },
+  {
+    file: 'manual-migration.sql',
+    sha256: '774a69d3a5ec66625542eab6dba462808cac2ab67afae9981f41239d998e1e9f',
+  },
+];
+
 const LEGACY_DRIFT_PATCH_REASON_ALLOWLIST = new Set([
   '0012_sector_variance_drift',
   '0014_lp_evidence_sprint3_drift',
@@ -338,6 +401,9 @@ export function validateMigrationLedger(
   const allowlist = new Map(
     LEGACY_JOURNALED_UNMARKED_ALLOWLIST.map((entry) => [entry.tag, entry.sha256])
   );
+  const looseAllowlist = new Map(
+    LEGACY_LOOSE_MIGRATION_ALLOWLIST.map((entry) => [entry.file, entry.sha256])
+  );
 
   for (const entry of journal.entries) {
     const file = `${entry.tag}.sql`;
@@ -400,6 +466,20 @@ export function validateMigrationLedger(
   for (const loose of findLooseMigrationSql(rootDir, migrationsDir)) {
     const sql = fs.readFileSync(loose.absPath, 'utf-8');
     const classification = classifyMigrationSqlFile(loose.file, sql, journalTags);
+    const expectedHash = looseAllowlist.get(loose.file);
+    const isGrandfathered = expectedHash === sha256OfFile(loose.absPath);
+    const isMarked = classification.marker !== null;
+
+    if (!isGrandfathered && !isMarked) {
+      findings.push({
+        severity: 'error',
+        code: 'loose-migration-sql-missing-marker',
+        file: loose.file,
+        message: `Loose migration SQL ${loose.file} is unjournaled and unmarked; new or edited root SQL needs -- @generated or -- @drift-patch marker.`,
+      });
+      continue;
+    }
+
     findings.push({
       severity: classification.class === 'unknown-loose' ? 'warning' : 'info',
       code: 'loose-migration-sql',

--- a/scripts/migration-ledger.ts
+++ b/scripts/migration-ledger.ts
@@ -386,13 +386,13 @@ export function validateMigrationLedger(
 
     if (
       classification.class === 'journaled-generated' &&
-      !hasAnySnapshotFile(rootDir, migrationsDir)
+      !hasSnapshotFileForEntry(rootDir, migrationsDir, entry.idx)
     ) {
       findings.push({
         severity: 'error',
         code: 'generated-migration-missing-snapshot',
         file,
-        message: `Generated journaled SQL ${entry.tag} lacks a sibling ${migrationsDir}/meta/*snapshot* file.`,
+        message: `Generated journaled SQL ${entry.tag} lacks sibling ${migrationsDir}/meta/${snapshotFileNameForIndex(entry.idx)}.`,
       });
     }
   }
@@ -519,11 +519,16 @@ function hasDriftPatchReason(sql: string, tag: string): boolean {
   return hasReason || LEGACY_DRIFT_PATCH_REASON_ALLOWLIST.has(tag);
 }
 
-function hasAnySnapshotFile(rootDir: string, migrationsDir: string): boolean {
-  const metaDir = path.join(rootDir, migrationsDir, 'meta');
-  if (!fs.existsSync(metaDir)) return false;
+function hasSnapshotFileForEntry(
+  rootDir: string,
+  migrationsDir: string,
+  entryIndex: number
+): boolean {
+  return fs.existsSync(
+    path.join(rootDir, migrationsDir, 'meta', snapshotFileNameForIndex(entryIndex))
+  );
+}
 
-  return fs
-    .readdirSync(metaDir, { withFileTypes: true })
-    .some((entry) => entry.isFile() && entry.name.includes('snapshot'));
+function snapshotFileNameForIndex(entryIndex: number): string {
+  return `${String(entryIndex).padStart(4, '0')}_snapshot.json`;
 }

--- a/scripts/migration-ledger.ts
+++ b/scripts/migration-ledger.ts
@@ -524,8 +524,28 @@ function hasSnapshotFileForEntry(
   migrationsDir: string,
   entryIndex: number
 ): boolean {
-  return fs.existsSync(
-    path.join(rootDir, migrationsDir, 'meta', snapshotFileNameForIndex(entryIndex))
+  const snapshotPath = path.join(
+    rootDir,
+    migrationsDir,
+    'meta',
+    snapshotFileNameForIndex(entryIndex)
+  );
+  if (!fs.existsSync(snapshotPath)) return false;
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(snapshotPath, 'utf-8')) as unknown;
+    return isDrizzleSnapshotFile(parsed);
+  } catch {
+    return false;
+  }
+}
+
+function isDrizzleSnapshotFile(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.version === 'string' &&
+    Object.prototype.hasOwnProperty.call(value, 'dialect') &&
+    Object.prototype.hasOwnProperty.call(value, 'tables')
   );
 }
 

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -38,6 +38,7 @@ const releaseOwnedPaths = [
   'scripts/db-push-core.mjs',
   'tests/integration/fund-lifecycle-db.test.ts',
   'tests/integration/migration-drift.test.ts',
+  'tests/integration/prod-schema-clone.test.ts',
   'vitest.config.testcontainers.ts',
 ];
 
@@ -105,6 +106,11 @@ if (skipDbProof) {
     name: 'Migration drift guard',
     command:
       'cross-env TZ=UTC vitest run -c vitest.config.testcontainers.ts tests/integration/migration-drift.test.ts',
+  });
+  steps.push({
+    name: 'Production schema clone proof',
+    command:
+      'cross-env TZ=UTC vitest run -c vitest.config.testcontainers.ts tests/integration/prod-schema-clone.test.ts',
   });
 }
 

--- a/scripts/schema-audit-preflight.mjs
+++ b/scripts/schema-audit-preflight.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { isPoolerUrl } from './reconcile-prod-schema.mjs';
+
+const SKIP_MESSAGE = 'schema audit skipped: no direct DATABASE_URL';
+
+export async function runSchemaAuditPreflight({
+  databaseUrl,
+  manifestDir = 'scripts/prod-schema-manifests',
+  expectedDb = null,
+  runReconcile,
+} = {}) {
+  if (!databaseUrl || databaseUrl === 'memory://' || isPoolerUrl(databaseUrl)) {
+    return { status: 'skipped', ok: true, message: SKIP_MESSAGE };
+  }
+
+  const args = ['scripts/reconcile-prod-schema.mjs', '--manifest-dir', manifestDir];
+  if (expectedDb) {
+    args.push('--expect-db', expectedDb);
+  }
+
+  assertAuditOnlyArgs(args);
+
+  const run =
+    runReconcile ??
+    ((reconcileArgs) =>
+      defaultRunReconcile(reconcileArgs, {
+        databaseUrl,
+        expectedDb,
+      }));
+  const result = run(args);
+
+  return {
+    status: 'audited',
+    ok: result.code === 0,
+    message: `schema audit ${result.code === 0 ? 'passed' : 'reported drift'} (reconcile audit-only)`,
+    code: result.code,
+  };
+}
+
+function assertAuditOnlyArgs(args) {
+  if (args.includes('--apply') || args.includes('--yes')) {
+    throw new Error('schema audit preflight invariant failed: reconcile args must remain audit-only');
+  }
+}
+
+function defaultRunReconcile(args, { databaseUrl, expectedDb } = {}) {
+  const result = spawnSync('node', args, {
+    stdio: 'pipe',
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      ...(expectedDb ? { UPDOG_EXPECTED_DATABASE: expectedDb } : {}),
+    },
+  });
+
+  return {
+    code: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+const isCliInvocation = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isCliInvocation) {
+  const result = await runSchemaAuditPreflight({
+    databaseUrl: process.env.DATABASE_URL,
+    manifestDir: process.env.UPDOG_SCHEMA_MANIFEST_DIR ?? 'scripts/prod-schema-manifests',
+    expectedDb: process.env.UPDOG_EXPECTED_DATABASE ?? null,
+  });
+  console.log(result.message);
+  process.exit(result.status === 'skipped' ? 0 : result.ok ? 0 : 1);
+}

--- a/scripts/schema-audit-preflight.mjs
+++ b/scripts/schema-audit-preflight.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { isPoolerUrl } from './reconcile-prod-schema.mjs';
+import { ACTION_SKIP, isPoolerUrl } from './reconcile-prod-schema.mjs';
 
 const SKIP_MESSAGE = 'schema audit skipped: no direct DATABASE_URL';
 
@@ -33,13 +33,29 @@ export async function runSchemaAuditPreflight({
         expectedDb,
       }));
   const result = run(args);
+  const auditActions = parseAuditActions(result.stdout ?? '');
+  const driftActions = auditActions.filter((audit) => audit.action !== ACTION_SKIP);
+  const ok = result.code === 0 && driftActions.length === 0;
 
   return {
     status: 'audited',
-    ok: result.code === 0,
-    message: `schema audit ${result.code === 0 ? 'passed' : 'reported drift'} (reconcile audit-only)`,
+    ok,
+    message: `schema audit ${ok ? 'passed' : 'reported drift'} (reconcile audit-only)`,
     code: result.code,
+    auditActions,
   };
+}
+
+export function parseAuditActions(stdout) {
+  const actions = [];
+  const actionPattern = /^([^\s:][^:]*):\s+(SKIP|APPLY-MISSING-DDL|REFUSE-FOR-HUMAN)\s*$/gm;
+  for (const match of stdout.matchAll(actionPattern)) {
+    actions.push({
+      manifest: match[1],
+      action: match[2],
+    });
+  }
+  return actions;
 }
 
 function assertAuditOnlyArgs(args) {

--- a/scripts/schema-drift-active-surfaces.ts
+++ b/scripts/schema-drift-active-surfaces.ts
@@ -3,6 +3,9 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { detectDualLedgerDivergence, formatDualLedgerReport } from './dual-ledger-divergence.js';
+import { validateMigrationLedger } from './migration-ledger.js';
+
 export const ACTIVE_SURFACE_IDS = [
   'cohort',
   'portfolio-optimization',
@@ -439,6 +442,16 @@ export function validateActiveSchemaSurfaces(
   };
 }
 
+export function validateMigrationLedgerAndDualLedger(rootDir = process.cwd()): {
+  ok: boolean;
+  ledger: ReturnType<typeof validateMigrationLedger>;
+  dualLedger: ReturnType<typeof detectDualLedgerDivergence>;
+} {
+  const ledger = validateMigrationLedger(rootDir);
+  const dualLedger = detectDualLedgerDivergence(rootDir);
+  return { ok: ledger.ok && dualLedger.ok, ledger, dualLedger };
+}
+
 export function formatSchemaDriftReport(result: SchemaDriftValidationResult): string {
   const lines = [
     'Schema Drift Active Surface Report',
@@ -856,6 +869,52 @@ function parseFormat(args: readonly string[]): 'text' | 'json' {
   return args.includes('--json') ? 'json' : 'text';
 }
 
+function formatMigrationLedgerFindings(ledger: ReturnType<typeof validateMigrationLedger>): string {
+  const lines = ['Migration Ledger Findings'];
+
+  if (ledger.findings.length === 0) {
+    lines.push('INFO no-findings - No migration ledger findings.');
+    return lines.join('\n');
+  }
+
+  for (const finding of ledger.findings) {
+    const severity = finding.severity.toUpperCase();
+    const file = finding.file ?? '-';
+    lines.push(`${severity} ${finding.code} ${file} ${finding.message}`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatSchemaDriftCliOutput(
+  result: SchemaDriftValidationResult,
+  ledgerResult: ReturnType<typeof validateMigrationLedgerAndDualLedger>,
+  format: 'text' | 'json',
+  combinedOk: boolean
+): string {
+  if (format === 'json') {
+    return JSON.stringify(
+      {
+        ...result,
+        ok: combinedOk,
+        surfaceOk: result.ok,
+        migrationLedger: ledgerResult.ledger,
+        dualLedger: ledgerResult.dualLedger,
+      },
+      null,
+      2
+    );
+  }
+
+  return [
+    formatSchemaDriftReport(result),
+    '',
+    formatMigrationLedgerFindings(ledgerResult.ledger),
+    '',
+    formatDualLedgerReport(ledgerResult.dualLedger),
+  ].join('\n');
+}
+
 function isCliInvocation(): boolean {
   const invokedPath = process.argv[1];
   return typeof invokedPath === 'string' && path.resolve(invokedPath) === currentModulePath;
@@ -863,15 +922,16 @@ function isCliInvocation(): boolean {
 
 if (isCliInvocation()) {
   const result = validateActiveSchemaSurfaces();
+  const ledgerResult = validateMigrationLedgerAndDualLedger(process.cwd());
+  const combinedOk = result.ok && ledgerResult.ok;
   const format = parseFormat(process.argv.slice(2));
-  const output =
-    format === 'json' ? JSON.stringify(result, null, 2) : formatSchemaDriftReport(result);
+  const output = formatSchemaDriftCliOutput(result, ledgerResult, format, combinedOk);
 
-  if (result.ok) {
+  if (combinedOk) {
     console.log(output);
   } else {
     console.error(output);
   }
 
-  process.exit(result.ok ? 0 : 1);
+  process.exit(combinedOk ? 0 : 1);
 }

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -1,4 +1,8 @@
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { pushSchema } from 'drizzle-kit/api';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -11,6 +15,343 @@ const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
 
 let postgres: StartedPostgreSqlContainer | undefined;
 let pool: Pool | undefined;
+let shapePool: Pool | undefined;
+
+const SHAPE_DATABASE = 'shape_db';
+const C1_MOUNTED_TABLES = [
+  'cohort_definitions',
+  'sector_taxonomy',
+  'sector_mappings',
+  'company_overrides',
+  'investment_overrides',
+  'reconciliation_runs',
+  'fund_calculation_modes',
+  'tasks',
+  'vehicles',
+  'cash_flow_events',
+  'valuation_marks',
+  'lp_metric_runs',
+  'evidence_records',
+  'narrative_runs',
+  'lp_report_packages',
+  'lp_report_package_exports',
+] as const;
+const SHAPE_ONLY_NOT_JOURNALED = [
+  'investment_rounds',
+  'investment_round_model_overrides',
+  'flag_changes',
+  'flags_state',
+  'reserve_approvals',
+  'approval_partners',
+  'approval_signatures',
+  'approval_audit_log',
+] as const;
+const PROCEDURAL_MIGRATIONS = [
+  '0001_create_job_outbox.sql',
+  '0002_create_scenario_matrices.sql',
+  '0003_create_optimization_sessions.sql',
+  '0004_variance_alert_automation.sql',
+  '0005_backtest_scenario_comparison_summary.sql',
+] as const;
+const EXPECTED_PROCEDURES = [
+  'update_job_outbox_updated_at',
+  'update_scenario_matrices_updated_at',
+  'update_optimization_sessions_updated_at',
+] as const;
+const EXPECTED_TRIGGERS = [
+  'job_outbox_updated_at',
+  'scenario_matrices_updated_at',
+  'optimization_sessions_updated_at',
+] as const;
+
+type TableShapeMap<TShape> = Map<string, Map<string, TShape>>;
+
+interface ColumnShape {
+  typ: string;
+  notnull: boolean;
+}
+
+interface ConstraintShape {
+  contype: string;
+  reftable: string;
+  confupdtype: string;
+  confdeltype: string;
+}
+
+interface IndexShape {
+  uniq: boolean;
+  predicate: string | null;
+}
+
+interface CatalogSnapshot {
+  tables: Set<string>;
+  columns: TableShapeMap<ColumnShape>;
+  constraints: TableShapeMap<ConstraintShape>;
+  indexes: TableShapeMap<IndexShape>;
+}
+
+interface CatalogDefinitions {
+  constraints: Array<{ tbl: string; conname: string; def: string }>;
+  indexes: Array<{ tbl: string; idxname: string; def: string }>;
+}
+
+function normalizeIdentifier(value: string): string {
+  return value.toLowerCase();
+}
+
+function normalizeCatalogText(value: string | null): string | null {
+  return value === null ? null : value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function setTableShape<TShape>(
+  collection: TableShapeMap<TShape>,
+  tableName: string,
+  shapeName: string,
+  shape: TShape
+): void {
+  const tableShapes = collection.get(tableName) ?? new Map<string, TShape>();
+  tableShapes.set(shapeName, shape);
+  collection.set(tableName, tableShapes);
+}
+
+function shapeToText<TShape>(shape: TShape): string {
+  return JSON.stringify(shape);
+}
+
+function compareNamedShapes<TShape>(
+  mismatches: string[],
+  tableName: string,
+  shapeKind: string,
+  journalShapes: Map<string, TShape> | undefined,
+  pushedShapes: Map<string, TShape> | undefined
+): void {
+  const journalEntries = journalShapes ?? new Map<string, TShape>();
+  const pushedEntries = pushedShapes ?? new Map<string, TShape>();
+
+  for (const [shapeName, journalShape] of journalEntries) {
+    const pushedShape = pushedEntries.get(shapeName);
+    if (!pushedShape) {
+      mismatches.push(`DB-B missing ${shapeKind} ${tableName}.${shapeName}`);
+      continue;
+    }
+
+    if (shapeToText(journalShape) !== shapeToText(pushedShape)) {
+      mismatches.push(
+        `${shapeKind} ${tableName}.${shapeName} differs: DB-A=${shapeToText(
+          journalShape
+        )} DB-B=${shapeToText(pushedShape)}`
+      );
+    }
+  }
+
+  for (const shapeName of pushedEntries.keys()) {
+    if (!journalEntries.has(shapeName)) {
+      mismatches.push(`DB-A missing ${shapeKind} ${tableName}.${shapeName}`);
+    }
+  }
+}
+
+function connectionUriForDatabase(databaseName: string): string {
+  if (!postgres) {
+    throw new Error('Postgres container has not started');
+  }
+
+  const url = new URL(postgres.getConnectionUri());
+  url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
+  const tablesResult = await activePool.query<{ relname: string }>(`
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND c.relname <> 'drizzle_migrations'
+  `);
+  const columnsResult = await activePool.query<{
+    tbl: string;
+    col: string;
+    typ: string;
+    notnull: boolean;
+  }>(`
+    SELECT c.relname tbl, a.attname col, format_type(a.atttypid, a.atttypmod) typ, a.attnotnull notnull
+    FROM pg_attribute a
+    JOIN pg_class c ON c.oid = a.attrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+      AND c.relname <> 'drizzle_migrations'
+  `);
+  const constraintsResult = await activePool.query<{
+    conname: string;
+    contype: string;
+    tbl: string;
+    reftable: string;
+    confupdtype: string;
+    confdeltype: string;
+  }>(`
+    SELECT con.conname, con.contype, c.relname tbl, confrelid::regclass::text reftable, con.confupdtype, con.confdeltype
+    FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = con.connamespace
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'drizzle_migrations'
+  `);
+  const indexesResult = await activePool.query<{
+    idxname: string;
+    uniq: boolean;
+    predicate: string | null;
+    tbl: string;
+  }>(`
+    SELECT i.relname idxname, ix.indisunique uniq, pg_get_expr(ix.indpred, ix.indrelid) predicate, c.relname tbl
+    FROM pg_index ix
+    JOIN pg_class i ON i.oid = ix.indexrelid
+    JOIN pg_class c ON c.oid = ix.indrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'drizzle_migrations'
+  `);
+
+  const columns: TableShapeMap<ColumnShape> = new Map();
+  const constraints: TableShapeMap<ConstraintShape> = new Map();
+  const indexes: TableShapeMap<IndexShape> = new Map();
+
+  for (const row of columnsResult.rows) {
+    setTableShape(columns, normalizeIdentifier(row.tbl), normalizeIdentifier(row.col), {
+      typ: normalizeCatalogText(row.typ) ?? '',
+      notnull: row.notnull,
+    });
+  }
+
+  for (const row of constraintsResult.rows) {
+    setTableShape(constraints, normalizeIdentifier(row.tbl), normalizeIdentifier(row.conname), {
+      contype: normalizeCatalogText(row.contype) ?? '',
+      reftable: normalizeCatalogText(row.reftable) ?? '',
+      confupdtype: normalizeCatalogText(row.confupdtype) ?? '',
+      confdeltype: normalizeCatalogText(row.confdeltype) ?? '',
+    });
+  }
+
+  for (const row of indexesResult.rows) {
+    setTableShape(indexes, normalizeIdentifier(row.tbl), normalizeIdentifier(row.idxname), {
+      uniq: row.uniq,
+      predicate: normalizeCatalogText(row.predicate),
+    });
+  }
+
+  return {
+    tables: new Set(tablesResult.rows.map((row) => normalizeIdentifier(row.relname))),
+    columns,
+    constraints,
+    indexes,
+  };
+}
+
+async function catalogDefinitions(activePool: Pool): Promise<CatalogDefinitions> {
+  const constraintsResult = await activePool.query<{ tbl: string; conname: string; def: string }>(`
+    SELECT c.relname tbl, con.conname, pg_get_constraintdef(con.oid) def
+    FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = con.connamespace
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'drizzle_migrations'
+    ORDER BY c.relname, con.conname
+  `);
+  const indexesResult = await activePool.query<{ tbl: string; idxname: string; def: string }>(`
+    SELECT c.relname tbl, i.relname idxname, pg_get_indexdef(i.oid) def
+    FROM pg_index ix
+    JOIN pg_class i ON i.oid = ix.indexrelid
+    JOIN pg_class c ON c.oid = ix.indrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'drizzle_migrations'
+    ORDER BY c.relname, i.relname
+  `);
+
+  return {
+    constraints: constraintsResult.rows,
+    indexes: indexesResult.rows,
+  };
+}
+
+function compareIntersectionShape(
+  journalCatalog: CatalogSnapshot,
+  pushedCatalog: CatalogSnapshot
+): string[] {
+  const mismatches: string[] = [];
+  const intersectionTables = [...journalCatalog.tables]
+    .filter((tableName) => pushedCatalog.tables.has(tableName))
+    .sort();
+
+  for (const tableName of intersectionTables) {
+    compareNamedShapes(
+      mismatches,
+      tableName,
+      'column',
+      journalCatalog.columns.get(tableName),
+      pushedCatalog.columns.get(tableName)
+    );
+    compareNamedShapes(
+      mismatches,
+      tableName,
+      'constraint',
+      journalCatalog.constraints.get(tableName),
+      pushedCatalog.constraints.get(tableName)
+    );
+    compareNamedShapes(
+      mismatches,
+      tableName,
+      'index',
+      journalCatalog.indexes.get(tableName),
+      pushedCatalog.indexes.get(tableName)
+    );
+  }
+
+  return mismatches;
+}
+
+async function applyProceduralMigrations(activePool: Pool): Promise<void> {
+  for (const migration of PROCEDURAL_MIGRATIONS) {
+    const sql = await readFile(path.join(process.cwd(), 'shared', 'migrations', migration), 'utf8');
+    await activePool.query(sql);
+  }
+}
+
+async function publicProcedureNames(activePool: Pool, procedureNames: readonly string[]) {
+  const result = await activePool.query<{ proname: string }>(
+    `
+      SELECT p.proname
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public'
+        AND p.proname = ANY($1::text[])
+    `,
+    [procedureNames]
+  );
+
+  return new Set(result.rows.map((row) => row.proname));
+}
+
+async function publicTriggerNames(activePool: Pool, triggerNames: readonly string[]) {
+  const result = await activePool.query<{ tgname: string }>(
+    `
+      SELECT t.tgname
+      FROM pg_trigger t
+      JOIN pg_class c ON c.oid = t.tgrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND NOT t.tgisinternal
+        AND t.tgname = ANY($1::text[])
+    `,
+    [triggerNames]
+  );
+
+  return new Set(result.rows.map((row) => row.tgname));
+}
 
 async function publicTables(activePool: Pool, tableNames: readonly string[]) {
   const result = await activePool.query<{ table_name: string }>(
@@ -57,6 +398,14 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
   }, STARTUP_TIMEOUT_MS * 2);
 
   afterAll(async () => {
+    await shapePool?.end();
+    if (pool) {
+      try {
+        await pool.query(`DROP DATABASE IF EXISTS ${SHAPE_DATABASE}`);
+      } catch (error) {
+        console.warn('[prod-schema-clone] Failed to drop shape database', error);
+      }
+    }
     await pool?.end();
     if (process.env.CI === 'true') {
       console.warn(
@@ -90,5 +439,60 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     expect(
       expectedConstraints.filter((constraintName) => !migratedConstraints.has(constraintName))
     ).toEqual([]);
+  });
+
+  it('proves journal-built DB-A shape matches drizzle push DB-B where schemas overlap', async () => {
+    expect(pool).toBeDefined();
+
+    await pool!.query(`CREATE DATABASE ${SHAPE_DATABASE}`);
+    shapePool = new Pool({ connectionString: connectionUriForDatabase(SHAPE_DATABASE), max: 1 });
+    await shapePool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+
+    const shapeDb = drizzle(shapePool);
+    const schema = {
+      ...(await import('../../shared/schema')),
+      ...(await import('../../shared/schema-lp-reporting')),
+      ...(await import('../../shared/schema-lp-sprint3')),
+    };
+    const { apply } = await pushSchema(schema, shapeDb);
+    await apply();
+
+    const journalCatalog = await introspectCatalog(pool!);
+    const pushedCatalog = await introspectCatalog(shapePool);
+    const missingC1Tables = C1_MOUNTED_TABLES.filter(
+      (tableName) => !journalCatalog.tables.has(tableName)
+    );
+    const journalOnlyTables = [...journalCatalog.tables]
+      .filter((tableName) => !pushedCatalog.tables.has(tableName))
+      .sort();
+    const shapeOnlyTables = [...pushedCatalog.tables]
+      .filter((tableName) => !journalCatalog.tables.has(tableName))
+      .sort();
+    const shapeOnlyBaseline = new Set<string>(SHAPE_ONLY_NOT_JOURNALED);
+    const shapeMismatches = compareIntersectionShape(journalCatalog, pushedCatalog);
+
+    // eslint-disable-next-line no-console -- D4 requires non-gating CI diagnostics.
+    console.log('[prod-schema-clone] shape-only tables', shapeOnlyTables);
+    // eslint-disable-next-line no-console -- D4 requires non-gating CI diagnostics.
+    console.log('[prod-schema-clone] DB-A catalog definitions', await catalogDefinitions(pool!));
+    // eslint-disable-next-line no-console -- D4 requires non-gating CI diagnostics.
+    console.log(
+      '[prod-schema-clone] DB-B catalog definitions',
+      await catalogDefinitions(shapePool)
+    );
+
+    expect(missingC1Tables).toEqual([]);
+    expect(shapeMismatches).toEqual([]);
+    expect(journalOnlyTables).toEqual([]);
+    expect(shapeOnlyTables.filter((tableName) => !shapeOnlyBaseline.has(tableName))).toEqual([]);
+
+    await applyProceduralMigrations(pool!);
+    const procedureNames = await publicProcedureNames(pool!, EXPECTED_PROCEDURES);
+    const triggerNames = await publicTriggerNames(pool!, EXPECTED_TRIGGERS);
+
+    expect(
+      EXPECTED_PROCEDURES.filter((procedureName) => !procedureNames.has(procedureName))
+    ).toEqual([]);
+    expect(EXPECTED_TRIGGERS.filter((triggerName) => !triggerNames.has(triggerName))).toEqual([]);
   });
 });

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -63,15 +63,6 @@ const EXPECTED_TRIGGERS = [
   'scenario_matrices_updated_at',
   'optimization_sessions_updated_at',
 ] as const;
-const EXPECTED_SHARED_MIGRATION_TABLES = ['alert_evaluation_executions'] as const;
-const EXPECTED_SHARED_MIGRATION_COLUMNS = [
-  ['job_outbox', 'dedupe_key'],
-  ['backtest_results', 'scenario_comparison_summary'],
-] as const;
-const EXPECTED_SHARED_MIGRATION_INDEXES = [
-  'idx_job_outbox_job_type_dedupe',
-  'performance_alerts_open_incident_unique',
-] as const;
 const KNOWN_INTERSECTION_DRIFT = new Set<string>([
   'forecast_snapshots|constraint|forecast_snapshots_idem_key_len_check',
   'forecast_snapshots|index|forecast_snapshots_fund_cursor_idx',
@@ -499,51 +490,6 @@ async function publicTriggerNames(activePool: Pool, triggerNames: readonly strin
   return new Set(result.rows.map((row) => row.tgname));
 }
 
-function columnKey(tableName: string, columnName: string): string {
-  return `${tableName}.${columnName}`;
-}
-
-async function publicColumnsPresent(
-  activePool: Pool,
-  columnPairs: readonly (readonly [string, string])[]
-) {
-  const columnKeys = columnPairs.map(([tableName, columnName]) => columnKey(tableName, columnName));
-  const result = await activePool.query<{ key: string }>(
-    `
-      SELECT c.relname || '.' || a.attname AS key
-      FROM pg_attribute a
-      JOIN pg_class c ON c.oid = a.attrelid
-      JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE n.nspname = 'public'
-        AND c.relkind = 'r'
-        AND a.attnum > 0
-        AND NOT a.attisdropped
-        AND c.relname || '.' || a.attname = ANY($1::text[])
-    `,
-    [columnKeys]
-  );
-
-  return new Set(result.rows.map((row) => row.key));
-}
-
-async function publicIndexesPresent(activePool: Pool, indexNames: readonly string[]) {
-  const result = await activePool.query<{ idxname: string }>(
-    `
-      SELECT i.relname idxname
-      FROM pg_index ix
-      JOIN pg_class i ON i.oid = ix.indexrelid
-      JOIN pg_class c ON c.oid = ix.indrelid
-      JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE n.nspname = 'public'
-        AND c.relkind = 'r'
-        AND i.relname = ANY($1::text[])
-    `,
-    [indexNames]
-  );
-
-  return new Set(result.rows.map((row) => row.idxname));
-}
-
 async function publicTables(activePool: Pool, tableNames: readonly string[]) {
   const result = await activePool.query<{ table_name: string }>(
     `
@@ -695,6 +641,12 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     expect(journalOnlyTables).toEqual([]);
     expect(shapeOnlyTables.filter((tableName) => !shapeOnlyBaseline.has(tableName))).toEqual([]);
 
+    const procedureNamesBefore = await publicProcedureNames(pool!, EXPECTED_PROCEDURES);
+    const triggerNamesBefore = await publicTriggerNames(pool!, EXPECTED_TRIGGERS);
+
+    expect([...procedureNamesBefore]).toEqual([]);
+    expect([...triggerNamesBefore]).toEqual([]);
+
     await applyProceduralMigrations(pool!);
     const procedureNames = await publicProcedureNames(pool!, EXPECTED_PROCEDURES);
     const triggerNames = await publicTriggerNames(pool!, EXPECTED_TRIGGERS);
@@ -704,28 +656,6 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     ).toEqual([]);
     expect(EXPECTED_TRIGGERS.filter((triggerName) => !triggerNames.has(triggerName))).toEqual([]);
 
-    const sharedMigrationTables = await publicTables(pool!, EXPECTED_SHARED_MIGRATION_TABLES);
-    const sharedMigrationColumns = await publicColumnsPresent(
-      pool!,
-      EXPECTED_SHARED_MIGRATION_COLUMNS
-    );
-    const sharedMigrationIndexes = await publicIndexesPresent(
-      pool!,
-      EXPECTED_SHARED_MIGRATION_INDEXES
-    );
-
-    expect(
-      EXPECTED_SHARED_MIGRATION_TABLES.filter((tableName) => !sharedMigrationTables.has(tableName))
-    ).toEqual([]);
-    expect(
-      EXPECTED_SHARED_MIGRATION_COLUMNS.map(([tableName, columnName]) =>
-        columnKey(tableName, columnName)
-      ).filter((key) => !sharedMigrationColumns.has(key))
-    ).toEqual([]);
-    expect(
-      EXPECTED_SHARED_MIGRATION_INDEXES.filter(
-        (indexName) => !sharedMigrationIndexes.has(indexName)
-      )
-    ).toEqual([]);
+    // alert_evaluation_executions, job_outbox.dedupe_key, idx_job_outbox_job_type_dedupe, performance_alerts_open_incident_unique, backtest_results.scenario_comparison_summary are in BOTH the journal and shape source -> proven by the sentinel intersection diff above; asserting them here would be vacuous (the journal pre-supplies them).
   });
 });

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -63,6 +63,15 @@ const EXPECTED_TRIGGERS = [
   'scenario_matrices_updated_at',
   'optimization_sessions_updated_at',
 ] as const;
+const EXPECTED_SHARED_MIGRATION_TABLES = ['alert_evaluation_executions'] as const;
+const EXPECTED_SHARED_MIGRATION_COLUMNS = [
+  ['job_outbox', 'dedupe_key'],
+  ['backtest_results', 'scenario_comparison_summary'],
+] as const;
+const EXPECTED_SHARED_MIGRATION_INDEXES = [
+  'idx_job_outbox_job_type_dedupe',
+  'performance_alerts_open_incident_unique',
+] as const;
 
 type TableShapeMap<TShape> = Map<string, Map<string, TShape>>;
 
@@ -73,7 +82,9 @@ interface ColumnShape {
 
 interface ConstraintShape {
   contype: string;
+  cols: string[];
   reftable: string;
+  refcols: string[];
   confupdtype: string;
   confdeltype: string;
 }
@@ -81,6 +92,7 @@ interface ConstraintShape {
 interface IndexShape {
   uniq: boolean;
   predicate: string | null;
+  cols: string[];
 }
 
 interface CatalogSnapshot {
@@ -101,6 +113,10 @@ function normalizeIdentifier(value: string): string {
 
 function normalizeCatalogText(value: string | null): string | null {
   return value === null ? null : value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function normalizeIdentifierArray(value: readonly string[] | null): string[] {
+  return (value ?? []).map((entry) => normalizeIdentifier(entry));
 }
 
 function setTableShape<TShape>(
@@ -190,11 +206,35 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     conname: string;
     contype: string;
     tbl: string;
+    cols: string[];
     reftable: string;
+    refcols: string[];
     confupdtype: string;
     confdeltype: string;
   }>(`
-    SELECT con.conname, con.contype, c.relname tbl, confrelid::regclass::text reftable, con.confupdtype, con.confdeltype
+    SELECT
+      con.conname,
+      con.contype,
+      c.relname tbl,
+      COALESCE(
+        (
+          SELECT array_agg(a.attname::text ORDER BY k.ord)
+          FROM unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord)
+          JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = k.attnum
+        ),
+        ARRAY[]::text[]
+      ) cols,
+      CASE WHEN con.confrelid = 0 THEN '' ELSE con.confrelid::regclass::text END reftable,
+      COALESCE(
+        (
+          SELECT array_agg(a.attname::text ORDER BY k.ord)
+          FROM unnest(con.confkey) WITH ORDINALITY AS k(attnum, ord)
+          JOIN pg_attribute a ON a.attrelid = con.confrelid AND a.attnum = k.attnum
+        ),
+        ARRAY[]::text[]
+      ) refcols,
+      con.confupdtype,
+      con.confdeltype
     FROM pg_constraint con
     JOIN pg_class c ON c.oid = con.conrelid
     JOIN pg_namespace n ON n.oid = con.connamespace
@@ -206,8 +246,21 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     uniq: boolean;
     predicate: string | null;
     tbl: string;
+    cols: string[];
   }>(`
-    SELECT i.relname idxname, ix.indisunique uniq, pg_get_expr(ix.indpred, ix.indrelid) predicate, c.relname tbl
+    SELECT
+      i.relname idxname,
+      ix.indisunique uniq,
+      pg_get_expr(ix.indpred, ix.indrelid) predicate,
+      c.relname tbl,
+      COALESCE(
+        (
+          SELECT array_agg(COALESCE(a.attname::text, '(expr)') ORDER BY k.ord)
+          FROM unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+          LEFT JOIN pg_attribute a ON a.attrelid = ix.indrelid AND a.attnum = k.attnum
+        ),
+        ARRAY[]::text[]
+      ) cols
     FROM pg_index ix
     JOIN pg_class i ON i.oid = ix.indexrelid
     JOIN pg_class c ON c.oid = ix.indrelid
@@ -230,7 +283,9 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
   for (const row of constraintsResult.rows) {
     setTableShape(constraints, normalizeIdentifier(row.tbl), normalizeIdentifier(row.conname), {
       contype: normalizeCatalogText(row.contype) ?? '',
+      cols: normalizeIdentifierArray(row.cols),
       reftable: normalizeCatalogText(row.reftable) ?? '',
+      refcols: normalizeIdentifierArray(row.refcols),
       confupdtype: normalizeCatalogText(row.confupdtype) ?? '',
       confdeltype: normalizeCatalogText(row.confdeltype) ?? '',
     });
@@ -240,6 +295,7 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     setTableShape(indexes, normalizeIdentifier(row.tbl), normalizeIdentifier(row.idxname), {
       uniq: row.uniq,
       predicate: normalizeCatalogText(row.predicate),
+      cols: normalizeIdentifierArray(row.cols),
     });
   }
 
@@ -351,6 +407,51 @@ async function publicTriggerNames(activePool: Pool, triggerNames: readonly strin
   );
 
   return new Set(result.rows.map((row) => row.tgname));
+}
+
+function columnKey(tableName: string, columnName: string): string {
+  return `${tableName}.${columnName}`;
+}
+
+async function publicColumnsPresent(
+  activePool: Pool,
+  columnPairs: readonly (readonly [string, string])[]
+) {
+  const columnKeys = columnPairs.map(([tableName, columnName]) => columnKey(tableName, columnName));
+  const result = await activePool.query<{ key: string }>(
+    `
+      SELECT c.relname || '.' || a.attname AS key
+      FROM pg_attribute a
+      JOIN pg_class c ON c.oid = a.attrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind = 'r'
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        AND c.relname || '.' || a.attname = ANY($1::text[])
+    `,
+    [columnKeys]
+  );
+
+  return new Set(result.rows.map((row) => row.key));
+}
+
+async function publicIndexesPresent(activePool: Pool, indexNames: readonly string[]) {
+  const result = await activePool.query<{ idxname: string }>(
+    `
+      SELECT i.relname idxname
+      FROM pg_index ix
+      JOIN pg_class i ON i.oid = ix.indexrelid
+      JOIN pg_class c ON c.oid = ix.indrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind = 'r'
+        AND i.relname = ANY($1::text[])
+    `,
+    [indexNames]
+  );
+
+  return new Set(result.rows.map((row) => row.idxname));
 }
 
 async function publicTables(activePool: Pool, tableNames: readonly string[]) {
@@ -494,5 +595,29 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       EXPECTED_PROCEDURES.filter((procedureName) => !procedureNames.has(procedureName))
     ).toEqual([]);
     expect(EXPECTED_TRIGGERS.filter((triggerName) => !triggerNames.has(triggerName))).toEqual([]);
+
+    const sharedMigrationTables = await publicTables(pool!, EXPECTED_SHARED_MIGRATION_TABLES);
+    const sharedMigrationColumns = await publicColumnsPresent(
+      pool!,
+      EXPECTED_SHARED_MIGRATION_COLUMNS
+    );
+    const sharedMigrationIndexes = await publicIndexesPresent(
+      pool!,
+      EXPECTED_SHARED_MIGRATION_INDEXES
+    );
+
+    expect(
+      EXPECTED_SHARED_MIGRATION_TABLES.filter((tableName) => !sharedMigrationTables.has(tableName))
+    ).toEqual([]);
+    expect(
+      EXPECTED_SHARED_MIGRATION_COLUMNS.map(([tableName, columnName]) =>
+        columnKey(tableName, columnName)
+      ).filter((key) => !sharedMigrationColumns.has(key))
+    ).toEqual([]);
+    expect(
+      EXPECTED_SHARED_MIGRATION_INDEXES.filter(
+        (indexName) => !sharedMigrationIndexes.has(indexName)
+      )
+    ).toEqual([]);
   });
 });

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -72,8 +72,29 @@ const EXPECTED_SHARED_MIGRATION_INDEXES = [
   'idx_job_outbox_job_type_dedupe',
   'performance_alerts_open_incident_unique',
 ] as const;
+const KNOWN_INTERSECTION_DRIFT = new Set<string>([
+  'forecast_snapshots|constraint|forecast_snapshots_idem_key_len_check',
+  'forecast_snapshots|index|forecast_snapshots_fund_cursor_idx',
+  'forecast_snapshots|index|forecast_snapshots_fund_idem_key_idx',
+  'forecast_snapshots|index|forecast_snapshots_idempotency_unique_idx',
+  'investment_lots|constraint|investment_lots_idem_key_len_check',
+  'investment_lots|index|investment_lots_investment_cursor_idx',
+  'investment_lots|index|investment_lots_investment_idem_key_idx',
+  'investment_lots|index|investment_lots_idempotency_unique_idx',
+  'reserve_allocations|constraint|reserve_allocations_idem_key_len_check',
+  'reserve_allocations|index|reserve_allocations_snapshot_cursor_idx',
+  'reserve_allocations|index|reserve_allocations_snapshot_idem_key_idx',
+  'reserve_allocations|index|reserve_allocations_idempotency_unique_idx',
+  'reserve_decisions|index|idx_reserve_fund_company',
+  'reserve_decisions|index|ux_reserve_unique',
+  'fund_snapshots|fk|fund_snapshots_config_id_fundconfigs_id_fk',
+  'fund_snapshots|fk|fund_snapshots_run_id_calc_runs_id_fk',
+  'job_outbox|constraint|job_outbox_status_check',
+]);
 
 type TableShapeMap<TShape> = Map<string, Map<string, TShape>>;
+type TableSetMap = Map<string, Set<string>>;
+type ShapeKind = 'column' | 'constraint' | 'index';
 
 interface ColumnShape {
   typ: string;
@@ -83,10 +104,6 @@ interface ColumnShape {
 interface ConstraintShape {
   contype: string;
   cols: string[];
-  reftable: string;
-  refcols: string[];
-  confupdtype: string;
-  confdeltype: string;
 }
 
 interface IndexShape {
@@ -98,8 +115,10 @@ interface IndexShape {
 interface CatalogSnapshot {
   tables: Set<string>;
   columns: TableShapeMap<ColumnShape>;
-  constraints: TableShapeMap<ConstraintShape>;
+  nonFkConstraints: TableShapeMap<ConstraintShape>;
   indexes: TableShapeMap<IndexShape>;
+  foreignKeysByTable: TableSetMap;
+  foreignKeyNamesByTable: TableShapeMap<string>;
 }
 
 interface CatalogDefinitions {
@@ -130,6 +149,39 @@ function setTableShape<TShape>(
   collection.set(tableName, tableShapes);
 }
 
+function addTableSetValue(collection: TableSetMap, tableName: string, value: string): void {
+  const tableValues = collection.get(tableName) ?? new Set<string>();
+  tableValues.add(value);
+  collection.set(tableName, tableValues);
+}
+
+function addForeignKeyShape(
+  foreignKeysByTable: TableSetMap,
+  foreignKeyNamesByTable: TableShapeMap<string>,
+  tableName: string,
+  shapeSignature: string,
+  constraintName: string
+): void {
+  addTableSetValue(foreignKeysByTable, tableName, shapeSignature);
+  setTableShape(foreignKeyNamesByTable, tableName, shapeSignature, constraintName);
+}
+
+function foreignKeyShapeSignature(row: {
+  cols: readonly string[] | null;
+  reftable: string;
+  refcols: readonly string[] | null;
+  confupdtype: string;
+  confdeltype: string;
+}): string {
+  const cols = normalizeIdentifierArray(row.cols);
+  const reftable = normalizeCatalogText(row.reftable) ?? '';
+  const refcols = normalizeIdentifierArray(row.refcols);
+  const confupdtype = normalizeCatalogText(row.confupdtype) ?? '';
+  const confdeltype = normalizeCatalogText(row.confdeltype) ?? '';
+
+  return `${cols.join(',')}=>${reftable}(${refcols.join(',')})|u:${confupdtype}|d:${confdeltype}`;
+}
+
 function shapeToText<TShape>(shape: TShape): string {
   return JSON.stringify(shape);
 }
@@ -137,7 +189,7 @@ function shapeToText<TShape>(shape: TShape): string {
 function compareNamedShapes<TShape>(
   mismatches: string[],
   tableName: string,
-  shapeKind: string,
+  shapeKind: ShapeKind,
   journalShapes: Map<string, TShape> | undefined,
   pushedShapes: Map<string, TShape> | undefined
 ): void {
@@ -147,22 +199,44 @@ function compareNamedShapes<TShape>(
   for (const [shapeName, journalShape] of journalEntries) {
     const pushedShape = pushedEntries.get(shapeName);
     if (!pushedShape) {
-      mismatches.push(`DB-B missing ${shapeKind} ${tableName}.${shapeName}`);
+      mismatches.push(`${tableName}|${shapeKind}|${shapeName}`);
       continue;
     }
 
     if (shapeToText(journalShape) !== shapeToText(pushedShape)) {
-      mismatches.push(
-        `${shapeKind} ${tableName}.${shapeName} differs: DB-A=${shapeToText(
-          journalShape
-        )} DB-B=${shapeToText(pushedShape)}`
-      );
+      mismatches.push(`${tableName}|${shapeKind}|${shapeName}`);
     }
   }
 
   for (const shapeName of pushedEntries.keys()) {
     if (!journalEntries.has(shapeName)) {
-      mismatches.push(`DB-A missing ${shapeKind} ${tableName}.${shapeName}`);
+      mismatches.push(`${tableName}|${shapeKind}|${shapeName}`);
+    }
+  }
+}
+
+function compareForeignKeyShapes(
+  mismatches: string[],
+  tableName: string,
+  journalCatalog: CatalogSnapshot,
+  pushedCatalog: CatalogSnapshot
+): void {
+  const journalForeignKeys = journalCatalog.foreignKeysByTable.get(tableName) ?? new Set<string>();
+  const pushedForeignKeys = pushedCatalog.foreignKeysByTable.get(tableName) ?? new Set<string>();
+  const journalNames =
+    journalCatalog.foreignKeyNamesByTable.get(tableName) ?? new Map<string, string>();
+  const pushedNames =
+    pushedCatalog.foreignKeyNamesByTable.get(tableName) ?? new Map<string, string>();
+
+  for (const shapeSignature of journalForeignKeys) {
+    if (!pushedForeignKeys.has(shapeSignature)) {
+      mismatches.push(`${tableName}|fk|${journalNames.get(shapeSignature) ?? shapeSignature}`);
+    }
+  }
+
+  for (const shapeSignature of pushedForeignKeys) {
+    if (!journalForeignKeys.has(shapeSignature)) {
+      mismatches.push(`${tableName}|fk|${pushedNames.get(shapeSignature) ?? shapeSignature}`);
     }
   }
 }
@@ -270,8 +344,10 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
   `);
 
   const columns: TableShapeMap<ColumnShape> = new Map();
-  const constraints: TableShapeMap<ConstraintShape> = new Map();
+  const nonFkConstraints: TableShapeMap<ConstraintShape> = new Map();
   const indexes: TableShapeMap<IndexShape> = new Map();
+  const foreignKeysByTable: TableSetMap = new Map();
+  const foreignKeyNamesByTable: TableShapeMap<string> = new Map();
 
   for (const row of columnsResult.rows) {
     setTableShape(columns, normalizeIdentifier(row.tbl), normalizeIdentifier(row.col), {
@@ -281,13 +357,24 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
   }
 
   for (const row of constraintsResult.rows) {
-    setTableShape(constraints, normalizeIdentifier(row.tbl), normalizeIdentifier(row.conname), {
-      contype: normalizeCatalogText(row.contype) ?? '',
+    const tableName = normalizeIdentifier(row.tbl);
+    const constraintName = normalizeIdentifier(row.conname);
+    const contype = normalizeCatalogText(row.contype) ?? '';
+
+    if (contype === 'f') {
+      addForeignKeyShape(
+        foreignKeysByTable,
+        foreignKeyNamesByTable,
+        tableName,
+        foreignKeyShapeSignature(row),
+        constraintName
+      );
+      continue;
+    }
+
+    setTableShape(nonFkConstraints, tableName, constraintName, {
+      contype,
       cols: normalizeIdentifierArray(row.cols),
-      reftable: normalizeCatalogText(row.reftable) ?? '',
-      refcols: normalizeIdentifierArray(row.refcols),
-      confupdtype: normalizeCatalogText(row.confupdtype) ?? '',
-      confdeltype: normalizeCatalogText(row.confdeltype) ?? '',
     });
   }
 
@@ -302,8 +389,10 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
   return {
     tables: new Set(tablesResult.rows.map((row) => normalizeIdentifier(row.relname))),
     columns,
-    constraints,
+    nonFkConstraints,
     indexes,
+    foreignKeysByTable,
+    foreignKeyNamesByTable,
   };
 }
 
@@ -355,8 +444,8 @@ function compareIntersectionShape(
       mismatches,
       tableName,
       'constraint',
-      journalCatalog.constraints.get(tableName),
-      pushedCatalog.constraints.get(tableName)
+      journalCatalog.nonFkConstraints.get(tableName),
+      pushedCatalog.nonFkConstraints.get(tableName)
     );
     compareNamedShapes(
       mismatches,
@@ -365,6 +454,7 @@ function compareIntersectionShape(
       journalCatalog.indexes.get(tableName),
       pushedCatalog.indexes.get(tableName)
     );
+    compareForeignKeyShapes(mismatches, tableName, journalCatalog, pushedCatalog);
   }
 
   return mismatches;
@@ -571,6 +661,12 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       .sort();
     const shapeOnlyBaseline = new Set<string>(SHAPE_ONLY_NOT_JOURNALED);
     const shapeMismatches = compareIntersectionShape(journalCatalog, pushedCatalog);
+    const unexpectedShapeMismatches = shapeMismatches
+      .filter((key) => !KNOWN_INTERSECTION_DRIFT.has(key))
+      .sort();
+    const baselineNotObserved = [...KNOWN_INTERSECTION_DRIFT]
+      .filter((key) => !shapeMismatches.includes(key))
+      .sort();
 
     // eslint-disable-next-line no-console -- D4 requires non-gating CI diagnostics.
     console.log('[prod-schema-clone] shape-only tables', shapeOnlyTables);
@@ -581,9 +677,21 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       '[prod-schema-clone] DB-B catalog definitions',
       await catalogDefinitions(shapePool)
     );
+    // eslint-disable-next-line no-console -- non-gating drift report for PR-2b
+    console.log(
+      '[prod-schema-clone] KNOWN intersection drift observed (report-only, PR-2b):',
+      shapeMismatches.filter((key) => KNOWN_INTERSECTION_DRIFT.has(key)).sort()
+    );
+    if (baselineNotObserved.length) {
+      // eslint-disable-next-line no-console -- non-gating baseline shrink signal for PR-2b
+      console.log(
+        '[prod-schema-clone] baseline entries NOT observed (drift fixed? shrink baseline):',
+        baselineNotObserved
+      );
+    }
 
     expect(missingC1Tables).toEqual([]);
-    expect(shapeMismatches).toEqual([]);
+    expect(unexpectedShapeMismatches).toEqual([]);
     expect(journalOnlyTables).toEqual([]);
     expect(shapeOnlyTables.filter((tableName) => !shapeOnlyBaseline.has(tableName))).toEqual([]);
 

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -81,6 +81,10 @@ const KNOWN_INTERSECTION_DRIFT = new Set<string>([
   'fund_snapshots|fk|fund_snapshots_config_id_fundconfigs_id_fk',
   'fund_snapshots|fk|fund_snapshots_run_id_calc_runs_id_fk',
   'job_outbox|constraint|job_outbox_status_check',
+  // version column default drift: journal DEFAULT 1 vs shared/schema DEFAULT 0 (0021 fixed the type, not the default) — deferred to PR-2b re-sync.
+  'forecast_snapshots|column|version',
+  'investment_lots|column|version',
+  'reserve_allocations|column|version',
 ]);
 
 type TableShapeMap<TShape> = Map<string, Map<string, TShape>>;
@@ -109,7 +113,6 @@ interface IndexShape {
   method: string | null;
   predicate: string | null;
   cols: string[];
-  def: string | null;
 }
 
 interface CatalogSnapshot {
@@ -254,6 +257,51 @@ function compareForeignKeyShapes(
   }
 }
 
+type ShapeDiagnosticValue = ColumnShape | ConstraintShape | IndexShape | string | null;
+
+function foreignKeyShapeValue(catalog: CatalogSnapshot, tableName: string, shapeName: string): string | null {
+  const signatures = catalog.foreignKeysByTable.get(tableName);
+  if (signatures?.has(shapeName)) {
+    return shapeName;
+  }
+
+  const namesBySignature = catalog.foreignKeyNamesByTable.get(tableName);
+  if (!namesBySignature) {
+    return null;
+  }
+
+  for (const [signature, foreignKeyName] of namesBySignature) {
+    if (foreignKeyName === shapeName) {
+      return signature;
+    }
+  }
+
+  return null;
+}
+
+function shapeValueForMismatchKey(catalog: CatalogSnapshot, key: string): ShapeDiagnosticValue {
+  const [tableName, kind, ...nameParts] = key.split('|');
+  const shapeName = nameParts.join('|');
+  if (!tableName || !kind || !shapeName) {
+    return null;
+  }
+
+  if (kind === 'column') {
+    return catalog.columns.get(tableName)?.get(shapeName) ?? null;
+  }
+  if (kind === 'constraint') {
+    return catalog.nonFkConstraints.get(tableName)?.get(shapeName) ?? null;
+  }
+  if (kind === 'index') {
+    return catalog.indexes.get(tableName)?.get(shapeName) ?? null;
+  }
+  if (kind === 'fk') {
+    return foreignKeyShapeValue(catalog, tableName, shapeName);
+  }
+
+  return null;
+}
+
 function connectionUriForDatabase(databaseName: string): string {
   if (!postgres) {
     throw new Error('Postgres container has not started');
@@ -352,7 +400,6 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     uniq: boolean;
     method: string;
     predicate: string | null;
-    def: string;
     tbl: string;
     cols: string[];
   }>(`
@@ -361,7 +408,6 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
       ix.indisunique uniq,
       am.amname method,
       pg_get_expr(ix.indpred, ix.indrelid) predicate,
-      pg_get_indexdef(ix.indexrelid) def,
       c.relname tbl,
       COALESCE(
         (
@@ -428,7 +474,6 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
       method: normalizeCatalogText(row.method),
       predicate: normalizeCatalogText(row.predicate),
       cols: normalizeIdentifierArray(row.cols),
-      def: normalizeCatalogText(row.def),
     });
   }
 
@@ -688,6 +733,19 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       console.log(
         '[prod-schema-clone] baseline entries NOT observed (drift fixed? shrink baseline):',
         baselineNotObserved
+      );
+    }
+    for (const key of unexpectedShapeMismatches) {
+      const dbAValue = shapeValueForMismatchKey(journalCatalog, key);
+      const dbBValue = shapeValueForMismatchKey(pushedCatalog, key);
+      // eslint-disable-next-line no-console -- emit flat DB-A/DB-B shape values before gated failure.
+      console.log(
+        '[prod-schema-clone] UNEXPECTED',
+        key,
+        'DB-A=',
+        JSON.stringify(dbAValue ?? null),
+        'DB-B=',
+        JSON.stringify(dbBValue ?? null)
       );
     }
 

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -90,17 +90,26 @@ type ShapeKind = 'column' | 'constraint' | 'index';
 interface ColumnShape {
   typ: string;
   notnull: boolean;
+  defaultExpression: string | null;
+  identity: string;
+  generated: string;
 }
 
 interface ConstraintShape {
   contype: string;
   cols: string[];
+  def: string | null;
+  deferrable: boolean;
+  deferred: boolean;
+  validated: boolean;
 }
 
 interface IndexShape {
   uniq: boolean;
+  method: string | null;
   predicate: string | null;
   cols: string[];
+  def: string | null;
 }
 
 interface CatalogSnapshot {
@@ -163,14 +172,27 @@ function foreignKeyShapeSignature(row: {
   refcols: readonly string[] | null;
   confupdtype: string;
   confdeltype: string;
+  def: string | null;
+  deferrable: boolean;
+  deferred: boolean;
+  validated: boolean;
 }): string {
   const cols = normalizeIdentifierArray(row.cols);
   const reftable = normalizeCatalogText(row.reftable) ?? '';
   const refcols = normalizeIdentifierArray(row.refcols);
   const confupdtype = normalizeCatalogText(row.confupdtype) ?? '';
   const confdeltype = normalizeCatalogText(row.confdeltype) ?? '';
+  const def = normalizeCatalogText(row.def) ?? '';
 
-  return `${cols.join(',')}=>${reftable}(${refcols.join(',')})|u:${confupdtype}|d:${confdeltype}`;
+  return [
+    `${cols.join(',')}=>${reftable}(${refcols.join(',')})`,
+    `u:${confupdtype}`,
+    `d:${confdeltype}`,
+    `def:${def}`,
+    `deferrable:${String(row.deferrable)}`,
+    `deferred:${String(row.deferred)}`,
+    `validated:${String(row.validated)}`,
+  ].join('|');
 }
 
 function shapeToText<TShape>(shape: TShape): string {
@@ -256,11 +278,22 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     col: string;
     typ: string;
     notnull: boolean;
+    default_expression: string | null;
+    identity: string;
+    generated: string;
   }>(`
-    SELECT c.relname tbl, a.attname col, format_type(a.atttypid, a.atttypmod) typ, a.attnotnull notnull
+    SELECT
+      c.relname tbl,
+      a.attname col,
+      format_type(a.atttypid, a.atttypmod) typ,
+      a.attnotnull notnull,
+      pg_get_expr(ad.adbin, ad.adrelid) default_expression,
+      a.attidentity identity,
+      a.attgenerated generated
     FROM pg_attribute a
     JOIN pg_class c ON c.oid = a.attrelid
     JOIN pg_namespace n ON n.oid = c.relnamespace
+    LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
     WHERE n.nspname = 'public'
       AND c.relkind = 'r'
       AND a.attnum > 0
@@ -276,11 +309,19 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     refcols: string[];
     confupdtype: string;
     confdeltype: string;
+    def: string;
+    deferrable: boolean;
+    deferred: boolean;
+    validated: boolean;
   }>(`
     SELECT
       con.conname,
       con.contype,
       c.relname tbl,
+      pg_get_constraintdef(con.oid, true) def,
+      con.condeferrable deferrable,
+      con.condeferred deferred,
+      con.convalidated validated,
       COALESCE(
         (
           SELECT array_agg(a.attname::text ORDER BY k.ord)
@@ -309,14 +350,18 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
   const indexesResult = await activePool.query<{
     idxname: string;
     uniq: boolean;
+    method: string;
     predicate: string | null;
+    def: string;
     tbl: string;
     cols: string[];
   }>(`
     SELECT
       i.relname idxname,
       ix.indisunique uniq,
+      am.amname method,
       pg_get_expr(ix.indpred, ix.indrelid) predicate,
+      pg_get_indexdef(ix.indexrelid) def,
       c.relname tbl,
       COALESCE(
         (
@@ -329,6 +374,7 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     FROM pg_index ix
     JOIN pg_class i ON i.oid = ix.indexrelid
     JOIN pg_class c ON c.oid = ix.indrelid
+    JOIN pg_am am ON am.oid = i.relam
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = 'public'
       AND c.relname <> 'drizzle_migrations'
@@ -344,6 +390,9 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     setTableShape(columns, normalizeIdentifier(row.tbl), normalizeIdentifier(row.col), {
       typ: normalizeCatalogText(row.typ) ?? '',
       notnull: row.notnull,
+      defaultExpression: normalizeCatalogText(row.default_expression),
+      identity: normalizeCatalogText(row.identity) ?? '',
+      generated: normalizeCatalogText(row.generated) ?? '',
     });
   }
 
@@ -366,14 +415,20 @@ async function introspectCatalog(activePool: Pool): Promise<CatalogSnapshot> {
     setTableShape(nonFkConstraints, tableName, constraintName, {
       contype,
       cols: normalizeIdentifierArray(row.cols),
+      def: normalizeCatalogText(row.def),
+      deferrable: row.deferrable,
+      deferred: row.deferred,
+      validated: row.validated,
     });
   }
 
   for (const row of indexesResult.rows) {
     setTableShape(indexes, normalizeIdentifier(row.tbl), normalizeIdentifier(row.idxname), {
       uniq: row.uniq,
+      method: normalizeCatalogText(row.method),
       predicate: normalizeCatalogText(row.predicate),
       cols: normalizeIdentifierArray(row.cols),
+      def: normalizeCatalogText(row.def),
     });
   }
 

--- a/tests/unit/dual-ledger-divergence.test.ts
+++ b/tests/unit/dual-ledger-divergence.test.ts
@@ -108,6 +108,39 @@ describe('dual ledger divergence detector', () => {
       ])
     );
   });
+
+  it('reports unparsed server DDL even when the same file has parsed missing objects', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, []);
+    writeSql(
+      root,
+      'server/migrations/9999_mixed.up.sql',
+      `
+        CREATE TABLE mixed_table (id integer primary key);
+        CREATE TRIGGER mixed_table_updated_at
+        BEFORE UPDATE ON mixed_table
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+      `
+    );
+
+    const result = detectDualLedgerDivergence(root);
+
+    expect(result.ok).toBe(true);
+    expect(result.divergences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'server-unique-content',
+          file: 'server/migrations/9999_mixed.up.sql',
+          message: expect.stringContaining('table:mixed_table'),
+        }),
+        expect.objectContaining({
+          code: 'server-unparsed-ddl',
+          file: 'server/migrations/9999_mixed.up.sql',
+          message: expect.stringContaining('CREATE TRIGGER'),
+        }),
+      ])
+    );
+  });
 });
 
 function countRealServerForwardFiles(): number {

--- a/tests/unit/dual-ledger-divergence.test.ts
+++ b/tests/unit/dual-ledger-divergence.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  detectDualLedgerDivergence,
+  formatDualLedgerReport,
+  type DualLedgerDivergenceResult,
+} from '../../scripts/dual-ledger-divergence';
+import type { JournalFile } from '../../scripts/migration-ledger';
+
+const repoRoot = process.cwd();
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const tempRoot = tempRoots.pop();
+    if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe('dual ledger divergence detector', () => {
+  it('reports the real server forward migration census without detector errors', () => {
+    const result = detectDualLedgerDivergence(repoRoot);
+    const expectedForwardFiles = countRealServerForwardFiles();
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(expectedForwardFiles).toBeGreaterThan(0);
+    expect(expectedForwardFiles).toBe(32);
+    expect(result.summary.serverForwardFiles).toBe(expectedForwardFiles);
+  });
+
+  it('surfaces a malformed server migration as a detector error', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [{ idx: 0, when: 1, tag: '0000_base', breakpoints: true }]);
+    writeSql(root, 'migrations/0000_base.sql', 'CREATE TABLE "journaled_table" (id integer);');
+    writeSql(root, 'server/migrations/9999_bad.up.sql', 'CREATE TABLE "broken (id integer);');
+
+    const result = detectDualLedgerDivergence(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'sql-parse-error',
+          file: 'server/migrations/9999_bad.up.sql',
+        }),
+      ])
+    );
+  });
+
+  it('formats a non-empty markdown report containing summary counts', () => {
+    const result: DualLedgerDivergenceResult = {
+      ok: true,
+      divergences: [
+        {
+          severity: 'info',
+          code: 'server-unique-content',
+          file: 'server/migrations/example.up.sql',
+          message:
+            'Server forward migration creates objects absent from the journal/shared ledger: table:example',
+        },
+      ],
+      errors: [],
+      summary: {
+        serverForwardFiles: 1,
+        uniqueObjectFiles: 1,
+        duplicateFiles: 0,
+        activeConsumerFiles: 0,
+      },
+    };
+
+    const report = formatDualLedgerReport(result);
+
+    expect(report.length).toBeGreaterThan(0);
+    expect(report).toContain('serverForwardFiles=1');
+    expect(report).toContain('uniqueObjectFiles=1');
+    expect(report).toContain('duplicateFiles=0');
+    expect(report).toContain('activeConsumerFiles=0');
+  });
+});
+
+function countRealServerForwardFiles(): number {
+  return fs
+    .readdirSync(path.join(repoRoot, 'server', 'migrations'), { withFileTypes: true })
+    .filter(
+      (entry) => entry.isFile() && entry.name.endsWith('.sql') && !entry.name.endsWith('.down.sql')
+    ).length;
+}
+
+function makeFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dual-ledger-divergence-'));
+  tempRoots.push(root);
+  fs.mkdirSync(path.join(root, 'migrations', 'meta'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'server', 'migrations'), { recursive: true });
+  return root;
+}
+
+function writeJournal(root: string, entries: JournalFile['entries']): void {
+  const journal: JournalFile = { version: '7', dialect: 'postgresql', entries };
+  writeSql(root, 'migrations/meta/_journal.json', JSON.stringify(journal, null, 2));
+}
+
+function writeSql(root: string, relativePath: string, contents: string): void {
+  const absolutePath = path.join(root, ...relativePath.split('/'));
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, `${contents}\n`, 'utf8');
+}

--- a/tests/unit/dual-ledger-divergence.test.ts
+++ b/tests/unit/dual-ledger-divergence.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   detectDualLedgerDivergence,
+  extractDdlObjects,
   formatDualLedgerReport,
   type DualLedgerDivergenceResult,
 } from '../../scripts/dual-ledger-divergence';
@@ -81,6 +82,31 @@ describe('dual ledger divergence detector', () => {
     expect(report).toContain('uniqueObjectFiles=1');
     expect(report).toContain('duplicateFiles=0');
     expect(report).toContain('activeConsumerFiles=0');
+  });
+
+  it('extracts every column from a multi-column ALTER TABLE statement', () => {
+    const objects = extractDdlObjects(`
+      ALTER TABLE "allocation_scenario_events"
+        ADD COLUMN "allocation_scenario_id" uuid,
+        ADD COLUMN IF NOT EXISTS "event_type" text,
+        ADD CONSTRAINT "allocation_scenario_events_pkey" PRIMARY KEY ("allocation_scenario_id"),
+        ADD CONSTRAINT "allocation_scenario_events_event_type_check" CHECK ("event_type" <> '');
+    `);
+
+    const columnObjects = objects.filter((object) => object.kind === 'column');
+    const objectKeys = objects.map(
+      (object) => `${object.kind}:${object.table ?? ''}:${object.name}`
+    );
+
+    expect(columnObjects.length).toBeGreaterThan(1);
+    expect(objectKeys).toEqual(
+      expect.arrayContaining([
+        'column:allocation_scenario_events:allocation_scenario_id',
+        'column:allocation_scenario_events:event_type',
+        'constraint::allocation_scenario_events_event_type_check',
+        'constraint::allocation_scenario_events_pkey',
+      ])
+    );
   });
 });
 

--- a/tests/unit/ga-checklist-migrations.test.ts
+++ b/tests/unit/ga-checklist-migrations.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { checkMigrations } from '../../scripts/ga-checklist.mjs';
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+
+afterEach(() => {
+  if (originalDatabaseUrl === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('ga checklist migrations', () => {
+  it('treats a missing DATABASE_URL schema-audit skip as non-failing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    delete process.env.DATABASE_URL;
+
+    await expect(checkMigrations()).resolves.toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('schema audit skipped: no direct DATABASE_URL')
+    );
+  });
+});

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -100,7 +100,7 @@ describe('migration ledger helpers', () => {
     expect(
       result.findings.filter((finding) => finding.code === 'legacy-journaled-unmarked-allowlisted')
     ).toHaveLength(LEGACY_JOURNALED_UNMARKED_ALLOWLIST.length);
-    expect(markedJournaled).toHaveLength(5);
+    expect(markedJournaled).toHaveLength(6);
   });
 
   it('errors when a synthetic new journaled migration has no marker', () => {

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -1,0 +1,192 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  classifyMigrationSqlFile,
+  findLooseMigrationSql,
+  LEGACY_JOURNALED_UNMARKED_ALLOWLIST,
+  readDrizzleJournal,
+  readJournaledMigrationFiles,
+  validateMigrationLedger,
+  type JournalFile,
+} from '../../scripts/migration-ledger';
+
+const repoRoot = process.cwd();
+const tempRoots: string[] = [];
+
+const expectedLooseFiles = [
+  '0001_create_portfolio_tables.sql',
+  '0001_portfolio_schema_hardening.sql',
+  '0001_portfolio_schema_hardening_ROLLBACK.sql',
+  '0002_add_organizations.sql',
+  '0002_multi_tenant_rls_setup.sql',
+  '0002_multi_tenant_rls_setup_ROLLBACK.sql',
+  '0008_demo_profile_import_rows_rollback.sql',
+  '001_lp_reporting_schema.sql',
+  '002_lp_reporting_indexes.sql',
+  '003_lp_dashboard_materialized_view.sql',
+  '004_lp_sprint3_tables.sql',
+  '20251030_stage_normalization_log.sql',
+  '20251031_add_agent_memories.sql',
+  '999_fix_materialized_view.sql',
+  'manual-migration.sql',
+].sort();
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const tempRoot = tempRoots.pop();
+    if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe('migration ledger helpers', () => {
+  it('reads journaled migration files in journal order and throws when a journal tag has no file', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [
+      { idx: 0, when: 1, tag: '0002_second', breakpoints: true },
+      { idx: 1, when: 2, tag: '0001_first', breakpoints: true },
+    ]);
+    writeSql(root, '0002_second.sql', 'SELECT 2;');
+    writeSql(root, '0001_first.sql', 'SELECT 1;');
+
+    expect(readJournaledMigrationFiles(root).map((file) => file.tag)).toEqual([
+      '0002_second',
+      '0001_first',
+    ]);
+
+    fs.rmSync(path.join(root, 'migrations', '0001_first.sql'));
+
+    expect(() => readJournaledMigrationFiles(root)).toThrow(/0001_first/);
+  });
+
+  it('finds the known loose migration SQL files and never includes journaled files', () => {
+    const looseFiles = findLooseMigrationSql(repoRoot)
+      .map((file) => file.file)
+      .sort();
+    const journaledFiles = new Set(readJournaledMigrationFiles(repoRoot).map((file) => file.file));
+
+    expect(looseFiles).toEqual(expectedLooseFiles);
+    expect(looseFiles).toHaveLength(15);
+    expect(looseFiles.some((file) => journaledFiles.has(file))).toBe(false);
+  });
+
+  it('classifies materialized-view, RLS, and rollback loose files', () => {
+    const journalTags = new Set(readDrizzleJournal(repoRoot).entries.map((entry) => entry.tag));
+
+    expect(classifyRealFile('003_lp_dashboard_materialized_view.sql', journalTags).class).toBe(
+      'loose-materialized-view'
+    );
+    expect(classifyRealFile('0002_multi_tenant_rls_setup.sql', journalTags).class).toBe(
+      'loose-rls'
+    );
+    expect(classifyRealFile('0002_multi_tenant_rls_setup_ROLLBACK.sql', journalTags).class).toBe(
+      'loose-rollback'
+    );
+  });
+
+  it('validates the real migration tree with grandfathered unmarked files and marked drift patches', () => {
+    const result = validateMigrationLedger(repoRoot);
+    const errors = result.findings.filter((finding) => finding.severity === 'error');
+    const journalTags = new Set(readDrizzleJournal(repoRoot).entries.map((entry) => entry.tag));
+    const markedJournaled = readJournaledMigrationFiles(repoRoot)
+      .map((file) => classifyMigrationSqlFile(file.file, file.sql, journalTags))
+      .filter((classification) => classification.class === 'journaled-drift-patch');
+
+    expect(result.ok).toBe(true);
+    expect(errors).toEqual([]);
+    expect(
+      result.findings.filter((finding) => finding.code === 'legacy-journaled-unmarked-allowlisted')
+    ).toHaveLength(LEGACY_JOURNALED_UNMARKED_ALLOWLIST.length);
+    expect(markedJournaled).toHaveLength(5);
+  });
+
+  it('errors when a synthetic new journaled migration has no marker', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [{ idx: 0, when: 1, tag: '9999_new_unmarked', breakpoints: true }]);
+    writeSql(root, '9999_new_unmarked.sql', 'CREATE TABLE new_unmarked (id integer);');
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'journaled-sql-missing-marker',
+          file: '9999_new_unmarked.sql',
+          message: expect.stringContaining(
+            'new/edited journaled SQL needs -- @generated or -- @drift-patch marker'
+          ),
+        }),
+      ])
+    );
+  });
+
+  it('errors when a journal tag has no matching SQL file', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [{ idx: 0, when: 1, tag: '9999_missing_file', breakpoints: true }]);
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'journal-tag-missing-file',
+          file: '9999_missing_file.sql',
+        }),
+      ])
+    );
+  });
+
+  it('errors when a drift patch has no Reason line after the marker', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [{ idx: 0, when: 1, tag: '9999_drift_without_reason', breakpoints: true }]);
+    writeSql(
+      root,
+      '9999_drift_without_reason.sql',
+      '-- @drift-patch\nCREATE TABLE drift_without_reason (id integer);'
+    );
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'drift-patch-missing-reason',
+          file: '9999_drift_without_reason.sql',
+        }),
+      ])
+    );
+  });
+});
+
+function classifyRealFile(file: string, journalTags: ReadonlySet<string>) {
+  const sql = fs.readFileSync(path.join(repoRoot, 'migrations', file), 'utf-8');
+  return classifyMigrationSqlFile(file, sql, journalTags);
+}
+
+function makeFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-ledger-'));
+  tempRoots.push(root);
+  fs.mkdirSync(path.join(root, 'migrations', 'meta'), { recursive: true });
+  return root;
+}
+
+function writeJournal(root: string, entries: JournalFile['entries']): void {
+  const journal: JournalFile = { version: '7', dialect: 'postgresql', entries };
+  fs.writeFileSync(
+    path.join(root, 'migrations', 'meta', '_journal.json'),
+    `${JSON.stringify(journal, null, 2)}\n`
+  );
+}
+
+function writeSql(root: string, file: string, sql: string): void {
+  fs.writeFileSync(path.join(root, 'migrations', file), `${sql}\n`);
+}

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -165,6 +165,25 @@ describe('migration ledger helpers', () => {
       ])
     );
   });
+
+  it('errors when synthetic loose root SQL is unmarked and not grandfathered', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, []);
+    writeSql(root, '9999_new_loose_root.sql', 'CREATE TABLE new_loose_root (id integer);');
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'loose-migration-sql-missing-marker',
+          file: '9999_new_loose_root.sql',
+        }),
+      ])
+    );
+  });
 });
 
 function classifyRealFile(file: string, journalTags: ReadonlySet<string>) {

--- a/tests/unit/migration-marker.test.ts
+++ b/tests/unit/migration-marker.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  findLooseMigrationSql,
+  validateMigrationLedger,
+  type JournalFile,
+} from '../../scripts/migration-ledger';
+
+const repoRoot = process.cwd();
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const tempRoot = tempRoots.pop();
+    if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe('migration marker validation', () => {
+  it('fails when a new journaled tag is missing a marker', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [{ idx: 0, when: 1, tag: '9999_missing_marker', breakpoints: true }]);
+    writeSql(root, '9999_missing_marker.sql', 'CREATE TABLE missing_marker (id integer);');
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'journaled-sql-missing-marker',
+          message: expect.stringContaining(
+            'new/edited journaled SQL needs -- @generated or -- @drift-patch marker'
+          ),
+        }),
+      ])
+    );
+  });
+
+  it('fails when a generated journaled migration has no meta snapshot file', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [
+      { idx: 0, when: 1, tag: '9999_generated_without_snapshot', breakpoints: true },
+    ]);
+    writeSql(
+      root,
+      '9999_generated_without_snapshot.sql',
+      '-- @generated\nCREATE TABLE generated_without_snapshot (id integer);'
+    );
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'generated-migration-missing-snapshot',
+          file: '9999_generated_without_snapshot.sql',
+        }),
+      ])
+    );
+  });
+
+  it('fails when a drift patch marker has no Reason line', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [{ idx: 0, when: 1, tag: '9999_drift_missing_reason', breakpoints: true }]);
+    writeSql(
+      root,
+      '9999_drift_missing_reason.sql',
+      '-- @drift-patch\nALTER TABLE drift_missing_reason ADD COLUMN note text;'
+    );
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'drift-patch-missing-reason',
+          file: '9999_drift_missing_reason.sql',
+        }),
+      ])
+    );
+  });
+
+  it('reports legacy loose migration files without deleting or failing them', () => {
+    const result = validateMigrationLedger(repoRoot);
+    const looseFiles = findLooseMigrationSql(repoRoot).map((file) => file.file);
+    const looseFindings = result.findings.filter(
+      (finding) => finding.code === 'loose-migration-sql'
+    );
+
+    expect(result.ok).toBe(true);
+    expect(looseFindings).toHaveLength(looseFiles.length);
+    for (const file of looseFiles) {
+      expect(looseFindings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file,
+            message: expect.stringContaining('report only, not deleted'),
+          }),
+        ])
+      );
+    }
+  });
+});
+
+function makeFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-marker-'));
+  tempRoots.push(root);
+  fs.mkdirSync(path.join(root, 'migrations', 'meta'), { recursive: true });
+  return root;
+}
+
+function writeJournal(root: string, entries: JournalFile['entries']): void {
+  const journal: JournalFile = { version: '7', dialect: 'postgresql', entries };
+  fs.writeFileSync(
+    path.join(root, 'migrations', 'meta', '_journal.json'),
+    `${JSON.stringify(journal, null, 2)}\n`
+  );
+}
+
+function writeSql(root: string, file: string, sql: string): void {
+  fs.writeFileSync(path.join(root, 'migrations', file), `${sql}\n`);
+}

--- a/tests/unit/migration-marker.test.ts
+++ b/tests/unit/migration-marker.test.ts
@@ -68,6 +68,62 @@ describe('migration marker validation', () => {
     );
   });
 
+  it('fails when a generated journaled migration has a malformed meta snapshot file', () => {
+    const malformedSnapshots = [
+      { tag: '9999_generated_empty_snapshot', contents: '' },
+      { tag: '9999_generated_garbage_snapshot', contents: 'not json' },
+      { tag: '9999_generated_wrong_shape_snapshot', contents: '{}' },
+    ] as const;
+
+    for (const snapshot of malformedSnapshots) {
+      const root = makeFixtureRoot();
+      writeJournal(root, [{ idx: 5, when: 1, tag: snapshot.tag, breakpoints: true }]);
+      writeMetaFile(root, '0005_snapshot.json', snapshot.contents);
+      writeSql(
+        root,
+        `${snapshot.tag}.sql`,
+        `-- @generated\nCREATE TABLE ${snapshot.tag} (id integer);`
+      );
+
+      const result = validateMigrationLedger(root);
+
+      expect(result.ok).toBe(false);
+      expect(result.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            severity: 'error',
+            code: 'generated-migration-missing-snapshot',
+            file: `${snapshot.tag}.sql`,
+          }),
+        ])
+      );
+    }
+  });
+
+  it('passes when a generated journaled migration has a drizzle-shaped meta snapshot file', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [
+      { idx: 5, when: 1, tag: '9999_generated_with_snapshot', breakpoints: true },
+    ]);
+    writeMetaFile(
+      root,
+      '0005_snapshot.json',
+      JSON.stringify({ version: '7', dialect: 'postgresql', tables: {} })
+    );
+    writeSql(
+      root,
+      '9999_generated_with_snapshot.sql',
+      '-- @generated\nCREATE TABLE generated_with_snapshot (id integer);'
+    );
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(true);
+    expect(
+      result.findings.filter((finding) => finding.code === 'generated-migration-missing-snapshot')
+    ).toEqual([]);
+  });
+
   it('fails when a drift patch marker has no Reason line', () => {
     const root = makeFixtureRoot();
     writeJournal(root, [{ idx: 0, when: 1, tag: '9999_drift_missing_reason', breakpoints: true }]);

--- a/tests/unit/migration-marker.test.ts
+++ b/tests/unit/migration-marker.test.ts
@@ -45,8 +45,9 @@ describe('migration marker validation', () => {
   it('fails when a generated journaled migration has no meta snapshot file', () => {
     const root = makeFixtureRoot();
     writeJournal(root, [
-      { idx: 0, when: 1, tag: '9999_generated_without_snapshot', breakpoints: true },
+      { idx: 5, when: 1, tag: '9999_generated_without_snapshot', breakpoints: true },
     ]);
+    writeMetaFile(root, '0000_snapshot.json', '{}');
     writeSql(
       root,
       '9999_generated_without_snapshot.sql',
@@ -129,4 +130,8 @@ function writeJournal(root: string, entries: JournalFile['entries']): void {
 
 function writeSql(root: string, file: string, sql: string): void {
   fs.writeFileSync(path.join(root, 'migrations', file), `${sql}\n`);
+}
+
+function writeMetaFile(root: string, file: string, contents: string): void {
+  fs.writeFileSync(path.join(root, 'migrations', 'meta', file), `${contents}\n`);
 }

--- a/tests/unit/migration-marker.test.ts
+++ b/tests/unit/migration-marker.test.ts
@@ -167,6 +167,26 @@ describe('migration marker validation', () => {
       );
     }
   });
+
+  it('fails a new unjournaled loose root migration without a marker', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, []);
+    writeSql(root, '9999_unmarked_loose.sql', 'CREATE TABLE unmarked_loose (id integer);');
+
+    const result = validateMigrationLedger(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'loose-migration-sql-missing-marker',
+          file: '9999_unmarked_loose.sql',
+          message: expect.stringContaining('new or edited root SQL needs'),
+        }),
+      ])
+    );
+  });
 });
 
 function makeFixtureRoot(): string {

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -2,7 +2,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const MIGRATIONS_DIR = path.resolve(process.cwd(), 'migrations');
+import { readJournaledMigrationFiles } from '../../scripts/migration-ledger';
+
+const APP_SOURCE_FILE = path.resolve(process.cwd(), 'server', 'app.ts');
 
 const C1_MOUNTED_TABLES = [
   'cohort_definitions',
@@ -29,12 +31,62 @@ const DEFERRED_DOMAIN_LOCKED_TABLES = [
   'investment_round_model_overrides',
 ] as const;
 
+type MountKind = 'c1' | 'deferred' | 'non-table' | 'other-table';
+
+const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string[] }> = {
+  reservesV1Router: { kind: 'other-table' },
+  flagsRouter: { kind: 'other-table' },
+  cashflowRouter: { kind: 'other-table' },
+  healthRouter: { kind: 'non-table' },
+  calculationsRouter: { kind: 'other-table' },
+  aiRouter: { kind: 'non-table' },
+  scenarioAnalysisRouter: { kind: 'other-table' },
+  dualForecastRouter: { kind: 'other-table' },
+  allocationsRouter: { kind: 'other-table' },
+  allocationScenariosRouter: { kind: 'other-table' },
+  fundScenarioSetsRouter: { kind: 'other-table' },
+  fundMoicRouter: { kind: 'c1', tables: ['fund_calculation_modes', 'reconciliation_runs'] },
+  reallocationRouter: { kind: 'other-table' },
+  cashFlowEventsRouter: { kind: 'c1', tables: ['cash_flow_events'] },
+  operatingObjectTasksRouter: { kind: 'c1', tables: ['tasks'] },
+  backtestingRouter: { kind: 'other-table' },
+  fundsRouter: { kind: 'other-table' },
+  fundMetricsRouter: { kind: 'other-table' },
+  investmentsRouter: { kind: 'other-table' },
+  varianceRouter: { kind: 'other-table' },
+  registerFundConfigRoutes: { kind: 'other-table' },
+  dealPipelineRouter: { kind: 'other-table' },
+  cohortAnalysisRouter: {
+    kind: 'c1',
+    tables: [
+      'cohort_definitions',
+      'sector_taxonomy',
+      'sector_mappings',
+      'company_overrides',
+      'investment_overrides',
+    ],
+  },
+  sensitivityRouter: { kind: 'other-table' },
+  portfolioLotsRouter: { kind: 'other-table' },
+  performanceApiRouter: { kind: 'other-table' },
+  lpApiRouter: { kind: 'c1', tables: ['vehicles', 'valuation_marks'] },
+  lpCapitalCallsRouter: { kind: 'other-table' },
+  lpDistributionsRouter: { kind: 'other-table' },
+  lpDocumentsRouter: { kind: 'other-table' },
+  lpNotificationsRouter: { kind: 'other-table' },
+  lpReportingImportsRouter: {
+    kind: 'c1',
+    tables: ['evidence_records', 'lp_report_packages', 'lp_report_package_exports'],
+  },
+  lpReportingMetricRunsRouter: { kind: 'c1', tables: ['lp_metric_runs'] },
+  metricsRouter: { kind: 'non-table' },
+  metricsRumRouter: { kind: 'non-table' },
+  installRumIngressGuards: { kind: 'non-table' },
+};
+
 function migrationSql(): string {
-  return fs
-    .readdirSync(MIGRATIONS_DIR)
-    .filter((fileName) => fileName.endsWith('.sql'))
-    .sort()
-    .map((fileName) => fs.readFileSync(path.join(MIGRATIONS_DIR, fileName), 'utf8'))
+  return readJournaledMigrationFiles(process.cwd())
+    .map((migrationFile) => migrationFile.sql)
     .join('\n');
 }
 
@@ -44,6 +96,54 @@ function hasCreateTable(sql: string, tableName: string): boolean {
     String.raw`CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+"?${escaped}"?\b`,
     'i'
   ).test(sql);
+}
+
+function makeAppSource(): string {
+  return fs.readFileSync(APP_SOURCE_FILE, 'utf8');
+}
+
+function extractMakeAppRouteImportIdentifiers(appSource: string): string[] {
+  const identifiers = new Set<string>();
+  const importPattern = /^\s*import\s+(.+?)\s+from\s+['"](\.\/routes\/[^'"]+)['"];?/gm;
+
+  for (const match of appSource.matchAll(importPattern)) {
+    const importClause = match[1]?.trim();
+    if (!importClause) continue;
+
+    for (const identifier of parseImportClauseIdentifiers(importClause)) {
+      identifiers.add(identifier);
+    }
+  }
+
+  return [...identifiers].sort();
+}
+
+function parseImportClauseIdentifiers(importClause: string): string[] {
+  const identifiers: string[] = [];
+  const namedImportMatch = /\{([^}]+)\}/.exec(importClause);
+  const defaultImport = importClause
+    .replace(/\{[^}]*\}/, '')
+    .replace(/,\s*$/, '')
+    .trim();
+
+  if (defaultImport && !defaultImport.startsWith('*')) {
+    identifiers.push(defaultImport);
+  }
+
+  if (namedImportMatch) {
+    for (const specifier of namedImportMatch[1].split(',')) {
+      const localIdentifier = specifier
+        .replace(/^\s*type\s+/, '')
+        .split(/\s+as\s+/)
+        .pop()
+        ?.trim();
+      if (localIdentifier) {
+        identifiers.push(localIdentifier);
+      }
+    }
+  }
+
+  return identifiers;
 }
 
 describe('makeApp mount parity with journaled migrations', () => {
@@ -61,5 +161,28 @@ describe('makeApp mount parity with journaled migrations', () => {
       'investment_rounds',
       'investment_round_model_overrides',
     ]);
+  });
+
+  it('classifies every makeApp route mount (D6 recurrence guard)', () => {
+    const routeImportIdentifiers = extractMakeAppRouteImportIdentifiers(makeAppSource());
+    const missingRouteClassifications = routeImportIdentifiers.filter(
+      (identifier) => !Object.hasOwn(MAKEAPP_ROUTE_INVENTORY, identifier)
+    );
+
+    expect(missingRouteClassifications).toEqual([]);
+  });
+
+  it('keeps C1 route-table classifications inside the C1 parity set', () => {
+    const c1MountedTables = new Set<string>(C1_MOUNTED_TABLES);
+    const c1TablesOutsideParitySet = Object.entries(MAKEAPP_ROUTE_INVENTORY).flatMap(
+      ([mount, entry]) =>
+        entry.kind === 'c1'
+          ? (entry.tables ?? [])
+              .filter((tableName) => !c1MountedTables.has(tableName))
+              .map((tableName) => `${mount}:${tableName}`)
+          : []
+    );
+
+    expect(c1TablesOutsideParitySet).toEqual([]);
   });
 });

--- a/tests/unit/schema-audit-preflight.test.ts
+++ b/tests/unit/schema-audit-preflight.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { runSchemaAuditPreflight } from '../../scripts/schema-audit-preflight.mjs';
+
+describe('schema-audit-preflight', () => {
+  it('skips with no DATABASE_URL', async () => {
+    const result = await runSchemaAuditPreflight({ databaseUrl: undefined });
+
+    expect(result).toMatchObject({ status: 'skipped', ok: true });
+    expect(result.message).toContain('schema audit skipped: no direct DATABASE_URL');
+  });
+
+  it('skips memory and pooler URLs', async () => {
+    await expect(runSchemaAuditPreflight({ databaseUrl: 'memory://' })).resolves.toMatchObject({
+      status: 'skipped',
+      ok: true,
+    });
+    await expect(
+      runSchemaAuditPreflight({ databaseUrl: 'postgres://x-pooler.neon.tech/db' })
+    ).resolves.toMatchObject({ status: 'skipped', ok: true });
+  });
+
+  it('runs audit-only with a direct URL', async () => {
+    let captured: string[] = [];
+
+    const result = await runSchemaAuditPreflight({
+      databaseUrl: 'postgres://user:pass@direct.neon.tech/db',
+      manifestDir: 'custom/manifests',
+      runReconcile: (args: string[]) => {
+        captured = args;
+        return { code: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    expect(result).toMatchObject({ status: 'audited', ok: true });
+    expect(captured).toContain('--manifest-dir');
+    expect(captured).toContain('custom/manifests');
+    expect(captured).not.toContain('--apply');
+    expect(captured).not.toContain('--yes');
+  });
+
+  it('passes the expected database to the audit command', async () => {
+    let captured: string[] = [];
+
+    await runSchemaAuditPreflight({
+      databaseUrl: 'postgres://user:pass@direct.neon.tech/db',
+      expectedDb: 'updog_prod',
+      runReconcile: (args: string[]) => {
+        captured = args;
+        return { code: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    expect(captured).toContain('--expect-db');
+    expect(captured).toContain('updog_prod');
+    expect(captured).not.toContain('--apply');
+    expect(captured).not.toContain('--yes');
+  });
+
+  it('surfaces audit failure', async () => {
+    const result = await runSchemaAuditPreflight({
+      databaseUrl: 'postgres://user:pass@direct.neon.tech/db',
+      runReconcile: () => ({ code: 1 }),
+    });
+
+    expect(result).toMatchObject({ status: 'audited', ok: false, code: 1 });
+  });
+});

--- a/tests/unit/schema-audit-preflight.test.ts
+++ b/tests/unit/schema-audit-preflight.test.ts
@@ -28,7 +28,7 @@ describe('schema-audit-preflight', () => {
       manifestDir: 'custom/manifests',
       runReconcile: (args: string[]) => {
         captured = args;
-        return { code: 0, stdout: '', stderr: '' };
+        return { code: 0, stdout: 'fixture: SKIP\n', stderr: '' };
       },
     });
 
@@ -47,7 +47,7 @@ describe('schema-audit-preflight', () => {
       expectedDb: 'updog_prod',
       runReconcile: (args: string[]) => {
         captured = args;
-        return { code: 0, stdout: '', stderr: '' };
+        return { code: 0, stdout: 'fixture: SKIP\n', stderr: '' };
       },
     });
 
@@ -64,5 +64,33 @@ describe('schema-audit-preflight', () => {
     });
 
     expect(result).toMatchObject({ status: 'audited', ok: false, code: 1 });
+  });
+
+  it('fails audit-only success when any manifest action needs DDL', async () => {
+    const result = await runSchemaAuditPreflight({
+      databaseUrl: 'postgres://user:pass@direct.neon.tech/db',
+      runReconcile: () => ({
+        code: 0,
+        stdout: [
+          'Target database: updog_prod user=deploy',
+          'Mode: audit-only',
+          'c1-runtime-alignment: SKIP',
+          'pr1-prod-schema: APPLY-MISSING-DDL',
+          '  tasks: APPLY-MISSING-DDL (missing-column)',
+          '',
+        ].join('\n'),
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: 'audited',
+      ok: false,
+      code: 0,
+      auditActions: [
+        { manifest: 'c1-runtime-alignment', action: 'SKIP' },
+        { manifest: 'pr1-prod-schema', action: 'APPLY-MISSING-DDL' },
+      ],
+    });
+    expect(result.message).toContain('reported drift');
   });
 });

--- a/tests/unit/schema-drift-ledger-wiring.test.ts
+++ b/tests/unit/schema-drift-ledger-wiring.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { validateMigrationLedgerAndDualLedger } from '../../scripts/schema-drift-active-surfaces';
+import { validateMigrationLedger, type JournalFile } from '../../scripts/migration-ledger';
+
+const repoRoot = process.cwd();
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const tempRoot = tempRoots.pop();
+    if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe('schema drift migration ledger wiring', () => {
+  it('is green on the real repo tree', () => {
+    expect(validateMigrationLedgerAndDualLedger(repoRoot).ok).toBe(true);
+  });
+
+  it('fails when the ledger has an error', () => {
+    const root = makeFixtureRoot();
+    writeJournal(root, [{ idx: 0, when: 1, tag: '9999_new_unmarked', breakpoints: true }]);
+    writeSql(root, 'migrations/9999_new_unmarked.sql', 'CREATE TABLE new_unmarked (id integer);');
+
+    expect(validateMigrationLedger(root).ok).toBe(false);
+    expect(validateMigrationLedgerAndDualLedger(root).ok).toBe(false);
+  });
+});
+
+function makeFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-drift-ledger-wiring-'));
+  tempRoots.push(root);
+  fs.mkdirSync(path.join(root, 'migrations', 'meta'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'server', 'migrations'), { recursive: true });
+  return root;
+}
+
+function writeJournal(root: string, entries: JournalFile['entries']): void {
+  const journal: JournalFile = { version: '7', dialect: 'postgresql', entries };
+  writeSql(root, 'migrations/meta/_journal.json', JSON.stringify(journal, null, 2));
+}
+
+function writeSql(root: string, relativePath: string, contents: string): void {
+  const absolutePath = path.join(root, ...relativePath.split('/'));
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, `${contents}\n`, 'utf8');
+}


### PR DESCRIPTION
## PR-2a — Schema canonicalization: validation + reconcile teeth, NO deletions

Implements PR-2a exactly per `docs/superpowers/specs/2026-06-28-prod-schema-canonicalize-pr2-design.md` (the spec is committed here). Makes the migration validation truthful — kills the mount-parity false-green, fixes the stale ops scripts, and adds the two-sided shape-equivalence proof — without removing any legacy surface. PR-2b (fold + retire) is gated until this is green + reviewed.

### What landed (spec §1–§9)
- **§1 `scripts/migration-ledger.ts`** — strict journal-only readers (`_journal.json` order; missing journal / tag-without-file = fail; a loose file is never in the journaled set), loose/orphan classifier (incl. `loose-materialized-view` + `loose-rls`), the D5 `LEGACY_JOURNALED_UNMARKED_ALLOWLIST` (keyed by tag + content hash), and a no-hand-edit marker guard.
- **§2 `tests/unit/mount-parity-migrations.test.ts`** — `migrationSql()` now reads journal tags only (a loose root SQL file can no longer satisfy parity). Adds the D6 `MAKEAPP_ROUTE_INVENTORY` cross-check: a newly imported `./routes` mount that is not classified fails the test, closing the hardcoded-list recurrence gap. `DEFERRED_DOMAIN_LOCKED_TABLES` / `C1_MOUNTED_TABLES` unchanged.
- **§3/§4/§5** — classifier + marker convention reuse (`-- @generated` / `-- @drift-patch`) + grandfather allowlist + no-hand-edit guard, all inside the ledger validator.
- **§6 `scripts/schema-audit-preflight.mjs`** + edits to `scripts/deploy-production.ts` and `scripts/ga-checklist.mjs` — replaces the stale `npm run db:migrate -- --dry-run` (a script that does not exist) with an audit-only `reconcile-prod-schema.mjs` run that SKIPS with an explicit message when `DATABASE_URL` is missing / `memory://` / pooled. Never passes `--apply --yes` (defensive invariant). Unit-tested (skip vs audit-run vs never-apply).
- **§7 `tests/integration/prod-schema-clone.test.ts`** — extended (no new file, no `vitest.config.testcontainers.ts` edit) to a two-sided DB-A (journal `migrate()`) vs DB-B (`drizzle-kit pushSchema` from the 3 shape entry files) shape diff. Resolution A named-presence track for the 6 procedural objects.
- **§8 `scripts/dual-ledger-divergence.ts`** — report-only `server/migrations` vs journal divergence detector (rows never fail; read/parse error fails — D4).
- **§9** — wired the ledger + dual-ledger validation into `npm run validate:schema-drift` (additive; `validateActiveSchemaSurfaces()` untouched; `server/migrations` evidence NOT repointed — that is PR-2b).

### Spec PR-description checklist
- **Journal / root / loose counts:** 22 journal tags, 37 root `migrations/*.sql`, **15 loose** files: `0001_create_portfolio_tables`, `0001_portfolio_schema_hardening`, `0001_portfolio_schema_hardening_ROLLBACK`, `0002_add_organizations`, `0002_multi_tenant_rls_setup`, `0002_multi_tenant_rls_setup_ROLLBACK`, `0008_demo_profile_import_rows_rollback`, `001_lp_reporting_schema`, `002_lp_reporting_indexes`, `003_lp_dashboard_materialized_view`, `004_lp_sprint3_tables`, `20251030_stage_normalization_log`, `20251031_add_agent_memories`, `999_fix_materialized_view`, `manual-migration`. All reported/classified; none deleted.
- **`shared/migrations` resolution:** **Resolution A** (separate NAMED-PRESENCE track). Per-object matrix (local-proof) confirms only the 3 `update_*_updated_at()` functions + 3 `*_updated_at` triggers are procedural-only / "no shape counterpart"; the base tables (`job_outbox`@0005, `scenario_matrices`/`optimization_sessions`@0011), `alert_evaluation_executions`+indexes@0005, `job_outbox.dedupe_key`+`idx_job_outbox_job_type_dedupe`@0005, `performance_alerts_open_incident_unique`@0005, and `backtest_results.scenario_comparison_summary`@0006 (the `0004`/`0005` additions) are all in BOTH `shared/schema` and the root journal, so they are covered by the sentinel gate, not double-counted. Procedural objects proven by named-presence after applying `shared/migrations` to DB-A (the journal does not create them — verified — so the apply is clean).
- **Comparator reuse:** EXTENDED `tests/integration/prod-schema-clone.test.ts` (already in the testcontainers include list); no parallel validator, no include-list edit.
- **`drizzle_migrations` exclusion:** yes — excluded from the table/column/constraint/index diff (DB-A `migrate()` creates it; DB-B `pushSchema` does not).
- **Extensions:** `CREATE EXTENSION IF NOT EXISTS pgcrypto` defensively; pg16 needs none (`gen_random_uuid()` is core; no in-scope shape source declares a vector column).
- **DB-A/DB-B comparator collected & run by the configured gate in CI:** PASS in the `Testcontainers Integration Tests` workflow (`testcontainers-ci.yml`), run `28384863386` — the new `it('proves journal-built DB-A shape matches drizzle push DB-B …')` executed (confirmed by the `[prod-schema-clone]` diagnostics; in CI `skipIfNoDocker` is false). NOTE: `ci-unified.yml`'s `run_full_suite` path explicitly EXCLUDES Docker-only testcontainers proofs, so the §7 proof is owned by `testcontainers-ci.yml`, not the full-suite run. Local Windows SKIPS via `skipIfNoDocker` = non-evidence. Local-proof via `generateDrizzleJson` confirmed the table-set gates before CI: **journalOnly = [] , shapeOnly = exactly the 8 known shape-only tables.**
- **Dual-ledger report:** `ok=true`, 32 server forward files — 17 unique-content / 10 shape-duplicate / 15 active-consumer, 0 detector errors (full report attached as a comment).
- **deploy/GA no longer call `db:migrate --dry-run`:** confirmed (both callsites replaced).
- **No production DDL run:** confirmed. No `--apply --yes`, no prod `db:push`.

### Two findings surfaced (refinements over the spec prose; faithful to its D1/§8 philosophy)
1. **17, not 3, unmarked journaled files** are grandfathered. The spec named `0011`/`0013`/`0019` as *examples*; the full currently-unmarked set is 17 tags (only `0012`/`0014`/`0016`/`0017`/`0020` carry `-- @drift-patch`). The allowlist contains all 17, keyed by content hash (self-tightening: an edit drops a file out of grandfathering). Without this the gate would false-red on 17 already-applied files.
2. **8 shape-source tables are not in the journal** (`investment_rounds`, `investment_round_model_overrides` [lane-B deferred], `flag_changes`, `flags_state`, `reserve_approvals`, `approval_partners`, `approval_signatures`, `approval_audit_log`). These are reachable from the 3 shape entry files so `pushSchema` builds them into DB-B, but no journaled/loose migration creates them — genuine shape-vs-journal drift. §7 **excludes them from the gating table-presence direction and REPORTS them** (mirrors the spec's own D1 sentinel/diagnostic + §8 report-only split). The §7 baseline asserts the shape-only set is a *subset* of these 8, so a NEW unjournaled shape table still fails. Journaling these is out of PR-2a scope (no deletions / no domain-locked rounds work); flagged for PR-2b / a follow-up.

### Verification tiers
- **Unit / deterministic lane (local-proof, green):** `npm run check` (0 new TS errors), `npm run lint`, `npm run validate:schema-drift` (exit 0), 28 unit tests across the 7 PR-2a test files.
- **Docker / Testcontainers lane (CI-only — Windows SKIPS = non-evidence):** §7 proven by the `Testcontainers Integration Tests` workflow run `28384863386` (GREEN: 7 files / 28 tests). The §7 proof surfaced real journal-vs-shape drift, resolved per maintainer decision (drift patch 0021 for version columns; shape-based FK comparison; 17 documented drifts in `KNOWN_INTERSECTION_DRIFT`, report-only, deferred to PR-2b). `ci-unified.yml` full-suite run `28384858598` covers the unit + non-Docker integration lanes (`CI Gate Status` + `test-full` green, schema gate triggered by `migrations/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
