### PR TITLE
feat(routes): mount timeline router on makeApp (#1036 burn-down)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -18,6 +18,7 @@ import allocationScenariosRouter from './routes/allocation-scenarios.js';
 import planningFmvOverridesRouter from './routes/planning-fmv-overrides.js';
 import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
 import fundMoicRouter from './routes/fund-moic.js';
+import timelineRouter from './routes/timeline.js';
 import reallocationRouter from './routes/reallocation.js';
 import cashFlowEventsRouter from './routes/cash-flow-events.js';
 import operatingObjectTasksRouter from './routes/operating-object-tasks.js';
@@ -232,6 +233,11 @@ export function makeApp() {
   app.use('/api', planningFmvOverridesRouter);
   app.use('/api', fundScenarioSetsRouter);
   app.use('/api', fundMoicRouter);
+  // Timeline / time-travel API (#1036 burn-down). Mounted here so the
+  // Vercel/makeApp surface matches the Docker routes.ts mount; without it the
+  // client's /api/timeline calls 404 in prod. /events/latest self-gates with
+  // requireAuth()+requireRole('admin') inside the router (cross-surface safe).
+  app.use('/api/timeline', timelineRouter);
 
   // Reallocation API (Phase 1b) - mounted at root; the router self-defines its
   // full /api/funds/:fundId/reallocation/* paths (mirrors the registerRoutes mount).

--- a/server/routes/timeline.ts
+++ b/server/routes/timeline.ts
@@ -20,6 +20,7 @@ import { asyncHandler } from '../middleware/async';
 import { validateRequest } from '../middleware/validation';
 import { TimeTravelAnalyticsService, type Cache } from '../services/time-travel-analytics';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { requireAuth, requireRole } from '../lib/auth/jwt';
 
 const timelineReadLimiter = rateLimit({
   windowMs: 60_000,
@@ -301,6 +302,8 @@ export function createTimelineRouter(service: TimeTravelAnalyticsService) {
    */
   router.get(
     '/events/latest',
+    requireAuth(),
+    requireRole('admin'),
     timelineReadLimiter,
     validateRequest({
       query: z.object({

--- a/tests/unit/api/time-travel-api.test.ts
+++ b/tests/unit/api/time-travel-api.test.ts
@@ -93,6 +93,18 @@ vi.mock('../../../server/db', () => ({
   },
 }));
 
+// Inject an admin user so the /events/latest admin gate passes; this file
+// verifies response format only. The real auth boundary (401/403) is proven in
+// tests/unit/routes/timeline-makeapp-surface.contract.test.ts with real tokens.
+vi.mock('../../../server/lib/auth/jwt', () => ({
+  requireAuth: () => (req: any, _res: any, next: any) => {
+    req.user = { id: '1', role: 'admin', roles: ['admin'], fundIds: [] };
+    next();
+  },
+  requireRole: (role: string) => (req: any, res: any, next: any) =>
+    req.user?.role === role ? next() : res.sendStatus(403),
+}));
+
 // Import the router and mock instance after mocking
 import { db } from '../../../server/db';
 import timelineRouter from '../../../server/routes/timeline';

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -84,6 +84,9 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   backtestingRouter: { kind: 'other-table' },
   fundsRouter: { kind: 'other-table' },
   fundMetricsRouter: { kind: 'other-table' },
+  // TimeTravelAnalyticsService reads fund_events, fund_snapshots, funds; also
+  // funds in POST /:fundId/snapshot. None are in C1_MOUNTED_TABLES.
+  timelineRouter: { kind: 'other-table' },
   investmentsRouter: { kind: 'c1', tables: ['investment_rounds'] },
   varianceRouter: { kind: 'other-table' },
   registerFundConfigRoutes: { kind: 'other-table' },

--- a/tests/unit/routes/timeline-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/timeline-makeapp-surface.contract.test.ts
@@ -1,0 +1,165 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function authorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '1',
+    email: 'route-surface-test@example.com',
+    role: 'admin',
+    fundIds: [],
+  })}`;
+}
+
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('timeline makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('mounts the timeline router on the production makeApp API surface', async () => {
+    // Non-numeric fundId reaches the mounted /:fundId handler's own guard:
+    // parseTimelineFundId rejects it -> 400 { error: 'Invalid fund ID' } before
+    // any DB access. When NOT mounted, the same request falls through to the
+    // makeApp catch-all 404 { error: 'not_found' } (the mount-parity defect).
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/timeline/abc')
+      .set('Authorization', await authorizationHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+  }, 30_000);
+
+  // NOTE: this 401 comes from the PRE-EXISTING global /api auth boundary
+  // (app.ts:187), NOT from the route-local requireAuth() this PR adds -- it would
+  // 401 even if timeline were unmounted. It is a boundary sanity check, not proof
+  // of the new admin gate. The 403 test below is the proof of the new gate.
+  it('401s an unauthenticated /events/latest at the pre-existing global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/timeline/events/latest');
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  it('rejects a signed non-admin /events/latest with 403 (proves the new route-local admin gate)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/timeline/events/latest')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+    expect(res.status).toBe(403);
+  }, 30_000);
+
+  it('lets an authenticated fund-scoped GET /api/timeline/:fundId clear auth+scope into the service', async () => {
+    // The mount exists to fix the CLIENT's fund-scoped timeline reads (useTimelineData),
+    // so prove one actually reaches the service on makeApp. A signed token scoped to fund 1
+    // (role is irrelevant here -- the /:fundId routes use enforceProvidedFundScope, not
+    // requireRole). Assert the status is NOT 401/403/404: 404 => not mounted, 401 => global
+    // auth rejected the token, 403 => fund-scope denied. Any other status (200, or a DB-driven
+    // 500 from the eager default service / REFL-037) proves the request cleared the mount, the
+    // /api auth boundary, AND the fund-scope gate. We deliberately do NOT assert 200:
+    // timeline.ts:334-343 injects the real DB on this surface (REFL-037); the 200 body is
+    // covered by timeline.contract.test.ts via createTimelineRouter(mockService).
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/timeline/1')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+
+    expect([401, 403, 404]).not.toContain(res.status);
+  }, 30_000);
+});

--- a/tests/unit/routes/timeline.contract.test.ts
+++ b/tests/unit/routes/timeline.contract.test.ts
@@ -15,6 +15,30 @@ vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
   enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
 }));
 
+const authState = vi.hoisted(() => ({
+  user: { id: '1', role: 'admin', roles: ['admin'], fundIds: [] } as {
+    id: string;
+    role: string;
+    roles: string[];
+    fundIds: number[];
+  } | null,
+}));
+
+vi.mock('../../../server/lib/auth/jwt', () => ({
+  requireAuth: () => (req: Request, _res: Response, next: () => void) => {
+    (req as unknown as { user: unknown }).user = authState.user;
+    next();
+  },
+  requireRole: (role: string) => (req: Request, res: Response, next: () => void) => {
+    const user = (req as unknown as { user?: { role?: string } }).user;
+    if (!user || user.role !== role) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    next();
+  },
+}));
+
 vi.mock('../../../server/db', () => ({
   db: { query: { funds: { findFirst: dbState.findFirst } } },
 }));
@@ -77,6 +101,7 @@ describe('timeline route contracts', () => {
     dbState.findFirst.mockReset();
     dbState.findFirst.mockResolvedValue(null);
     service = makeService();
+    authState.user = { id: '1', role: 'admin', roles: ['admin'], fundIds: [] };
   });
 
   it('GET /:fundId rejects non-canonical fundId before scope check and event read', async () => {
@@ -146,5 +171,18 @@ describe('timeline route contracts', () => {
       1
     );
     expect(service.getTimelineEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET /events/latest rejects a non-admin before reading events', async () => {
+    authState.user = { id: '9', role: 'user', roles: ['user'], fundIds: [] };
+    const res = await request(makeApp(service)).get('/api/timeline/events/latest');
+    expect(res.status).toBe(403);
+    expect(service.getLatestEvents).not.toHaveBeenCalled();
+  });
+
+  it('GET /events/latest returns events for an admin', async () => {
+    const res = await request(makeApp(service)).get('/api/timeline/events/latest?limit=5');
+    expect(res.status).toBe(200);
+    expect(service.getLatestEvents).toHaveBeenCalledWith(5, undefined);
   });
 });

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -194,10 +194,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     kind: 'gap-pending',
     reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
   },
-  './routes/timeline.js': {
-    kind: 'gap-pending',
-    reason: 'client useTimelineData hits /api/timeline heavily -- likely real 404',
-  },
   './routes/shares.js': {
     kind: 'gap-pending',
     reason: 'client dashboard-modern.tsx hits /api/shares',
@@ -227,7 +223,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 12;
+const GAP_PENDING_COUNT = 11;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -242,11 +238,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (timeline) is Docker-only today', () => {
+  it('a known gap-pending router (shares) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/timeline.js')).toBe(true);
-    expect(makeApp.has('./routes/timeline.js')).toBe(false);
+    expect(docker.has('./routes/shares.js')).toBe(true);
+    expect(makeApp.has('./routes/shares.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## Mount the timeline router on the makeApp / Vercel prod surface (#1036 burn-down)

`server/routes.ts` (Docker-only) mounts `./routes/timeline.js` at `/api/timeline`, but
`server/app.ts` (the live Vercel `makeApp` surface) did not — so the client's fund-scoped
`/api/timeline` reads (via `useTimelineData`) 404'd in prod. This mounts it on `makeApp`, admin-gates
the newly-exposed all-funds `/events/latest`, and burns the route-mount-parity ledger 12 -> 11.

**Provenance:** plan scrutinized by a multi-model debate (codex / kimi / agy + claude; synthesis
`.claude/artifacts/timeline-makeapp-debate.md`), then implemented via Hermes/Codex (production lane)
with two-stage Claude review (spec + code-quality) per commit and three Claude-owned negative controls.

### Route inventory (5 routes)
- `GET /api/timeline/:fundId`, `/:fundId/state`, `POST /:fundId/snapshot`, `GET /:fundId/compare`
  — fund-scoped via `enforceProvidedFundScope` (re-verifies the bearer token, builds `req.user.fundIds`
  from claims; surface-agnostic).
- `GET /api/timeline/events/latest` — the ONLY all-funds route; now `requireAuth()+requireRole('admin')`.

### Auth decision
Route-local `requireAuth()+requireRole('admin')` on `/events/latest` only (the `fund-moic.ts:185-189`
convention). `git grep -n 'useLatestEvents'` returns only the definition at `useTimelineData.ts:165`
(zero callers), so this is security hardening, not feature restoration.

**Auth-proof labeling (important):**
- The **403** (signed non-admin) test proves the NEW route-local admin gate.
- The **401** (no token) test only exercises the PRE-EXISTING global `/api` auth boundary
  (`app.ts:187`) — it 401s whether or not timeline is mounted and independent of the route-local
  guard. It is a boundary sanity check, NOT proof of the new work.
- The **fund-scoped reachability** test (`GET /api/timeline/1`, status ∉ {401,403,404}) proves an
  authenticated read clears mount + `/api` auth + fund-scope into the service. It deliberately does
  NOT assert a 200 body — the eager default service runs the real DB on this surface (REFL-037); the
  functional 200 read is covered by `timeline.contract.test.ts` via `createTimelineRouter(mockService)`.

### Cross-surface behavior
`/events/latest` now returns 401 on the Docker/registerRoutes surface (which sets `req.context`, not
`req.user`). Safe: zero callers. The four fund-scoped routes are unchanged.

### Middleware order
`requireAuth()+requireRole('admin')` run before `timelineReadLimiter` so an authz decision wins over a
429 and rate-limit state is not leaked to unauthorized callers. Safe: tokens are HS256 (cheap
synchronous HMAC, `jwt.ts:72-74,303`); makeApp already throttles unauthenticated floods at the global
60/min limiter (`app.ts:141`) before `/api` auth runs.

### Parity ledger
Timeline exemption deleted; `GAP_PENDING_COUNT` 12 -> 11; Docker-only canary retargeted timeline ->
shares; D6 inventory classifies `timelineRouter: {kind:'other-table'}` (`fund_events`/`fund_snapshots`/
`funds` are absent from `C1_MOUNTED_TABLES`).

### Local verification
- `npm run check`: 0 new TypeScript errors (baseline clean).
- `npm run lint`: pass.
- Affected server suite (5 files): 46 passed, 13 skipped, 0 failed.

### Negative controls (RED proofs — the tests discriminate)
- **Mount** (surface): comment out `app.use('/api/timeline', ...)` -> surface mount test
  `expected 404 to be 400` (3 failed | 1 passed; the 401 passes vacuously). Reverted.
- **Parity** (source-scan): remove the import -> `#1032 guard` flags
  `[ './routes/timeline.js' ]`. Reverted.
- **Gate** (authz): drop `requireRole('admin')` -> non-admin contract test `expected 200 to be 403`.
  Reverted. (Codex's TDD RED for the same test was independently verified in the run log.)

### Diff scope
2 commits, 6 files: `server/routes/timeline.ts`, `server/app.ts`,
`tests/unit/routes/timeline.contract.test.ts`, `tests/unit/api/time-travel-api.test.ts`,
`tests/unit/routes/timeline-makeapp-surface.contract.test.ts` (new),
`tests/unit/server/route-mount-parity.test.ts`, `tests/unit/mount-parity-migrations.test.ts`.

**Non-goals:** no auto-merge, no unrelated cleanup, no docs/session artifacts, no dependency changes.

**CI:** touches only `server/**` + `tests/**`, so the new contract tests are not auto-run on the PR —
dispatch a full run: `gh workflow run ci-unified.yml --ref feat/1036-burndown-timeline-makeapp-mount -f run_full_suite=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
