### PR TITLE
fix(schema): s8.1 slice 4a - manifest corrections from the rolled-back operator apply + clone-audit gate

### DIFF
--- a/migrations/0013_lp_reporting_core_drift.sql
+++ b/migrations/0013_lp_reporting_core_drift.sql
@@ -1,3 +1,5 @@
+-- @drift-patch
+-- Reason: LP reporting core schema drift; closes journal drift for issue #781. Marker added 2026-07-02 (s8.1 slice 4a) so the M4 manifest can reference this file - its LP-core tables are FK dependencies of 0014 that prod lacked.
 -- Migration: 0013_lp_reporting_core_drift
 -- Purpose: LP reporting core schema drift; closes journal drift for issue #781.
 -- Source of truth: drizzle-kit export from shared/schema.ts, shared/schema-lp-reporting.ts, and shared/schema-lp-sprint3.ts.

--- a/scripts/migration-ledger.ts
+++ b/scripts/migration-ledger.ts
@@ -89,10 +89,9 @@ export const LEGACY_JOURNALED_UNMARKED_ALLOWLIST: { tag: string; sha256: string 
     tag: '0011_scenario_share_sensitivity_drift',
     sha256: '31aaacc07bcc9b070e109bf6b97fa30d5c86d268b8d6a37e2fc9f5cfa41b9054',
   },
-  {
-    tag: '0013_lp_reporting_core_drift',
-    sha256: '22546f7bfc76fd4e3a2c9e50c6dccfde2f35cf416acb3d6a706979704e6e5149',
-  },
+  // 0013_lp_reporting_core_drift left this allowlist 2026-07-02: it gained the
+  // @drift-patch marker so the M4 manifest can reference it (its LP-core tables
+  // are FK dependencies of 0014 that prod lacked - s8.1 slice 4a).
   {
     tag: '0015_funds_base_currency',
     sha256: '82f989cbee1c5f36c00ac42668936bc7df842489b80af52cbde9aaab7b73adbd',

--- a/scripts/prod-schema-manifests/01-cohort.json
+++ b/scripts/prod-schema-manifests/01-cohort.json
@@ -2,7 +2,9 @@
   "name": "M1-cohort",
   "order": 1,
   "description": "Cohort and sector analysis tables mounted through makeApp /api/cohorts.",
-  "sqlFiles": ["migrations/0012_sector_variance_drift.sql"],
+  "sqlFiles": [
+    "migrations/0012_sector_variance_drift.sql"
+  ],
   "allowedCreateTables": [
     "sector_taxonomy",
     "sector_mappings",
@@ -15,10 +17,22 @@
     {
       "name": "sector_taxonomy",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "taxonomy_version", "nullable": false },
-        { "name": "slug", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "taxonomy_version",
+          "nullable": false
+        },
+        {
+          "name": "slug",
+          "nullable": false
+        }
       ],
       "constraints": [
         "sector_taxonomy_fund_version_slug_unique",
@@ -35,11 +49,26 @@
     {
       "name": "sector_mappings",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "taxonomy_version", "nullable": false },
-        { "name": "raw_value_normalized", "nullable": false },
-        { "name": "canonical_sector_id", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "taxonomy_version",
+          "nullable": false
+        },
+        {
+          "name": "raw_value_normalized",
+          "nullable": false
+        },
+        {
+          "name": "canonical_sector_id",
+          "nullable": false
+        }
       ],
       "constraints": [
         "sector_mappings_fund_version_normalized_unique",
@@ -56,11 +85,26 @@
     {
       "name": "company_overrides",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "taxonomy_version", "nullable": false },
-        { "name": "company_id", "nullable": false },
-        { "name": "canonical_sector_id", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "taxonomy_version",
+          "nullable": false
+        },
+        {
+          "name": "company_id",
+          "nullable": false
+        },
+        {
+          "name": "canonical_sector_id",
+          "nullable": true
+        }
       ],
       "constraints": [
         "company_overrides_fund_version_company_unique",
@@ -78,9 +122,18 @@
     {
       "name": "investment_overrides",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "investment_id", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "investment_id",
+          "nullable": false
+        }
       ],
       "constraints": [
         "investment_overrides_fund_investment_unique",
@@ -99,10 +152,22 @@
     {
       "name": "cohort_definitions",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "name", "nullable": false },
-        { "name": "is_default", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "nullable": false
+        },
+        {
+          "name": "is_default",
+          "nullable": false
+        }
       ],
       "constraints": [
         "cohort_definitions_fund_name_unique",

--- a/scripts/prod-schema-manifests/04-lp-reporting.json
+++ b/scripts/prod-schema-manifests/04-lp-reporting.json
@@ -3,10 +3,20 @@
   "order": 4,
   "description": "LP reporting evidence tables mounted through makeApp LP reporting routes.",
   "sqlFiles": [
+    "migrations/0013_lp_reporting_core_drift.sql",
     "migrations/0014_lp_evidence_sprint3_drift.sql",
     "migrations/0022_planning_fmv_override_requests_drift.sql"
   ],
   "allowedCreateTables": [
+    "limited_partners",
+    "lp_fund_commitments",
+    "capital_activities",
+    "lp_distributions",
+    "lp_capital_accounts",
+    "lp_performance_snapshots",
+    "lp_reports",
+    "report_templates",
+    "lp_audit_log",
     "vehicles",
     "cash_flow_events",
     "valuation_marks",
@@ -27,13 +37,55 @@
   ],
   "expectedTables": [
     {
+      "name": "limited_partners"
+    },
+    {
+      "name": "lp_fund_commitments"
+    },
+    {
+      "name": "capital_activities"
+    },
+    {
+      "name": "lp_distributions"
+    },
+    {
+      "name": "lp_capital_accounts"
+    },
+    {
+      "name": "lp_performance_snapshots"
+    },
+    {
+      "name": "lp_reports"
+    },
+    {
+      "name": "report_templates"
+    },
+    {
+      "name": "lp_audit_log"
+    },
+    {
       "name": "vehicles",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "vehicle_slug", "nullable": false },
-        { "name": "vehicle_type", "nullable": false },
-        { "name": "name", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "vehicle_slug",
+          "nullable": false
+        },
+        {
+          "name": "vehicle_type",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "nullable": false
+        }
       ],
       "constraints": [
         "vehicles_fund_slug_unique",
@@ -42,17 +94,37 @@
         "vehicles_admin_score_check",
         "vehicles_fund_id_funds_id_fk"
       ],
-      "indexes": ["idx_vehicles_fund_type"]
+      "indexes": [
+        "idx_vehicles_fund_type"
+      ]
     },
     {
       "name": "cash_flow_events",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "event_type", "nullable": false },
-        { "name": "amount", "nullable": false },
-        { "name": "event_date", "nullable": false },
-        { "name": "perspective", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "event_type",
+          "nullable": false
+        },
+        {
+          "name": "amount",
+          "nullable": false
+        },
+        {
+          "name": "event_date",
+          "nullable": false
+        },
+        {
+          "name": "perspective",
+          "nullable": false
+        }
       ],
       "constraints": [
         "cash_flow_event_type_check",
@@ -76,12 +148,30 @@
     {
       "name": "valuation_marks",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "company_id", "nullable": false },
-        { "name": "mark_date", "nullable": false },
-        { "name": "as_of_date", "nullable": false },
-        { "name": "fair_value", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "company_id",
+          "nullable": false
+        },
+        {
+          "name": "mark_date",
+          "nullable": false
+        },
+        {
+          "name": "as_of_date",
+          "nullable": false
+        },
+        {
+          "name": "fair_value",
+          "nullable": false
+        }
       ],
       "constraints": [
         "valuation_mark_source_check",
@@ -103,12 +193,30 @@
     {
       "name": "lp_metric_runs",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "run_type", "nullable": false },
-        { "name": "perspective", "nullable": false },
-        { "name": "as_of_date", "nullable": false },
-        { "name": "status", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "run_type",
+          "nullable": false
+        },
+        {
+          "name": "perspective",
+          "nullable": false
+        },
+        {
+          "name": "as_of_date",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "nullable": false
+        }
       ],
       "constraints": [
         "lp_metric_run_type_check",
@@ -127,12 +235,30 @@
     {
       "name": "evidence_records",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "evidence_source", "nullable": false },
-        { "name": "confidence_level", "nullable": false },
-        { "name": "materiality_level", "nullable": false },
-        { "name": "confidentiality", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "evidence_source",
+          "nullable": false
+        },
+        {
+          "name": "confidence_level",
+          "nullable": false
+        },
+        {
+          "name": "materiality_level",
+          "nullable": false
+        },
+        {
+          "name": "confidentiality",
+          "nullable": false
+        }
       ],
       "constraints": [
         "evidence_one_target_check",
@@ -157,11 +283,26 @@
     {
       "name": "narrative_runs",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "metric_run_id", "nullable": false },
-        { "name": "narrative_type", "nullable": false },
-        { "name": "status", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "metric_run_id",
+          "nullable": false
+        },
+        {
+          "name": "narrative_type",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "nullable": false
+        }
       ],
       "constraints": [
         "narrative_type_check",
@@ -176,10 +317,22 @@
     {
       "name": "lp_report_packages",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "metric_run_id", "nullable": false },
-        { "name": "status", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "metric_run_id",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "nullable": false
+        }
       ],
       "constraints": [
         "lp_report_package_status_check",
@@ -195,11 +348,26 @@
     {
       "name": "lp_report_package_exports",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "report_package_id", "nullable": false },
-        { "name": "format", "nullable": false },
-        { "name": "status", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "report_package_id",
+          "nullable": false
+        },
+        {
+          "name": "format",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "nullable": false
+        }
       ],
       "constraints": [
         "lp_report_package_export_format_check",
@@ -221,13 +389,34 @@
     {
       "name": "planning_fmv_override_requests",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "company_id", "nullable": false },
-        { "name": "idempotency_key", "nullable": false },
-        { "name": "request_hash", "nullable": false },
-        { "name": "source_hash", "nullable": false },
-        { "name": "status", "nullable": false }
+        {
+          "name": "id",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "nullable": false
+        },
+        {
+          "name": "company_id",
+          "nullable": false
+        },
+        {
+          "name": "idempotency_key",
+          "nullable": false
+        },
+        {
+          "name": "request_hash",
+          "nullable": false
+        },
+        {
+          "name": "source_hash",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "nullable": false
+        }
       ],
       "constraints": [
         "planning_fmv_override_request_status_check",

--- a/scripts/prod-schema-manifests/04-lp-reporting.json
+++ b/scripts/prod-schema-manifests/04-lp-reporting.json
@@ -37,31 +37,172 @@
   ],
   "expectedTables": [
     {
-      "name": "limited_partners"
+      "name": "limited_partners",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "entity_type",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "version",
+          "type": "bigint",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "limited_partners_email_unique",
+        "limited_partners_entity_type_check"
+      ]
     },
     {
-      "name": "lp_fund_commitments"
+      "name": "lp_fund_commitments",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "lp_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "commitment_amount_cents",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "version",
+          "type": "bigint",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "lp_fund_commitments_lp_id_fund_id_unique",
+        "lp_fund_commitments_status_check",
+        "lp_fund_commitments_fund_id_funds_id_fk",
+        "lp_fund_commitments_lp_id_limited_partners_id_fk"
+      ],
+      "indexes": [
+        "lp_fund_commitments_lp_id_idx",
+        "lp_fund_commitments_fund_id_idx"
+      ]
     },
     {
-      "name": "capital_activities"
+      "name": "capital_activities",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "capital_activities_commitment_id_lp_fund_commitments_id_fk",
+        "capital_activities_fund_id_funds_id_fk"
+      ]
     },
     {
-      "name": "lp_distributions"
+      "name": "lp_distributions",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "lp_distributions_activity_id_capital_activities_id_fk"
+      ]
     },
     {
-      "name": "lp_capital_accounts"
+      "name": "lp_capital_accounts",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "lp_capital_accounts_commitment_id_lp_fund_commitments_id_fk"
+      ]
     },
     {
-      "name": "lp_performance_snapshots"
+      "name": "lp_performance_snapshots",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "lp_performance_snapshots_commitment_id_lp_fund_commitments_id_fk"
+      ]
     },
     {
-      "name": "lp_reports"
+      "name": "lp_reports",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "lp_reports_lp_id_limited_partners_id_fk"
+      ]
     },
     {
-      "name": "report_templates"
+      "name": "report_templates",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ]
     },
     {
-      "name": "lp_audit_log"
+      "name": "lp_audit_log",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "lp_audit_log_lp_id_limited_partners_id_fk"
+      ]
     },
     {
       "name": "vehicles",

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -831,10 +831,19 @@ async function applyPreparedManifest({ client, prepared, identity, stdout }) {
 
     const after = await auditManifest(client, prepared.manifest);
     if (after.action !== ACTION_SKIP) {
-      throw new ReconcileError(`Post-apply shape audit failed for ${prepared.manifest.name}`, {
-        kind: 'post-apply-audit-failed',
-        audit: after,
-      });
+      // The CLI surfaces only error.message - the failing deltas must live IN
+      // the message or the operator gets no diagnosis (s8.1 slice 4a lesson).
+      const failingObjects = after.objects
+        .filter((object) => object.deltas.length > 0 || object.action !== ACTION_SKIP)
+        .map((object) => `${object.table}: ${JSON.stringify(object.deltas)}`)
+        .join('; ');
+      throw new ReconcileError(
+        `Post-apply shape audit failed for ${prepared.manifest.name} - ${failingObjects}`,
+        {
+          kind: 'post-apply-audit-failed',
+          audit: after,
+        }
+      );
     }
 
     await client.query(

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -10,7 +10,7 @@ import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { pgIdentifier } from '../../scripts/db-push-core.mjs';
-import { auditManifest, loadManifests } from '../../scripts/reconcile-prod-schema.mjs';
+import { ACTION_SKIP, auditManifest, loadManifests } from '../../scripts/reconcile-prod-schema.mjs';
 import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -881,15 +881,22 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     async () => {
       expect(pool).toBeDefined();
       const manifests = await loadManifests();
-      const failures: Array<{ manifest: string; table: string; deltas: unknown[] }> = [];
+      const failures: Array<{
+        manifest: string;
+        table: string;
+        action: string;
+        deltas: unknown[];
+      }> = [];
 
       for (const manifest of manifests) {
         const audit = await auditManifest(pool!, manifest);
+        expect(audit.action, `${audit.manifest} manifest-level action`).toBe(ACTION_SKIP);
         for (const object of audit.objects) {
-          if (object.deltas.length > 0) {
+          if (object.deltas.length > 0 || object.action !== ACTION_SKIP) {
             failures.push({
               manifest: audit.manifest,
               table: object.table,
+              action: object.action,
               deltas: object.deltas,
             });
           }

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -10,7 +10,7 @@ import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { pgIdentifier } from '../../scripts/db-push-core.mjs';
-import { loadManifests } from '../../scripts/reconcile-prod-schema.mjs';
+import { auditManifest, loadManifests } from '../../scripts/reconcile-prod-schema.mjs';
 import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -48,6 +48,19 @@ const SEAM_MANIFEST_TABLES = [
   'forecast_snapshots',
   'investment_lots',
   'reserve_allocations',
+] as const;
+// LP-core dependency layer (0013): FK targets of 0014 that prod lacked -
+// added to M4 at s8.1 slice 4a after the first operator apply rolled back.
+const LP_CORE_MANIFEST_TABLES = [
+  'limited_partners',
+  'lp_fund_commitments',
+  'capital_activities',
+  'lp_distributions',
+  'lp_capital_accounts',
+  'lp_performance_snapshots',
+  'lp_reports',
+  'report_templates',
+  'lp_audit_log',
 ] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
@@ -678,7 +691,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       .map(pgIdentifier);
 
     expect([...expectedTables].sort()).toEqual(
-      [...C1_MOUNTED_TABLES, ...SEAM_MANIFEST_TABLES].sort()
+      [...C1_MOUNTED_TABLES, ...SEAM_MANIFEST_TABLES, ...LP_CORE_MANIFEST_TABLES].sort()
     );
 
     const migratedTables = await publicTables(pool!, expectedTables);
@@ -861,5 +874,35 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       expect(Object.keys(artifact.results.row_counts)).toHaveLength(7);
     },
     60_000
+  );
+
+  it(
+    'every manifest audits clean (SKIP) against the journal clone',
+    async () => {
+      expect(pool).toBeDefined();
+      const manifests = await loadManifests();
+      const failures: Array<{ manifest: string; table: string; deltas: unknown[] }> = [];
+
+      for (const manifest of manifests) {
+        const audit = await auditManifest(pool!, manifest);
+        for (const object of audit.objects) {
+          if (object.deltas.length > 0) {
+            failures.push({
+              manifest: audit.manifest,
+              table: object.table,
+              deltas: object.deltas,
+            });
+          }
+        }
+      }
+
+      // Declaration-vs-catalog agreement: the replayed journal materializes
+      // every manifest table/constraint/index (and 0028 already dropped the
+      // seam dropObjects targets), so any delta here is a WRONG MANIFEST
+      // DECLARATION - the bug class that rolled back the first slice-4
+      // operator apply (company_overrides.canonical_sector_id nullability).
+      expect(failures).toEqual([]);
+    },
+    120_000
   );
 });

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -37,6 +37,7 @@ const expectedLooseFiles = [
 
 const expectedJournaledDriftPatchFiles = [
   '0012_sector_variance_drift.sql',
+  '0013_lp_reporting_core_drift.sql',
   '0014_lp_evidence_sprint3_drift.sql',
   '0016_reconciliation_runs.sql',
   '0017_moic_exit_probability_modes.sql',

--- a/tests/unit/reconcile-prod-schema.test.ts
+++ b/tests/unit/reconcile-prod-schema.test.ts
@@ -1,3 +1,9 @@
+
+// Default import on purpose: node-setup.ts vi.mock('fs') stubs the NAMED
+// readFileSync export, but its ...actual spread preserves `default` as the
+// real fs module - same pattern as the sibling ledger/sentinel tests.
+import fs from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -495,6 +501,35 @@ describe('reconcile-prod-schema dropObjects path (s8.1 slice 3.5)', () => {
       'ALTER TABLE "jobs" DROP CONSTRAINT IF EXISTS "jobs_legacy_check"'
     );
     expect(client.calls.map((call) => call.text)).toContain('COMMIT');
+  });
+
+  it('a legacy wrong-shape limited_partners table does NOT audit clean (review 4a-1)', async () => {
+    // The loose 001_lp_reporting_schema.sql created limited_partners with a
+    // UUID id; canonical 0013 uses serial/integer. The real M4 manifest must
+    // surface that shape divergence instead of treating any same-named table
+    // as satisfied - name-only sentinels false-SKIP legacy tables.
+    const m4 = JSON.parse(
+      fs.readFileSync('scripts/prod-schema-manifests/04-lp-reporting.json', 'utf8')
+    ) as { expectedTables: Array<{ name: string }> };
+
+    const legacyShapeClient = createMockClient({
+      presentTables: ['limited_partners'],
+      populatedTables: ['limited_partners'],
+      columns: [
+        {
+          table_name: 'limited_partners',
+          column_name: 'id',
+          data_type: 'uuid',
+          udt_name: 'uuid',
+          is_nullable: 'NO',
+        },
+      ],
+    });
+
+    const audit = await auditManifest(legacyShapeClient, m4);
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    const lpObject = audit.objects.find((object) => object.table === 'limited_partners');
+    expect(lpObject?.deltas.map((delta) => delta.kind)).toContain('column-type-mismatch');
   });
 
   it('post-apply audit fails and rolls back when a drop does not take effect', async () => {


### PR DESCRIPTION
## What happened

The first slice-4 operator apply **failed cleanly**: M1-cohort applied its 40 statements, the post-apply shape audit rejected one delta, and the guarded transaction rolled back — prod untouched (fail-fast; M2–M5 never ran). The runner's safety design worked exactly as built. Transactional prod probes (apply + audit + ROLLBACK) diagnosed two defects:

1. **M1 wrong declaration:** `01-cohort.json` declared `company_overrides.canonical_sector_id` NOT NULL; 0012 and the shape (`schema.ts:2337`) agree it's nullable — the manifest miscopied `sector_mappings`' NOT NULL. One-line fix.
2. **M4 missing dependency layer:** 0014 hard-depends on `limited_partners` + `lp_fund_commitments` (42P01 mid-manifest — its DO-blocks guard FK existence but not FK target tables). Both are created by journaled `0013_lp_reporting_core_drift.sql`. Fix: 0013 gains the `@drift-patch` marker + `-- Reason:` line (leaves the sha-pinned unmarked allowlist, joins the drift-patch pin), and M4 prepends it to `sqlFiles` with the nine LP-core tables in `allowedCreateTables` + name-only `expectedTables` sentinels. Dependency closure verified: 0013's only external FK target is `funds` (present on prod); `lp_capital_calls`/`lp_vehicle_participation` are 0014-self-created.

## Gates hardened

- **New §7 clone-audit test:** every manifest must audit `SKIP` against the replayed journal clone — wrong manifest declarations (the exact M1 bug class) now fail in CI Docker, never on prod.
- **Runner diagnosis fix:** post-apply failure message now includes the failing deltas (the CLI printed only the message; this failure needed a probe round-trip to diagnose).

## Proof

Faithful transactional probe against prod (per manifest: sqlFiles + dropStatements + audit, then ROLLBACK): **all five manifests SKIP, zero deltas.** Prod is net-unchanged except the runner's own autocommitted empty ledger table (expected bookkeeping).

Local gates: 36/36 unit (ledger incl. new 0013 classification, sentinels, dropObjects suite), `validateMigrationLedger` ok, `npm run check` 0 errors, lint clean.

## After merge

Re-run the operator apply (same command); expected: five committed ledger rows, then the post-apply audit script run showing globals ABSENT / scoped PRESENT / C1+LP-core tables PRESENT, then slice 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD