### PR TITLE
feat(moic): operator-truthful state display on V2 rankings page (PLAN(48) P4)

### DIFF
--- a/client/src/pages/fund-model-results-moic-analysis.tsx
+++ b/client/src/pages/fund-model-results-moic-analysis.tsx
@@ -19,6 +19,26 @@ type FundIdParseResult =
   | { status: 'valid'; fundId: number };
 
 type FundMoicRankingV2 = FundMoicRankingsResponseV2['rankings'][number];
+type LatestReconciliationV2 = FundMoicRankingsResponseV2['latestReconciliation'];
+
+const ACTIVATION_BLOCKER_LABELS: Record<string, string> = {
+  accepted_reconciliation_required: 'Accepted reconciliation required',
+  accepted_reconciliation_not_found: 'No accepted reconciliation found',
+  current_source_changed: 'Unreconciled source edits',
+  exit_probability_source_incomplete: 'Exit probabilities incomplete',
+  kill_switch_active: 'Kill switch active',
+  reserve_exit_multiple_source_incomplete: 'Reserve exit multiples incomplete',
+  shadow_residency_pending: 'Shadow residency period pending',
+};
+
+const ROUND_EVIDENCE_WARNING_LABELS: Record<string, string> = {
+  ROLE_CLASSIFICATION_AMBIGUOUS: 'Round role classification ambiguous',
+  CURRENCY_MISMATCH_BLOCK: 'Currency mismatch (blocking)',
+  ROUND_MODEL_OVERRIDE_APPLIED: 'Round model override applied',
+  NON_EQUITY_AMOUNT_ONLY: 'Non-equity amounts only',
+  EMPTY_FUND: 'No round data for fund',
+  ROUND_ADAPTER_FAILED: 'Round evidence unavailable (adapter failed)',
+};
 
 function parseFundIdParam(rawValue: string | undefined): FundIdParseResult {
   if (rawValue === undefined) {
@@ -37,6 +57,36 @@ function parseFundIdParam(rawValue: string | undefined): FundIdParseResult {
 
 function formatMoicValue(value: number | null): string {
   return value === null ? 'Unavailable' : `${value.toFixed(2)}x`;
+}
+
+export function formatRankingsSource(
+  mode: FundMoicRankingsResponseV2['provenance']['mode']
+): string {
+  return mode === 'candidate'
+    ? 'Showing candidate rankings - values use reconciled round evidence.'
+    : 'Showing legacy rankings - baseline values from recorded portfolio data.';
+}
+
+export function formatMaterialityStatus(
+  status: FundMoicRankingsResponseV2['materiality']['status']
+): string {
+  if (status === 'recorded') return 'Recorded';
+  if (status === 'stale') return 'Stale - rerun required';
+  return 'Not run';
+}
+
+function formatUnreconciledEdits(hasUnreconciledEdits: boolean): string {
+  return hasUnreconciledEdits
+    ? 'Source data changed since the last accepted reconciliation'
+    : 'None';
+}
+
+function formatBlockingCount(count: number, label: string): string {
+  return count > 0 ? `${count} blocking (${label})` : '0';
+}
+
+function formatMappedCode(code: string, labels: Record<string, string>): string {
+  return labels[code] ?? code;
 }
 
 function StateCard({
@@ -63,64 +113,158 @@ function StateCard({
   );
 }
 
-function ProvenanceStrip({ data }: { data: FundMoicRankingsResponseV2 }) {
-  const warningCodes = data.roundEvidenceSummary.warningCodes;
-  const modeBlockers = data.modePreview.blockers;
+function WarningBanner({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-warning-dark">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <p className="font-medium">{message}</p>
+    </div>
+  );
+}
+
+function StatusField({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string;
+  tone?: 'default' | 'warning';
+}) {
+  const valueClass = tone === 'warning' ? 'text-warning-dark' : 'text-pov-charcoal';
 
   return (
-    <Card className="border-presson-info/20 bg-presson-info/10">
-      <CardContent className="grid gap-3 p-4 text-sm md:grid-cols-4">
-        <div>
-          <p className="text-muted-foreground">Materiality</p>
-          <p className="font-medium text-pov-charcoal">{data.materiality.status}</p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Mode</p>
-          <p className="font-medium text-pov-charcoal">
-            {data.modePreview.configuredMode} / {data.modePreview.effectiveMode}
+    <div>
+      <p className="text-muted-foreground">{label}</p>
+      <p className={`font-medium ${valueClass}`}>{value}</p>
+    </div>
+  );
+}
+
+function CodeBadge({ code, label }: { code: string; label: string }) {
+  const titleProps: { title?: string } = label === code ? {} : { title: code };
+
+  return (
+    <Badge
+      {...titleProps}
+      variant="outline"
+      className="border-beige-200 bg-pov-gray text-charcoal-700"
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function MappedCodeList({
+  codes,
+  labels,
+}: {
+  codes: readonly string[];
+  labels: Record<string, string>;
+}) {
+  const uniqueCodes = [...new Set(codes)];
+
+  if (uniqueCodes.length === 0) {
+    return <span className="font-medium text-pov-charcoal">None</span>;
+  }
+
+  return (
+    <div className="mt-1 flex flex-wrap gap-2">
+      {uniqueCodes.map((code) => (
+        <CodeBadge key={code} code={code} label={formatMappedCode(code, labels)} />
+      ))}
+    </div>
+  );
+}
+
+function LatestReconciliationSummary({ latest }: { latest: LatestReconciliationV2 }) {
+  if (!latest) {
+    return (
+      <div className="md:col-span-4">
+        <p className="text-muted-foreground">Latest reconciliation</p>
+        <p className="font-medium text-pov-charcoal">No reconciliation recorded</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="md:col-span-4">
+      <p className="text-muted-foreground">Latest reconciliation</p>
+      <div className="mt-1 grid gap-2 rounded-md border border-beige-200 bg-pov-gray p-3 md:grid-cols-4">
+        <p className="font-medium text-pov-charcoal">Run ID: {latest.runId ?? 'Unknown'}</p>
+        <p className="font-medium text-pov-charcoal">Created: {latest.createdAt ?? 'Unknown'}</p>
+        <p className="font-medium text-pov-charcoal">
+          {latest.currentInputMatches ? 'Inputs match' : 'Inputs changed'}
+        </p>
+        <p className="font-medium text-pov-charcoal">
+          {latest.sourceFingerprintMatches ? 'Fingerprint match' : 'Fingerprint changed'}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ProvenanceStrip({ data }: { data: FundMoicRankingsResponseV2 }) {
+  const materialityStatus = formatMaterialityStatus(data.materiality.status);
+  const exitProbabilityCount =
+    data.moicInputSummary.activationBlockingDefaultedExitProbabilityCount;
+  const reserveMultipleCount =
+    data.moicInputSummary.activationBlockingDefaultedReserveExitMultipleCount;
+
+  return (
+    <Card className="border-beige-200 bg-pov-white">
+      <CardContent className="space-y-4 p-4 text-sm">
+        <div className="rounded-md border border-beige-200 bg-pov-gray p-3">
+          <p className="text-muted-foreground">Rankings source</p>
+          <p className="font-semibold text-pov-charcoal">
+            {formatRankingsSource(data.provenance.mode)}
           </p>
         </div>
-        <div>
-          <p className="text-muted-foreground">Residency</p>
-          <p className="font-medium text-pov-charcoal">{data.modePreview.residencyStatus}</p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Kill switch</p>
-          <p className="font-medium text-pov-charcoal">
-            {data.modePreview.killSwitchActive ? 'Active' : 'Inactive'}
-          </p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Unreconciled edits</p>
-          <p className="font-medium text-pov-charcoal">
-            {data.modePreview.unreconciledEditsPresent ? 'Yes' : 'No'}
-          </p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Missing probabilities</p>
-          <p className="font-medium text-pov-charcoal tabular-nums">
-            {data.moicInputSummary.activationBlockingDefaultedExitProbabilityCount}
-          </p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Missing reserve multiples</p>
-          <p className="font-medium text-pov-charcoal tabular-nums">
-            {data.moicInputSummary.activationBlockingDefaultedReserveExitMultipleCount}
-          </p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Warning codes</p>
-          <div className="mt-1 flex flex-wrap gap-2">
-            {[...new Set([...warningCodes, ...modeBlockers])].length > 0 ? (
-              [...new Set([...warningCodes, ...modeBlockers])].map((code) => (
-                <Badge key={code} variant="outline" className="border-beige-200 text-charcoal-700">
-                  {code}
-                </Badge>
-              ))
-            ) : (
-              <span className="font-medium text-pov-charcoal">None</span>
-            )}
+
+        {data.modePreview.killSwitchActive ? (
+          <WarningBanner message="Kill switch active. Candidate mode is disabled; legacy rankings are shown." />
+        ) : null}
+
+        {data.materiality.status === 'stale' ? (
+          <WarningBanner message="Materiality check is stale. Displayed rankings may not reflect current inputs." />
+        ) : null}
+
+        <div className="grid gap-3 md:grid-cols-4">
+          <StatusField label="Materiality" value={materialityStatus} />
+          <StatusField
+            label="Mode"
+            value={`${data.modePreview.configuredMode} / ${data.modePreview.effectiveMode}`}
+          />
+          <StatusField label="Residency" value={data.modePreview.residencyStatus} />
+          <StatusField
+            label="Kill switch"
+            value={data.modePreview.killSwitchActive ? 'Active' : 'Inactive'}
+          />
+          <StatusField
+            label="Unreconciled edits"
+            value={formatUnreconciledEdits(data.modePreview.unreconciledEditsPresent)}
+            tone={data.modePreview.unreconciledEditsPresent ? 'warning' : 'default'}
+          />
+          <StatusField
+            label="Missing probabilities"
+            value={formatBlockingCount(exitProbabilityCount, 'defaulted exit probabilities')}
+          />
+          <StatusField
+            label="Missing reserve multiples"
+            value={formatBlockingCount(reserveMultipleCount, 'defaulted reserve exit multiples')}
+          />
+          <div className="md:col-span-2">
+            <p className="text-muted-foreground">Activation blockers</p>
+            <MappedCodeList codes={data.modePreview.blockers} labels={ACTIVATION_BLOCKER_LABELS} />
           </div>
+          <div className="md:col-span-2">
+            <p className="text-muted-foreground">Round evidence warnings</p>
+            <MappedCodeList
+              codes={data.roundEvidenceSummary.warningCodes}
+              labels={ROUND_EVIDENCE_WARNING_LABELS}
+            />
+          </div>
+          <LatestReconciliationSummary latest={data.latestReconciliation} />
         </div>
       </CardContent>
     </Card>

--- a/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
+++ b/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
@@ -1,73 +1,101 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createWouterWrapper } from '../../utils/withWouter';
 import FundModelResultsMoicAnalysisPage from '../../../client/src/pages/fund-model-results-moic-analysis';
-import type { FundMoicRankingsResponseV2 } from '../../../shared/contracts/fund-moic-v2.contract';
+import {
+  FundMoicRankingsResponseV2Schema,
+  type FundMoicRankingsResponseV2,
+} from '../../../shared/contracts/fund-moic-v2.contract';
 
-const useFundMoicRankingsV2 = vi.fn();
+type HookError = { code: string };
+type HookResult = {
+  data: FundMoicRankingsResponseV2 | null;
+  error: HookError | null;
+  isLoading: boolean;
+};
+
+const useFundMoicRankingsV2 = vi.fn<(fundId: number | null) => HookResult>();
 
 vi.mock('../../../client/src/hooks/use-moic', () => ({
   useFundMoicRankingsV2: (fundId: number | null) => useFundMoicRankingsV2(fundId),
 }));
 
-function makeV2(): FundMoicRankingsResponseV2 {
-  return {
-    contractVersion: '2.1.0',
-    fundId: 7,
-    rankings: [
-      {
-        rank: 1,
-        investmentId: '101',
-        investmentName: 'Acme Corp',
-        reservesMoic: {
-          value: 2.8,
-          description: 'Expected return on planned reserves',
-          formula: 'reserve exit value / planned reserves',
-        },
+const canonicalFixture = {
+  contractVersion: '2.1.0',
+  fundId: 7,
+  rankings: [
+    {
+      rank: 1,
+      investmentId: '101',
+      investmentName: 'Acme Corp',
+      reservesMoic: {
+        value: 2.8,
+        description: 'Expected return on planned reserves',
+        formula: 'reserve exit value / planned reserves',
       },
+    },
+  ],
+  provenance: {
+    mode: 'legacy',
+    warnings: ['shadow_residency_pending'],
+  },
+  latestReconciliation: {
+    runId: '55',
+    createdAt: '2026-06-24T00:00:00.000Z',
+    currentInputMatches: false,
+    sourceFingerprintMatches: false,
+  },
+  materiality: { status: 'stale', candidateMaterial: true, epsilon: 1e-8 },
+  modePreview: {
+    calculationKey: 'fund_moic_rankings_exit_probability',
+    configuredMode: 'shadow',
+    effectiveMode: 'off',
+    killSwitchActive: true,
+    shadowStartedAt: '2026-06-24T00:00:00.000Z',
+    eligibleAt: '2026-07-01T00:00:00.000Z',
+    residencyDaysRequired: 7,
+    residencyStatus: 'pending',
+    currentSourceMatchesAccepted: false,
+    unreconciledEditsPresent: true,
+    blockers: [
+      'accepted_reconciliation_required',
+      'accepted_reconciliation_not_found',
+      'current_source_changed',
+      'exit_probability_source_incomplete',
+      'kill_switch_active',
+      'reserve_exit_multiple_source_incomplete',
+      'shadow_residency_pending',
     ],
-    provenance: {
-      mode: 'legacy',
-      warnings: ['shadow_residency_pending'],
-    },
-    latestReconciliation: {
-      runId: '55',
-      createdAt: '2026-06-24T00:00:00.000Z',
-      currentInputMatches: false,
-    },
-    materiality: { status: 'stale', candidateMaterial: true, epsilon: 1e-8 },
-    modePreview: {
-      calculationKey: 'fund_moic_rankings_exit_probability',
-      configuredMode: 'shadow',
-      effectiveMode: 'shadow',
-      killSwitchActive: true,
-      shadowStartedAt: '2026-06-24T00:00:00.000Z',
-      eligibleAt: '2026-07-01T00:00:00.000Z',
-      residencyDaysRequired: 7,
-      residencyStatus: 'pending',
-      currentSourceMatchesAccepted: false,
-      unreconciledEditsPresent: true,
-      blockers: ['kill_switch_active', 'reserve_exit_multiple_source_incomplete'],
-      version: 2,
-    },
-    moicInputSummary: {
-      sourceVersion: 'moic-exit-probability-v1',
-      explicitExitProbabilityCount: 1,
-      defaultedExitProbabilityCount: 1,
-      activationBlockingDefaultedExitProbabilityCount: 0,
-      explicitReserveExitMultipleCount: 1,
-      defaultedReserveExitMultipleCount: 1,
-      activationBlockingDefaultedReserveExitMultipleCount: 1,
-    },
-    roundEvidenceSummary: {
-      activeRoundCount: 0,
-      activeOverrideCount: 0,
-      warningCodes: [],
-    },
-    generatedAt: '2026-06-24T00:00:00.000Z',
-  };
+    version: 2,
+  },
+  moicInputSummary: {
+    sourceVersion: 'moic-exit-probability-v1',
+    explicitExitProbabilityCount: 1,
+    defaultedExitProbabilityCount: 2,
+    activationBlockingDefaultedExitProbabilityCount: 2,
+    explicitReserveExitMultipleCount: 1,
+    defaultedReserveExitMultipleCount: 3,
+    activationBlockingDefaultedReserveExitMultipleCount: 3,
+  },
+  roundEvidenceSummary: {
+    activeRoundCount: 3,
+    activeOverrideCount: 1,
+    warningCodes: [
+      'ROLE_CLASSIFICATION_AMBIGUOUS',
+      'CURRENCY_MISMATCH_BLOCK',
+      'ROUND_MODEL_OVERRIDE_APPLIED',
+      'NON_EQUITY_AMOUNT_ONLY',
+      'EMPTY_FUND',
+      'ROUND_ADAPTER_FAILED',
+      'UNMAPPED_ROUND_WARNING',
+    ],
+  },
+  generatedAt: '2026-06-24T00:00:00.000Z',
+} satisfies FundMoicRankingsResponseV2;
+
+function makeV2(): FundMoicRankingsResponseV2 {
+  return FundMoicRankingsResponseV2Schema.parse(structuredClone(canonicalFixture));
 }
 
 function renderPage(path = '/fund-model-results/7/moic-analysis') {
@@ -79,28 +107,178 @@ function renderPage(path = '/fund-model-results/7/moic-analysis') {
   );
 }
 
+function mockHook(result: HookResult) {
+  useFundMoicRankingsV2.mockReturnValue(result);
+}
+
 describe('FundModelResultsMoicAnalysisPage', () => {
   beforeEach(() => {
     useFundMoicRankingsV2.mockReset();
   });
 
-  it('renders mode, stale materiality, source completeness, and blockers', () => {
-    useFundMoicRankingsV2.mockReturnValue({
-      data: makeV2(),
+  it('renders legacy source, warning banners, mapped codes, blocking counts, and reconciliation indicators', () => {
+    mockHook({ data: makeV2(), error: null, isLoading: false });
+
+    renderPage();
+
+    expect(
+      screen.getByText('Showing legacy rankings - baseline values from recorded portfolio data.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Kill switch active. Candidate mode is disabled; legacy rankings are shown.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Materiality check is stale. Displayed rankings may not reflect current inputs.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Stale - rerun required')).toBeInTheDocument();
+    expect(
+      screen.getByText('Source data changed since the last accepted reconciliation')
+    ).toBeInTheDocument();
+    expect(screen.getByText('2 blocking (defaulted exit probabilities)')).toBeInTheDocument();
+    expect(screen.getByText('3 blocking (defaulted reserve exit multiples)')).toBeInTheDocument();
+    expect(screen.getByText('Kill switch active')).toBeInTheDocument();
+    expect(screen.getByTitle('kill_switch_active')).toBeInTheDocument();
+    expect(screen.getByText('Unreconciled source edits')).toBeInTheDocument();
+    expect(screen.getByText('Exit probabilities incomplete')).toBeInTheDocument();
+    expect(screen.getByText('Reserve exit multiples incomplete')).toBeInTheDocument();
+    expect(screen.getByText('Accepted reconciliation required')).toBeInTheDocument();
+    expect(screen.getByText('No accepted reconciliation found')).toBeInTheDocument();
+    expect(screen.getByText('Shadow residency period pending')).toBeInTheDocument();
+    expect(screen.getByText('Round role classification ambiguous')).toBeInTheDocument();
+    expect(screen.getByText('Currency mismatch (blocking)')).toBeInTheDocument();
+    expect(screen.getByText('Round model override applied')).toBeInTheDocument();
+    expect(screen.getByText('Non-equity amounts only')).toBeInTheDocument();
+    expect(screen.getByText('No round data for fund')).toBeInTheDocument();
+    expect(screen.getByText('Round evidence unavailable (adapter failed)')).toBeInTheDocument();
+    expect(screen.getByText('UNMAPPED_ROUND_WARNING')).toBeInTheDocument();
+    expect(screen.getByText('Run ID: 55')).toBeInTheDocument();
+    expect(screen.getByText('Created: 2026-06-24T00:00:00.000Z')).toBeInTheDocument();
+    expect(screen.getByText('Inputs changed')).toBeInTheDocument();
+    expect(screen.getByText('Fingerprint changed')).toBeInTheDocument();
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+  });
+
+  it('renders candidate source copy when candidate rankings are active', () => {
+    const fixture = makeV2();
+    fixture.provenance.mode = 'candidate';
+    fixture.modePreview.configuredMode = 'on';
+    fixture.modePreview.effectiveMode = 'on';
+    fixture.modePreview.killSwitchActive = false;
+    fixture.modePreview.blockers = [];
+    fixture.materiality.status = 'recorded';
+    fixture.latestReconciliation = {
+      runId: '56',
+      createdAt: '2026-06-25T00:00:00.000Z',
+      currentInputMatches: true,
+      sourceFingerprintMatches: true,
+    };
+
+    mockHook({
+      data: FundMoicRankingsResponseV2Schema.parse(fixture),
       error: null,
       isLoading: false,
     });
 
     renderPage();
 
-    expect(screen.getByText('stale')).toBeInTheDocument();
-    expect(screen.getByText('shadow / shadow')).toBeInTheDocument();
-    expect(screen.getByText('pending')).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Yes')).toBeInTheDocument();
-    expect(screen.getByText('reserve_exit_multiple_source_incomplete')).toBeInTheDocument();
-    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
-    expect(screen.queryByText('candidate-output-a')).not.toBeInTheDocument();
-    expect(screen.queryByText('rawDiff')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Showing candidate rankings - values use reconciled round evidence.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Recorded')).toBeInTheDocument();
+    expect(screen.getByText('Inputs match')).toBeInTheDocument();
+    expect(screen.getByText('Fingerprint match')).toBeInTheDocument();
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('renders zero blocking counts, empty warning groups, and no reconciliation copy', () => {
+    const fixture = makeV2();
+    fixture.modePreview.blockers = [];
+    fixture.modePreview.killSwitchActive = false;
+    fixture.modePreview.unreconciledEditsPresent = false;
+    fixture.moicInputSummary.activationBlockingDefaultedExitProbabilityCount = 0;
+    fixture.moicInputSummary.activationBlockingDefaultedReserveExitMultipleCount = 0;
+    fixture.roundEvidenceSummary.warningCodes = [];
+    fixture.latestReconciliation = null;
+    fixture.materiality.status = 'not_run';
+
+    mockHook({
+      data: FundMoicRankingsResponseV2Schema.parse(fixture),
+      error: null,
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Not run')).toBeInTheDocument();
+    expect(screen.getAllByText('0')).toHaveLength(2);
+    expect(screen.getAllByText('None').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText('No reconciliation recorded')).toBeInTheDocument();
+  });
+
+  it('shows contract mismatch and does not render the rankings table on parse errors', () => {
+    mockHook({
+      data: null,
+      error: { code: 'CONTRACT_PARSE_ERROR' },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('MOIC contract mismatch')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The response did not match the required V2 contract, so rankings are not shown.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('shows a generic load error and does not render rankings', () => {
+    mockHook({
+      data: null,
+      error: { code: 'LOAD_ERROR' },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Unable to load MOIC rankings')).toBeInTheDocument();
+    expect(
+      screen.getByText('The rankings endpoint returned a load error, so rankings are not shown.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty rankings state without rendering the table', () => {
+    const fixture = makeV2();
+    fixture.rankings = [];
+
+    mockHook({
+      data: FundMoicRankingsResponseV2Schema.parse(fixture),
+      error: null,
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('No rankings available')).toBeInTheDocument();
+    expect(
+      screen.getByText('The V2 response returned zero reserves MOIC ranking rows for this fund.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('shows the loading state before data is available', () => {
+    mockHook({ data: null, error: null, isLoading: true });
+
+    renderPage();
+
+    expect(screen.getByText('Loading MOIC rankings')).toBeInTheDocument();
+    expect(
+      screen.getByText('Fetching the fund-scoped MOIC rankings response.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/routes/fund-moic-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-rankings.behavior.test.ts
@@ -1,0 +1,303 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FundMoicRankingsResponseV2Schema } from '../../../shared/contracts/fund-moic-v2.contract';
+import type { FundMoicRankingSources } from '../../../server/services/fund-moic-ranking-service';
+import type {
+  FundCalculationModePreview,
+  MoicActionabilityResult,
+} from '../../../server/services/fund-calculation-mode-service';
+
+const authState = vi.hoisted(() => ({
+  user: null as null | { id: number | string; sub?: string; role: string; fundIds: number[] },
+}));
+
+const svc = vi.hoisted(() => ({
+  getFundMoicRankingSources: vi.fn(),
+  getLatestCompletedMoicReconciliation: vi.fn(),
+  resolveFundCalculationMode: vi.fn(),
+  resolveMoicActionability: vi.fn(),
+  buildRoundsToModelEvidence: vi.fn(),
+}));
+
+vi.mock('../../../server/services/fund-moic-ranking-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-moic-ranking-service')>();
+  return { ...actual, getFundMoicRankingSources: svc.getFundMoicRankingSources };
+});
+
+vi.mock('../../../server/services/fund-moic-reconciliation-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../server/services/fund-moic-reconciliation-service')
+    >();
+  return {
+    ...actual,
+    getLatestCompletedMoicReconciliation: svc.getLatestCompletedMoicReconciliation,
+  };
+});
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
+  return {
+    ...actual,
+    resolveFundCalculationMode: svc.resolveFundCalculationMode,
+    resolveMoicActionability: svc.resolveMoicActionability,
+  };
+});
+
+vi.mock('../../../server/services/rounds-to-model-evidence-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../server/services/rounds-to-model-evidence-service')
+    >();
+  return { ...actual, buildRoundsToModelEvidence: svc.buildRoundsToModelEvidence };
+});
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
+      if (!authState.user) return res.sendStatus(401);
+      (req as Request & { user: unknown }).user = { ...authState.user };
+      next();
+    },
+  };
+});
+
+import fundMoicRouter from '../../../server/routes/fund-moic';
+
+const generatedAt = '2026-06-24T00:00:00.000Z';
+const USER = { id: 101, role: 'admin', fundIds: [1] };
+
+function rankingItem(investmentId: string, value: number) {
+  return {
+    rank: 1,
+    investmentId,
+    investmentName: investmentId,
+    reservesMoic: { value, description: 'desc', formula: 'formula' },
+  };
+}
+
+function sourceBundle(overrides: Partial<FundMoicRankingSources> = {}): FundMoicRankingSources {
+  return {
+    legacy: {
+      fundId: 1,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt,
+      rankings: [rankingItem('legacy-output-a', 1.2)],
+    },
+    candidate: {
+      fundId: 1,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt,
+      rankings: [rankingItem('candidate-output-a', 2.4)],
+    },
+    moicInputSummary: {
+      sourceVersion: 'moic-exit-probability-v1',
+      explicitExitProbabilityCount: 1,
+      defaultedExitProbabilityCount: 0,
+      activationBlockingDefaultedExitProbabilityCount: 0,
+      explicitReserveExitMultipleCount: 1,
+      defaultedReserveExitMultipleCount: 0,
+      activationBlockingDefaultedReserveExitMultipleCount: 0,
+    },
+    moicSourceInputHash: 'moic-source-input-a',
+    ...overrides,
+  };
+}
+
+function modePreview(
+  overrides: Partial<FundCalculationModePreview> = {}
+): FundCalculationModePreview {
+  return {
+    calculationKey: 'fund_moic_rankings_exit_probability',
+    configuredMode: 'off',
+    effectiveMode: 'off',
+    killSwitchActive: false,
+    shadowStartedAt: null,
+    eligibleAt: null,
+    residencyDaysRequired: 7,
+    residencyStatus: 'not_applicable',
+    currentSourceMatchesAccepted: false,
+    unreconciledEditsPresent: false,
+    blockers: [],
+    version: 0,
+    ...overrides,
+  };
+}
+
+function actionability(overrides: Partial<MoicActionabilityResult> = {}): MoicActionabilityResult {
+  const status = overrides.actionability ?? 'non_actionable';
+  return {
+    sourceFingerprintMatches: false,
+    actionability: status,
+    actionabilityStatus: status,
+    acceptedReconciliationRunId: null,
+    sourceFingerprint: {
+      moicSourceInputHash: 'moic-source-input-a',
+      roundEvidenceInputHash: 'round-evidence-input-a',
+      roundEvidenceAssumptionsHash: 'round-evidence-assumptions-a',
+      fingerprintHash: 'fingerprint-a',
+      policyVersion: 'h9-policy-v1',
+    },
+    ...overrides,
+  };
+}
+
+function roundsEvidence(warningCodes: string[] = []) {
+  return {
+    coverage: {
+      activeRoundCount: 2,
+      activeOverrideCount: 1,
+      warningsByCode: Object.fromEntries(warningCodes.map((code) => [code, 1])),
+    },
+  };
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', fundMoicRouter);
+  app.use((_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
+    res.status(500).json({ error: 'internal_error' })
+  );
+  return app;
+}
+
+function getRankings(path = '/api/funds/1/moic/rankings?contract=v2') {
+  return request(buildApp()).get(path);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = USER;
+  svc.getFundMoicRankingSources.mockResolvedValue(sourceBundle());
+  svc.getLatestCompletedMoicReconciliation.mockResolvedValue(null);
+  svc.resolveFundCalculationMode.mockResolvedValue(modePreview());
+  svc.resolveMoicActionability.mockResolvedValue(actionability());
+  svc.buildRoundsToModelEvidence.mockResolvedValue(roundsEvidence());
+});
+
+describe('fund MOIC rankings route - behavioral state machine', () => {
+  it('returns a schema-valid V2 legacy response for contract=v2 by default', async () => {
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.provenance.mode).toBe('legacy');
+    expect(parsed.rankings[0]?.investmentId).toBe('legacy-output-a');
+  });
+
+  it('returns candidate rankings when mode is on and actionability is actionable', async () => {
+    svc.resolveFundCalculationMode.mockResolvedValue(
+      modePreview({ configuredMode: 'on', effectiveMode: 'on' })
+    );
+    svc.resolveMoicActionability.mockResolvedValue(
+      actionability({
+        sourceFingerprintMatches: true,
+        actionability: 'actionable',
+        actionabilityStatus: 'actionable',
+      })
+    );
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.provenance.mode).toBe('candidate');
+    expect(parsed.rankings[0]?.investmentId).toBe('candidate-output-a');
+  });
+
+  it('keeps legacy rankings and surfaces blocker state when the kill switch is active', async () => {
+    svc.resolveFundCalculationMode.mockResolvedValue(
+      modePreview({
+        configuredMode: 'on',
+        effectiveMode: 'off',
+        killSwitchActive: true,
+        blockers: ['kill_switch_active'],
+      })
+    );
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.provenance.mode).toBe('legacy');
+    expect(parsed.modePreview.killSwitchActive).toBe(true);
+    expect(parsed.modePreview.blockers).toContain('kill_switch_active');
+    expect(parsed.rankings[0]?.investmentId).toBe('legacy-output-a');
+  });
+
+  it('propagates stale materiality when the latest reconciliation fingerprint no longer matches', async () => {
+    svc.getLatestCompletedMoicReconciliation.mockResolvedValue({
+      runId: '55',
+      createdAt: generatedAt,
+      candidateInputHash: 'moic-source-input-a',
+      evidenceInputHash: 'old-round-evidence',
+      candidateMaterial: true,
+    });
+    svc.resolveMoicActionability.mockResolvedValue(
+      actionability({ sourceFingerprintMatches: false })
+    );
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.materiality.status).toBe('stale');
+    expect(parsed.latestReconciliation).toMatchObject({
+      currentInputMatches: true,
+      sourceFingerprintMatches: false,
+    });
+  });
+
+  it('propagates round evidence warning codes verbatim', async () => {
+    svc.buildRoundsToModelEvidence.mockResolvedValue(
+      roundsEvidence(['ROUND_MODEL_OVERRIDE_APPLIED', 'UNKNOWN_WARNING'])
+    );
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.roundEvidenceSummary.warningCodes).toEqual([
+      'ROUND_MODEL_OVERRIDE_APPLIED',
+      'UNKNOWN_WARNING',
+    ]);
+  });
+
+  it('rejects unsupported contracts', async () => {
+    const res = await getRankings('/api/funds/1/moic/rankings?contract=v3');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_contract' });
+  });
+
+  it('returns the unchanged V1 payload when no contract query is provided', async () => {
+    const sources = sourceBundle();
+    svc.getFundMoicRankingSources.mockResolvedValue(sources);
+
+    const res = await getRankings('/api/funds/1/moic/rankings');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(sources.legacy);
+    expect(res.body).not.toHaveProperty('modePreview');
+    expect(res.body).not.toHaveProperty('materiality');
+    expect(res.body).not.toHaveProperty('latestReconciliation');
+    expect(res.body).not.toHaveProperty('roundEvidenceSummary');
+  });
+});


### PR DESCRIPTION
Implements PLAN(48) **P4 (MOIC/H9 Operator Truthfulness)**. Display-only: no server, contract, or schema changes; no render gating added (H9 gates persistence/reuse/export, not read-model display).

## What the operator now sees (`/fund-model-results/:fundId/moic-analysis`)

- **Rankings source line (new)**: `provenance.mode` was never rendered - operators could not tell legacy from candidate numbers. Now: "Showing legacy rankings..." / "Showing candidate rankings...".
- **Kill switch**: warning banner ("Kill switch active. Candidate mode is disabled; legacy rankings are shown.") in addition to the strip cell.
- **Stale materiality**: enum mapped ("Stale - rerun required") + warning banner; `not_run`/`recorded` mapped to plain labels.
- **Unreconciled edits**: "Source data changed since the last accepted reconciliation" instead of bare Yes/No.
- **Missing probability inputs / reserve multiples**: "{n} blocking (defaulted ...)" instead of raw counts.
- **Warnings split into two labeled groups** (previously one undifferentiated badge list): activation blockers (7 codes mapped) and round-evidence warnings (6 codes mapped); unknown codes render raw (fail-truthful); raw code preserved in badge title.
- **Latest reconciliation (new)**: run id, date, inputs-match and fingerprint-match indicators; "No reconciliation recorded" when null.

Fail-closed behavior preserved and now tested: parse failure renders the mismatch banner and never the table.

## Tests

- Page suite rewritten (7 tests): canonical fixture validated with `FundMoicRankingsResponseV2Schema.parse` (old fixture was silently schema-invalid - omitted `sourceFingerprintMatches`); covers all seven operator states + parse-error/load-error/empty/loading fail-closed states + unmapped-code raw rendering.
- **New** `tests/unit/routes/fund-moic-rankings.behavior.test.ts` (7 cases) closes the known GET `?contract=v2` assembly test debt: legacy default, candidate switch (mode on + actionable), kill-switch forces legacy + blocker surfaced, stale materiality propagation, warning-code propagation, `400 invalid_contract`, V1 payload unchanged.

## Verification

- Page tests 7/7 (client project); behavior + contract suites 54/54 (server project); TZ=UTC.
- `npm run check` 0 errors; eslint clean on touched files (max-warnings 0).
- `git diff --name-only server/ shared/` = empty (V2 contract preserved by construction; behavior test pins it).

Implemented via Hermes (Codex lane) from a reviewed brief; independently verified.

Known follow-up (not in this PR, needs a scope decision): the V1 `/moic-analysis` page silently serves candidate-or-legacy numbers with no mode/stale/kill-switch disclosure, and the declared `staleBlocksRender` policy has no runtime consumer on any surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS