### PR TITLE
feat(lp-reporting): embed H9 reserve stamp in export artifact (PRD #996 PR-1, AC-4)

### DIFF
--- a/server/services/lp-reporting/report-package-csv-stored-export-service.ts
+++ b/server/services/lp-reporting/report-package-csv-stored-export-service.ts
@@ -420,7 +420,18 @@ export async function createMetricRunReportPackageStoredCsvExport(
     throw new ReportPackageCsvSourceJsonExportRequiredError();
   }
 
-  const sourceArtifact = ReportPackageJsonExportArtifactSchema.parse(sourceJson.artifactPayload);
+  const parsedSourceArtifact = ReportPackageJsonExportArtifactSchema.safeParse(
+    sourceJson.artifactPayload
+  );
+  if (!parsedSourceArtifact.success) {
+    throw new MetricRunCommitError(
+      500,
+      'REPORT_PACKAGE_EXPORT_ROW_INVALID',
+      'Stored report package export artifact does not match the export contract.',
+      parsedSourceArtifact.error.issues
+    );
+  }
+  const sourceArtifact = parsedSourceArtifact.data;
   assertJsonSourceRouteScope(input, sourceArtifact);
   const csvDocument = buildCsvDocument(input, sourceJson, sourceArtifact);
   const contentHash = sha256Csv(csvDocument.csv);

--- a/server/services/lp-reporting/report-package-json-stored-export-service.ts
+++ b/server/services/lp-reporting/report-package-json-stored-export-service.ts
@@ -286,7 +286,16 @@ export async function getMetricRunReportPackageStoredJsonArtifact(
     throw new ReportPackageExportNotFoundError();
   }
 
-  const artifact = ReportPackageJsonExportArtifactSchema.parse(existing.artifactPayload);
+  const parsedArtifact = ReportPackageJsonExportArtifactSchema.safeParse(existing.artifactPayload);
+  if (!parsedArtifact.success) {
+    throw new MetricRunCommitError(
+      500,
+      'REPORT_PACKAGE_EXPORT_ROW_INVALID',
+      'Stored report package export artifact does not match the export contract.',
+      parsedArtifact.error.issues
+    );
+  }
+  const artifact = parsedArtifact.data;
   assertRouteScope(input, artifact);
 
   // Finding 8: the stored-readiness status endpoint (getMetricRunReportPackageStoredJsonExport)

--- a/server/services/lp-reporting/report-package-render-model-service.ts
+++ b/server/services/lp-reporting/report-package-render-model-service.ts
@@ -360,6 +360,13 @@ export async function getMetricRunReportPackageRenderModel(
   const reportPackage = toReportPackageRecord(rawPackage);
   const fundDisplay = await loadFundDisplay(database, input.fundId);
   const payload = reportPackage.payload;
+  if (reportPackage.h9Metadata == null) {
+    throw new MetricRunCommitError(
+      500,
+      'REPORT_PACKAGE_ROW_INVALID',
+      'Report package H9 metadata is required on render-model responses.'
+    );
+  }
 
   return ReportPackageRenderModelResponseSchema.parse({
     renderModel: {
@@ -377,6 +384,11 @@ export async function getMetricRunReportPackageRenderModel(
         assembledAt: reportPackage.assembledAt,
         packageVersion: reportPackage.version,
         payloadVersion: payload.payloadVersion,
+        h9Stamp: {
+          fingerprintHash: reportPackage.h9Metadata.fingerprintHash,
+          policyVersion: reportPackage.h9Metadata.policyVersion,
+          actionabilityStatus: reportPackage.h9Metadata.actionabilityStatus,
+        },
       },
       fundDisplay,
       metricSections: buildMetricSections(payload),

--- a/shared/contracts/lp-reporting/lp-report-package-render-model.contract.ts
+++ b/shared/contracts/lp-reporting/lp-report-package-render-model.contract.ts
@@ -14,7 +14,10 @@ import { z } from 'zod';
 import { DecimalStringSchema } from './cash-flow-event.contract';
 import { XirrDiagnosticSchema } from './lp-metric-run.contract';
 import { NarrativeTypeSchema } from './lp-narrative-run.contract';
-import { ReportPackageStatusSchema } from './lp-report-package.contract';
+import {
+  ReportPackageH9MetadataSchema,
+  ReportPackageStatusSchema,
+} from './lp-report-package.contract';
 
 const PositiveIdSchema = z.number().int().positive();
 const PositiveVersionSchema = z.number().int().positive();
@@ -50,6 +53,12 @@ export const ReportPackageRenderMetricValueKindSchema = z.enum([
   'count',
 ]);
 
+export const ReportPackageRenderSourceH9StampSchema = ReportPackageH9MetadataSchema.pick({
+  fingerprintHash: true,
+  policyVersion: true,
+  actionabilityStatus: true,
+});
+
 export const ReportPackageRenderSourceSchema = z
   .object({
     reportPackageId: PositiveIdSchema,
@@ -64,6 +73,7 @@ export const ReportPackageRenderSourceSchema = z
     assembledAt: z.string().datetime(),
     packageVersion: PositiveVersionSchema,
     payloadVersion: z.literal(1),
+    h9Stamp: ReportPackageRenderSourceH9StampSchema,
   })
   .strict();
 
@@ -163,6 +173,9 @@ export type ReportPackageRenderMetricSectionId = z.infer<
 export type ReportPackageRenderMetricId = z.infer<typeof ReportPackageRenderMetricIdSchema>;
 export type ReportPackageRenderMetricValueKind = z.infer<
   typeof ReportPackageRenderMetricValueKindSchema
+>;
+export type ReportPackageRenderSourceH9Stamp = z.infer<
+  typeof ReportPackageRenderSourceH9StampSchema
 >;
 export type ReportPackageRenderSource = z.infer<typeof ReportPackageRenderSourceSchema>;
 export type ReportPackageRenderFundDisplay = z.infer<typeof ReportPackageRenderFundDisplaySchema>;

--- a/tests/unit/contract/lp-reporting/lp-report-package.contract.test.ts
+++ b/tests/unit/contract/lp-reporting/lp-report-package.contract.test.ts
@@ -25,6 +25,7 @@ import {
   ReportPackagePayloadSchema,
   ReportPackageRecordSchema,
   ReportPackageRenderModelResponseSchema,
+  ReportPackageRenderSourceSchema,
   ReportPackageStatusSchema,
   type LpMetricRunDiagnostics,
   type LpMetricRunResults,
@@ -108,6 +109,11 @@ const record = {
   createdAt: '2026-05-10T01:05:00.000Z',
   updatedAt: '2026-05-10T01:05:00.000Z',
 } as const;
+const h9Stamp = {
+  fingerprintHash: 'd'.repeat(64),
+  policyVersion: 'h9-policy-v1',
+  actionabilityStatus: 'actionable' as const,
+};
 
 describe('report package enums', () => {
   it('accepts assembled status only', () => {
@@ -220,6 +226,7 @@ describe('ReportPackageRenderModelResponseSchema', () => {
         assembledAt: record.assembledAt,
         packageVersion: record.version,
         payloadVersion: record.payload.payloadVersion,
+        h9Stamp,
       },
       fundDisplay: {
         fundId: 1,
@@ -275,8 +282,33 @@ describe('ReportPackageRenderModelResponseSchema', () => {
     const parsed = ReportPackageRenderModelResponseSchema.parse(renderModelResponse);
 
     expect(parsed.renderModel.source.reportPackageId).toBe(501);
+    expect(parsed.renderModel.source.h9Stamp).toEqual(h9Stamp);
     expect(parsed.renderModel.fundDisplay.name).toBe('Press On Fund I');
     expect(parsed.renderModel.metricSections[0]?.rows[0]?.metricId).toBe('dpi');
+  });
+
+  it('pins render source fields and requires the H9 stamp', () => {
+    expect(Object.keys(ReportPackageRenderSourceSchema.shape)).toEqual([
+      'reportPackageId',
+      'fundId',
+      'metricRunId',
+      'reportPackageStatus',
+      'asOfDate',
+      'metricRunVersion',
+      'metricRunLockedBy',
+      'metricRunLockedAt',
+      'assembledBy',
+      'assembledAt',
+      'packageVersion',
+      'payloadVersion',
+      'h9Stamp',
+    ]);
+
+    const sourceWithoutStamp: Record<string, unknown> = {
+      ...renderModelResponse.renderModel.source,
+    };
+    delete sourceWithoutStamp.h9Stamp;
+    expect(() => ReportPackageRenderSourceSchema.parse(sourceWithoutStamp)).toThrow();
   });
 
   it.each(['record', 'downloadUrl', 'fileUrl', 'signedUrl', 'storageKey', 'queueJobId'])(

--- a/tests/unit/contract/report-package-h9-metadata.contract.test.ts
+++ b/tests/unit/contract/report-package-h9-metadata.contract.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   ReportPackageH9MetadataSchema,
   ReportPackageRecordSchema,
-} from '@shared/contracts/lp-reporting/lp-report-package.contract';
+  ReportPackageRenderSourceH9StampSchema,
+  type ReportPackageRenderSourceH9Stamp,
+} from '@shared/contracts/lp-reporting';
 
 const h9 = {
   moicSourceInputHash: 'a'.repeat(64),
@@ -69,6 +71,28 @@ const baseRecord = {
 describe('ReportPackageH9MetadataSchema', () => {
   it('accepts a full H9 metadata object', () => {
     expect(ReportPackageH9MetadataSchema.parse(h9)).toEqual(h9);
+  });
+
+  it('pins the full metadata fields and render-source stamp subset', () => {
+    expect(Object.keys(ReportPackageH9MetadataSchema.shape)).toEqual([
+      'moicSourceInputHash',
+      'roundEvidenceInputHash',
+      'roundEvidenceAssumptionsHash',
+      'fingerprintHash',
+      'policyVersion',
+      'actionabilityStatus',
+    ]);
+    expect(Object.keys(ReportPackageRenderSourceH9StampSchema.shape)).toEqual([
+      'fingerprintHash',
+      'policyVersion',
+      'actionabilityStatus',
+    ]);
+    const stamp: ReportPackageRenderSourceH9Stamp = {
+      fingerprintHash: h9.fingerprintHash,
+      policyVersion: h9.policyVersion,
+      actionabilityStatus: h9.actionabilityStatus,
+    };
+    expect(ReportPackageRenderSourceH9StampSchema.parse(stamp)).toEqual(stamp);
   });
 
   it('rejects an unknown actionability status', () => {

--- a/tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx
+++ b/tests/unit/hooks/lp-reporting/useMetricsDryRun.test.tsx
@@ -123,6 +123,12 @@ const baseRequest: MetricsDryRunRequest = {
   sourceMarkIds: [],
 };
 
+const H9_STAMP = {
+  fingerprintHash: 'd'.repeat(64),
+  policyVersion: 'h9-policy-v1',
+  actionabilityStatus: 'actionable' as const,
+};
+
 function makeDryRunResponse(): MetricRunDryRunResponse {
   return {
     results: makeCanonicalResults(),
@@ -357,6 +363,7 @@ function makeReportPackageRenderModelResponse(): ReportPackageRenderModelRespons
         assembledAt: record.assembledAt,
         packageVersion: record.version,
         payloadVersion: record.payload.payloadVersion,
+        h9Stamp: H9_STAMP,
       },
       fundDisplay: {
         fundId: 7,

--- a/tests/unit/pages/lp-reporting/metrics.test.tsx
+++ b/tests/unit/pages/lp-reporting/metrics.test.tsx
@@ -40,23 +40,27 @@ vi.mock('@/contexts/FundContext', () => ({
 }));
 
 import LpReportingMetricsPage from '@/pages/lp-reporting/metrics';
-import type {
-  LpMetricRunResults,
-  MetricRunCommitResponse,
-  MetricRunDetailResponse,
-  MetricRunDryRunResponse,
-  MetricRunLifecycleResponse,
-  NarrativeRunRecord,
-  ReportPackageCsvStoredArtifactResponse,
-  ReportPackageCsvStoredExportGetResponse,
-  ReportPackageCsvStoredExportResponse,
-  ReportPackageExportRecord,
-  ReportPackageJsonExportResponse,
-  ReportPackageJsonStoredArtifactResponse,
-  ReportPackageJsonStoredExportGetResponse,
-  ReportPackageJsonStoredExportResponse,
-  ReportPackageRecord,
-  ReportPackageRenderModelResponse,
+import {
+  ReportPackageJsonExportResponseSchema,
+  ReportPackageJsonStoredArtifactResponseSchema,
+  ReportPackageRecordSchema,
+  ReportPackageRenderModelResponseSchema,
+  type LpMetricRunResults,
+  type MetricRunCommitResponse,
+  type MetricRunDetailResponse,
+  type MetricRunDryRunResponse,
+  type MetricRunLifecycleResponse,
+  type NarrativeRunRecord,
+  type ReportPackageCsvStoredArtifactResponse,
+  type ReportPackageCsvStoredExportGetResponse,
+  type ReportPackageCsvStoredExportResponse,
+  type ReportPackageExportRecord,
+  type ReportPackageJsonExportResponse,
+  type ReportPackageJsonStoredArtifactResponse,
+  type ReportPackageJsonStoredExportGetResponse,
+  type ReportPackageJsonStoredExportResponse,
+  type ReportPackageRecord,
+  type ReportPackageRenderModelResponse,
 } from '@shared/contracts/lp-reporting';
 
 function renderPage() {
@@ -258,6 +262,20 @@ function makeApprovedNarratives(): NarrativeRunRecord[] {
   ];
 }
 
+const H9_METADATA = {
+  moicSourceInputHash: 'a'.repeat(64),
+  roundEvidenceInputHash: 'b'.repeat(64),
+  roundEvidenceAssumptionsHash: 'c'.repeat(64),
+  fingerprintHash: 'd'.repeat(64),
+  policyVersion: 'h9-policy-v1',
+  actionabilityStatus: 'actionable' as const,
+};
+const H9_STAMP = {
+  fingerprintHash: H9_METADATA.fingerprintHash,
+  policyVersion: H9_METADATA.policyVersion,
+  actionabilityStatus: H9_METADATA.actionabilityStatus,
+};
+
 function makeReportPackageRecord(): ReportPackageRecord {
   const narrativeRows = makeApprovedNarratives().map((record) => {
     const ref = {
@@ -277,7 +295,7 @@ function makeReportPackageRecord(): ReportPackageRecord {
     };
   });
   const narrativeRefs = narrativeRows.map((row) => row.ref);
-  return {
+  return ReportPackageRecordSchema.parse({
     reportPackageId: 501,
     fundId: 7,
     metricRunId: 17,
@@ -296,18 +314,18 @@ function makeReportPackageRecord(): ReportPackageRecord {
       evidenceRecordIds: [1000],
       narratives: narrativeRows.map((row) => row.payload),
     },
-    h9Metadata: null,
+    h9Metadata: H9_METADATA,
     assembledBy: 7,
     assembledAt: '2026-05-10T03:00:00.000Z',
     version: 1,
     createdAt: '2026-05-10T03:00:00.000Z',
     updatedAt: '2026-05-10T03:00:00.000Z',
-  };
+  });
 }
 
 function makeReportPackageRenderModelResponse(): ReportPackageRenderModelResponse {
   const record = makeReportPackageRecord();
-  return {
+  return ReportPackageRenderModelResponseSchema.parse({
     renderModel: {
       renderModelVersion: 1,
       source: {
@@ -323,6 +341,7 @@ function makeReportPackageRenderModelResponse(): ReportPackageRenderModelRespons
         assembledAt: record.assembledAt,
         packageVersion: record.version,
         payloadVersion: record.payload.payloadVersion,
+        h9Stamp: H9_STAMP,
       },
       fundDisplay: {
         fundId: 7,
@@ -410,12 +429,12 @@ function makeReportPackageRenderModelResponse(): ReportPackageRenderModelRespons
         narrativeRunIds: record.narrativeRefs.map((ref) => ref.narrativeRunId),
       },
     },
-  };
+  });
 }
 
 function makeReportPackageJsonExportResponse(): ReportPackageJsonExportResponse {
   const renderModelResponse = makeReportPackageRenderModelResponse();
-  return {
+  return ReportPackageJsonExportResponseSchema.parse({
     export: {
       exportVersion: 1,
       format: 'json',
@@ -424,7 +443,7 @@ function makeReportPackageJsonExportResponse(): ReportPackageJsonExportResponse 
       contentHashAlgorithm: 'sha256',
       contentHash: 'c'.repeat(64),
     },
-  };
+  });
 }
 
 function makeReportPackageStoredExportRecord(): ReportPackageExportRecord {
@@ -462,10 +481,10 @@ function makeReportPackageStoredExportResponse(
 }
 
 function makeReportPackageStoredArtifactResponse(): ReportPackageJsonStoredArtifactResponse {
-  return {
+  return ReportPackageJsonStoredArtifactResponseSchema.parse({
     record: makeReportPackageStoredExportRecord(),
     export: makeReportPackageJsonExportResponse().export,
-  };
+  });
 }
 
 function makeReportPackageStoredCsvExportRecord(): ReportPackageExportRecord {

--- a/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
+++ b/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
@@ -63,6 +63,11 @@ const dbState = vi.hoisted(() => ({
   dropNextInsert: false,
 }));
 let nextUserId = 800;
+const H9_STAMP = {
+  fingerprintHash: 'd'.repeat(64),
+  policyVersion: 'h9-policy-v1',
+  actionabilityStatus: 'actionable' as const,
+};
 
 vi.mock('../../../../server/lib/auth/jwt', () => ({
   requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
@@ -1795,6 +1800,7 @@ describe('metric-run report package routes', () => {
     expect(res.status).toBe(200);
     const parsed = ReportPackageRenderModelResponseSchema.parse(res.body);
     expect(parsed.renderModel.source.reportPackageId).toBe(3000);
+    expect(parsed.renderModel.source.h9Stamp).toEqual(H9_STAMP);
     expect(parsed.renderModel.fundDisplay.name).toBe('Press On Fund I');
     expect(parsed.renderModel.metricSections.map((section) => section.sectionId)).toEqual([
       'performance',
@@ -1829,6 +1835,8 @@ describe('metric-run report package routes', () => {
     expect(parsed.export.source.reportPackageId).toBe(3000);
     expect(parsed.export.source.fundId).toBe(1);
     expect(parsed.export.source.metricRunId).toBe(500);
+    expect(parsed.export.source.h9Stamp).toEqual(H9_STAMP);
+    expect(parsed.export.renderModel.source.h9Stamp).toEqual(H9_STAMP);
     expect(parsed.export.renderModel.narrativeSections.map((section) => section.sectionId)).toEqual(
       ['no_dpi', 'methodology', 'portfolio_update', 'risk_disclosure']
     );

--- a/tests/unit/services/lp-reporting/report-package-csv-stored-export-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-csv-stored-export-service.test.ts
@@ -12,7 +12,11 @@ import {
   getMetricRunReportPackageStoredCsvArtifact,
   getMetricRunReportPackageStoredCsvExport,
 } from '../../../../server/services/lp-reporting/report-package-csv-stored-export-service';
-import type { ReportPackageJsonExportArtifact } from '@shared/contracts/lp-reporting';
+import {
+  ReportPackageJsonExportArtifactSchema,
+  type ReportPackageJsonExportArtifact,
+  type ReportPackageRenderSource,
+} from '@shared/contracts/lp-reporting';
 import {
   lpReportPackageExports,
   lpReportPackages,
@@ -42,6 +46,11 @@ const storedPackageRow = {
   h9FingerprintHash: H9_FP,
   h9PolicyVersion: 'h9-policy-v1',
   h9ActionabilityStatus: 'actionable',
+};
+const H9_STAMP = {
+  fingerprintHash: H9_FP,
+  policyVersion: 'h9-policy-v1',
+  actionabilityStatus: 'actionable' as const,
 };
 
 interface State {
@@ -76,6 +85,7 @@ const artifact: ReportPackageJsonExportArtifact = {
     assembledAt: '2026-05-10T03:00:00.000Z',
     packageVersion: 1,
     payloadVersion: 1,
+    h9Stamp: H9_STAMP,
   },
   renderModel: {
     renderModelVersion: 1,
@@ -92,6 +102,7 @@ const artifact: ReportPackageJsonExportArtifact = {
       assembledAt: '2026-05-10T03:00:00.000Z',
       packageVersion: 1,
       payloadVersion: 1,
+      h9Stamp: H9_STAMP,
     },
     fundDisplay: {
       fundId: 1,
@@ -164,6 +175,34 @@ const artifact: ReportPackageJsonExportArtifact = {
     },
   },
 };
+
+function legacyRenderSource(source: ReportPackageRenderSource) {
+  return {
+    reportPackageId: source.reportPackageId,
+    fundId: source.fundId,
+    metricRunId: source.metricRunId,
+    reportPackageStatus: source.reportPackageStatus,
+    asOfDate: source.asOfDate,
+    metricRunVersion: source.metricRunVersion,
+    metricRunLockedBy: source.metricRunLockedBy,
+    metricRunLockedAt: source.metricRunLockedAt,
+    assembledBy: source.assembledBy,
+    assembledAt: source.assembledAt,
+    packageVersion: source.packageVersion,
+    payloadVersion: source.payloadVersion,
+  };
+}
+
+function legacyArtifactPayload() {
+  return {
+    ...artifact,
+    source: legacyRenderSource(artifact.source),
+    renderModel: {
+      ...artifact.renderModel,
+      source: legacyRenderSource(artifact.renderModel.source),
+    },
+  };
+}
 
 function sha256(text: string): string {
   return createHash('sha256').update(text, 'utf8').digest('hex');
@@ -257,6 +296,7 @@ function seedStoredJson(overrides: Partial<LpReportPackageExport> = {}): LpRepor
 }
 
 beforeEach(() => {
+  ReportPackageJsonExportArtifactSchema.parse(artifact);
   state.exportRows = [];
   state.insertedRows = [];
   state.users = [7];
@@ -322,6 +362,21 @@ describe('stored report package CSV exports', () => {
     ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
       status: 409,
       code: 'REPORT_PACKAGE_CSV_SOURCE_JSON_EXPORT_REQUIRED',
+    });
+    expect(state.insertedRows).toHaveLength(0);
+  });
+
+  it('returns a structured contract error when the stored JSON source is legacy pre-stamp', async () => {
+    seedStoredJson({ artifactPayload: legacyArtifactPayload() });
+
+    await expect(
+      createMetricRunReportPackageStoredCsvExport(
+        { fundId: 1, metricRunId: 500, userId: 7 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 500,
+      code: 'REPORT_PACKAGE_EXPORT_ROW_INVALID',
     });
     expect(state.insertedRows).toHaveLength(0);
   });

--- a/tests/unit/services/lp-reporting/report-package-json-export-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-json-export-service.test.ts
@@ -37,6 +37,11 @@ const validXirrDiagnostic = {
   boundHit: null,
   failureReason: null,
 } as const;
+const H9_STAMP = {
+  fingerprintHash: 'd'.repeat(64),
+  policyVersion: 'h9-policy-v1',
+  actionabilityStatus: 'actionable' as const,
+};
 
 const renderModel = {
   renderModelVersion: 1,
@@ -53,6 +58,7 @@ const renderModel = {
     assembledAt: '2026-05-10T03:00:00.000Z',
     packageVersion: 1,
     payloadVersion: 1,
+    h9Stamp: H9_STAMP,
   },
   fundDisplay: {
     fundId: 1,
@@ -171,6 +177,12 @@ function artifactFrom(response: ReportPackageJsonExportResponse) {
 }
 
 beforeEach(() => {
+  ReportPackageJsonExportArtifactSchema.parse({
+    exportVersion: 1,
+    format: 'json',
+    source: renderModel.source,
+    renderModel,
+  });
   state.evidenceRows = [evidenceRow({ id: 300 }), evidenceRow({ id: 301 })];
   state.writeCalls = [];
 });
@@ -188,6 +200,8 @@ describe('getMetricRunReportPackageJsonExport', () => {
     expect(response.export.exportVersion).toBe(1);
     expect(response.export.format).toBe('json');
     expect(response.export.source.reportPackageId).toBe(501);
+    expect(response.export.source.h9Stamp).toEqual(H9_STAMP);
+    expect(response.export.renderModel.source.h9Stamp).toEqual(H9_STAMP);
     expect(response.export.renderModel.references.evidenceRecordIds).toEqual([301, 300, 301]);
     expect(contentHashAlgorithm).toBe('sha256');
     expect(contentHash).toBe(
@@ -278,5 +292,26 @@ describe('canonicalJson', () => {
     expect(canonicalJson({ b: 2, a: [3, { d: 4, c: 5 }] })).toBe('{"a":[3,{"c":5,"d":4}],"b":2}');
     expect(() => canonicalJson({ a: undefined })).toThrow(/undefined field/);
     expect(() => canonicalJson(new Date('2026-05-10T00:00:00Z'))).toThrow(/non-plain/);
+  });
+
+  it('covers render-source H9 stamp fields in the canonical hash', () => {
+    const baseArtifact = ReportPackageJsonExportArtifactSchema.parse({
+      exportVersion: 1,
+      format: 'json',
+      source: renderModel.source,
+      renderModel,
+    });
+    const changedArtifact = ReportPackageJsonExportArtifactSchema.parse({
+      ...baseArtifact,
+      source: {
+        ...baseArtifact.source,
+        h9Stamp: {
+          ...baseArtifact.source.h9Stamp,
+          policyVersion: 'h9-policy-v2',
+        },
+      },
+    });
+
+    expect(sha256CanonicalJson(changedArtifact)).not.toBe(sha256CanonicalJson(baseArtifact));
   });
 });

--- a/tests/unit/services/lp-reporting/report-package-json-stored-export-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-json-stored-export-service.test.ts
@@ -11,9 +11,11 @@ import {
   getMetricRunReportPackageStoredJsonArtifact,
   getMetricRunReportPackageStoredJsonExport,
 } from '../../../../server/services/lp-reporting/report-package-json-stored-export-service';
-import type {
-  ReportPackageJsonExportArtifact,
-  ReportPackageJsonExportResponse,
+import {
+  ReportPackageJsonExportArtifactSchema,
+  type ReportPackageJsonExportArtifact,
+  type ReportPackageJsonExportResponse,
+  type ReportPackageRenderSource,
 } from '@shared/contracts/lp-reporting';
 import {
   lpReportPackageExports,
@@ -44,6 +46,11 @@ const storedPackageRow = {
   h9FingerprintHash: H9_FP,
   h9PolicyVersion: 'h9-policy-v1',
   h9ActionabilityStatus: 'actionable',
+};
+const H9_STAMP = {
+  fingerprintHash: H9_FP,
+  policyVersion: 'h9-policy-v1',
+  actionabilityStatus: 'actionable' as const,
 };
 
 interface State {
@@ -78,6 +85,7 @@ const artifact: ReportPackageJsonExportArtifact = {
     assembledAt: '2026-05-10T03:00:00.000Z',
     packageVersion: 1,
     payloadVersion: 1,
+    h9Stamp: H9_STAMP,
   },
   renderModel: {
     renderModelVersion: 1,
@@ -94,6 +102,7 @@ const artifact: ReportPackageJsonExportArtifact = {
       assembledAt: '2026-05-10T03:00:00.000Z',
       packageVersion: 1,
       payloadVersion: 1,
+      h9Stamp: H9_STAMP,
     },
     fundDisplay: {
       fundId: 1,
@@ -133,6 +142,34 @@ const artifact: ReportPackageJsonExportArtifact = {
     },
   },
 };
+
+function legacyRenderSource(source: ReportPackageRenderSource) {
+  return {
+    reportPackageId: source.reportPackageId,
+    fundId: source.fundId,
+    metricRunId: source.metricRunId,
+    reportPackageStatus: source.reportPackageStatus,
+    asOfDate: source.asOfDate,
+    metricRunVersion: source.metricRunVersion,
+    metricRunLockedBy: source.metricRunLockedBy,
+    metricRunLockedAt: source.metricRunLockedAt,
+    assembledBy: source.assembledBy,
+    assembledAt: source.assembledAt,
+    packageVersion: source.packageVersion,
+    payloadVersion: source.payloadVersion,
+  };
+}
+
+function legacyArtifactPayload() {
+  return {
+    ...artifact,
+    source: legacyRenderSource(artifact.source),
+    renderModel: {
+      ...artifact.renderModel,
+      source: legacyRenderSource(artifact.renderModel.source),
+    },
+  };
+}
 
 function makeResponse(hash = 'c'.repeat(64)): ReportPackageJsonExportResponse {
   return {
@@ -209,6 +246,7 @@ function makeDatabase(): typeof db {
 }
 
 beforeEach(() => {
+  ReportPackageJsonExportArtifactSchema.parse(artifact);
   state.exportRows = [];
   state.insertedRows = [];
   state.users = [7];
@@ -231,6 +269,10 @@ describe('stored report package JSON exports', () => {
     expect(response.record.contentHash).toBe('c'.repeat(64));
     expect(response.record.artifactSizeBytes).toBeGreaterThan(0);
     expect(state.insertedRows).toHaveLength(1);
+    const inserted = state.insertedRows[0] as { artifactPayload: unknown };
+    const persistedArtifact = ReportPackageJsonExportArtifactSchema.parse(inserted.artifactPayload);
+    expect(persistedArtifact.source.h9Stamp).toEqual(H9_STAMP);
+    expect(persistedArtifact.renderModel.source.h9Stamp).toEqual(H9_STAMP);
     expect(liveExport).toHaveBeenCalledWith(
       { fundId: 1, metricRunId: 500 },
       { database: expect.any(Object) }
@@ -275,6 +317,39 @@ describe('stored report package JSON exports', () => {
       currentContentHash: 'd'.repeat(64),
     });
     expect(state.insertedRows).toHaveLength(1);
+  });
+
+  it('keeps legacy pre-stamp rows on the hash-conflict path during create replay', async () => {
+    state.exportRows.push({
+      id: 4100,
+      fundId: 1,
+      metricRunId: 500,
+      reportPackageId: 3000,
+      format: 'json',
+      exportVersion: 1,
+      status: 'ready',
+      contentHashAlgorithm: 'sha256',
+      contentHash: 'b'.repeat(64),
+      artifactPayload: legacyArtifactPayload(),
+      artifactSizeBytes: 1000,
+      createdBy: 7,
+      readyAt: new Date('2026-05-10T04:00:00Z'),
+      createdAt: new Date('2026-05-10T04:00:00Z'),
+      updatedAt: new Date('2026-05-10T04:00:00Z'),
+    });
+
+    await expect(
+      createMetricRunReportPackageStoredJsonExport(
+        { fundId: 1, metricRunId: 500, userId: 7 },
+        { database: makeDatabase(), jsonExportService: vi.fn(async () => makeResponse()) }
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'EXPORT_CONTENT_HASH_CONFLICT',
+      storedContentHash: 'b'.repeat(64),
+      currentContentHash: 'c'.repeat(64),
+    });
+    expect(state.insertedRows).toHaveLength(0);
   });
 
   it('reloads an existing row after an insert race', async () => {
@@ -346,6 +421,36 @@ describe('stored report package JSON exports', () => {
     expect(artifactResponse.record.reportPackageExportId).toBe(4100);
     expect(artifactResponse.export.contentHash).toBe('c'.repeat(64));
     expect(artifactResponse.export.source.reportPackageId).toBe(3000);
+  });
+
+  it('returns a structured contract error when reading a legacy pre-stamp artifact row', async () => {
+    state.exportRows.push({
+      id: 4100,
+      fundId: 1,
+      metricRunId: 500,
+      reportPackageId: 3000,
+      format: 'json',
+      exportVersion: 1,
+      status: 'ready',
+      contentHashAlgorithm: 'sha256',
+      contentHash: 'b'.repeat(64),
+      artifactPayload: legacyArtifactPayload(),
+      artifactSizeBytes: 1000,
+      createdBy: 7,
+      readyAt: new Date('2026-05-10T04:00:00Z'),
+      createdAt: new Date('2026-05-10T04:00:00Z'),
+      updatedAt: new Date('2026-05-10T04:00:00Z'),
+    });
+
+    await expect(
+      getMetricRunReportPackageStoredJsonArtifact(
+        { fundId: 1, metricRunId: 500 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 500,
+      code: 'REPORT_PACKAGE_EXPORT_ROW_INVALID',
+    });
   });
 
   it('serves the stored JSON artifact when H9 matches', async () => {

--- a/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
@@ -14,21 +14,15 @@ import {
   type LpReportPackage,
 } from '@shared/schema/lp-reporting-evidence';
 
-const { resolveForFund } = vi.hoisted(() => ({ resolveForFund: vi.fn() }));
+const { assertH9ExportActionable } = vi.hoisted(() => ({
+  assertH9ExportActionable: vi.fn(),
+}));
 
-vi.mock('../../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
-  const actual =
-    await importOriginal<
-      typeof import('../../../../server/services/fund-calculation-mode-service')
-    >();
-  return { ...actual, createMoicActionabilityResolver: () => ({ resolveForFund }) };
+vi.mock('../../../../server/services/lp-reporting/h9-export-gate', () => {
+  return { assertH9ExportActionable };
 });
 
 const H9_FP = 'd'.repeat(64);
-const CURRENT_OK = {
-  actionability: 'actionable' as const,
-  sourceFingerprint: { fingerprintHash: H9_FP, policyVersion: 'h9-policy-v1' },
-};
 const H9_COLUMNS = {
   h9MoicSourceInputHash: 'a'.repeat(64),
   h9RoundEvidenceInputHash: 'b'.repeat(64),
@@ -36,6 +30,11 @@ const H9_COLUMNS = {
   h9FingerprintHash: H9_FP,
   h9PolicyVersion: 'h9-policy-v1',
   h9ActionabilityStatus: 'actionable',
+} as const;
+const H9_STAMP = {
+  fingerprintHash: H9_COLUMNS.h9FingerprintHash,
+  policyVersion: H9_COLUMNS.h9PolicyVersion,
+  actionabilityStatus: H9_COLUMNS.h9ActionabilityStatus,
 };
 
 const validXirrDiagnostic = {
@@ -229,7 +228,8 @@ beforeEach(() => {
   state.metricRuns = [metricRunRow()];
   state.reportPackages = [reportPackageRow()];
   state.writeCalls = [];
-  resolveForFund.mockResolvedValue(CURRENT_OK);
+  assertH9ExportActionable.mockReset();
+  assertH9ExportActionable.mockResolvedValue(undefined);
 });
 
 describe('getMetricRunReportPackageRenderModel', () => {
@@ -263,6 +263,7 @@ describe('getMetricRunReportPackageRenderModel', () => {
       evidenceRecordIds: [300, 301],
       narrativeRunIds: [100, 101, 102, 103],
     });
+    expect(response.renderModel.source.h9Stamp).toEqual(H9_STAMP);
     expect(response.renderModel.diagnostics.excludedFutureMarks).toEqual([800, 900]);
     expect(state.writeCalls).toEqual([]);
   });
@@ -276,16 +277,38 @@ describe('getMetricRunReportPackageRenderModel', () => {
   });
 
   it('blocks H9_FINGERPRINT_STALE when the source fingerprint has drifted', async () => {
-    resolveForFund.mockResolvedValue({
-      actionability: 'actionable',
-      sourceFingerprint: { fingerprintHash: 'e'.repeat(64), policyVersion: 'h9-policy-v1' },
-    });
+    assertH9ExportActionable.mockRejectedValueOnce(
+      Object.assign(new Error('stale'), { code: 'H9_FINGERPRINT_STALE' })
+    );
     await expect(
       getMetricRunReportPackageRenderModel(
         { fundId: 1, metricRunId: 11 },
         { database: makeDatabase() }
       )
     ).rejects.toMatchObject({ code: 'H9_FINGERPRINT_STALE' });
+  });
+
+  it('returns REPORT_PACKAGE_ROW_INVALID when H9 metadata is missing after the gate', async () => {
+    state.reportPackages = [
+      reportPackageRow({
+        h9MoicSourceInputHash: null,
+        h9RoundEvidenceInputHash: null,
+        h9RoundEvidenceAssumptionsHash: null,
+        h9FingerprintHash: null,
+        h9PolicyVersion: null,
+        h9ActionabilityStatus: null,
+      }),
+    ];
+
+    await expect(
+      getMetricRunReportPackageRenderModel(
+        { fundId: 1, metricRunId: 11 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 500,
+      code: 'REPORT_PACKAGE_ROW_INVALID',
+    });
   });
 
   it('returns REPORT_PACKAGE_NOT_FOUND when the package has not been assembled', async () => {


### PR DESCRIPTION
## Summary

PRD #996 slice PR-1 (AC-4, decision-free). The render-model service computed `h9Metadata` in `toReportPackageRecord` then dropped it before return, so the reserve stamp gated exports but never appeared in the artifact. This PR embeds the stamp and puts it under `contentHash`.

- `ReportPackageRenderSourceSchema` gains **required** `h9Stamp` (`fingerprintHash`, `policyVersion`, `actionabilityStatus`), picked from `ReportPackageH9MetadataSchema` (`shared/contracts/lp-reporting/lp-report-package-render-model.contract.ts`). The JSON export artifact composes the source schema twice (`source` + `renderModel.source`), so `contentHash = sha256(canonicalJson(artifact))` covers the stamp with no export-contract change.
- Render-model service projects the stamp from the stored package row and fails closed with `REPORT_PACKAGE_ROW_INVALID` (500) if H9 metadata is absent after the gate (defense-in-depth behind `assertH9ExportActionable`).
- Stored JSON artifact GET and CSV create now `safeParse` the persisted `artifactPayload`; legacy pre-stamp rows fail **structured** (`REPORT_PACKAGE_EXPORT_ROW_INVALID` 500) instead of raw ZodError. Create-replay over a legacy row still returns `EXPORT_CONTENT_HASH_CONFLICT` 409 (PRD-required semantics preserved).

## Scope

Fail-closed by design: no backfill of pre-stamp export rows (recreate-the-export is the recovery path); no role/workflow/watermark changes (PR-2..PR-4 pending D1/D2/D3); CSV body columns unchanged (CSV provenance chains via `sourceJsonContentHash`).

## Tests

- AC-4 core: artifact stamp fields equal the stored `lp_report_packages` H9 columns.
- Hash coverage: stamp change changes `contentHash`.
- Legacy rows: structured 500 on artifact GET / CSV create; 409 hash conflict on create-replay.
- Contract pins updated (missing `h9Stamp` fails the source schema); route/page/hook fixtures schema-validated.
- AC-5 baseline intact: `h9-export-gate` suite untouched, 9/9 green; verified locally 151/151 (server, TZ=UTC) + 26/26 metrics page + 43/43 useMetricsDryRun (client).

Full CI run ID will be cited on this PR after checks complete (per PRD #996 DoD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS