### PR TITLE
docs(plans): PLAN(48) P5 acceptance criteria + evidence

### DIFF
--- a/docs/superpowers/plans/2026-07-03-trust-activation.md
+++ b/docs/superpowers/plans/2026-07-03-trust-activation.md
@@ -160,13 +160,60 @@ V1 `/moic-analysis` page lacks mode/stale/kill-switch disclosure; declared
 
 ### P5: LP Export Production-Trust Qualification
 
-- [ ] Treat current H9 export blockers as necessary but insufficient.
-- [ ] Add acceptance criteria for role policy, workflow state, watermark/admin
+- [x] Treat current H9 export blockers as necessary but insufficient.
+- [x] Add acceptance criteria for role policy, workflow state, watermark/admin
       policy, provenance, and export eligibility before any production-ready
       claim.
-- [ ] Keep `REPORT_PACKAGE_JSON_EXPORT_BLOCKED` structured responses covered.
-- [ ] Do not call exports production-trust-qualified until
+- [x] Keep `REPORT_PACKAGE_JSON_EXPORT_BLOCKED` structured responses covered.
+- [x] Do not call exports production-trust-qualified until
       role/workflow/watermark/provenance gates are accepted.
+
+Accepted criteria (2026-07-04). Production-trust-qualified requires AC-1 through
+AC-4 implemented and proven with cited CI run IDs; AC-5 must stay green. Until
+then exports are NOT production-trust-qualified. Current enforcement:
+eligibility ENFORCED+tested; role ABSENT; workflow-at-export DECLARED-ONLY;
+watermark ORPHANED; artifact provenance PARTIAL.
+
+- AC-1 Role policy: every Surface-A export route in
+  `server/routes/lp-reporting/metric-runs.ts` (render-model, live JSON, stored
+  JSON/CSV create/status/artifact) carries an explicit role guard beyond
+  `requireAuth` + `requireFundAccess` (today `requireRole` is never applied to
+  any export route and no `gp` role exists); `api-route-policy-registry.ts`
+  gains explicit API entries for these paths (none exist today); the privileged
+  empty-`fundIds` bypass in `requireFundAccess` is explicitly decided for
+  exports. Tests: 403 role-denied and role-allowed per endpoint.
+- AC-2 Workflow state: export endpoints re-gate on `lp_metric_runs.status` at
+  export time (today only assembly gates on `locked`; export never re-checks)
+  and a successful export transitions the run to `exported` (enum value exists;
+  nothing writes it today) - or an ADR explicitly rejects the transition. Tests:
+  export blocked per disallowed status; transition asserted.
+- AC-3 Watermark/admin policy: resolve the orphaned watermark seam -
+  `workers/report-worker.ts` watermarks a queue nothing enqueues to, while the
+  live `lp-report-generation` worker applies none. Either the live path applies
+  the policy (and the orphan is wired or deleted) or an ADR scopes watermarking
+  out for Surface A. Tests: watermark asserted on whichever path claims it.
+- AC-4 Provenance in artifact: the export artifact embeds the reserve stamp (H9
+  fingerprint hash + policy version + actionability status) in the
+  render-source/artifact contract with `contentHash` covering it - today
+  `h9Metadata` is computed in the render-model service and dropped before
+  return, so the stamp gates the export but is not in the artifact. Tests:
+  artifact fields match the stored package row.
+- AC-5 Export eligibility (enforced today - keep green): H9 fail-closed codes
+  (`H9_METADATA_MISSING`, `H9_REVALIDATION_UNAVAILABLE`, `H9_NOT_ACTIONABLE`,
+  `H9_FINGERPRINT_STALE`) and evidence blockers (`EVIDENCE_REFERENCE_INVALID`,
+  `EVIDENCE_RESTRICTED`, `EVIDENCE_REDACTION_REQUIRED`) keep returning
+  structured 409s.
+
+P5 evidence (2026-07-04): enforcement map from full surface audit on
+`09ea2080` - Surface A = metric-run report-package export routes
+(`lpReportingMetricRunsRouter`, app.ts mount), two distinct 409 families
+(`REPORT_PACKAGE_JSON_EXPORT_BLOCKED` with per-blocker evidence ids; H9\_\* with
+`details.surface`). Coverage green on `09ea2080`: 128/128 across
+report-package-json-export-service, json-stored-export-service, h9-export-gate,
+lp-report-package contract, and metric-runs-routes suites (TZ=UTC, server
+project). Verdict: NOT production-trust-qualified (1 of 5 dimensions enforced);
+AC-1..AC-4 are the implementation backlog and need their own PRD/spec per
+Strategic Backlog rules.
 
 ## Strategic Backlog Only
 


### PR DESCRIPTION
Closes out PLAN(48) **P5 (LP Export Production-Trust Qualification)** - the criteria-definition gate, not an implementation claim.

## Verdict

**Exports are NOT production-trust-qualified**: of the five dimensions, only export **eligibility** is enforced and tested (H9 fail-closed gate + evidence blockers). Full-surface audit on `09ea2080`:

| Dimension | Status |
|---|---|
| Export eligibility | ENFORCED + tested (H9_* 409s + `REPORT_PACKAGE_JSON_EXPORT_BLOCKED`) |
| Role policy | ABSENT (`requireRole` never applied to export routes; no registry entries; privileged empty-`fundIds` bypass undecided) |
| Workflow state at export | DECLARED-ONLY (`exported` status exists, nothing writes it; export never re-gates on run status) |
| Watermark/admin policy | ORPHANED (`workers/report-worker.ts` watermarks a queue nothing enqueues to; live `lp-report-generation` worker applies none) |
| Provenance in artifact | PARTIAL (run IDs/versions embedded; `h9Metadata` computed then dropped - reserve stamp gates but is not stamped) |

## What this PR records

- Five acceptance criteria (AC-1..AC-5) with concrete code anchors, each with required tests, written into the plan's P5 section.
- Standing rule: production-trust-qualified requires AC-1..AC-4 implemented and proven with cited CI run IDs; AC-1..AC-4 need their own PRD/spec per the plan's Strategic Backlog rules.
- Coverage evidence: 128/128 green on `09ea2080` across the five export/gate suites (TZ=UTC).

Docs-only; `docs:routing:check` PASS. Applied via Hermes (postflight `npm run check` PASS).

**This completes all six PLAN(48) gates (P0-P5).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS