### PR TITLE
fix(schema): s8.4 journal drift-patch - recreate reserve_decisions indexes

### DIFF
--- a/migrations/0026_reserve_decisions_index_resync_drift.sql
+++ b/migrations/0026_reserve_decisions_index_resync_drift.sql
@@ -1,0 +1,4 @@
+-- @drift-patch
+-- Reason: resync journal to shared/schema; 0001_certain_miracleman DROP COLUMN + ADD COLUMN of reserve_decisions fund_id/company_id implicitly dropped the two 0000_quick_vivisector indexes that referenced them (ux_reserve_unique, idx_reserve_fund_company) and no later journal migration recreated them, while the Drizzle shape push still emits both (shared/schema.ts reserveDecisions). Statements mirror 0000 verbatim so DB-A catalog definitions converge with DB-B by name AND shape. Additive (CREATE-only); no prod apply — prod (built via db:push) already has both.
+CREATE UNIQUE INDEX "ux_reserve_unique" ON "reserve_decisions" USING btree ("company_id","period_start","period_end","engine_type","engine_version");
+CREATE INDEX "idx_reserve_fund_company" ON "reserve_decisions" USING btree ("fund_id","company_id");

--- a/migrations/0026_reserve_decisions_index_resync_drift.sql
+++ b/migrations/0026_reserve_decisions_index_resync_drift.sql
@@ -1,4 +1,7 @@
 -- @drift-patch
 -- Reason: resync journal to shared/schema; 0001_certain_miracleman DROP COLUMN + ADD COLUMN of reserve_decisions fund_id/company_id implicitly dropped the two 0000_quick_vivisector indexes that referenced them (ux_reserve_unique, idx_reserve_fund_company) and no later journal migration recreated them, while the Drizzle shape push still emits both (shared/schema.ts reserveDecisions). Statements mirror 0000 verbatim so DB-A catalog definitions converge with DB-B by name AND shape. Additive (CREATE-only); no prod apply — prod (built via db:push) already has both.
-CREATE UNIQUE INDEX "ux_reserve_unique" ON "reserve_decisions" USING btree ("company_id","period_start","period_end","engine_type","engine_version");
-CREATE INDEX "idx_reserve_fund_company" ON "reserve_decisions" USING btree ("fund_id","company_id");
+-- IF NOT EXISTS: drift patches are the narrow-apply set for the gated operator path against
+-- db:push-built databases that already carry both indexes; unguarded CREATE would abort there.
+-- Same-name/wrong-shape divergence stays the job of the s7 comparator and the operator re-audit.
+CREATE UNIQUE INDEX IF NOT EXISTS "ux_reserve_unique" ON "reserve_decisions" USING btree ("company_id","period_start","period_end","engine_type","engine_version");
+CREATE INDEX IF NOT EXISTS "idx_reserve_fund_company" ON "reserve_decisions" USING btree ("fund_id","company_id");

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1782777604000,
       "tag": "0025_allocation_scenarios_promote_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1782952890536,
+      "tag": "0026_reserve_decisions_index_resync_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -72,12 +72,12 @@ const KNOWN_INTERSECTION_DRIFT = new Set<string>([
   'forecast_snapshots|index|forecast_snapshots_idempotency_unique_idx',
   'investment_lots|index|investment_lots_idempotency_unique_idx',
   'reserve_allocations|index|reserve_allocations_idempotency_unique_idx',
-  // §7 (run 28437747790) CONFIRMED these as still-observed = REAL drift, not stale: identical
-  // column set / method / uniqueness by introspection, yet DB-A (journal) != DB-B (shape push)
-  // on some catalog detail the comparator gates (storage param / collation). Deferred to
+  // §7 (run 28437747790) CONFIRMED these as still-observed = REAL drift, not stale. Deferred to
   // PR-1/operator; do NOT shrink without a fresh §7 baselineNotObserved signal.
-  'reserve_decisions|index|idx_reserve_fund_company',
-  'reserve_decisions|index|ux_reserve_unique',
+  // NB (s8.4): the two reserve_decisions index entries formerly baselined here were NOT a
+  // catalog-detail mismatch — they were missing from DB-A outright (0001's DROP/ADD COLUMN
+  // dropped them; nothing recreated them). Fixed by 0026_reserve_decisions_index_resync_drift;
+  // §7 run 28557795657 reported both under baselineNotObserved, so they were shrunk.
   'fund_snapshots|fk|fund_snapshots_config_id_fundconfigs_id_fk',
   'fund_snapshots|fk|fund_snapshots_run_id_calc_runs_id_fk',
   'job_outbox|constraint|job_outbox_status_check',

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -46,6 +46,7 @@ const expectedJournaledDriftPatchFiles = [
   '0023_version_default_resync_drift.sql',
   '0024_idempotency_cursor_resync_drift.sql',
   '0025_allocation_scenarios_promote_drift.sql',
+  '0026_reserve_decisions_index_resync_drift.sql',
 ].sort();
 
 afterEach(() => {


### PR DESCRIPTION
## What

PR-2b follow-up **section 8.4**: additive journal drift-patch recreating the two `reserve_decisions` indexes the canonical journal loses mid-replay.

- `migrations/0026_reserve_decisions_index_resync_drift.sql` (+ `_journal.json` idx 27)
- Statements mirror `0000_quick_vivisector.sql:453-454` **verbatim** so DB-A catalog definitions converge with DB-B by name AND shape

## Root cause (verified twice: Hermes research lane + independent re-check)

`migrations/0001_certain_miracleman.sql:504-507` does `DROP COLUMN fund_id/company_id` + `ADD COLUMN` on `reserve_decisions`. PostgreSQL silently drops dependent indexes on `DROP COLUMN`, killing both `ux_reserve_unique` (company_id,...) and `idx_reserve_fund_company` (fund_id, company_id) created in `0000`. `rg -F` proves no later journal migration recreates either name, while the Drizzle shape push (`shared/schema.ts:856-863`) emits both.

**Note:** the current baseline comment (`prod-schema-clone.test.ts:75-78`) attributes these two entries to a "storage param / collation" catalog detail — that mechanism claim is unsupported for these entries (the §7 comparator emits the same key for missing-on-one-side and shape-mismatch; run 28437747790's log shows only the report-only known-drift array). The comment gets corrected in the follow-up commit with this PR's own dump evidence.

## Staged verification (repo doctrine: no baseline shrink without a fresh s7 signal)

1. **This commit:** migration only; `KNOWN_INTERSECTION_DRIFT` entries intentionally KEPT (`baselineNotObserved` is report-only, so CI stays green either way).
2. **s7 proof:** `test:docker` label triggers Testcontainers; expect `[prod-schema-clone] baseline entries NOT observed (drift fixed? shrink baseline)` listing both `reserve_decisions|index|*` keys, with matching DB-A/DB-B `catalogDefinitions` dumps.
3. **Follow-up commit on this PR:** shrink the two baseline entries + correct the baseline comment, citing the run evidence.

If step 2 instead shows the entries still observed, the "catalog detail" theory wins and this PR stops for re-analysis rather than merging.

## Gates

- `validate:schema-drift`: pass (report-only INFO lines unchanged)
- `npm run check`: only the 6 pre-existing Redis-6 errors
- `npm run lint` + guardrails: pass
- Journal JSON parses; 28 entries, head `0026_reserve_decisions_index_resync_drift`

Heads-up for #972 sequencing: this PR uses the label mechanism since #972 (schema auto-run) is still open; once #972 merges, any subsequent push here also live-validates its positive path. Lane-D's drafted investment_rounds migration renumbers to 0027/idx 28 after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD