### PR TITLE
chore(deps): prune 14 no-longer-load-bearing npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,25 +247,11 @@
     "npm": "10.9.2"
   },
   "overrides": {
-    "nats": "2.29.3",
     "esbuild": "^0.28.1",
-    "diff": "^8.0.3",
-    "@grpc/grpc-js": "1.14.4",
     "@react-pdf/pdfkit": "^4.1.0",
-    "@isaacs/brace-expansion": "5.0.1",
-    "axios": "1.16.0",
-    "fast-uri": "3.1.2",
-    "lodash": "^4.18.1",
-    "lodash-es": "^4.18.1",
-    "protobufjs": "^7.6.4",
-    "shell-quote": "^1.8.4",
     "uuid": "^11.1.1",
-    "form-data": "^4.0.6",
-    "tmp": "^0.2.7",
     "ws": "^8.21.0",
-    "undici": "7.28.0",
-    "@opentelemetry/core": "2.8.0",
-    "@babel/core": "7.29.6"
+    "@opentelemetry/core": "2.8.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.11.3",


### PR DESCRIPTION
Empirical prune of the package.json overrides block (19 -> 5), package.json-only change with a byte-identical package-lock.json.

Method: removed all 19 overrides, re-resolved, and audited the result. Without overrides the tree reintroduces 38 vulnerabilities (1 high: ws 8.x under the socket.io chain; 37 moderate: esbuild <=0.24.2 nested copy, @opentelemetry/core <2.8.0 fan-out across the OTel suite, uuid <11.1.1 under dockerode/exceljs) plus an out-of-scope @react-pdf/pdfkit 4->5 major jump.

KEEP (5, load-bearing): esbuild, ws, @opentelemetry/core, uuid, @react-pdf/pdfkit (audit-clean but pins back a major upgrade; needs its own validated bump lane).
REMOVE (14, proven redundant): nats, diff, @grpc/grpc-js, @isaacs/brace-expansion, axios, fast-uri, lodash, lodash-es, protobufjs, shell-quote, form-data, tmp, undici, @babel/core - regenerating package-lock.json from pristine HEAD with only the 5 kept overrides yields a byte-identical lockfile; npm audit = 0 vulnerabilities.

Local full-run pre-push validation: build + full unit suite, 636 files / 7,605 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS