### PR TITLE
fix(schema): s8.2 slice 1 - journal the investment_rounds family

### DIFF
--- a/migrations/0027_investment_rounds_journal_drift.sql
+++ b/migrations/0027_investment_rounds_journal_drift.sql
@@ -1,0 +1,99 @@
+-- @drift-patch
+-- Reason: journal the live investment_rounds family (ADR-023 L3b) so the canonical migrations/ ledger covers what shared/schema already ships via db:push, unblocking lane-B retirement of server/migrations (PR-2b s8.2 slice 1). Content mirrors server/migrations/20260621_z_investment_rounds_v1 + 20260623_z_investment_rounds_operational_v1 + 20260624_investment_round_model_overrides_v1 with ONE deliberate delta: investment_rounds_id_fund_uq and investment_round_model_overrides_id_fund_round_uq are UNIQUE CONSTRAINTS (as shared/schema declares them -- the PG 42830 FK-ordering fix; see shared/schema/investment-rounds.ts) rather than the unique INDEXES the legacy server files created. Fully guarded (IF NOT EXISTS / DO-block) so the gated operator narrow-apply path is idempotent against db:push-built databases that already carry these objects; same-name/wrong-shape divergence stays the job of the s7 comparator and operator re-audit. Additive (CREATE-only); no prod apply -- prod (built via db:push) already has the push shape.
+CREATE TABLE IF NOT EXISTS investment_rounds (
+  id SERIAL PRIMARY KEY,
+  investment_id INTEGER NOT NULL,
+  fund_id INTEGER NOT NULL REFERENCES funds(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  round_name VARCHAR(120) NOT NULL,
+  security_type VARCHAR(32) NOT NULL,
+  round_date DATE NOT NULL,
+  currency VARCHAR(3) NOT NULL DEFAULT 'USD',
+  investment_amount NUMERIC(20,6) NOT NULL,
+  round_size NUMERIC(20,6),
+  pre_money_valuation NUMERIC(20,6),
+  idempotency_key VARCHAR(255) NOT NULL,
+  request_hash VARCHAR(64) NOT NULL,
+  supersedes_round_id INTEGER REFERENCES investment_rounds(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  CONSTRAINT investment_rounds_security_type_check
+    CHECK (security_type IN ('equity', 'convertible_note', 'safe', 'warrant', 'other')),
+  CONSTRAINT investment_rounds_amount_positive CHECK (investment_amount > 0),
+  CONSTRAINT investment_rounds_investment_fund_fk
+    FOREIGN KEY (investment_id, fund_id)
+    REFERENCES investments(id, fund_id)
+    ON UPDATE RESTRICT
+    ON DELETE RESTRICT,
+  CONSTRAINT investment_rounds_fund_idem_key UNIQUE (fund_id, idempotency_key),
+  CONSTRAINT investment_rounds_id_fund_uq UNIQUE (id, fund_id)
+);
+
+CREATE INDEX IF NOT EXISTS investment_rounds_fund_investment_idx
+  ON investment_rounds (fund_id, investment_id);
+
+CREATE INDEX IF NOT EXISTS investment_rounds_investment_round_date_idx
+  ON investment_rounds (investment_id, round_date DESC);
+
+CREATE INDEX IF NOT EXISTS investment_rounds_fund_round_order_idx
+  ON investment_rounds (fund_id, investment_id, round_date, created_at, id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS investment_rounds_supersedes_uq
+  ON investment_rounds (supersedes_round_id)
+  WHERE supersedes_round_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS investment_round_model_overrides (
+  id SERIAL PRIMARY KEY,
+  fund_id INTEGER NOT NULL REFERENCES funds(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  round_id INTEGER NOT NULL,
+  override_role VARCHAR(32) NOT NULL,
+  reason TEXT NOT NULL,
+  created_by INTEGER REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  supersedes_override_id INTEGER REFERENCES investment_round_model_overrides(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  idempotency_key VARCHAR(255),
+  request_hash VARCHAR(64),
+  CONSTRAINT investment_round_model_overrides_role_check
+    CHECK (override_role IN ('initial', 'follow_on', 'amount_only')),
+  CONSTRAINT investment_round_model_overrides_id_fund_round_uq UNIQUE (id, fund_id, round_id)
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'investment_round_model_overrides_round_fund_fk'
+      AND conrelid = 'public.investment_round_model_overrides'::regclass
+  ) THEN
+    ALTER TABLE investment_round_model_overrides
+      ADD CONSTRAINT investment_round_model_overrides_round_fund_fk
+      FOREIGN KEY (round_id, fund_id) REFERENCES investment_rounds(id, fund_id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'investment_round_model_overrides_supersedes_lineage_fk'
+      AND conrelid = 'public.investment_round_model_overrides'::regclass
+  ) THEN
+    ALTER TABLE investment_round_model_overrides
+      ADD CONSTRAINT investment_round_model_overrides_supersedes_lineage_fk
+      FOREIGN KEY (supersedes_override_id, fund_id, round_id)
+      REFERENCES investment_round_model_overrides(id, fund_id, round_id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS investment_round_model_overrides_supersedes_uq
+  ON investment_round_model_overrides (supersedes_override_id)
+  WHERE supersedes_override_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS investment_round_model_overrides_root_lineage_uq
+  ON investment_round_model_overrides (fund_id, round_id)
+  WHERE supersedes_override_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS investment_round_model_overrides_fund_round_idx
+  ON investment_round_model_overrides (fund_id, round_id, created_at, id);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1782952890536,
       "tag": "0026_reserve_decisions_index_resync_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1782957704018,
+      "tag": "0027_investment_rounds_journal_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -38,8 +38,6 @@ const C1_MOUNTED_TABLES = [
   'planning_fmv_override_requests',
 ] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
-  'investment_rounds',
-  'investment_round_model_overrides',
   'flag_changes',
   'flags_state',
   'reserve_approvals',

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -47,6 +47,7 @@ const expectedJournaledDriftPatchFiles = [
   '0024_idempotency_cursor_resync_drift.sql',
   '0025_allocation_scenarios_promote_drift.sql',
   '0026_reserve_decisions_index_resync_drift.sql',
+  '0027_investment_rounds_journal_drift.sql',
 ].sort();
 
 afterEach(() => {


### PR DESCRIPTION
## What

PR-2b **section 8.2, slice 1 of 3**: journal the live `investment_rounds` family into the canonical Drizzle ledger, so the last 8 lane-B `server/migrations` files can retire (slice 2 = helper repoint, slice 3 = deletion + `LANE_B_ALLOWLIST` trim).

- `migrations/0027_investment_rounds_journal_drift.sql` (+ `_journal.json` idx 28): `investment_rounds` + `investment_round_model_overrides` — all columns, named checks, composite FKs, partial unique indexes, operational indexes.
- `SHAPE_ONLY_NOT_JOURNALED` drops both tables — the s7 comparator now **gates** them (journal replay must converge with the shape push).
- Pinned drift-patch list extended for 0027.

## Design decisions

1. **Unique CONSTRAINTS, not unique indexes**, for the two composite FK targets (`investment_rounds_id_fund_uq`, `investment_round_model_overrides_id_fund_round_uq`). This is the ONE deliberate delta vs the legacy server files, and it follows `shared/schema` (the PG 42830 FK-ordering fix). s7's DB-B is pure `pushSchema` output and prod is push-built, so Drizzle's declaration is the convergence target — the legacy files' unique indexes would mismatch the comparator's constraint catalog.
2. **Fully guarded** (`CREATE TABLE/INDEX IF NOT EXISTS`, `pg_constraint`-checked DO-blocks for the composite-FK ALTERs), applying the #973 review finding: drift patches are the operator narrow-apply set against db:push-built databases that already carry these objects. DO-block-in-journal replay is the proven `0019` pattern.
3. Everything else mirrors the lane-B files verbatim by name (checks, FK names, index names, DESC ordering, NOT NULL/defaults cross-checked against both the legacy SQL and `shared/schema/investment-rounds{,-model-overrides}.ts`).

## Verification

- Local: migration-ledger 9/9 (marker + Reason + pin), mount-parity 4/4 (deferred-tables pin unaffected — it documents, doesn't assert non-journaled), `validate:schema-drift` PASS, eslint PASS.
- CI: this PR touches `migrations/**`, so the **#972 detect-schema gate auto-runs Testcontainers** — the first schema PR through the new trigger (its positive-path validation). The s7 run proves journal-replay DB-A == push DB-B for both newly gated tables; any hand-authoring error fails as an unexpected mismatch.

## Follow-ups (not this PR)

- Slice 2: repoint `tests/helpers/apply-investment-round-constraints.ts` from the `20260621_*` server SQL to `migrations/0019` + `0027`.
- Slice 3: delete the 8 lane-B files, trim `LANE_B_ALLOWLIST` to `[]`, pin the guard test to the empty allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD