### PR TITLE
feat(lp-reporting): wire Planning-FMV override writes into the H9 invalidation seam

### DIFF
--- a/server/services/h9-artifact-invalidation-service.ts
+++ b/server/services/h9-artifact-invalidation-service.ts
@@ -7,9 +7,9 @@ const log = logger.child({ service: 'h9-artifact-invalidation' });
  * H9 artifact invalidation seam.
  *
  * Source-mutation sites (rounds, investments, MOIC inputs, reconciliations,
- * calculation-mode changes, realized proceeds) call this AFTER a successful
- * write so stale current/actionable artifacts cannot be reused, cached, or
- * exported after the source changed.
+ * calculation-mode changes, realized proceeds, Planning-FMV mark writes) call
+ * this AFTER a successful write so stale current/actionable artifacts cannot be
+ * reused, cached, or exported after the source changed.
  *
  * Today the only live fund-keyed cache is the 300s metrics cache, which is NOT
  * fingerprint-protected, so it must be busted explicitly on mutation. The

--- a/server/services/lp-reporting/planning-fmv-override-service.ts
+++ b/server/services/lp-reporting/planning-fmv-override-service.ts
@@ -21,6 +21,7 @@ import {
   type ValuationMark,
 } from '@shared/schema/lp-reporting-evidence';
 import { portfolioCompanies } from '@shared/schema/portfolio';
+import { invalidateH9Artifacts } from '../h9-artifact-invalidation-service';
 import { selectActiveValuationMarks } from './active-valuation-mark-selector';
 import type { ConfidenceLevel, MarkStatus, ParsedValuationMark } from './metrics-engine';
 
@@ -435,7 +436,9 @@ export async function createPlanningFmvOverride(
   }
 
   try {
-    return await writePlanningFmvMark(database, input, pending, sourceHash);
+    const response = await writePlanningFmvMark(database, input, pending, sourceHash);
+    await invalidateH9Artifacts(input.fundId);
+    return response;
   } catch (error) {
     const mappedError =
       error instanceof PlanningFmvOverrideError

--- a/tests/unit/services/h9-invalidation-service-wiring.test.ts
+++ b/tests/unit/services/h9-invalidation-service-wiring.test.ts
@@ -14,6 +14,8 @@ vi.mock('../../../server/services/h9-artifact-invalidation-service', () => ({
 import { createRound } from '../../../server/services/investments/investment-round-service';
 import { updateFundMoicInputs } from '../../../server/services/fund-moic-input-service';
 import { updateFundMoicCalculationMode } from '../../../server/services/fund-calculation-mode-service';
+import { createPlanningFmvOverride } from '../../../server/services/lp-reporting/planning-fmv-override-service';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
 
 const FUND_ID = 7;
 
@@ -164,6 +166,169 @@ describe('updateFundMoicCalculationMode -> H9 invalidation wiring', () => {
 
   it('does NOT invalidate on an idempotent replay', async () => {
     await updateFundMoicCalculationMode({ ...params(), database: transactionDb(true) as never });
+
+    expect(invalidateH9Artifacts).not.toHaveBeenCalled();
+  });
+});
+
+// ---- Planning-FMV marks: createPlanningFmvOverride --------------------------
+
+function planningFmvInput() {
+  return {
+    fundId: FUND_ID,
+    idempotencyKey: 'idem-planning-mark',
+    actor: { userId: 1 },
+    body: {
+      companyId: 1,
+      markDate: '2026-06-01',
+      fairValue: '1000000',
+      currency: 'USD' as const,
+      confidenceLevel: 'medium' as const,
+      reason: 'quarterly planning update',
+      source: {
+        allocationVersion: 1,
+        plannedReservesCents: 1000000,
+        allocationReason: 'quarterly planning update',
+      },
+    },
+  };
+}
+
+function planningFmvMark(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 101,
+    fundId: FUND_ID,
+    companyId: 1,
+    markDate: '2026-06-01',
+    asOfDate: '2026-06-01',
+    fairValue: '1000000',
+    currency: 'USD',
+    confidenceLevel: 'medium',
+    status: 'approved',
+    priorMarkId: null,
+    methodologyNotes: 'quarterly planning update',
+    approvedBy: 1,
+    approvedAt: '2026-06-01T00:00:00.000Z',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function planningFmvResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    requestId: 501,
+    idempotencyKey: 'idem-planning-mark',
+    replayed: false,
+    valuationMark: planningFmvMark(),
+    ...overrides,
+  };
+}
+
+function pendingPlanningFmvRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 501,
+    fundId: FUND_ID,
+    companyId: 1,
+    valuationMarkId: null,
+    idempotencyKey: 'idem-planning-mark',
+    requestHash: 'pending-request-hash',
+    sourceHash: 'pending-source-hash',
+    status: 'pending',
+    responseBody: null,
+    failureCode: null,
+    failureMessage: null,
+    createdBy: 1,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    completedAt: null,
+    updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function completedPlanningFmvRequest(overrides: Record<string, unknown> = {}) {
+  const input = planningFmvInput();
+
+  return pendingPlanningFmvRequest({
+    valuationMarkId: 101,
+    requestHash: canonicalSha256({ fundId: input.fundId, body: input.body }),
+    status: 'completed',
+    responseBody: planningFmvResponse(),
+    completedAt: new Date('2026-06-01T00:00:00.000Z'),
+    ...overrides,
+  });
+}
+
+function planningFmvDb(opts: {
+  insertReturns: unknown[];
+  existing?: unknown[];
+  transactionResult?: unknown;
+  transactionError?: Error;
+}) {
+  return {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(async () => opts.insertReturns),
+        })),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => opts.existing ?? []),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(async () => undefined),
+      })),
+    })),
+    transaction: vi.fn(async () => {
+      if (opts.transactionError) {
+        throw opts.transactionError;
+      }
+      return opts.transactionResult;
+    }),
+  };
+}
+
+describe('createPlanningFmvOverride -> H9 invalidation wiring', () => {
+  it('invalidates H9 artifacts when a new Planning FMV mark is written', async () => {
+    const result = await createPlanningFmvOverride(planningFmvInput(), {
+      database: planningFmvDb({
+        insertReturns: [pendingPlanningFmvRequest()],
+        transactionResult: planningFmvResponse(),
+      }) as never,
+    });
+
+    expect(result.replayed).toBe(false);
+    expect(invalidateH9Artifacts).toHaveBeenCalledWith(FUND_ID);
+  });
+
+  it('does NOT invalidate on an idempotent replay (no mark written)', async () => {
+    const result = await createPlanningFmvOverride(planningFmvInput(), {
+      database: planningFmvDb({
+        insertReturns: [],
+        existing: [completedPlanningFmvRequest()],
+      }) as never,
+    });
+
+    expect(result.replayed).toBe(true);
+    expect(invalidateH9Artifacts).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invalidate when the mark write fails', async () => {
+    const writeError = new Error('Planning FMV write failed');
+
+    await expect(
+      createPlanningFmvOverride(planningFmvInput(), {
+        database: planningFmvDb({
+          insertReturns: [pendingPlanningFmvRequest()],
+          transactionError: writeError,
+        }) as never,
+      })
+    ).rejects.toBe(writeError);
 
     expect(invalidateH9Artifacts).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Implements ADR-031 decision 4 (PRD #1020): the one remaining non-compliant source-mutation path - Planning-FMV override mark writes - now calls the `invalidateH9Artifacts` seam post-success.

- `createPlanningFmvOverride` invalidates after a successful mark write only; idempotent replays and failed writes do not invalidate (mirrors the `createRound` service-layer pattern at `investment-round-service.ts:209`)
- Seam doc comment (`h9-artifact-invalidation-service.ts`) now names Planning-FMV mark writes among the source-mutation sites
- Three wiring tests added to `tests/unit/services/h9-invalidation-service-wiring.test.ts` (created / replay / failure), same direct-call mock pattern as the existing round and MOIC cases

Marks do not feed `UnifiedFundMetrics` today, so this is prospective seam compliance per the ADR - it becomes user-visible once facts drive the forecast surfaces (#1020 PR-1/PR-2).

## Verification

- `npx vitest run tests/unit/services/h9-invalidation-service-wiring.test.ts` - 9/9 pass
- `npm run check` - 0 errors, no baseline drift
- ESLint on all three touched files - clean

Implemented via a Hermes production lane in an isolated worktree; diff and tests independently re-verified before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS