### PR TITLE
feat(routes): mount shares routers on makeApp (#1036 burn-down)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,7 @@ import planningFmvOverridesRouter from './routes/planning-fmv-overrides.js';
 import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
 import fundMoicRouter from './routes/fund-moic.js';
 import timelineRouter from './routes/timeline.js';
+import { sharesRouter, publicSharesRouter } from './routes/shares.js';
 import reallocationRouter from './routes/reallocation.js';
 import cashFlowEventsRouter from './routes/cash-flow-events.js';
 import operatingObjectTasksRouter from './routes/operating-object-tasks.js';
@@ -238,6 +239,13 @@ export function makeApp() {
   // client's /api/timeline calls 404 in prod. /events/latest self-gates with
   // requireAuth()+requireRole('admin') inside the router (cross-surface safe).
   app.use('/api/timeline', timelineRouter);
+  // Shares API (#1036 burn-down). Mounted here so the Vercel/makeApp surface matches the Docker
+  // routes.ts mount; without it /api/shares and /api/public/shares 404 in prod. Management
+  // self-gates per-handler (requireAuthenticatedUser + canManageFund); the public routes stay
+  // anonymous via isPublicApiPath (GET /public/shares/:id and POST /public/shares/:id/verify
+  // bypass the global /api auth). Placed AFTER the global /api auth boundary.
+  app.use('/api/shares', sharesRouter);
+  app.use('/api/public/shares', publicSharesRouter);
 
   // Reallocation API (Phase 1b) - mounted at root; the router self-defines its
   // full /api/funds/:fundId/reallocation/* paths (mirrors the registerRoutes mount).

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -87,6 +87,10 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   // TimeTravelAnalyticsService reads fund_events, fund_snapshots, funds; also
   // funds in POST /:fundId/snapshot. None are in C1_MOUNTED_TABLES.
   timelineRouter: { kind: 'other-table' },
+  // Shares management + anonymous public snapshot. Reads/writes shares, shareAnalytics, and share
+  // snapshots -- none are in C1_MOUNTED_TABLES.
+  sharesRouter: { kind: 'other-table' },
+  publicSharesRouter: { kind: 'other-table' },
   investmentsRouter: { kind: 'c1', tables: ['investment_rounds'] },
   varianceRouter: { kind: 'other-table' },
   registerFundConfigRoutes: { kind: 'other-table' },

--- a/tests/unit/routes/shares-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/shares-makeapp-surface.contract.test.ts
@@ -1,0 +1,149 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('shares makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // (a) Management mount + reachability. A fund-1 token clears the global /api auth boundary AND
+  // the handler's requireAuthenticatedUser + canManageFund into the service. Mounted -> 200 or a
+  // DB-stub 500 (REFL-037); never 401/404. Unmounted -> makeApp catch-all 404 { error: 'not_found' }.
+  it('mounts the shares management router on the production makeApp API surface', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/shares?fundId=1')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+
+    expect([401, 404]).not.toContain(res.status);
+  }, 30_000);
+
+  // (b) Management auth boundary. This 401 is the PRE-EXISTING global /api boundary, NOT the mount
+  // (GET /api/shares 401s with no token whether or not shares is mounted). Boundary sanity check.
+  it('401s an unauthenticated GET /api/shares at the pre-existing global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/shares?fundId=1');
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  // (c) Public GET mount + anonymous bypass. isPublicApiPath whitelists GET /public/shares/:id so
+  // the global /api auth bypasses (status !== 401 proves the bypass). Mounted -> router 404
+  // { error: 'Share not found' } or a DB-stub 500; NEITHER is the catch-all { error: 'not_found' }.
+  // Unmounted -> catch-all 404 { error: 'not_found' } (the mount RED). Do NOT hard-pin 404.
+  it('reaches the public shares GET handler anonymously (mount + isPublicApiPath bypass)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/public/shares/nonexistent-share-id');
+
+    expect(res.status).not.toBe(401);
+    expect(res.body).not.toMatchObject({ error: 'not_found' });
+  }, 30_000);
+
+  // (d) PRIMARY public proof. POST .send({}) sets application/json (clears the 415 guard).
+  // isPublicApiPath whitelists POST /public/shares/:id/verify -> auth bypass -> the passkey Zod
+  // schema rejects {} BEFORE any DB lookup -> 400 { error: 'Validation error' }. DB-independent.
+  // Discriminates BOTH failures: unmounted -> 404 not_found; broken bypass -> 401.
+  it('reaches the public verify handler anonymously and 400s an empty body (load-bearing public proof)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).post('/api/public/shares/nonexistent-share-id/verify').send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Validation error' });
+  }, 30_000);
+});

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -194,10 +194,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     kind: 'gap-pending',
     reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
   },
-  './routes/shares.js': {
-    kind: 'gap-pending',
-    reason: 'client dashboard-modern.tsx hits /api/shares',
-  },
   './routes/capital-allocation.js': {
     kind: 'gap-pending',
     reason: 'client use-capital-allocation + CapitalAllocationStep',
@@ -223,7 +219,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 11;
+const GAP_PENDING_COUNT = 10;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -238,11 +234,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (shares) is Docker-only today', () => {
+  it('a known gap-pending router (capital-allocation) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/shares.js')).toBe(true);
-    expect(makeApp.has('./routes/shares.js')).toBe(false);
+    expect(docker.has('./routes/capital-allocation.js')).toBe(true);
+    expect(makeApp.has('./routes/capital-allocation.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## What

Continues the route-mount-parity burn-down (#1036) by mounting BOTH `shares` routers on the Vercel/`makeApp` production surface (`server/app.ts`), so they stop 404-ing in prod. This is the next gap-pending router after timeline (#1039).

**Two mounts** (mirroring the Docker `server/routes.ts:146-148` mount):
- `app.use('/api/shares', sharesRouter)` — authenticated share management.
- `app.use('/api/public/shares', publicSharesRouter)` — anonymous public snapshot.

Real client callers that 404 in prod today:
- `client/src/pages/dashboard-modern.tsx:161` -> `/api/shares` (management).
- `client/src/pages/shared-dashboard.tsx:88,115` -> `/api/public/shares/:id` and `/verify` (anonymous public).

No router modification and no new middleware gate — see auth model below.

## Auth model (cross-surface-safe)

- **Management** self-gates per-handler: every `sharesRouter` handler calls `requireAuthenticatedUser` + `canManageFund` (`server/routes/shares.ts` POST/GET/PATCH/DELETE/analytics). On `makeApp` the global `/api` auth boundary (`server/app.ts:189-194`) also 401s unauthenticated callers first (defense-in-depth). No cross-tenant path.
- **Public** stays anonymous by construction: the global `/api` boundary calls `isPublicApiPath(req.method, req.path)` and bypasses auth only for the pre-existing whitelist in `server/lib/public-api-boundary.ts` — exactly `GET /public/shares/:id` and `POST /public/shares/:id/verify` (single-segment regex; `…/analytics` etc. fall through to 401). **`public-api-boundary.ts` is untouched by this PR** — the bypass surface pre-existed and is not widened. Public GET returns only metadata (no snapshot) for passkey-protected shares (`shares.ts:346-357`); rate limiters travel with the router.

## Test discrimination (proves the mount, not just presence)

New `tests/unit/routes/shares-makeapp-surface.contract.test.ts` (REFL-001 frozen-config harness, HS256 signed tokens):
- **(a)** `GET /api/shares?fundId=1` + fund-1 token -> `[401,404]` excluded (mounted -> 200/DB-stub-500 via `canManageFund` fundIds path; unmounted -> catch-all 404).
- **(b)** `GET /api/shares` no token -> 401. **Labeled** as the pre-existing global `/api` boundary check, NOT a mount proof (401 either way).
- **(c)** `GET /api/public/shares/:id` no token -> `status !== 401` (bypass) AND `body` not `{ error: 'not_found' }` (mount). Robust to mounted 404 `Share not found` OR a DB-stub 500 (REFL-037).
- **(d) load-bearing public proof:** `POST /api/public/shares/:id/verify` `.send({})` -> `400 { error: 'Validation error' }`. The Zod `passkey` schema rejects `{}` BEFORE any DB (`shares.ts:706` precedes `findShare` at 707), so it is deterministic + DB-independent, and it discriminates BOTH failure modes: unmounted -> 404, broken public boundary -> 401.

The naive `GET /api/public/shares/:id -> NOT 401` assertion would have been **vacuous** (isPublicApiPath bypasses auth whether or not the router is mounted, so the unmounted case is a 404, not a 401). This was caught in a multi-model debate (codex/kimi/agy + claude) and replaced with (c)/(d) above.

## Parity ledger

- Deleted the `./routes/shares.js` gap-pending exemption (mount forces the delete; else `findStaleExemptions` fails).
- `GAP_PENDING_COUNT` 11 -> 10 (matches the 10 remaining gap-pending entries).
- Retargeted the Docker-only canary `shares` -> `capital-allocation` (still Docker-only at `routes.ts:93`, still gap-pending, absent from `app.ts`).
- D6 inventory (`mount-parity-migrations.test.ts`): classified `sharesRouter` + `publicSharesRouter` as `other-table` (`shares`/`share_analytics`/snapshot tables are not in `C1_MOUNTED_TABLES`).

## Verification (local)

- `npm run check`: 0 new TypeScript errors.
- `npm run lint`: clean.
- Affected server suite (surface + `shares.contract` + `route-mount-parity` + `mount-parity-migrations`): **67 passed**.
- **Four negative controls** (Edit/revert, each confirmed RED then restored):
  - **A** drop only the public mount -> (c) RED (`{error:'not_found'}`), (d) RED (`404 != 400`).
  - **B** break `isPublicApiPath` (mount intact) -> (c)/(d) RED at **401** (distinct failure from A — proves the test catches a broken public boundary, not just a missing mount).
  - **C** drop only the mgmt mount -> (a) RED (catch-all 404).
  - **D** remove the import -> `route-mount-parity` RED (`['./routes/shares.js']` flagged as unexempted Docker-only).

## Scope / non-goals

- Diff: 4 files (`server/app.ts` +8; the new surface test; the two parity ledgers). No router logic changed; `public-api-boundary.ts` untouched.
- No auto-merge. No unrelated cleanup, no docs/session artifacts, no dependency changes.
- Note (pre-existing, out of scope): the public share rate limiters use the default in-memory store, so they are best-effort per-instance on Vercel serverless (`RATE_LIMIT_REDIS_URL` already supported). Orthogonal to mount parity.

## CI

Touches only `server/**` + `tests/**`, so the new contract tests are not auto-run on the PR — a full run is dispatched separately (`ci-unified.yml … run_full_suite=true`).

Closes part of #1036.
