### PR TITLE
test(schema): s8.1 slice 0 - untruncate s7 dumps; read-only prod operator-seam audit script + smoke test; ADR-023

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -300,3 +300,4 @@ schema_tests:
   - 'tests/integration/migration-drift.test.ts'
   - 'tests/integration/prod-schema-clone.test.ts'
   - 'tests/integration/investment-scenario-capability.test.ts'
+  - 'scripts/audit-prod-operator-seam.mjs'

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -26,6 +26,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-020: Phase 3C Track B Go/No-Go Deadline](#adr-020-phase-3c-track-b-gono-go-deadline)
 - [ADR-021: Single Required CI Gate with Internal Conditional Jobs](#adr-021-single-required-ci-gate-with-internal-conditional-jobs)
 - [ADR-022: SSE Event Routes Protected by Bearer Fund-Scope; Native EventSource Transport Deferred](#adr-022-sse-event-routes-protected-by-bearer-fund-scope-native-eventsource-transport-deferred)
+- [ADR-023: s8.1 Operator Seam - Evidence-First Slice Ordering and D1 Triage-First Decision Procedure](#adr-023-s81-operator-seam---evidence-first-slice-ordering-and-d1-triage-first-decision-procedure)
 
 ---
 
@@ -5008,3 +5009,75 @@ other Tranche A route.
   deferred to when a real consumer's requirements exist.
 - The simulation route gains auth-required immediately; full simulation
   fund-scoping remains a follow-up.
+
+## ADR-023: s8.1 Operator Seam - Evidence-First Slice Ordering and D1 Triage-First Decision Procedure
+
+**Date:** 2026-07-02 **Status:** [ACCEPTED] Accepted **Decision:** Retire the
+6-entry `KNOWN_INTERSECTION_DRIFT` baseline via a locked evidence-first slice
+pipeline (audit before any decision, reviewed code before any prod apply,
+fresh-signal-plus-prod-outcome pin before any baseline shrink), with the
+fund_snapshots-FK / job_outbox-CHECK direction (D1) decided by a triage-first
+procedure rather than by fiat.
+
+### Context
+
+The prod-schema drift gate (`tests/integration/prod-schema-clone.test.ts`)
+tolerates six known intersection-drift entries: three stale global idempotency
+unique indexes (journal `0001` created them; `0024` added the scoped
+replacements; nothing journaled drops the old ones), two journal-only
+fund_snapshots FKs (`0002`), and a journal-only `job_outbox_status_check`
+(`0005`). The gate compares journal-replay (DB-A) against shape-push (DB-B) in
+Docker; production (Neon, historically push-built) is not in that loop, so the
+baseline could shrink while prod still carried a latent hazard: if prod retains
+the old GLOBAL unique index, it enforces cross-scope idempotency-key uniqueness
+that the scoped design (#924 lineage) deliberately relaxed - a latent 409/23505
+on legitimate key reuse. Evidence cut both ways on D1 (drop the journal-side
+constraints vs add them to shape+prod): real readers join snapshots by these
+columns and `fund_metrics` keeps equivalent FKs in shape, but adding FKs to prod
+validates existing rows (orphan/lock risk). Gate reviews ran 2026-07-02 (CEO
+hold-scope, engineering, codex red-team; plan
+`~/.claude/plans/EXECUTE-s81-operator-seam.md` section 6 holds the full log).
+
+### Decision
+
+1. Slice ordering locked: 0 (read-only prod audit + un-truncated §7 dumps) ->
+   1 (decision lock) -> 2 (journal drift-patch `0028`) -> 3 (FK-name manifest
+   reconcile) -> 3.5 (drop-capable manifest path in `reconcile-prod-schema.mjs`
+   as its own reviewed PR) -> 4 (guarded operator apply, only if audit demands)
+   -> 5 (baseline shrink). Manifest reconcile precedes prod apply; operator
+   sessions run only reviewed code; the shrink commit must pin the fresh §7 run
+   ID, the slice-4 outcome, the audit-artifact sha256, the target DB identity,
+   and this decision record.
+2. D1 procedure locked (triage-first): zero orphans and in-list status values ->
+   lane B (add `.references()`/`check()` to shape; prod gains constraints via
+   `NOT VALID` then `VALIDATE`). Nonzero orphans -> triage first
+   (count/age/repairability); cheaply repairable -> repair then lane B; only
+   unrepairable or ambiguous -> lane A (journal-side drop), recording explicitly
+   that DB integrity is being relaxed. Repairable orphans never decide permanent
+   integrity relaxation.
+3. Slice-4 lock strategy: plain `DROP INDEX` inside the guarded transaction by
+   default; `CONCURRENTLY` outside the transaction only on row-count/traffic
+   evidence, with mandatory `pg_index.indisvalid`/`indisready` prechecks on the
+   scoped replacement before any global-index drop.
+
+### Alternatives Considered
+
+- **Journal-only reconcile (no prod audit):** disqualified - the §7 gate cannot
+  see prod, so the baseline would clear while the latent global-index hazard
+  persisted silently.
+- **Big-bang (journal patch + same-day prod apply + immediate shrink):**
+  rejected - violates the shrink-only-after-fresh-signal rule that previously
+  caused a gate failure, and applies prod DDL on unaudited state.
+- **Nonzero orphans -> lane A directly (pre-red-team procedure):** rejected -
+  lets temporary bad data decide permanent integrity relaxation.
+
+### Consequences
+
+- Positive: the drift gate ends with zero tolerated entries backed by prod
+  evidence, not assumption; every prod-affecting step has a reviewed-code and
+  recorded-evidence gate; the latent 409 hazard is either disproven or fixed.
+- Negative: more PRs and two human operator touchpoints (read-only audit,
+  possible apply) before the baseline can shrink; D1 remains open until slice-0
+  evidence lands (by design).
+- Neutral: `reconcile-prod-schema.mjs` gains a drop-capable manifest path whose
+  checksum must cover drop entries and reverse SQL.

--- a/scripts/audit-prod-operator-seam.mjs
+++ b/scripts/audit-prod-operator-seam.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+// READ-ONLY prod audit for the s8.1 operator seam.
+// Plan: ~/.claude/plans/EXECUTE-s81-operator-seam.md (slice 0b); ADR-023.
+//
+// Collects, in one pass against the Neon DIRECT endpoint:
+//   1. Presence + validity of the 3 old GLOBAL idempotency unique indexes and
+//      their 3 SCOPED replacements (pg_index.indisvalid / indisready).
+//   2. Presence of the 2 fund_snapshots FKs under BOTH name styles
+//      (drizzle `_fk` and PG-default `_fkey`) plus convalidated.
+//   3. Presence of job_outbox_status_check (+ any `%status_check` variant).
+//   4. Full public-schema FK-name inventory (63-byte truncation flagged).
+//   5. D1 deciding evidence: orphan counts (NOT EXISTS, non-NULL only),
+//      distinct job_outbox.status values vs the 0005 CHECK list, duplicate
+//      scoped-idempotency-key groups (predicate mirrors the partial indexes).
+//   6. Row counts for lock-strategy sizing.
+//
+// Safety: refuses pooler URLs; forces default_transaction_read_only=on;
+// 30s statement_timeout; connection string from env only and never echoed;
+// output is a single atomic JSON artifact with a `completed` marker so a
+// partial run can never be mistaken for a complete one.
+//
+// Usage: DATABASE_URL=postgres://... node scripts/audit-prod-operator-seam.mjs [--out <path>]
+
+import { rename, writeFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+
+import pg from 'pg';
+
+import { assertDirectDatabaseUrl } from './reconcile-prod-schema.mjs';
+
+const OLD_GLOBAL_INDEXES = [
+  'forecast_snapshots_idempotency_unique_idx',
+  'investment_lots_idempotency_unique_idx',
+  'reserve_allocations_idempotency_unique_idx',
+];
+
+const SCOPED_INDEXES = [
+  'forecast_snapshots_fund_idem_key_idx',
+  'investment_lots_investment_idem_key_idx',
+  'reserve_allocations_snapshot_idem_key_idx',
+];
+
+// Journal 0002 names these drizzle-style in raw SQL; a push-built origin would
+// have produced no FK at all (shape omits .references()); audit both styles.
+const FUND_SNAPSHOT_FK_CANDIDATES = [
+  'fund_snapshots_run_id_calc_runs_id_fk',
+  'fund_snapshots_run_id_fkey',
+  'fund_snapshots_config_id_fundconfigs_id_fk',
+  'fund_snapshots_config_id_fkey',
+];
+
+// migrations/0005_phase1c2_alert_automation.sql:21-22
+const OUTBOX_CHECK_EXPECTED_STATUSES = [
+  'pending',
+  'processing',
+  'completed',
+  'failed',
+  'cancelled',
+];
+
+// (table, scope column) pairs mirror the 0024 partial unique indexes exactly.
+const SCOPED_KEY_TABLES = [
+  { table: 'forecast_snapshots', scopeColumn: 'fund_id' },
+  { table: 'investment_lots', scopeColumn: 'investment_id' },
+  { table: 'reserve_allocations', scopeColumn: 'snapshot_id' },
+];
+
+const ROW_COUNT_TABLES = [
+  'fund_snapshots',
+  'calc_runs',
+  'fundconfigs',
+  'job_outbox',
+  'forecast_snapshots',
+  'investment_lots',
+  'reserve_allocations',
+];
+
+const PG_IDENTIFIER_MAX_BYTES = 63;
+
+function endpointHost(connectionString) {
+  try {
+    return new URL(connectionString).hostname;
+  } catch {
+    return 'unparseable';
+  }
+}
+
+async function indexPresence(client, indexNames) {
+  const result = await client.query(
+    `
+      SELECT
+        i.relname AS index_name,
+        c.relname AS table_name,
+        ix.indisunique AS is_unique,
+        ix.indisvalid AS is_valid,
+        ix.indisready AS is_ready,
+        pg_get_indexdef(i.oid) AS definition
+      FROM pg_index ix
+      JOIN pg_class i ON i.oid = ix.indexrelid
+      JOIN pg_class c ON c.oid = ix.indrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND i.relname = ANY($1::text[])
+    `,
+    [indexNames]
+  );
+  const found = new Map(result.rows.map((row) => [row.index_name, row]));
+  return indexNames.map((name) => found.get(name) ?? { index_name: name, absent: true });
+}
+
+async function constraintPresence(client, constraintNames) {
+  const result = await client.query(
+    `
+      SELECT
+        con.conname AS constraint_name,
+        c.relname AS table_name,
+        con.contype AS constraint_type,
+        con.convalidated AS is_validated,
+        pg_get_constraintdef(con.oid) AS definition
+      FROM pg_constraint con
+      JOIN pg_class c ON c.oid = con.conrelid
+      JOIN pg_namespace n ON n.oid = con.connamespace
+      WHERE n.nspname = 'public'
+        AND con.conname = ANY($1::text[])
+    `,
+    [constraintNames]
+  );
+  const found = new Map(result.rows.map((row) => [row.constraint_name, row]));
+  return constraintNames.map(
+    (name) => found.get(name) ?? { constraint_name: name, absent: true }
+  );
+}
+
+async function outboxCheckVariants(client) {
+  const result = await client.query(`
+    SELECT con.conname AS constraint_name, pg_get_constraintdef(con.oid) AS definition
+    FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = con.connamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'job_outbox'
+      AND con.contype = 'c'
+      AND con.conname LIKE '%status_check'
+  `);
+  return result.rows;
+}
+
+async function foreignKeyInventory(client) {
+  const result = await client.query(`
+    SELECT
+      c.relname AS table_name,
+      con.conname AS constraint_name,
+      con.convalidated AS is_validated,
+      pg_get_constraintdef(con.oid) AS definition
+    FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = con.connamespace
+    WHERE n.nspname = 'public'
+      AND con.contype = 'f'
+    ORDER BY c.relname, con.conname
+  `);
+  return result.rows.map((row) => ({
+    ...row,
+    at_63_byte_limit: Buffer.byteLength(row.constraint_name, 'utf8') === PG_IDENTIFIER_MAX_BYTES,
+  }));
+}
+
+async function orphanCounts(client) {
+  const runOrphans = await client.query(`
+    SELECT count(*)::bigint AS orphans
+    FROM fund_snapshots fs
+    WHERE fs.run_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM calc_runs cr WHERE cr.id = fs.run_id)
+  `);
+  const configOrphans = await client.query(`
+    SELECT count(*)::bigint AS orphans
+    FROM fund_snapshots fs
+    WHERE fs.config_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM fundconfigs fc WHERE fc.id = fs.config_id)
+  `);
+  return {
+    fund_snapshots_run_id_orphans: Number(runOrphans.rows[0]?.orphans ?? -1),
+    fund_snapshots_config_id_orphans: Number(configOrphans.rows[0]?.orphans ?? -1),
+  };
+}
+
+async function outboxStatusValues(client) {
+  const result = await client.query(`
+    SELECT status, count(*)::bigint AS row_count
+    FROM job_outbox
+    GROUP BY status
+    ORDER BY status
+  `);
+  const observed = result.rows.map((row) => ({
+    status: row.status,
+    row_count: Number(row.row_count),
+  }));
+  const outsideCheckList = observed
+    .map((row) => row.status)
+    .filter((status) => !OUTBOX_CHECK_EXPECTED_STATUSES.includes(status));
+  return { observed, expected: OUTBOX_CHECK_EXPECTED_STATUSES, outsideCheckList };
+}
+
+async function duplicateScopedKeyGroups(client, table, scopeColumn) {
+  const result = await client.query(`
+    SELECT ${scopeColumn} AS scope_value, idempotency_key, count(*)::bigint AS row_count
+    FROM ${table}
+    WHERE idempotency_key IS NOT NULL
+    GROUP BY ${scopeColumn}, idempotency_key
+    HAVING count(*) > 1
+    ORDER BY count(*) DESC
+    LIMIT 20
+  `);
+  return {
+    table,
+    scope_column: scopeColumn,
+    duplicate_groups: result.rows.length,
+    sample: result.rows.map((row) => ({
+      scope_value: row.scope_value,
+      idempotency_key: row.idempotency_key,
+      row_count: Number(row.row_count),
+    })),
+  };
+}
+
+async function rowCounts(client) {
+  const counts = {};
+  for (const table of ROW_COUNT_TABLES) {
+    const result = await client.query(`SELECT count(*)::bigint AS n FROM ${table}`);
+    counts[table] = Number(result.rows[0]?.n ?? -1);
+  }
+  return counts;
+}
+
+async function writeArtifactAtomically(outPath, artifact) {
+  const tempPath = `${outPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8');
+  await rename(tempPath, outPath);
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: { out: { type: 'string', default: 's81-prod-audit-output.json' } },
+  });
+  const outPath = values.out;
+
+  const connectionString = process.env.DATABASE_URL;
+  assertDirectDatabaseUrl(connectionString);
+
+  const client = new pg.Client({ connectionString });
+  const results = {};
+  let queryCount = 0;
+  const counted = async (promise) => {
+    queryCount += 1;
+    return promise;
+  };
+
+  try {
+    await client.connect();
+    await client.query('SET default_transaction_read_only = on');
+    await client.query("SET statement_timeout = '30s'");
+
+    const meta = await counted(
+      client.query('SELECT version() AS pg_version, current_database() AS database_name')
+    );
+    results.server = {
+      endpoint_host: endpointHost(connectionString),
+      pg_version: meta.rows[0]?.pg_version,
+      database_name: meta.rows[0]?.database_name,
+    };
+
+    results.old_global_indexes = await counted(indexPresence(client, OLD_GLOBAL_INDEXES));
+    results.scoped_indexes = await counted(indexPresence(client, SCOPED_INDEXES));
+    results.fund_snapshot_fks = await counted(
+      constraintPresence(client, FUND_SNAPSHOT_FK_CANDIDATES)
+    );
+    results.outbox_status_checks = await counted(outboxCheckVariants(client));
+    results.foreign_key_inventory = await counted(foreignKeyInventory(client));
+    results.orphan_counts = await counted(orphanCounts(client));
+    results.outbox_status_values = await counted(outboxStatusValues(client));
+    results.duplicate_scoped_key_groups = [];
+    for (const { table, scopeColumn } of SCOPED_KEY_TABLES) {
+      results.duplicate_scoped_key_groups.push(
+        await counted(duplicateScopedKeyGroups(client, table, scopeColumn))
+      );
+    }
+    results.row_counts = await counted(rowCounts(client));
+
+    const artifact = {
+      audit: 's8.1-operator-seam',
+      completed: true,
+      generated_at: new Date().toISOString(),
+      query_count: queryCount,
+      results,
+    };
+    await writeArtifactAtomically(outPath, artifact);
+    console.log(JSON.stringify(artifact));
+  } catch (error) {
+    const artifact = {
+      audit: 's8.1-operator-seam',
+      completed: false,
+      generated_at: new Date().toISOString(),
+      query_count: queryCount,
+      error: error instanceof Error ? error.message : String(error),
+      partial_results: results,
+    };
+    await writeArtifactAtomically(outPath, artifact).catch(() => {});
+    console.error(JSON.stringify(artifact));
+    process.exitCode = 1;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+await main();

--- a/scripts/audit-prod-operator-seam.mjs
+++ b/scripts/audit-prod-operator-seam.mjs
@@ -26,7 +26,12 @@ import { parseArgs } from 'node:util';
 
 import pg from 'pg';
 
-import { assertDirectDatabaseUrl } from './reconcile-prod-schema.mjs';
+// Captured BEFORE importing reconcile-prod-schema.mjs (dynamic import in main):
+// that module runs dotenv config() at module load, which would silently fill
+// DATABASE_URL from a local .env and produce a complete-looking audit against
+// the wrong database. This tool only accepts a URL from the actual invocation
+// environment.
+const CONNECTION_STRING_FROM_INVOCATION = process.env.DATABASE_URL;
 
 const OLD_GLOBAL_INDEXES = [
   'forecast_snapshots_idempotency_unique_idx',
@@ -244,18 +249,22 @@ async function main() {
   });
   const outPath = values.out;
 
-  const connectionString = process.env.DATABASE_URL;
-  assertDirectDatabaseUrl(connectionString);
-
-  const client = new pg.Client({ connectionString });
+  const connectionString = CONNECTION_STRING_FROM_INVOCATION;
   const results = {};
   let queryCount = 0;
+  let client;
   const counted = async (promise) => {
     queryCount += 1;
     return promise;
   };
 
   try {
+    // Inside the try so a refusal (missing URL, memory://, pooler URL) still
+    // writes the completed:false artifact instead of exiting artifact-less.
+    const { assertDirectDatabaseUrl } = await import('./reconcile-prod-schema.mjs');
+    assertDirectDatabaseUrl(connectionString);
+
+    client = new pg.Client({ connectionString });
     await client.connect();
     await client.query('SET default_transaction_read_only = on');
     await client.query("SET statement_timeout = '30s'");
@@ -308,7 +317,7 @@ async function main() {
     console.error(JSON.stringify(artifact));
     process.exitCode = 1;
   } finally {
-    await client.end().catch(() => {});
+    await client?.end().catch(() => {});
   }
 }
 

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -1,8 +1,11 @@
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { pushSchema } from 'drizzle-kit/api';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -12,6 +15,7 @@ import { runMigrationsWithConnectionString } from '../helpers/testcontainers-mig
 
 const STARTUP_TIMEOUT_MS = 90_000;
 const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
+const execFileAsync = promisify(execFile);
 
 let postgres: StartedPostgreSqlContainer | undefined;
 let pool: Pool | undefined;
@@ -715,11 +719,14 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     // eslint-disable-next-line no-console -- D4 requires non-gating CI diagnostics.
     console.log('[prod-schema-clone] shape-only tables', shapeOnlyTables);
     // eslint-disable-next-line no-console -- D4 requires non-gating CI diagnostics.
-    console.log('[prod-schema-clone] DB-A catalog definitions', await catalogDefinitions(pool!));
+    console.log(
+      '[prod-schema-clone] DB-A catalog definitions',
+      JSON.stringify(await catalogDefinitions(pool!))
+    );
     // eslint-disable-next-line no-console -- D4 requires non-gating CI diagnostics.
     console.log(
       '[prod-schema-clone] DB-B catalog definitions',
-      await catalogDefinitions(shapePool)
+      JSON.stringify(await catalogDefinitions(shapePool))
     );
     // eslint-disable-next-line no-console -- non-gating drift report for PR-2b
     console.log(
@@ -769,4 +776,69 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
 
     // alert_evaluation_executions, job_outbox.dedupe_key, idx_job_outbox_job_type_dedupe, performance_alerts_open_incident_unique, backtest_results.scenario_comparison_summary are in BOTH the journal and shape source -> proven by the sentinel intersection diff above; asserting them here would be vacuous (the journal pre-supplies them).
   });
+
+  it(
+    'smoke-runs the s8.1 operator-seam audit script against the journal clone',
+    async () => {
+      expect(postgres).toBeDefined();
+      const outPath = path.join(
+        os.tmpdir(),
+        `s81-audit-smoke-${process.pid}-${Date.now()}.json`
+      );
+
+      await execFileAsync('node', ['scripts/audit-prod-operator-seam.mjs', '--out', outPath], {
+        cwd: process.cwd(),
+        env: { ...process.env, DATABASE_URL: postgres!.getConnectionUri() },
+      });
+
+      const artifact = JSON.parse(await readFile(outPath, 'utf8')) as {
+        completed: boolean;
+        query_count: number;
+        results: {
+          old_global_indexes: Array<{ index_name: string; absent?: boolean }>;
+          scoped_indexes: Array<{
+            index_name: string;
+            absent?: boolean;
+            is_valid?: boolean;
+            is_ready?: boolean;
+          }>;
+          fund_snapshot_fks: Array<{ constraint_name: string; absent?: boolean }>;
+          outbox_status_checks: Array<{ constraint_name: string }>;
+          orphan_counts: {
+            fund_snapshots_run_id_orphans: number;
+            fund_snapshots_config_id_orphans: number;
+          };
+          row_counts: Record<string, number>;
+        };
+      };
+
+      // Positive control: DB-A (journal replay) MUST contain all six seam objects,
+      // so every detection query is proven before an operator session relies on it.
+      expect(artifact.completed).toBe(true);
+      expect(artifact.query_count).toBeGreaterThan(0);
+      expect(
+        artifact.results.old_global_indexes.filter((entry) => entry.absent)
+      ).toEqual([]);
+      expect(
+        artifact.results.scoped_indexes.filter(
+          (entry) => entry.absent || !entry.is_valid || !entry.is_ready
+        )
+      ).toEqual([]);
+      const foundFks = artifact.results.fund_snapshot_fks
+        .filter((entry) => !entry.absent)
+        .map((entry) => entry.constraint_name)
+        .sort();
+      expect(foundFks).toEqual([
+        'fund_snapshots_config_id_fundconfigs_id_fk',
+        'fund_snapshots_run_id_calc_runs_id_fk',
+      ]);
+      expect(
+        artifact.results.outbox_status_checks.map((entry) => entry.constraint_name)
+      ).toContain('job_outbox_status_check');
+      expect(artifact.results.orphan_counts.fund_snapshots_run_id_orphans).toBe(0);
+      expect(artifact.results.orphan_counts.fund_snapshots_config_id_orphans).toBe(0);
+      expect(Object.keys(artifact.results.row_counts)).toHaveLength(7);
+    },
+    60_000
+  );
 });


### PR DESCRIPTION
## What

s8.1 operator seam, slice 0 (evidence completion; repo-only, no prod writes). Plan: `EXECUTE-s81-operator-seam.md`, gated 2026-07-02 (CEO hold-scope / eng / codex red-team, 6 red-team findings folded). ADR-023 (in this PR) locks the slice ordering and the D1 triage-first decision procedure.

- **0a** `tests/integration/prod-schema-clone.test.ts`: DB-A/DB-B `catalogDefinitions` dumps now emit complete `JSON.stringify` output. Node's `console.log` truncates arrays at 100 items (run 28575393308 showed `... 373 more items`) - truncated diagnostics can never prove absence (the #976 lesson). Permanent, report-only.
- **0b** `scripts/audit-prod-operator-seam.mjs`: standalone READ-ONLY audit for the six `KNOWN_INTERSECTION_DRIFT` objects + D1 deciding evidence. Hardened per gate review: pooler-URL refusal (reuses `assertDirectDatabaseUrl`), `default_transaction_read_only=on`, 30s `statement_timeout`, env-only connection string (never echoed; artifact carries endpoint host only), atomic JSON artifact with `completed` marker and non-zero exit on error.
- **Smoke test** (new third `it()` in the s7 suite): runs the script against the journal-built Docker clone as a positive control - DB-A carries all six seam objects, so every detection query is proven working before a human operator session relies on it.
- `path-filters.yml`: the audit script joins `schema_tests` so script-only edits fire the Docker proof.

## Operator instructions (after merge)

Run read-only against the Neon DIRECT endpoint (never the pooler; the script refuses it):

```
DATABASE_URL=<direct-endpoint-url> node scripts/audit-prod-operator-seam.mjs --out s81-prod-audit-output.json
```

Paste the artifact JSON into this PR (comment) + the plan. It decides D1 per the ADR-023 triage-first procedure and gates slices 2/4.

## Evidence (per the s8.1 acceptance pattern)

- Head: `50a45db9`
- `schema_tests == true` expected label-free via dorny detect job (both `tests/integration/prod-schema-clone.test.ts` and `.github/path-filters.yml` are in the filter)
- Testcontainers run URL + six-file proof set: recorded here after CI completes
- Local gates re-run post-codex: `npm run check` 0 errors; eslint clean on the test file (script is repo-pattern eslint-ignored)
- `CI Gate Status` = the only required gate; Vercel-preview UNSTABLE is mergeable

## Not in this PR

No journal changes (slice 2 = `0028`), no baseline shrink (slice 5; still-observed removal = gate-FAIL), no prod writes anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD