### PR TITLE
feat(routes): mount portfolio-companies router on makeApp (#1036 burn-down)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -30,6 +30,7 @@ import backtestingRouter from './routes/backtesting.js';
 import fundsRouter from './routes/funds.js';
 import fundMetricsRouter from './routes/fund-metrics.js';
 import investmentsRouter from './routes/investments.js';
+import portfolioCompaniesRouter from './routes/portfolio-companies.js';
 import varianceRouter from './routes/variance.js';
 import { registerFundConfigRoutes } from './routes/fund-config.js';
 import { dealPipelineRouter } from './routes/deal-pipeline.js';
@@ -226,6 +227,12 @@ export function makeApp() {
   app.use('/api', fundsRouter);
   app.use(fundMetricsRouter);
   app.use('/api', investmentsRouter);
+  // Portfolio Companies API (#1036 burn-down). Fund-scoped reads/writes of portfolio_companies via
+  // IStorage; protected by the global /api auth boundary above + per-request enforceProvidedFundScope.
+  // Mounted at the bare /api root (routes self-define relative /portfolio-companies paths), mirroring
+  // the Docker routes.ts mount; without it /api/portfolio-companies 404s in prod. Closes the parity
+  // 404 gap; does NOT by itself restore the prod client flow (apiRequest sends cookies, not Bearer).
+  app.use('/api', portfolioCompaniesRouter);
   app.use('/api', portfolioLotsRouter);
   app.use(performanceApiRouter);
   app.use('/', varianceRouter);

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -94,6 +94,7 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   capitalAllocationRouter: { kind: 'non-table' },
   liquidityRouter: { kind: 'non-table' },
   graduationRouter: { kind: 'non-table' },
+  portfolioCompaniesRouter: { kind: 'other-table' },
   investmentsRouter: { kind: 'c1', tables: ['investment_rounds'] },
   varianceRouter: { kind: 'other-table' },
   registerFundConfigRoutes: { kind: 'other-table' },

--- a/tests/unit/routes/portfolio-companies-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/portfolio-companies-makeapp-surface.contract.test.ts
@@ -1,0 +1,146 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('portfolio-companies makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // (a) PRIMARY mount proof — the CLEANEST DB-independent discriminator of the burn-down. A signed token
+  // clears the global /api auth boundary; GET /api/portfolio-companies with NO fundId returns
+  // 400 { error: 'fund_scope_required' } at the TOP of the handler, BEFORE toNumber / enforceProvidedFundScope /
+  // any storage call (portfolio-companies.ts:53-58). Deterministic — no seeding, no engine, no throw. GET
+  // skips the makeApp 415 body guard. Mounted -> 400 fund_scope_required; unmounted -> catch-all 404
+  // { error: 'not_found' }; no token -> 401 (before routing). HARD PIN both status AND body shape. DO NOT copy
+  // graduation's 200, capital-allocation's fund-guard 400, or liquidity's 500.
+  it('mounts portfolio-companies on the makeApp API surface (GET no fundId -> 400 fund_scope_required)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/portfolio-companies')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'fund_scope_required' });
+  }, 30_000);
+
+  // (b) Auth-boundary sanity. This 401 is the PRE-EXISTING global /api boundary, NOT the mount (a no-token
+  // GET 401s whether or not portfolio-companies is mounted). Non-vacuous here: portfolio-companies has NO
+  // isPublicApiPath bypass (its paths are /portfolio-companies, not /public/...). Boundary check only.
+  it('401s an unauthenticated GET /api/portfolio-companies at the global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/portfolio-companies');
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  // (c) Second-route coverage (belt-and-suspenders; all three routes share ONE default router, so (a) already
+  // proves the mount). POST /portfolio-companies runs insertPortfolioCompanySchema.safeParse(req.body); an
+  // empty body FAILS safeParse -> graceful 400 { error: 'Invalid company data' } (NOT a 500 throw). Mounted ->
+  // reachable (not 401/404); unmounted -> catch-all 404. Do NOT hard-pin 500 (liquidity) or a fund-guard 400
+  // shape. NOTE: makeApp 415s a body-less POST, so ALWAYS `.send({})` (sets application/json). The GETs do not.
+  it('reaches the POST /portfolio-companies handler when mounted (not 401/404 with a token)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .post('/api/portfolio-companies')
+      .set('Authorization', await nonAdminAuthorizationHeader())
+      .send({});
+
+    expect([401, 404]).not.toContain(res.status);
+  }, 30_000);
+});

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -194,10 +194,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     kind: 'gap-pending',
     reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
   },
-  './routes/portfolio-companies.js': {
-    kind: 'gap-pending',
-    reason: 'client likely use-fund-data; confirm caller path',
-  },
   './routes/lp-health.js': { kind: 'gap-pending', reason: 'GET /api/lp/health; verify caller' },
 };
 
@@ -210,7 +206,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 7;
+const GAP_PENDING_COUNT = 6;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -225,11 +221,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (portfolio-companies) is Docker-only today', () => {
+  it('a known gap-pending router (portfolio-overview) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/portfolio-companies.js')).toBe(true);
-    expect(makeApp.has('./routes/portfolio-companies.js')).toBe(false);
+    expect(docker.has('./routes/portfolio-overview.js')).toBe(true);
+    expect(makeApp.has('./routes/portfolio-overview.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## What

Closes the `routes.ts`↔`app.ts` parity 404 gap for **portfolio-companies**. The router was mounted only on the Docker/`registerRoutes` surface (`routes.ts:66`, `mountPath '/api'`) and absent from the makeApp/Vercel prod surface, so `/api/portfolio-companies` **404'd in prod**. This mounts it on `app.ts` at the bare `/api` root (routes self-define relative `/portfolio-companies` paths), after the global `/api` auth boundary, mirroring the Docker mount.

Sixth mount in the #1036 burn-down (after timeline #1039, shares #1040, capital-allocation #1041, liquidity #1042, graduation #1043).

## Scope framing (parity, not feature-restore)

This closes the **404 gap only**. The browser client (`apiRequest`) authenticates with cookies, which `requireAuth` ignores (Bearer-only), so in prod this may expose a latent **401** unless `REQUIRE_AUTH=0`. Tracked as a separate client-auth follow-up. The surface test uses an explicit signed token, so it proves the **mount**, not the prod client flow.

## How portfolio-companies differs (4 departures from prior mechanical mounts)

1. **Bare `/api` mount** (not `/api/portfolio-companies`) — routes are relative.
2. **D6 kind `other-table`** — reads/writes `portfolio_companies` via IStorage; not in `C1_MOUNTED_TABLES` (a `c1` classification would fail the C1-parity test). Same posture as `dashboardSummaryRouter`.
3. **Mount proof = `GET` no-`fundId` → `400 fund_scope_required`** — returns at the top of the handler before any DB/scope call (deterministic). 5th distinct discriminator in the series.
4. **POST uses `safeParse`** → graceful 400, never a 500 throw.

## Ledger

- `GAP_PENDING_COUNT` 7 → 6
- portfolio-companies exemption removed
- Docker-only canary retargeted `portfolio-companies` → `portfolio-overview`
- `MAKEAPP_ROUTE_INVENTORY`: `portfolioCompaniesRouter: { kind: 'other-table' }`

## Verification

- **19/19 GREEN** across the 3 affected test files (`portfolio-companies-makeapp-surface.contract`, `route-mount-parity`, `mount-parity-migrations`).
- **Negative control A** (rename mount path → un-mount): surface (a)/(c) RED-proven, reverted.
- **Negative control B** (rename import module path): `#1032` parity guard RED-proven (`['./routes/portfolio-companies.js']`), reverted.
- eslint clean (`--max-warnings 0`); 0 new TS errors (baseline:check).

Full CI dispatched with `run_full_suite=true`. **No auto-merge** — awaiting CI Gate Status.