### PR TITLE
feat(dual-forecast): trust-blended Current/Actual NAV + variance per ADR-029/030/032 (#1020 PR-2)

### DIFF
--- a/server/services/actual-metrics-calculator.ts
+++ b/server/services/actual-metrics-calculator.ts
@@ -38,6 +38,39 @@ type PortfolioCompanyFactRow = {
   investmentDate?: Date | string | null;
 };
 
+function normalizeCompanyStatus(status: string | null | undefined): string {
+  return (status ?? 'active')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-');
+}
+
+function isExitedCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
+  const status = normalizeCompanyStatus(company.status);
+  return status === 'exited' || status === 'exit' || status === 'realized' || status === 'realised';
+}
+
+function isWrittenOffCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
+  const status = normalizeCompanyStatus(company.status);
+  return (
+    status === 'written-off' ||
+    status === 'write-off' ||
+    status === 'writtenoff' ||
+    status === 'failed' ||
+    status === 'lost' ||
+    status === 'inactive'
+  );
+}
+
+/**
+ * NAV-universe classification. Exported because the dual-forecast blend
+ * (ADR-029) retains this exact live-company universe; any change here changes
+ * both surfaces by construction.
+ */
+export function isLivePortfolioCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
+  return !isExitedCompany(company) && !isWrittenOffCompany(company);
+}
+
 export class ActualMetricsCalculator {
   /**
    * Calculate actual metrics from database records
@@ -174,33 +207,19 @@ export class ActualMetricsCalculator {
   }
 
   private normalizeCompanyStatus(status: string | null | undefined): string {
-    return (status ?? 'active')
-      .trim()
-      .toLowerCase()
-      .replace(/[\s_]+/g, '-');
+    return normalizeCompanyStatus(status);
   }
 
   private isExitedCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
-    const status = this.normalizeCompanyStatus(company.status);
-    return (
-      status === 'exited' || status === 'exit' || status === 'realized' || status === 'realised'
-    );
+    return isExitedCompany(company);
   }
 
   private isWrittenOffCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
-    const status = this.normalizeCompanyStatus(company.status);
-    return (
-      status === 'written-off' ||
-      status === 'write-off' ||
-      status === 'writtenoff' ||
-      status === 'failed' ||
-      status === 'lost' ||
-      status === 'inactive'
-    );
+    return isWrittenOffCompany(company);
   }
 
   private isLivePortfolioCompany(company: Pick<PortfolioCompany, 'status'>): boolean {
-    return !this.isExitedCompany(company) && !this.isWrittenOffCompany(company);
+    return isLivePortfolioCompany(company);
   }
 
   /**

--- a/server/services/metrics-aggregator.ts
+++ b/server/services/metrics-aggregator.ts
@@ -489,6 +489,10 @@ export class MetricsAggregator {
           planningFmvStatus: fact.planningFmvStatus,
           currency: fact.currency,
           currencyStatus: fact.currencyStatus,
+          // ADR-032 decision 1: round ids and supersede lineage surface fully
+          // even when the company's monetary values are currency-blocked.
+          activeRoundIds: fact.activeRoundIds,
+          supersedeLineage: fact.supersedeLineage,
           latestRoundDate: fact.latestRoundDate,
           latestRoundValuation: fact.latestRoundValuation,
           latestPlanningFmvDate: fact.latestPlanningFmvDate,

--- a/server/services/metrics-aggregator.ts
+++ b/server/services/metrics-aggregator.ts
@@ -22,13 +22,18 @@ import type {
 } from '@shared/types/metrics';
 import type {
   DualForecastActualsFacts,
+  DualForecastActualsFactsCompany,
   DualForecastConfigMetadata,
+  DualForecastCurrentProjection,
   DualForecastMetrics,
+  DualForecastNavAnchor,
+  DualForecastNavAnchorCompany,
+  DualForecastNavAnchoring,
   DualForecastPoint,
   DualForecastResponse,
 } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
 import { buildFundCompanyActualsFacts } from './fund-actuals/fund-company-actuals-facts-service';
-import { ActualMetricsCalculator } from './actual-metrics-calculator';
+import { ActualMetricsCalculator, isLivePortfolioCompany } from './actual-metrics-calculator';
 import { ProjectedMetricsCalculator } from './projected-metrics-calculator';
 import { VarianceCalculator } from './variance-calculator';
 import {
@@ -37,7 +42,7 @@ import {
 } from './construction-forecast-calculator';
 import { getFundAge, isConstructionPhase, type FundAge } from '@shared/lib/lifecycle-rules';
 import { funds, type Fund, type PortfolioCompany } from '@shared/schema';
-import { toDecimal } from '@shared/lib/decimal-utils';
+import { toDecimal, type Decimal } from '@shared/lib/decimal-utils';
 import { FundDraftWriteV1Schema } from '@shared/contracts/fund-draft-write-v1.contract';
 import { db } from '../db';
 import { eq } from 'drizzle-orm';
@@ -382,6 +387,10 @@ export class MetricsAggregator {
 
       const actual = await this.actualCalculator.calculate(fundId);
       const actualsFacts = await this.fetchActualsFactsBlock(fundId, actual.asOfDate, warnings);
+      // PR-2 blend (ADR-029/030/032): a null facts block means no blend - the
+      // series keeps the legacy calculator NAV, disclosed via warnings.
+      const navAnchoring = this.buildNavAnchoring(companies, actualsFacts);
+      const anchoredActual = navAnchoring ? this.applyNavAnchoring(actual, navAnchoring) : actual;
       const constructionStartIndex = this.getElapsedQuarterIndex(
         effectiveFund.establishmentDate ?? effectiveFund.createdAt,
         actual.asOfDate
@@ -390,6 +399,10 @@ export class MetricsAggregator {
 
       let projected: ProjectedMetrics;
       let currentProjectionStartIndex = 0;
+      let currentProjection: DualForecastCurrentProjection = {
+        status: 'projected',
+        fallbackReason: null,
+      };
       try {
         projected = await this.calculateProjectedMetrics(
           fund,
@@ -400,15 +413,15 @@ export class MetricsAggregator {
         );
         currentProjectionStartIndex = usesConstructionProjection ? constructionStartIndex + 1 : 0;
       } catch (error) {
-        warnings.push(
-          `Projected metrics calculation failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-        );
+        const fallbackReason = error instanceof Error ? error.message : 'Unknown error';
+        warnings.push(`Projected metrics calculation failed: ${fallbackReason}`);
         projected = this.getDefaultProjectedMetrics(config);
+        currentProjection = { status: 'fallback_default', fallbackReason };
       }
 
       const constructionForecast = this.buildConstructionForecast(effectiveFund, config);
       const series = this.buildDualForecastSeries(
-        actual,
+        anchoredActual,
         projected,
         constructionForecast,
         toDecimal(effectiveFund.size),
@@ -429,6 +442,8 @@ export class MetricsAggregator {
         },
         config: metadata,
         actualsFacts,
+        navAnchoring,
+        currentProjection,
         warnings,
       };
     } catch (error) {
@@ -488,6 +503,141 @@ export class MetricsAggregator {
       );
       return null;
     }
+  }
+
+  /**
+   * PR-2 blend disclosure (ADR-029/030/032): per-company anchor attribution
+   * over the FULL portfolio read plus the ADR-030 per-trust-state count map
+   * over the facts companies. The NAV universe is exactly the live-company
+   * universe the legacy calculator uses (`isLivePortfolioCompany`); exited and
+   * written-off companies stay disclosed but contribute nothing.
+   */
+  private buildNavAnchoring(
+    companies: MetricsPortfolioCompany[],
+    actualsFacts: DualForecastActualsFacts | null
+  ): DualForecastNavAnchoring | null {
+    if (!actualsFacts) {
+      return null;
+    }
+
+    const countsByTrustState = { LIVE: 0, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 };
+    for (const factCompany of actualsFacts.companies) {
+      countsByTrustState[factCompany.trustState] += 1;
+    }
+
+    const factsByCompanyId = new Map(
+      actualsFacts.companies.map((factCompany) => [factCompany.companyId, factCompany])
+    );
+    const portfolioCompanyIds = new Set(companies.map((company) => company.id));
+
+    let blendedNav = toDecimal(0);
+    const entries: DualForecastNavAnchorCompany[] = companies.map((company) => {
+      const fact = factsByCompanyId.get(company.id) ?? null;
+      if (!isLivePortfolioCompany(company)) {
+        return {
+          companyId: company.id,
+          companyName: company.name,
+          inNavUniverse: false,
+          trustState: fact?.trustState ?? null,
+          anchor: null,
+          contribution: null,
+        };
+      }
+
+      const { anchor, contribution } = this.resolveNavAnchor(company, fact);
+      blendedNav = blendedNav.plus(contribution);
+      return {
+        companyId: company.id,
+        companyName: company.name,
+        inNavUniverse: true,
+        trustState: fact?.trustState ?? null,
+        anchor,
+        contribution: contribution.toFixed(6),
+      };
+    });
+
+    // Facts can carry companies the portfolio read no longer returns; disclose
+    // them outside the NAV universe instead of dropping them silently.
+    for (const factCompany of actualsFacts.companies) {
+      if (!portfolioCompanyIds.has(factCompany.companyId)) {
+        entries.push({
+          companyId: factCompany.companyId,
+          companyName: factCompany.companyName,
+          inNavUniverse: false,
+          trustState: factCompany.trustState,
+          anchor: null,
+          contribution: null,
+        });
+      }
+    }
+
+    return {
+      blendedNav: blendedNav.toFixed(6),
+      countsByTrustState,
+      companies: entries,
+    };
+  }
+
+  /**
+   * ADR-029 anchor ladder. UNAVAILABLE/FAILED envelopes and currency-blocked
+   * companies contribute no facts-derived money (ADR-030/ADR-032) and descend
+   * to the legacy rungs. `latestRoundValuation` (pre-money) NEVER enters NAV.
+   */
+  private resolveNavAnchor(
+    company: MetricsPortfolioCompany,
+    fact: DualForecastActualsFactsCompany | null
+  ): { anchor: DualForecastNavAnchor; contribution: Decimal } {
+    const factsMoneyUsable =
+      fact !== null &&
+      fact.trustState !== 'UNAVAILABLE' &&
+      fact.trustState !== 'FAILED' &&
+      fact.currencyStatus !== 'mismatch_blocked';
+
+    if (factsMoneyUsable && fact.latestPlanningFmvValue !== null) {
+      if (fact.planningFmvStatus === 'active') {
+        return { anchor: 'planning_fmv', contribution: toDecimal(fact.latestPlanningFmvValue) };
+      }
+      if (fact.planningFmvStatus === 'stale') {
+        return {
+          anchor: 'planning_fmv_stale',
+          contribution: toDecimal(fact.latestPlanningFmvValue),
+        };
+      }
+    }
+
+    if (company.currentValuation != null) {
+      return {
+        anchor: 'legacy_current_valuation',
+        contribution: toDecimal(company.currentValuation),
+      };
+    }
+
+    return { anchor: 'none', contribution: toDecimal(0) };
+  }
+
+  /**
+   * Re-anchor the as-of Current/Actual point on the blended NAV (ADR-029).
+   * TVPI/RVPI mirror ActualMetricsCalculator semantics (0, not null, when no
+   * capital is called). DPI and IRR are cash-flow-derived and unchanged by a
+   * NAV re-anchor; IRR keeps the legacy calculator's terminal-value basis.
+   */
+  private applyNavAnchoring(
+    actual: ActualMetrics,
+    navAnchoring: DualForecastNavAnchoring
+  ): ActualMetrics {
+    const nav = toDecimal(navAnchoring.blendedNav);
+    const totalCalled = toDecimal(actual.totalCalled);
+    const totalValue = nav.plus(toDecimal(actual.totalDistributions));
+    const tvpi = totalCalled.gt(0) ? totalValue.div(totalCalled) : toDecimal(0);
+    const rvpi = totalCalled.gt(0) ? nav.div(totalCalled) : toDecimal(0);
+
+    return {
+      ...actual,
+      currentNAV: nav.toNumber(),
+      totalValue: totalValue.toNumber(),
+      tvpi: tvpi.toNumber(),
+      rvpi: rvpi.toNumber(),
+    };
   }
 
   /**
@@ -594,29 +744,57 @@ export class MetricsAggregator {
 
     return Array.from({ length: horizon }, (_, quarterIndex) => {
       const actualPoint = quarterIndex === 0 ? this.mapActualMetrics(actual) : null;
+      const construction = this.mapConstructionMetrics(
+        constructionForecast,
+        fundSize,
+        config,
+        constructionStartIndex + quarterIndex
+      );
+      const current =
+        actualPoint ??
+        this.mapCurrentForecastMetrics(
+          actual,
+          projected,
+          quarterIndex,
+          currentProjectionStartIndex
+        );
 
       return {
         quarterIndex,
         label: quarterIndex === 0 ? 'As of' : `Q+${quarterIndex}`,
         date: this.addQuarters(actual.asOfDate, quarterIndex),
-        construction: this.mapConstructionMetrics(
-          constructionForecast,
-          fundSize,
-          config,
-          constructionStartIndex + quarterIndex
-        ),
+        construction,
         actual: actualPoint,
         currentMode: quarterIndex === 0 ? 'actual' : 'forecast',
-        current:
-          actualPoint ??
-          this.mapCurrentForecastMetrics(
-            actual,
-            projected,
-            quarterIndex,
-            currentProjectionStartIndex
-          ),
+        current,
+        variance: this.mapVariance(current, construction),
       };
     });
+  }
+
+  /**
+   * PR-2 per-quarter Construction-vs-Current variance: `current` minus
+   * `construction`, null-propagating on the nullable ratios. Both inputs are
+   * already number-typed series values, so this is plain number arithmetic -
+   * no decimal strings are involved at this seam.
+   */
+  private mapVariance(
+    current: DualForecastMetrics,
+    construction: DualForecastMetrics
+  ): DualForecastMetrics {
+    return {
+      nav: current.nav - construction.nav,
+      calledCapital: current.calledCapital - construction.calledCapital,
+      distributions: current.distributions - construction.distributions,
+      tvpi: this.nullableDelta(current.tvpi, construction.tvpi),
+      dpi: this.nullableDelta(current.dpi, construction.dpi),
+      rvpi: this.nullableDelta(current.rvpi, construction.rvpi),
+      irr: this.nullableDelta(current.irr, construction.irr),
+    };
+  }
+
+  private nullableDelta(current: number | null, construction: number | null): number | null {
+    return current == null || construction == null ? null : current - construction;
   }
 
   private mapActualMetrics(actual: ActualMetrics): DualForecastMetrics {

--- a/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
+++ b/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
@@ -5,6 +5,7 @@ import { DatasetTrustStateSchema, StructuredWarningSchema } from '../provenance-
 import {
   FundCompanyActualsCurrencyStatusSchema,
   FundCompanyActualsPlanningFmvStatusSchema,
+  FundCompanyActualsSupersedeLineageSchema,
 } from '../fund-actuals/fund-company-actuals-fact.contract';
 
 /**
@@ -80,10 +81,12 @@ export const DualForecastPointSchema = z
   .strict();
 
 /**
- * PR-1 shadow-read provenance (ADR-031): per-company trust state and anchor
- * attribution copied verbatim from the facts contract - money stays decimal
- * strings, never parsed numbers. The numeric series are NOT derived from
- * these values until the PR-2 blend lands.
+ * Per-company facts provenance copied verbatim from the facts contract -
+ * money stays decimal strings, never parsed numbers (ADR-031). ADR-032
+ * decision 1 requires the non-monetary facts to surface FULLY even (and
+ * especially) for currency-blocked companies: `activeRoundIds` and
+ * `supersedeLineage` carry the round identity/lineage a blocked company
+ * still discloses while its monetary values are refused.
  */
 export const DualForecastActualsFactsCompanySchema = z
   .object({
@@ -93,6 +96,8 @@ export const DualForecastActualsFactsCompanySchema = z
     planningFmvStatus: FundCompanyActualsPlanningFmvStatusSchema,
     currency: CurrencyCodeSchema,
     currencyStatus: FundCompanyActualsCurrencyStatusSchema,
+    activeRoundIds: z.array(PositiveIdSchema),
+    supersedeLineage: z.array(FundCompanyActualsSupersedeLineageSchema),
     latestRoundDate: IsoDateSchema.nullable(),
     latestRoundValuation: DecimalStringSchema.nullable(),
     latestPlanningFmvDate: IsoDateSchema.nullable(),

--- a/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
+++ b/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
@@ -59,6 +59,13 @@ export const DualForecastMetricsSchema = z
 
 export const DualForecastPointModeSchema = z.enum(['actual', 'forecast']);
 
+/**
+ * PR-2 per-quarter Construction-vs-Current variance (PRD #1020): each field is
+ * `current` minus `construction` for the same quarter; ratio deltas are null
+ * whenever either side is null. Same shape as the metrics they difference.
+ */
+export const DualForecastVarianceSchema = DualForecastMetricsSchema;
+
 export const DualForecastPointSchema = z
   .object({
     quarterIndex: z.number().int(),
@@ -68,6 +75,7 @@ export const DualForecastPointSchema = z
     actual: DualForecastMetricsSchema.nullable(),
     currentMode: DualForecastPointModeSchema,
     current: DualForecastMetricsSchema,
+    variance: DualForecastVarianceSchema,
   })
   .strict();
 
@@ -108,6 +116,81 @@ export const DualForecastActualsFactsSchema = z
   })
   .strict();
 
+/**
+ * ADR-029 anchor ladder attribution: which value anchored a company's NAV
+ * contribution. `planning_fmv` = active Planning FMV mark; `planning_fmv_stale`
+ * = stale mark, disclosed; `legacy_current_valuation` = the un-provenanced
+ * `portfolio_companies.currentValuation` fallback; `none` = the disclosed zero
+ * that used to be silent.
+ */
+export const DualForecastNavAnchorSchema = z.enum([
+  'planning_fmv',
+  'planning_fmv_stale',
+  'legacy_current_valuation',
+  'none',
+]);
+
+const NonNegativeIntSchema = z.number().int().nonnegative();
+
+/**
+ * ADR-030 response-level rollup: a per-trust-state count map over the facts
+ * companies. Deliberately NOT a worst-of scalar; a badge stays derivable
+ * client-side.
+ */
+export const DualForecastTrustCountsSchema = z
+  .object({
+    LIVE: NonNegativeIntSchema,
+    PARTIAL: NonNegativeIntSchema,
+    UNAVAILABLE: NonNegativeIntSchema,
+    FAILED: NonNegativeIntSchema,
+  })
+  .strict();
+
+/**
+ * Per-company NAV anchor attribution (ADR-029/030). `inNavUniverse` is false
+ * for exited/written-off companies and for facts companies missing from the
+ * portfolio read - they contribute no NAV and `anchor`/`contribution` are
+ * null. `trustState` is null when the company has no facts entry (a live
+ * company outside the facts universe descends the ladder on legacy rungs).
+ * `contribution` is money, so it stays a decimal string.
+ */
+export const DualForecastNavAnchorCompanySchema = z
+  .object({
+    companyId: PositiveIdSchema,
+    companyName: z.string().min(1),
+    inNavUniverse: z.boolean(),
+    trustState: DatasetTrustStateSchema.nullable(),
+    anchor: DualForecastNavAnchorSchema.nullable(),
+    contribution: DecimalStringSchema.nullable(),
+  })
+  .strict();
+
+/**
+ * PR-2 blend disclosure block (ADR-029/030/032). `null` means the facts fetch
+ * failed (`actualsFacts` is null too) and the series is NOT blended - it falls
+ * back to the legacy calculator NAV, disclosed via the top-level warnings.
+ */
+export const DualForecastNavAnchoringSchema = z
+  .object({
+    blendedNav: DecimalStringSchema,
+    countsByTrustState: DualForecastTrustCountsSchema,
+    companies: z.array(DualForecastNavAnchorCompanySchema),
+  })
+  .strict();
+
+/**
+ * PR-2 structured disclosure of the Current-projection fallback (PRD #1020):
+ * `fallback_default` means the projection engine failed and the future
+ * Current quarters come from `getDefaultProjectedMetrics` - previously a
+ * silent string warning.
+ */
+export const DualForecastCurrentProjectionSchema = z
+  .object({
+    status: z.enum(['projected', 'fallback_default']),
+    fallbackReason: z.string().nullable(),
+  })
+  .strict();
+
 export const DualForecastResponseSchema = z
   .object({
     fundId: PositiveIdSchema,
@@ -117,6 +200,8 @@ export const DualForecastResponseSchema = z
     sources: DualForecastSourceMetadataSchema,
     config: DualForecastConfigMetadataSchema,
     actualsFacts: DualForecastActualsFactsSchema.nullable(),
+    navAnchoring: DualForecastNavAnchoringSchema.nullable(),
+    currentProjection: DualForecastCurrentProjectionSchema,
     warnings: z.array(z.string()),
   })
   .strict();
@@ -129,4 +214,9 @@ export type DualForecastPointMode = z.infer<typeof DualForecastPointModeSchema>;
 export type DualForecastPoint = z.infer<typeof DualForecastPointSchema>;
 export type DualForecastActualsFactsCompany = z.infer<typeof DualForecastActualsFactsCompanySchema>;
 export type DualForecastActualsFacts = z.infer<typeof DualForecastActualsFactsSchema>;
+export type DualForecastNavAnchor = z.infer<typeof DualForecastNavAnchorSchema>;
+export type DualForecastTrustCounts = z.infer<typeof DualForecastTrustCountsSchema>;
+export type DualForecastNavAnchorCompany = z.infer<typeof DualForecastNavAnchorCompanySchema>;
+export type DualForecastNavAnchoring = z.infer<typeof DualForecastNavAnchoringSchema>;
+export type DualForecastCurrentProjection = z.infer<typeof DualForecastCurrentProjectionSchema>;
 export type DualForecastResponse = z.infer<typeof DualForecastResponseSchema>;

--- a/tests/e2e/fixtures/qa-audit-api.ts
+++ b/tests/e2e/fixtures/qa-audit-api.ts
@@ -668,6 +668,15 @@ const DUAL_FORECAST_RESPONSE = {
         rvpi: UNIFIED_METRICS.actual.rvpi,
         irr: UNIFIED_METRICS.actual.irr,
       },
+      variance: {
+        nav: 0,
+        calledCapital: 0,
+        distributions: 0,
+        tvpi: 0,
+        dpi: 0,
+        rvpi: 0,
+        irr: 0,
+      },
     },
     {
       quarterIndex: 1,
@@ -693,6 +702,15 @@ const DUAL_FORECAST_RESPONSE = {
         rvpi: 2.34,
         irr: 0.188,
       },
+      variance: {
+        nav: -500_000,
+        calledCapital: -500_000,
+        distributions: -50_000,
+        tvpi: -0.02,
+        dpi: 0,
+        rvpi: -0.02,
+        irr: -0.002,
+      },
     },
   ],
   sources: {
@@ -707,6 +725,8 @@ const DUAL_FORECAST_RESPONSE = {
     fallbackReason: null,
   },
   actualsFacts: null,
+  navAnchoring: null,
+  currentProjection: { status: 'projected', fallbackReason: null },
   warnings: [],
 };
 

--- a/tests/e2e/qa-audit-latest-route-publish.spec.ts
+++ b/tests/e2e/qa-audit-latest-route-publish.spec.ts
@@ -132,6 +132,15 @@ const ROUTE_DUAL_FORECAST = {
         rvpi: ROUTE_UNIFIED_METRICS.actual.rvpi,
         irr: ROUTE_UNIFIED_METRICS.actual.irr,
       },
+      variance: {
+        nav: 0,
+        calledCapital: 0,
+        distributions: 0,
+        tvpi: 0,
+        dpi: 0,
+        rvpi: 0,
+        irr: 0,
+      },
     },
     {
       quarterIndex: 1,
@@ -157,6 +166,15 @@ const ROUTE_DUAL_FORECAST = {
         rvpi: 2.77,
         irr: 0.185,
       },
+      variance: {
+        nav: -500_000,
+        calledCapital: -500_000,
+        distributions: -50_000,
+        tvpi: -0.06,
+        dpi: -0.01,
+        rvpi: -0.05,
+        irr: -0.005,
+      },
     },
     {
       quarterIndex: 2,
@@ -177,6 +195,15 @@ const ROUTE_DUAL_FORECAST = {
         nav: 50_000_000,
         calledCapital: 29_000_000,
         distributions: 1_800_000,
+        tvpi: null,
+        dpi: null,
+        rvpi: null,
+        irr: null,
+      },
+      variance: {
+        nav: -2_000_000,
+        calledCapital: 1_000_000,
+        distributions: -200_000,
         tvpi: null,
         dpi: null,
         rvpi: null,
@@ -207,6 +234,15 @@ const ROUTE_DUAL_FORECAST = {
         rvpi: null,
         irr: null,
       },
+      variance: {
+        nav: -8_000_000,
+        calledCapital: 5_000_000,
+        distributions: -500_000,
+        tvpi: null,
+        dpi: null,
+        rvpi: null,
+        irr: null,
+      },
     },
   ],
   sources: {
@@ -220,6 +256,9 @@ const ROUTE_DUAL_FORECAST = {
     publishedAt: '2026-01-31T00:00:00.000Z',
     fallbackReason: null,
   },
+  actualsFacts: null,
+  navAnchoring: null,
+  currentProjection: { status: 'projected', fallbackReason: null },
   warnings: [],
 };
 

--- a/tests/e2e/route-fund-context-fidelity.spec.ts
+++ b/tests/e2e/route-fund-context-fidelity.spec.ts
@@ -158,6 +158,15 @@ const FIDELITY_DUAL_FORECAST = {
         rvpi: FIDELITY_METRICS.actual.rvpi,
         irr: FIDELITY_METRICS.actual.irr,
       },
+      variance: {
+        nav: 0,
+        calledCapital: 0,
+        distributions: 0,
+        tvpi: 0,
+        dpi: 0,
+        rvpi: 0,
+        irr: 0,
+      },
     },
     {
       quarterIndex: 1,
@@ -183,6 +192,15 @@ const FIDELITY_DUAL_FORECAST = {
         rvpi: 2.34,
         irr: 0.188,
       },
+      variance: {
+        nav: -1_000_000,
+        calledCapital: -500_000,
+        distributions: -100_000,
+        tvpi: -0.05,
+        dpi: -0.01,
+        rvpi: -0.04,
+        irr: -0.002,
+      },
     },
   ],
   sources: {
@@ -196,6 +214,9 @@ const FIDELITY_DUAL_FORECAST = {
     publishedAt: '2026-02-01T00:00:00.000Z',
     fallbackReason: null,
   },
+  actualsFacts: null,
+  navAnchoring: null,
+  currentProjection: { status: 'projected', fallbackReason: null },
   warnings: [],
 };
 

--- a/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
+++ b/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import DualForecastDashboard from '@/components/dashboard/dual-forecast-dashboard';
+import { DualForecastResponseSchema } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
 
 type MockFundContext = {
   currentFund: { id: number; name: string } | null;
@@ -124,6 +125,15 @@ function makeDualForecast() {
           rvpi: 1.4,
           irr: 0.18,
         },
+        variance: {
+          nav: 1_000_000,
+          calledCapital: 0,
+          distributions: 0,
+          tvpi: 0.2,
+          dpi: 0,
+          rvpi: 0.2,
+          irr: -0.02,
+        },
       },
       {
         quarterIndex: 1,
@@ -149,6 +159,15 @@ function makeDualForecast() {
           rvpi: 1.2,
           irr: 0.18,
         },
+        variance: {
+          nav: 1_000_000,
+          calledCapital: 500_000,
+          distributions: 500_000,
+          tvpi: 0.13,
+          dpi: 0.07,
+          rvpi: 0.06,
+          irr: -0.02,
+        },
       },
       {
         quarterIndex: 2,
@@ -168,6 +187,15 @@ function makeDualForecast() {
         current: {
           nav: 38_000_000,
           calledCapital: 26_000_000,
+          distributions: 0,
+          tvpi: null,
+          dpi: null,
+          rvpi: null,
+          irr: null,
+        },
+        variance: {
+          nav: -2_000_000,
+          calledCapital: 1_000_000,
           distributions: 0,
           tvpi: null,
           dpi: null,
@@ -199,6 +227,15 @@ function makeDualForecast() {
           rvpi: null,
           irr: null,
         },
+        variance: {
+          nav: -8_000_000,
+          calledCapital: 5_000_000,
+          distributions: 0,
+          tvpi: null,
+          dpi: null,
+          rvpi: null,
+          irr: null,
+        },
       },
     ],
     sources: {
@@ -213,11 +250,18 @@ function makeDualForecast() {
       fallbackReason: null,
     },
     actualsFacts: null,
+    navAnchoring: null,
+    currentProjection: { status: 'projected', fallbackReason: null },
     warnings: [],
   };
 }
 
 describe('DualForecastDashboard', () => {
+  it('uses a fixture that satisfies the response contract (fixture guard)', () => {
+    const fixture = makeDualForecast();
+    expect(DualForecastResponseSchema.parse(fixture)).toEqual(fixture);
+  });
+
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();

--- a/tests/unit/hooks/useDualForecast.test.tsx
+++ b/tests/unit/hooks/useDualForecast.test.tsx
@@ -49,6 +49,15 @@ const dualForecast = {
         rvpi: 1.8,
         irr: 0.18,
       },
+      variance: {
+        nav: -1_000_000,
+        calledCapital: 0,
+        distributions: 0,
+        tvpi: -0.2,
+        dpi: 0,
+        rvpi: -0.2,
+        irr: -0.02,
+      },
     },
   ],
   sources: {
@@ -83,6 +92,21 @@ const dualForecast = {
     ],
     warnings: [factsWarning],
   },
+  navAnchoring: {
+    blendedNav: '9000000.000000',
+    countsByTrustState: { LIVE: 0, PARTIAL: 1, UNAVAILABLE: 0, FAILED: 0 },
+    companies: [
+      {
+        companyId: 10,
+        companyName: 'Northstar AI',
+        inNavUniverse: true,
+        trustState: 'PARTIAL',
+        anchor: 'legacy_current_valuation',
+        contribution: '9000000.000000',
+      },
+    ],
+  },
+  currentProjection: { status: 'projected', fallbackReason: null },
   warnings: [],
 };
 

--- a/tests/unit/hooks/useDualForecast.test.tsx
+++ b/tests/unit/hooks/useDualForecast.test.tsx
@@ -83,6 +83,8 @@ const dualForecast = {
         planningFmvStatus: 'none',
         currency: 'USD',
         currencyStatus: 'base_currency',
+        activeRoundIds: [5],
+        supersedeLineage: [{ roundId: 5, supersedesRoundId: null }],
         latestRoundDate: '2026-01-15',
         latestRoundValuation: '120000000.000000',
         latestPlanningFmvDate: null,

--- a/tests/unit/routes/dual-forecast-route.test.ts
+++ b/tests/unit/routes/dual-forecast-route.test.ts
@@ -58,6 +58,8 @@ function dualForecastPayload() {
       fallbackReason: null,
     },
     actualsFacts: null,
+    navAnchoring: null,
+    currentProjection: { status: 'projected', fallbackReason: null },
     warnings: [],
   };
 }

--- a/tests/unit/services/metrics-aggregator-config.test.ts
+++ b/tests/unit/services/metrics-aggregator-config.test.ts
@@ -1,31 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { isUnifiedFundMetrics } from '@shared/types/metrics';
 
-const {
-  storageMock,
-  actualCalculateMock,
-  projectedCalculateMock,
-  varianceCalculateMock,
-} = vi.hoisted(() => ({
-  storageMock: {
-    getFund: vi.fn(),
-    getPortfolioCompanies: vi.fn(),
-    getFundConfig: vi.fn(),
-  },
-  actualCalculateMock: vi.fn(),
-  projectedCalculateMock: vi.fn(),
-  varianceCalculateMock: vi.fn(),
-}));
+const { storageMock, actualCalculateMock, projectedCalculateMock, varianceCalculateMock } =
+  vi.hoisted(() => ({
+    storageMock: {
+      getFund: vi.fn(),
+      getPortfolioCompanies: vi.fn(),
+      getFundConfig: vi.fn(),
+    },
+    actualCalculateMock: vi.fn(),
+    projectedCalculateMock: vi.fn(),
+    varianceCalculateMock: vi.fn(),
+  }));
 
 vi.mock('../../../server/storage', () => ({
   storage: storageMock,
 }));
 
-vi.mock('../../../server/services/actual-metrics-calculator', () => ({
-  ActualMetricsCalculator: class {
-    calculate = actualCalculateMock;
-  },
-}));
+// Spread importOriginal so new module exports (e.g. isLivePortfolioCompany)
+// keep flowing to importers; only the class is replaced.
+vi.mock('../../../server/services/actual-metrics-calculator', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../../../server/services/actual-metrics-calculator')>();
+  return {
+    ...original,
+    ActualMetricsCalculator: class {
+      calculate = actualCalculateMock;
+    },
+  };
+});
 
 vi.mock('../../../server/services/projected-metrics-calculator', () => ({
   ProjectedMetricsCalculator: class {
@@ -82,23 +85,25 @@ describe('MetricsAggregator config-backed target metrics', () => {
       fundAgeMonths: 3,
     });
 
-    projectedCalculateMock.mockImplementation(async (_fund: unknown, _companies: unknown, config: any) => ({
-      asOfDate: '2026-04-01T00:00:00.000Z',
-      projectionDate: '2026-04-01T00:00:00.000Z',
-      projectedDeployment: Array(12).fill(0),
-      projectedDistributions: Array(12).fill(0),
-      projectedNAV: Array(12).fill(0),
-      expectedTVPI: config.targetTVPI ?? 2.5,
-      expectedIRR: config.targetIRR ?? 0.25,
-      expectedDPI: config.targetDPI ?? 1,
-      totalReserveNeeds: 0,
-      allocatedReserves: 0,
-      unallocatedReserves: 0,
-      reserveAllocationRate: 0,
-      deploymentPace: 'on-track',
-      quartersRemaining: 12,
-      recommendedQuarterlyDeployment: 0,
-    }));
+    projectedCalculateMock.mockImplementation(
+      async (_fund: unknown, _companies: unknown, config: any) => ({
+        asOfDate: '2026-04-01T00:00:00.000Z',
+        projectionDate: '2026-04-01T00:00:00.000Z',
+        projectedDeployment: Array(12).fill(0),
+        projectedDistributions: Array(12).fill(0),
+        projectedNAV: Array(12).fill(0),
+        expectedTVPI: config.targetTVPI ?? 2.5,
+        expectedIRR: config.targetIRR ?? 0.25,
+        expectedDPI: config.targetDPI ?? 1,
+        totalReserveNeeds: 0,
+        allocatedReserves: 0,
+        unallocatedReserves: 0,
+        reserveAllocationRate: 0,
+        deploymentPace: 'on-track',
+        quartersRemaining: 12,
+        recommendedQuarterlyDeployment: 0,
+      })
+    );
 
     varianceCalculateMock.mockImplementation((actual: any, projected: any, target: any) => ({
       deploymentVariance: {
@@ -209,9 +214,7 @@ describe('MetricsAggregator config-backed target metrics', () => {
       })
     );
     expect(result._status?.warnings ?? []).not.toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('legacy generic targets'),
-      ])
+      expect.arrayContaining([expect.stringContaining('legacy generic targets')])
     );
   });
 
@@ -243,9 +246,7 @@ describe('MetricsAggregator config-backed target metrics', () => {
     expect(result.target.targetDeploymentYears).toBe(4);
     expect(result.projected.expectedIRR).toBe(0.25);
     expect(result._status?.warnings).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('has no targetMetrics block'),
-      ])
+      expect.arrayContaining([expect.stringContaining('has no targetMetrics block')])
     );
   });
 
@@ -312,9 +313,7 @@ describe('MetricsAggregator config-backed target metrics', () => {
     expect(result.target.targetIRR).toBe(0.25);
     expect(result.target.targetTVPI).toBe(2.5);
     expect(result._status?.warnings).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('invalid for target extraction'),
-      ])
+      expect.arrayContaining([expect.stringContaining('invalid for target extraction')])
     );
   });
 });

--- a/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
+++ b/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
@@ -188,6 +188,8 @@ function expectedActualsFactsBlock(facts = factsFixture) {
       planningFmvStatus: fact.planningFmvStatus,
       currency: fact.currency,
       currencyStatus: fact.currencyStatus,
+      activeRoundIds: fact.activeRoundIds,
+      supersedeLineage: fact.supersedeLineage,
       latestRoundDate: fact.latestRoundDate,
       latestRoundValuation: fact.latestRoundValuation,
       latestPlanningFmvDate: fact.latestPlanningFmvDate,
@@ -725,6 +727,56 @@ describe('MetricsAggregator dual forecast', () => {
       expect(result.actualsFacts?.warnings).toEqual(
         expect.arrayContaining([expect.objectContaining({ code: 'CURRENCY_MISMATCH_BLOCK' })])
       );
+    });
+
+    it('ADR-032: a blocked superseded-round chain surfaces ids and lineage while its money stays out', async () => {
+      // Round 7 (EUR) supersedes round 5: the company is currency-blocked,
+      // the 999M mark is refused, but activeRoundIds + supersedeLineage
+      // must surface fully (ADR-032 decision 1).
+      buildFundCompanyActualsFactsMock.mockResolvedValue(
+        makeFacts({
+          allRounds: [
+            BASE_EQUITY_ROUND,
+            {
+              ...BASE_EQUITY_ROUND,
+              id: 7,
+              roundDate: '2026-02-15',
+              currency: 'EUR',
+              investmentAmount: '30000000.000000',
+              preMoneyValuation: '150000000.000000',
+              supersedesRoundId: 5,
+            },
+          ],
+          planningMarks: [
+            {
+              id: 301,
+              fundId: 1,
+              companyId: 10,
+              markDate: '2026-03-01',
+              fairValue: '999000000.000000',
+              currency: 'USD',
+              status: 'approved',
+            },
+          ],
+        })
+      );
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      expect(result.actualsFacts?.companies[0]).toMatchObject({
+        currencyStatus: 'mismatch_blocked',
+        activeRoundIds: [7],
+        supersedeLineage: [
+          { roundId: 5, supersedesRoundId: null },
+          { roundId: 7, supersedesRoundId: 5 },
+        ],
+      });
+      // Money refused: neither the 999M mark nor the 150M pre-money enters;
+      // the company descends to the legacy fallback.
+      expect(result.series[0]?.actual?.nav).toBe(10_000_000);
+      expect(result.navAnchoring?.blendedNav).toBe('10000000.000000');
+      expect(result.navAnchoring?.countsByTrustState).toEqual(trustCounts({ UNAVAILABLE: 1 }));
     });
 
     it('exited companies stay out of the NAV universe regardless of anchor state', async () => {

--- a/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
+++ b/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
@@ -22,11 +22,19 @@ vi.mock('../../../server/storage', () => ({
   storage: storageMock,
 }));
 
-vi.mock('../../../server/services/actual-metrics-calculator', () => ({
-  ActualMetricsCalculator: class {
-    calculate = actualCalculateMock;
-  },
-}));
+// Spread importOriginal so isLivePortfolioCompany (the shared NAV-universe
+// classifier, ADR-029) keeps flowing to the aggregator; only the class mock
+// is replaced.
+vi.mock('../../../server/services/actual-metrics-calculator', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../../../server/services/actual-metrics-calculator')>();
+  return {
+    ...original,
+    ActualMetricsCalculator: class {
+      calculate = actualCalculateMock;
+    },
+  };
+});
 
 vi.mock('../../../server/services/projected-metrics-calculator', () => ({
   ProjectedMetricsCalculator: class {
@@ -41,7 +49,7 @@ vi.mock('../../../server/services/variance-calculator', () => ({
 }));
 
 // Mock ONLY the db-backed entrypoint; keep the pure row-builder real so the
-// facts fixture below is produced by the actual producer (importOriginal
+// facts fixtures below are produced by the actual producer (importOriginal
 // spread also survives new exports on the module).
 vi.mock(
   '../../../server/services/fund-actuals/fund-company-actuals-facts-service',
@@ -58,7 +66,10 @@ vi.mock(
 );
 
 import { MetricsAggregator } from '../../../server/services/metrics-aggregator';
-import { buildFundCompanyActualsFactsFromRows } from '../../../server/services/fund-actuals/fund-company-actuals-facts-service';
+import {
+  buildFundCompanyActualsFactsFromRows,
+  type FundCompanyActualsFactsRows,
+} from '../../../server/services/fund-actuals/fund-company-actuals-facts-service';
 import { FundCompanyActualsFactsResponseSchema } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 import { DualForecastResponseSchema } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
 
@@ -102,45 +113,68 @@ const projectedMetrics = {
   recommendedQuarterlyDeployment: 5_000_000,
 };
 
-// Facts fixture produced by the REAL row-builder so it always matches what the
-// facts service emits; validated against the facts contract in a guard test.
-const factsFixture = buildFundCompanyActualsFactsFromRows({
+const BASE_EQUITY_ROUND = {
+  id: 5,
   fundId: 1,
-  asOfDate: '2026-04-01',
-  now: new Date('2026-04-01T00:00:00.000Z'),
-  rows: {
-    fund: { id: 1, baseCurrency: 'USD' },
-    companies: [{ id: 10, fundId: 1, name: 'Northstar AI' }],
-    investments: [{ id: 201, fundId: 1, companyId: 10 }],
-    allRounds: [
-      {
-        id: 5,
-        fundId: 1,
-        investmentId: 201,
-        roundDate: '2026-01-15',
-        createdAt: new Date('2026-01-16T00:00:00.000Z'),
-        securityType: 'equity',
-        currency: 'USD',
-        investmentAmount: '24000000.000000',
-        preMoneyValuation: '120000000.000000',
-        roundSize: null,
-        supersedesRoundId: null,
-      },
-    ],
-    activeOverrides: [],
-    planningMarks: [
-      {
-        id: 301,
-        fundId: 1,
-        companyId: 10,
-        markDate: '2026-03-01',
-        fairValue: '30000000.000000',
-        currency: 'USD',
-        status: 'approved',
-      },
-    ],
-  },
-});
+  investmentId: 201,
+  roundDate: '2026-01-15',
+  createdAt: new Date('2026-01-16T00:00:00.000Z'),
+  securityType: 'equity' as const,
+  currency: 'USD',
+  investmentAmount: '24000000.000000',
+  preMoneyValuation: '120000000.000000',
+  roundSize: null,
+  supersedesRoundId: null,
+};
+
+const BASE_ROWS: FundCompanyActualsFactsRows = {
+  fund: { id: 1, baseCurrency: 'USD' },
+  companies: [{ id: 10, fundId: 1, name: 'Northstar AI' }],
+  investments: [{ id: 201, fundId: 1, companyId: 10 }],
+  allRounds: [BASE_EQUITY_ROUND],
+  activeOverrides: [],
+  planningMarks: [
+    {
+      id: 301,
+      fundId: 1,
+      companyId: 10,
+      markDate: '2026-03-01',
+      fairValue: '30000000.000000',
+      currency: 'USD',
+      status: 'approved' as const,
+    },
+  ],
+};
+
+// Facts fixtures produced by the REAL row-builder so they always match what
+// the facts service emits; the base fixture is validated against the facts
+// contract in a guard test below.
+function makeFacts(rows: Partial<FundCompanyActualsFactsRows> = {}) {
+  return buildFundCompanyActualsFactsFromRows({
+    fundId: 1,
+    asOfDate: '2026-04-01',
+    now: new Date('2026-04-01T00:00:00.000Z'),
+    rows: { ...BASE_ROWS, ...rows },
+  });
+}
+
+const factsFixture = makeFacts();
+
+function baseStorageCompany() {
+  return {
+    id: 10,
+    fundId: 1,
+    name: 'Northstar AI',
+    status: 'active',
+    currentValuation: '10000000.00',
+    investmentAmount: '24000000',
+    stage: 'Seed',
+    currentStage: 'Seed',
+    sector: 'AI',
+    ownershipCurrentPct: '0.1',
+    investmentDate: new Date('2024-06-01T00:00:00.000Z'),
+  };
+}
 
 function expectedActualsFactsBlock(facts = factsFixture) {
   return {
@@ -164,15 +198,11 @@ function expectedActualsFactsBlock(facts = factsFixture) {
   };
 }
 
-// Pre-change output captured on main (fd0788bf) before the actualsFacts block
-// landed. The numeric series MUST stay byte-identical in PR-1 (shadow read).
-const BASELINE_FUNDED = JSON.parse(
-  '{"fundId":1,"fundName":"Dual Forecast Fund","asOfDate":"2026-04-01T00:00:00.000Z","series":[{"quarterIndex":0,"label":"As of","date":"2026-04-01T00:00:00.000Z","construction":{"nav":47500000,"calledCapital":50000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.95,"irr":0.22},"actual":{"nav":30000000,"calledCapital":25000000,"distributions":2000000,"tvpi":1.28,"dpi":0.08,"rvpi":1.2,"irr":0.14},"currentMode":"actual","current":{"nav":30000000,"calledCapital":25000000,"distributions":2000000,"tvpi":1.28,"dpi":0.08,"rvpi":1.2,"irr":0.14}},{"quarterIndex":1,"label":"Q+1","date":"2026-07-01T00:00:00.000Z","construction":{"nav":52250000,"calledCapital":55000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.95,"irr":0.22},"actual":null,"currentMode":"forecast","current":{"nav":36000000,"calledCapital":30000000,"distributions":3000000,"tvpi":1.3,"dpi":0.1,"rvpi":1.2,"irr":0.22}},{"quarterIndex":2,"label":"Q+2","date":"2026-10-01T00:00:00.000Z","construction":{"nav":59363771.005187295,"calledCapital":60000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.9893961834197883,"irr":0.22},"actual":null,"currentMode":"forecast","current":{"nav":44000000,"calledCapital":36000000,"distributions":5000000,"tvpi":1.3611111111111112,"dpi":0.1388888888888889,"rvpi":1.2222222222222223,"irr":0.22}}],"sources":{"construction":"construction_forecast_jcurve","current":"projected_metrics_calculator","actual":"actual_metrics_calculator"},"config":{"source":"published","version":4,"publishedAt":"2026-03-01T00:00:00.000Z","fallbackReason":null},"warnings":[]}'
-) as Record<string, unknown>;
-
-const BASELINE_NO_INVESTMENTS = JSON.parse(
-  '{"fundId":1,"fundName":"Dual Forecast Fund","asOfDate":"2026-04-01T00:00:00.000Z","series":[{"quarterIndex":0,"label":"As of","date":"2026-04-01T00:00:00.000Z","construction":{"nav":9500000,"calledCapital":10000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.95,"irr":0.22},"actual":{"nav":0,"calledCapital":0,"distributions":0,"tvpi":0,"dpi":null,"rvpi":0,"irr":null},"currentMode":"actual","current":{"nav":0,"calledCapital":0,"distributions":0,"tvpi":0,"dpi":null,"rvpi":0,"irr":null}},{"quarterIndex":1,"label":"Q+1","date":"2026-07-01T00:00:00.000Z","construction":{"nav":14250000,"calledCapital":15000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.95,"irr":0.22},"actual":null,"currentMode":"forecast","current":{"nav":12000000,"calledCapital":3000000,"distributions":300000,"tvpi":4.1,"dpi":0.1,"rvpi":4,"irr":0.22}},{"quarterIndex":2,"label":"Q+2","date":"2026-10-01T00:00:00.000Z","construction":{"nav":19000000,"calledCapital":20000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.95,"irr":0.22},"actual":null,"currentMode":"forecast","current":{"nav":15000000,"calledCapital":7000000,"distributions":700000,"tvpi":2.242857142857143,"dpi":0.1,"rvpi":2.142857142857143,"irr":0.22}},{"quarterIndex":3,"label":"Q+3","date":"2027-01-01T00:00:00.000Z","construction":{"nav":23750000,"calledCapital":25000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.95,"irr":0.22},"actual":null,"currentMode":"forecast","current":{"nav":15000000,"calledCapital":7000000,"distributions":700000,"tvpi":2.242857142857143,"dpi":0.1,"rvpi":2.142857142857143,"irr":0.22}},{"quarterIndex":4,"label":"Q+4","date":"2027-04-01T00:00:00.000Z","construction":{"nav":28500000,"calledCapital":30000000,"distributions":0,"tvpi":0.95,"dpi":0,"rvpi":0.95,"irr":0.22},"actual":null,"currentMode":"forecast","current":{"nav":15000000,"calledCapital":7000000,"distributions":700000,"tvpi":2.242857142857143,"dpi":0.1,"rvpi":2.142857142857143,"irr":0.22}}],"sources":{"construction":"construction_forecast_jcurve","current":"projected_metrics_calculator","actual":"actual_metrics_calculator"},"config":{"source":"published","version":4,"publishedAt":"2026-03-01T00:00:00.000Z","fallbackReason":null},"warnings":["Using J-curve construction forecast (no investments yet)"]}'
-) as Record<string, unknown>;
+function trustCounts(
+  overrides: Partial<Record<'LIVE' | 'PARTIAL' | 'UNAVAILABLE' | 'FAILED', number>> = {}
+) {
+  return { LIVE: 0, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0, ...overrides };
+}
 
 describe('MetricsAggregator dual forecast', () => {
   beforeEach(() => {
@@ -191,19 +221,7 @@ describe('MetricsAggregator dual forecast', () => {
       isActive: true,
       createdAt: new Date('2024-01-01T00:00:00.000Z'),
     });
-    storageMock.getPortfolioCompanies.mockResolvedValue([
-      {
-        id: 10,
-        fundId: 1,
-        name: 'Northstar AI',
-        investmentAmount: '24000000',
-        stage: 'Seed',
-        currentStage: 'Seed',
-        sector: 'AI',
-        ownershipCurrentPct: '0.1',
-        investmentDate: new Date('2024-06-01T00:00:00.000Z'),
-      },
-    ]);
+    storageMock.getPortfolioCompanies.mockResolvedValue([baseStorageCompany()]);
     storageMock.getFundConfig.mockResolvedValue({
       id: 11,
       fundId: 1,
@@ -250,7 +268,10 @@ describe('MetricsAggregator dual forecast', () => {
       publishedAt: '2026-03-01T00:00:00.000Z',
       fallbackReason: null,
     });
+    expect(result.currentProjection).toEqual({ status: 'projected', fallbackReason: null });
 
+    // Fixture blend: active mark 30M == the mocked calculator NAV, so the
+    // as-of numbers are unchanged while the anchor discloses planning_fmv.
     expect(result.series).toHaveLength(3);
     expect(result.series[0]).toMatchObject({
       quarterIndex: 0,
@@ -354,6 +375,9 @@ describe('MetricsAggregator dual forecast', () => {
     const aggregator = new MetricsAggregator();
     const result = await aggregator.getDualForecast(1);
 
+    // Empty NAV universe: TVPI/RVPI keep the calculator's 0-not-null
+    // semantics when no capital is called.
+    expect(result.series[0]?.actual).toMatchObject({ nav: 0, tvpi: 0, rvpi: 0, dpi: null });
     expect(result.series[1]?.current).toMatchObject({
       nav: 12_000_000,
       calledCapital: 3_000_000,
@@ -363,6 +387,22 @@ describe('MetricsAggregator dual forecast', () => {
       nav: 15_000_000,
       calledCapital: 7_000_000,
       distributions: 700_000,
+    });
+    // The facts company is not in the portfolio read: disclosed outside the
+    // NAV universe, counted in the trust rollup, contributing nothing.
+    expect(result.navAnchoring).toEqual({
+      blendedNav: '0.000000',
+      countsByTrustState: trustCounts({ LIVE: 1 }),
+      companies: [
+        {
+          companyId: 10,
+          companyName: 'Northstar AI',
+          inNavUniverse: false,
+          trustState: 'LIVE',
+          anchor: null,
+          contribution: null,
+        },
+      ],
     });
     expect(projectedCalculateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -423,75 +463,421 @@ describe('MetricsAggregator dual forecast', () => {
     expect(DualForecastResponseSchema.parse(result)).toEqual(result);
   });
 
-  it('discloses a facts failure with a null block and an unchanged numeric series', async () => {
+  it('discloses a facts failure with null blocks and an unblended series', async () => {
     buildFundCompanyActualsFactsMock.mockRejectedValueOnce(new Error('facts backend down'));
 
     const aggregator = new MetricsAggregator();
     const result = await aggregator.getDualForecast(1);
 
-    expect(result).toEqual({
-      ...BASELINE_FUNDED,
-      actualsFacts: null,
-      warnings: [expect.stringContaining('Actuals facts unavailable: facts backend down')],
+    expect(result.actualsFacts).toBeNull();
+    expect(result.navAnchoring).toBeNull();
+    expect(result.warnings).toEqual([
+      expect.stringContaining('Actuals facts unavailable: facts backend down'),
+    ]);
+    // No blend: the as-of point keeps the legacy calculator values verbatim.
+    expect(result.series[0]?.actual).toEqual({
+      nav: 30_000_000,
+      calledCapital: 25_000_000,
+      distributions: 2_000_000,
+      tvpi: 1.28,
+      dpi: 0.08,
+      rvpi: 1.2,
+      irr: 0.14,
     });
+    expect(result.currentProjection).toEqual({ status: 'projected', fallbackReason: null });
   });
 
-  describe('PR-1 numeric-series snapshot equality (baseline captured on main @ fd0788bf)', () => {
-    it('funded-portfolio scenario is byte-identical outside the additive block', async () => {
+  describe('PR-2 blend (ADR-029 anchor ladder / ADR-030 trust / ADR-032 currency)', () => {
+    it('rung 1: an active Planning FMV mark re-anchors the as-of NAV over the legacy value', async () => {
+      buildFundCompanyActualsFactsMock.mockResolvedValue(
+        makeFacts({
+          planningMarks: [
+            {
+              id: 301,
+              fundId: 1,
+              companyId: 10,
+              markDate: '2026-03-01',
+              fairValue: '42000000.000000',
+              currency: 'USD',
+              status: 'approved',
+            },
+          ],
+        })
+      );
+
       const aggregator = new MetricsAggregator();
       const result = await aggregator.getDualForecast(1);
 
-      expect(result).toEqual({
-        ...BASELINE_FUNDED,
-        actualsFacts: expectedActualsFactsBlock(),
+      // NAV = mark fairValue, not currentValuation (10M), not the calculator
+      // NAV (30M), and NEVER the round pre-money (120M).
+      expect(result.series[0]?.actual).toEqual({
+        nav: 42_000_000,
+        calledCapital: 25_000_000,
+        distributions: 2_000_000,
+        tvpi: 1.76, // (42M + 2M) / 25M
+        dpi: 0.08, // cash-flow-derived, unchanged
+        rvpi: 1.68, // 42M / 25M
+        irr: 0.14, // cash-flow-derived, unchanged
+      });
+      expect(result.series[0]?.current).toEqual(result.series[0]?.actual);
+      expect(result.navAnchoring).toEqual({
+        blendedNav: '42000000.000000',
+        countsByTrustState: trustCounts({ LIVE: 1 }),
+        companies: [
+          {
+            companyId: 10,
+            companyName: 'Northstar AI',
+            inNavUniverse: true,
+            trustState: 'LIVE',
+            anchor: 'planning_fmv',
+            contribution: '42000000.000000',
+          },
+        ],
       });
     });
 
-    it('no-investment scenario is byte-identical outside the additive block', async () => {
-      storageMock.getFund.mockResolvedValueOnce({
-        id: 1,
-        name: 'Dual Forecast Fund',
-        size: '90000000',
-        deployedCapital: '0',
-        managementFee: '0.02',
-        carryPercentage: '0.2',
-        vintageYear: 2026,
-        establishmentDate: '2026-01-01',
-        status: 'active',
-        isActive: true,
-        createdAt: new Date('2026-01-01T00:00:00.000Z'),
-      });
-      storageMock.getPortfolioCompanies.mockResolvedValue([]);
-      actualCalculateMock.mockResolvedValue({
-        ...actualMetrics,
-        totalCalled: 0,
-        totalDeployed: 0,
-        currentNAV: 0,
-        totalDistributions: 0,
-        totalValue: 0,
-        irr: null,
-        tvpi: 0,
-        dpi: null,
-        rvpi: 0,
-        activeCompanies: 0,
-        totalCompanies: 0,
-        deploymentRate: 0,
-        averageCheckSize: 0,
-      });
-      projectedCalculateMock.mockResolvedValueOnce({
-        ...projectedMetrics,
-        projectedDeployment: [1_000_000, 2_000_000, 3_000_000, 4_000_000],
-        projectedDistributions: [100_000, 200_000, 300_000, 400_000],
-        projectedNAV: [5_000_000, 9_000_000, 12_000_000, 15_000_000],
-      });
+    it('rung 2: a stale mark contributes the same value with degraded disclosure (PARTIAL)', async () => {
+      buildFundCompanyActualsFactsMock.mockResolvedValue(
+        makeFacts({
+          planningMarks: [
+            {
+              id: 301,
+              fundId: 1,
+              companyId: 10,
+              markDate: '2025-11-01', // 151 days before as-of > 120-day policy
+              fairValue: '42000000.000000',
+              currency: 'USD',
+              status: 'approved',
+            },
+          ],
+        })
+      );
 
       const aggregator = new MetricsAggregator();
       const result = await aggregator.getDualForecast(1);
 
-      expect(result).toEqual({
-        ...BASELINE_NO_INVESTMENTS,
-        actualsFacts: expectedActualsFactsBlock(),
+      // Same numbers as rung 1 - staleness changes disclosure, never value.
+      expect(result.series[0]?.actual).toMatchObject({ nav: 42_000_000, tvpi: 1.76, rvpi: 1.68 });
+      expect(result.navAnchoring?.blendedNav).toBe('42000000.000000');
+      expect(result.navAnchoring?.countsByTrustState).toEqual(trustCounts({ PARTIAL: 1 }));
+      expect(result.navAnchoring?.companies[0]).toMatchObject({
+        companyId: 10,
+        inNavUniverse: true,
+        trustState: 'PARTIAL',
+        anchor: 'planning_fmv_stale',
+        contribution: '42000000.000000',
       });
+      expect(result.actualsFacts?.warnings).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'PLANNING_FMV_STALE' })])
+      );
+    });
+
+    it('adversarial (PRD DoD): a PARTIAL fixture changes disclosure, never numbers, vs LIVE at the same anchor rung', async () => {
+      const liveFacts = makeFacts({
+        planningMarks: [
+          {
+            id: 301,
+            fundId: 1,
+            companyId: 10,
+            markDate: '2026-03-01',
+            fairValue: '42000000.000000',
+            currency: 'USD',
+            status: 'approved',
+          },
+        ],
+      });
+      // Same active mark, same rung; a convertible note adds a
+      // warning-severity NON_EQUITY_AMOUNT_ONLY -> the envelope leaves LIVE.
+      const partialFacts = makeFacts({
+        allRounds: [
+          BASE_EQUITY_ROUND,
+          {
+            ...BASE_EQUITY_ROUND,
+            id: 6,
+            roundDate: '2026-02-01',
+            securityType: 'convertible_note',
+            investmentAmount: '1000000.000000',
+            preMoneyValuation: null,
+          },
+        ],
+        planningMarks: [
+          {
+            id: 301,
+            fundId: 1,
+            companyId: 10,
+            markDate: '2026-03-01',
+            fairValue: '42000000.000000',
+            currency: 'USD',
+            status: 'approved',
+          },
+        ],
+      });
+
+      const aggregator = new MetricsAggregator();
+      buildFundCompanyActualsFactsMock.mockResolvedValueOnce(liveFacts);
+      const liveResult = await aggregator.getDualForecast(1);
+      buildFundCompanyActualsFactsMock.mockResolvedValueOnce(partialFacts);
+      const partialResult = await aggregator.getDualForecast(1);
+
+      expect(liveFacts.facts[0]?.provenance.trustState).toBe('LIVE');
+      expect(partialFacts.facts[0]?.provenance.trustState).toBe('PARTIAL');
+      expect(partialFacts.facts[0]?.planningFmvStatus).toBe('active');
+
+      // Identical numeric series; only disclosure moves.
+      expect(partialResult.series).toEqual(liveResult.series);
+      expect(partialResult.navAnchoring?.blendedNav).toBe(liveResult.navAnchoring?.blendedNav);
+      expect(liveResult.navAnchoring?.countsByTrustState).toEqual(trustCounts({ LIVE: 1 }));
+      expect(partialResult.navAnchoring?.countsByTrustState).toEqual(trustCounts({ PARTIAL: 1 }));
+      expect(partialResult.navAnchoring?.companies[0]?.anchor).toBe('planning_fmv');
+      expect(partialResult.actualsFacts?.warnings).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'NON_EQUITY_AMOUNT_ONLY' })])
+      );
+    });
+
+    it('rung 3: no usable mark falls back to currentValuation, disclosed', async () => {
+      buildFundCompanyActualsFactsMock.mockResolvedValue(makeFacts({ planningMarks: [] }));
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      expect(result.series[0]?.actual).toEqual({
+        nav: 10_000_000,
+        calledCapital: 25_000_000,
+        distributions: 2_000_000,
+        tvpi: 0.48, // (10M + 2M) / 25M
+        dpi: 0.08,
+        rvpi: 0.4, // 10M / 25M
+        irr: 0.14,
+      });
+      expect(result.navAnchoring).toMatchObject({
+        blendedNav: '10000000.000000',
+        countsByTrustState: trustCounts({ PARTIAL: 1 }), // PLANNING_FMV_MISSING
+      });
+      expect(result.navAnchoring?.companies[0]).toMatchObject({
+        anchor: 'legacy_current_valuation',
+        contribution: '10000000.000000',
+        trustState: 'PARTIAL',
+      });
+      expect(result.actualsFacts?.warnings).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'PLANNING_FMV_MISSING' })])
+      );
+    });
+
+    it('rung 4: no mark and no legacy value is a DISCLOSED zero, and pre-money never enters NAV', async () => {
+      storageMock.getPortfolioCompanies.mockResolvedValue([
+        { ...baseStorageCompany(), currentValuation: null },
+      ]);
+      buildFundCompanyActualsFactsMock.mockResolvedValue(makeFacts({ planningMarks: [] }));
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      // The facts carry latestRoundValuation 120M pre-money; NAV must be 0.
+      expect(result.actualsFacts?.companies[0]?.latestRoundValuation).toBe('120000000.000000');
+      expect(result.series[0]?.actual).toMatchObject({ nav: 0, rvpi: 0 });
+      expect(result.series[0]?.actual?.tvpi).toBeCloseTo(0.08, 10); // (0 + 2M) / 25M
+      expect(result.navAnchoring?.blendedNav).toBe('0.000000');
+      expect(result.navAnchoring?.companies[0]).toMatchObject({
+        anchor: 'none',
+        contribution: '0.000000',
+      });
+    });
+
+    it('ADR-032 adversarial: a currency-blocked company with a large mark changes disclosure only', async () => {
+      buildFundCompanyActualsFactsMock.mockResolvedValue(
+        makeFacts({
+          allRounds: [{ ...BASE_EQUITY_ROUND, currency: 'EUR' }],
+          planningMarks: [
+            {
+              id: 301,
+              fundId: 1,
+              companyId: 10,
+              markDate: '2026-03-01',
+              fairValue: '999000000.000000',
+              currency: 'USD',
+              status: 'approved',
+            },
+          ],
+        })
+      );
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      // The 999M mark is CARRIED by the facts but contributes nothing; the
+      // company descends to the base-currency legacy fallback (rung 3).
+      expect(result.actualsFacts?.companies[0]).toMatchObject({
+        currencyStatus: 'mismatch_blocked',
+        planningFmvStatus: 'blocked',
+        latestPlanningFmvValue: '999000000.000000',
+      });
+      expect(result.series[0]?.actual).toMatchObject({ nav: 10_000_000, tvpi: 0.48, rvpi: 0.4 });
+      expect(result.navAnchoring).toMatchObject({
+        blendedNav: '10000000.000000',
+        countsByTrustState: trustCounts({ UNAVAILABLE: 1 }),
+      });
+      expect(result.navAnchoring?.companies[0]).toMatchObject({
+        inNavUniverse: true,
+        trustState: 'UNAVAILABLE',
+        anchor: 'legacy_current_valuation',
+        contribution: '10000000.000000',
+      });
+      expect(result.actualsFacts?.warnings).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'CURRENCY_MISMATCH_BLOCK' })])
+      );
+    });
+
+    it('exited companies stay out of the NAV universe regardless of anchor state', async () => {
+      storageMock.getPortfolioCompanies.mockResolvedValue([
+        { ...baseStorageCompany(), currentValuation: null },
+        {
+          ...baseStorageCompany(),
+          id: 20,
+          name: 'Exited Co',
+          status: 'exited',
+          currentValuation: '50000000.00',
+        },
+      ]);
+      buildFundCompanyActualsFactsMock.mockResolvedValue(
+        makeFacts({
+          companies: [
+            { id: 10, fundId: 1, name: 'Northstar AI' },
+            { id: 20, fundId: 1, name: 'Exited Co' },
+          ],
+          planningMarks: [
+            {
+              id: 301,
+              fundId: 1,
+              companyId: 10,
+              markDate: '2026-03-01',
+              fairValue: '42000000.000000',
+              currency: 'USD',
+              status: 'approved',
+            },
+            {
+              id: 302,
+              fundId: 1,
+              companyId: 20,
+              markDate: '2026-03-01',
+              fairValue: '50000000.000000',
+              currency: 'USD',
+              status: 'approved',
+            },
+          ],
+        })
+      );
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      // Only the live company contributes; the exited company's active 50M
+      // mark and 50M legacy value both stay out (ADR-029 universe rule).
+      expect(result.navAnchoring?.blendedNav).toBe('42000000.000000');
+      expect(result.series[0]?.actual?.nav).toBe(42_000_000);
+      const exited = result.navAnchoring?.companies.find((entry) => entry.companyId === 20);
+      expect(exited).toEqual({
+        companyId: 20,
+        companyName: 'Exited Co',
+        inNavUniverse: false,
+        trustState: 'LIVE',
+        anchor: null,
+        contribution: null,
+      });
+    });
+
+    it('a live company outside the facts universe descends to the legacy rungs', async () => {
+      storageMock.getPortfolioCompanies.mockResolvedValue([
+        baseStorageCompany(),
+        {
+          ...baseStorageCompany(),
+          id: 30,
+          name: 'Legacy Co',
+          currentValuation: '5000000.00',
+        },
+      ]);
+      buildFundCompanyActualsFactsMock.mockResolvedValue(
+        makeFacts({
+          planningMarks: [
+            {
+              id: 301,
+              fundId: 1,
+              companyId: 10,
+              markDate: '2026-03-01',
+              fairValue: '42000000.000000',
+              currency: 'USD',
+              status: 'approved',
+            },
+          ],
+        })
+      );
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      expect(result.navAnchoring?.blendedNav).toBe('47000000.000000');
+      expect(result.series[0]?.actual?.nav).toBe(47_000_000);
+      const legacyCo = result.navAnchoring?.companies.find((entry) => entry.companyId === 30);
+      expect(legacyCo).toEqual({
+        companyId: 30,
+        companyName: 'Legacy Co',
+        inNavUniverse: true,
+        trustState: null, // no facts entry for this company
+        anchor: 'legacy_current_valuation',
+        contribution: '5000000.000000',
+      });
+    });
+
+    it('a projection-engine failure becomes a disclosed structured fallback state', async () => {
+      projectedCalculateMock.mockRejectedValueOnce(new Error('projection engine down'));
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      expect(result.currentProjection).toEqual({
+        status: 'fallback_default',
+        fallbackReason: 'projection engine down',
+      });
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining('projection engine down')])
+      );
+      // The as-of point still blends; future quarters come from the default
+      // (zero) projection, disclosed rather than silent.
+      expect(result.series[0]?.actual?.nav).toBe(30_000_000);
+      expect(result.series[1]?.current).toMatchObject({
+        nav: 0,
+        calledCapital: 25_000_000,
+        distributions: 2_000_000,
+      });
+      expect(DualForecastResponseSchema.parse(result)).toEqual(result);
+    });
+
+    it('every series point carries current-minus-construction variance', async () => {
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      for (const point of result.series) {
+        expect(point.variance.nav).toBe(point.current.nav - point.construction.nav);
+        expect(point.variance.calledCapital).toBe(
+          point.current.calledCapital - point.construction.calledCapital
+        );
+        expect(point.variance.distributions).toBe(
+          point.current.distributions - point.construction.distributions
+        );
+        for (const ratio of ['tvpi', 'dpi', 'rvpi', 'irr'] as const) {
+          const current = point.current[ratio];
+          const construction = point.construction[ratio];
+          if (current == null || construction == null) {
+            expect(point.variance[ratio]).toBeNull();
+          } else {
+            expect(point.variance[ratio]).toBe(current - construction);
+          }
+        }
+      }
+
+      // Spot check the as-of quarter against explicit expectations.
+      const asOf = result.series[0];
+      expect(asOf?.variance.nav).toBeCloseTo(30_000_000 - (asOf?.construction.nav ?? 0), 6);
+      expect(asOf?.variance.distributions).toBe(2_000_000);
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements PRD #1020 PR-2 (the blend) per ratified ADR-029 (NAV anchor ladder), ADR-030 (trust blending + count-map rollup), and ADR-032 (currency blocks). Read surface only: no cache, no new mounts, no exports, H9 untouched (ADR-028 disclose-not-block).

### ADR-029 - anchor ladder
- Per-company NAV contribution over the live-company universe: active Planning FMV > stale FMV (disclosed) > `currentValuation` fallback (disclosed) > disclosed zero. `latestRoundValuation` (pre-money) never enters NAV.
- `isLivePortfolioCompany` is now exported from `actual-metrics-calculator` so the blend and the legacy NAV share one universe definition by construction.
- The blended NAV re-anchors the as-of Current/Actual point via Decimal (`@shared/lib/decimal-utils`); TVPI/RVPI recomputed mirroring calculator semantics (0-not-null at zero called); DPI/IRR stay cash-flow-derived.

### ADR-030 - trust blending
- LIVE blends normally; PARTIAL include-with-flag; UNAVAILABLE/FAILED contribute no facts-derived money and descend the ladder.
- New additive nullable `navAnchoring` block: `blendedNav` (decimal string), `countsByTrustState` (count map, no worst-of scalar), and full-universe per-company attribution (`inNavUniverse`, `trustState`, `anchor`, `contribution`). The PR-1 `actualsFacts` block is byte-unchanged.

### ADR-032 - currency
- `mismatch_blocked` companies contribute no facts-derived monetary values even though the facts carry them; ids/lineage/warnings surface; the company descends to the base-currency legacy rungs; universe membership is stable.

### PRD deliverables 4-5
- Additive per-point `variance` (current minus construction, null-propagating ratios).
- The silent `getDefaultProjectedMetrics` fallback is now a structured `currentProjection` state (`projected | fallback_default` + reason), alongside the existing string warning.

### Tests
- The PR-1 snapshot-equality tests are REPLACED with ADR-driven expectations (per the PRD, not re-baselined): every ladder rung, trust state, currency block, exited/missing-facts universe edges, structured fallback, per-point variance.
- PRD DoD adversarial cases: a PARTIAL fixture vs an equivalent LIVE fixture at the same anchor rung changes disclosure, never numbers; a currency-blocked fixture with a 999M mark changes disclosure only.
- Fixtures built with the real `buildFundCompanyActualsFactsFromRows` row-builder + importOriginal-spread mocks; downstream fixtures swept (route/hook/dashboard/e2e qa-audit); dashboard test gains a `Schema.parse` fixture guard.
- Facts-seam guard test untouched and green.

## Gates (local)
- `npm run check` PASS, `npm run lint` PASS, `npm run phoenix:truth` 273/273 PASS
- Full `npm test`: 7672 passed; 2 known app-bootstrap resource-ceiling timeouts pass standalone (24/24)
- Full post-merge main CI run ID to be cited on this PR after merge (PR-head runs are affected-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUPk5Sru7yEWn1PGwoT1kS