### PR TITLE
feat(routes): mount portfolio-overview router on makeApp (#1036 burn-down)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -31,6 +31,7 @@ import fundsRouter from './routes/funds.js';
 import fundMetricsRouter from './routes/fund-metrics.js';
 import investmentsRouter from './routes/investments.js';
 import portfolioCompaniesRouter from './routes/portfolio-companies.js';
+import portfolioOverviewRouter from './routes/portfolio-overview.js';
 import varianceRouter from './routes/variance.js';
 import { registerFundConfigRoutes } from './routes/fund-config.js';
 import { dealPipelineRouter } from './routes/deal-pipeline.js';
@@ -233,6 +234,14 @@ export function makeApp() {
   // the Docker routes.ts mount; without it /api/portfolio-companies 404s in prod. Closes the parity
   // 404 gap; does NOT by itself restore the prod client flow (apiRequest sends cookies, not Bearer).
   app.use('/api', portfolioCompaniesRouter);
+  // Portfolio Overview API (#1036 burn-down). Fund-scoped server-computed overview (KPIs + per-company
+  // MOIC) read from funds/portfolio_companies via IStorage; protected by the global /api auth boundary
+  // above + per-request enforceProvidedFundScope. Mounted at the bare /api root (route self-defines the
+  // relative /portfolio-overview path), mirroring the Docker routes.ts mount; without it
+  // /api/portfolio-overview 404s in prod (live: /portfolio -> PortfolioTabs -> OverviewTab ->
+  // usePortfolioOverview). Closes the parity 404 gap; does NOT by itself restore the prod client flow
+  // (apiRequest sends cookies, not Bearer).
+  app.use('/api', portfolioOverviewRouter);
   app.use('/api', portfolioLotsRouter);
   app.use(performanceApiRouter);
   app.use('/', varianceRouter);

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -95,6 +95,7 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   liquidityRouter: { kind: 'non-table' },
   graduationRouter: { kind: 'non-table' },
   portfolioCompaniesRouter: { kind: 'other-table' },
+  portfolioOverviewRouter: { kind: 'other-table' },
   investmentsRouter: { kind: 'c1', tables: ['investment_rounds'] },
   varianceRouter: { kind: 'other-table' },
   registerFundConfigRoutes: { kind: 'other-table' },

--- a/tests/unit/routes/portfolio-overview-makeapp-surface.contract.test.ts
+++ b/tests/unit/routes/portfolio-overview-makeapp-surface.contract.test.ts
@@ -1,0 +1,131 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function saveEnv() {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '0';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'route-surface-test-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'route-surface-session-secret-32-chars-min';
+}
+
+async function makeAppWithTestAuth() {
+  configureTestAuthEnv();
+  const { makeApp } = await import('../../../server/app');
+  return makeApp();
+}
+
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('portfolio-overview makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // (a) PRIMARY mount proof — same DB-independent discriminator as portfolio-companies. A signed token
+  // clears the global /api auth boundary; GET /api/portfolio-overview with NO fundId returns
+  // 400 { error: 'fund_scope_required' } at the TOP of the handler, BEFORE parseFundIdParam /
+  // enforceProvidedFundScope / getPortfolioOverview (portfolio-overview.ts:51-57). Deterministic — no
+  // seeding, no service call, no throw. GET skips the makeApp 415 body guard. Mounted -> 400
+  // fund_scope_required; unmounted -> catch-all 404 { error: 'not_found' }; no token -> 401 (before routing).
+  // HARD PIN both status AND body shape.
+  it('mounts portfolio-overview on the makeApp API surface (GET no fundId -> 400 fund_scope_required)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/portfolio-overview')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'fund_scope_required' });
+  }, 30_000);
+
+  // (b) Auth-boundary sanity. This 401 is the PRE-EXISTING global /api boundary, NOT the mount (a no-token
+  // GET 401s whether or not portfolio-overview is mounted). Non-vacuous: portfolio-overview has NO
+  // isPublicApiPath bypass (its path is /portfolio-overview, not /public/...). Boundary check only.
+  it('401s an unauthenticated GET /api/portfolio-overview at the global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/portfolio-overview');
+    expect(res.status).toBe(401);
+  }, 30_000);
+});

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -182,10 +182,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     kind: 'gap-pending',
     reason: 'no client caller found; verify internal-only then reclassify',
   },
-  './routes/portfolio-overview.js': {
-    kind: 'gap-pending',
-    reason: 'overview adoption (bad6655a); confirm superseded vs live',
-  },
   './routes/activities.js': {
     kind: 'gap-pending',
     reason: 'POST /activities; confirm no live client writer',
@@ -206,7 +202,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 6;
+const GAP_PENDING_COUNT = 5;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -221,11 +217,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (portfolio-overview) is Docker-only today', () => {
+  it('a known gap-pending router (moic) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/portfolio-overview.js')).toBe(true);
-    expect(makeApp.has('./routes/portfolio-overview.js')).toBe(false);
+    expect(docker.has('./routes/moic.js')).toBe(true);
+    expect(makeApp.has('./routes/moic.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## What

Closes the `routes.ts`↔`app.ts` parity 404 gap for **portfolio-overview**. The router was Docker-only (`routes.ts:67`, `mountPath '/api'`) and absent from makeApp/Vercel, so `GET /api/portfolio-overview` **404'd in prod**. Mounts it on `app.ts` at the bare `/api` root (route self-defines the relative `/portfolio-overview` path), after the global `/api` auth boundary and the portfolio-companies mount.

Seventh mount in the #1036 burn-down.

## Verified LIVE, not superseded

Before mounting, the `confirm superseded vs live` exemption question was resolved with a full trace:
```
/portfolio route (app-routes.tsx:91) -> Portfolio -> ModernPortfolio
  -> <PortfolioTabs> -> <OverviewTab> -> usePortfolioOverview()
    -> GET /api/portfolio-overview  (404 in prod today; Docker-only)
```
Versioned **V1 contract**, trusted-only fail-closed hook, cache invalidation, route-policy registry + telemetry, e2e + unit + contract tests. `#1030` *"overview adoption"* moved the client onto this endpoint (adoption, not deprecation).

## Scope framing (parity, not feature-restore)

Closes the **404 gap only**. `usePortfolioOverview` calls via `apiRequest` (cookies), which `requireAuth` ignores (Bearer-only), so prod may expose a latent **401** unless `REQUIRE_AUTH=0`. Same systemic client-auth follow-up as prior mounts. Surface test uses an explicit signed token → proves the **mount**, not the prod client flow.

## Shape (near-copy of #1044, one difference)

- ONE route (`GET /portfolio-overview`), bare `/api` root mount.
- D6 kind **`other-table`** — service reads `funds` + `portfolio_companies` via IStorage; none in `C1_MOUNTED_TABLES`.
- Mount proof = `GET` +token, no `fundId` → `400 fund_scope_required` (before any scope/service call). **Single route → surface test is (a)+(b) only, no POST/(c).**

## Ledger

- `GAP_PENDING_COUNT` 6 → 5
- portfolio-overview exemption removed
- Docker-only canary retargeted `portfolio-overview` → `moic`
- `MAKEAPP_ROUTE_INVENTORY`: `portfolioOverviewRouter: { kind: 'other-table' }`

## Verification

- **18/18 GREEN** across the 3 affected test files.
- **Negative control A** (rename mount path): surface (a) RED-proven, reverted.
- **Negative control B** (rename import module path): `#1032` parity guard RED-proven (`['./routes/portfolio-overview.js']`), reverted.
- eslint clean (`--max-warnings 0`); 0 new TS errors.

Full CI dispatched with `run_full_suite=true`. **No auto-merge** — awaiting CI Gate Status.