### PR TITLE
PRD #996 AC-3: close out Surface-A watermark decision

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5289,6 +5289,20 @@ be filed as its own issue or PRD amendment.
 - Before deletion, the only code hits for `addWatermark` and the report
   `watermarked` context field were in `workers/report-worker.ts`.
 
+### Current-Main Revalidation (2026-07-05)
+
+On current `main` at `dfb24b8a45e6f5851b948c5a26c732d44eab04fd` (`HEAD`,
+`origin/main`, and `FETCH_HEAD` matched after `git fetch origin main`):
+
+- `Test-Path workers\report-worker.ts` returned `False`.
+- `server/queues/report-generation-queue.ts` declares
+  `const QUEUE_NAME = 'lp-report-generation'`.
+- `server/queues/registry.ts` declares `queueName: 'lp-report-generation'`.
+- `server/routes/lp-api.ts` is the route path that calls
+  `enqueueReportGeneration` from `/api/lp/reports/generate`.
+- `server/routes/lp-reporting/metric-runs.ts` Surface-A export routes do not
+  call `enqueueReportGeneration` or reference `lp-report-generation`.
+
 ### Alternatives Considered
 
 - **Wire the legacy worker into the live queue:** rejected because it expands

--- a/docs/BUILD_READINESS.md
+++ b/docs/BUILD_READINESS.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-06-22
+last_updated: 2026-07-05
 ---
 
 # Build Readiness Verification Report
@@ -32,13 +32,17 @@ Authoritative product surface:
 - Investment round create/list/read routes enforce fund scope through the parent
   investment before returning round data
 - LP dashboard/profile widget routes are mounted in both active server surfaces
-- LP Reporting export and report-download routes already exist and are mounted
-  (`server/routes/lp-reporting/metric-runs.ts` JSON/CSV exports behind
-  `requireAuth`+`requireFundAccess`; `server/routes/lp-api.ts` report download
-  behind `requireAuth`+`requireLPAccess`, filtered by `lpId`). They are
-  authenticated but not yet admin-only or watermarked, so they are not
-  production-trust-qualified until role, workflow-state, provenance, and
-  export-eligibility gates are accepted
+- LP Reporting Surface-A report-package JSON/CSV exports in
+  `server/routes/lp-reporting/metric-runs.ts` are production-trust-qualified:
+  partner/admin role gates, fund-scope checks, locked/exported workflow gates,
+  H9/evidence blockers, `h9Stamp`, and `contentHash` provenance are enforced.
+  ADR-027 scopes visual watermarking out for these machine-readable artifacts;
+  `workers/report-worker.ts` is deleted, and the live `lp-report-generation`
+  queue remains the separate legacy PDF/XLSX/CSV report path.
+- `/api/lp/reports/*` generation/download in `server/routes/lp-api.ts` remains
+  the LP-access report-center path backed by `lp-report-generation`. It is not
+  the PRD #996 Surface-A export surface, and any future PDF/report-center
+  watermark requirement needs its own issue or PRD amendment.
 
 ## Required Validation Commands
 

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -462,7 +462,7 @@ function governanceRefForPortfolioIntelligenceRoute(
 const PROTOTYPE_ROUTE_NOTE = 'Prototype route must return 501 with non_actionable provenance.';
 const LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT = 'metric_run_locked_or_exported';
 const LP_REPORT_PACKAGE_EXPORT_NOTE =
-  'PRD #996 AC-1, AC-2, D1, and D2: Surface-A report-package export requires partner/admin role, denies empty-fundIds non-admin exports, and requires metric-run workflow state locked or exported.';
+  'PRD #996 AC-1, AC-2, AC-3, D1, D2, and D3: Surface-A report-package export requires partner/admin role, denies empty-fundIds non-admin exports, requires metric-run workflow state locked or exported, and scopes visual watermarking out by ADR-027 because h9Stamp plus contentHash provide JSON/CSV hash attestation.';
 
 const PORTFOLIO_INTELLIGENCE_ROUTE_POLICY_DECISIONS: Readonly<PortfolioIntelligenceRouteDecisionMap> =
   {

--- a/tests/unit/source/lp-reporting-report-package-source-guards.test.ts
+++ b/tests/unit/source/lp-reporting-report-package-source-guards.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from 'vitest';
 const read = (relativePath: string) =>
   fs.readFileSync(path.resolve(process.cwd(), relativePath), 'utf8');
 
+const exists = (relativePath: string) => fs.existsSync(path.resolve(process.cwd(), relativePath));
+
 describe('LP Reporting report-package source guards', () => {
   it('does not add a standalone /lp-reporting/reports client route or navigation item', () => {
     const appRoutesSource = read('client/src/app/app-routes.tsx');
@@ -108,6 +110,48 @@ describe('LP Reporting report-package source guards', () => {
     expect(metricsPageSource).not.toContain('@/hooks/useLPReports');
     expect(metricsPageSource).not.toMatch(
       /\bDownload\b|\bShare\b|Export PDF|Export XLSX|Public link|\bEmail\b|LP portal/
+    );
+  });
+
+  it('locks PRD #996 AC-3 to the ADR-027 Surface-A watermark decision', () => {
+    const queueSource = read('server/queues/report-generation-queue.ts');
+    const queueRegistrySource = read('server/queues/registry.ts');
+    const lpApiRouteSource = read('server/routes/lp-api.ts');
+    const reportPackageRouteSource = read('server/routes/lp-reporting/metric-runs.ts');
+    const routePolicySource = read('server/route-policy/api-route-policy-registry.ts');
+    const decisionsSource = read('DECISIONS.md');
+    const buildReadinessSource = read('docs/BUILD_READINESS.md');
+
+    expect(exists('workers/report-worker.ts')).toBe(false);
+    expect(queueSource).toContain("const QUEUE_NAME = 'lp-report-generation'");
+    expect(queueRegistrySource).toContain("queueName: 'lp-report-generation'");
+    expect(lpApiRouteSource).toContain('enqueueReportGeneration');
+    expect(lpApiRouteSource).toContain('/api/lp/reports/generate');
+    expect(reportPackageRouteSource).not.toMatch(/enqueueReportGeneration|lp-report-generation/);
+
+    for (const source of [
+      queueSource,
+      queueRegistrySource,
+      lpApiRouteSource,
+      reportPackageRouteSource,
+      routePolicySource,
+    ]) {
+      expect(source).not.toContain("'report-generation'");
+      expect(source).not.toMatch(/\baddWatermark\b|\bwatermarked\b/);
+    }
+
+    expect(routePolicySource).toContain('scopes visual watermarking out by ADR-027');
+    expect(routePolicySource).toContain('h9Stamp plus contentHash');
+    expect(decisionsSource).toContain('## ADR-027: LP Export Watermark Policy (PRD #996 D3)');
+    expect(decisionsSource).toContain('Watermarking is out of scope for Surface-A JSON/CSV');
+    expect(decisionsSource).toContain('Delete `workers/report-worker.ts` instead of wiring it');
+    expect(decisionsSource).toContain('### Current-Main Revalidation (2026-07-05)');
+    expect(decisionsSource).toContain("`const QUEUE_NAME = 'lp-report-generation'`");
+    expect(buildReadinessSource).toContain(
+      'ADR-027 scopes visual watermarking out for these machine-readable artifacts'
+    );
+    expect(buildReadinessSource).toContain(
+      '`workers/report-worker.ts` is deleted, and the live `lp-report-generation`'
     );
   });
 });


### PR DESCRIPTION
## Summary

- Record current-main revalidation for ADR-027 at `dfb24b8a45e6f5851b948c5a26c732d44eab04fd`.
- Align `docs/BUILD_READINESS.md` with the implemented Surface-A production-trust decision.
- Update the route-policy note to include AC-3 / D3 and the `h9Stamp` + `contentHash` hash-attestation decision.
- Add source-guard coverage proving `workers/report-worker.ts` stays deleted, the live queue remains `lp-report-generation`, and Surface-A report-package exports do not call the LP report queue.

## Trust Decision

Do not wire watermarking into `lp-report-generation` for PRD #996 AC-3. Surface-A JSON/CSV report-package exports are machine-readable artifacts governed by role, fund-scope, workflow-state, H9/evidence, `h9Stamp`, and `contentHash` gates. `/api/lp/reports/*` remains the separate report-center/PDF path; future PDF/report-center watermarking needs a separate issue or PRD amendment.

## Verification

- `npm test -- --project=server tests/unit/source/lp-reporting-report-package-source-guards.test.ts`
- `npm test -- --project=server tests/unit/route-policy/route-policy-coverage.test.ts`
- `npm run check`
- `npm run lint`
- `git diff --cached --check`
- Pre-push hook reran TypeScript baseline and targeted changed-file tests: 22/22 passed.

## Notes

- Pre-push documentation freshness still reports unrelated stale docs as warnings; `docs/BUILD_READINESS.md` was refreshed and is no longer listed as stale.
- Full `npm test` and `release:check` were not run for this narrow docs/source-guard slice.