### PR TITLE
test(schema): s8.1 slice 3 - manifest sentinel self-consistency pin + schema_tests filter gap

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -301,3 +301,4 @@ schema_tests:
   - 'tests/integration/prod-schema-clone.test.ts'
   - 'tests/integration/investment-scenario-capability.test.ts'
   - 'scripts/audit-prod-operator-seam.mjs'
+  - 'scripts/prod-schema-manifests/**'

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -40,28 +40,35 @@ function loadManifestFiles(): Array<{ file: string; manifest: Manifest }> {
     }));
 }
 
-function namesCreatedBySql(sqlFiles: string[]): Set<string> {
-  const created = new Set<string>();
-  const patterns = [
-    /CONSTRAINT\s+"([^"]+)"/gi,
-    /CONSTRAINT\s+([a-z0-9_]+)\s/gi,
-    /CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?/gi,
-  ];
+// Single alternation, applied left-to-right so each statement is exactly one
+// event: DROP alternatives are listed first and consume through the name, so
+// the CONSTRAINT-create alternative can never re-match the name inside a
+// "DROP CONSTRAINT" statement. Names created after a drop survive (0017's
+// scoped replacement pattern); names dropped and never recreated do not
+// (review 4621209185 - the pin must reject sentinels the SQL sequence drops).
+const SQL_NAME_EVENT =
+  /(?<dropIndex>DROP\s+INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?"?([a-z0-9_]+)"?)|(?<dropConstraint>DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?"?([a-z0-9_]+)"?)|(?<createConstraint>CONSTRAINT\s+"?([a-z0-9_]+)"?)|(?<createIndex>CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?)/gi;
+
+function namesSurvivingSql(sqlFiles: string[]): Set<string> {
+  const surviving = new Set<string>();
 
   for (const sqlFile of sqlFiles) {
     const sql = fs.readFileSync(path.join(repoRoot, sqlFile), 'utf8');
-    for (const pattern of patterns) {
-      let match: RegExpExecArray | null;
-      while ((match = pattern.exec(sql)) !== null) {
-        const name = match[1];
-        if (name) {
-          created.add(pgIdentifier(name.toLowerCase()));
-        }
+    const pattern = new RegExp(SQL_NAME_EVENT.source, 'gi');
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(sql)) !== null) {
+      const [, , droppedIndexName, , droppedConstraintName, , constraintName, , indexName] = match;
+      const dropped = droppedIndexName ?? droppedConstraintName;
+      const created = constraintName ?? indexName;
+      if (dropped) {
+        surviving.delete(pgIdentifier(dropped.toLowerCase()));
+      } else if (created) {
+        surviving.add(pgIdentifier(created.toLowerCase()));
       }
     }
   }
 
-  return created;
+  return surviving;
 }
 
 describe('prod-schema manifest sentinels', () => {
@@ -84,14 +91,14 @@ describe('prod-schema manifest sentinels', () => {
     }
   });
 
-  it('every sentinel name is created by the manifest own SQL (63-byte aware)', () => {
+  it('every sentinel name SURVIVES the manifest own SQL sequence (63-byte aware)', () => {
     const failures: string[] = [];
 
     for (const { file, manifest } of manifests) {
-      const created = namesCreatedBySql(manifest.sqlFiles ?? []);
+      const surviving = namesSurvivingSql(manifest.sqlFiles ?? []);
       for (const table of manifest.expectedTables ?? []) {
         for (const sentinel of [...(table.constraints ?? []), ...(table.indexes ?? [])]) {
-          if (!created.has(pgIdentifier(sentinel.toLowerCase()))) {
+          if (!surviving.has(pgIdentifier(sentinel.toLowerCase()))) {
             failures.push(`${file}: ${sentinel}`);
           }
         }
@@ -99,6 +106,18 @@ describe('prod-schema manifest sentinels', () => {
     }
 
     expect(failures).toEqual([]);
+  });
+
+  it('negative control: a dropped-then-replaced name does not survive (0016/0017 case)', () => {
+    const fundMoic = manifests.find((entry) => entry.file === '02-fund-moic.json');
+    expect(fundMoic).toBeDefined();
+    const surviving = namesSurvivingSql(fundMoic!.manifest.sqlFiles ?? []);
+
+    // 0016 creates the global unique; 0017 drops it and adds the fund-scoped
+    // replacement. A manifest regression back to the dropped name must FAIL
+    // the survival pin, because post-apply reconciliation checks the catalog.
+    expect(surviving.has('reconciliation_runs_idempotency_key_unique')).toBe(false);
+    expect(surviving.has('reconciliation_runs_fund_id_idempotency_key_unique')).toBe(true);
   });
 
   it('no duplicate sentinel names within a manifest', () => {

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { pgIdentifier } from '../../scripts/db-push-core.mjs';
+
+// s8.1 slice 3 (ADR-023): reconcile-prod-schema.mjs verifies sentinels BY NAME
+// (findMissingSentinels), so a manifest sentinel that its own SQL never creates
+// would false-fail every post-apply prod verification. The Docker clone proof
+// covers this end-to-end but only fires on schema-path changes; this pin covers
+// every manifest edit at unit speed. Prod audit 2026-07-02 (artifact sha256
+// 62131f6a...cf72b86) established the C1 manifest tables are NOT YET on prod,
+// so self-consistency against the manifests' own SQL is the reconcile target
+// until the operator apply happens.
+
+const repoRoot = process.cwd();
+const manifestDir = path.join(repoRoot, 'scripts', 'prod-schema-manifests');
+
+interface ManifestTable {
+  name: string;
+  constraints?: string[];
+  indexes?: string[];
+}
+
+interface Manifest {
+  name: string;
+  sqlFiles?: string[];
+  expectedTables?: ManifestTable[];
+}
+
+function loadManifestFiles(): Array<{ file: string; manifest: Manifest }> {
+  return fs
+    .readdirSync(manifestDir)
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => ({
+      file,
+      manifest: JSON.parse(fs.readFileSync(path.join(manifestDir, file), 'utf8')) as Manifest,
+    }));
+}
+
+function namesCreatedBySql(sqlFiles: string[]): Set<string> {
+  const created = new Set<string>();
+  const patterns = [
+    /CONSTRAINT\s+"([^"]+)"/gi,
+    /CONSTRAINT\s+([a-z0-9_]+)\s/gi,
+    /CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?/gi,
+  ];
+
+  for (const sqlFile of sqlFiles) {
+    const sql = fs.readFileSync(path.join(repoRoot, sqlFile), 'utf8');
+    for (const pattern of patterns) {
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(sql)) !== null) {
+        const name = match[1];
+        if (name) {
+          created.add(pgIdentifier(name.toLowerCase()));
+        }
+      }
+    }
+  }
+
+  return created;
+}
+
+describe('prod-schema manifest sentinels', () => {
+  const manifests = loadManifestFiles();
+
+  it('finds the four PR-1 manifests', () => {
+    expect(manifests.map((entry) => entry.file)).toEqual([
+      '01-cohort.json',
+      '02-fund-moic.json',
+      '03-operating-tasks.json',
+      '04-lp-reporting.json',
+    ]);
+  });
+
+  it('every referenced sqlFile exists in the repo', () => {
+    for (const { file, manifest } of manifests) {
+      for (const sqlFile of manifest.sqlFiles ?? []) {
+        expect(fs.existsSync(path.join(repoRoot, sqlFile)), `${file} -> ${sqlFile}`).toBe(true);
+      }
+    }
+  });
+
+  it('every sentinel name is created by the manifest own SQL (63-byte aware)', () => {
+    const failures: string[] = [];
+
+    for (const { file, manifest } of manifests) {
+      const created = namesCreatedBySql(manifest.sqlFiles ?? []);
+      for (const table of manifest.expectedTables ?? []) {
+        for (const sentinel of [...(table.constraints ?? []), ...(table.indexes ?? [])]) {
+          if (!created.has(pgIdentifier(sentinel.toLowerCase()))) {
+            failures.push(`${file}: ${sentinel}`);
+          }
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it('no duplicate sentinel names within a manifest', () => {
+    for (const { file, manifest } of manifests) {
+      const seen: string[] = [];
+      for (const table of manifest.expectedTables ?? []) {
+        seen.push(...(table.constraints ?? []), ...(table.indexes ?? []));
+      }
+      const duplicates = seen.filter((name, index) => seen.indexOf(name) !== index);
+      expect(duplicates, `${file} duplicate sentinels`).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## What

s8.1 operator seam slice 3 (recast on slice-0 evidence; plan `EXECUTE-s81-operator-seam.md`, ADR-023).

**Material finding driving the recast:** the slice-0 prod audit + a follow-up read-only presence check proved **all 17 C1 manifest tables are ABSENT on prod** (60 public tables; zero C1 FKs in the 123-FK inventory). The PR-1 manifest apply never ran against production, so the original slice-3 premise ("fix manifest FK names to prod reality") has no prod reality to reconcile against. The latent-500 exposure on the mounted C1 routes is still live — surfaced separately as an operator-scope decision.

What ships here (repo-only):

- **`tests/unit/prod-schema-manifest-sentinels.test.ts`** — self-consistency pin: all 141 sentinels across the 4 manifests must be names their own `sqlFiles` actually create (`findMissingSentinels` matches BY NAME, `pgIdentifier` 63-byte-aware; 4 manifest names exceed 63 chars and truncate). Plus sqlFile-existence and duplicate-sentinel guards. 4/4 green.
- **`path-filters.yml`** — `scripts/prod-schema-manifests/**` joins `schema_tests`: manifest edits previously fired NO Docker proof (the §7 clone test validates manifest apply-ability end-to-end but never ran on manifest-only changes).

Sentinel-vs-prod reconciliation becomes POST-APPLY acceptance in the operator session (slice 4), where it belongs given the audited state.

## Evidence

- Local: pin test 4/4; `npm run check` 0 errors; lint clean
- `schema_tests` fires on this PR (path-filters.yml is itself in-filter); §7 proof validates the journal+manifests as usual
- Prod evidence: #979 issuecomment-4869988644 (artifact) + C1 presence check (17/17 absent, this PR description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD