### PR TITLE
test(routes): routes.ts<->makeApp mount-parity guard (#1036)

### DIFF
--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -22,10 +22,25 @@ import { describe, expect, it } from 'vitest';
 const DYNAMIC_IMPORT = /import\(\s*['"](\.\/routes\/[^'"]+)['"]\s*\)/g;
 const STATIC_IMPORT = /import\s+[^;]*?\s+from\s+['"](\.\/routes\/[^'"]+)['"]/g;
 
+// Strip comments before scanning so a commented-out import does NOT read as a live mount.
+// Otherwise removing a router from app.ts but leaving its old import in a comment would
+// false-GREEN the #1032 guard -- the exact regression this test exists to catch. Block
+// comments first, then line comments.
+//
+// BOUNDARY: string literals are NOT stripped. The module specifiers we extract live INSIDE
+// string literals (import('./routes/x.js')), so stripping strings would delete the very
+// target we scan for. A complete `import('./routes/x')` embedded in an unrelated string
+// literal would still be miscounted; closing that edge needs an AST, disproportionate for a
+// source-scan guard. The realistic accidental vector is a comment, and that is closed here.
+export function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
 export function extractRouteModulePaths(source: string): Set<string> {
+  const src = stripComments(source);
   const found = new Set<string>();
   for (const re of [DYNAMIC_IMPORT, STATIC_IMPORT]) {
-    for (const m of source.matchAll(re)) found.add(m[1]!);
+    for (const m of src.matchAll(re)) found.add(m[1]!);
   }
   return found;
 }
@@ -90,6 +105,28 @@ describe('route-mount-parity: pure diff logic (synthetic)', () => {
     expect(findStaleExemptions(routesFixture, appFixture, ['./routes/shared.js'])).toEqual([
       './routes/shared.js',
     ]);
+  });
+
+  it('does NOT count a commented-out import as route presence (finding 1)', () => {
+    const appWithCommentedImports = `
+      import sharedRouter from './routes/shared.js';
+      // import alphaRouter from './routes/alpha.js';   // unmounted, left in a line comment
+      /* app.use(await import('./routes/beta.js')); */
+      app.use('/api', sharedRouter);
+    `;
+    const makeApp = extractRouteModulePaths(appWithCommentedImports);
+    expect(makeApp.has('./routes/shared.js')).toBe(true);
+    expect(makeApp.has('./routes/alpha.js')).toBe(false); // line comment stripped
+    expect(makeApp.has('./routes/beta.js')).toBe(false); // block comment stripped
+  });
+
+  it('still flags a Docker-only module whose only makeApp import is commented out (#1032)', () => {
+    // The false-green: alpha was unmounted from makeApp but its import survives as a
+    // comment. The guard must STILL report alpha as an unexempted Docker-only gap.
+    const appOnlyComment = `// import('./routes/alpha.js');`;
+    expect(findUnexemptedDockerOnly(routesFixture, appOnlyComment, [])).toContain(
+      './routes/alpha.js'
+    );
   });
 });
 
@@ -181,9 +218,16 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
   './routes/lp-health.js': { kind: 'gap-pending', reason: 'GET /api/lp/health; verify caller' },
 };
 
-// gap-pending ratchet (R4): may only DECREASE. A new gap-pending must come with a
-// lowered ceiling or a mount. Current live count (routes.ts - app.ts, gap-pending) = 12.
-const GAP_PENDING_CEILING = 12;
+// gap-pending pin (R4): exact count of gap-pending exemptions, pinned to the committed
+// ledger. Any ledger change -- a burn-down mount (count down) or a newly-discovered gap
+// (count up) -- forces a deliberate edit to this constant in the SAME PR, visible in the
+// diff and reviewable. Burn-down edits it strictly downward.
+//
+// LIMIT: a self-contained unit test cannot see git history, so it cannot mathematically
+// forbid raising this number. The exact pin is the strongest available substitute: it
+// removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
+// passes a ceiling but fails this pin until the constant is edited back up, in view).
+const GAP_PENDING_COUNT = 12;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -213,11 +257,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(findStaleExemptions(routesSrc, appSrc, exemptions)).toEqual([]);
   });
 
-  it('gap-pending exemption count only ratchets down', () => {
+  it('gap-pending count is pinned to the committed ledger (edit downward on burn-down)', () => {
     const gapPending = Object.values(DOCKER_ONLY_EXEMPTIONS).filter(
       (e) => e.kind === 'gap-pending'
     );
-    expect(gapPending.length).toBeLessThanOrEqual(GAP_PENDING_CEILING);
+    expect(gapPending.length).toBe(GAP_PENDING_COUNT);
   });
 
   it('pins the createServer -> registerRoutes delegation (keeps the guard 2-way)', () => {

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Route mount-parity guard (#1036; kills the #1032 class of silent prod 404s).
+ *
+ * Pure source-scan unit test (NO server boot). Fails when a router mounted by the
+ * Docker/registerRoutes surface (server/routes.ts) is absent from the makeApp/Vercel
+ * production surface (server/app.ts) without a documented exemption -- the exact
+ * failure of #1032, where a router lived only in routes.ts and 404'd in prod.
+ *
+ * BOUNDARY (R2): this guard proves source-PRESENCE only, NOT mount-path correctness.
+ * A router imported into app.ts but mounted at the wrong path (or used non-mount) still
+ * satisfies this guard yet can 404. Path-correctness is owned by the per-route makeApp
+ * contract tests (400-on-bad-fundId, per #1035) added in the later burn-down PRs.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// -- Pure core (exported for synthetic testing) -------------------------------
+// routes.ts mounts route modules via BOTH dynamic import('./routes/X') and static
+// `from './routes/X'` idioms (e.g. registerFundConfigRoutes). Union both (R1) so a
+// future function-style Docker-only router cannot slip past the guard.
+const DYNAMIC_IMPORT = /import\(\s*['"](\.\/routes\/[^'"]+)['"]\s*\)/g;
+const STATIC_IMPORT = /import\s+[^;]*?\s+from\s+['"](\.\/routes\/[^'"]+)['"]/g;
+
+export function extractRouteModulePaths(source: string): Set<string> {
+  const found = new Set<string>();
+  for (const re of [DYNAMIC_IMPORT, STATIC_IMPORT]) {
+    for (const m of source.matchAll(re)) found.add(m[1]!);
+  }
+  return found;
+}
+
+export function findUnexemptedDockerOnly(
+  routesSrc: string,
+  appSrc: string,
+  exemptions: readonly string[]
+): string[] {
+  const docker = extractRouteModulePaths(routesSrc);
+  const makeApp = extractRouteModulePaths(appSrc);
+  const exempt = new Set(exemptions);
+  return [...docker].filter((m) => !makeApp.has(m) && !exempt.has(m)).sort();
+}
+
+export function findStaleExemptions(
+  routesSrc: string,
+  appSrc: string,
+  exemptions: readonly string[]
+): string[] {
+  const docker = extractRouteModulePaths(routesSrc);
+  const makeApp = extractRouteModulePaths(appSrc);
+  // Stale = an exemption for a module that is no longer Docker-only: it either left
+  // routes.ts entirely, or it is now mounted on makeApp (mount forces the delete).
+  return exemptions.filter((m) => !docker.has(m) || makeApp.has(m)).sort();
+}
+
+// -- Synthetic self-tests (R3): the guard's own logic is continuously verified --
+describe('route-mount-parity: pure diff logic (synthetic)', () => {
+  const routesFixture = `
+    await mountDefaultRoute(app, { load: () => import('./routes/alpha.js') });
+    import { registerBetaRoutes } from './routes/beta.js';   // static/function-style
+    await mountDefaultRoute(app, { load: () => import('./routes/shared.js') });
+  `;
+  const appFixture = `
+    import sharedRouter from './routes/shared.js';
+    app.use('/api', sharedRouter);
+  `;
+
+  it('extracts BOTH dynamic import() and static from idioms (R1)', () => {
+    const docker = extractRouteModulePaths(routesFixture);
+    expect(docker.has('./routes/alpha.js')).toBe(true);
+    expect(docker.has('./routes/beta.js')).toBe(true); // would escape a dynamic-only regex
+    expect(docker.has('./routes/shared.js')).toBe(true);
+  });
+
+  it('flags a Docker-only module with no mount and no exemption', () => {
+    expect(findUnexemptedDockerOnly(routesFixture, appFixture, [])).toEqual([
+      './routes/alpha.js',
+      './routes/beta.js',
+    ]);
+  });
+
+  it('respects exemptions', () => {
+    expect(
+      findUnexemptedDockerOnly(routesFixture, appFixture, ['./routes/alpha.js', './routes/beta.js'])
+    ).toEqual([]);
+  });
+
+  it('flags a stale exemption once a module is mounted on makeApp', () => {
+    // shared is in both surfaces -> exempting it is stale.
+    expect(findStaleExemptions(routesFixture, appFixture, ['./routes/shared.js'])).toEqual([
+      './routes/shared.js',
+    ]);
+  });
+});
+
+// -- Exemption ledger = the machine-visible burn-down worklist (R4) ------------
+const SERVER_DIR = path.resolve(process.cwd(), 'server');
+const read = (f: string) => fs.readFileSync(path.join(SERVER_DIR, f), 'utf8');
+
+type ExemptionKind =
+  | 'permanent-infra'
+  | 'permanent-dev-only'
+  | 'permanent-serverless-incompatible'
+  | 'permanent-superseded'
+  | 'gap-pending';
+
+// gap-pending = confirmed/suspected prod gap awaiting its mount PR; permanent-* =
+// intentional divergence. Burn-down drives gap-pending to zero (see #1036 checklist).
+const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: string }> = {
+  './routes/dev-dashboard.js': {
+    kind: 'permanent-dev-only',
+    reason: 'NODE_ENV=development gate (routes.ts)',
+  },
+  './routes/admin/engine.js': {
+    kind: 'permanent-dev-only',
+    reason: 'engine admin, non-prod only (routes.ts)',
+  },
+  './routes/cache.js': { kind: 'permanent-infra', reason: 'cache monitoring/mgmt, internal ops' },
+  './routes/sse-events.js': {
+    kind: 'permanent-serverless-incompatible',
+    reason: 'long-lived SSE unsupported on Vercel serverless',
+  },
+  './routes/operations.js': { kind: 'permanent-infra', reason: 'ops polling, internal' },
+  './routes/error-budget.js': {
+    kind: 'permanent-infra',
+    reason: 'observability, feature-flagged (FEATURES.metrics)',
+  },
+  './routes/portfolio-intelligence.js': {
+    kind: 'permanent-infra',
+    reason: 'feature-flagged (FEATURES.portfolioIntelligence)',
+  },
+  './routes/fund-metrics-legacy.js': {
+    kind: 'permanent-superseded',
+    reason: 'superseded by fund-metrics (on makeApp)',
+  },
+  './routes/engine-summaries.js': {
+    kind: 'permanent-superseded',
+    reason: 'extracted into dedicated modules (routes.ts)',
+  },
+  './routes/monte-carlo.js': {
+    kind: 'gap-pending',
+    reason: 'no client caller found; MC may run via BullMQ -- verify then reclassify',
+  },
+  './routes/performance-metrics.js': {
+    kind: 'gap-pending',
+    reason: 'no client caller found; verify internal-only then reclassify',
+  },
+  './routes/portfolio-overview.js': {
+    kind: 'gap-pending',
+    reason: 'overview adoption (bad6655a); confirm superseded vs live',
+  },
+  './routes/activities.js': {
+    kind: 'gap-pending',
+    reason: 'POST /activities; confirm no live client writer',
+  },
+  './routes/moic.js': {
+    kind: 'gap-pending',
+    reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
+  },
+  './routes/timeline.js': {
+    kind: 'gap-pending',
+    reason: 'client useTimelineData hits /api/timeline heavily -- likely real 404',
+  },
+  './routes/shares.js': {
+    kind: 'gap-pending',
+    reason: 'client dashboard-modern.tsx hits /api/shares',
+  },
+  './routes/capital-allocation.js': {
+    kind: 'gap-pending',
+    reason: 'client use-capital-allocation + CapitalAllocationStep',
+  },
+  './routes/liquidity.js': {
+    kind: 'gap-pending',
+    reason: 'client use-liquidity + CashflowDashboard',
+  },
+  './routes/graduation.js': { kind: 'gap-pending', reason: 'client use-graduation.ts' },
+  './routes/portfolio-companies.js': {
+    kind: 'gap-pending',
+    reason: 'client likely use-fund-data; confirm caller path',
+  },
+  './routes/lp-health.js': { kind: 'gap-pending', reason: 'GET /api/lp/health; verify caller' },
+};
+
+// gap-pending ratchet (R4): may only DECREASE. A new gap-pending must come with a
+// lowered ceiling or a mount. Current live count (routes.ts - app.ts, gap-pending) = 12.
+const GAP_PENDING_CEILING = 12;
+
+// -- Real-source parity assertions (the actual guard) -------------------------
+describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
+  const routesSrc = read('routes.ts');
+  const appSrc = read('app.ts');
+  const exemptions = Object.keys(DOCKER_ONLY_EXEMPTIONS);
+
+  it('extractor sanity: a known shared router (funds) is on BOTH surfaces', () => {
+    const docker = extractRouteModulePaths(routesSrc);
+    const makeApp = extractRouteModulePaths(appSrc);
+    expect(docker.has('./routes/funds.js')).toBe(true);
+    expect(makeApp.has('./routes/funds.js')).toBe(true);
+  });
+
+  it('a known gap-pending router (timeline) is Docker-only today', () => {
+    const docker = extractRouteModulePaths(routesSrc);
+    const makeApp = extractRouteModulePaths(appSrc);
+    expect(docker.has('./routes/timeline.js')).toBe(true);
+    expect(makeApp.has('./routes/timeline.js')).toBe(false);
+  });
+
+  it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {
+    expect(findUnexemptedDockerOnly(routesSrc, appSrc, exemptions)).toEqual([]);
+  });
+
+  it('has no stale exemptions (a router landing on makeApp forces its exemption delete)', () => {
+    expect(findStaleExemptions(routesSrc, appSrc, exemptions)).toEqual([]);
+  });
+
+  it('gap-pending exemption count only ratchets down', () => {
+    const gapPending = Object.values(DOCKER_ONLY_EXEMPTIONS).filter(
+      (e) => e.kind === 'gap-pending'
+    );
+    expect(gapPending.length).toBeLessThanOrEqual(GAP_PENDING_CEILING);
+  });
+
+  it('pins the createServer -> registerRoutes delegation (keeps the guard 2-way)', () => {
+    expect(read('server.ts')).toContain('registerRoutes(app)');
+  });
+});


### PR DESCRIPTION
## What

Adds a CI-blocking **source-scan** unit test that fails when a `server/routes.ts`
(Docker / `registerRoutes`) router is absent from `server/app.ts` (makeApp / Vercel
prod surface) without a documented exemption — killing the #1032 class of silent prod
404s.

PR-1 is the **guard only**: no routes are mounted; `server/app.ts`, `server/routes.ts`,
and `tests/unit/mount-parity-migrations.test.ts` are untouched. One new file:
`tests/unit/server/route-mount-parity.test.ts`.

Implements the revised guard spec from the #1036 owner comment (R1–R6):

- **R1** — routes.ts extractor unions dynamic `import('./routes/X')` **and** static
  `from './routes/X'` idioms, so a function-style Docker-only router (e.g.
  `registerFundConfigRoutes`) can't slip past the guard.
- **R2** — guard proves source-**presence** only, not mount-path correctness (stated in
  the file header). Path-correctness stays with the per-route makeApp contract tests
  (400-on-bad-fundId, per #1035) added in later burn-down PRs.
- **R3** — core diff is pure, exported functions (`stripComments`,
  `extractRouteModulePaths`, `findUnexemptedDockerOnly`, `findStaleExemptions`)
  continuously verified against synthetic fixtures, so the guard's own logic never goes
  vacuous.
- **R4** — `DOCKER_ONLY_EXEMPTIONS` splits `kind` into `permanent-infra |
  permanent-dev-only | permanent-serverless-incompatible | permanent-superseded |
  gap-pending`; the `gap-pending` count is pinned exactly to `GAP_PENDING_COUNT = 12`.

### Live reconciliation (current `main`)

Docker (routes.ts) − makeApp (app.ts) = **21 Docker-only modules**, matching the encoded
ledger 1:1:

- **permanent (9):** dev-dashboard, admin/engine, cache, sse-events, operations,
  error-budget, portfolio-intelligence, fund-metrics-legacy, engine-summaries
- **gap-pending (12):** monte-carlo, performance-metrics, portfolio-overview, activities,
  moic, timeline, shares, capital-allocation, liquidity, graduation, portfolio-companies,
  lp-health

`dashboardSummaryRouter` (from #1035) is mounted on app.ts; `server.ts` delegates via
`registerRoutes(app)`; the 9 makeApp-only routers are out of scope.

## Review response (P2 findings)

Three P2 findings from code review, all addressed inside the single test file (+ this
body). No change to `app.ts`/`routes.ts`.

1. **Raw-text scan false-green (comments/strings).** The regex counted a commented-out
   or stringified import as a live mount — so unmounting a router from `app.ts` but
   leaving the old import in a comment would false-GREEN the guard. Fixed: added
   `stripComments()` (block then line comments) ahead of extraction, plus two negative
   synthetic tests (a commented-out import no longer counts; a Docker-only module whose
   only `app.ts` import is commented out is still flagged).
   **Boundary (accepted):** string literals are **not** stripped — the module specifiers
   we scan for live *inside* string literals, so stripping strings would delete the
   extraction target. A complete `import('./routes/x')` embedded in an unrelated string
   is contrived; closing it needs an AST, disproportionate for a source-scan guard. The
   realistic accidental vector is a comment, which is now closed.
2. **Ratchet had slack.** `length <= CEILING` allowed 12→11→12 without failing. Replaced
   with an exact pin `expect(gapPending.length).toBe(GAP_PENDING_COUNT)`. Any ledger
   change now forces a deliberate, diff-visible edit to the constant in the same PR.
   **Limit (stated in code):** a self-contained unit test cannot see git history, so it
   cannot mathematically forbid raising the constant; the exact pin is the strongest
   available substitute and removes the silent-re-add slack.
3. **R6 proof claim was unsatisfiable.** See the corrected CI-proof section below.

## Local verification

- `TZ=UTC npm test -- --project=server route-mount-parity` → **12 passed** (10 + 2 new
  negative tests)
- `TZ=UTC npm test -- --project=server` (full server project) → green (CI is
  authoritative; see checks)

### Negative control (guard is non-vacuous)

Temporarily removed the `./routes/cache.js` **permanent** exemption line (a permanent
exemption trips only the #1032 parity guard, leaving the count-pin and stale checks green
— a clean single-assertion demonstration):

```
 × route-mount-parity: routes.ts <-> makeApp (real sources) > every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)
   → expected [ './routes/cache.js' ] to deeply equal []
AssertionError: expected [ './routes/cache.js' ] to deeply equal []
- Expected
+ Received
+   "./routes/cache.js",
 ❯ tests/unit/server/route-mount-parity.test.ts:252:69
 Test Files  1 failed (1)
      Tests  1 failed | 11 passed (12)
```

Exactly **one** assertion (the #1032 parity guard) went RED, naming the module; the
count-pin and stale-exemption assertions stayed green. Restored the line via edit (never
`git checkout --`); re-ran → **12 passed**. Final `git diff --check` clean; the
negative-control deletion is not in the committed diff.

## CI proof (R6) — corrected

The unit-fast lane runs `npm run test:unit -- --bail=1 --reporter=dot || npm run
test:quick`. The **dot reporter prints one `·` per test and does NOT emit passing
filenames**, so grepping the job log for `route-mount-parity` finds nothing *even when the
file ran*. The earlier acceptance criterion ("log contains `route-mount-parity`") was
therefore unsatisfiable — a real defect in this section, now corrected.

Correct proof that this file executed and passed in CI:

1. The `test:quick` fallback did **not** run — no `test:quick` script header in the
   unit-fast job log ⇒ `test:unit` exited 0.
2. The run collected the server project glob `tests/unit/**/*.test.ts` (no `--changed`/
   path filter); this file is in that glob (verified locally with
   `--project=server route-mount-parity`).
3. `--bail=1` means any failure in this file would have aborted the run and triggered the
   fallback. Full green + no fallback ⇒ it ran and passed.

The durable, local anti-vacuity proof is the negative control above (delete an exemption
→ exactly one assertion RED naming the module → restore → green), not the CI filename.

## Scope / boundary

- Guard = source-presence; path-correctness is owned by per-route makeApp contract tests.
- Burn-down of the 12 `gap-pending` routers (timeline, shares, …) is **out of scope here**
  — one mount per sequential follow-up PR (they all edit `app.ts` + the shared ledger).

Part of #1036.
