### PR TITLE
docs(decisions): ADR-024 active_as_of API-only + PLAN(48) P2 evidence

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-05-21
+last_updated: 2026-07-04
 owner: Core Team
 review_cadence: P90D
 ---
@@ -27,6 +27,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-021: Single Required CI Gate with Internal Conditional Jobs](#adr-021-single-required-ci-gate-with-internal-conditional-jobs)
 - [ADR-022: SSE Event Routes Protected by Bearer Fund-Scope; Native EventSource Transport Deferred](#adr-022-sse-event-routes-protected-by-bearer-fund-scope-native-eventsource-transport-deferred)
 - [ADR-023: s8.1 Operator Seam - Evidence-First Slice Ordering and D1 Triage-First Decision Procedure](#adr-023-s81-operator-seam---evidence-first-slice-ordering-and-d1-triage-first-decision-procedure)
+- [ADR-024: LP Metric-Run active_as_of Source-Mark Selection Is API-Only](#adr-024-lp-metric-run-active_as_of-source-mark-selection-is-api-only)
 
 ---
 
@@ -5040,8 +5041,8 @@ hold-scope, engineering, codex red-team; plan
 
 ### Decision
 
-1. Slice ordering locked: 0 (read-only prod audit + un-truncated §7 dumps) ->
-   1 (decision lock) -> 2 (journal drift-patch `0028`) -> 3 (FK-name manifest
+1. Slice ordering locked: 0 (read-only prod audit + un-truncated §7 dumps) -> 1
+   (decision lock) -> 2 (journal drift-patch `0028`) -> 3 (FK-name manifest
    reconcile) -> 3.5 (drop-capable manifest path in `reconcile-prod-schema.mjs`
    as its own reviewed PR) -> 4 (guarded operator apply, only if audit demands)
    -> 5 (baseline shrink). Manifest reconcile precedes prod apply; operator
@@ -5081,3 +5082,45 @@ hold-scope, engineering, codex red-team; plan
   evidence lands (by design).
 - Neutral: `reconcile-prod-schema.mjs` gains a drop-capable manifest path whose
   checksum must cover drop entries and reverse SQL.
+
+---
+
+## ADR-024: LP Metric-Run active_as_of Source-Mark Selection Is API-Only
+
+**Date:** 2026-07-04 **Status:** [IMPLEMENTED] Implemented **Decision:** Keep
+`sourceMarkSelection: 'active_as_of'` as an API-only capability; do not expose
+it in `MetricRunForm`.
+
+### Context
+
+The LP metric-run contract supports two source-mark selection modes: `explicit`
+(operator-chosen mark IDs, the default) and `active_as_of` (server resolves the
+active approved marks as of the run date). PLAN(48) trust-activation P2 required
+deciding whether operators get UI access to `active_as_of` in `MetricRunForm`
+(docs/superpowers/plans/2026-07-03-trust-activation.md).
+
+### Decision
+
+API-only. `MetricRunForm` continues to submit `sourceMarkSelection: 'explicit'`
+with explicit `sourceMarkIds`
+(client/src/components/lp-reporting/MetricRunForm.tsx:115-116). The contract
+keeps enforcing the `active_as_of` invariant server-side: request-level
+`sourceMarkIds` must be empty
+(shared/contracts/lp-reporting/lp-metric-run.contract.ts:167-178), and the
+commit service resolves and stores the concrete contributing mark IDs.
+
+### Rationale
+
+- Trust-activation sequencing: the operator surface stays single-path until the
+  P4/P5 gates improve operator-facing language; a second selection mode in the
+  form adds decision burden without a proven operator need.
+- The invariant surface is already server-enforced and test-covered; API
+  consumers (automation) can use `active_as_of` today.
+- Reversible: exposing it later is additive UI work; supersede this ADR on
+  operator demand.
+
+### Consequences
+
+- `MetricRunForm` requires no change; the behavioral default is pinned by
+  tests/unit/contract/lp-reporting/lp-metric-run.contract.test.ts:119.
+- Any future UI exposure must revisit this ADR and PLAN(48) P2.

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -3113,17 +3113,17 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
-        "last_updated": "2026-05-21",
+        "last_updated": "2026-07-04",
         "owner": "Core Team",
         "review_cadence": "P90D",
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
       "isStale": false,
-      "lastUpdated": "2026-05-21",
+      "lastUpdated": "2026-07-04",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 44,
+      "staleDays": 0,
       "status": "ACTIVE"
     },
     {

--- a/docs/superpowers/plans/2026-07-03-trust-activation.md
+++ b/docs/superpowers/plans/2026-07-03-trust-activation.md
@@ -79,16 +79,27 @@ gate all executed, proving the skip path was not taken.
 
 ### P2: Planning FMV Activation Closeout
 
-- [ ] Confirm `enable_planning_fmv_overrides` remains production-off.
-- [ ] Decide and document whether LP metric-run `active_as_of` is API-only or
+- [x] Confirm `enable_planning_fmv_overrides` remains production-off.
+- [x] Decide and document whether LP metric-run `active_as_of` is API-only or
       exposed in `MetricRunForm`.
 - [ ] If UI exposure is chosen, update
       `client/src/components/lp-reporting/MetricRunForm.tsx` so operators can
-      choose explicit marks vs active approved marks.
-- [ ] Test default `sourceMarkSelection: 'explicit'` remains unchanged.
-- [ ] Test `active_as_of` submits empty `sourceMarkIds`.
-- [ ] Test Planning FMV UI remains disabled outside the live allocation
+      choose explicit marks vs active approved marks. (N/A: API-only chosen,
+      ADR-024.)
+- [x] Test default `sourceMarkSelection: 'explicit'` remains unchanged.
+- [x] Test `active_as_of` submits empty `sourceMarkIds`.
+- [x] Test Planning FMV UI remains disabled outside the live allocation
       workspace.
+
+P2 evidence (2026-07-04): flag production-off - registry default false
+(flags/registry.yaml), generated defaults false, and Vercel production env
+contains no VITE_ENABLE_PLANNING_FMV_OVERRIDES (verified via
+`vercel env ls production`); UI gate point is AllocationsTab.tsx
+`useFlag('enable_planning_fmv_overrides')`. Decision: `active_as_of` is API-only
+(ADR-024); `MetricRunForm` hardcodes `explicit` + empty `sourceMarkIds`. Tests
+green: lp-metric-run contract + metric-run commit service (55/55, server
+project) and enable-planning-fmv-overrides flag gating (3/3, client project),
+TZ=UTC.
 
 ### P3: Investment Rounds Controlled Soak
 


### PR DESCRIPTION
Closes out PLAN(48) **P2 (Planning FMV Activation Closeout)** and records the operator decision as ADR-024.

## Decision (ADR-024)

LP metric-run `sourceMarkSelection: 'active_as_of'` stays **API-only** - no `MetricRunForm` exposure. The form keeps hardcoding `explicit` + empty `sourceMarkIds` (MetricRunForm.tsx:115-116); the contract keeps enforcing the active_as_of invariant server-side (empty request `sourceMarkIds`, commit service stores resolved concrete mark IDs). Reversible on operator demand by superseding the ADR.

## P2 evidence

- **Flag production-off**: `enable_planning_fmv_overrides` default false in `flags/registry.yaml` + generated defaults; Vercel production env has **no** `VITE_ENABLE_PLANNING_FMV_OVERRIDES` (verified `vercel env ls production`, 2026-07-04). UI gate: `AllocationsTab.tsx` `useFlag(...)`.
- **Tests green** (local, TZ=UTC): lp-metric-run contract + metric-run commit service **55/55** (server project - pins the `explicit` default and the active_as_of/empty-markIds invariant); enable-planning-fmv-overrides flag gating **3/3** (client project).
- Zero code changes required - the decided posture is the current shipped behavior.

Plan doc P2 boxes checked with evidence block; UI-exposure item marked N/A. Router artifacts regenerated, `docs:routing:check` PASS. Applied via Hermes (postflight `npm run check` PASS). Docs-only.

Next gate: P3 (investment rounds controlled soak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS