### PR TITLE
feat(routes): mount liquidity router on makeApp (#1036 burn-down)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,7 @@ import fundMoicRouter from './routes/fund-moic.js';
 import timelineRouter from './routes/timeline.js';
 import { sharesRouter, publicSharesRouter } from './routes/shares.js';
 import capitalAllocationRouter from './routes/capital-allocation.js';
+import liquidityRouter from './routes/liquidity.js';
 import reallocationRouter from './routes/reallocation.js';
 import cashFlowEventsRouter from './routes/cash-flow-events.js';
 import operatingObjectTasksRouter from './routes/operating-object-tasks.js';
@@ -253,6 +254,11 @@ export function makeApp() {
   // 404s in prod. This closes the parity 404 gap; it does NOT by itself restore the prod client flow
   // (the client hook sends no Bearer token — see the handoff TODO).
   app.use('/api/capital-allocation', capitalAllocationRouter);
+  // Liquidity API (#1036 burn-down). Pure deterministic compute (no DB, NOT fund-scoped, no
+  // route-local auth) — protected only by the global /api auth boundary above. Mounted here so the
+  // Vercel/makeApp surface matches the Docker routes.ts mount; without it /api/liquidity 404s in prod.
+  // Closes the parity 404 gap; does NOT by itself restore the prod client flow (hook sends no Bearer).
+  app.use('/api/liquidity', liquidityRouter);
 
   // Reallocation API (Phase 1b) - mounted at root; the router self-defines its
   // full /api/funds/:fundId/reallocation/* paths (mirrors the registerRoutes mount).

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -92,6 +92,7 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   sharesRouter: { kind: 'other-table' },
   publicSharesRouter: { kind: 'other-table' },
   capitalAllocationRouter: { kind: 'non-table' },
+  liquidityRouter: { kind: 'non-table' },
   investmentsRouter: { kind: 'c1', tables: ['investment_rounds'] },
   varianceRouter: { kind: 'other-table' },
   registerFundConfigRoutes: { kind: 'other-table' },

--- a/tests/unit/routes/liquidity-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/liquidity-makeapp-surface.contract.test.ts
@@ -1,0 +1,145 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('liquidity makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // (a) PRIMARY mount + reachability proof. A signed token clears the global /api auth boundary; the
+  // /analyze handler's FIRST line is `analyzeCashFlowsSchema.parse(req.body)`, which THROWS on `{}`.
+  // asyncHandler (server/middleware/async.ts) catches the throw and returns 500 { error: 'Internal
+  // server error' }. Liquidity has NO pre-parse invalid_request guard, so DO NOT `toBe(400)`. The
+  // discriminator is exclusion: mounted -> 500 (reachable); unmounted -> makeApp catch-all 404
+  // { error: 'not_found' }; no token -> 401 (before routing). Both assertions together prove the mount.
+  // DO NOT upgrade to a happy-path 200 — a real valid body enters the throw-prone LiquidityEngine.
+  // NOTE: makeApp 415s a body-less POST, so ALWAYS `.send({})` (sets application/json).
+  it('mounts liquidity on the makeApp API surface (reachable handler, not 404/401)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .post('/api/liquidity/analyze')
+      .set('Authorization', await nonAdminAuthorizationHeader())
+      .send({});
+
+    expect([401, 404]).not.toContain(res.status);
+    expect(res.body).not.toMatchObject({ error: 'not_found' });
+  }, 30_000);
+
+  // (b) Auth-boundary sanity. This 401 is the PRE-EXISTING global /api boundary, NOT the mount
+  // (a no-token POST 401s whether or not liquidity is mounted). Boundary check only.
+  it('401s an unauthenticated POST /api/liquidity/analyze at the global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).post('/api/liquidity/analyze').send({});
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  // (c) Second-route coverage (belt-and-suspenders; all four routes share ONE default router, so (a)
+  // already proves the mount). /forecast also runs `schema.parse({})` -> throws -> asyncHandler 500.
+  // Mounted -> reachable (not 401/404); unmounted -> catch-all 404. Do NOT hard-pin the status.
+  it('reaches the /forecast handler when mounted (not 401/404 with a token)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .post('/api/liquidity/forecast')
+      .set('Authorization', await nonAdminAuthorizationHeader())
+      .send({});
+
+    expect([401, 404]).not.toContain(res.status);
+  }, 30_000);
+});

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -194,10 +194,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     kind: 'gap-pending',
     reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
   },
-  './routes/liquidity.js': {
-    kind: 'gap-pending',
-    reason: 'client use-liquidity + CashflowDashboard',
-  },
   './routes/graduation.js': { kind: 'gap-pending', reason: 'client use-graduation.ts' },
   './routes/portfolio-companies.js': {
     kind: 'gap-pending',
@@ -215,7 +211,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 9;
+const GAP_PENDING_COUNT = 8;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -230,11 +226,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (liquidity) is Docker-only today', () => {
+  it('a known gap-pending router (graduation) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/liquidity.js')).toBe(true);
-    expect(makeApp.has('./routes/liquidity.js')).toBe(false);
+    expect(docker.has('./routes/graduation.js')).toBe(true);
+    expect(makeApp.has('./routes/graduation.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## What

Mounts `liquidityRouter` on the Vercel/makeApp production surface (`server/app.ts`) at `/api/liquidity`, matching the Docker `routes.ts` mount (`server/routes.ts:95`). Next gap-pending after capital-allocation (#1041).

Without the mount, all four liquidity POSTs (`/analyze`, `/forecast`, `/stress-test`, `/optimize-calls`) return prod 404s. Pure deterministic compute: no DB, NOT fund-scoped, no route-local auth -- protected only by the global `/api` auth boundary.

## Scope framing (parity, not feature-restore)

This closes the `routes.ts`<->`app.ts` parity 404 gap. It does **NOT** by itself restore the prod client flow: the `use-liquidity` hooks send no `Authorization: Bearer` token and `REQUIRE_AUTH` defaults `true`, so the mount may only turn a prod 404 into a latent 401. That client-auth mismatch is a separate systemic follow-up (affects every remaining mount), out of scope here.

## Changes (4 files)

- **`server/app.ts`** -- default import + mount after the capital-allocation mount.
- **`tests/unit/routes/liquidity-makeapp-surface.contract.test.ts`** (new) -- surface contract test. Unlike capital-allocation, liquidity has **no** pre-parse `invalid_request` guard: each route's first line is `<schema>.parse(req.body)`, which throws on `{}` and is caught by `asyncHandler` as a **500**. So the mount discriminator is a `[401,404]` exclusion + `not_found` body exclusion, not a `400` pin (mounted=500, unmounted=404, no-token=401).
- **`tests/unit/server/route-mount-parity.test.ts`** -- delete the liquidity `gap-pending` exemption; `GAP_PENDING_COUNT` 9->8; retarget the Docker-only canary to `graduation`.
- **`tests/unit/mount-parity-migrations.test.ts`** -- classify `liquidityRouter` as `non-table` (D6 recurrence guard).

## Verification

- Both negative controls RED-proven: (A) unmount via path-rename -> surface test RED at 404; (B) drop the real import path -> `#1032` parity guard flags `./routes/liquidity.js`.
- GREEN: 3 affected test files (19 tests) pass.
- `npm run check` clean (0 new TS errors); `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)