### PR TITLE
feat(routes): mount graduation router on makeApp (#1036 burn-down)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -22,6 +22,7 @@ import timelineRouter from './routes/timeline.js';
 import { sharesRouter, publicSharesRouter } from './routes/shares.js';
 import capitalAllocationRouter from './routes/capital-allocation.js';
 import liquidityRouter from './routes/liquidity.js';
+import graduationRouter from './routes/graduation.js';
 import reallocationRouter from './routes/reallocation.js';
 import cashFlowEventsRouter from './routes/cash-flow-events.js';
 import operatingObjectTasksRouter from './routes/operating-object-tasks.js';
@@ -259,6 +260,11 @@ export function makeApp() {
   // Vercel/makeApp surface matches the Docker routes.ts mount; without it /api/liquidity 404s in prod.
   // Closes the parity 404 gap; does NOT by itself restore the prod client flow (hook sends no Bearer).
   app.use('/api/liquidity', liquidityRouter);
+  // Graduation API (#1036 burn-down). Pure deterministic compute (no DB, no fund-scope, no
+  // route-local auth) — protected only by the global /api auth boundary above. Mounted here so the
+  // Vercel/makeApp surface matches the Docker routes.ts mount; without it /api/graduation 404s in prod.
+  // Closes the parity 404 gap; does NOT by itself restore the prod client flow (hook sends no Bearer).
+  app.use('/api/graduation', graduationRouter);
 
   // Reallocation API (Phase 1b) - mounted at root; the router self-defines its
   // full /api/funds/:fundId/reallocation/* paths (mirrors the registerRoutes mount).

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -93,6 +93,7 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   publicSharesRouter: { kind: 'other-table' },
   capitalAllocationRouter: { kind: 'non-table' },
   liquidityRouter: { kind: 'non-table' },
+  graduationRouter: { kind: 'non-table' },
   investmentsRouter: { kind: 'c1', tables: ['investment_rounds'] },
   varianceRouter: { kind: 'other-table' },
   registerFundConfigRoutes: { kind: 'other-table' },

--- a/tests/unit/routes/graduation-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/graduation-makeapp-surface.contract.test.ts
@@ -1,0 +1,143 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('graduation makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // (a) PRIMARY mount proof — the CLEANEST of the burn-down (a hard pin, not an exclusion). A signed token
+  // clears the global /api auth boundary; GET /api/graduation/defaults returns createDefaultGraduationConfig
+  // (pure config — NO engine run, NO request body, NO throw risk) and GET skips the makeApp 415 body guard.
+  // Mounted -> deterministic 200; unmounted -> makeApp catch-all 404; no token -> 401 (before routing).
+  // graduation's POST /project fills VALID DEFAULTS (20/16) on `.send({})` and returns 200 (see (c)); it does
+  // NOT schema.parse and has NO fund guard, so DO NOT copy capital-allocation's 400 or liquidity's 500.
+  it('mounts graduation on the makeApp API surface (GET /defaults -> 200)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/graduation/defaults')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+
+    expect(res.status).toBe(200);
+  }, 30_000);
+
+  // (b) Auth-boundary sanity. This 401 is the PRE-EXISTING global /api boundary, NOT the mount
+  // (a no-token GET 401s whether or not graduation is mounted). Boundary check only.
+  it('401s an unauthenticated GET /api/graduation/defaults at the global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/graduation/defaults');
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  // (c) Second-route coverage (belt-and-suspenders; both routes share ONE default router, so (a) already
+  // proves the mount). POST /project fills valid defaults (20, 16) on `.send({})` -> passes the numeric
+  // guards -> engine runs -> 200. Mounted -> reachable (not 401/404); unmounted -> catch-all 404. Do NOT
+  // `toBe(400)` (empty body is VALID via defaults) and do NOT copy liquidity's 500.
+  // NOTE: makeApp 415s a body-less POST, so ALWAYS `.send({})` (sets application/json). The GETs above do not.
+  it('reaches the /project handler when mounted (not 401/404 with a token)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .post('/api/graduation/project')
+      .set('Authorization', await nonAdminAuthorizationHeader())
+      .send({});
+
+    expect([401, 404]).not.toContain(res.status);
+  }, 30_000);
+});

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -194,7 +194,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     kind: 'gap-pending',
     reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
   },
-  './routes/graduation.js': { kind: 'gap-pending', reason: 'client use-graduation.ts' },
   './routes/portfolio-companies.js': {
     kind: 'gap-pending',
     reason: 'client likely use-fund-data; confirm caller path',
@@ -211,7 +210,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 8;
+const GAP_PENDING_COUNT = 7;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -226,11 +225,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (graduation) is Docker-only today', () => {
+  it('a known gap-pending router (portfolio-companies) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/graduation.js')).toBe(true);
-    expect(makeApp.has('./routes/graduation.js')).toBe(false);
+    expect(docker.has('./routes/portfolio-companies.js')).toBe(true);
+    expect(makeApp.has('./routes/portfolio-companies.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## What

Mount the `graduation` router on the makeApp/Vercel production surface so it matches the Docker `registerRoutes` mount (`server/routes.ts:91`). Next gap-pending after liquidity (#1042).

Closes the `routes.ts`<->`app.ts` parity 404 gap for graduation (the #1032 class of silent prod 404s). **This does NOT by itself restore the prod client flow** — `client/src/hooks/use-graduation.ts` sends no `Authorization: Bearer`, and `requireAuth` ignores cookies; the systemic client-auth gap is tracked separately. Frame: parity/404-gap closure, not feature-restore.

## Changes (4 files)

- **`server/app.ts`**: import + mount `graduationRouter` at `/api/graduation` (single-line default import; parity-guard identifier regex has no `s` flag).
- **`tests/unit/routes/graduation-makeapp-surface.contract.test.ts`** (new): 
  - (a) PRIMARY mount proof — `GET /api/graduation/defaults` + token -> **hard-pin `toBe(200)`** (pure `createDefaultGraduationConfig`, no engine run, GET skips the makeApp 415 body guard). The cleanest proof of the burn-down.
  - (b) no-token -> `401` (pre-existing global `/api` boundary, not the mount).
  - (c) `POST /api/graduation/project` + token `.send({})` -> reachable (not 401/404). Empty body fills **valid defaults (20/16)** -> passes the numeric guards -> engine runs -> 200. **NOT** cap-alloc's 400, **NOT** liquidity's 500.
- **`route-mount-parity.test.ts`**: drop the graduation gap-pending exemption; `GAP_PENDING_COUNT` 8->7; retarget the Docker-only canary to `portfolio-companies` (`routes.ts:66`, still gap-pending + absent from app.ts).
- **`mount-parity-migrations.test.ts`**: classify `graduationRouter` as `non-table` (GraduationRateEngine reads no DB tables).

## Verification

- `npm run check`: 0 new TS errors. ESLint (4 files, `--max-warnings 0`): clean.
- 3 affected test files GREEN (19/19).
- **Negative controls RED-proven** (both reverted): mount-path rename -> surface test RED (404≠200); import-path rename -> #1032 parity guard RED (flags `./routes/graduation.js`).

The mount discriminator differs per router (cap-alloc=400 guard, liquidity=500 parse-throw, graduation=200 valid-defaults) — verified against the actual handler before writing the assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)