### PR TITLE
fix(schema): PR-2b-1 journal resync + allocation promotion

### DIFF
--- a/migrations/0023_version_default_resync_drift.sql
+++ b/migrations/0023_version_default_resync_drift.sql
@@ -1,0 +1,5 @@
+-- @drift-patch
+-- Reason: resync journal to shared/schema; version columns default 0 (shape) not 1 (journal). 0021_version_columns_bigint_drift fixed int->bigint type only; this fixes the residual DEFAULT drift. Additive ALTER; no prod apply.
+ALTER TABLE forecast_snapshots ALTER COLUMN version SET DEFAULT 0;
+ALTER TABLE investment_lots ALTER COLUMN version SET DEFAULT 0;
+ALTER TABLE reserve_allocations ALTER COLUMN version SET DEFAULT 0;

--- a/migrations/0024_idempotency_cursor_resync_drift.sql
+++ b/migrations/0024_idempotency_cursor_resync_drift.sql
@@ -1,0 +1,14 @@
+-- @drift-patch
+-- Reason: resync journal to shared/schema; add idempotency-key length CHECKs, the fund/investment/snapshot-scoped idempotency unique indexes, and the cursor indexes that exist in the Drizzle shape but lived only in the loose (non-journaled) 0001_portfolio_schema_hardening file. Additive (CREATE-only); no prod apply. The pre-existing global *_idempotency_unique_idx (journal 0001_certain_miracleman) is intentionally retained here and deferred to PR-1/operator alongside the FK-name reconcile seam.
+-- forecast_snapshots
+ALTER TABLE forecast_snapshots ADD CONSTRAINT forecast_snapshots_idem_key_len_check CHECK (idempotency_key IS NULL OR (length(idempotency_key) >= 1 AND length(idempotency_key) <= 128));
+CREATE UNIQUE INDEX forecast_snapshots_fund_idem_key_idx ON forecast_snapshots (fund_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX forecast_snapshots_fund_cursor_idx ON forecast_snapshots (fund_id, snapshot_time DESC, id DESC);
+-- investment_lots
+ALTER TABLE investment_lots ADD CONSTRAINT investment_lots_idem_key_len_check CHECK (idempotency_key IS NULL OR (length(idempotency_key) >= 1 AND length(idempotency_key) <= 128));
+CREATE UNIQUE INDEX investment_lots_investment_idem_key_idx ON investment_lots (investment_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX investment_lots_investment_cursor_idx ON investment_lots (investment_id, created_at DESC, id DESC);
+-- reserve_allocations
+ALTER TABLE reserve_allocations ADD CONSTRAINT reserve_allocations_idem_key_len_check CHECK (idempotency_key IS NULL OR (length(idempotency_key) >= 1 AND length(idempotency_key) <= 128));
+CREATE UNIQUE INDEX reserve_allocations_snapshot_idem_key_idx ON reserve_allocations (snapshot_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX reserve_allocations_snapshot_cursor_idx ON reserve_allocations (snapshot_id, created_at DESC, id DESC);

--- a/migrations/0025_allocation_scenarios_promote_drift.sql
+++ b/migrations/0025_allocation_scenarios_promote_drift.sql
@@ -1,0 +1,77 @@
+-- @drift-patch
+-- Reason: promote the live allocation-scenario surface (allocation_scenarios + _items + _ic_decisions + _events) from server/migrations (20260330_*/20260406_*) into the canonical Drizzle shape (shared/schema/allocation-scenarios.ts) + journal. These 4 tables are a mounted makeApp prod surface absent from both shape and journal; promotion gives them a canonical home so the server files can retire (PR-2b-3). allocation_scenario_decisions is dead (no consumer) and is intentionally NOT promoted. Additive (CREATE-only); no prod apply.
+CREATE TABLE allocation_scenarios (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  fund_id integer NOT NULL REFERENCES funds(id) ON DELETE CASCADE,
+  name varchar(120) NOT NULL,
+  notes text,
+  source_allocation_version integer,
+  company_count integer NOT NULL DEFAULT 0,
+  total_planned_cents bigint NOT NULL DEFAULT 0,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  last_applied_at timestamp with time zone,
+  last_applied_by text,
+  last_applied_allocation_version integer,
+  last_synced_at timestamp with time zone,
+  last_synced_by text
+);
+CREATE INDEX allocation_scenarios_fund_updated_idx ON allocation_scenarios (fund_id, updated_at DESC, id DESC);
+
+CREATE TABLE allocation_scenario_items (
+  scenario_id uuid NOT NULL REFERENCES allocation_scenarios(id) ON DELETE CASCADE,
+  company_id integer NOT NULL REFERENCES portfoliocompanies(id) ON DELETE CASCADE,
+  planned_reserves_cents bigint NOT NULL DEFAULT 0,
+  allocation_cap_cents bigint,
+  allocation_reason text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  PRIMARY KEY (scenario_id, company_id),
+  CONSTRAINT allocation_scenario_items_non_negative_planned CHECK (planned_reserves_cents >= 0),
+  CONSTRAINT allocation_scenario_items_non_negative_cap CHECK (allocation_cap_cents IS NULL OR allocation_cap_cents >= 0),
+  CONSTRAINT allocation_scenario_items_cap_gte_planned CHECK (allocation_cap_cents IS NULL OR allocation_cap_cents >= planned_reserves_cents)
+);
+CREATE INDEX allocation_scenario_items_scenario_idx ON allocation_scenario_items (scenario_id, company_id);
+
+CREATE TABLE allocation_scenario_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scenario_id uuid NOT NULL REFERENCES allocation_scenarios(id) ON DELETE CASCADE,
+  fund_id integer NOT NULL REFERENCES funds(id) ON DELETE CASCADE,
+  event_type varchar(32) NOT NULL,
+  actor_user_id integer REFERENCES users(id),
+  actor_label text,
+  note text,
+  source_allocation_version integer,
+  resulting_allocation_version integer,
+  change_summary_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT allocation_scenario_events_type_check CHECK (event_type IN ('applied', 'synced'))
+);
+CREATE INDEX allocation_scenario_events_scenario_created_idx ON allocation_scenario_events (scenario_id, created_at DESC, id DESC);
+CREATE INDEX allocation_scenario_events_fund_created_idx ON allocation_scenario_events (fund_id, created_at DESC, id DESC);
+
+CREATE TABLE allocation_scenario_ic_decisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scenario_id uuid NOT NULL REFERENCES allocation_scenarios(id) ON DELETE CASCADE,
+  fund_id integer NOT NULL REFERENCES funds(id) ON DELETE CASCADE,
+  company_id integer NOT NULL REFERENCES portfoliocompanies(id) ON DELETE CASCADE,
+  decision_type varchar(32) NOT NULL,
+  decision_status varchar(32) NOT NULL DEFAULT 'draft',
+  rationale text NOT NULL,
+  proposed_planned_reserves_cents bigint,
+  final_planned_reserves_cents bigint,
+  decided_by_user_id integer REFERENCES users(id),
+  decided_by_label text,
+  decided_at timestamp with time zone,
+  source_allocation_version integer,
+  live_allocation_version integer,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT allocation_scenario_ic_decisions_unique_company UNIQUE (scenario_id, company_id),
+  CONSTRAINT allocation_scenario_ic_decisions_type_check CHECK (decision_type IN ('follow_on', 'defer', 'cut_reserve', 'no_action')),
+  CONSTRAINT allocation_scenario_ic_decisions_status_check CHECK (decision_status IN ('draft', 'proposed', 'approved', 'rejected')),
+  CONSTRAINT allocation_scenario_ic_decisions_proposed_non_negative CHECK (proposed_planned_reserves_cents IS NULL OR proposed_planned_reserves_cents >= 0),
+  CONSTRAINT allocation_scenario_ic_decisions_final_non_negative CHECK (final_planned_reserves_cents IS NULL OR final_planned_reserves_cents >= 0)
+);
+CREATE INDEX allocation_scenario_ic_decisions_scenario_idx ON allocation_scenario_ic_decisions (scenario_id, company_id);
+CREATE INDEX allocation_scenario_ic_decisions_fund_idx ON allocation_scenario_ic_decisions (fund_id, scenario_id, updated_at DESC, id DESC);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -169,6 +169,27 @@
       "when": 1782777601000,
       "tag": "0022_planning_fmv_override_requests_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1782777602000,
+      "tag": "0023_version_default_resync_drift",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1782777603000,
+      "tag": "0024_idempotency_cursor_resync_drift",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1782777604000,
+      "tag": "0025_allocation_scenarios_promote_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -34,6 +34,7 @@ export * from './schema/fund';
 export * from './schema/portfolio';
 export * from './schema/scenario';
 export * from './schema/shares';
+export * from './schema/allocation-scenarios';
 export * from './schema/user';
 export * from './schema/lp-reporting-evidence';
 export * from './schema/operating-objects';

--- a/shared/schema/allocation-scenarios.ts
+++ b/shared/schema/allocation-scenarios.ts
@@ -1,0 +1,201 @@
+import { sql } from 'drizzle-orm';
+import {
+  bigint,
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  unique,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { funds } from './fund';
+import { portfolioCompanies } from './portfolio';
+import { users } from './user';
+
+// ============================================================================
+// ALLOCATION SCENARIOS — durable allocation planning surface.
+// Promoted PR-2b-1 from server/migrations (20260330_*/20260406_*) into the
+// canonical Drizzle shape + journal (0025). Live makeApp prod surface
+// (server/routes/allocation-scenarios.ts). allocation_scenario_decisions is
+// dead (no consumer) and intentionally NOT promoted.
+// ============================================================================
+
+export const allocationScenarios = pgTable(
+  'allocation_scenarios',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 120 }).notNull(),
+    notes: text('notes'),
+    sourceAllocationVersion: integer('source_allocation_version'),
+    companyCount: integer('company_count').notNull().default(0),
+    totalPlannedCents: bigint('total_planned_cents', { mode: 'bigint' })
+      .notNull()
+      .default(sql`0`),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    lastAppliedAt: timestamp('last_applied_at', { withTimezone: true }),
+    lastAppliedBy: text('last_applied_by'),
+    lastAppliedAllocationVersion: integer('last_applied_allocation_version'),
+    lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
+    lastSyncedBy: text('last_synced_by'),
+  },
+  (table) => ({
+    fundUpdatedIdx: index('allocation_scenarios_fund_updated_idx').on(
+      table.fundId,
+      table.updatedAt.desc(),
+      table.id.desc()
+    ),
+  })
+);
+
+export const allocationScenarioItems = pgTable(
+  'allocation_scenario_items',
+  {
+    scenarioId: uuid('scenario_id')
+      .notNull()
+      .references(() => allocationScenarios.id, { onDelete: 'cascade' }),
+    companyId: integer('company_id')
+      .notNull()
+      .references(() => portfolioCompanies.id, { onDelete: 'cascade' }),
+    plannedReservesCents: bigint('planned_reserves_cents', { mode: 'bigint' })
+      .notNull()
+      .default(sql`0`),
+    allocationCapCents: bigint('allocation_cap_cents', { mode: 'bigint' }),
+    allocationReason: text('allocation_reason'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    pk: primaryKey({
+      name: 'allocation_scenario_items_pkey',
+      columns: [table.scenarioId, table.companyId],
+    }),
+    scenarioIdx: index('allocation_scenario_items_scenario_idx').on(
+      table.scenarioId,
+      table.companyId
+    ),
+    nonNegativePlanned: check(
+      'allocation_scenario_items_non_negative_planned',
+      sql`${table.plannedReservesCents} >= 0`
+    ),
+    nonNegativeCap: check(
+      'allocation_scenario_items_non_negative_cap',
+      sql`${table.allocationCapCents} IS NULL OR ${table.allocationCapCents} >= 0`
+    ),
+    capGtePlanned: check(
+      'allocation_scenario_items_cap_gte_planned',
+      sql`${table.allocationCapCents} IS NULL OR ${table.allocationCapCents} >= ${table.plannedReservesCents}`
+    ),
+  })
+);
+
+export const allocationScenarioEvents = pgTable(
+  'allocation_scenario_events',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    scenarioId: uuid('scenario_id')
+      .notNull()
+      .references(() => allocationScenarios.id, { onDelete: 'cascade' }),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    eventType: varchar('event_type', { length: 32 }).notNull(),
+    actorUserId: integer('actor_user_id').references(() => users.id),
+    actorLabel: text('actor_label'),
+    note: text('note'),
+    sourceAllocationVersion: integer('source_allocation_version'),
+    resultingAllocationVersion: integer('resulting_allocation_version'),
+    changeSummaryJson: jsonb('change_summary_json').notNull().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    scenarioCreatedIdx: index('allocation_scenario_events_scenario_created_idx').on(
+      table.scenarioId,
+      table.createdAt.desc(),
+      table.id.desc()
+    ),
+    fundCreatedIdx: index('allocation_scenario_events_fund_created_idx').on(
+      table.fundId,
+      table.createdAt.desc(),
+      table.id.desc()
+    ),
+    typeCheck: check(
+      'allocation_scenario_events_type_check',
+      sql`${table.eventType} IN ('applied', 'synced')`
+    ),
+  })
+);
+
+export const allocationScenarioIcDecisions = pgTable(
+  'allocation_scenario_ic_decisions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    scenarioId: uuid('scenario_id')
+      .notNull()
+      .references(() => allocationScenarios.id, { onDelete: 'cascade' }),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    companyId: integer('company_id')
+      .notNull()
+      .references(() => portfolioCompanies.id, { onDelete: 'cascade' }),
+    decisionType: varchar('decision_type', { length: 32 }).notNull(),
+    decisionStatus: varchar('decision_status', { length: 32 }).notNull().default('draft'),
+    rationale: text('rationale').notNull(),
+    proposedPlannedReservesCents: bigint('proposed_planned_reserves_cents', { mode: 'bigint' }),
+    finalPlannedReservesCents: bigint('final_planned_reserves_cents', { mode: 'bigint' }),
+    decidedByUserId: integer('decided_by_user_id').references(() => users.id),
+    decidedByLabel: text('decided_by_label'),
+    decidedAt: timestamp('decided_at', { withTimezone: true }),
+    sourceAllocationVersion: integer('source_allocation_version'),
+    liveAllocationVersion: integer('live_allocation_version'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    uniqueCompany: unique('allocation_scenario_ic_decisions_unique_company').on(
+      table.scenarioId,
+      table.companyId
+    ),
+    scenarioIdx: index('allocation_scenario_ic_decisions_scenario_idx').on(
+      table.scenarioId,
+      table.companyId
+    ),
+    fundIdx: index('allocation_scenario_ic_decisions_fund_idx').on(
+      table.fundId,
+      table.scenarioId,
+      table.updatedAt.desc(),
+      table.id.desc()
+    ),
+    typeCheck: check(
+      'allocation_scenario_ic_decisions_type_check',
+      sql`${table.decisionType} IN ('follow_on', 'defer', 'cut_reserve', 'no_action')`
+    ),
+    statusCheck: check(
+      'allocation_scenario_ic_decisions_status_check',
+      sql`${table.decisionStatus} IN ('draft', 'proposed', 'approved', 'rejected')`
+    ),
+    proposedNonNegative: check(
+      'allocation_scenario_ic_decisions_proposed_non_negative',
+      sql`${table.proposedPlannedReservesCents} IS NULL OR ${table.proposedPlannedReservesCents} >= 0`
+    ),
+    finalNonNegative: check(
+      'allocation_scenario_ic_decisions_final_non_negative',
+      sql`${table.finalPlannedReservesCents} IS NULL OR ${table.finalPlannedReservesCents} >= 0`
+    ),
+  })
+);
+
+export type AllocationScenario = typeof allocationScenarios.$inferSelect;
+export type AllocationScenarioItem = typeof allocationScenarioItems.$inferSelect;
+export type AllocationScenarioEvent = typeof allocationScenarioEvents.$inferSelect;
+export type AllocationScenarioIcDecision = typeof allocationScenarioIcDecisions.$inferSelect;

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -72,8 +72,10 @@ const KNOWN_INTERSECTION_DRIFT = new Set<string>([
   'forecast_snapshots|index|forecast_snapshots_idempotency_unique_idx',
   'investment_lots|index|investment_lots_idempotency_unique_idx',
   'reserve_allocations|index|reserve_allocations_idempotency_unique_idx',
-  // Pending §7 baselineNotObserved: identical columns/method/uniqueness on both sides; if the
-  // testcontainers run lists these as not-observed, shrink them in a follow-up Set edit.
+  // §7 (run 28437747790) CONFIRMED these as still-observed = REAL drift, not stale: identical
+  // column set / method / uniqueness by introspection, yet DB-A (journal) != DB-B (shape push)
+  // on some catalog detail the comparator gates (storage param / collation). Deferred to
+  // PR-1/operator; do NOT shrink without a fresh §7 baselineNotObserved signal.
   'reserve_decisions|index|idx_reserve_fund_company',
   'reserve_decisions|index|ux_reserve_unique',
   'fund_snapshots|fk|fund_snapshots_config_id_fundconfigs_id_fk',

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -65,27 +65,20 @@ const EXPECTED_TRIGGERS = [
   'optimization_sessions_updated_at',
 ] as const;
 const KNOWN_INTERSECTION_DRIFT = new Set<string>([
-  'forecast_snapshots|constraint|forecast_snapshots_idem_key_len_check',
-  'forecast_snapshots|index|forecast_snapshots_fund_cursor_idx',
-  'forecast_snapshots|index|forecast_snapshots_fund_idem_key_idx',
+  // Deferred to PR-1/operator (NOT additive journal catch-up): these three are a global->scoped
+  // idempotency rename — journal 0001_certain_miracleman created UNIQUE(idempotency_key) alone;
+  // shared/schema now declares the scoped *_idem_key_idx (added by 0024). Reconciling the old name
+  // means a DROP that implicates prod, so it ships with the FK-name seam in PR-1/operator scope.
   'forecast_snapshots|index|forecast_snapshots_idempotency_unique_idx',
-  'investment_lots|constraint|investment_lots_idem_key_len_check',
-  'investment_lots|index|investment_lots_investment_cursor_idx',
-  'investment_lots|index|investment_lots_investment_idem_key_idx',
   'investment_lots|index|investment_lots_idempotency_unique_idx',
-  'reserve_allocations|constraint|reserve_allocations_idem_key_len_check',
-  'reserve_allocations|index|reserve_allocations_snapshot_cursor_idx',
-  'reserve_allocations|index|reserve_allocations_snapshot_idem_key_idx',
   'reserve_allocations|index|reserve_allocations_idempotency_unique_idx',
+  // Pending §7 baselineNotObserved: identical columns/method/uniqueness on both sides; if the
+  // testcontainers run lists these as not-observed, shrink them in a follow-up Set edit.
   'reserve_decisions|index|idx_reserve_fund_company',
   'reserve_decisions|index|ux_reserve_unique',
   'fund_snapshots|fk|fund_snapshots_config_id_fundconfigs_id_fk',
   'fund_snapshots|fk|fund_snapshots_run_id_calc_runs_id_fk',
   'job_outbox|constraint|job_outbox_status_check',
-  // version column default drift: journal DEFAULT 1 vs shared/schema DEFAULT 0 (0021 fixed the type, not the default) — deferred to PR-2b re-sync.
-  'forecast_snapshots|column|version',
-  'investment_lots|column|version',
-  'reserve_allocations|column|version',
 ]);
 
 type TableShapeMap<TShape> = Map<string, Map<string, TShape>>;

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -43,6 +43,9 @@ const expectedJournaledDriftPatchFiles = [
   '0020_operating_tasks_drift.sql',
   '0021_version_columns_bigint_drift.sql',
   '0022_planning_fmv_override_requests_drift.sql',
+  '0023_version_default_resync_drift.sql',
+  '0024_idempotency_cursor_resync_drift.sql',
+  '0025_allocation_scenarios_promote_drift.sql',
 ].sort();
 
 afterEach(() => {

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -24,6 +24,10 @@ const C1_MOUNTED_TABLES = [
   'narrative_runs',
   'lp_report_packages',
   'lp_report_package_exports',
+  'allocation_scenarios',
+  'allocation_scenario_items',
+  'allocation_scenario_ic_decisions',
+  'allocation_scenario_events',
 ] as const;
 
 const DEFERRED_DOMAIN_LOCKED_TABLES = [
@@ -44,7 +48,15 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   scenarioAnalysisRouter: { kind: 'other-table' },
   dualForecastRouter: { kind: 'other-table' },
   allocationsRouter: { kind: 'other-table' },
-  allocationScenariosRouter: { kind: 'other-table' },
+  allocationScenariosRouter: {
+    kind: 'c1',
+    tables: [
+      'allocation_scenarios',
+      'allocation_scenario_items',
+      'allocation_scenario_ic_decisions',
+      'allocation_scenario_events',
+    ],
+  },
   planningFmvOverridesRouter: {
     kind: 'c1',
     tables: ['valuation_marks', 'planning_fmv_override_requests'],


### PR DESCRIPTION
## PR-2b-1: Journal resync + allocation promotion

First of the three-PR series retiring the legacy `server/migrations/` topology. **Additive only — no deletions, no repoints, no prod DDL.** Catches the canonical root journal up to the Drizzle shape source and gives the live allocation-scenario surface a canonical home, now that PR-2a (#953) gave the validation path teeth.

### Task 0 preflight (live)
Base = `main` @ `4e71484f` (== `origin/main`, FMV #962 merged). Journal max idx 23 / tag `0022` → next tag **`0023`**, next idx **24** (idx ≠ tag-number). New tags: `0023`/`0024`/`0025` (idx 24/25/26). No file collision.

### Journal catch-up (additive CREATE/ALTER, mirrors `shared/schema` exactly)
- **`0023_version_default_resync_drift`** — `version` DEFAULT 1→0 on `forecast_snapshots` / `investment_lots` / `reserve_allocations` (`0021` fixed int→bigint type only). Behaviorally safe: inserts write `version` explicitly (`lot-service.ts:183`, `snapshot-service.ts:171`); no `WHERE version = N` start-value guard.
- **`0024_idempotency_cursor_resync_drift`** — `*_idem_key_len_check` CHECKs + fund/investment/snapshot-scoped idempotency unique indexes + cursor indexes that existed in the shape but lived only in the **loose, non-journaled** `0001_portfolio_schema_hardening.sql`.

### Allocation promotion (decision 8 — live `makeApp` prod surface, absent from shape+journal)
- **`shared/schema/allocation-scenarios.ts`** — 4 first-class Drizzle tables: `allocation_scenarios` + `allocation_scenario_items` + `allocation_scenario_ic_decisions` + `allocation_scenario_events` (all read by `allocation-scenario-service.ts`). The dead `allocation_scenario_decisions` (**zero repo-wide consumers**) is NOT promoted (retire-only in PR-2b-3).
- **`0025_allocation_scenarios_promote_drift`** — matching journal patch; constraint/index/PK names mirror drizzle's emission so the §7 name-keyed comparator matches.
- **mount-parity** — `allocationScenariosRouter` reclassified `other-table` → `c1` with the 4 tables added to `C1_MOUNTED_TABLES` (recurrence guard now asserts they stay journaled).

### Baseline (`KNOWN_INTERSECTION_DRIFT`) shrunk 20 → 8
**Shrunk 12** (additive catch-up, now journaled by 0023/0024): 3 version-default + 3 `_idem_key_len_check` + 3 cursor idx + 3 scoped `_idem_key_idx`.

**Kept 8 (deferred):**
- 3 `*_idempotency_unique_idx` — these are a **global→scoped rename**: journal `0001_certain_miracleman` created `UNIQUE(idempotency_key)` alone; the shape now declares the scoped `_idem_key_idx` (added by `0024`). Reconciling the old name means a journal **DROP** that would leave the journal ahead of prod — non-additive, so deferred to PR-1/operator alongside the FK-name reconcile seam. (The plan's "17 additive" premise was corrected here after verifying the journaled SQL vs shape.)
- 2 `reserve_decisions` (`ux_reserve_unique`, `idx_reserve_fund_company`) — identical columns/method/uniqueness on both sides, likely already-fixed/stale; kept pending the §7 `baselineNotObserved` signal (risk-asymmetry: removing a still-observed entry would gate-fail).
- 3 original deferred (`job_outbox_status_check`, 2 `fund_snapshots` FKs).

### Verification
| Lane | Result |
| --- | --- |
| `npm run check` (TS, client/server/shared) | **0 errors** |
| `npm run validate:schema-drift` | **ok=true, errors=0** |
| `npm run lint` (changed TS) | **clean** |
| `migration-ledger` / `migration-marker` / `mount-parity` unit | **20/20** |
| §7 `testcontainers-ci.yml` `prod-schema-clone` | **pending CI — run ID to be cited** |

§7 is the gating proof that journal ≡ shape on a fresh clone; `ci-unified run_full_suite` is vacuous for it. The run should show `baselineNotObserved` for the 12 shrunk entries (and resolve the 2 `reserve_decisions`).

### Out of scope (later PRs)
PR-2b-2 repoints every `server/migrations` consumer; PR-2b-3 deletes the non-lane-B server files + adds the new-file guard. Lane-B (`investment_rounds`/overrides) is carved out throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
