### PR TITLE
fix(schema): s8.1 slice 2 - journal 0028 retires stale global idem indexes; shape regains fund_snapshots FKs + job_outbox CHECK (D1 lane B)

### DIFF
--- a/migrations/0028_operator_seam_drift.sql
+++ b/migrations/0028_operator_seam_drift.sql
@@ -1,0 +1,20 @@
+-- @drift-patch
+-- Migration: 0028_operator_seam_drift
+-- Reason: s8.1 operator seam (ADR-023, D1 = lane B). Journal 0001_certain_miracleman
+-- created GLOBAL UNIQUE(idempotency_key) indexes on forecast_snapshots,
+-- investment_lots, and reserve_allocations; 0024 added the fund/investment/
+-- snapshot-SCOPED replacements the shape declares. Nothing journaled dropped the
+-- old globals, so journal-built databases enforce cross-scope idempotency-key
+-- uniqueness the scoped design (#924 lineage) deliberately relaxed. This patch
+-- retires the three stale globals. Entries 4-6 of the drift baseline
+-- (fund_snapshots FKs, job_outbox_status_check) are intentionally NOT touched
+-- here: prod audit 2026-07-02 (artifact sha256 62131f6a...cf72b86) showed prod
+-- carries them validated, so the shape gains .references()/check() in the same
+-- PR and the journal side (0002/0005) stays as-is.
+-- Replay safety: DROP INDEX IF EXISTS only; idempotent, forward-only.
+
+DROP INDEX IF EXISTS "forecast_snapshots_idempotency_unique_idx";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "investment_lots_idempotency_unique_idx";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "reserve_allocations_idempotency_unique_idx";

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1782957704018,
       "tag": "0027_investment_rounds_journal_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1783022913852,
+      "tag": "0028_operator_seam_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2522,6 +2522,12 @@ export const jobOutbox = pgTable(
       .where(sql`${table.status} = 'processing'`),
     jobTypeIdx: index('idx_job_outbox_job_type').on(table.jobType),
     dedupeKeyIdx: uniqueIndex('idx_job_outbox_job_type_dedupe').on(table.jobType, table.dedupeKey),
+    // Restored 2026-07-02 (ADR-023, D1 lane B): journal 0005 and prod both carry
+    // this CHECK; the shape had only the TS $type. Predicate matches 0005 verbatim.
+    statusCheck: check(
+      'job_outbox_status_check',
+      sql`${table.status} IN ('pending', 'processing', 'completed', 'failed', 'cancelled')`
+    ),
   })
 );
 

--- a/shared/schema/fund.ts
+++ b/shared/schema/fund.ts
@@ -146,9 +146,11 @@ export const fundSnapshots = pgTable(
     eventCount: integer('event_count').default(0),
     stateHash: varchar('state_hash', { length: 64 }),
     state: jsonb('state'), // Snapshot state data
-    // Phase 2A Item 8: snapshot attribution (nullable for legacy rows)
-    runId: integer('run_id'),
-    configId: integer('config_id'),
+    // Phase 2A Item 8: snapshot attribution (nullable for legacy rows).
+    // FKs restored 2026-07-02 (ADR-023, D1 lane B): journal 0002 and prod both
+    // carry them validated; the shape omission was drift, not design.
+    runId: integer('run_id').references(() => calcRuns.id),
+    configId: integer('config_id').references(() => fundConfigs.id),
     configVersion: integer('config_version'),
     scenarioSetId: uuid('scenario_set_id'),
     h9MoicSourceInputHash: text('h9_moic_source_input_hash'),

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -812,13 +812,24 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         };
       };
 
-      // Positive control: DB-A (journal replay) MUST contain all six seam objects,
-      // so every detection query is proven before an operator session relies on it.
+      // Positive control on the detection queries, pinned to post-0028 DB-A truth:
+      // the three old GLOBAL idempotency indexes are DROPPED by 0028 (the script
+      // must report them absent, not error), while the scoped indexes (0024),
+      // fund_snapshots FKs (0002), and job_outbox_status_check (0005) remain
+      // present. This proves detection in BOTH directions before an operator
+      // session relies on it.
       expect(artifact.completed).toBe(true);
       expect(artifact.query_count).toBeGreaterThan(0);
       expect(
-        artifact.results.old_global_indexes.filter((entry) => entry.absent)
-      ).toEqual([]);
+        artifact.results.old_global_indexes
+          .filter((entry) => entry.absent)
+          .map((entry) => entry.index_name)
+          .sort()
+      ).toEqual([
+        'forecast_snapshots_idempotency_unique_idx',
+        'investment_lots_idempotency_unique_idx',
+        'reserve_allocations_idempotency_unique_idx',
+      ]);
       expect(
         artifact.results.scoped_indexes.filter(
           (entry) => entry.absent || !entry.is_valid || !entry.is_ready

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -48,6 +48,7 @@ const expectedJournaledDriftPatchFiles = [
   '0025_allocation_scenarios_promote_drift.sql',
   '0026_reserve_decisions_index_resync_drift.sql',
   '0027_investment_rounds_journal_drift.sql',
+  '0028_operator_seam_drift.sql',
 ].sort();
 
 afterEach(() => {


### PR DESCRIPTION
## What

s8.1 operator seam slice 2 (plan `EXECUTE-s81-operator-seam.md`; ADR-023; slice-0 evidence = #979 issuecomment-4869988644, artifact sha256 `62131f6aa21bf7ad32c57c9c748b966526e956cb451311571326a0c05cf72b86`).

Resolves ALL SIX `KNOWN_INTERSECTION_DRIFT` entries at the DB-A/DB-B layer, lane-explicit per D1 = **lane B**:

- **Entries 1-3 (journal side):** `0028_operator_seam_drift.sql` (journal idx 29) drops the three 0001-era GLOBAL `UNIQUE(idempotency_key)` indexes — `0024`'s fund/investment/snapshot-scoped replacements are the canonical design. `DROP INDEX IF EXISTS` only; idempotent, forward-only.
- **Entries 4-6 (shape side, NO journal DDL):** `fund_snapshots.run_id/config_id` regain `.references()` and `job_outbox` regains `check('job_outbox_status_check', ...)` with the 0005 predicate verbatim. Prod carries all three constraints VALIDATED (slice-0 audit) — the shape omission was drift, not design. Journal 0002/0005 already supply DB-A, so adding journal DDL would duplicate on replay (red-team F1 rule).
- Ledger pin 12 → 13.

## Acceptance (s8.1 pattern + lane-explicit rule)

- `schema_tests == true` label-free (dorny detect job) — `migrations/**` + `shared/schema/**` both trigger
- Fresh §7 run: **all SIX entries under `baselineNotObserved`**; zero `unexpectedShapeMismatches`
- Baseline itself NOT shrunk here — that is slice 5, pinned to the §7 run + slice-4 outcome + artifact sha256
- `CI Gate Status` = only required gate; Vercel-preview UNSTABLE mergeable

## Not in this PR

No baseline shrink; no prod writes (slice 4 = operator CREATE 3 scoped + DROP 3 globals per the audited matrix); no manifest changes (slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD