### PR TITLE
feat(routes): mount capital-allocation router on makeApp (#1036 burn-down)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -20,6 +20,7 @@ import fundScenarioSetsRouter from './routes/fund-scenario-sets.js';
 import fundMoicRouter from './routes/fund-moic.js';
 import timelineRouter from './routes/timeline.js';
 import { sharesRouter, publicSharesRouter } from './routes/shares.js';
+import capitalAllocationRouter from './routes/capital-allocation.js';
 import reallocationRouter from './routes/reallocation.js';
 import cashFlowEventsRouter from './routes/cash-flow-events.js';
 import operatingObjectTasksRouter from './routes/operating-object-tasks.js';
@@ -246,6 +247,12 @@ export function makeApp() {
   // bypass the global /api auth). Placed AFTER the global /api auth boundary.
   app.use('/api/shares', sharesRouter);
   app.use('/api/public/shares', publicSharesRouter);
+  // Capital-allocation API (#1036 burn-down). Pure deterministic compute (no DB, no fund-scope,
+  // no route-local auth) — protected only by the global /api auth boundary above. Mounted here so
+  // the Vercel/makeApp surface matches the Docker routes.ts mount; without it /api/capital-allocation
+  // 404s in prod. This closes the parity 404 gap; it does NOT by itself restore the prod client flow
+  // (the client hook sends no Bearer token — see the handoff TODO).
+  app.use('/api/capital-allocation', capitalAllocationRouter);
 
   // Reallocation API (Phase 1b) - mounted at root; the router self-defines its
   // full /api/funds/:fundId/reallocation/* paths (mirrors the registerRoutes mount).

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -91,6 +91,7 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   // snapshots -- none are in C1_MOUNTED_TABLES.
   sharesRouter: { kind: 'other-table' },
   publicSharesRouter: { kind: 'other-table' },
+  capitalAllocationRouter: { kind: 'non-table' },
   investmentsRouter: { kind: 'c1', tables: ['investment_rounds'] },
   varianceRouter: { kind: 'other-table' },
   registerFundConfigRoutes: { kind: 'other-table' },

--- a/tests/unit/routes/capital-allocation-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/capital-allocation-makeapp-surface.contract.test.ts
@@ -1,0 +1,143 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('capital-allocation makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // (a) PRIMARY mount + reachability proof. A signed token clears the global /api auth boundary; the
+  // /calculate handler's `if (!input || !input.fund)` guard returns 400 { error: 'invalid_request' }
+  // BEFORE any compute (DB-free, engine-free). This single assertion discriminates the mount:
+  // mounted -> 400; unmounted -> makeApp catch-all 404 { error: 'not_found' }; no token -> 401.
+  // DO NOT upgrade this to a happy-path 200 — a real { fund } body enters the throw-prone engine.
+  // NOTE: makeApp 415s a body-less POST, so ALWAYS `.send({})` (sets application/json).
+  it('mounts capital-allocation on the makeApp API surface (400 invalid_request, not 404/401)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .post('/api/capital-allocation/calculate')
+      .set('Authorization', await nonAdminAuthorizationHeader())
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_request' });
+  }, 30_000);
+
+  // (b) Auth-boundary sanity. This 401 is the PRE-EXISTING global /api boundary, NOT the mount
+  // (a no-token POST 401s whether or not capital-allocation is mounted). Boundary check only.
+  it('401s an unauthenticated POST /api/capital-allocation/calculate at the global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).post('/api/capital-allocation/calculate').send({});
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  // (c) Second-route coverage (belt-and-suspenders; both routes share ONE default router, so (a)
+  // already proves the mount). /validate runs `schema.parse({})` which THROWS a ZodError -> errorHandler.
+  // Mounted -> 400/500 (error path); unmounted -> catch-all 404. Do NOT hard-pin the status.
+  it('reaches the /validate handler when mounted (not 401/404 with a token)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .post('/api/capital-allocation/validate')
+      .set('Authorization', await nonAdminAuthorizationHeader())
+      .send({});
+
+    expect([401, 404]).not.toContain(res.status);
+  }, 30_000);
+});

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -194,10 +194,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     kind: 'gap-pending',
     reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
   },
-  './routes/capital-allocation.js': {
-    kind: 'gap-pending',
-    reason: 'client use-capital-allocation + CapitalAllocationStep',
-  },
   './routes/liquidity.js': {
     kind: 'gap-pending',
     reason: 'client use-liquidity + CashflowDashboard',
@@ -219,7 +215,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 10;
+const GAP_PENDING_COUNT = 9;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -234,11 +230,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (capital-allocation) is Docker-only today', () => {
+  it('a known gap-pending router (liquidity) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/capital-allocation.js')).toBe(true);
-    expect(makeApp.has('./routes/capital-allocation.js')).toBe(false);
+    expect(docker.has('./routes/liquidity.js')).toBe(true);
+    expect(makeApp.has('./routes/liquidity.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## What

Mounts the `capital-allocation` router on the makeApp/Vercel production surface, closing the next `routes.ts` <-> `app.ts` parity 404 gap in the #1036 burn-down (after timeline #1039 and shares #1040).

The router was Docker-only (`registerRoutes`), so `POST /api/capital-allocation/{calculate,validate}` 404'd in prod. Live client callers: `client/src/hooks/use-capital-allocation.ts` (CapitalAllocationStep).

## Changes

- `server/app.ts`: single-line default import + `app.use('/api/capital-allocation', capitalAllocationRouter)` after the global `/api` auth boundary.
- `tests/unit/routes/capital-allocation-makeapp-surface.contract.test.ts` (new): harness copied from the shares surface test; `POST /calculate` +token +`.send({})` -> `400 invalid_request` is the mount discriminator (unmounted=404, no-token=401); +`/validate` coverage.
- `tests/unit/server/route-mount-parity.test.ts`: delete the gap-pending exemption, `GAP_PENDING_COUNT` 10 -> 9, retarget the Docker-only canary to `liquidity`.
- `tests/unit/mount-parity-migrations.test.ts`: classify `capitalAllocationRouter` as D6 `non-table` (pure compute, no tables).

## Verification

- `npm run check`: 0 TS errors (client/server/shared). ESLint `--max-warnings 0`: clean.
- Affected suite: 19/19 green (`--project=server`).
- Negative controls proven RED: un-mount (path rename) -> surface `expected 404 to be 400`; drop the import -> parity guard flags `./routes/capital-allocation.js`. Both reverted; tree matches intended diff.

## Scope note (important)

This closes the parity **404** gap; it does **not** by itself restore the prod client flow. The client hook sends no `Authorization: Bearer` token anywhere (raw hooks and the shared `apiRequest`/`getQueryFn` send cookies, which `requireAuth` ignores), and `REQUIRE_AUTH` defaults `true`, so in prod the mount may convert `404 -> 401` unless the Vercel env sets `REQUIRE_AUTH=0`. That is a pre-existing, systemic client->/api auth issue (affects every gap-pending hook), tracked as a separate follow-up. The surface test uses an explicit signed token, so it proves the mount, not the prod client flow.

Refs #1036. Implemented via Hermes/Codex production lane; reviewed + verified by Claude.

Generated with [Claude Code](https://claude.com/claude-code)
