### PR TITLE
feat(schema): s8.1 slice 3.5 - dropObjects manifest path in the guarded runner + M5 operator-seam manifest

### DIFF
--- a/scripts/prod-schema-manifests/05-operator-seam.json
+++ b/scripts/prod-schema-manifests/05-operator-seam.json
@@ -1,0 +1,50 @@
+{
+  "name": "M5-operator-seam",
+  "order": 5,
+  "description": "s8.1 operator seam (ADR-023, D1 lane B). Creates the fund/investment/snapshot-scoped idempotency indexes, length CHECKs, and cursor indexes (0024 design) on the three snapshot tables, then retires the stale 0001-era GLOBAL idempotency uniques that enforce cross-scope uniqueness the #924 scoped design deliberately relaxed. Prod audit 2026-07-02 (artifact sha256 62131f6aa21bf7ad32c57c9c748b966526e956cb451311571326a0c05cf72b86): globals PRESENT valid+ready, scoped ABSENT, all three tables 0 rows, duplicate scoped-key groups 0/0/0. Creates run before drops in one transaction, so the scoped replacement provably exists before its global predecessor is removed.",
+  "sqlFiles": ["migrations/0024_idempotency_cursor_resync_drift.sql"],
+  "allowedCreateTables": [],
+  "expectedTables": [
+    {
+      "name": "forecast_snapshots",
+      "constraints": ["forecast_snapshots_idem_key_len_check"],
+      "indexes": ["forecast_snapshots_fund_idem_key_idx", "forecast_snapshots_fund_cursor_idx"]
+    },
+    {
+      "name": "investment_lots",
+      "constraints": ["investment_lots_idem_key_len_check"],
+      "indexes": [
+        "investment_lots_investment_idem_key_idx",
+        "investment_lots_investment_cursor_idx"
+      ]
+    },
+    {
+      "name": "reserve_allocations",
+      "constraints": ["reserve_allocations_idem_key_len_check"],
+      "indexes": [
+        "reserve_allocations_snapshot_idem_key_idx",
+        "reserve_allocations_snapshot_cursor_idx"
+      ]
+    }
+  ],
+  "dropObjects": [
+    {
+      "kind": "index",
+      "name": "forecast_snapshots_idempotency_unique_idx",
+      "reason": "Stale 0001-era GLOBAL unique on idempotency_key; enforces cross-scope uniqueness the #924 fund-scoped design relaxed (latent 409/23505 on legitimate key reuse). Replaced by forecast_snapshots_fund_idem_key_idx. Rollback caveat: recreating the global index FAILS if legitimate cross-scope duplicate keys were inserted after the drop - accepted, the scoped design permits them.",
+      "reverseSql": "CREATE UNIQUE INDEX \"forecast_snapshots_idempotency_unique_idx\" ON \"forecast_snapshots\" USING btree (\"idempotency_key\") WHERE \"forecast_snapshots\".\"idempotency_key\" IS NOT NULL"
+    },
+    {
+      "kind": "index",
+      "name": "investment_lots_idempotency_unique_idx",
+      "reason": "Stale 0001-era GLOBAL unique on idempotency_key; replaced by investment_lots_investment_idem_key_idx (investment-scoped). Same rollback caveat as forecast_snapshots.",
+      "reverseSql": "CREATE UNIQUE INDEX \"investment_lots_idempotency_unique_idx\" ON \"investment_lots\" USING btree (\"idempotency_key\") WHERE \"investment_lots\".\"idempotency_key\" IS NOT NULL"
+    },
+    {
+      "kind": "index",
+      "name": "reserve_allocations_idempotency_unique_idx",
+      "reason": "Stale 0001-era GLOBAL unique on idempotency_key; replaced by reserve_allocations_snapshot_idem_key_idx (snapshot-scoped). Same rollback caveat as forecast_snapshots.",
+      "reverseSql": "CREATE UNIQUE INDEX \"reserve_allocations_idempotency_unique_idx\" ON \"reserve_allocations\" USING btree (\"idempotency_key\") WHERE \"reserve_allocations\".\"idempotency_key\" IS NOT NULL"
+    }
+  ]
+}

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -133,18 +133,79 @@ export function manifestChecksum(manifest, sqlFiles) {
       name: manifest.name,
       sqlFiles: sqlFiles.map((file) => ({ path: file.path, checksum: file.checksum })),
       expectedTables: manifest.expectedTables ?? [],
+      // Drop entries (incl. reverseSql) are ledger-identity: a materially
+      // different drop manifest must never dedup against a committed row
+      // (s8.1 red-team F3). Safe to add while the prod ledger is empty.
+      dropObjects: manifest.dropObjects ?? [],
     })
   );
 }
 
-export function statementHashes(sqlFiles) {
-  return sqlFiles.flatMap((file) =>
-    file.statements.map((statement, index) => ({
-      file: file.path,
+export function statementHashes(sqlFiles, extraStatements = []) {
+  return [
+    ...sqlFiles.flatMap((file) =>
+      file.statements.map((statement, index) => ({
+        file: file.path,
+        index,
+        hash: sha256(statement),
+      }))
+    ),
+    ...extraStatements.map((statement, index) => ({
+      file: '<dropObjects>',
       index,
       hash: sha256(statement),
-    }))
-  );
+    })),
+  ];
+}
+
+export function validateDropObjects(manifest) {
+  for (const drop of manifest.dropObjects ?? []) {
+    if (drop.kind !== 'index' && drop.kind !== 'constraint') {
+      throw new ReconcileError(
+        `Manifest ${manifest.name} dropObjects: unsupported kind ${String(drop.kind)}`,
+        { kind: 'unsupported-drop-kind', manifest: manifest.name, drop }
+      );
+    }
+    assertSafeIdentifier(drop.name);
+    if (drop.name.length > 63) {
+      throw new ReconcileError(
+        `Manifest ${manifest.name} dropObjects: ${drop.name} exceeds the 63-byte identifier limit; drop targets must be actual catalog names`,
+        { kind: 'drop-name-too-long', manifest: manifest.name, name: drop.name }
+      );
+    }
+    if (drop.kind === 'constraint') {
+      if (!drop.table) {
+        throw new ReconcileError(
+          `Manifest ${manifest.name} dropObjects: constraint ${drop.name} is missing its table`,
+          { kind: 'missing-drop-table', manifest: manifest.name, name: drop.name }
+        );
+      }
+      assertSafeIdentifier(drop.table);
+    }
+    if (typeof drop.reverseSql !== 'string' || drop.reverseSql.trim().length === 0) {
+      throw new ReconcileError(
+        `Manifest ${manifest.name} dropObjects: ${drop.name} is missing reverseSql (emergency rollback must be written down, not improvised)`,
+        { kind: 'missing-reverse-sql', manifest: manifest.name, name: drop.name }
+      );
+    }
+    if (typeof drop.reason !== 'string' || drop.reason.trim().length === 0) {
+      throw new ReconcileError(
+        `Manifest ${manifest.name} dropObjects: ${drop.name} is missing its reason`,
+        { kind: 'missing-drop-reason', manifest: manifest.name, name: drop.name }
+      );
+    }
+  }
+}
+
+export function dropStatements(manifest) {
+  return (manifest.dropObjects ?? []).map((drop) => {
+    assertSafeIdentifier(drop.name);
+    if (drop.kind === 'index') {
+      return `DROP INDEX IF EXISTS "${drop.name}"`;
+    }
+    assertSafeIdentifier(drop.table);
+    return `ALTER TABLE "${drop.table}" DROP CONSTRAINT IF EXISTS "${drop.name}"`;
+  });
 }
 
 export function validateManifestSql(manifest, sqlFiles) {
@@ -196,8 +257,9 @@ export function extractCreateTableNames(sql) {
 
 export async function auditManifest(client, manifest) {
   const expectedTables = manifest.expectedTables ?? [];
+  const dropObjects = manifest.dropObjects ?? [];
   const tableNames = expectedTables.map((table) => table.name);
-  if (tableNames.length === 0) {
+  if (tableNames.length === 0 && dropObjects.length === 0) {
     return {
       manifest: manifest.name,
       action: ACTION_SKIP,
@@ -205,23 +267,30 @@ export async function auditManifest(client, manifest) {
     };
   }
 
-  const presentTables = await loadPresentTables(client, tableNames);
-  const columns = await loadColumns(client, tableNames);
-  const constraints = await loadConstraints(client, tableNames, expectedTables);
-  const indexes = await loadIndexes(client, expectedTables);
   const objects = [];
 
-  for (const expectedTable of expectedTables) {
-    objects.push(
-      await auditTable({
-        client,
-        expectedTable,
-        tablePresent: presentTables.has(expectedTable.name),
-        columns: columns.get(expectedTable.name) ?? new Map(),
-        constraints,
-        indexes,
-      })
-    );
+  if (tableNames.length > 0) {
+    const presentTables = await loadPresentTables(client, tableNames);
+    const columns = await loadColumns(client, tableNames);
+    const constraints = await loadConstraints(client, tableNames, expectedTables);
+    const indexes = await loadIndexes(client, expectedTables);
+
+    for (const expectedTable of expectedTables) {
+      objects.push(
+        await auditTable({
+          client,
+          expectedTable,
+          tablePresent: presentTables.has(expectedTable.name),
+          columns: columns.get(expectedTable.name) ?? new Map(),
+          constraints,
+          indexes,
+        })
+      );
+    }
+  }
+
+  if (dropObjects.length > 0) {
+    objects.push(...(await auditDropObjects(client, dropObjects)));
   }
 
   return {
@@ -229,6 +298,57 @@ export async function auditManifest(client, manifest) {
     action: summarizeAction(objects.map((object) => object.action)),
     objects,
   };
+}
+
+// Extra-objects audit: a dropObject PRESENT on the target means the manifest
+// still has work (APPLY); absent means done (SKIP). The post-apply re-audit
+// therefore verifies drops through the same must-be-SKIP gate as creates.
+async function auditDropObjects(client, dropObjects) {
+  const indexNames = dropObjects.filter((drop) => drop.kind === 'index').map((drop) => drop.name);
+  const constraintDrops = dropObjects.filter((drop) => drop.kind === 'constraint');
+
+  const presentIndexes = await loadPresentDropIndexes(client, indexNames);
+  const presentConstraints = await loadPresentDropConstraints(client, constraintDrops);
+
+  return dropObjects.map((drop) => {
+    const present =
+      drop.kind === 'index' ? presentIndexes.has(drop.name) : presentConstraints.has(drop.name);
+    return {
+      table: drop.table ?? drop.name,
+      present,
+      populated: false,
+      deltas: present
+        ? [{ kind: 'extra-object-present', name: drop.name, additiveSafe: true }]
+        : [],
+      action: present ? ACTION_APPLY_MISSING_DDL : ACTION_SKIP,
+    };
+  });
+}
+
+async function loadPresentDropIndexes(client, names) {
+  if (names.length === 0) return new Set();
+  const result = await client.query(
+    `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname = ANY($1::text[])`,
+    [names]
+  );
+  return new Set(result.rows.map((row) => row.indexname));
+}
+
+async function loadPresentDropConstraints(client, constraintDrops) {
+  if (constraintDrops.length === 0) return new Set();
+  const result = await client.query(
+    `
+      SELECT con.conname
+      FROM pg_constraint con
+      JOIN pg_class c ON c.oid = con.conrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relname = ANY($1::text[])
+        AND con.conname = ANY($2::text[])
+    `,
+    [constraintDrops.map((drop) => drop.table), constraintDrops.map((drop) => drop.name)]
+  );
+  return new Set(result.rows.map((row) => row.conname));
 }
 
 export function decideObjectAction({ tablePresent, deltas, populated }) {
@@ -342,11 +462,14 @@ export async function runReconciliation({
   for (const manifest of manifests) {
     const sqlFiles = await readManifestSql(manifest, rootDir);
     validateManifestSql(manifest, sqlFiles);
+    validateDropObjects(manifest);
+    const manifestDropStatements = dropStatements(manifest);
     preparedManifests.push({
       manifest,
       sqlFiles,
       checksum: manifestChecksum(manifest, sqlFiles),
-      statementHashes: statementHashes(sqlFiles),
+      statementHashes: statementHashes(sqlFiles, manifestDropStatements),
+      dropStatements: manifestDropStatements,
     });
   }
 
@@ -693,6 +816,15 @@ async function applyPreparedManifest({ client, prepared, identity, stdout }) {
     for (const file of prepared.sqlFiles) {
       stdout.write(`\nApplying ${file.path} (${file.statements.length} statements)\n`);
       for (const statement of file.statements) {
+        await client.query(statement);
+      }
+    }
+
+    if (prepared.dropStatements.length > 0) {
+      stdout.write(
+        `\nApplying ${prepared.dropStatements.length} dropObjects statements for ${prepared.manifest.name}\n`
+      );
+      for (const statement of prepared.dropStatements) {
         await client.query(statement);
       }
     }

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -41,6 +41,14 @@ const C1_MOUNTED_TABLES = [
   'lp_report_package_exports',
   'planning_fmv_override_requests',
 ] as const;
+// Manifest 05-operator-seam declares existing journal tables (scoped idem
+// indexes + len-checks via 0024; global idem drops via dropObjects) rather
+// than new C1 mounts.
+const SEAM_MANIFEST_TABLES = [
+  'forecast_snapshots',
+  'investment_lots',
+  'reserve_allocations',
+] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
   'flags_state',
@@ -669,7 +677,9 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       )
       .map(pgIdentifier);
 
-    expect([...expectedTables].sort()).toEqual([...C1_MOUNTED_TABLES].sort());
+    expect([...expectedTables].sort()).toEqual(
+      [...C1_MOUNTED_TABLES, ...SEAM_MANIFEST_TABLES].sort()
+    );
 
     const migratedTables = await publicTables(pool!, expectedTables);
     const migratedConstraints = await publicConstraints(pool!, expectedConstraints);

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -23,10 +23,17 @@ interface ManifestTable {
   indexes?: string[];
 }
 
+interface DropObject {
+  kind: 'index' | 'constraint';
+  table?: string;
+  name: string;
+}
+
 interface Manifest {
   name: string;
   sqlFiles?: string[];
   expectedTables?: ManifestTable[];
+  dropObjects?: DropObject[];
 }
 
 function loadManifestFiles(): Array<{ file: string; manifest: Manifest }> {
@@ -74,12 +81,13 @@ function namesSurvivingSql(sqlFiles: string[]): Set<string> {
 describe('prod-schema manifest sentinels', () => {
   const manifests = loadManifestFiles();
 
-  it('finds the four PR-1 manifests', () => {
+  it('finds the four PR-1 manifests plus the s8.1 operator-seam manifest', () => {
     expect(manifests.map((entry) => entry.file)).toEqual([
       '01-cohort.json',
       '02-fund-moic.json',
       '03-operating-tasks.json',
       '04-lp-reporting.json',
+      '05-operator-seam.json',
     ]);
   });
 
@@ -118,6 +126,16 @@ describe('prod-schema manifest sentinels', () => {
     // the survival pin, because post-apply reconciliation checks the catalog.
     expect(surviving.has('reconciliation_runs_idempotency_key_unique')).toBe(false);
     expect(surviving.has('reconciliation_runs_fund_id_idempotency_key_unique')).toBe(true);
+  });
+
+  it('dropObjects never target a name the manifest own SQL creates', () => {
+    for (const { file, manifest } of manifests) {
+      const surviving = namesSurvivingSql(manifest.sqlFiles ?? []);
+      const incoherent = (manifest.dropObjects ?? [])
+        .map((drop) => drop.name)
+        .filter((name) => surviving.has(pgIdentifier(name.toLowerCase())));
+      expect(incoherent, `${file} drops what its own SQL creates`).toEqual([]);
+    }
   });
 
   it('no duplicate sentinel names within a manifest', () => {

--- a/tests/unit/reconcile-prod-schema.test.ts
+++ b/tests/unit/reconcile-prod-schema.test.ts
@@ -10,8 +10,12 @@ import {
   assertExpectedDatabase,
   auditManifest,
   decideObjectAction,
+  dropStatements,
+  manifestChecksum,
   parseReconcileArgs,
   runReconciliation,
+  statementHashes,
+  validateDropObjects,
   validateManifestSql,
   extractCreateTableNames,
 } from '../../scripts/reconcile-prod-schema.mjs';
@@ -34,6 +38,9 @@ interface MockClientOptions {
   readonly constraints?: readonly string[];
   readonly indexes?: readonly string[];
   readonly populatedTables?: readonly string[];
+  /** When true, DROP statements do NOT mutate mock state - simulates a drop
+   * that silently fails to take effect, so the post-apply audit must catch it. */
+  readonly dropsHaveNoEffect?: boolean;
 }
 
 function createMockClient(options: MockClientOptions = {}) {
@@ -124,6 +131,44 @@ function createMockClient(options: MockClientOptions = {}) {
 
       if (text === 'SELECT pg_advisory_unlock($1)') {
         return { rows: [{ pg_advisory_unlock: true }], rowCount: 1 };
+      }
+
+      const dropIndexMatch = text.match(/^DROP INDEX IF EXISTS "([^"]+)"$/);
+      if (dropIndexMatch?.[1]) {
+        if (!options.dropsHaveNoEffect) {
+          indexes.delete(dropIndexMatch[1]);
+        }
+        return { rows: [], rowCount: 0 };
+      }
+
+      const dropConstraintMatch = text.match(
+        /^ALTER TABLE "[^"]+" DROP CONSTRAINT IF EXISTS "([^"]+)"$/
+      );
+      if (dropConstraintMatch?.[1]) {
+        if (!options.dropsHaveNoEffect) {
+          constraints.delete(dropConstraintMatch[1]);
+        }
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (/^(BEGIN|COMMIT|ROLLBACK)$/.test(text) || text.startsWith('SET ')) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (text.includes('CREATE TABLE IF NOT EXISTS') || text.includes('CREATE UNIQUE INDEX IF NOT EXISTS')) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (text.includes('"committed_at" IS NOT NULL')) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (text.includes('INSERT INTO')) {
+        return { rows: [{ id: 1 }], rowCount: 1 };
+      }
+
+      if (text.includes('UPDATE')) {
+        return { rows: [], rowCount: 0 };
       }
 
       throw new Error(`Unexpected query: ${text}`);
@@ -336,5 +381,138 @@ describe('reconcile-prod-schema shape decisions', () => {
     expect(
       client.calls.some((call) => /\bBEGIN\b|INSERT INTO|CREATE TABLE|COMMIT/.test(call.text))
     ).toBe(false);
+  });
+});
+
+describe('reconcile-prod-schema dropObjects path (s8.1 slice 3.5)', () => {
+  const dropManifest = {
+    name: 'seam-fixture',
+    dropObjects: [
+      {
+        kind: 'index',
+        name: 'legacy_global_idx',
+        reason: 'stale global unique replaced by scoped design',
+        reverseSql: 'CREATE UNIQUE INDEX "legacy_global_idx" ON "t" ("k")',
+      },
+      {
+        kind: 'constraint',
+        table: 'jobs',
+        name: 'jobs_legacy_check',
+        reason: 'stale check',
+        reverseSql: 'ALTER TABLE "jobs" ADD CONSTRAINT "jobs_legacy_check" CHECK (true)',
+      },
+    ],
+  };
+
+  it('manifest checksum changes when a drop entry changes (red-team F3)', () => {
+    const base = manifestChecksum(dropManifest, []);
+    const identical = manifestChecksum({ ...dropManifest }, []);
+    const reverseSqlChanged = manifestChecksum(
+      {
+        ...dropManifest,
+        dropObjects: [
+          { ...dropManifest.dropObjects[0]!, reverseSql: 'CREATE INDEX "other" ON "t" ("k")' },
+          dropManifest.dropObjects[1]!,
+        ],
+      },
+      []
+    );
+    const entryRemoved = manifestChecksum(
+      { ...dropManifest, dropObjects: [dropManifest.dropObjects[0]!] },
+      []
+    );
+
+    expect(identical).toBe(base);
+    expect(reverseSqlChanged).not.toBe(base);
+    expect(entryRemoved).not.toBe(base);
+  });
+
+  it('statement hashes include generated drop statements', () => {
+    const hashes = statementHashes([], dropStatements(dropManifest));
+    expect(hashes).toHaveLength(2);
+    expect(hashes.every((entry) => entry.file === '<dropObjects>')).toBe(true);
+  });
+
+  it('generates guarded drop statements per kind', () => {
+    expect(dropStatements(dropManifest)).toEqual([
+      'DROP INDEX IF EXISTS "legacy_global_idx"',
+      'ALTER TABLE "jobs" DROP CONSTRAINT IF EXISTS "jobs_legacy_check"',
+    ]);
+  });
+
+  it('rejects malformed drop objects', () => {
+    const bad = [
+      { kind: 'table', name: 'x', reason: 'r', reverseSql: 's' },
+      { kind: 'index', name: 'x; DROP TABLE users', reason: 'r', reverseSql: 's' },
+      { kind: 'constraint', name: 'x', reason: 'r', reverseSql: 's' },
+      { kind: 'index', name: 'x', reason: 'r', reverseSql: '   ' },
+      { kind: 'index', name: 'x', reason: '', reverseSql: 's' },
+      { kind: 'index', name: `x${'y'.repeat(70)}`, reason: 'r', reverseSql: 's' },
+    ];
+    for (const drop of bad) {
+      expect(() => validateDropObjects({ name: 'm', dropObjects: [drop] })).toThrow(
+        ReconcileError
+      );
+    }
+    expect(() => validateDropObjects(dropManifest)).not.toThrow();
+  });
+
+  it('audits a present drop target as APPLY and an absent one as SKIP', async () => {
+    const presentClient = createMockClient({
+      indexes: ['legacy_global_idx'],
+      constraints: ['jobs_legacy_check'],
+    });
+    const presentAudit = await auditManifest(presentClient, dropManifest);
+    expect(presentAudit.action).toBe(ACTION_APPLY_MISSING_DDL);
+    expect(
+      presentAudit.objects.flatMap((object) => object.deltas.map((delta) => delta.kind))
+    ).toEqual(['extra-object-present', 'extra-object-present']);
+
+    const absentClient = createMockClient();
+    const absentAudit = await auditManifest(absentClient, dropManifest);
+    expect(absentAudit.action).toBe(ACTION_SKIP);
+  });
+
+  it('apply executes drops in the guarded flow and post-apply audit passes', async () => {
+    const client = createMockClient({
+      indexes: ['legacy_global_idx'],
+      constraints: ['jobs_legacy_check'],
+    });
+    const output: string[] = [];
+
+    const result = await runReconciliation({
+      client,
+      manifests: [dropManifest],
+      apply: true,
+      stdout: { write: (chunk: string) => output.push(chunk) },
+    });
+
+    expect(result.applied).toEqual(['seam-fixture']);
+    expect(client.calls.map((call) => call.text)).toContain(
+      'DROP INDEX IF EXISTS "legacy_global_idx"'
+    );
+    expect(client.calls.map((call) => call.text)).toContain(
+      'ALTER TABLE "jobs" DROP CONSTRAINT IF EXISTS "jobs_legacy_check"'
+    );
+    expect(client.calls.map((call) => call.text)).toContain('COMMIT');
+  });
+
+  it('post-apply audit fails and rolls back when a drop does not take effect', async () => {
+    const client = createMockClient({
+      indexes: ['legacy_global_idx'],
+      constraints: ['jobs_legacy_check'],
+      dropsHaveNoEffect: true,
+    });
+    const output: string[] = [];
+
+    await expect(
+      runReconciliation({
+        client,
+        manifests: [dropManifest],
+        apply: true,
+        stdout: { write: (chunk: string) => output.push(chunk) },
+      })
+    ).rejects.toThrow(/Post-apply shape audit failed/);
+    expect(client.calls.map((call) => call.text)).toContain('ROLLBACK');
   });
 });


### PR DESCRIPTION
## What

s8.1 operator seam slice 3.5 (plan `EXECUTE-s81-operator-seam.md`, ADR-023; CEO-gate lock: operator sessions run reviewed code, never fresh code). This is the last repo-side slice before the combined operator session.

**Runner (`reconcile-prod-schema.mjs`) gains the explicit extra-objects path:**
- `dropObjects` manifest entries (`kind: index|constraint`, `name`, `table`, `reason`, `reverseSql`) with validation: safe identifiers, 63-byte catalog-name limit, non-empty `reverseSql` + `reason` (rollback written down, not improvised).
- **Red-team F3 closed:** `manifestChecksum` now covers `dropObjects` incl. `reverseSql` — unit-proven that a drop-entry change changes the checksum, so `hasCommittedLedger` can never dedup a materially different drop manifest. (Checksum change is safe: the prod ledger has no committed rows.)
- `auditManifest` audits drop targets: PRESENT → APPLY, ABSENT → SKIP — so the existing post-apply re-audit-must-be-SKIP gate verifies drops through the same mechanism as creates. Negative test proves a drop that silently fails rolls the transaction back.
- `applyPreparedManifest` executes generated drop statements AFTER `sqlFiles` in the same txn; statement hashes cover them in the ledger.

**M5 operator-seam manifest (`05-operator-seam.json`):** `sqlFiles=[0024]` creates the scoped idem indexes + len-checks + cursor indexes; `dropObjects` retire the three 0001-era global idem uniques (0001-verbatim `reverseSql`, cross-scope-dup rollback caveat recorded). Creates-before-drops is structural (one txn), satisfying the scoped-index-exists precheck transactionally. Ordering per the user decision: `loadManifests` order-sort applies C1 (01-04) before the seam (05) in one `--apply --yes` run.

**Test updates:** §7 clone test expects seam tables alongside C1 mounts; sentinel pin expects 5 manifests + new coherence rule (dropObjects never target names the manifest's own SQL creates); mock client supports the apply path with state-mutating drops.

## Evidence

- Local: 36/36 across the three affected unit files; `npm run check` 0 errors; lint clean; `node --check` on the runner
- Prod evidence base: #979 issuecomment-4869988644 (artifact sha256 `62131f6aa21bf7ad32c57c9c748b966526e956cb451311571326a0c05cf72b86`)
- `schema_tests` fires (manifests + §7 test file + path-filter all in-filter); §7 run URL recorded when green

## Not in this PR

No prod writes. The operator session (slice 4) runs after merge: single `--apply --yes` against the direct endpoint applies C1 + seam, then the post-apply audit re-run + fresh FK inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD