### PR TITLE
feat(routes): mount dashboard-summary router in makeApp (#1032)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -11,6 +11,7 @@ import calculationsRouter from './routes/calculations.js';
 import aiRouter from './routes/ai.js';
 import scenarioAnalysisRouter from './routes/scenario-analysis.js';
 import dualForecastRouter from './routes/dual-forecast.js';
+import dashboardSummaryRouter from './routes/dashboard-summary.js';
 import fundActualsRouter from './routes/fund-actuals.js';
 import allocationsRouter from './routes/allocations.js';
 import allocationScenariosRouter from './routes/allocation-scenarios.js';
@@ -209,6 +210,10 @@ export function makeApp() {
   // Scenario Analysis API (Construction vs Current, deal modeling)
   app.use('/api', scenarioAnalysisRouter);
   app.use('/api', dualForecastRouter);
+  // Dashboard header KPI cards + Portfolio Allocation read model (#1032). Mounted
+  // here so the Vercel/makeApp surface matches the Docker routes.ts mount; without
+  // it the endpoint 404s in prod and the KPI provenance envelope stays invisible.
+  app.use('/api', dashboardSummaryRouter);
   app.use('/api', fundActualsRouter);
 
   // Keep the makeApp/serverless surface aligned with the canonical fund routes

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -46,6 +46,9 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   aiRouter: { kind: 'non-table' },
   scenarioAnalysisRouter: { kind: 'other-table' },
   dualForecastRouter: { kind: 'other-table' },
+  // Reads fund_metrics/portfolio_companies/activities via IStorage (no direct DB
+  // writes, none in C1_MOUNTED_TABLES) — same posture as fundMetricsRouter (#1032).
+  dashboardSummaryRouter: { kind: 'other-table' },
   allocationsRouter: { kind: 'other-table' },
   allocationScenariosRouter: {
     kind: 'c1',

--- a/tests/unit/routes/dashboard-summary-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/dashboard-summary-makeapp-surface.contract.test.ts
@@ -1,0 +1,128 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function authorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '1',
+    email: 'route-surface-test@example.com',
+    role: 'admin',
+    fundIds: [],
+  })}`;
+}
+
+describe('dashboard summary makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('mounts the dashboard summary router on the production makeApp API surface', async () => {
+    const app = await makeAppWithTestAuth();
+
+    // A non-numeric fundId reaches the mounted dashboard-summary handler's own
+    // guard: parseFundIdParam rejects it, toNumber throws NumberParseError, and the
+    // catch returns 400 { error: 'Invalid fund ID' } before any DB access. When the
+    // router is NOT mounted (the production mount-parity defect this test guards
+    // against), the identical request falls through to the makeApp catch-all
+    // 404 { error: 'not_found' }.
+    //
+    // We assert the specific `error: 'Invalid fund ID'` string, not merely
+    // status 400: it proves THIS handler answered, discriminating a genuine mount
+    // from both the non-mount (404) and a coincidental 400 emitted by some other
+    // router mounted earlier at '/api'. 400-vs-404 with the handler-specific label
+    // is a fast, DB-free mount proof.
+    const res = await request(app)
+      .get('/api/dashboard-summary/abc')
+      .set('Authorization', await authorizationHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Closes #1032. `/api/dashboard-summary/:fundId` was mounted only in the Docker-only `server/routes.ts`, so it **404'd on the Vercel/makeApp prod surface**. The dashboard header KPI cards + Portfolio Allocation always rendered behind the CP1 degraded-summary notice, and the KPI provenance evidence envelope shipped in #1020 PR-3 (Dashboard IRR `unverified` labeling, per-KPI source/freshness lines, allocation evidence rail) was invisible to GPs in prod.

The handler (`server/routes/dashboard-summary.ts`) was already complete and guarded (`parseFundIdParam` strict-reject, `enforceProvidedFundScope`, rate limit, GET-only). This is purely an `app.ts` mount + test-parity gap.

## Changes

- **`server/app.ts`** — import + `app.use('/api', dashboardSummaryRouter)`, adjacent to the dual-forecast fund-data routes. Docker parity is exact (`routes.ts:64` also mounts at `/api`).
- **`tests/unit/mount-parity-migrations.test.ts`** — classify `dashboardSummaryRouter` as `{ kind: 'other-table' }` for the D6 recurrence guard (reads `fund_metrics`/`portfolio_companies`/`activities` via `IStorage`; none in `C1_MOUNTED_TABLES`; same posture as `fundMetricsRouter`).
- **`tests/unit/routes/dashboard-summary-makeapp-surface.contract.test.ts`** — new mount pin. `GET /api/dashboard-summary/abc` → `400 { error: 'Invalid fund ID' }`. Asserts the **handler-specific error label** (not bare 400) so it discriminates a genuine mount from both the non-mount 404 and a coincidental 400 from a router mounted earlier at `/api`.

## Verification

- `npm run check` — 0 new errors (strict baseline compile)
- Targeted: `mount-parity-migrations` + new contract test — 5 passed
- Perturbation-risk suites (route-surface-inventory, app-bootstrap, portfolio-intelligence-route-inventory, metrics-rum ×3, import-smoke) — 43 passed
- `npm run lint` — 0 errors / 0 warnings (+ guardrails)

## Security note

Mounting exposes a previously Docker-internal endpoint on prod. `enforceProvidedFundScope` denies a restricted caller cross-fund (403); empty `fundIds` = unrestricted admin by design — the same guard posture as already-mounted siblings (`fundMoicRouter`, `fundActualsRouter`). No new leak class.

## Follow-up (out of scope)

The `routes.ts`↔`app.ts` set-diff shows other Docker-only routers absent from makeApp. The mount-parity test never diffs the two surfaces, so this class recurs. A parity-guard follow-up should be filed to make this the last hand-found instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)