### PR TITLE
Add Planning FMV override approvals

### DIFF
--- a/client/src/components/lp-reporting/MetricRunForm.tsx
+++ b/client/src/components/lp-reporting/MetricRunForm.tsx
@@ -35,17 +35,15 @@ import { Label } from '@/components/ui/label';
 import { useMetricsDryRun } from '@/hooks/lp-reporting';
 import type { LpReportingHookError } from '@/hooks/lp-reporting';
 import {
-  MetricRunDryRunRequestSchema,
+  LpMetricRunTypeSchema,
   type MetricRunDryRunRequest,
   type MetricRunDryRunResponse,
 } from '@shared/contracts/lp-reporting';
 
-export const MetricRunDryRunRequestClientSchema = MetricRunDryRunRequestSchema.pick({
-  asOfDate: true,
-  runType: true,
-  perspective: true,
-})
-  .extend({
+export const MetricRunDryRunRequestClientSchema = z
+  .object({
+    asOfDate: z.string().date(),
+    runType: LpMetricRunTypeSchema,
     perspective: z.enum(['lp_net', 'fund_gross']),
   })
   .strict();
@@ -115,6 +113,7 @@ export function MetricRunForm({ fundId, onSuccess, onError }: MetricRunFormProps
         perspective: values.perspective,
         sourceEventIds: [],
         sourceMarkIds: [],
+        sourceMarkSelection: 'explicit',
       };
       const result = await mutation.mutateAsync(request);
       onSuccess(result, request);

--- a/client/src/components/portfolio/tabs/AllocationsTab.tsx
+++ b/client/src/components/portfolio/tabs/AllocationsTab.tsx
@@ -21,8 +21,9 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { useFundContext } from '@/contexts/FundContext';
+import { useFlag } from '@/shared/useFlags';
 import { format } from 'date-fns';
-import { AlertCircle, ArrowLeft, Plus, RefreshCw, Save, Search } from 'lucide-react';
+import { AlertCircle, ArrowLeft, Banknote, Plus, RefreshCw, Save, Search } from 'lucide-react';
 import { useLatestAllocations } from './hooks/useLatestAllocations';
 import {
   useAllocationScenarioApplyPreview,
@@ -39,10 +40,12 @@ import {
 import { useReserveIcPacketEvidence } from './hooks/useReserveIcPacketEvidence';
 import { AddCompanyDialog } from './AddCompanyDialog';
 import { EditAllocationDialog } from './EditAllocationDialog';
+import { FmvOverrideDialog } from './FmvOverrideDialog';
 import { ReserveIcPacketCard } from './ReserveIcPacketCard';
-import { createAllocationsColumns } from './allocations-table-columns';
+import { createAllocationsColumns, type ColumnDef } from './allocations-table-columns';
 import { formatCents } from '@/lib/units';
 import { buildReserveIcPacket } from './reserve-ic-packet';
+import { useLatestPlanningFmvOverrides } from './hooks/usePlanningFmvOverrides';
 import type {
   AllocationCompany,
   AllocationScenarioCollaborationContext,
@@ -55,6 +58,7 @@ import type {
   CreateAllocationScenarioPayload,
   UpdateAllocationPayload,
 } from './types';
+import type { PlanningFmvOverrideRecord } from '@shared/contracts/lp-reporting';
 
 const EMPTY_RESERVE_IC_DECISIONS: ReserveIcDecision[] = [];
 
@@ -175,6 +179,23 @@ function formatDeltaLabel(value: number) {
 
   const absoluteValue = formatCents(Math.abs(value), { compact: true });
   return `${value > 0 ? '+' : '-'}${absoluteValue}`;
+}
+
+function formatPlanningFmvValue(value: string | null | undefined): string {
+  if (!value) {
+    return 'No approved mark';
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(numeric);
 }
 
 function formatAppliedStatusLabel(
@@ -318,6 +339,7 @@ function CollaborationContextEventCard({
 export function AllocationsTab() {
   const { toast } = useToast();
   const { fundId } = useFundContext();
+  const planningFmvEnabled = useFlag('enable_planning_fmv_overrides');
   const { data, isLoading, error, refetch } = useLatestAllocations();
   const {
     data: scenarioListData,
@@ -325,7 +347,9 @@ export function AllocationsTab() {
     error: scenarioListError,
   } = useAllocationScenarioList();
   const [selectedCompanyId, setSelectedCompanyId] = useState<number | null>(null);
+  const [selectedFmvCompanyId, setSelectedFmvCompanyId] = useState<number | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isFmvDialogOpen, setIsFmvDialogOpen] = useState(false);
   const [isAddCompanyDialogOpen, setIsAddCompanyDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [sectorFilter, setSectorFilter] = useState<string>('all');
@@ -365,6 +389,7 @@ export function AllocationsTab() {
   const syncScenarioMutation = useSyncAllocationScenario(activeScenarioId);
   const applyScenarioMutation = useApplyAllocationScenario(activeScenarioId);
   const { publishedResultsQuery, comparisonQuery } = useReserveIcPacketEvidence(!!activeScenarioId);
+  const latestPlanningFmvQuery = useLatestPlanningFmvOverrides({ enabled: planningFmvEnabled });
 
   const liveCompanies = useMemo(() => data?.companies ?? [], [data?.companies]);
   const displayedCompanies = workspaceCompanies.length > 0 ? workspaceCompanies : liveCompanies;
@@ -445,6 +470,20 @@ export function AllocationsTab() {
     [displayedCompanies, selectedCompanyId]
   );
 
+  const planningFmvByCompanyId = useMemo(() => {
+    const marks = latestPlanningFmvQuery.data?.marks ?? [];
+    return new Map<number, PlanningFmvOverrideRecord>(marks.map((mark) => [mark.companyId, mark]));
+  }, [latestPlanningFmvQuery.data?.marks]);
+
+  const selectedFmvCompany = useMemo(
+    () => displayedCompanies.find((company) => company.company_id === selectedFmvCompanyId) ?? null,
+    [displayedCompanies, selectedFmvCompanyId]
+  );
+
+  const selectedFmvMark = selectedFmvCompany
+    ? (planningFmvByCompanyId.get(selectedFmvCompany.company_id) ?? null)
+    : null;
+
   const selectedDecisionCompany = useMemo(
     () =>
       displayedCompanies.find((company) => company.company_id === selectedDecisionCompanyId) ??
@@ -490,6 +529,11 @@ export function AllocationsTab() {
     setIsEditDialogOpen(true);
   }, []);
 
+  const handleFmvOverride = useCallback((company: AllocationCompany) => {
+    setSelectedFmvCompanyId(company.company_id);
+    setIsFmvDialogOpen(true);
+  }, []);
+
   const handleScenarioWorkspaceSave = useCallback((update: UpdateAllocationPayload) => {
     setWorkspaceCompanies((current) =>
       current.map((company) =>
@@ -506,7 +550,47 @@ export function AllocationsTab() {
     setWorkspaceDirty(true);
   }, []);
 
-  const columns = useMemo(() => createAllocationsColumns(handleEdit), [handleEdit]);
+  const columns = useMemo(() => {
+    const baseColumns = createAllocationsColumns(handleEdit);
+    if (!planningFmvEnabled) {
+      return baseColumns;
+    }
+
+    const currentFmvColumn: ColumnDef<AllocationCompany> = {
+      id: 'current_fmv',
+      header: 'Current FMV',
+      cell: ({ row }) => {
+        const mark = planningFmvByCompanyId.get(row.original.company_id);
+        return (
+          <div className="min-w-[150px] space-y-2">
+            <div>
+              <div className="text-right font-medium text-pov-charcoal">
+                {formatPlanningFmvValue(mark?.fairValue)}
+              </div>
+              <div className="text-right text-xs text-charcoal-500">
+                {mark?.markDate ?? 'No mark date'}
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 w-full"
+              onClick={() => handleFmvOverride(row.original)}
+            >
+              <Banknote className="mr-1 h-4 w-4" />
+              Save approved mark
+            </Button>
+          </div>
+        );
+      },
+    };
+
+    const actionColumn = baseColumns.at(-1);
+    const leadingColumns = actionColumn ? baseColumns.slice(0, -1) : baseColumns;
+    return actionColumn
+      ? [...leadingColumns, currentFmvColumn, actionColumn]
+      : [...leadingColumns, currentFmvColumn];
+  }, [handleEdit, handleFmvOverride, planningFmvByCompanyId, planningFmvEnabled]);
 
   const reservePlanCount = useMemo(
     () => displayedCompanies.filter((company) => company.planned_reserves_cents > 0).length,
@@ -643,6 +727,7 @@ export function AllocationsTab() {
     setScenarioActionNote('');
     setApplyPreview(null);
     setSelectedCompanyId(null);
+    setSelectedFmvCompanyId(null);
   }, [liveCompanies]);
 
   const handleResumeScenario = useCallback((scenarioId: string) => {
@@ -652,6 +737,7 @@ export function AllocationsTab() {
     setScenarioActionNote('');
     setApplyPreview(null);
     setSelectedCompanyId(null);
+    setSelectedFmvCompanyId(null);
   }, []);
 
   const buildScenarioPayload = useCallback((): CreateAllocationScenarioPayload => {
@@ -1816,6 +1902,17 @@ export function AllocationsTab() {
         </div>
       ) : null}
 
+      {planningFmvEnabled && latestPlanningFmvQuery.error ? (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {latestPlanningFmvQuery.error instanceof Error
+              ? latestPlanningFmvQuery.error.message
+              : 'Failed to load Planning FMV marks'}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
       <Card>
         <CardContent className="p-0">
           <Table>
@@ -1866,6 +1963,13 @@ export function AllocationsTab() {
         onOpenChange={setIsEditDialogOpen}
         mode={activeScenarioId ? 'scenario' : 'live'}
         onSaveScenarioDraft={handleScenarioWorkspaceSave}
+      />
+      <FmvOverrideDialog
+        company={selectedFmvCompany}
+        currentMark={selectedFmvMark}
+        open={isFmvDialogOpen}
+        onOpenChange={setIsFmvDialogOpen}
+        scenarioActive={!!activeScenarioId}
       />
     </div>
   );

--- a/client/src/components/portfolio/tabs/FmvOverrideDialog.tsx
+++ b/client/src/components/portfolio/tabs/FmvOverrideDialog.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { formatCents } from '@/lib/units';
+import type { PlanningFmvOverrideRecord } from '@shared/contracts/lp-reporting';
+import type { AllocationCompany } from './types';
+import { useCreatePlanningFmvOverride } from './hooks/usePlanningFmvOverrides';
+
+interface FmvOverrideDialogProps {
+  company: AllocationCompany | null;
+  currentMark: PlanningFmvOverrideRecord | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scenarioActive: boolean;
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function formatDecimalCurrency(value: string | null | undefined): string {
+  if (!value) {
+    return 'No approved mark';
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(numeric);
+}
+
+function normalizeDecimalInput(value: string): string {
+  const normalized = value.trim().replace(/,/g, '');
+  if (!/^\d+(\.\d{1,6})?$/.test(normalized)) {
+    throw new Error('Fair value must be a non-negative decimal amount');
+  }
+  return normalized;
+}
+
+export function FmvOverrideDialog({
+  company,
+  currentMark,
+  open,
+  onOpenChange,
+  scenarioActive,
+}: FmvOverrideDialogProps) {
+  const { toast } = useToast();
+  const createMutation = useCreatePlanningFmvOverride();
+  const [fairValue, setFairValue] = useState('');
+  const [markDate, setMarkDate] = useState(todayIsoDate());
+  const [reason, setReason] = useState('');
+  const [methodologyNotes, setMethodologyNotes] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!company) {
+      return;
+    }
+
+    setFairValue(currentMark?.fairValue ?? '');
+    setMarkDate(todayIsoDate());
+    setReason(company.allocation_reason ?? '');
+    setMethodologyNotes('');
+    setErrors({});
+  }, [company, currentMark]);
+
+  const validate = (): string | null => {
+    const nextErrors: Record<string, string> = {};
+    let normalizedFairValue: string | null = null;
+
+    try {
+      normalizedFairValue = normalizeDecimalInput(fairValue);
+    } catch (error) {
+      nextErrors['fairValue'] = error instanceof Error ? error.message : 'Invalid fair value';
+    }
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(markDate)) {
+      nextErrors['markDate'] = 'Mark date must be YYYY-MM-DD';
+    }
+
+    if (!reason.trim()) {
+      nextErrors['reason'] = 'Approval reason is required';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0 ? normalizedFairValue : null;
+  };
+
+  const handleSubmit = async () => {
+    if (!company || scenarioActive) {
+      return;
+    }
+
+    const normalizedFairValue = validate();
+    if (!normalizedFairValue) {
+      return;
+    }
+
+    try {
+      await createMutation.mutateAsync({
+        companyId: company.company_id,
+        markDate,
+        fairValue: normalizedFairValue,
+        currency: 'USD',
+        confidenceLevel: 'medium',
+        reason: reason.trim(),
+        methodologyNotes: methodologyNotes.trim() || undefined,
+        source: {
+          allocationVersion: company.allocation_version,
+          plannedReservesCents: company.planned_reserves_cents,
+          allocationReason: company.allocation_reason,
+        },
+      });
+
+      toast({
+        title: 'Approved mark saved',
+        description: `${company.company_name} now has an approved Planning FMV mark.`,
+      });
+      onOpenChange(false);
+    } catch (error) {
+      toast({
+        title: 'Planning FMV save failed',
+        description: error instanceof Error ? error.message : 'Failed to save approved mark',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (!company) {
+    return null;
+  }
+
+  const isPending = createMutation.isPending;
+  const saveDisabled = scenarioActive || isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Planning FMV - {company.company_name}</DialogTitle>
+          <DialogDescription>
+            Save an approved GP estimate from the live reserve planning workspace.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {scenarioActive ? (
+            <Alert variant="default">
+              <AlertDescription>
+                Planning FMV overrides can only be saved from the live allocation workspace.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="grid grid-cols-2 gap-4 rounded-md bg-pov-gray p-3">
+            <div>
+              <p className="text-sm text-charcoal-500">Current FMV</p>
+              <p className="text-sm font-medium">{formatDecimalCurrency(currentMark?.fairValue)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-charcoal-500">Current Mark Date</p>
+              <p className="text-sm font-medium">{currentMark?.markDate ?? 'No mark'}</p>
+            </div>
+            <div>
+              <p className="text-sm text-charcoal-500">Planned Reserves</p>
+              <p className="text-sm font-medium">
+                {formatCents(company.planned_reserves_cents, { compact: true })}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-charcoal-500">Allocation Version</p>
+              <p className="text-sm font-medium">v{company.allocation_version}</p>
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="planning-fmv-fair-value">
+              Fair Value <span className="text-error">*</span>
+            </Label>
+            <Input
+              id="planning-fmv-fair-value"
+              type="number"
+              step="0.01"
+              min="0"
+              value={fairValue}
+              onChange={(event) => setFairValue(event.target.value)}
+              placeholder="e.g., 12500000"
+              className={errors['fairValue'] ? 'border-error' : ''}
+              disabled={saveDisabled}
+            />
+            {errors['fairValue'] ? (
+              <p className="text-sm text-error">{errors['fairValue']}</p>
+            ) : null}
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="planning-fmv-mark-date">
+              Mark Date <span className="text-error">*</span>
+            </Label>
+            <Input
+              id="planning-fmv-mark-date"
+              type="date"
+              value={markDate}
+              onChange={(event) => setMarkDate(event.target.value)}
+              className={errors['markDate'] ? 'border-error' : ''}
+              disabled={saveDisabled}
+            />
+            {errors['markDate'] ? <p className="text-sm text-error">{errors['markDate']}</p> : null}
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="planning-fmv-reason">
+              Approval Reason <span className="text-error">*</span>
+            </Label>
+            <Textarea
+              id="planning-fmv-reason"
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              className={`min-h-[88px] ${errors['reason'] ? 'border-error' : ''}`}
+              maxLength={1000}
+              disabled={saveDisabled}
+            />
+            {errors['reason'] ? <p className="text-sm text-error">{errors['reason']}</p> : null}
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="planning-fmv-methodology">Methodology Notes</Label>
+            <Textarea
+              id="planning-fmv-methodology"
+              value={methodologyNotes}
+              onChange={(event) => setMethodologyNotes(event.target.value)}
+              className="min-h-[88px]"
+              maxLength={4000}
+              disabled={saveDisabled}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saveDisabled}>
+            {isPending ? 'Saving...' : 'Save approved mark'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/portfolio/tabs/hooks/usePlanningFmvOverrides.ts
+++ b/client/src/components/portfolio/tabs/hooks/usePlanningFmvOverrides.ts
@@ -1,0 +1,85 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useFundContext } from '@/contexts/FundContext';
+import type {
+  PlanningFmvOverrideCreateRequest,
+  PlanningFmvOverrideCreateResponse,
+  PlanningFmvOverrideLatestResponse,
+} from '@shared/contracts/lp-reporting';
+import { buildErrorMessage, readApiErrorBody, readJsonResponse } from './jsonResponse';
+
+export type CreatePlanningFmvOverridePayload = PlanningFmvOverrideCreateRequest;
+
+export function getPlanningFmvLatestQueryKey(fundId: number | null | undefined) {
+  return ['allocations', 'planning-fmv-overrides', 'latest', fundId] as const;
+}
+
+function createIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `planning-fmv-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function useLatestPlanningFmvOverrides(options?: { enabled?: boolean }) {
+  const { fundId } = useFundContext();
+
+  return useQuery<PlanningFmvOverrideLatestResponse>({
+    queryKey: getPlanningFmvLatestQueryKey(fundId),
+    queryFn: async () => {
+      if (!fundId) {
+        throw new Error('Fund ID is required');
+      }
+
+      const response = await fetch(`/api/funds/${fundId}/planning/fmv-overrides/latest`);
+      if (!response.ok) {
+        const errorData = await readApiErrorBody(
+          response,
+          'Failed to fetch Planning FMV overrides'
+        );
+        throw new Error(buildErrorMessage(errorData, 'Failed to fetch Planning FMV overrides'));
+      }
+
+      return readJsonResponse<PlanningFmvOverrideLatestResponse>(
+        response,
+        'Failed to fetch Planning FMV overrides'
+      );
+    },
+    enabled: !!fundId && (options?.enabled ?? true),
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useCreatePlanningFmvOverride() {
+  const { fundId } = useFundContext();
+  const queryClient = useQueryClient();
+
+  return useMutation<PlanningFmvOverrideCreateResponse, Error, CreatePlanningFmvOverridePayload>({
+    mutationFn: async (payload) => {
+      if (!fundId) {
+        throw new Error('Fund ID is required');
+      }
+
+      const response = await fetch(`/api/funds/${fundId}/planning/fmv-overrides`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Idempotency-Key': createIdempotencyKey(),
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorData = await readApiErrorBody(response, 'Failed to save Planning FMV override');
+        throw new Error(buildErrorMessage(errorData, 'Failed to save Planning FMV override'));
+      }
+
+      return readJsonResponse<PlanningFmvOverrideCreateResponse>(
+        response,
+        'Failed to save Planning FMV override'
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: getPlanningFmvLatestQueryKey(fundId) });
+    },
+  });
+}

--- a/client/src/core/flags/unifiedClientFlags.ts
+++ b/client/src/core/flags/unifiedClientFlags.ts
@@ -36,6 +36,7 @@ const CANONICAL_TO_LEGACY_ALIASES: Record<ClientFlagKey, string[]> = {
   enable_investment_rounds: [],
   enable_lp_reporting: [],
   enable_lp_snapshot_mode: [],
+  enable_planning_fmv_overrides: [],
   enable_reserve_engine: [],
   enable_portfolio_table_v2: [],
   enable_engine_integration: [],

--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -139,6 +139,19 @@ flags:
     dependencies: []
     expiresAt: null
 
+  enable_planning_fmv_overrides:
+    default: false
+    description: 'Approved Planning FMV override workflow in the reserve allocation workspace.'
+    owner: 'gp-team'
+    risk: medium
+    exposeToClient: true
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: null
+
   enable_reserve_engine:
     default: false
     description: 'Deterministic reserve allocation engine'

--- a/migrations/0022_planning_fmv_override_requests_drift.sql
+++ b/migrations/0022_planning_fmv_override_requests_drift.sql
@@ -1,0 +1,91 @@
+-- @drift-patch
+-- Reason: Add journaled production drift patch for Planning FMV Override request ledger and active-mark lookup index.
+
+CREATE TABLE IF NOT EXISTS planning_fmv_override_requests (
+  id SERIAL PRIMARY KEY,
+  fund_id INTEGER NOT NULL,
+  company_id INTEGER NOT NULL,
+  valuation_mark_id INTEGER,
+  idempotency_key VARCHAR(128) NOT NULL,
+  request_hash VARCHAR(64) NOT NULL,
+  source_hash VARCHAR(128) NOT NULL,
+  status VARCHAR(16) NOT NULL DEFAULT 'pending',
+  response_body JSONB,
+  failure_code VARCHAR(64),
+  failure_message TEXT,
+  created_by INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMP WITH TIME ZONE,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT planning_fmv_override_request_status_check
+    CHECK (status IN ('pending', 'completed', 'failed')),
+  CONSTRAINT planning_fmv_override_requests_idempotency_unique
+    UNIQUE (fund_id, idempotency_key)
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'planning_fmv_override_requests'::regclass
+      AND conname = 'planning_fmv_override_requests_fund_id_funds_id_fk'
+  ) THEN
+    ALTER TABLE "planning_fmv_override_requests"
+      ADD CONSTRAINT "planning_fmv_override_requests_fund_id_funds_id_fk"
+      FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'planning_fmv_override_requests'::regclass
+      AND conname = 'planning_fmv_override_requests_company_id_portfoliocompanies_id'
+  ) THEN
+    ALTER TABLE "planning_fmv_override_requests"
+      ADD CONSTRAINT "planning_fmv_override_requests_company_id_portfoliocompanies_id_fk"
+      FOREIGN KEY ("company_id") REFERENCES "public"."portfoliocompanies"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'planning_fmv_override_requests'::regclass
+      AND conname = 'planning_fmv_override_requests_valuation_mark_id_valuation_mark'
+  ) THEN
+    ALTER TABLE "planning_fmv_override_requests"
+      ADD CONSTRAINT "planning_fmv_override_requests_valuation_mark_id_valuation_marks_id_fk"
+      FOREIGN KEY ("valuation_mark_id") REFERENCES "public"."valuation_marks"("id") ON DELETE restrict ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'planning_fmv_override_requests'::regclass
+      AND conname = 'planning_fmv_override_requests_created_by_users_id_fk'
+  ) THEN
+    ALTER TABLE "planning_fmv_override_requests"
+      ADD CONSTRAINT "planning_fmv_override_requests_created_by_users_id_fk"
+      FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_planning_fmv_override_requests_fund_company_created
+  ON planning_fmv_override_requests(fund_id, company_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_planning_fmv_override_requests_valuation_mark
+  ON planning_fmv_override_requests(valuation_mark_id);
+
+CREATE INDEX IF NOT EXISTS idx_valuation_marks_planning_active_mark_date
+  ON valuation_marks(fund_id, company_id, mark_date DESC, id DESC)
+  WHERE imported_from = 'planning_fmv_override'
+    AND status IN ('approved', 'locked');

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1782777600000,
       "tag": "0021_version_columns_bigint_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1782777601000,
+      "tag": "0022_planning_fmv_override_requests_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/04-lp-reporting.json
+++ b/scripts/prod-schema-manifests/04-lp-reporting.json
@@ -2,7 +2,10 @@
   "name": "M4-lp-reporting",
   "order": 4,
   "description": "LP reporting evidence tables mounted through makeApp LP reporting routes.",
-  "sqlFiles": ["migrations/0014_lp_evidence_sprint3_drift.sql"],
+  "sqlFiles": [
+    "migrations/0014_lp_evidence_sprint3_drift.sql",
+    "migrations/0022_planning_fmv_override_requests_drift.sql"
+  ],
   "allowedCreateTables": [
     "vehicles",
     "cash_flow_events",
@@ -19,7 +22,8 @@
     "lp_distribution_details",
     "lp_documents",
     "lp_notifications",
-    "lp_notification_preferences"
+    "lp_notification_preferences",
+    "planning_fmv_override_requests"
   ],
   "expectedTables": [
     {
@@ -91,6 +95,7 @@
         "idx_valuation_marks_fund_asof",
         "idx_valuation_marks_company_asof",
         "idx_valuation_marks_vehicle_asof",
+        "idx_valuation_marks_planning_active_mark_date",
         "idx_valuation_marks_import_batch",
         "valuation_marks_fund_source_hash_unique"
       ]
@@ -211,6 +216,29 @@
         "idx_lp_report_package_exports_fund_metric",
         "idx_lp_report_package_exports_fund_metric_package",
         "idx_lp_report_package_exports_fund_ready_at"
+      ]
+    },
+    {
+      "name": "planning_fmv_override_requests",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "company_id", "nullable": false },
+        { "name": "idempotency_key", "nullable": false },
+        { "name": "request_hash", "nullable": false },
+        { "name": "source_hash", "nullable": false },
+        { "name": "status", "nullable": false }
+      ],
+      "constraints": [
+        "planning_fmv_override_request_status_check",
+        "planning_fmv_override_requests_idempotency_unique",
+        "planning_fmv_override_requests_fund_id_funds_id_fk",
+        "planning_fmv_override_requests_company_id_portfoliocompanies_id_fk",
+        "planning_fmv_override_requests_valuation_mark_id_valuation_marks_id_fk"
+      ],
+      "indexes": [
+        "idx_planning_fmv_override_requests_fund_company_created",
+        "idx_planning_fmv_override_requests_valuation_mark"
       ]
     }
   ]

--- a/scripts/schema-drift-active-surfaces.ts
+++ b/scripts/schema-drift-active-surfaces.ts
@@ -190,6 +190,7 @@ export const ACTIVE_SCHEMA_SURFACES: readonly ActiveSchemaSurface[] = [
           'vehicles',
           'cashFlowEvents',
           'valuationMarks',
+          'planningFmvOverrideRequests',
           'lpMetricRuns',
           'narrativeRuns',
           'evidenceRecords',
@@ -204,6 +205,9 @@ export const ACTIVE_SCHEMA_SURFACES: readonly ActiveSchemaSurface[] = [
         layer: 'contract-or-zod',
         names: [
           'LpMetricRunCreateSchema',
+          'PlanningFmvOverrideCreateRequestSchema',
+          'PlanningFmvOverrideCreateResponseSchema',
+          'PlanningFmvOverrideLatestResponseSchema',
           'MetricRunDetailResponseSchema',
           'ReportPackageRecordSchema',
           'ReportPackageGetResponseSchema',

--- a/server/app.ts
+++ b/server/app.ts
@@ -13,6 +13,7 @@ import scenarioAnalysisRouter from './routes/scenario-analysis.js';
 import dualForecastRouter from './routes/dual-forecast.js';
 import allocationsRouter from './routes/allocations.js';
 import allocationScenariosRouter from './routes/allocation-scenarios.js';
+import planningFmvOverridesRouter from './routes/planning-fmv-overrides.js';
 import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
 import fundMoicRouter from './routes/fund-moic.js';
 import reallocationRouter from './routes/reallocation.js';
@@ -221,6 +222,7 @@ export function makeApp() {
   // Fund Allocation Management API (Phase 1b - Reserve allocations with optimistic locking)
   app.use('/api', allocationsRouter);
   app.use('/api', allocationScenariosRouter);
+  app.use('/api', planningFmvOverridesRouter);
   app.use('/api', fundScenarioSetsRouter);
   app.use('/api', fundMoicRouter);
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -67,6 +67,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     { mountPath: '/api', load: () => import('./routes/portfolio-overview.js') },
     { mountPath: '/api', load: () => import('./routes/portfolio/lots.js') },
     { mountPath: '/api', load: () => import('./routes/allocation-scenarios.js') },
+    { mountPath: '/api', load: () => import('./routes/planning-fmv-overrides.js') },
     { mountPath: '/api', load: () => import('./routes/fund-scenario-sets.js') },
     { mountPath: '/api', load: () => import('./routes/allocations.js') },
     { mountPath: '/api', load: () => import('./routes/activities.js') },

--- a/server/routes/planning-fmv-overrides.ts
+++ b/server/routes/planning-fmv-overrides.ts
@@ -1,0 +1,167 @@
+import { Router } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+
+import {
+  PlanningFmvOverrideCreateRequestSchema,
+  PlanningFmvOverrideLatestQuerySchema,
+} from '@shared/contracts/lp-reporting';
+import { parseFundIdParam } from '@shared/number';
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { requireAuth } from '../lib/auth/jwt';
+import { firstString } from '../lib/request-values';
+import { sendBodyValidationError } from '../lib/validation-response';
+import {
+  createPlanningFmvOverride,
+  listLatestPlanningFmvOverrides,
+  PlanningFmvOverrideError,
+} from '../services/lp-reporting/planning-fmv-override-service';
+
+const router = Router();
+
+function routeHandler(handler: (req: Request, res: Response) => Promise<unknown>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(handler(req, res)).catch(next);
+  };
+}
+
+function parseRouteFundId(req: Request, res: Response): number | null {
+  const fundId = parseFundIdParam(firstString(req.params['fundId']));
+  if (fundId === null) {
+    res.status(400).json({
+      error: 'invalid_fund_id',
+      message: 'Fund ID must be a positive integer',
+    });
+    return null;
+  }
+  return fundId;
+}
+
+function requirePlanningFmvFundAccess(req: Request, res: Response, next: NextFunction) {
+  try {
+    const fundId = parseRouteFundId(req, res);
+    if (fundId === null) {
+      return;
+    }
+
+    void Promise.resolve(enforceProvidedFundScope(req, res, fundId))
+      .then((allowed) => {
+        if (allowed) {
+          next();
+        }
+      })
+      .catch(next);
+  } catch (error) {
+    next(error);
+  }
+}
+
+function parseActorUserId(req: Request): number | null {
+  const rawUserId = req.user?.id;
+  if (typeof rawUserId === 'number' && Number.isSafeInteger(rawUserId) && rawUserId > 0) {
+    return rawUserId;
+  }
+  if (typeof rawUserId === 'string' && /^[1-9]\d*$/.test(rawUserId)) {
+    const parsed = Number(rawUserId);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function enforcePlanningFmvApprovalAuthority(req: Request, res: Response): boolean {
+  const role = req.user?.role;
+  const roles = req.user?.roles ?? [];
+  if (role === 'admin' || roles.includes('admin')) {
+    return true;
+  }
+
+  res.status(403).json({
+    error: 'planning_fmv_approval_forbidden',
+    code: 'planning_fmv_approval_forbidden',
+    message: 'Planning FMV overrides require admin approval authority.',
+  });
+  return false;
+}
+
+function idempotencyKeyFrom(req: Request): string | null {
+  const headerValue = firstString(req.headers['idempotency-key']);
+  const trimmed = headerValue?.trim();
+  return trimmed ? trimmed : null;
+}
+
+router.post(
+  '/funds/:fundId/planning/fmv-overrides',
+  requireAuth(),
+  requirePlanningFmvFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseRouteFundId(req, res);
+    if (fundId === null) {
+      return;
+    }
+    if (!enforcePlanningFmvApprovalAuthority(req, res)) {
+      return;
+    }
+
+    const idempotencyKey = idempotencyKeyFrom(req);
+    if (idempotencyKey === null) {
+      res.status(428).json({
+        error: 'planning_fmv_idempotency_key_required',
+        code: 'planning_fmv_idempotency_key_required',
+        message: 'Idempotency-Key header is required for Planning FMV overrides.',
+      });
+      return;
+    }
+
+    const parsed = PlanningFmvOverrideCreateRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendBodyValidationError(res, parsed.error, 'Invalid Planning FMV override payload');
+      return;
+    }
+
+    const result = await createPlanningFmvOverride({
+      fundId,
+      idempotencyKey,
+      actor: { userId: parseActorUserId(req) },
+      body: parsed.data,
+    });
+    res.status(result.replayed ? 200 : 201).json(result);
+  })
+);
+
+router.get(
+  '/funds/:fundId/planning/fmv-overrides/latest',
+  requireAuth(),
+  requirePlanningFmvFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseRouteFundId(req, res);
+    if (fundId === null) {
+      return;
+    }
+
+    const parsed = PlanningFmvOverrideLatestQuerySchema.safeParse({
+      asOfDate: firstString(req.query['asOfDate']),
+    });
+    if (!parsed.success) {
+      sendBodyValidationError(res, parsed.error, 'Invalid Planning FMV override query');
+      return;
+    }
+
+    const asOfDate = parsed.data.asOfDate ?? new Date().toISOString().slice(0, 10);
+    const result = await listLatestPlanningFmvOverrides(fundId, asOfDate);
+    res.status(200).json(result);
+  })
+);
+
+router.use((error: unknown, _req: Request, res: Response, next: NextFunction) => {
+  if (error instanceof PlanningFmvOverrideError) {
+    res.status(error.status).json({
+      error: error.code,
+      code: error.code,
+      message: error.message,
+      ...(error.details !== undefined ? { details: error.details } : {}),
+    });
+    return;
+  }
+  next(error);
+});
+
+export default router;

--- a/server/services/lp-reporting/active-valuation-mark-selector.ts
+++ b/server/services/lp-reporting/active-valuation-mark-selector.ts
@@ -1,0 +1,63 @@
+import type { MarkStatus, ParsedValuationMark } from './metrics-engine';
+
+const EXCLUDED_MARK_STATUS = new Set<MarkStatus>(['superseded', 'reversed']);
+
+export interface ActiveValuationMarkSelection<T extends ParsedValuationMark> {
+  active: T[];
+  excludedFutureMarkIds: number[];
+}
+
+export function isoDay(value: Date | string): string {
+  return value instanceof Date ? value.toISOString().slice(0, 10) : value.slice(0, 10);
+}
+
+function isPreferredMark<T extends ParsedValuationMark>(candidate: T, existing: T): boolean {
+  const candidateDay = isoDay(candidate.markDate);
+  const existingDay = isoDay(existing.markDate);
+  if (candidateDay > existingDay) {
+    return true;
+  }
+  if (candidateDay < existingDay) {
+    return false;
+  }
+  return candidate.id > existing.id;
+}
+
+/**
+ * Select the valuation marks that contribute to NAV at an as-of date.
+ *
+ * Rules:
+ * - markDate must be on or before the asOfDate.
+ * - superseded/reversed marks do not contribute.
+ * - one mark is selected per companyId; missing companyId falls back to mark id.
+ * - the selected mark is the latest markDate, tie-broken by higher id.
+ */
+export function selectActiveValuationMarks<T extends ParsedValuationMark>(
+  marks: readonly T[],
+  asOfDate: string
+): ActiveValuationMarkSelection<T> {
+  const asOfDay = isoDay(asOfDate);
+  const excludedFutureMarkIds: number[] = [];
+  const byKey = new Map<string, T>();
+
+  for (const mark of marks) {
+    if (isoDay(mark.markDate) > asOfDay) {
+      excludedFutureMarkIds.push(mark.id);
+      continue;
+    }
+    if (mark.status && EXCLUDED_MARK_STATUS.has(mark.status)) {
+      continue;
+    }
+
+    const key = mark.companyId !== undefined ? `c:${mark.companyId}` : `m:${mark.id}`;
+    const existing = byKey.get(key);
+    if (!existing || isPreferredMark(mark, existing)) {
+      byKey.set(key, mark);
+    }
+  }
+
+  return {
+    active: Array.from(byKey.values()),
+    excludedFutureMarkIds,
+  };
+}

--- a/server/services/lp-reporting/metric-run-commit-service.ts
+++ b/server/services/lp-reporting/metric-run-commit-service.ts
@@ -11,6 +11,7 @@ import { createHash } from 'node:crypto';
 import { and, eq, inArray } from 'drizzle-orm';
 
 import { db } from '../../db';
+import { logger } from '../../lib/logger';
 import {
   LpMetricRunCreateSchema,
   type LpMetricRunDiagnostics,
@@ -19,6 +20,7 @@ import {
   type LpMetricRunType,
   type MetricRunCommitResponse,
   type MetricRunDryRunResponse,
+  type MetricRunSourceMarkSelection,
 } from '@shared/contracts/lp-reporting';
 import {
   cashFlowEvents,
@@ -41,8 +43,11 @@ import {
   type ParsedCashFlowEvent,
   type ParsedValuationMark,
 } from './metrics-engine';
+import { selectActiveValuationMarks } from './active-valuation-mark-selector';
 
 type MetricRunDatabase = typeof db;
+
+const log = logger.child({ module: 'lp-reporting:metric-run-commit' });
 
 export class MetricRunCommitError extends Error {
   readonly status: number;
@@ -65,6 +70,7 @@ export interface MetricRunRequestInput {
   perspective: LpMetricRunPerspective;
   sourceEventIds?: number[];
   sourceMarkIds?: number[];
+  sourceMarkSelection?: MetricRunSourceMarkSelection;
 }
 
 export interface MetricRunCommitInput extends MetricRunRequestInput {
@@ -79,6 +85,7 @@ interface MetricRunServiceOptions {
 interface MetricRunSources {
   eventRows: CashFlowEvent[];
   markRows: ValuationMark[];
+  sourceMarkIds: number[];
 }
 
 interface MetricRunPreviewParts {
@@ -86,6 +93,7 @@ interface MetricRunPreviewParts {
   asOfDate: string;
   runType: LpMetricRunType;
   perspective: LpMetricRunPerspective;
+  sourceMarkSelection: MetricRunSourceMarkSelection;
   sourceEventIds: number[];
   sourceMarkIds: number[];
   eventRows: CashFlowEvent[];
@@ -93,6 +101,7 @@ interface MetricRunPreviewParts {
   results: LpMetricRunResults;
   diagnostics: LpMetricRunDiagnostics;
   inputsHash: string;
+  previewHash: string;
 }
 
 const METHODOLOGY_VERSION = 'lp-reporting-methodology-v1';
@@ -152,6 +161,16 @@ function assertAllRequestedRowsFound(
   const missing = requestedIds.filter((id) => !found.has(id));
   if (missing.length > 0) {
     throw new MetricRunCommitError(404, code, message, { ids: missing });
+  }
+}
+
+function assertActiveAsOfRequestIsImplicit(sourceMarkIds: number[]): void {
+  if (sourceMarkIds.length > 0) {
+    throw new MetricRunCommitError(
+      400,
+      'ACTIVE_AS_OF_SOURCE_MARK_IDS_NOT_ALLOWED',
+      'sourceMarkIds must be empty when sourceMarkSelection is active_as_of.'
+    );
   }
 }
 
@@ -234,6 +253,7 @@ function computePreviewHash(parts: MetricRunPreviewParts): string {
     asOfDate: parts.asOfDate,
     runType: parts.runType,
     perspective: parts.perspective,
+    sourceMarkSelection: parts.sourceMarkSelection,
     sourceEventIds: parts.sourceEventIds,
     sourceMarkIds: parts.sourceMarkIds,
     eventFingerprints: parts.eventRows
@@ -275,15 +295,44 @@ function toParsedValuationMark(row: ValuationMark): ParsedValuationMark {
 async function loadSources(
   database: MetricRunDatabase,
   fundId: number,
+  asOfDate: string,
   sourceEventIds: number[],
-  sourceMarkIds: number[]
+  requestedSourceMarkIds: number[],
+  sourceMarkSelection: MetricRunSourceMarkSelection
 ): Promise<MetricRunSources> {
   const eventRows = sourceEventIds.length
     ? await database.select().from(cashFlowEvents).where(inArray(cashFlowEvents.id, sourceEventIds))
     : [];
-  const markRows = sourceMarkIds.length
-    ? await database.select().from(valuationMarks).where(inArray(valuationMarks.id, sourceMarkIds))
-    : [];
+  let markRows: ValuationMark[] = [];
+  let sourceMarkIds = requestedSourceMarkIds;
+
+  if (sourceMarkSelection === 'explicit') {
+    markRows = requestedSourceMarkIds.length
+      ? await database
+          .select()
+          .from(valuationMarks)
+          .where(inArray(valuationMarks.id, requestedSourceMarkIds))
+      : [];
+  } else {
+    assertActiveAsOfRequestIsImplicit(requestedSourceMarkIds);
+    const candidateRows = await database
+      .select()
+      .from(valuationMarks)
+      .where(eq(valuationMarks.fundId, fundId));
+    const fundRows = candidateRows.filter((row) => row.fundId === fundId);
+    const selection = selectActiveValuationMarks(fundRows.map(toParsedValuationMark), asOfDate);
+    sourceMarkIds = uniqueSorted(selection.active.map((mark) => mark.id));
+    markRows = fundRows;
+    log.info(
+      {
+        fundId,
+        asOfDate,
+        sourceMarkIds,
+        excludedFutureMarkIds: selection.excludedFutureMarkIds,
+      },
+      'lp_reporting.metric_run.active_as_of_selection'
+    );
+  }
 
   assertAllRequestedRowsFound(
     sourceEventIds,
@@ -291,16 +340,18 @@ async function loadSources(
     'SOURCE_EVENT_NOT_FOUND',
     'One or more source event IDs were not found.'
   );
-  assertAllRequestedRowsFound(
-    sourceMarkIds,
-    markRows.map((row) => row.id),
-    'SOURCE_MARK_NOT_FOUND',
-    'One or more source mark IDs were not found.'
-  );
+  if (sourceMarkSelection === 'explicit') {
+    assertAllRequestedRowsFound(
+      requestedSourceMarkIds,
+      markRows.map((row) => row.id),
+      'SOURCE_MARK_NOT_FOUND',
+      'One or more source mark IDs were not found.'
+    );
+  }
   assertRowsBelongToFund(fundId, eventRows, markRows);
   assertRealizedProceedsValid(eventRows);
 
-  return { eventRows, markRows };
+  return { eventRows, markRows, sourceMarkIds };
 }
 
 async function assertUserExists(database: MetricRunDatabase, userId: number): Promise<void> {
@@ -345,7 +396,7 @@ async function findExistingMetricRun(
 
 function metricRunInsertValues(
   input: MetricRunCommitInput,
-  preview: MetricRunDryRunResponse
+  preview: MetricRunPreviewParts
 ): InsertLpMetricRun {
   const create = LpMetricRunCreateSchema.parse({
     fundId: input.fundId,
@@ -355,7 +406,7 @@ function metricRunInsertValues(
     status: 'draft',
     inputsHash: preview.inputsHash,
     sourceEventIds: uniqueSorted(input.sourceEventIds),
-    sourceMarkIds: uniqueSorted(input.sourceMarkIds),
+    sourceMarkIds: preview.sourceMarkIds,
     sourceEvidenceIds: [],
     methodologyVersion: METHODOLOGY_VERSION,
     calculationVersion: CALCULATION_VERSION,
@@ -382,19 +433,22 @@ function metricRunInsertValues(
   };
 }
 
-export async function buildMetricRunDryRun(
+async function buildMetricRunPreviewParts(
   input: MetricRunRequestInput,
   options: MetricRunServiceOptions = {}
-): Promise<MetricRunDryRunResponse> {
+): Promise<MetricRunPreviewParts> {
   const database = options.database ?? db;
   assertSupportedPerspective(input.perspective);
   const sourceEventIds = uniqueSorted(input.sourceEventIds);
-  const sourceMarkIds = uniqueSorted(input.sourceMarkIds);
-  const { eventRows, markRows } = await loadSources(
+  const requestedSourceMarkIds = uniqueSorted(input.sourceMarkIds);
+  const sourceMarkSelection = input.sourceMarkSelection ?? 'explicit';
+  const { eventRows, markRows, sourceMarkIds } = await loadSources(
     database,
     input.fundId,
+    input.asOfDate,
     sourceEventIds,
-    sourceMarkIds
+    requestedSourceMarkIds,
+    sourceMarkSelection
   );
 
   const computed = computeMetrics({
@@ -404,8 +458,9 @@ export async function buildMetricRunDryRun(
     cashFlowEvents: eventRows.map(toParsedCashFlowEvent),
     valuationMarks: markRows.map(toParsedValuationMark),
   });
-  const previewHash = computePreviewHash({
+  const parts = {
     ...input,
+    sourceMarkSelection,
     sourceEventIds,
     sourceMarkIds,
     eventRows,
@@ -413,14 +468,26 @@ export async function buildMetricRunDryRun(
     results: computed.results,
     diagnostics: computed.diagnostics,
     inputsHash: computed.inputsHash,
-  });
+    previewHash: '',
+  };
 
   return {
-    results: computed.results,
-    diagnostics: computed.diagnostics,
-    inputsHash: computed.inputsHash,
-    runType: input.runType,
-    previewHash,
+    ...parts,
+    previewHash: computePreviewHash(parts),
+  };
+}
+
+export async function buildMetricRunDryRun(
+  input: MetricRunRequestInput,
+  options: MetricRunServiceOptions = {}
+): Promise<MetricRunDryRunResponse> {
+  const preview = await buildMetricRunPreviewParts(input, options);
+  return {
+    results: preview.results,
+    diagnostics: preview.diagnostics,
+    inputsHash: preview.inputsHash,
+    runType: preview.runType,
+    previewHash: preview.previewHash,
   };
 }
 
@@ -429,7 +496,7 @@ export async function commitMetricRun(
   options: MetricRunServiceOptions = {}
 ): Promise<MetricRunCommitResponse> {
   const database = options.database ?? db;
-  const preview = await buildMetricRunDryRun(input, { database });
+  const preview = await buildMetricRunPreviewParts(input, { database });
   if (preview.previewHash !== input.previewHash) {
     throw new MetricRunCommitError(
       409,

--- a/server/services/lp-reporting/metrics-engine.ts
+++ b/server/services/lp-reporting/metrics-engine.ts
@@ -25,6 +25,7 @@ import type {
   XirrDiagnostic,
 } from '@shared/contracts/lp-reporting';
 
+import { isoDay, selectActiveValuationMarks } from './active-valuation-mark-selector';
 import { xirrDiagnostic } from './xirr-diagnostic-service';
 
 const ENGINE_VERSION = '1.0.0';
@@ -104,23 +105,12 @@ export interface ComputeMetricsOutput {
 // ============================================================================
 
 const REVERSED_EVENT_STATUS = new Set<EventStatus>(['reversed']);
-const EXCLUDED_MARK_STATUS = new Set<MarkStatus>(['superseded', 'reversed']);
-
 /**
  * Render a Decimal as a fixed-precision decimal string at engine precision
  * (6 dp).  Mirrors the toFixed(6) calls used in import-reconciliation-service.
  */
 function decToString(value: Decimal): string {
   return value.toFixed(DECIMAL_PRECISION);
-}
-
-/**
- * Calendar-day comparison.  All event/mark dates in this engine are
- * compared as ISO date strings (YYYY-MM-DD), which is lexicographically
- * date-ordered.  We slice to 10 chars to be tolerant of full ISO datetimes.
- */
-function isoDay(value: string): string {
-  return value.slice(0, 10);
 }
 
 function isLiveEvent(event: ParsedCashFlowEvent): boolean {
@@ -147,56 +137,6 @@ function sumAmountsByType(
   return events
     .filter((e) => isLiveEvent(e) && types.has(e.eventType))
     .reduce((acc, e) => acc.plus(new Decimal(e.amount).abs()), new Decimal(0));
-}
-
-/**
- * Select the marks that contribute to currentNav at asOfDate:
- *   - markDate <= asOfDate (future-dated marks excluded)
- *   - status NOT IN (superseded, reversed)
- *   - one mark per company (or per mark id when companyId is absent);
- *     pick the most recent markDate <= asOfDate.
- *
- * Returns { active: chosen marks, excludedFutureMarkIds }.
- */
-function selectActiveMarks(
-  marks: ParsedValuationMark[],
-  asOfDate: string
-): {
-  active: ParsedValuationMark[];
-  excludedFutureMarkIds: number[];
-} {
-  const asOfDay = isoDay(asOfDate);
-  const excludedFutureMarkIds: number[] = [];
-
-  // Step 1: drop future-dated marks (regardless of status).  They are
-  // surfaced in diagnostics so reviewers can see them.
-  const onOrBefore: ParsedValuationMark[] = [];
-  for (const m of marks) {
-    if (isoDay(m.markDate) > asOfDay) {
-      excludedFutureMarkIds.push(m.id);
-    } else {
-      onOrBefore.push(m);
-    }
-  }
-
-  // Step 2: drop marks whose status excludes them from the live set.
-  const live = onOrBefore.filter((m) => !(m.status && EXCLUDED_MARK_STATUS.has(m.status)));
-
-  // Step 3: deduplicate by companyId (or by id when companyId is absent),
-  // keeping the most recent markDate.
-  const byKey = new Map<string, ParsedValuationMark>();
-  for (const m of live) {
-    const key = m.companyId !== undefined ? `c:${m.companyId}` : `m:${m.id}`;
-    const existing = byKey.get(key);
-    if (!existing || isoDay(m.markDate) > isoDay(existing.markDate)) {
-      byKey.set(key, m);
-    }
-  }
-
-  return {
-    active: Array.from(byKey.values()),
-    excludedFutureMarkIds,
-  };
 }
 
 function tallyConfidence(activeMarks: ParsedValuationMark[]): MarkConfidenceMix {
@@ -357,7 +297,10 @@ export function computeMetrics(input: ComputeMetricsInput): ComputeMetricsOutput
   );
 
   // ---- NAV (active marks at asOfDate) ----
-  const { active, excludedFutureMarkIds } = selectActiveMarks(input.valuationMarks, input.asOfDate);
+  const { active, excludedFutureMarkIds } = selectActiveValuationMarks(
+    input.valuationMarks,
+    input.asOfDate
+  );
   const currentNav = active.reduce((acc, m) => acc.plus(new Decimal(m.fairValue)), new Decimal(0));
   const markConfidenceMix = tallyConfidence(active);
 

--- a/server/services/lp-reporting/planning-fmv-override-service.ts
+++ b/server/services/lp-reporting/planning-fmv-override-service.ts
@@ -1,0 +1,495 @@
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { logger } from '../../lib/logger';
+import { generateLockKey } from '../../lib/locks';
+import type {
+  PlanningFmvOverrideCreateRequest,
+  PlanningFmvOverrideCreateResponse,
+  PlanningFmvOverrideLatestResponse,
+  PlanningFmvOverrideRecord,
+} from '@shared/contracts/lp-reporting';
+import {
+  PlanningFmvOverrideCreateResponseSchema,
+  PlanningFmvOverrideRecordSchema,
+} from '@shared/contracts/lp-reporting';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+import {
+  planningFmvOverrideRequests,
+  valuationMarks,
+  type PlanningFmvOverrideRequest,
+  type ValuationMark,
+} from '@shared/schema/lp-reporting-evidence';
+import { portfolioCompanies } from '@shared/schema/portfolio';
+import { selectActiveValuationMarks } from './active-valuation-mark-selector';
+import type { ConfidenceLevel, MarkStatus, ParsedValuationMark } from './metrics-engine';
+
+type PlanningFmvDatabase = typeof db;
+
+const log = logger.child({ module: 'lp-reporting:planning-fmv-override' });
+
+export class PlanningFmvOverrideError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details?: unknown;
+
+  constructor(status: number, code: string, message: string, details?: unknown) {
+    super(message);
+    this.name = 'PlanningFmvOverrideError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface PlanningFmvActor {
+  userId: number | null;
+}
+
+export interface CreatePlanningFmvOverrideInput {
+  fundId: number;
+  idempotencyKey: string;
+  actor: PlanningFmvActor;
+  body: PlanningFmvOverrideCreateRequest;
+}
+
+export interface PlanningFmvOverrideServiceOptions {
+  database?: PlanningFmvDatabase;
+}
+
+function isoDateTime(value: Date | string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+function isoDay(value: Date | string): string {
+  return isoDateTime(value)?.slice(0, 10) ?? '';
+}
+
+function isUniqueConstraintViolation(error: unknown, constraintName: string): boolean {
+  const candidate = error as { code?: unknown; constraint?: unknown; message?: unknown };
+  return (
+    candidate.code === '23505' &&
+    (candidate.constraint === constraintName ||
+      (typeof candidate.message === 'string' && candidate.message.includes(constraintName)))
+  );
+}
+
+function requestHashFor(input: CreatePlanningFmvOverrideInput): string {
+  return canonicalSha256({
+    fundId: input.fundId,
+    body: input.body,
+  });
+}
+
+function sourceHashFor(input: CreatePlanningFmvOverrideInput): string {
+  return canonicalSha256({
+    origin: 'planning_fmv_override',
+    fundId: input.fundId,
+    companyId: input.body.companyId,
+    markDate: input.body.markDate,
+    asOfDate: input.body.asOfDate ?? input.body.markDate,
+    fairValue: input.body.fairValue,
+    currency: input.body.currency,
+    confidenceLevel: input.body.confidenceLevel,
+    source: input.body.source,
+  });
+}
+
+function toParsedMark(row: ValuationMark): ParsedValuationMark {
+  return {
+    id: row.id,
+    fairValue: row.fairValue,
+    markDate: isoDay(row.markDate),
+    asOfDate: isoDay(row.asOfDate),
+    ...(row.status != null && { status: row.status as MarkStatus }),
+    confidenceLevel: row.confidenceLevel as ConfidenceLevel,
+    companyId: row.companyId,
+  };
+}
+
+function toPlanningRecord(row: ValuationMark): PlanningFmvOverrideRecord {
+  return PlanningFmvOverrideRecordSchema.parse({
+    id: row.id,
+    fundId: row.fundId,
+    companyId: row.companyId,
+    markDate: isoDay(row.markDate),
+    asOfDate: isoDay(row.asOfDate),
+    fairValue: row.fairValue,
+    currency: row.currency,
+    confidenceLevel: row.confidenceLevel,
+    status: row.status,
+    priorMarkId: row.priorMarkId ?? null,
+    methodologyNotes: row.methodologyNotes ?? null,
+    approvedBy: row.approvedBy ?? null,
+    approvedAt: isoDateTime(row.approvedAt),
+    createdAt: isoDateTime(row.createdAt),
+  });
+}
+
+async function withTransaction<T>(
+  database: PlanningFmvDatabase,
+  operation: (transaction: PlanningFmvDatabase) => Promise<T>
+): Promise<T> {
+  const candidate = database as PlanningFmvDatabase & {
+    transaction?: (operation: (transaction: PlanningFmvDatabase) => Promise<T>) => Promise<T>;
+  };
+  if (typeof candidate.transaction === 'function') {
+    return candidate.transaction((transaction) => operation(transaction));
+  }
+  return operation(database);
+}
+
+async function acquirePlanningFmvLock(
+  database: PlanningFmvDatabase,
+  fundId: number,
+  companyId: number
+): Promise<void> {
+  const candidate = database as PlanningFmvDatabase & {
+    execute?: (query: unknown) => Promise<unknown>;
+  };
+  if (typeof candidate.execute !== 'function') {
+    return;
+  }
+
+  const lockKey = generateLockKey('planning-fmv-override', `${fundId}:${companyId}`);
+  await candidate.execute(sql`SELECT pg_advisory_xact_lock(${lockKey.toString()}::bigint)`);
+}
+
+async function loadRequestByIdempotencyKey(
+  database: PlanningFmvDatabase,
+  fundId: number,
+  idempotencyKey: string
+): Promise<PlanningFmvOverrideRequest | undefined> {
+  const rows = await database
+    .select()
+    .from(planningFmvOverrideRequests)
+    .where(
+      and(
+        eq(planningFmvOverrideRequests.fundId, fundId),
+        eq(planningFmvOverrideRequests.idempotencyKey, idempotencyKey)
+      )
+    )
+    .limit(1);
+  return rows[0];
+}
+
+async function loadPlanningMarksForCompany(
+  database: PlanningFmvDatabase,
+  fundId: number,
+  companyId: number
+): Promise<ValuationMark[]> {
+  const rows = await database
+    .select()
+    .from(valuationMarks)
+    .where(and(eq(valuationMarks.fundId, fundId), eq(valuationMarks.companyId, companyId)))
+    .orderBy(desc(valuationMarks.markDate), desc(valuationMarks.id));
+  return rows.filter(
+    (row) =>
+      row.fundId === fundId &&
+      row.companyId === companyId &&
+      row.importedFrom === 'planning_fmv_override' &&
+      (row.status === 'approved' || row.status === 'locked')
+  );
+}
+
+async function assertCompanyBelongsToFund(
+  database: PlanningFmvDatabase,
+  fundId: number,
+  companyId: number
+): Promise<void> {
+  const rows = await database
+    .select({ id: portfolioCompanies.id, fundId: portfolioCompanies.fundId })
+    .from(portfolioCompanies)
+    .where(and(eq(portfolioCompanies.id, companyId), eq(portfolioCompanies.fundId, fundId)))
+    .limit(1);
+
+  const matched = rows.some((row) => row.id === companyId && row.fundId === fundId);
+  if (!matched) {
+    throw new PlanningFmvOverrideError(
+      404,
+      'planning_fmv_company_not_found',
+      `Portfolio company ${companyId} was not found in fund ${fundId}.`
+    );
+  }
+}
+
+async function insertPendingRequest(
+  database: PlanningFmvDatabase,
+  input: CreatePlanningFmvOverrideInput,
+  requestHash: string,
+  sourceHash: string
+): Promise<PlanningFmvOverrideRequest | null> {
+  const inserted = await database
+    .insert(planningFmvOverrideRequests)
+    .values({
+      fundId: input.fundId,
+      companyId: input.body.companyId,
+      idempotencyKey: input.idempotencyKey,
+      requestHash,
+      sourceHash,
+      status: 'pending',
+      createdBy: input.actor.userId,
+    })
+    .onConflictDoNothing({
+      target: [planningFmvOverrideRequests.fundId, planningFmvOverrideRequests.idempotencyKey],
+    })
+    .returning();
+  return inserted[0] ?? null;
+}
+
+function replayCompletedRequest(
+  row: PlanningFmvOverrideRequest,
+  idempotencyKey: string
+): PlanningFmvOverrideCreateResponse {
+  if (row.responseBody === null) {
+    throw new PlanningFmvOverrideError(
+      409,
+      'planning_fmv_request_failed',
+      'The completed Planning FMV override request has no stored response body.'
+    );
+  }
+
+  const parsed = PlanningFmvOverrideCreateResponseSchema.parse(row.responseBody);
+  return {
+    ...parsed,
+    idempotencyKey,
+    replayed: true,
+  };
+}
+
+function handleExistingRequest(
+  existing: PlanningFmvOverrideRequest,
+  requestHash: string,
+  idempotencyKey: string
+): PlanningFmvOverrideCreateResponse {
+  if (existing.requestHash !== requestHash) {
+    log.info(
+      {
+        fundId: existing.fundId,
+        companyId: existing.companyId,
+        requestId: existing.id,
+      },
+      'lp_reporting.planning_fmv_override.idempotency_conflict'
+    );
+    throw new PlanningFmvOverrideError(
+      409,
+      'planning_fmv_idempotency_key_reused',
+      'Idempotency-Key was already used for a different Planning FMV override request.'
+    );
+  }
+
+  if (existing.status === 'completed') {
+    log.info(
+      {
+        fundId: existing.fundId,
+        companyId: existing.companyId,
+        requestId: existing.id,
+      },
+      'lp_reporting.planning_fmv_override.replay'
+    );
+    return replayCompletedRequest(existing, idempotencyKey);
+  }
+
+  if (existing.status === 'pending') {
+    throw new PlanningFmvOverrideError(
+      409,
+      'planning_fmv_request_pending',
+      'A Planning FMV override request with this Idempotency-Key is still pending.'
+    );
+  }
+
+  throw new PlanningFmvOverrideError(
+    409,
+    'planning_fmv_request_failed',
+    'A Planning FMV override request with this Idempotency-Key previously failed.'
+  );
+}
+
+async function markRequestFailed(
+  database: PlanningFmvDatabase,
+  requestId: number,
+  error: PlanningFmvOverrideError
+): Promise<void> {
+  await database
+    .update(planningFmvOverrideRequests)
+    .set({
+      status: 'failed',
+      failureCode: error.code,
+      failureMessage: error.message,
+      updatedAt: new Date(),
+    })
+    .where(eq(planningFmvOverrideRequests.id, requestId));
+}
+
+async function writePlanningFmvMark(
+  database: PlanningFmvDatabase,
+  input: CreatePlanningFmvOverrideInput,
+  requestRow: PlanningFmvOverrideRequest,
+  sourceHash: string
+): Promise<PlanningFmvOverrideCreateResponse> {
+  return withTransaction(database, async (transaction) => {
+    await acquirePlanningFmvLock(transaction, input.fundId, input.body.companyId);
+    await assertCompanyBelongsToFund(transaction, input.fundId, input.body.companyId);
+
+    const priorCandidates = await loadPlanningMarksForCompany(
+      transaction,
+      input.fundId,
+      input.body.companyId
+    );
+    const priorSelection = selectActiveValuationMarks(
+      priorCandidates.map(toParsedMark),
+      input.body.markDate
+    );
+    const priorMarkId = priorSelection.active[0]?.id ?? null;
+    const now = new Date();
+    const asOfDate = input.body.asOfDate ?? input.body.markDate;
+    const [insertedMark] = await transaction
+      .insert(valuationMarks)
+      .values({
+        fundId: input.fundId,
+        companyId: input.body.companyId,
+        markDate: input.body.markDate,
+        asOfDate,
+        fairValue: input.body.fairValue,
+        currency: input.body.currency,
+        markSource: 'gp_estimate',
+        confidenceLevel: input.body.confidenceLevel,
+        valuationMethod: 'planning_fmv_override',
+        methodologyNotes: input.body.methodologyNotes ?? input.body.reason,
+        status: 'approved',
+        priorMarkId,
+        approvedBy: input.actor.userId,
+        approvedAt: now,
+        importedFrom: 'planning_fmv_override',
+        sourceHash,
+        createdBy: input.actor.userId,
+      })
+      .returning();
+
+    if (!insertedMark) {
+      throw new PlanningFmvOverrideError(
+        500,
+        'planning_fmv_invalid_request',
+        'Planning FMV override did not return an inserted valuation mark.'
+      );
+    }
+
+    const response = PlanningFmvOverrideCreateResponseSchema.parse({
+      requestId: requestRow.id,
+      idempotencyKey: input.idempotencyKey,
+      replayed: false,
+      valuationMark: toPlanningRecord(insertedMark),
+    });
+
+    await transaction
+      .update(planningFmvOverrideRequests)
+      .set({
+        valuationMarkId: insertedMark.id,
+        status: 'completed',
+        responseBody: response,
+        completedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(planningFmvOverrideRequests.id, requestRow.id));
+
+    log.info(
+      {
+        fundId: input.fundId,
+        companyId: input.body.companyId,
+        requestId: requestRow.id,
+        valuationMarkId: insertedMark.id,
+        priorMarkId,
+      },
+      'lp_reporting.planning_fmv_override.write'
+    );
+
+    return response;
+  });
+}
+
+export async function createPlanningFmvOverride(
+  input: CreatePlanningFmvOverrideInput,
+  options: PlanningFmvOverrideServiceOptions = {}
+): Promise<PlanningFmvOverrideCreateResponse> {
+  const database = options.database ?? db;
+  const requestHash = requestHashFor(input);
+  const sourceHash = sourceHashFor(input);
+  const pending = await insertPendingRequest(database, input, requestHash, sourceHash);
+
+  if (!pending) {
+    const existing = await loadRequestByIdempotencyKey(
+      database,
+      input.fundId,
+      input.idempotencyKey
+    );
+    if (!existing) {
+      throw new PlanningFmvOverrideError(
+        409,
+        'planning_fmv_request_pending',
+        'Planning FMV override idempotency conflict could not be resolved.'
+      );
+    }
+    return handleExistingRequest(existing, requestHash, input.idempotencyKey);
+  }
+
+  try {
+    return await writePlanningFmvMark(database, input, pending, sourceHash);
+  } catch (error) {
+    const mappedError =
+      error instanceof PlanningFmvOverrideError
+        ? error
+        : isUniqueConstraintViolation(error, 'valuation_marks_fund_source_hash_unique')
+          ? new PlanningFmvOverrideError(
+              409,
+              'planning_fmv_source_conflict',
+              'A Planning FMV valuation mark with the same source evidence already exists.'
+            )
+          : error;
+
+    if (mappedError instanceof PlanningFmvOverrideError) {
+      await markRequestFailed(database, pending.id, mappedError);
+      log.info(
+        {
+          fundId: input.fundId,
+          companyId: input.body.companyId,
+          requestId: pending.id,
+          code: mappedError.code,
+        },
+        'lp_reporting.planning_fmv_override.failed'
+      );
+    }
+    throw mappedError;
+  }
+}
+
+export async function listLatestPlanningFmvOverrides(
+  fundId: number,
+  asOfDate: string,
+  options: PlanningFmvOverrideServiceOptions = {}
+): Promise<PlanningFmvOverrideLatestResponse> {
+  const database = options.database ?? db;
+  const rows = await database
+    .select()
+    .from(valuationMarks)
+    .where(eq(valuationMarks.fundId, fundId))
+    .orderBy(desc(valuationMarks.markDate), desc(valuationMarks.id));
+  const planningRows = rows.filter(
+    (row) =>
+      row.fundId === fundId &&
+      row.importedFrom === 'planning_fmv_override' &&
+      (row.status === 'approved' || row.status === 'locked')
+  );
+  const selection = selectActiveValuationMarks(planningRows.map(toParsedMark), asOfDate);
+  const activeIds = new Set(selection.active.map((mark) => mark.id));
+  const marks = planningRows
+    .filter((row) => activeIds.has(row.id))
+    .sort((a, b) => a.companyId - b.companyId)
+    .map(toPlanningRecord);
+
+  return {
+    asOfDate,
+    marks,
+  };
+}

--- a/shared/contracts/lp-reporting/index.ts
+++ b/shared/contracts/lp-reporting/index.ts
@@ -20,3 +20,4 @@ export * from './lp-report-package-render-model.contract';
 export * from './lp-report-package-json-export.contract';
 export * from './import-dry-run.contract';
 export * from './import-commit.contract';
+export * from './planning-fmv-override.contract';

--- a/shared/contracts/lp-reporting/lp-metric-run.contract.ts
+++ b/shared/contracts/lp-reporting/lp-metric-run.contract.ts
@@ -42,6 +42,10 @@ export type LpMetricRunType = z.infer<typeof LpMetricRunTypeSchema>;
 export type LpMetricRunPerspective = z.infer<typeof LpMetricRunPerspectiveSchema>;
 export type LpMetricRunStatus = z.infer<typeof LpMetricRunStatusSchema>;
 
+export const MetricRunSourceMarkSelectionSchema = z.enum(['explicit', 'active_as_of']);
+
+export type MetricRunSourceMarkSelection = z.infer<typeof MetricRunSourceMarkSelectionSchema>;
+
 // ---------------------------------------------------------------------------
 // XIRR diagnostic enums + shape (per ADR-010, mirrors XIRRResult in
 // shared/lib/finance/xirr.ts and the Phase 1 diagnostic wrapper contract).
@@ -148,15 +152,35 @@ export type LpMetricRunDiagnostics = z.infer<typeof LpMetricRunDiagnosticsSchema
 // Dry-run + commit endpoint contracts.
 // ---------------------------------------------------------------------------
 
+const MetricRunSourceSelectionMessage =
+  'sourceMarkIds must be empty when sourceMarkSelection is active_as_of';
+
+const MetricRunRequestBaseShape = {
+  asOfDate: z.string().date(),
+  runType: LpMetricRunTypeSchema,
+  perspective: LpMetricRunPerspectiveSchema,
+  sourceEventIds: z.array(z.number().int().positive()).default([]),
+  sourceMarkIds: z.array(z.number().int().positive()).default([]),
+  sourceMarkSelection: MetricRunSourceMarkSelectionSchema.default('explicit'),
+} as const;
+
+function rejectExplicitMarksWithActiveSelection(
+  value: { sourceMarkSelection: MetricRunSourceMarkSelection; sourceMarkIds: number[] },
+  context: z.RefinementCtx
+) {
+  if (value.sourceMarkSelection === 'active_as_of' && value.sourceMarkIds.length > 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['sourceMarkIds'],
+      message: MetricRunSourceSelectionMessage,
+    });
+  }
+}
+
 export const MetricRunDryRunRequestSchema = z
-  .object({
-    asOfDate: z.string().date(),
-    runType: LpMetricRunTypeSchema,
-    perspective: LpMetricRunPerspectiveSchema,
-    sourceEventIds: z.array(z.number().int().positive()).default([]),
-    sourceMarkIds: z.array(z.number().int().positive()).default([]),
-  })
-  .strict();
+  .object(MetricRunRequestBaseShape)
+  .strict()
+  .superRefine(rejectExplicitMarksWithActiveSelection);
 
 export const MetricRunDryRunResponseSchema = z
   .object({
@@ -168,9 +192,13 @@ export const MetricRunDryRunResponseSchema = z
   })
   .strict();
 
-export const MetricRunCommitRequestSchema = MetricRunDryRunRequestSchema.extend({
-  previewHash: PreviewHashSchema,
-}).strict();
+export const MetricRunCommitRequestSchema = z
+  .object({
+    ...MetricRunRequestBaseShape,
+    previewHash: PreviewHashSchema,
+  })
+  .strict()
+  .superRefine(rejectExplicitMarksWithActiveSelection);
 
 export const MetricRunCommitResponseSchema = z
   .object({

--- a/shared/contracts/lp-reporting/planning-fmv-override.contract.ts
+++ b/shared/contracts/lp-reporting/planning-fmv-override.contract.ts
@@ -1,0 +1,103 @@
+/**
+ * LP Reporting -- Planning FMV Override Contract.
+ *
+ * Planning FMV overrides are approved GP valuation marks created from the
+ * reserve-planning workspace. They intentionally do not carry round identity or
+ * scenario identity; the durable evidence row is a valuation mark.
+ *
+ * @module shared/contracts/lp-reporting/planning-fmv-override.contract
+ */
+
+import { z } from 'zod';
+
+import { DecimalStringSchema } from './cash-flow-event.contract';
+
+export const PlanningFmvOverrideErrorCodeSchema = z.enum([
+  'planning_fmv_invalid_request',
+  'planning_fmv_idempotency_key_required',
+  'planning_fmv_idempotency_key_reused',
+  'planning_fmv_request_pending',
+  'planning_fmv_request_failed',
+  'planning_fmv_source_conflict',
+  'planning_fmv_approval_forbidden',
+]);
+
+export const PlanningFmvConfidenceLevelSchema = z.enum(['high', 'medium', 'low']);
+
+export const PlanningFmvSourceContextSchema = z
+  .object({
+    allocationVersion: z.number().int().positive().nullable().optional(),
+    plannedReservesCents: z.number().int().nonnegative().nullable().optional(),
+    allocationReason: z.string().max(1000).nullable().optional(),
+  })
+  .strict();
+
+export const PlanningFmvOverrideCreateRequestSchema = z
+  .object({
+    companyId: z.number().int().positive(),
+    markDate: z.string().date(),
+    asOfDate: z.string().date().optional(),
+    fairValue: DecimalStringSchema.refine((value) => !value.startsWith('-'), {
+      message: 'fairValue must be non-negative',
+    }),
+    currency: z.literal('USD').default('USD'),
+    confidenceLevel: PlanningFmvConfidenceLevelSchema.default('medium'),
+    reason: z.string().trim().min(1).max(1000),
+    methodologyNotes: z.string().trim().min(1).max(4000).optional(),
+    source: PlanningFmvSourceContextSchema.default({}),
+  })
+  .strict();
+
+export const PlanningFmvOverrideRecordSchema = z
+  .object({
+    id: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    companyId: z.number().int().positive(),
+    markDate: z.string().date(),
+    asOfDate: z.string().date(),
+    fairValue: DecimalStringSchema,
+    currency: z.literal('USD'),
+    confidenceLevel: PlanningFmvConfidenceLevelSchema,
+    status: z.enum(['approved', 'locked']),
+    priorMarkId: z.number().int().positive().nullable(),
+    methodologyNotes: z.string().nullable(),
+    approvedBy: z.number().int().positive().nullable(),
+    approvedAt: z.string().datetime().nullable(),
+    createdAt: z.string().datetime().nullable(),
+  })
+  .strict();
+
+export const PlanningFmvOverrideCreateResponseSchema = z
+  .object({
+    requestId: z.number().int().positive(),
+    idempotencyKey: z.string().min(1).max(128),
+    replayed: z.boolean(),
+    valuationMark: PlanningFmvOverrideRecordSchema,
+  })
+  .strict();
+
+export const PlanningFmvOverrideLatestQuerySchema = z
+  .object({
+    asOfDate: z.string().date().optional(),
+  })
+  .strict();
+
+export const PlanningFmvOverrideLatestResponseSchema = z
+  .object({
+    asOfDate: z.string().date(),
+    marks: z.array(PlanningFmvOverrideRecordSchema),
+  })
+  .strict();
+
+export type PlanningFmvOverrideErrorCode = z.infer<typeof PlanningFmvOverrideErrorCodeSchema>;
+export type PlanningFmvOverrideCreateRequest = z.infer<
+  typeof PlanningFmvOverrideCreateRequestSchema
+>;
+export type PlanningFmvOverrideRecord = z.infer<typeof PlanningFmvOverrideRecordSchema>;
+export type PlanningFmvOverrideCreateResponse = z.infer<
+  typeof PlanningFmvOverrideCreateResponseSchema
+>;
+export type PlanningFmvOverrideLatestQuery = z.infer<typeof PlanningFmvOverrideLatestQuerySchema>;
+export type PlanningFmvOverrideLatestResponse = z.infer<
+  typeof PlanningFmvOverrideLatestResponseSchema
+>;

--- a/shared/generated/flag-defaults.ts
+++ b/shared/generated/flag-defaults.ts
@@ -12,11 +12,11 @@ import type { FlagKey, FlagDefinition, FlagRecord } from './flag-types.js';
  * Complete flag definitions
  */
 export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
-  'enable_new_ia': {
+  enable_new_ia: {
     default: false,
-    description: "5-route navigation (Overview, Portfolio, Model, Operate, Report)",
-    owner: "gp-team",
-    risk: "low",
+    description: '5-route navigation (Overview, Portfolio, Model, Operate, Report)',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -26,14 +26,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-    aliases: ["NEW_IA", "new_ia"],
-
+    aliases: ['NEW_IA', 'new_ia'],
   },
-  'enable_kpi_selectors': {
+  enable_kpi_selectors: {
     default: false,
-    description: "KPI selector system for metrics dashboard",
-    owner: "gp-team",
-    risk: "low",
+    description: 'KPI selector system for metrics dashboard',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -41,16 +40,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_new_ia"],
+    dependencies: ['enable_new_ia'],
     expiresAt: null,
-    aliases: ["ENABLE_SELECTOR_KPIS"],
-
+    aliases: ['ENABLE_SELECTOR_KPIS'],
   },
-  'enable_brand_tokens': {
+  enable_brand_tokens: {
     default: false,
-    description: "Press On Ventures brand token system",
-    owner: "design",
-    risk: "low",
+    description: 'Press On Ventures brand token system',
+    owner: 'design',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -60,14 +58,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_cap_table_tabs': {
+  enable_cap_table_tabs: {
     default: false,
-    description: "Cap table access inside company detail tabs",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Cap table access inside company detail tabs',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -75,16 +71,14 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_new_ia"],
+    dependencies: ['enable_new_ia'],
     expiresAt: null,
-
-
   },
-  'enable_modeling_wizard': {
+  enable_modeling_wizard: {
     default: false,
-    description: "7-step modeling wizard",
-    owner: "gp-team",
-    risk: "medium",
+    description: '7-step modeling wizard',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -92,16 +86,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_new_ia", "enable_kpi_selectors"],
+    dependencies: ['enable_new_ia', 'enable_kpi_selectors'],
     expiresAt: null,
-    aliases: ["ENABLE_MODELING_WIZARD"],
-
+    aliases: ['ENABLE_MODELING_WIZARD'],
   },
-  'enable_operations_hub': {
+  enable_operations_hub: {
     default: false,
-    description: "Capital calls and distributions hub",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'Capital calls and distributions hub',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -109,16 +102,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_new_ia", "enable_kpi_selectors"],
+    dependencies: ['enable_new_ia', 'enable_kpi_selectors'],
     expiresAt: null,
-    aliases: ["ENABLE_OPERATIONS_HUB"],
-
+    aliases: ['ENABLE_OPERATIONS_HUB'],
   },
-  'enable_investment_rounds': {
+  enable_investment_rounds: {
     default: false,
-    description: "Investment round persistence",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'Investment round persistence',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -127,15 +119,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       production: false,
     },
     dependencies: [],
-    expiresAt: "2026-12-31",
-
-
+    expiresAt: '2026-12-31',
   },
-  'enable_lp_reporting': {
+  enable_lp_reporting: {
     default: false,
-    description: "LP reporting dashboard",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'LP reporting dashboard',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -143,16 +133,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_kpi_selectors", "enable_operations_hub"],
+    dependencies: ['enable_kpi_selectors', 'enable_operations_hub'],
     expiresAt: null,
-    aliases: ["ENABLE_LP_REPORTING"],
-
+    aliases: ['ENABLE_LP_REPORTING'],
   },
-  'enable_lp_snapshot_mode': {
+  enable_lp_snapshot_mode: {
     default: false,
-    description: "Immutable-snapshot summary in the LP share modal for GP verification.",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Immutable-snapshot summary in the LP share modal for GP verification.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -162,48 +151,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_reserve_engine': {
+  enable_planning_fmv_overrides: {
     default: false,
-    description: "Deterministic reserve allocation engine",
-    owner: "analytics",
-    risk: "medium",
-    exposeToClient: true,
-
-    environments: {
-      development: true,
-      staging: false,
-      production: false,
-    },
-    dependencies: ["enable_kpi_selectors"],
-    expiresAt: null,
-
-
-  },
-  'enable_portfolio_table_v2': {
-    default: false,
-    description: "Unified portfolio table with virtualization",
-    owner: "gp-team",
-    risk: "medium",
-    exposeToClient: true,
-
-    environments: {
-      development: true,
-      staging: false,
-      production: false,
-    },
-    dependencies: ["enable_new_ia"],
-    expiresAt: null,
-
-
-  },
-  'enable_engine_integration': {
-    default: false,
-    description: "Wizard engine comparison and recommendations panel",
-    owner: "analytics",
-    risk: "medium",
+    description: 'Approved Planning FMV override workflow in the reserve allocation workspace.',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -213,14 +166,58 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-    aliases: ["ENABLE_ENGINE_INTEGRATION"],
-
   },
-  'enable_gp_economics_engine': {
+  enable_reserve_engine: {
     default: false,
-    description: "Experimental GP economics engine and results section",
-    owner: "analytics",
-    risk: "high",
+    description: 'Deterministic reserve allocation engine',
+    owner: 'analytics',
+    risk: 'medium',
+    exposeToClient: true,
+
+    environments: {
+      development: true,
+      staging: false,
+      production: false,
+    },
+    dependencies: ['enable_kpi_selectors'],
+    expiresAt: null,
+  },
+  enable_portfolio_table_v2: {
+    default: false,
+    description: 'Unified portfolio table with virtualization',
+    owner: 'gp-team',
+    risk: 'medium',
+    exposeToClient: true,
+
+    environments: {
+      development: true,
+      staging: false,
+      production: false,
+    },
+    dependencies: ['enable_new_ia'],
+    expiresAt: null,
+  },
+  enable_engine_integration: {
+    default: false,
+    description: 'Wizard engine comparison and recommendations panel',
+    owner: 'analytics',
+    risk: 'medium',
+    exposeToClient: true,
+
+    environments: {
+      development: false,
+      staging: false,
+      production: false,
+    },
+    dependencies: [],
+    expiresAt: null,
+    aliases: ['ENABLE_ENGINE_INTEGRATION'],
+  },
+  enable_gp_economics_engine: {
+    default: false,
+    description: 'Experimental GP economics engine and results section',
+    owner: 'analytics',
+    risk: 'high',
     exposeToClient: true,
 
     environments: {
@@ -230,14 +227,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-    aliases: ["ENABLE_GP_ECONOMICS_ENGINE"],
-
+    aliases: ['ENABLE_GP_ECONOMICS_ENGINE'],
   },
-  'ts_reserves': {
+  ts_reserves: {
     default: true,
-    description: "TypeScript reserves calculation engine",
-    owner: "analytics",
-    risk: "low",
+    description: 'TypeScript reserves calculation engine',
+    owner: 'analytics',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -250,11 +246,11 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
 
     rolloutPercentage: 100,
   },
-  'wasm_reserves': {
+  wasm_reserves: {
     default: false,
-    description: "WebAssembly reserves calculation engine (experimental)",
-    owner: "analytics",
-    risk: "high",
+    description: 'WebAssembly reserves calculation engine (experimental)',
+    owner: 'analytics',
+    risk: 'high',
     exposeToClient: true,
 
     environments: {
@@ -267,11 +263,11 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
 
     rolloutPercentage: 0,
   },
-  'shadow_compare': {
+  shadow_compare: {
     default: false,
-    description: "Shadow comparison between TS and WASM engines",
-    owner: "analytics",
-    risk: "low",
+    description: 'Shadow comparison between TS and WASM engines',
+    owner: 'analytics',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -279,16 +275,16 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["ts_reserves", "wasm_reserves"],
+    dependencies: ['ts_reserves', 'wasm_reserves'],
     expiresAt: null,
 
     rolloutPercentage: 0,
   },
-  'reserves_v11': {
+  reserves_v11: {
     default: true,
-    description: "Reserves v1.1 calculation improvements",
-    owner: "analytics",
-    risk: "medium",
+    description: 'Reserves v1.1 calculation improvements',
+    owner: 'analytics',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -298,14 +294,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'remain_pass': {
+  remain_pass: {
     default: true,
-    description: "Remaining pass calculation",
-    owner: "analytics",
-    risk: "low",
+    description: 'Remaining pass calculation',
+    owner: 'analytics',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -315,14 +309,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'stage_based_caps': {
+  stage_based_caps: {
     default: true,
-    description: "Stage-based capital allocation caps",
-    owner: "analytics",
-    risk: "low",
+    description: 'Stage-based capital allocation caps',
+    owner: 'analytics',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -332,14 +324,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'export_async': {
+  export_async: {
     default: true,
-    description: "Async export functionality",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Async export functionality',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -349,14 +339,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'metrics_collection': {
+  metrics_collection: {
     default: true,
-    description: "Client-side metrics collection",
-    owner: "analytics",
-    risk: "low",
+    description: 'Client-side metrics collection',
+    owner: 'analytics',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -366,14 +354,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_pipeline_bulk_actions': {
+  enable_pipeline_bulk_actions: {
     default: false,
-    description: "Pipeline selection and bulk status actions",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'Pipeline selection and bulk status actions',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -383,14 +369,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_pipeline_dnd': {
+  enable_pipeline_dnd: {
     default: false,
-    description: "Drag deal cards between pipeline status columns",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'Drag deal cards between pipeline status columns',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -400,14 +384,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_work_panel': {
+  enable_work_panel: {
     default: false,
-    description: "Context-preserving drill-down panels (side Sheet) on the GP dashboard.",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Context-preserving drill-down panels (side Sheet) on the GP dashboard.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -417,14 +399,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_context_rail': {
+  enable_context_rail: {
     default: false,
-    description: "Fourth-zone context rail on the GP dashboard (freshness/attention/activity).",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Fourth-zone context rail on the GP dashboard (freshness/attention/activity).',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -434,14 +414,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_cash_event_object': {
+  enable_cash_event_object: {
     default: false,
-    description: "Read-only WorkPanel list of persisted cash-flow events on the cashflow dashboard.",
-    owner: "gp-team",
-    risk: "low",
+    description:
+      'Read-only WorkPanel list of persisted cash-flow events on the cashflow dashboard.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -451,14 +430,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_cash_event_edit': {
+  enable_cash_event_edit: {
     default: false,
-    description: "Draft-only editing of persisted cash events in the WorkPanel detail view (PATCH If-Match).",
-    owner: "gp-team",
-    risk: "low",
+    description:
+      'Draft-only editing of persisted cash events in the WorkPanel detail view (PATCH If-Match).',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -466,16 +444,14 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_cash_event_object"],
+    dependencies: ['enable_cash_event_object'],
     expiresAt: null,
-
-
   },
-  'enable_route_redirects': {
+  enable_route_redirects: {
     default: false,
-    description: "Hard redirects from old routes to new IA.",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Hard redirects from old routes to new IA.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -483,16 +459,14 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_new_ia"],
-    expiresAt: "2026-04-01T00:00:00Z",
-
-
+    dependencies: ['enable_new_ia'],
+    expiresAt: '2026-04-01T00:00:00Z',
   },
-  'enable_observability': {
+  enable_observability: {
     default: false,
-    description: "Error boundaries, Sentry, vitals logging per route.",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Error boundaries, Sentry, vitals logging per route.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -502,14 +476,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'ui_catalog': {
+  ui_catalog: {
     default: false,
-    description: "Admin UI component catalog",
-    owner: "design",
-    risk: "low",
+    description: 'Admin UI component catalog',
+    owner: 'design',
+    risk: 'low',
     exposeToClient: true,
     adminOnly: true,
     environments: {
@@ -519,14 +491,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-    aliases: ["UI_CATALOG"],
-
+    aliases: ['UI_CATALOG'],
   },
-  'onboarding_tour': {
+  onboarding_tour: {
     default: false,
-    description: "GP onboarding tour for new users",
-    owner: "gp-team",
-    risk: "low",
+    description: 'GP onboarding tour for new users',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -536,14 +507,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-    aliases: ["ONBOARDING_TOUR"],
-
+    aliases: ['ONBOARDING_TOUR'],
   },
-  'demo_mode': {
+  demo_mode: {
     default: false,
-    description: "Demo mode with sample data",
-    owner: "platform",
-    risk: "low",
+    description: 'Demo mode with sample data',
+    owner: 'platform',
+    risk: 'low',
     exposeToClient: false,
 
     environments: {
@@ -553,14 +523,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'require_auth': {
+  require_auth: {
     default: false,
-    description: "Require authentication for API access",
-    owner: "platform",
-    risk: "high",
+    description: 'Require authentication for API access',
+    owner: 'platform',
+    risk: 'high',
     exposeToClient: false,
 
     environments: {
@@ -570,14 +538,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_portfolio_intelligence': {
+  enable_portfolio_intelligence: {
     default: false,
-    description: "Gates Portfolio Intelligence prototype endpoints that remain fail-closed until backed by computed financial data",
-    owner: "platform",
-    risk: "high",
+    description:
+      'Gates Portfolio Intelligence prototype endpoints that remain fail-closed until backed by computed financial data',
+    owner: 'platform',
+    risk: 'high',
     exposeToClient: false,
 
     environments: {
@@ -587,14 +554,13 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-    aliases: ["ENABLE_PORTFOLIO_INTELLIGENCE"],
-
+    aliases: ['ENABLE_PORTFOLIO_INTELLIGENCE'],
   },
-  'enable_faults': {
+  enable_faults: {
     default: false,
-    description: "Enable fault injection for testing",
-    owner: "platform",
-    risk: "high",
+    description: 'Enable fault injection for testing',
+    owner: 'platform',
+    risk: 'high',
     exposeToClient: false,
 
     environments: {
@@ -604,14 +570,12 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     },
     dependencies: [],
     expiresAt: null,
-
-
   },
-  'enable_wizard_step_general': {
+  enable_wizard_step_general: {
     default: false,
-    description: "Wizard Step 1: General fund info",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Wizard Step 1: General fund info',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -619,16 +583,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_modeling_wizard"],
+    dependencies: ['enable_modeling_wizard'],
     expiresAt: null,
-    aliases: ["ENABLE_WIZARD_STEP_GENERAL"],
-
+    aliases: ['ENABLE_WIZARD_STEP_GENERAL'],
   },
-  'enable_wizard_step_sectors': {
+  enable_wizard_step_sectors: {
     default: false,
-    description: "Wizard Step 2: Sector Profiles.",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Wizard Step 2: Sector Profiles.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -636,16 +599,14 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_general"],
+    dependencies: ['enable_wizard_step_general'],
     expiresAt: null,
-
-
   },
-  'enable_wizard_step_allocations': {
+  enable_wizard_step_allocations: {
     default: false,
-    description: "Wizard Step 3: Capital Allocations.",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Wizard Step 3: Capital Allocations.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -653,16 +614,14 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_sectors"],
+    dependencies: ['enable_wizard_step_sectors'],
     expiresAt: null,
-
-
   },
-  'enable_wizard_step_sizing': {
+  enable_wizard_step_sizing: {
     default: false,
-    description: "Wizard Step 2: Fund sizing",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Wizard Step 2: Fund sizing',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -670,16 +629,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_general"],
+    dependencies: ['enable_wizard_step_general'],
     expiresAt: null,
-    aliases: ["ENABLE_WIZARD_STEP_SIZING", "ENABLE_WIZARD_STEP_SECTORS"],
-
+    aliases: ['ENABLE_WIZARD_STEP_SIZING', 'ENABLE_WIZARD_STEP_SECTORS'],
   },
-  'enable_wizard_step_pacing': {
+  enable_wizard_step_pacing: {
     default: false,
-    description: "Wizard Step 3: Pacing and deployment",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Wizard Step 3: Pacing and deployment',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -687,16 +645,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_sizing"],
+    dependencies: ['enable_wizard_step_sizing'],
     expiresAt: null,
-    aliases: ["ENABLE_WIZARD_STEP_PACING"],
-
+    aliases: ['ENABLE_WIZARD_STEP_PACING'],
   },
-  'enable_wizard_step_reserves': {
+  enable_wizard_step_reserves: {
     default: false,
-    description: "Wizard Step 4: Reserve allocation",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'Wizard Step 4: Reserve allocation',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -704,16 +661,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_pacing"],
+    dependencies: ['enable_wizard_step_pacing'],
     expiresAt: null,
-    aliases: ["ENABLE_WIZARD_STEP_RESERVES", "ENABLE_WIZARD_STEP_ALLOCATIONS"],
-
+    aliases: ['ENABLE_WIZARD_STEP_RESERVES', 'ENABLE_WIZARD_STEP_ALLOCATIONS'],
   },
-  'enable_wizard_step_fees': {
+  enable_wizard_step_fees: {
     default: false,
-    description: "Wizard Step 5: Fee structure",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'Wizard Step 5: Fee structure',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -721,16 +677,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_reserves"],
+    dependencies: ['enable_wizard_step_reserves'],
     expiresAt: null,
-    aliases: ["ENABLE_WIZARD_STEP_FEES"],
-
+    aliases: ['ENABLE_WIZARD_STEP_FEES'],
   },
-  'enable_wizard_step_recycling': {
+  enable_wizard_step_recycling: {
     default: false,
-    description: "Wizard Step 5: Exit Recycling.",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Wizard Step 5: Exit Recycling.',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -738,16 +693,14 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_fees"],
+    dependencies: ['enable_wizard_step_fees'],
     expiresAt: null,
-
-
   },
-  'enable_wizard_step_waterfall': {
+  enable_wizard_step_waterfall: {
     default: false,
-    description: "Wizard Step 6: Waterfall distribution",
-    owner: "gp-team",
-    risk: "medium",
+    description: 'Wizard Step 6: Waterfall distribution',
+    owner: 'gp-team',
+    risk: 'medium',
     exposeToClient: true,
 
     environments: {
@@ -755,16 +708,15 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_fees"],
+    dependencies: ['enable_wizard_step_fees'],
     expiresAt: null,
-    aliases: ["ENABLE_WIZARD_STEP_WATERFALL", "ENABLE_WIZARD_STEP_RECYCLING"],
-
+    aliases: ['ENABLE_WIZARD_STEP_WATERFALL', 'ENABLE_WIZARD_STEP_RECYCLING'],
   },
-  'enable_wizard_step_results': {
+  enable_wizard_step_results: {
     default: false,
-    description: "Wizard Step 7: Results summary",
-    owner: "gp-team",
-    risk: "low",
+    description: 'Wizard Step 7: Results summary',
+    owner: 'gp-team',
+    risk: 'low',
     exposeToClient: true,
 
     environments: {
@@ -772,10 +724,9 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
       staging: false,
       production: false,
     },
-    dependencies: ["enable_wizard_step_waterfall"],
+    dependencies: ['enable_wizard_step_waterfall'],
     expiresAt: null,
-    aliases: ["ENABLE_WIZARD_STEP_RESULTS"],
-
+    aliases: ['ENABLE_WIZARD_STEP_RESULTS'],
   },
 };
 
@@ -783,51 +734,52 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
  * Default flag values (from registry)
  */
 export const FLAG_DEFAULTS: FlagRecord = {
-  'enable_new_ia': false,
-  'enable_kpi_selectors': false,
-  'enable_brand_tokens': false,
-  'enable_cap_table_tabs': false,
-  'enable_modeling_wizard': false,
-  'enable_operations_hub': false,
-  'enable_investment_rounds': false,
-  'enable_lp_reporting': false,
-  'enable_lp_snapshot_mode': false,
-  'enable_reserve_engine': false,
-  'enable_portfolio_table_v2': false,
-  'enable_engine_integration': false,
-  'enable_gp_economics_engine': false,
-  'ts_reserves': true,
-  'wasm_reserves': false,
-  'shadow_compare': false,
-  'reserves_v11': true,
-  'remain_pass': true,
-  'stage_based_caps': true,
-  'export_async': true,
-  'metrics_collection': true,
-  'enable_pipeline_bulk_actions': false,
-  'enable_pipeline_dnd': false,
-  'enable_work_panel': false,
-  'enable_context_rail': false,
-  'enable_cash_event_object': false,
-  'enable_cash_event_edit': false,
-  'enable_route_redirects': false,
-  'enable_observability': false,
-  'ui_catalog': false,
-  'onboarding_tour': false,
-  'demo_mode': false,
-  'require_auth': false,
-  'enable_portfolio_intelligence': false,
-  'enable_faults': false,
-  'enable_wizard_step_general': false,
-  'enable_wizard_step_sectors': false,
-  'enable_wizard_step_allocations': false,
-  'enable_wizard_step_sizing': false,
-  'enable_wizard_step_pacing': false,
-  'enable_wizard_step_reserves': false,
-  'enable_wizard_step_fees': false,
-  'enable_wizard_step_recycling': false,
-  'enable_wizard_step_waterfall': false,
-  'enable_wizard_step_results': false,
+  enable_new_ia: false,
+  enable_kpi_selectors: false,
+  enable_brand_tokens: false,
+  enable_cap_table_tabs: false,
+  enable_modeling_wizard: false,
+  enable_operations_hub: false,
+  enable_investment_rounds: false,
+  enable_lp_reporting: false,
+  enable_lp_snapshot_mode: false,
+  enable_planning_fmv_overrides: false,
+  enable_reserve_engine: false,
+  enable_portfolio_table_v2: false,
+  enable_engine_integration: false,
+  enable_gp_economics_engine: false,
+  ts_reserves: true,
+  wasm_reserves: false,
+  shadow_compare: false,
+  reserves_v11: true,
+  remain_pass: true,
+  stage_based_caps: true,
+  export_async: true,
+  metrics_collection: true,
+  enable_pipeline_bulk_actions: false,
+  enable_pipeline_dnd: false,
+  enable_work_panel: false,
+  enable_context_rail: false,
+  enable_cash_event_object: false,
+  enable_cash_event_edit: false,
+  enable_route_redirects: false,
+  enable_observability: false,
+  ui_catalog: false,
+  onboarding_tour: false,
+  demo_mode: false,
+  require_auth: false,
+  enable_portfolio_intelligence: false,
+  enable_faults: false,
+  enable_wizard_step_general: false,
+  enable_wizard_step_sectors: false,
+  enable_wizard_step_allocations: false,
+  enable_wizard_step_sizing: false,
+  enable_wizard_step_pacing: false,
+  enable_wizard_step_reserves: false,
+  enable_wizard_step_fees: false,
+  enable_wizard_step_recycling: false,
+  enable_wizard_step_waterfall: false,
+  enable_wizard_step_results: false,
 };
 
 /**
@@ -893,27 +845,27 @@ export function resolveFlagWithDependencies(
  * Legacy alias mapping (for migration)
  */
 export const FLAG_ALIASES: Record<string, FlagKey> = {
-  'NEW_IA': 'enable_new_ia',
-  'new_ia': 'enable_new_ia',
-  'ENABLE_SELECTOR_KPIS': 'enable_kpi_selectors',
-  'ENABLE_MODELING_WIZARD': 'enable_modeling_wizard',
-  'ENABLE_OPERATIONS_HUB': 'enable_operations_hub',
-  'ENABLE_LP_REPORTING': 'enable_lp_reporting',
-  'ENABLE_ENGINE_INTEGRATION': 'enable_engine_integration',
-  'ENABLE_GP_ECONOMICS_ENGINE': 'enable_gp_economics_engine',
-  'UI_CATALOG': 'ui_catalog',
-  'ONBOARDING_TOUR': 'onboarding_tour',
-  'ENABLE_PORTFOLIO_INTELLIGENCE': 'enable_portfolio_intelligence',
-  'ENABLE_WIZARD_STEP_GENERAL': 'enable_wizard_step_general',
-  'ENABLE_WIZARD_STEP_SIZING': 'enable_wizard_step_sizing',
-  'ENABLE_WIZARD_STEP_SECTORS': 'enable_wizard_step_sizing',
-  'ENABLE_WIZARD_STEP_PACING': 'enable_wizard_step_pacing',
-  'ENABLE_WIZARD_STEP_RESERVES': 'enable_wizard_step_reserves',
-  'ENABLE_WIZARD_STEP_ALLOCATIONS': 'enable_wizard_step_reserves',
-  'ENABLE_WIZARD_STEP_FEES': 'enable_wizard_step_fees',
-  'ENABLE_WIZARD_STEP_WATERFALL': 'enable_wizard_step_waterfall',
-  'ENABLE_WIZARD_STEP_RECYCLING': 'enable_wizard_step_waterfall',
-  'ENABLE_WIZARD_STEP_RESULTS': 'enable_wizard_step_results',
+  NEW_IA: 'enable_new_ia',
+  new_ia: 'enable_new_ia',
+  ENABLE_SELECTOR_KPIS: 'enable_kpi_selectors',
+  ENABLE_MODELING_WIZARD: 'enable_modeling_wizard',
+  ENABLE_OPERATIONS_HUB: 'enable_operations_hub',
+  ENABLE_LP_REPORTING: 'enable_lp_reporting',
+  ENABLE_ENGINE_INTEGRATION: 'enable_engine_integration',
+  ENABLE_GP_ECONOMICS_ENGINE: 'enable_gp_economics_engine',
+  UI_CATALOG: 'ui_catalog',
+  ONBOARDING_TOUR: 'onboarding_tour',
+  ENABLE_PORTFOLIO_INTELLIGENCE: 'enable_portfolio_intelligence',
+  ENABLE_WIZARD_STEP_GENERAL: 'enable_wizard_step_general',
+  ENABLE_WIZARD_STEP_SIZING: 'enable_wizard_step_sizing',
+  ENABLE_WIZARD_STEP_SECTORS: 'enable_wizard_step_sizing',
+  ENABLE_WIZARD_STEP_PACING: 'enable_wizard_step_pacing',
+  ENABLE_WIZARD_STEP_RESERVES: 'enable_wizard_step_reserves',
+  ENABLE_WIZARD_STEP_ALLOCATIONS: 'enable_wizard_step_reserves',
+  ENABLE_WIZARD_STEP_FEES: 'enable_wizard_step_fees',
+  ENABLE_WIZARD_STEP_WATERFALL: 'enable_wizard_step_waterfall',
+  ENABLE_WIZARD_STEP_RECYCLING: 'enable_wizard_step_waterfall',
+  ENABLE_WIZARD_STEP_RESULTS: 'enable_wizard_step_results',
 };
 
 /**

--- a/shared/generated/flag-types.ts
+++ b/shared/generated/flag-types.ts
@@ -19,6 +19,7 @@ export type FlagKey =
   | 'enable_investment_rounds'
   | 'enable_lp_reporting'
   | 'enable_lp_snapshot_mode'
+  | 'enable_planning_fmv_overrides'
   | 'enable_reserve_engine'
   | 'enable_portfolio_table_v2'
   | 'enable_engine_integration'
@@ -69,6 +70,7 @@ export type ClientFlagKey =
   | 'enable_investment_rounds'
   | 'enable_lp_reporting'
   | 'enable_lp_snapshot_mode'
+  | 'enable_planning_fmv_overrides'
   | 'enable_reserve_engine'
   | 'enable_portfolio_table_v2'
   | 'enable_engine_integration'
@@ -114,8 +116,7 @@ export type ServerOnlyFlagKey =
 /**
  * Admin flags (no localStorage override)
  */
-export type AdminFlagKey =
-  | 'ui_catalog';
+export type AdminFlagKey = 'ui_catalog';
 
 /**
  * Flag risk levels
@@ -166,6 +167,7 @@ export const ALL_FLAG_KEYS: readonly FlagKey[] = [
   'enable_investment_rounds',
   'enable_lp_reporting',
   'enable_lp_snapshot_mode',
+  'enable_planning_fmv_overrides',
   'enable_reserve_engine',
   'enable_portfolio_table_v2',
   'enable_engine_integration',
@@ -217,6 +219,7 @@ export const CLIENT_FLAG_KEYS: readonly ClientFlagKey[] = [
   'enable_investment_rounds',
   'enable_lp_reporting',
   'enable_lp_snapshot_mode',
+  'enable_planning_fmv_overrides',
   'enable_reserve_engine',
   'enable_portfolio_table_v2',
   'enable_engine_integration',
@@ -254,9 +257,7 @@ export const CLIENT_FLAG_KEYS: readonly ClientFlagKey[] = [
 /**
  * Array of admin flag keys (no localStorage override)
  */
-export const ADMIN_FLAG_KEYS: readonly AdminFlagKey[] = [
-  'ui_catalog',
-] as const;
+export const ADMIN_FLAG_KEYS: readonly AdminFlagKey[] = ['ui_catalog'] as const;
 
 /**
  * Check if a key is a valid flag key

--- a/shared/schema/lp-reporting-evidence.ts
+++ b/shared/schema/lp-reporting-evidence.ts
@@ -246,6 +246,11 @@ export const valuationMarks = pgTable(
       table.vehicleId,
       table.asOfDate.desc()
     ),
+    planningActiveIdx: index('idx_valuation_marks_planning_active_mark_date')
+      .on(table.fundId, table.companyId, table.markDate.desc(), table.id.desc())
+      .where(
+        sql`${table.importedFrom} = 'planning_fmv_override' AND ${table.status} IN ('approved', 'locked')`
+      ),
     importBatchIdx: index('idx_valuation_marks_import_batch').on(table.importBatchId),
     sourceHashUniqueIdx: uniqueIndex('valuation_marks_fund_source_hash_unique')
       .on(table.fundId, table.sourceHash)
@@ -255,6 +260,58 @@ export const valuationMarks = pgTable(
 
 export type ValuationMark = typeof valuationMarks.$inferSelect;
 export type InsertValuationMark = typeof valuationMarks.$inferInsert;
+
+// ============================================================================
+// PLANNING FMV OVERRIDE REQUESTS
+// ============================================================================
+
+export const planningFmvOverrideRequests = pgTable(
+  'planning_fmv_override_requests',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    companyId: integer('company_id')
+      .notNull()
+      .references(() => portfolioCompanies.id, { onDelete: 'cascade' }),
+    valuationMarkId: integer('valuation_mark_id').references(() => valuationMarks.id, {
+      onDelete: 'restrict',
+    }),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    sourceHash: varchar('source_hash', { length: 128 }).notNull(),
+    status: varchar('status', { length: 16 }).notNull().default('pending'),
+    responseBody: jsonb('response_body'),
+    failureCode: varchar('failure_code', { length: 64 }),
+    failureMessage: text('failure_message'),
+    createdBy: integer('created_by').references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    statusCheck: check(
+      'planning_fmv_override_request_status_check',
+      sql`${table.status} IN ('pending', 'completed', 'failed')`
+    ),
+    idempotencyUnique: unique('planning_fmv_override_requests_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    fundCompanyCreatedIdx: index('idx_planning_fmv_override_requests_fund_company_created').on(
+      table.fundId,
+      table.companyId,
+      table.createdAt.desc()
+    ),
+    valuationMarkIdx: index('idx_planning_fmv_override_requests_valuation_mark').on(
+      table.valuationMarkId
+    ),
+  })
+);
+
+export type PlanningFmvOverrideRequest = typeof planningFmvOverrideRequests.$inferSelect;
+export type InsertPlanningFmvOverrideRequest = typeof planningFmvOverrideRequests.$inferInsert;
 
 // ============================================================================
 // LP METRIC RUNS

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -35,6 +35,7 @@ const C1_MOUNTED_TABLES = [
   'narrative_runs',
   'lp_report_packages',
   'lp_report_package_exports',
+  'planning_fmv_override_requests',
 ] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'investment_rounds',
@@ -259,7 +260,11 @@ function compareForeignKeyShapes(
 
 type ShapeDiagnosticValue = ColumnShape | ConstraintShape | IndexShape | string | null;
 
-function foreignKeyShapeValue(catalog: CatalogSnapshot, tableName: string, shapeName: string): string | null {
+function foreignKeyShapeValue(
+  catalog: CatalogSnapshot,
+  tableName: string,
+  shapeName: string
+): string | null {
   const signatures = catalog.foreignKeysByTable.get(tableName);
   if (signatures?.has(shapeName)) {
     return shapeName;
@@ -667,7 +672,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       )
       .map(pgIdentifier);
 
-    expect(expectedTables).toHaveLength(16);
+    expect([...expectedTables].sort()).toEqual([...C1_MOUNTED_TABLES].sort());
 
     const migratedTables = await publicTables(pool!, expectedTables);
     const migratedConstraints = await publicConstraints(pool!, expectedConstraints);

--- a/tests/unit/components/lp-reporting/MetricRunForm.test.tsx
+++ b/tests/unit/components/lp-reporting/MetricRunForm.test.tsx
@@ -5,7 +5,7 @@
  *   - zodResolver rejects malformed asOfDate strings
  *   - default asOfDate is today's UTC date (TZ=UTC tests)
  *   - submitting fires `useMetricsDryRun.mutateAsync` with
- *     `{ asOfDate, runType, perspective, sourceEventIds, sourceMarkIds }`
+ *     `{ asOfDate, runType, perspective, sourceEventIds, sourceMarkIds, sourceMarkSelection }`
  *   - on success the parent's `onSuccess` callback receives the
  *     parsed metric-run dry-run envelope and original request
  *   - on 401 the parent's `onError` callback receives the typed error
@@ -202,6 +202,7 @@ describe('MetricRunForm', () => {
       perspective: 'fund_gross',
       sourceEventIds: [],
       sourceMarkIds: [],
+      sourceMarkSelection: 'explicit',
     });
 
     const passed = onSuccess.mock.calls[0]![0] as MetricRunDryRunResponse;
@@ -212,6 +213,7 @@ describe('MetricRunForm', () => {
       asOfDate: '2026-03-31',
       runType: 'quarterly_report',
       perspective: 'fund_gross',
+      sourceMarkSelection: 'explicit',
     });
   });
 

--- a/tests/unit/components/portfolio/fmv-override-dialog.test.tsx
+++ b/tests/unit/components/portfolio/fmv-override-dialog.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FmvOverrideDialog } from '@/components/portfolio/tabs/FmvOverrideDialog';
+import type { AllocationCompany } from '@/components/portfolio/tabs/types';
+import type { PlanningFmvOverrideRecord } from '@shared/contracts/lp-reporting';
+
+vi.mock('@/contexts/FundContext', () => ({
+  useFundContext: () => ({ fundId: 1 }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const company: AllocationCompany = {
+  company_id: 42,
+  company_name: 'TechCorp',
+  sector: 'FinTech',
+  stage: 'Series A',
+  status: 'active',
+  invested_amount_cents: 100000000,
+  deployed_reserves_cents: 50000000,
+  planned_reserves_cents: 150000000,
+  allocation_cap_cents: 300000000,
+  allocation_reason: 'Reserve for Series B',
+  allocation_version: 3,
+  last_allocation_at: '2026-03-31T00:00:00.000Z',
+};
+
+const currentMark: PlanningFmvOverrideRecord = {
+  id: 100,
+  fundId: 1,
+  companyId: 42,
+  markDate: '2026-03-31',
+  asOfDate: '2026-03-31',
+  fairValue: '12500000.000000',
+  currency: 'USD',
+  confidenceLevel: 'medium',
+  status: 'approved',
+  priorMarkId: null,
+  methodologyNotes: 'Approved FMV',
+  approvedBy: 7,
+  approvedAt: '2026-03-31T00:00:00.000Z',
+  createdAt: '2026-03-31T00:00:00.000Z',
+};
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe('FmvOverrideDialog', () => {
+  it('disables approved mark saving while a scenario workspace is active', () => {
+    renderWithQuery(
+      <FmvOverrideDialog
+        company={company}
+        currentMark={currentMark}
+        open={true}
+        onOpenChange={vi.fn()}
+        scenarioActive={true}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'Planning FMV overrides can only be saved from the live allocation workspace.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save approved mark/i })).toBeDisabled();
+    expect(screen.getByText('$12,500,000')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/contract/lp-reporting/lp-metric-run.contract.test.ts
+++ b/tests/unit/contract/lp-reporting/lp-metric-run.contract.test.ts
@@ -116,6 +116,31 @@ describe('Metric-run dry-run and commit endpoint contracts', () => {
 
     expect(parsed.sourceEventIds).toEqual([2, 1]);
     expect(parsed.sourceMarkIds).toEqual([10]);
+    expect(parsed.sourceMarkSelection).toBe('explicit');
+  });
+
+  it('accepts active_as_of only when sourceMarkIds is empty', () => {
+    const parsed = MetricRunDryRunRequestSchema.parse({
+      asOfDate: '2026-03-31',
+      runType: 'quarterly_report',
+      perspective: 'lp_net',
+      sourceMarkSelection: 'active_as_of',
+    });
+
+    expect(parsed.sourceMarkSelection).toBe('active_as_of');
+    expect(parsed.sourceMarkIds).toEqual([]);
+  });
+
+  it('rejects active_as_of with explicit sourceMarkIds', () => {
+    expect(() =>
+      MetricRunDryRunRequestSchema.parse({
+        asOfDate: '2026-03-31',
+        runType: 'quarterly_report',
+        perspective: 'lp_net',
+        sourceMarkSelection: 'active_as_of',
+        sourceMarkIds: [10],
+      })
+    ).toThrow(/sourceMarkIds must be empty/);
   });
 
   it('dry-run response wrapper requires results, diagnostics, inputsHash, runType, and previewHash', () => {

--- a/tests/unit/contract/lp-reporting/planning-fmv-override.contract.test.ts
+++ b/tests/unit/contract/lp-reporting/planning-fmv-override.contract.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PlanningFmvOverrideCreateRequestSchema,
+  PlanningFmvOverrideCreateResponseSchema,
+  PlanningFmvOverrideLatestResponseSchema,
+} from '@shared/contracts/lp-reporting/planning-fmv-override.contract';
+
+const happyRequest = {
+  companyId: 42,
+  markDate: '2026-06-30',
+  fairValue: '12500000.000000',
+  reason: 'Board-approved planning FMV for reserve allocation review.',
+  source: {
+    allocationVersion: 4,
+    plannedReservesCents: 25000000,
+    allocationReason: 'Series B follow-on reserve.',
+  },
+};
+
+const happyRecord = {
+  id: 100,
+  fundId: 1,
+  companyId: 42,
+  markDate: '2026-06-30',
+  asOfDate: '2026-06-30',
+  fairValue: '12500000.000000',
+  currency: 'USD',
+  confidenceLevel: 'medium',
+  status: 'approved',
+  priorMarkId: null,
+  methodologyNotes: 'Board-approved planning FMV for reserve allocation review.',
+  approvedBy: 7,
+  approvedAt: '2026-06-30T00:00:00.000Z',
+  createdAt: '2026-06-30T00:00:00.000Z',
+};
+
+describe('PlanningFmvOverrideCreateRequestSchema', () => {
+  it('accepts the approved Planning FMV request shape and defaults optional fields', () => {
+    const parsed = PlanningFmvOverrideCreateRequestSchema.parse(happyRequest);
+
+    expect(parsed.currency).toBe('USD');
+    expect(parsed.confidenceLevel).toBe('medium');
+    expect(parsed.asOfDate).toBeUndefined();
+  });
+
+  it('rejects roundId before route or service code can use it', () => {
+    expect(() =>
+      PlanningFmvOverrideCreateRequestSchema.parse({
+        ...happyRequest,
+        roundId: 10,
+      })
+    ).toThrow();
+  });
+
+  it('rejects scenario identity and numeric fair values', () => {
+    expect(() =>
+      PlanningFmvOverrideCreateRequestSchema.parse({
+        ...happyRequest,
+        activeScenarioId: 'b2e20d78-3d05-4d37-8ebf-f384d537e6e3',
+      })
+    ).toThrow();
+
+    expect(() =>
+      PlanningFmvOverrideCreateRequestSchema.parse({
+        ...happyRequest,
+        fairValue: 12500000,
+      })
+    ).toThrow();
+  });
+});
+
+describe('Planning FMV override response schemas', () => {
+  it('accepts create and latest responses with approved valuation marks', () => {
+    const create = PlanningFmvOverrideCreateResponseSchema.parse({
+      requestId: 10,
+      idempotencyKey: 'idem-1',
+      replayed: false,
+      valuationMark: happyRecord,
+    });
+    const latest = PlanningFmvOverrideLatestResponseSchema.parse({
+      asOfDate: '2026-06-30',
+      marks: [happyRecord],
+    });
+
+    expect(create.valuationMark.id).toBe(100);
+    expect(latest.marks).toHaveLength(1);
+  });
+});

--- a/tests/unit/flags/enable-planning-fmv-overrides.test.tsx
+++ b/tests/unit/flags/enable-planning-fmv-overrides.test.tsx
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { ALL_FLAGS } from '@shared/feature-flags/flag-definitions';
+import { getEnvFlag, getFlagSnapshot, useFlag } from '@/shared/useFlags';
+
+describe('enable_planning_fmv_overrides flag registration', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('is registered in ALL_FLAGS and the global default stays OFF', () => {
+    expect(Object.keys(ALL_FLAGS)).toContain('enable_planning_fmv_overrides');
+    expect(ALL_FLAGS['enable_planning_fmv_overrides']?.enabled).toBe(false);
+  });
+
+  it('defaults OFF but is runtime-overridable', () => {
+    const off = renderHook(() => useFlag('enable_planning_fmv_overrides'));
+    expect(off.result.current).toBe(false);
+
+    window.localStorage.setItem('ff_enable_planning_fmv_overrides', '1');
+    const on = renderHook(() => useFlag('enable_planning_fmv_overrides'));
+    expect(on.result.current).toBe(true);
+  });
+
+  it('VITE_ENABLE_PLANNING_FMV_OVERRIDES=true is the per-environment ON lever', () => {
+    const env = { VITE_ENABLE_PLANNING_FMV_OVERRIDES: 'true' };
+
+    expect(getEnvFlag('enable_planning_fmv_overrides', env)).toBe(true);
+    expect(getFlagSnapshot(env).enable_planning_fmv_overrides).toBe(true);
+  });
+});

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -35,6 +35,16 @@ const expectedLooseFiles = [
   'manual-migration.sql',
 ].sort();
 
+const expectedJournaledDriftPatchFiles = [
+  '0012_sector_variance_drift.sql',
+  '0014_lp_evidence_sprint3_drift.sql',
+  '0016_reconciliation_runs.sql',
+  '0017_moic_exit_probability_modes.sql',
+  '0020_operating_tasks_drift.sql',
+  '0021_version_columns_bigint_drift.sql',
+  '0022_planning_fmv_override_requests_drift.sql',
+].sort();
+
 afterEach(() => {
   while (tempRoots.length > 0) {
     const tempRoot = tempRoots.pop();
@@ -100,7 +110,26 @@ describe('migration ledger helpers', () => {
     expect(
       result.findings.filter((finding) => finding.code === 'legacy-journaled-unmarked-allowlisted')
     ).toHaveLength(LEGACY_JOURNALED_UNMARKED_ALLOWLIST.length);
-    expect(markedJournaled).toHaveLength(6);
+    expect(markedJournaled.map((classification) => classification.file).sort()).toEqual(
+      expectedJournaledDriftPatchFiles
+    );
+  });
+
+  it('keeps the Planning FMV drift patch aligned to the canonical portfolio company table', () => {
+    const sql = fs.readFileSync(
+      path.join(repoRoot, 'migrations', '0022_planning_fmv_override_requests_drift.sql'),
+      'utf8'
+    );
+
+    expect(sql).toMatch(/REFERENCES\s+"public"\."portfoliocompanies"\("id"\)\s+ON DELETE cascade/i);
+    expect(sql).not.toMatch(/REFERENCES\s+portfolio_companies\(id\)/i);
+    expect(sql).toMatch(/ADD CONSTRAINT "planning_fmv_override_requests_fund_id_funds_id_fk"/);
+    expect(sql).toMatch(
+      /ADD CONSTRAINT "planning_fmv_override_requests_company_id_portfoliocompanies_id_fk"/
+    );
+    expect(sql).toMatch(
+      /ADD CONSTRAINT "planning_fmv_override_requests_valuation_mark_id_valuation_marks_id_fk"/
+    );
   });
 
   it('errors when a synthetic new journaled migration has no marker', () => {

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -18,6 +18,7 @@ const C1_MOUNTED_TABLES = [
   'vehicles',
   'cash_flow_events',
   'valuation_marks',
+  'planning_fmv_override_requests',
   'lp_metric_runs',
   'evidence_records',
   'narrative_runs',
@@ -44,6 +45,10 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   dualForecastRouter: { kind: 'other-table' },
   allocationsRouter: { kind: 'other-table' },
   allocationScenariosRouter: { kind: 'other-table' },
+  planningFmvOverridesRouter: {
+    kind: 'c1',
+    tables: ['valuation_marks', 'planning_fmv_override_requests'],
+  },
   fundScenarioSetsRouter: { kind: 'other-table' },
   fundMoicRouter: { kind: 'c1', tables: ['fund_calculation_modes', 'reconciliation_runs'] },
   reallocationRouter: { kind: 'other-table' },

--- a/tests/unit/routes/planning-fmv-overrides-route.test.ts
+++ b/tests/unit/routes/planning-fmv-overrides-route.test.ts
@@ -1,0 +1,81 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createPlanningFmvOverrideMock } = vi.hoisted(() => ({
+  createPlanningFmvOverrideMock: vi.fn(),
+}));
+
+vi.mock('../../../server/services/lp-reporting/planning-fmv-override-service', () => {
+  class PlanningFmvOverrideError extends Error {
+    readonly status: number;
+    readonly code: string;
+    readonly details?: unknown;
+
+    constructor(status: number, code: string, message: string, details?: unknown) {
+      super(message);
+      this.status = status;
+      this.code = code;
+      this.details = details;
+    }
+  }
+
+  return {
+    PlanningFmvOverrideError,
+    createPlanningFmvOverride: createPlanningFmvOverrideMock,
+    listLatestPlanningFmvOverrides: vi.fn(),
+  };
+});
+
+async function authHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '7',
+    email: 'admin@example.com',
+    role: 'admin',
+    fundIds: [],
+  })}`;
+}
+
+async function makeApp() {
+  const { default: planningFmvOverridesRouter } =
+    await import('../../../server/routes/planning-fmv-overrides');
+  const app = express();
+  app.use(express.json());
+  app.use(planningFmvOverridesRouter);
+  return app;
+}
+
+describe('planning FMV overrides route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env._EXPLICIT_NODE_ENV = 'test';
+    process.env.JWT_ALG = 'HS256';
+    process.env._EXPLICIT_JWT_ALG = 'HS256';
+    process.env.JWT_SECRET = 'planning-fmv-route-test-secret-32-chars';
+    process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+    process.env.JWT_AUDIENCE = 'updog-test';
+    process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+    process.env.JWT_ISSUER = 'updog-test';
+    process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  });
+
+  it('rejects roundId before invoking the write service', async () => {
+    const app = await makeApp();
+    const response = await request(app)
+      .post('/funds/1/planning/fmv-overrides')
+      .set('Authorization', await authHeader())
+      .set('Idempotency-Key', 'planning-fmv-route-1')
+      .send({
+        companyId: 42,
+        markDate: '2026-06-30',
+        fairValue: '12500000.000000',
+        reason: 'Approved FMV',
+        roundId: 10,
+      });
+
+    expect(response.status).toBe(400);
+    expect(createPlanningFmvOverrideMock).not.toHaveBeenCalled();
+  }, 10_000);
+});

--- a/tests/unit/schema/lp-reporting-evidence-schema.test.ts
+++ b/tests/unit/schema/lp-reporting-evidence-schema.test.ts
@@ -31,6 +31,11 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       expect(typeof schema.valuationMarks).toBe('object');
     });
 
+    it('planningFmvOverrideRequests table is accessible', () => {
+      expect(schema.planningFmvOverrideRequests).toBeDefined();
+      expect(typeof schema.planningFmvOverrideRequests).toBe('object');
+    });
+
     it('lpMetricRuns table is accessible', () => {
       expect(schema.lpMetricRuns).toBeDefined();
       expect(typeof schema.lpMetricRuns).toBe('object');
@@ -72,6 +77,7 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       ['vehicles', schema.vehicles],
       ['cash_flow_events', schema.cashFlowEvents],
       ['valuation_marks', schema.valuationMarks],
+      ['planning_fmv_override_requests', schema.planningFmvOverrideRequests],
       ['lp_metric_runs', schema.lpMetricRuns],
       ['narrative_runs', schema.narrativeRuns],
       ['evidence_records', schema.evidenceRecords],
@@ -143,6 +149,12 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       expect(names).toContain('lp_metric_run_type_check');
       expect(names).toContain('lp_metric_run_perspective_check');
       expect(names).toContain('lp_metric_run_status_check');
+    });
+
+    it('planning_fmv_override_requests declares the status CHECK', () => {
+      const config = getTableConfig(schema.planningFmvOverrideRequests);
+      const names = config.checks.map((c) => c.name);
+      expect(names).toContain('planning_fmv_override_request_status_check');
     });
 
     it('lp_metric_runs exposes lifecycle concurrency and lock audit columns', () => {
@@ -266,6 +278,20 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       );
       expect(historyConfig.indexes.map((idx) => idx.config.name)).toContain(
         'idx_lp_vehicle_participation_history_parent_changed_at'
+      );
+    });
+
+    it('indexes Planning FMV override ledger and active valuation mark selection', () => {
+      const valuationConfig = getTableConfig(schema.valuationMarks);
+      const requestConfig = getTableConfig(schema.planningFmvOverrideRequests);
+      expect(valuationConfig.indexes.map((idx) => idx.config.name)).toContain(
+        'idx_valuation_marks_planning_active_mark_date'
+      );
+      expect(requestConfig.indexes.map((idx) => idx.config.name)).toContain(
+        'idx_planning_fmv_override_requests_fund_company_created'
+      );
+      expect(requestConfig.indexes.map((idx) => idx.config.name)).toContain(
+        'idx_planning_fmv_override_requests_valuation_mark'
       );
     });
   });
@@ -488,6 +514,7 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
       const vehicleSelect: schema.Vehicle | null = null;
       const cfeSelect: schema.CashFlowEvent | null = null;
       const vmSelect: schema.ValuationMark | null = null;
+      const pfmvSelect: schema.PlanningFmvOverrideRequest | null = null;
       const mrSelect: schema.LpMetricRun | null = null;
       const nrSelect: schema.NarrativeRun | null = null;
       const erSelect: schema.EvidenceRecord | null = null;
@@ -499,6 +526,7 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
         vehicleSelect,
         cfeSelect,
         vmSelect,
+        pfmvSelect,
         mrSelect,
         nrSelect,
         erSelect,
@@ -506,7 +534,7 @@ describe('LP Reporting Foundation Schema -- Drizzle bindings', () => {
         rpkeSelect,
         lvpSelect,
         lvphSelect,
-      ]).toHaveLength(10);
+      ]).toHaveLength(11);
     });
   });
 });

--- a/tests/unit/services/lp-reporting/active-valuation-mark-selector.test.ts
+++ b/tests/unit/services/lp-reporting/active-valuation-mark-selector.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectActiveValuationMarks } from '../../../../server/services/lp-reporting/active-valuation-mark-selector';
+import type { ParsedValuationMark } from '../../../../server/services/lp-reporting/metrics-engine';
+
+function mark(overrides: Partial<ParsedValuationMark> & Pick<ParsedValuationMark, 'id'>) {
+  return {
+    fairValue: '1000000.000000',
+    markDate: '2026-03-31',
+    asOfDate: '2026-03-31',
+    status: 'approved',
+    confidenceLevel: 'medium',
+    companyId: 42,
+    ...overrides,
+  } satisfies ParsedValuationMark;
+}
+
+describe('selectActiveValuationMarks', () => {
+  it('selects one latest mark per company and tie-breaks same-day marks by higher id', () => {
+    const result = selectActiveValuationMarks(
+      [
+        mark({ id: 10, fairValue: '1000000.000000' }),
+        mark({ id: 11, fairValue: '2000000.000000' }),
+        mark({ id: 12, fairValue: '3000000.000000', markDate: '2026-02-28' }),
+      ],
+      '2026-03-31'
+    );
+
+    expect(result.active.map((activeMark) => activeMark.id)).toEqual([11]);
+  });
+
+  it('excludes future, superseded, and reversed marks', () => {
+    const result = selectActiveValuationMarks(
+      [
+        mark({ id: 20, status: 'superseded' }),
+        mark({ id: 21, status: 'reversed' }),
+        mark({ id: 22, markDate: '2026-04-01' }),
+        mark({ id: 23, markDate: '2026-03-30' }),
+      ],
+      '2026-03-31'
+    );
+
+    expect(result.active.map((activeMark) => activeMark.id)).toEqual([23]);
+    expect(result.excludedFutureMarkIds).toEqual([22]);
+  });
+});

--- a/tests/unit/services/lp-reporting/metric-run-commit-service.test.ts
+++ b/tests/unit/services/lp-reporting/metric-run-commit-service.test.ts
@@ -241,6 +241,51 @@ describe('commitMetricRun', () => {
     expect(fakeDb.insertedMetricRows).toHaveLength(1);
   });
 
+  it('active_as_of resolves and stores concrete contributing mark IDs', async () => {
+    const fakeDb = new FakeMetricRunDb();
+    const sourceIds = seedHappyPath(fakeDb);
+    fakeDb.marks.push(
+      {
+        id: 202,
+        fundId: 1,
+        fairValue: '5000000.000000',
+        markDate: '2026-03-31',
+        asOfDate: '2026-03-31',
+        status: 'approved',
+        confidenceLevel: 'medium',
+        companyId: 42,
+        sourceHash: '5'.repeat(64),
+        importBatchId: 11,
+        updatedAt: new Date('2026-01-03T00:00:00Z'),
+      },
+      {
+        id: 203,
+        fundId: 1,
+        fairValue: '9000000.000000',
+        markDate: '2026-06-30',
+        asOfDate: '2026-06-30',
+        status: 'approved',
+        confidenceLevel: 'low',
+        companyId: 42,
+        sourceHash: '6'.repeat(64),
+        importBatchId: 11,
+        updatedAt: new Date('2026-01-04T00:00:00Z'),
+      }
+    );
+
+    const input = await buildCommitInput(
+      fakeDb,
+      { eventIds: sourceIds.eventIds, markIds: [] },
+      { sourceMarkSelection: 'active_as_of' }
+    );
+    await commitMetricRun(input, { database: fakeDb.asDatabase() });
+
+    const inserted = fakeDb.insertedMetricRows[0] as Record<string, unknown>;
+    const results = inserted['resultsJson'] as { currentNav?: string };
+    expect(inserted['sourceMarkIds']).toEqual([202]);
+    expect(results.currentNav).toBe('5000000.000000');
+  });
+
   it('rejects stale source-row fingerprints with PREVIEW_HASH_MISMATCH', async () => {
     const fakeDb = new FakeMetricRunDb();
     const sourceIds = seedHappyPath(fakeDb);

--- a/tests/unit/services/lp-reporting/planning-fmv-override-service.test.ts
+++ b/tests/unit/services/lp-reporting/planning-fmv-override-service.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import type { db } from '../../../../server/db';
+import {
+  createPlanningFmvOverride,
+  type CreatePlanningFmvOverrideInput,
+} from '../../../../server/services/lp-reporting/planning-fmv-override-service';
+import { planningFmvOverrideRequests, valuationMarks } from '@shared/schema/lp-reporting-evidence';
+import { portfolioCompanies } from '@shared/schema/portfolio';
+
+type PlanningFmvDatabase = typeof db;
+
+interface FakePlanningFmvRequest {
+  id: number;
+  fundId: number;
+  companyId: number;
+  valuationMarkId: number | null;
+  idempotencyKey: string;
+  requestHash: string;
+  sourceHash: string;
+  status: 'pending' | 'completed' | 'failed';
+  responseBody: unknown | null;
+  failureCode: string | null;
+  failureMessage: string | null;
+  createdBy: number | null;
+  createdAt: Date;
+  completedAt: Date | null;
+  updatedAt: Date;
+}
+
+interface FakeCompany {
+  id: number;
+  fundId: number;
+}
+
+class FakePlanningFmvDb {
+  readonly companies: FakeCompany[] = [];
+  readonly requests: FakePlanningFmvRequest[] = [];
+  readonly insertedMarks: unknown[] = [];
+  private nextRequestId = 700;
+
+  asDatabase(): PlanningFmvDatabase {
+    return this as unknown as PlanningFmvDatabase;
+  }
+
+  transaction<T>(operation: (transaction: PlanningFmvDatabase) => Promise<T>): Promise<T> {
+    return operation(this.asDatabase());
+  }
+
+  select(_projection?: unknown) {
+    return {
+      from: (table: unknown) => ({
+        where: (_condition: unknown) => ({
+          limit: (count: number) => Promise.resolve(this.rowsFor(table).slice(0, count)),
+          orderBy: (..._order: unknown[]) => Promise.resolve(this.rowsFor(table)),
+        }),
+      }),
+    };
+  }
+
+  insert(table: unknown) {
+    return {
+      values: (row: Record<string, unknown>) => ({
+        onConflictDoNothing: () => ({
+          returning: () => {
+            if (table !== planningFmvOverrideRequests) {
+              return Promise.resolve([]);
+            }
+
+            const request: FakePlanningFmvRequest = {
+              id: this.nextRequestId++,
+              fundId: row['fundId'] as number,
+              companyId: row['companyId'] as number,
+              valuationMarkId: null,
+              idempotencyKey: row['idempotencyKey'] as string,
+              requestHash: row['requestHash'] as string,
+              sourceHash: row['sourceHash'] as string,
+              status: 'pending',
+              responseBody: null,
+              failureCode: null,
+              failureMessage: null,
+              createdBy: row['createdBy'] as number | null,
+              createdAt: new Date('2026-06-30T00:00:00Z'),
+              completedAt: null,
+              updatedAt: new Date('2026-06-30T00:00:00Z'),
+            };
+            this.requests.push(request);
+            return Promise.resolve([request]);
+          },
+        }),
+        returning: () => {
+          if (table === valuationMarks) {
+            this.insertedMarks.push(row);
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    };
+  }
+
+  update(table: unknown) {
+    return {
+      set: (patch: Partial<FakePlanningFmvRequest>) => ({
+        where: (_condition: unknown) => {
+          if (table === planningFmvOverrideRequests) {
+            const request = this.requests.at(-1);
+            if (request) {
+              Object.assign(request, patch);
+            }
+          }
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  private rowsFor(table: unknown): Array<Record<string, unknown>> {
+    if (table === portfolioCompanies) {
+      return this.companies as unknown as Array<Record<string, unknown>>;
+    }
+    return [];
+  }
+}
+
+function createInput(
+  overrides: Partial<CreatePlanningFmvOverrideInput> = {}
+): CreatePlanningFmvOverrideInput {
+  return {
+    fundId: 1,
+    idempotencyKey: 'planning-fmv-service-test-1',
+    actor: { userId: 7 },
+    body: {
+      companyId: 42,
+      markDate: '2026-06-30',
+      fairValue: '12500000.000000',
+      currency: 'USD',
+      confidenceLevel: 'medium',
+      reason: 'Approved Planning FMV',
+      source: {
+        allocationVersion: 3,
+        plannedReservesCents: 5000000,
+        allocationReason: 'Follow-on plan',
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('createPlanningFmvOverride', () => {
+  it('rejects cross-fund companies before inserting a valuation mark', async () => {
+    const fakeDb = new FakePlanningFmvDb();
+    fakeDb.companies.push({ id: 42, fundId: 99 });
+
+    await expect(
+      createPlanningFmvOverride(createInput(), { database: fakeDb.asDatabase() })
+    ).rejects.toMatchObject({
+      status: 404,
+      code: 'planning_fmv_company_not_found',
+    });
+
+    expect(fakeDb.insertedMarks).toHaveLength(0);
+    expect(fakeDb.requests[0]).toMatchObject({
+      status: 'failed',
+      failureCode: 'planning_fmv_company_not_found',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a feature-flagged Planning FMV override workflow in the allocation workspace that writes append-only approved `valuation_marks` plus an idempotency ledger.
- Add strict Planning FMV contracts and API routes, mounted on both app route surfaces, with `roundId`/scenario identity rejected before service execution.
- Add active-as-of LP metric-run mark selection that resolves and stores concrete contributing valuation mark IDs.
- Add service-level company/fund ownership validation before inserting Planning FMV valuation marks, covering the verifier-identified cross-fund bug.

## Verification
- `npx cross-env TZ=UTC vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/contract/lp-reporting/lp-metric-run.contract.test.ts tests/unit/contract/lp-reporting/planning-fmv-override.contract.test.ts tests/unit/services/lp-reporting/active-valuation-mark-selector.test.ts tests/unit/services/lp-reporting/metric-run-commit-service.test.ts tests/unit/services/lp-reporting/planning-fmv-override-service.test.ts tests/unit/routes/planning-fmv-overrides-route.test.ts tests/unit/schema/lp-reporting-evidence-schema.test.ts tests/unit/mount-parity-migrations.test.ts`
- `npx cross-env TZ=UTC vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/components/lp-reporting/MetricRunForm.test.tsx tests/unit/flags/enable-planning-fmv-overrides.test.tsx tests/unit/components/portfolio/fmv-override-dialog.test.tsx tests/unit/components/portfolio/allocations-workspace.test.tsx tests/unit/components/portfolio/allocations-tab-empty-state.test.tsx`
- `npx cross-env TZ=UTC vitest run --config vitest.config.mjs --configLoader native tests/unit/flags/flag-registry-parity.test.ts`
- `npm run check`
- `npm run lint`
- `npm run validate:schema-drift`
- `npm run policy:verify`
- `git diff --check`
- `UPDOG_RELEASE_CHECK_SKIP_DB=1 npm run release:check`

## Proof boundary
- Full DB-backed `npm run release:check` was not completed on this Windows shell because local Testcontainers/container runtime support is unavailable. The skip-DB release check is diagnostic evidence only, not full release proof.