### PR TITLE
feat(lp-reporting): workflow-state re-gate at export (PRD #996 PR-3, AC-2)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -29,6 +29,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-023: s8.1 Operator Seam - Evidence-First Slice Ordering and D1 Triage-First Decision Procedure](#adr-023-s81-operator-seam---evidence-first-slice-ordering-and-d1-triage-first-decision-procedure)
 - [ADR-024: LP Metric-Run active_as_of Source-Mark Selection Is API-Only](#adr-024-lp-metric-run-active_as_of-source-mark-selection-is-api-only)
 - [ADR-025: LP Export Role Policy (PRD #996 D1)](#adr-025-lp-export-role-policy-prd-996-d1)
+- [ADR-026: LP Export Workflow State (PRD #996 D2)](#adr-026-lp-export-workflow-state-prd-996-d2)
 
 ---
 
@@ -5170,3 +5171,74 @@ for the route fund before they can export.
 - Admin empty-scope tokens continue to pass export authorization.
 - Route-policy registry entries now distinguish role-gated fund access from
   ordinary authenticated fund access for these export APIs.
+
+---
+
+## ADR-026: LP Export Workflow State (PRD #996 D2)
+
+**Date:** 2026-07-04 **Status:** [IMPLEMENTED] Implemented **Decision:** Require
+Surface-A LP report-package export routes to re-check metric-run workflow state
+at export time and allow only `locked` or `exported`.
+
+### Context
+
+PRD #996 AC-2 closes the gap between assembly readiness and export readiness.
+Surface-A exports must not serve draft, approved, or superseded metric runs,
+even when an older package/export row exists. The policy decision also requires
+the first successful stored JSON export to mark the metric run `exported`
+without changing version or lock audit fields, because bumping the metric-run
+version would make stored H9 fingerprints appear stale.
+
+### Decision
+
+All eight Surface-A export routes re-gate against
+`lp_metric_runs.status IN ('locked', 'exported')` at export time:
+
+- render model;
+- live JSON export;
+- stored JSON create, status GET, and artifact GET;
+- stored CSV create, status GET, and artifact GET.
+
+Stored JSON create performs the only workflow-state write in this policy. After
+a successful insert or idempotent replay with a matching hash, it runs a guarded
+update:
+
+`status='exported', updated_at=now WHERE fund_id=? AND id=? AND status='locked'`.
+
+The update intentionally does not touch `version`, `metricRunVersion`,
+`lockedAt`, or `lockedBy`. Live/preview routes, stored JSON GETs, and all CSV
+routes re-gate but never write. CSV creation depends on the stored JSON source;
+pre-PR-3 rows that are still `locked` are caught up by the stored JSON replay
+path, not by CSV.
+
+Assembly and narrative lifecycle surfaces remain locked-only. Post-export
+immutability is an accepted consequence: once a metric run is exported, package
+assembly and narrative edits must not reopen against it.
+
+### Supersede/New-Version Finding
+
+The metric-run commit path does not have a locked-only prior-version guard.
+`commitMetricRun` deduplicates by the unique fund/run/perspective/asOfDate/input
+hash and returns an existing row regardless of status, otherwise inserts a new
+draft row. No workflow-continuity guard needed widening from `locked` to
+`locked`/`exported` in this slice.
+
+### Alternatives Considered
+
+- **No workflow-state transition:** rejected because the approved D2 policy
+  requires stored JSON create to persist the export milestone.
+- **Transition from live/render routes:** rejected because read/preview surfaces
+  must remain side-effect free.
+- **Bump metric-run version on export:** rejected because it would cascade H9
+  fingerprint staleness into otherwise valid stored artifacts.
+- **Allow CSV to transition state:** rejected because CSV is derived from a
+  stored JSON source and must not become a second lifecycle writer.
+
+### Consequences
+
+- Draft, approved, and superseded metric runs now receive structured 409
+  `METRIC_RUN_NOT_EXPORTABLE` responses on Surface-A export routes.
+- Locked and exported metric runs can serve export routes subject to existing
+  role, fund-scope, H9, evidence, and artifact gates.
+- Stored JSON create and replay catch up locked metric runs to exported without
+  changing version, lock audit fields, package `metricRunVersion`, or H9 stamps.

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -504,8 +504,9 @@ function governanceRefForPortfolioIntelligenceRoute(
 }
 
 const PROTOTYPE_ROUTE_NOTE = 'Prototype route must return 501 with non_actionable provenance.';
+const LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT = 'metric_run_locked_or_exported';
 const LP_REPORT_PACKAGE_EXPORT_NOTE =
-  'PRD #996 AC-1 + D1: Surface-A report-package export requires partner/admin role and denies empty-fundIds non-admin exports; admin keeps the documented issuer-contract exemption.';
+  'PRD #996 AC-1, AC-2, D1, and D2: Surface-A report-package export requires partner/admin role, denies empty-fundIds non-admin exports, and requires metric-run workflow state locked or exported.';
 
 const PORTFOLIO_INTELLIGENCE_ROUTE_POLICY_DECISIONS: Readonly<PortfolioIntelligenceRouteDecisionMap> =
   {
@@ -804,7 +805,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,
@@ -828,7 +829,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,
@@ -852,7 +853,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,
@@ -876,7 +877,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,
@@ -900,7 +901,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,
@@ -924,7 +925,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,
@@ -948,7 +949,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,
@@ -972,7 +973,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     financialSurface: 'lp_reporting',
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
-    workflowRequirement: null,
+    workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
     exportPolicy: 'qualified_exportable',
     provenanceRequired: true,
     staleBlocksExport: true,

--- a/server/services/lp-reporting/metric-run-export-workflow-gate.ts
+++ b/server/services/lp-reporting/metric-run-export-workflow-gate.ts
@@ -1,0 +1,74 @@
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { lpMetricRuns, type LpMetricRun } from '@shared/schema/lp-reporting-evidence';
+import type { H9ExportSurface } from './h9-export-gate';
+import { MetricRunCommitError } from './metric-run-commit-service';
+
+type MetricRunExportWorkflowDatabase = typeof db;
+type MetricRunExportWorkflowRow = Pick<LpMetricRun, 'id' | 'fundId' | 'status'>;
+
+const EXPORTABLE_METRIC_RUN_STATUSES = ['locked', 'exported'] as const;
+
+function isExportableMetricRunStatus(status: string): boolean {
+  return (EXPORTABLE_METRIC_RUN_STATUSES as readonly string[]).includes(status);
+}
+
+async function loadMetricRunStatus(params: {
+  database: MetricRunExportWorkflowDatabase;
+  fundId: number;
+  metricRunId: number;
+}): Promise<MetricRunExportWorkflowRow> {
+  const rows = await params.database
+    .select({
+      id: lpMetricRuns.id,
+      fundId: lpMetricRuns.fundId,
+      status: lpMetricRuns.status,
+    })
+    .from(lpMetricRuns)
+    .where(and(eq(lpMetricRuns.fundId, params.fundId), eq(lpMetricRuns.id, params.metricRunId)))
+    .limit(1);
+
+  const row = (rows as MetricRunExportWorkflowRow[]).find(
+    (candidate) => candidate.id === params.metricRunId && candidate.fundId === params.fundId
+  );
+  if (!row) {
+    throw new MetricRunCommitError(
+      404,
+      'METRIC_RUN_NOT_FOUND',
+      'Metric run was not found for this fund.'
+    );
+  }
+  return row;
+}
+
+export async function assertMetricRunExportWorkflowState(params: {
+  surface: H9ExportSurface;
+  fundId: number;
+  metricRunId: number;
+  database?: MetricRunExportWorkflowDatabase;
+  preloaded?: MetricRunExportWorkflowRow;
+}): Promise<void> {
+  const row =
+    params.preloaded ??
+    (await loadMetricRunStatus({
+      database: params.database ?? db,
+      fundId: params.fundId,
+      metricRunId: params.metricRunId,
+    }));
+
+  if (isExportableMetricRunStatus(row.status)) {
+    return;
+  }
+
+  throw new MetricRunCommitError(
+    409,
+    'METRIC_RUN_NOT_EXPORTABLE',
+    'Metric run must be locked or exported before this export surface can be used.',
+    {
+      expected: [...EXPORTABLE_METRIC_RUN_STATUSES],
+      actual: row.status,
+      surface: params.surface,
+    }
+  );
+}

--- a/server/services/lp-reporting/report-package-csv-stored-export-service.ts
+++ b/server/services/lp-reporting/report-package-csv-stored-export-service.ts
@@ -41,6 +41,7 @@ import {
 } from '@shared/schema/lp-reporting-evidence';
 import { users } from '@shared/schema/user';
 import { assertH9PackageExportable } from './h9-export-gate';
+import { assertMetricRunExportWorkflowState } from './metric-run-export-workflow-gate';
 import { MetricRunCommitError } from './metric-run-commit-service';
 
 type StoredCsvExportDatabase = typeof db;
@@ -414,6 +415,12 @@ export async function createMetricRunReportPackageStoredCsvExport(
 ): Promise<ReportPackageCsvStoredExportResponse> {
   const database = options.database ?? db;
   await assertUserExists(database, input.userId);
+  await assertMetricRunExportWorkflowState({
+    surface: 'stored_csv_export',
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    database,
+  });
 
   const sourceJson = await loadStoredExport(database, input, 'json');
   if (sourceJson === null) {
@@ -480,6 +487,12 @@ export async function getMetricRunReportPackageStoredCsvExport(
   options: ReportPackageStoredCsvExportServiceOptions = {}
 ): Promise<ReportPackageCsvStoredExportGetResponse> {
   const database = options.database ?? db;
+  await assertMetricRunExportWorkflowState({
+    surface: 'stored_csv_export',
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    database,
+  });
   const existing = await loadStoredExport(database, input, 'csv');
   if (existing === null) {
     return ReportPackageCsvStoredExportGetResponseSchema.parse({ record: null });
@@ -497,6 +510,12 @@ export async function getMetricRunReportPackageStoredCsvArtifact(
   options: ReportPackageStoredCsvExportServiceOptions = {}
 ): Promise<ReportPackageCsvStoredArtifactResponse> {
   const database = options.database ?? db;
+  await assertMetricRunExportWorkflowState({
+    surface: 'stored_csv_export',
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    database,
+  });
   const existing = await loadStoredExport(database, input, 'csv');
   if (existing === null) {
     throw new ReportPackageCsvExportNotFoundError();

--- a/server/services/lp-reporting/report-package-json-stored-export-service.ts
+++ b/server/services/lp-reporting/report-package-json-stored-export-service.ts
@@ -26,12 +26,14 @@ import {
   type ReportPackageJsonStoredExportResponse,
 } from '@shared/contracts/lp-reporting';
 import {
+  lpMetricRuns,
   lpReportPackageExports,
   type InsertLpReportPackageExport,
   type LpReportPackageExport,
 } from '@shared/schema/lp-reporting-evidence';
 import { users } from '@shared/schema/user';
 import { assertH9PackageExportable } from './h9-export-gate';
+import { assertMetricRunExportWorkflowState } from './metric-run-export-workflow-gate';
 import { MetricRunCommitError } from './metric-run-commit-service';
 import {
   canonicalJson,
@@ -206,6 +208,23 @@ function assertHashMatch(row: LpReportPackageExport, currentContentHash: string)
   }
 }
 
+async function markMetricRunStoredJsonExported(
+  database: StoredExportDatabase,
+  input: ReportPackageStoredJsonExportInput
+): Promise<void> {
+  await database
+    .update(lpMetricRuns)
+    .set({ status: 'exported', updatedAt: new Date() })
+    .where(
+      and(
+        eq(lpMetricRuns.fundId, input.fundId),
+        eq(lpMetricRuns.id, input.metricRunId),
+        eq(lpMetricRuns.status, 'locked')
+      )
+    )
+    .returning({ id: lpMetricRuns.id });
+}
+
 export async function createMetricRunReportPackageStoredJsonExport(
   input: CreateReportPackageStoredJsonExportInput,
   options: ReportPackageStoredJsonExportServiceOptions = {}
@@ -244,6 +263,7 @@ export async function createMetricRunReportPackageStoredJsonExport(
 
   const inserted = (insertedRows as LpReportPackageExport[])[0];
   if (inserted) {
+    await markMetricRunStoredJsonExported(database, input);
     return ReportPackageJsonStoredExportResponseSchema.parse({
       record: toExportRecord(inserted),
       inserted: true,
@@ -259,6 +279,7 @@ export async function createMetricRunReportPackageStoredJsonExport(
     );
   }
   assertHashMatch(existing, contentHash);
+  await markMetricRunStoredJsonExported(database, input);
   return ReportPackageJsonStoredExportResponseSchema.parse({
     record: toExportRecord(existing),
     inserted: false,
@@ -270,6 +291,12 @@ export async function getMetricRunReportPackageStoredJsonExport(
   options: ReportPackageStoredJsonExportServiceOptions = {}
 ): Promise<ReportPackageJsonStoredExportGetResponse> {
   const database = options.database ?? db;
+  await assertMetricRunExportWorkflowState({
+    surface: 'stored_json_export',
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    database,
+  });
   const existing = await loadStoredExport(database, input);
   return ReportPackageJsonStoredExportGetResponseSchema.parse({
     record: existing === null ? null : toExportRecord(existing),
@@ -281,6 +308,12 @@ export async function getMetricRunReportPackageStoredJsonArtifact(
   options: ReportPackageStoredJsonExportServiceOptions = {}
 ): Promise<ReportPackageJsonStoredArtifactResponse> {
   const database = options.database ?? db;
+  await assertMetricRunExportWorkflowState({
+    surface: 'stored_json_export',
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    database,
+  });
   const existing = await loadStoredExport(database, input);
   if (existing === null) {
     throw new ReportPackageExportNotFoundError();

--- a/server/services/lp-reporting/report-package-render-model-service.ts
+++ b/server/services/lp-reporting/report-package-render-model-service.ts
@@ -32,6 +32,7 @@ import {
   type LpReportPackage,
 } from '@shared/schema/lp-reporting-evidence';
 import { assertH9ExportActionable, type H9ExportSurface } from './h9-export-gate';
+import { assertMetricRunExportWorkflowState } from './metric-run-export-workflow-gate';
 import { MetricRunCommitError } from './metric-run-commit-service';
 
 type ReportPackageRenderModelDatabase = typeof db;
@@ -349,7 +350,14 @@ export async function getMetricRunReportPackageRenderModel(
   options: ReportPackageRenderModelServiceOptions = {}
 ): Promise<ReportPackageRenderModelResponse> {
   const database = options.database ?? db;
-  await loadMetricRun(database, input.fundId, input.metricRunId);
+  const metricRun = await loadMetricRun(database, input.fundId, input.metricRunId);
+  await assertMetricRunExportWorkflowState({
+    surface: options.h9Surface ?? 'render_model',
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    database,
+    preloaded: metricRun,
+  });
   const rawPackage = await loadReportPackage(database, input.fundId, input.metricRunId);
   await assertH9ExportActionable({
     surface: options.h9Surface ?? 'render_model',

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -162,7 +162,7 @@ describe('route policy coverage', () => {
       expect(policyEntry.provenanceRequired, key).toBe(true);
       expect(policyEntry.staleBlocksExport, key).toBe(true);
       expect(policyEntry.staleBlocksRender, key).toBe(false);
-      expect(policyEntry.workflowRequirement, key).toBeNull();
+      expect(policyEntry.workflowRequirement, key).toBe('metric_run_locked_or_exported');
     }
   });
 

--- a/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
+++ b/tests/unit/routes/lp-reporting/metric-runs-routes.test.ts
@@ -605,7 +605,8 @@ vi.mock('../../../../server/db', () => {
                 values['status'] === 'locked' &&
                 current.status === 'approved' &&
                 (current.version ?? 1) === expectedVersion;
-              if (!validApprove && !validLock) {
+              const validExport = values['status'] === 'exported' && current.status === 'locked';
+              if (!validApprove && !validLock && !validExport) {
                 return [];
               }
               const updated = { ...current, ...values } as MockMetricRunRow;
@@ -1005,6 +1006,236 @@ function reportPackageBody() {
         expectedVersion: row.version,
       })),
   };
+}
+
+function reportPackagePayload() {
+  const narratives = dbState.narrativeRuns
+    .filter((row) => row.metricRunId === 500)
+    .map((row) => ({
+      narrativeType: row.narrativeType,
+      narrativeRunId: row.id,
+      narrativeVersion: row.version,
+      approvedBy: row.approvedBy,
+      approvedAt: row.approvedAt?.toISOString() ?? '2026-05-10T02:30:00.000Z',
+      textHash: 'a'.repeat(64),
+      effectiveText: row.editedText ?? row.generatedText,
+    }));
+
+  return {
+    payloadVersion: 1,
+    results: makeMetricResults(),
+    diagnostics: makeMetricDiagnostics(),
+    sourceEventIds: [101, 102],
+    sourceMarkIds: [201],
+    evidenceRecordIds: [1000],
+    narratives,
+  };
+}
+
+function renderModelSource() {
+  return {
+    reportPackageId: 3000,
+    fundId: 1,
+    metricRunId: 500,
+    reportPackageStatus: 'assembled',
+    asOfDate: '2026-03-31',
+    metricRunVersion: 3,
+    metricRunLockedBy: authState.userId,
+    metricRunLockedAt: '2026-05-10T02:00:00.000Z',
+    assembledBy: authState.userId,
+    assembledAt: '2026-05-10T03:00:00.000Z',
+    packageVersion: 1,
+    payloadVersion: 1,
+    h9Stamp: H9_STAMP,
+  };
+}
+
+function reportPackageJsonArtifact() {
+  const payload = reportPackagePayload();
+  const source = renderModelSource();
+  const renderModel = {
+    renderModelVersion: 1,
+    source,
+    fundDisplay: {
+      fundId: 1,
+      name: 'Press On Fund I',
+      vintageYear: 2024,
+      size: '100000000.00',
+    },
+    metricSections: [
+      {
+        sectionId: 'performance',
+        title: 'Performance',
+        rows: [
+          {
+            metricId: 'dpi',
+            label: 'DPI',
+            value: payload.results.dpi,
+            valueKind: 'multiple',
+            currency: null,
+          },
+        ],
+      },
+    ],
+    narrativeSections: payload.narratives.map((narrative) => ({
+      sectionId: narrative.narrativeType,
+      title: narrative.narrativeType,
+      narrativeType: narrative.narrativeType,
+      narrativeRunId: narrative.narrativeRunId,
+      narrativeVersion: narrative.narrativeVersion,
+      approvedBy: narrative.approvedBy,
+      approvedAt: narrative.approvedAt,
+      textHash: narrative.textHash,
+      body: narrative.effectiveText,
+    })),
+    diagnostics: {
+      engineVersion: payload.diagnostics.engineVersion,
+      decimalPrecision: payload.diagnostics.decimalPrecision,
+      excludedFutureMarks: payload.diagnostics.excludedFutureMarks,
+      warnings: payload.diagnostics.warnings,
+      xirr: payload.results.xirrDiagnostic,
+    },
+    references: {
+      sourceEventIds: payload.sourceEventIds,
+      sourceMarkIds: payload.sourceMarkIds,
+      evidenceRecordIds: payload.evidenceRecordIds,
+      narrativeRunIds: payload.narratives.map((narrative) => narrative.narrativeRunId),
+    },
+  };
+
+  return {
+    exportVersion: 1,
+    format: 'json',
+    source,
+    renderModel,
+  };
+}
+
+function seedAssembledReportPackage() {
+  dbState.reportPackages.push({
+    id: 3000,
+    fundId: 1,
+    metricRunId: 500,
+    status: 'assembled',
+    asOfDate: '2026-03-31',
+    metricRunVersion: 3,
+    metricRunLockedBy: authState.userId,
+    metricRunLockedAt: new Date('2026-05-10T02:00:00Z'),
+    narrativeRefs: dbState.narrativeRuns
+      .filter((row) => row.metricRunId === 500)
+      .map((row) => ({
+        narrativeType: row.narrativeType,
+        narrativeRunId: row.id,
+        narrativeVersion: row.version,
+        approvedBy: row.approvedBy,
+        approvedAt: row.approvedAt?.toISOString() ?? '2026-05-10T02:30:00.000Z',
+        textHash: 'a'.repeat(64),
+      })),
+    payload: reportPackagePayload(),
+    assembledBy: authState.userId,
+    assembledAt: new Date('2026-05-10T03:00:00Z'),
+    version: 1,
+    createdAt: new Date('2026-05-10T03:00:00Z'),
+    updatedAt: new Date('2026-05-10T03:00:00Z'),
+    h9MoicSourceInputHash: 'a'.repeat(64),
+    h9RoundEvidenceInputHash: 'b'.repeat(64),
+    h9RoundEvidenceAssumptionsHash: 'c'.repeat(64),
+    h9FingerprintHash: H9_STAMP.fingerprintHash,
+    h9PolicyVersion: H9_STAMP.policyVersion,
+    h9ActionabilityStatus: H9_STAMP.actionabilityStatus,
+  });
+}
+
+function seedStoredJsonExport() {
+  dbState.reportPackageExports.push({
+    id: 4000,
+    fundId: 1,
+    metricRunId: 500,
+    reportPackageId: 3000,
+    format: 'json',
+    exportVersion: 1,
+    status: 'ready',
+    contentHashAlgorithm: 'sha256',
+    contentHash: 'c'.repeat(64),
+    artifactPayload: reportPackageJsonArtifact(),
+    artifactSizeBytes: 1000,
+    createdBy: authState.userId,
+    readyAt: new Date('2026-05-10T04:00:00Z'),
+    createdAt: new Date('2026-05-10T04:00:00Z'),
+    updatedAt: new Date('2026-05-10T04:00:00Z'),
+  });
+}
+
+function seedStoredCsvExport() {
+  dbState.reportPackageExports.push({
+    id: 4001,
+    fundId: 1,
+    metricRunId: 500,
+    reportPackageId: 3000,
+    format: 'csv',
+    exportVersion: 1,
+    status: 'ready',
+    contentHashAlgorithm: 'sha256',
+    contentHash: 'd'.repeat(64),
+    artifactPayload: {
+      exportVersion: 1,
+      format: 'csv',
+      sourceJsonExportId: 4000,
+      sourceJsonContentHash: 'c'.repeat(64),
+      contentType: 'text/csv; charset=utf-8',
+      filename: 'lp-report-package-1-500-csv-v1.csv',
+      csv: 'section,field,value\n',
+    },
+    artifactSizeBytes: 20,
+    createdBy: authState.userId,
+    readyAt: new Date('2026-05-10T04:00:00Z'),
+    createdAt: new Date('2026-05-10T04:00:00Z'),
+    updatedAt: new Date('2026-05-10T04:00:00Z'),
+  });
+}
+
+function resetReportPackageProbeState() {
+  dbState.events = [];
+  dbState.marks = [];
+  dbState.metricRuns = [];
+  dbState.evidenceRecords = [];
+  dbState.narrativeRuns = [];
+  dbState.reportPackages = [];
+  dbState.reportPackageExports = [];
+  dbState.insertedReportPackageRows = [];
+  dbState.insertedReportPackageExportRows = [];
+  dbState.nextReportPackageExportId = 4000;
+}
+
+function seedExportRouteProbe(
+  status: string,
+  route: (typeof REPORT_PACKAGE_EXPORT_ROUTE_PROBES)[number]
+) {
+  resetReportPackageProbeState();
+  seedLockedMetricRun({ status });
+  seedMetricRunEvidence();
+  seedApprovedNarratives();
+  seedAssembledReportPackage();
+  if (
+    route.path.endsWith('/exports/json/artifact') ||
+    route.path.endsWith('/exports/csv') ||
+    route.path.endsWith('/exports/csv/artifact')
+  ) {
+    seedStoredJsonExport();
+  }
+  if (route.path.endsWith('/exports/csv/artifact')) {
+    seedStoredCsvExport();
+  }
+}
+
+async function requestExportProbe(
+  app: express.Express,
+  route: (typeof REPORT_PACKAGE_EXPORT_ROUTE_PROBES)[number]
+) {
+  if (route.method === 'POST') {
+    return request(app).post(route.path).send({});
+  }
+  return request(app).get(route.path);
 }
 
 beforeEach(() => {
@@ -1831,14 +2062,44 @@ describe('metric-run report package routes', () => {
     authState.fundIds = [1];
 
     for (const route of REPORT_PACKAGE_EXPORT_ROUTE_PROBES) {
-      const res =
-        route.method === 'POST'
-          ? await request(buildApp()).post(route.path).send({})
-          : await request(buildApp()).get(route.path);
+      const res = await requestExportProbe(buildApp(), route);
 
       expect(res.status, `${route.method} ${route.path}`).toBe(403);
     }
   });
+
+  it.each(['draft', 'approved', 'superseded'])(
+    'returns structured METRIC_RUN_NOT_EXPORTABLE across Surface-A export routes for %s metric runs',
+    async (status) => {
+      for (const route of REPORT_PACKAGE_EXPORT_ROUTE_PROBES) {
+        seedExportRouteProbe(status, route);
+
+        const res = await requestExportProbe(buildApp(), route);
+
+        expect(res.status, `${status} ${route.method} ${route.path}`).toBe(409);
+        expect(res.body).toMatchObject({
+          error: 'METRIC_RUN_NOT_EXPORTABLE',
+          details: {
+            expected: ['locked', 'exported'],
+            actual: status,
+          },
+        });
+      }
+    }
+  );
+
+  it.each(['locked', 'exported'])(
+    'allows Surface-A export routes for %s metric runs',
+    async (status) => {
+      for (const route of REPORT_PACKAGE_EXPORT_ROUTE_PROBES) {
+        seedExportRouteProbe(status, route);
+
+        const res = await requestExportProbe(buildApp(), route);
+
+        expect(res.status, `${status} ${route.method} ${route.path}`).toBeLessThan(400);
+      }
+    }
+  );
 
   it('allows partner export access when the token has an explicit matching fund grant', async () => {
     authState.role = 'partner';

--- a/tests/unit/services/lp-reporting/metric-run-export-workflow-gate.test.ts
+++ b/tests/unit/services/lp-reporting/metric-run-export-workflow-gate.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { db } from '../../../../server/db';
+import { assertMetricRunExportWorkflowState } from '../../../../server/services/lp-reporting/metric-run-export-workflow-gate';
+import { lpMetricRuns } from '@shared/schema/lp-reporting-evidence';
+
+interface MetricRunStatusRow {
+  id: number;
+  fundId: number;
+  status: string;
+}
+
+const state = {
+  rows: [] as MetricRunStatusRow[],
+  selectCalls: 0,
+};
+
+function queryResult<T>(rows: T[]): Promise<T[]> & { limit: (count: number) => Promise<T[]> } {
+  const promise = Promise.resolve(rows) as Promise<T[]> & {
+    limit: (count: number) => Promise<T[]>;
+  };
+  promise.limit = () => Promise.resolve(rows);
+  return promise;
+}
+
+function makeDatabase(): typeof db {
+  return {
+    select: () => {
+      state.selectCalls += 1;
+      return {
+        from: (table: unknown) => ({
+          where: () => queryResult(table === lpMetricRuns ? state.rows : []),
+        }),
+      };
+    },
+  } as unknown as typeof db;
+}
+
+beforeEach(() => {
+  state.rows = [{ id: 11, fundId: 1, status: 'locked' }];
+  state.selectCalls = 0;
+});
+
+describe('assertMetricRunExportWorkflowState', () => {
+  it.each(['locked', 'exported'])('allows %s metric runs', async (status) => {
+    state.rows = [{ id: 11, fundId: 1, status }];
+
+    await expect(
+      assertMetricRunExportWorkflowState({
+        surface: 'stored_json_export',
+        fundId: 1,
+        metricRunId: 11,
+        database: makeDatabase(),
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(['draft', 'approved', 'superseded'])('blocks %s metric runs', async (status) => {
+    state.rows = [{ id: 11, fundId: 1, status }];
+
+    await expect(
+      assertMetricRunExportWorkflowState({
+        surface: 'live_json_export',
+        fundId: 1,
+        metricRunId: 11,
+        database: makeDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'METRIC_RUN_NOT_EXPORTABLE',
+      details: {
+        expected: ['locked', 'exported'],
+        actual: status,
+        surface: 'live_json_export',
+      },
+    });
+  });
+
+  it('returns METRIC_RUN_NOT_FOUND when the metric run is absent', async () => {
+    state.rows = [];
+
+    await expect(
+      assertMetricRunExportWorkflowState({
+        surface: 'render_model',
+        fundId: 1,
+        metricRunId: 11,
+        database: makeDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 404,
+      code: 'METRIC_RUN_NOT_FOUND',
+    });
+  });
+
+  it('uses a preloaded row without issuing another query', async () => {
+    await expect(
+      assertMetricRunExportWorkflowState({
+        surface: 'render_model',
+        fundId: 1,
+        metricRunId: 11,
+        database: makeDatabase(),
+        preloaded: { id: 11, fundId: 1, status: 'exported' },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(state.selectCalls).toBe(0);
+  });
+});

--- a/tests/unit/services/lp-reporting/report-package-csv-stored-export-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-csv-stored-export-service.test.ts
@@ -18,6 +18,7 @@ import {
   type ReportPackageRenderSource,
 } from '@shared/contracts/lp-reporting';
 import {
+  lpMetricRuns,
   lpReportPackageExports,
   lpReportPackages,
   type LpReportPackageExport,
@@ -55,15 +56,25 @@ const H9_STAMP = {
 
 interface State {
   exportRows: LpReportPackageExport[];
+  metricRuns: MetricRunStatusRow[];
   insertedRows: unknown[];
+  statusUpdates: unknown[];
   users: number[];
   nextId: number;
   dropNextInsert: boolean;
 }
 
+interface MetricRunStatusRow {
+  id: number;
+  fundId: number;
+  status: string;
+}
+
 const state: State = {
   exportRows: [],
+  metricRuns: [],
   insertedRows: [],
+  statusUpdates: [],
   users: [7],
   nextId: 4101,
   dropNextInsert: false,
@@ -210,6 +221,7 @@ function sha256(text: string): string {
 
 function rowsFor(table: unknown): unknown[] {
   if (table === users) return state.users.map((id) => ({ id }));
+  if (table === lpMetricRuns) return [...state.metricRuns];
   if (table === lpReportPackageExports) return [...state.exportRows];
   if (table === lpReportPackages) return [storedPackageRow];
   return [];
@@ -269,6 +281,12 @@ function makeDatabase(): typeof db {
         }),
       }),
     }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        state.statusUpdates.push(values);
+        throw new Error('CSV export service must not update metric-run workflow state');
+      },
+    }),
   } as unknown as typeof db;
 }
 
@@ -298,7 +316,9 @@ function seedStoredJson(overrides: Partial<LpReportPackageExport> = {}): LpRepor
 beforeEach(() => {
   ReportPackageJsonExportArtifactSchema.parse(artifact);
   state.exportRows = [];
+  state.metricRuns = [{ id: 500, fundId: 1, status: 'locked' }];
   state.insertedRows = [];
+  state.statusUpdates = [];
   state.users = [7];
   state.nextId = 4101;
   state.dropNextInsert = false;
@@ -349,6 +369,7 @@ describe('stored report package CSV exports', () => {
     expect(state.exportRows.find((row) => row.format === 'csv')?.contentHash).toBe(
       sha256(payload.csv)
     );
+    expect(state.statusUpdates).toHaveLength(0);
   });
 
   it('requires a stored JSON source in the same route scope', async () => {
@@ -364,6 +385,7 @@ describe('stored report package CSV exports', () => {
       code: 'REPORT_PACKAGE_CSV_SOURCE_JSON_EXPORT_REQUIRED',
     });
     expect(state.insertedRows).toHaveLength(0);
+    expect(state.statusUpdates).toHaveLength(0);
   });
 
   it('returns a structured contract error when the stored JSON source is legacy pre-stamp', async () => {
@@ -475,6 +497,41 @@ describe('stored report package CSV exports', () => {
     expect(metadata.record?.format).toBe('csv');
     expect(artifactResponse.record.reportPackageExportId).toBe(4101);
     expect(artifactResponse.csv.csv).toBe(buildReportPackageCsv(artifact));
+    expect(state.statusUpdates).toHaveLength(0);
+  });
+
+  it('re-gates CSV create, metadata, and artifact paths without workflow writes', async () => {
+    state.metricRuns[0] = { ...state.metricRuns[0]!, status: 'approved' };
+    seedStoredJson();
+
+    await expect(
+      createMetricRunReportPackageStoredCsvExport(
+        { fundId: 1, metricRunId: 500, userId: 7 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 409,
+      code: 'METRIC_RUN_NOT_EXPORTABLE',
+    });
+    await expect(
+      getMetricRunReportPackageStoredCsvExport(
+        { fundId: 1, metricRunId: 500 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 409,
+      code: 'METRIC_RUN_NOT_EXPORTABLE',
+    });
+    await expect(
+      getMetricRunReportPackageStoredCsvArtifact(
+        { fundId: 1, metricRunId: 500 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 409,
+      code: 'METRIC_RUN_NOT_EXPORTABLE',
+    });
+    expect(state.statusUpdates).toHaveLength(0);
   });
 
   it('serves the stored CSV artifact when H9 matches', async () => {

--- a/tests/unit/services/lp-reporting/report-package-json-stored-export-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-json-stored-export-service.test.ts
@@ -18,6 +18,7 @@ import {
   type ReportPackageRenderSource,
 } from '@shared/contracts/lp-reporting';
 import {
+  lpMetricRuns,
   lpReportPackageExports,
   lpReportPackages,
   type LpReportPackageExport,
@@ -55,15 +56,29 @@ const H9_STAMP = {
 
 interface State {
   exportRows: LpReportPackageExport[];
+  metricRuns: MetricRunStatusRow[];
   insertedRows: unknown[];
+  statusUpdates: unknown[];
   users: number[];
   nextId: number;
   dropNextInsert: boolean;
 }
 
+interface MetricRunStatusRow {
+  id: number;
+  fundId: number;
+  status: string;
+  version: number;
+  updatedAt: Date;
+  lockedBy: number | null;
+  lockedAt: Date | null;
+}
+
 const state: State = {
   exportRows: [],
+  metricRuns: [],
   insertedRows: [],
+  statusUpdates: [],
   users: [7],
   nextId: 4100,
   dropNextInsert: false,
@@ -183,6 +198,7 @@ function makeResponse(hash = 'c'.repeat(64)): ReportPackageJsonExportResponse {
 
 function rowsFor(table: unknown): unknown[] {
   if (table === users) return state.users.map((id) => ({ id }));
+  if (table === lpMetricRuns) return [...state.metricRuns];
   if (table === lpReportPackageExports) return [...state.exportRows];
   if (table === lpReportPackages) return [storedPackageRow];
   return [];
@@ -242,13 +258,50 @@ function makeDatabase(): typeof db {
         }),
       }),
     }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            if (table !== lpMetricRuns) {
+              return [];
+            }
+            const current = state.metricRuns.find((row) => row.id === 500 && row.fundId === 1);
+            if (!current || current.status !== 'locked') {
+              return [];
+            }
+            const updated: MetricRunStatusRow = {
+              ...current,
+              status: values['status'] as string,
+              updatedAt: values['updatedAt'] as Date,
+            };
+            state.metricRuns = state.metricRuns.map((row) =>
+              row.id === updated.id && row.fundId === updated.fundId ? updated : row
+            );
+            state.statusUpdates.push(values);
+            return [updated];
+          },
+        }),
+      }),
+    }),
   } as unknown as typeof db;
 }
 
 beforeEach(() => {
   ReportPackageJsonExportArtifactSchema.parse(artifact);
   state.exportRows = [];
+  state.metricRuns = [
+    {
+      id: 500,
+      fundId: 1,
+      status: 'locked',
+      version: 3,
+      updatedAt: new Date('2026-05-10T02:00:00Z'),
+      lockedBy: 7,
+      lockedAt: new Date('2026-05-10T02:00:00Z'),
+    },
+  ];
   state.insertedRows = [];
+  state.statusUpdates = [];
   state.users = [7];
   state.nextId = 4100;
   state.dropNextInsert = false;
@@ -269,6 +322,14 @@ describe('stored report package JSON exports', () => {
     expect(response.record.contentHash).toBe('c'.repeat(64));
     expect(response.record.artifactSizeBytes).toBeGreaterThan(0);
     expect(state.insertedRows).toHaveLength(1);
+    expect(state.statusUpdates).toHaveLength(1);
+    expect(state.statusUpdates[0]).toMatchObject({ status: 'exported' });
+    expect(state.metricRuns[0]).toMatchObject({
+      status: 'exported',
+      version: 3,
+      lockedBy: 7,
+      lockedAt: new Date('2026-05-10T02:00:00Z'),
+    });
     const inserted = state.insertedRows[0] as { artifactPayload: unknown };
     const persistedArtifact = ReportPackageJsonExportArtifactSchema.parse(inserted.artifactPayload);
     expect(persistedArtifact.source.h9Stamp).toEqual(H9_STAMP);
@@ -296,6 +357,67 @@ describe('stored report package JSON exports', () => {
     expect(second.inserted).toBe(false);
     expect(second.record.reportPackageExportId).toBe(first.record.reportPackageExportId);
     expect(state.insertedRows).toHaveLength(1);
+    expect(state.statusUpdates).toHaveLength(1);
+    expect(state.metricRuns[0]?.status).toBe('exported');
+  });
+
+  it('replays an already exported metric run without a second status update', async () => {
+    state.metricRuns[0] = { ...state.metricRuns[0]!, status: 'exported' };
+    state.exportRows.push({
+      id: 4100,
+      fundId: 1,
+      metricRunId: 500,
+      reportPackageId: 3000,
+      format: 'json',
+      exportVersion: 1,
+      status: 'ready',
+      contentHashAlgorithm: 'sha256',
+      contentHash: 'c'.repeat(64),
+      artifactPayload: artifact,
+      artifactSizeBytes: 1000,
+      createdBy: 7,
+      readyAt: new Date('2026-05-10T04:00:00Z'),
+      createdAt: new Date('2026-05-10T04:00:00Z'),
+      updatedAt: new Date('2026-05-10T04:00:00Z'),
+    });
+
+    const response = await createMetricRunReportPackageStoredJsonExport(
+      { fundId: 1, metricRunId: 500, userId: 7 },
+      { database: makeDatabase(), jsonExportService: vi.fn(async () => makeResponse()) }
+    );
+
+    expect(response.inserted).toBe(false);
+    expect(state.metricRuns[0]?.status).toBe('exported');
+    expect(state.statusUpdates).toHaveLength(0);
+  });
+
+  it('replay catches up a locked pre-PR-3 stored JSON export row to exported', async () => {
+    state.exportRows.push({
+      id: 4100,
+      fundId: 1,
+      metricRunId: 500,
+      reportPackageId: 3000,
+      format: 'json',
+      exportVersion: 1,
+      status: 'ready',
+      contentHashAlgorithm: 'sha256',
+      contentHash: 'c'.repeat(64),
+      artifactPayload: artifact,
+      artifactSizeBytes: 1000,
+      createdBy: 7,
+      readyAt: new Date('2026-05-10T04:00:00Z'),
+      createdAt: new Date('2026-05-10T04:00:00Z'),
+      updatedAt: new Date('2026-05-10T04:00:00Z'),
+    });
+
+    const response = await createMetricRunReportPackageStoredJsonExport(
+      { fundId: 1, metricRunId: 500, userId: 7 },
+      { database: makeDatabase(), jsonExportService: vi.fn(async () => makeResponse()) }
+    );
+
+    expect(response.inserted).toBe(false);
+    expect(state.statusUpdates).toHaveLength(1);
+    expect(state.metricRuns[0]).toMatchObject({ status: 'exported', version: 3 });
   });
 
   it('rejects hash drift on the same package natural key', async () => {
@@ -391,6 +513,46 @@ describe('stored report package JSON exports', () => {
       code: 'REPORT_PACKAGE_JSON_EXPORT_BLOCKED',
     });
     expect(state.insertedRows).toHaveLength(0);
+  });
+
+  it('re-gates stored JSON metadata and artifact reads before serving export rows', async () => {
+    state.metricRuns[0] = { ...state.metricRuns[0]!, status: 'draft' };
+    state.exportRows.push({
+      id: 4100,
+      fundId: 1,
+      metricRunId: 500,
+      reportPackageId: 3000,
+      format: 'json',
+      exportVersion: 1,
+      status: 'ready',
+      contentHashAlgorithm: 'sha256',
+      contentHash: 'c'.repeat(64),
+      artifactPayload: artifact,
+      artifactSizeBytes: 1000,
+      createdBy: 7,
+      readyAt: new Date('2026-05-10T04:00:00Z'),
+      createdAt: new Date('2026-05-10T04:00:00Z'),
+      updatedAt: new Date('2026-05-10T04:00:00Z'),
+    });
+
+    await expect(
+      getMetricRunReportPackageStoredJsonExport(
+        { fundId: 1, metricRunId: 500 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 409,
+      code: 'METRIC_RUN_NOT_EXPORTABLE',
+    });
+    await expect(
+      getMetricRunReportPackageStoredJsonArtifact(
+        { fundId: 1, metricRunId: 500 },
+        { database: makeDatabase() }
+      )
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 409,
+      code: 'METRIC_RUN_NOT_EXPORTABLE',
+    });
   });
 
   it('returns nullable metadata before create and immutable artifact after create', async () => {

--- a/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
@@ -288,6 +288,30 @@ describe('getMetricRunReportPackageRenderModel', () => {
     ).rejects.toMatchObject({ code: 'H9_FINGERPRINT_STALE' });
   });
 
+  it.each(['draft', 'approved', 'superseded'])(
+    'blocks %s metric runs before H9 validation and without writes',
+    async (status) => {
+      state.metricRuns = [metricRunRow({ status })];
+
+      await expect(
+        getMetricRunReportPackageRenderModel(
+          { fundId: 1, metricRunId: 11 },
+          { database: makeDatabase() }
+        )
+      ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+        status: 409,
+        code: 'METRIC_RUN_NOT_EXPORTABLE',
+        details: {
+          expected: ['locked', 'exported'],
+          actual: status,
+          surface: 'render_model',
+        },
+      });
+      expect(assertH9ExportActionable).not.toHaveBeenCalled();
+      expect(state.writeCalls).toEqual([]);
+    }
+  );
+
   it('returns REPORT_PACKAGE_ROW_INVALID when H9 metadata is missing after the gate', async () => {
     state.reportPackages = [
       reportPackageRow({


### PR DESCRIPTION
## Summary

PRD #996 slice PR-3 (AC-2), implementing human-approved decision **D2** (recorded on #996, ADR-026 in this PR):

- **Export-time workflow gate**: new `metric-run-export-workflow-gate` service; all eight Surface-A export routes re-gate on `lp_metric_runs.status IN ('locked','exported')` at export time (previously only assembly checked `locked`; export never re-checked). Non-exportable statuses return structured 409 `METRIC_RUN_NOT_EXPORTABLE` with `{expected, actual, surface}`.
- **`exported` transition finally written**: stored JSON export create flips `locked -> exported` via guarded update (`WHERE status='locked'`; sets `status`+`updatedAt` only — no version bump, which would cascade H9 fingerprint staleness). Runs on both insert and hash-matched replay (catch-up for rows exported before this PR); a hash-conflict replay never transitions.
- **Read paths stay read-only**: render-model, live JSON, stored GET/artifact, and all CSV paths re-gate but never write (render-model gate reuses the already-loaded run row — no extra query).
- **Registry**: the eight export entries' `workflowRequirement` set to `metric_run_locked_or_exported`.

## Blast radius (enumerated per brief)

- Assembly (`report-package-service`) and narrative mutations keep requiring `locked` — post-export immutability is an accepted, ADR-documented consequence.
- Supersede path verified: `commitMetricRun` has no locked-only prior-version guard (dedupes by input hash, inserts draft), so exported runs cannot jam the workflow.

## Tests

148/148 locally across 10 suites (TZ=UTC, server project): per-route 409 matrix for draft/approved/superseded across all eight routes, allowed for locked AND exported, transition + idempotent replay + catch-up asserted with version unchanged, read-path no-write pins, new gate suite, H9 gate suite untouched (AC-5), route-policy coverage, and both registerRoutes mount suites (PR-2 lesson).

Full CI run ID will be cited after checks complete (PRD #996 DoD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS