### PR TITLE
Fix code-scanning security backlog sources

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -42,14 +42,16 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
           format: sarif
           output: trivy-fs-results.sarif
           severity: CRITICAL,HIGH,MEDIUM
+          skip-files: .config/.semgrep/semgrep_rules.json
           exit-code: '0'
+          version: v0.72.0
 
       - name: Upload Trivy FS results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -70,13 +72,14 @@ jobs:
         run: docker build -t povc-fund-platform:latest .
 
       - name: Run Trivy container scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: povc-fund-platform:latest
           format: sarif
           output: trivy-container-results.sarif
           severity: CRITICAL,HIGH,MEDIUM
           exit-code: '0'
+          version: v0.72.0
 
       - name: Upload Trivy container results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -109,7 +112,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: OWASP Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main as of 2026-07-05
         id: depcheck
         with:
           project: POVC-Fund-Platform

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ WORKDIR /app
 # hadolint ignore=DL3018
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nextjs -u 1001 && \
-    apk add --no-cache dumb-init
+    apk add --no-cache dumb-init && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Environment
 ENV NODE_ENV=production

--- a/docs/security/cve-exceptions.md
+++ b/docs/security/cve-exceptions.md
@@ -1,11 +1,12 @@
 ---
 status: ACTIVE
-last_updated: 2026-01-19
+last_updated: 2026-07-05
 ---
 
 # CVE Exception Log
 
-This document tracks security vulnerabilities that have been reviewed and accepted as false positives or mitigated risks.
+This document tracks security vulnerabilities that have been reviewed and
+accepted as false positives or mitigated risks.
 
 ## SheetJS xlsx (OSS) False Positives
 
@@ -15,7 +16,8 @@ This document tracks security vulnerabilities that have been reviewed and accept
   - CVE-2023-30533
   - CVE-2024-22363
 - **Rationale**:
-  - These CVEs reference SheetJS Pro/commercial versions (≥0.19.x, ≥0.20.x) which use a different release track and versioning scheme
+  - These CVEs reference SheetJS Pro/commercial versions (≥0.19.x, ≥0.20.x)
+    which use a different release track and versioning scheme
   - The open-source `xlsx` package maxes out at 0.18.5 on npm
   - Commercial versions have higher version numbers but are separate products
 - **Verification**:
@@ -27,6 +29,26 @@ This document tracks security vulnerabilities that have been reviewed and accept
   - Controlled input surfaces only
 - **Review Date**: 2026-01-01 (or earlier on next xlsx upgrade)
 - **Exception File**: `.trivyignore`
+
+## Semgrep Rule Fixture Slack Webhook False Positive
+
+- **Artifact**: `.config/.semgrep/semgrep_rules.json`
+- **Scanner**: Trivy filesystem secret scan
+- **Rule Ignored**: `slack-web-hook` at the vendored rule fixture path only
+- **Rationale**:
+  - The matched string is Semgrep rule data under `pattern-not`, not an
+    application credential
+  - The placeholder token is a public non-secret sentinel used to keep the
+    vendored rule from matching its own example
+  - Source files remain covered by the Trivy filesystem scan; only the
+    generated/vendored Semgrep rule bundle is skipped
+- **Verification**:
+  - GitHub code-scanning alert #1 points to
+    `.config/.semgrep/semgrep_rules.json`
+  - The workflow skip is file-specific via `.github/workflows/security-scan.yml`
+- **Review Date**: 2026-10-05, or earlier when the Semgrep rule bundle is
+  regenerated
+- **Exception File**: `.github/workflows/security-scan.yml`
 
 ## Review Process
 

--- a/ml-service/requirements.txt
+++ b/ml-service/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.0
 uvicorn==0.30.3
 scikit-learn==1.5.2
 pandas==2.2.2
-joblib==1.4.2
+joblib==1.5.3
 numpy==1.26.4
 pydantic==2.8.0
 python-multipart==0.0.31


### PR DESCRIPTION
## Summary

Addresses the currently open GitHub Security code-scanning backlog surfaces from `security-scan.yml`:

```text
GitHub code scanning
├─ Trivy container alerts #597/#596/#577/#464/#393/#392/#384
│  └─ default Dockerfile runtime image
│     └─ bundled global npm tree under /usr/local/lib/node_modules/npm/node_modules
│        └─ remove npm/npx from the final runtime stage
├─ dependency-check alert #228
│  └─ ml-service/requirements.txt joblib==1.4.2
│     └─ bump to joblib==1.5.3
└─ Trivy filesystem secret alert #1
   └─ .config/.semgrep/semgrep_rules.json vendored placeholder rule data
      └─ skip only that file and document the exception
```

Also pins the Security Deep Scan Trivy action and OWASP Dependency-Check action refs to immutable commit SHAs instead of branch refs.

## Verification

- `npm run check`
- `npm run lint`
- `npm audit --omit=dev --audit-level=moderate --json` -> 0 vulnerabilities
- `node` YAML parse of `.github/workflows/security-scan.yml`
- `npx prettier --check .github/workflows/security-scan.yml docs/security/cve-exceptions.md`
- `git diff --check`
- `python -m pip install --dry-run joblib==1.5.3`
- Pre-push hook reran TypeScript baseline successfully; targeted test selection found no matching tests for this workflow/Docker/requirements/doc-only change.

## Known local proof limits

- Local Docker/Trivy image proof was not run because `docker` and `trivy` are not installed in this environment.
- Full `ml-service/requirements.txt` dry-run is blocked locally by the existing Python 3.13/pandas wheel/toolchain issue; direct `joblib==1.5.3` resolution succeeds.
- Pre-push doc freshness reports pre-existing stale-doc warnings unrelated to this change.
