### PR TITLE
test(schema): s8.1 slice 5 - shrink KNOWN_INTERSECTION_DRIFT to empty (zero-drift gate)

### DIFF
--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -87,24 +87,10 @@ const EXPECTED_TRIGGERS = [
   'scenario_matrices_updated_at',
   'optimization_sessions_updated_at',
 ] as const;
-const KNOWN_INTERSECTION_DRIFT = new Set<string>([
-  // Deferred to PR-1/operator (NOT additive journal catch-up): these three are a global->scoped
-  // idempotency rename — journal 0001_certain_miracleman created UNIQUE(idempotency_key) alone;
-  // shared/schema now declares the scoped *_idem_key_idx (added by 0024). Reconciling the old name
-  // means a DROP that implicates prod, so it ships with the FK-name seam in PR-1/operator scope.
-  'forecast_snapshots|index|forecast_snapshots_idempotency_unique_idx',
-  'investment_lots|index|investment_lots_idempotency_unique_idx',
-  'reserve_allocations|index|reserve_allocations_idempotency_unique_idx',
-  // §7 (run 28437747790) CONFIRMED these as still-observed = REAL drift, not stale. Deferred to
-  // PR-1/operator; do NOT shrink without a fresh §7 baselineNotObserved signal.
-  // NB (s8.4): the two reserve_decisions index entries formerly baselined here were NOT a
-  // catalog-detail mismatch — they were missing from DB-A outright (0001's DROP/ADD COLUMN
-  // dropped them; nothing recreated them). Fixed by 0026_reserve_decisions_index_resync_drift;
-  // §7 run 28557795657 reported both under baselineNotObserved, so they were shrunk.
-  'fund_snapshots|fk|fund_snapshots_config_id_fundconfigs_id_fk',
-  'fund_snapshots|fk|fund_snapshots_run_id_calc_runs_id_fk',
-  'job_outbox|constraint|job_outbox_status_check',
-]);
+// Empty since s8.1 slice 5 (ADR-023): the final six entries were fixed by #980 (journal 0028 +
+// shape .references()/CHECK) and materialized on prod by the slice-4 operator apply. The gate now
+// tolerates ZERO intersection drift — new mismatches fail; fix the drift, don't re-baseline.
+const KNOWN_INTERSECTION_DRIFT = new Set<string>([]);
 
 type TableShapeMap<TShape> = Map<string, Map<string, TShape>>;
 type TableSetMap = Map<string, Set<string>>;


### PR DESCRIPTION
## s8.1 slice 5 — baseline shrink: `KNOWN_INTERSECTION_DRIFT` -> `[]`

Final PR-2b step per ADR-023 / red-team F6. Deletes the six baseline entries + their comment block from `tests/integration/prod-schema-clone.test.ts`. The s7 gate now tolerates ZERO intersection drift.

### Pins (ADR-023 / F6 requirement)

| Pin | Value |
|---|---|
| Fresh s7 run | Testcontainers run [28629921978](https://github.com/nikhillinit/Updog_restore/actions/runs/28629921978) (head `1b5601eb`, merged as `b5a90f4f` via #985) — all six `baselineNotObserved`, zero `unexpectedShapeMismatches` |
| Slice-4 outcome | Operator apply executed 2026-07-03, exit 0; FIVE committed ledger rows: M1-cohort `05:18:10.054Z`, M2-fund-moic `05:18:14.121Z`, M3-operating-tasks `05:18:16.741Z`, M4-lp-reporting `05:18:17.820Z`, M5-operator-seam `05:18:31.476Z` |
| Post-apply audit | 3 old globals ABSENT; 3 scoped PRESENT valid+ready; fund_snapshots FKs + job_outbox_status_check present validated; orphans 0/0; 26/26 manifest tables present |
| Slice-0 artifact sha256 | `62131f6aa21bf7ad32c57c9c748b966526e956cb451311571326a0c05cf72b86` |
| Post-apply artifact sha256 | `ce2ee83ea350c87c9a1017469d3b1295ed42b610d6bb411b622afe5c06b215f1` (`s81-prod-audit-post-apply.json`, local untracked; full evidence in `s81-slice4-apply-evidence.md`) |
| Target host | `ep-snowy-boat-ad1z3h07.c-2.us-east-1.aws.neon.tech` / `neondb` (PG 17.10) |
| ADR | ADR-023 (DECISIONS.md), plan `EXECUTE-s81-operator-seam.md` s6 |

### Note: prod table count 61 -> 97 (predicted 87)

Manifests apply whole journal files; those files create ~11 sibling tables beyond the 26 sentinel-pinned ones (`lp_capital_calls`, `lp_documents`, `lp_notifications`, `lp_notification_preferences`, `lp_payment_submissions`, `lp_distribution_details`, `lp_vehicle_participation` + `_history`, `fund_calculation_mode_requests`, `fund_moic_input_update_requests`, `variance_planner_leader`). The #985 clone-audit gate proved every manifest audits SKIP vs a replayed-journal clone, so these are journal-canonical. The 87 prediction under-counted; prod state is correct.

### Acceptance

- `schema_tests` filter fires (test file touched); s7 must pass with EMPTY baseline (zero drift observed).
- `CI Gate Status` green; human merges.
- `dropObjects` in `05-operator-seam.json` intentionally untouched (post-apply audit relies on absent = SKIP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKM7SEEmvBfWjZxgrNb3uD
