### PR TITLE
test(routes): reclassify moic router as permanent-superseded (#1036 burn-down)

### DIFF
--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -187,8 +187,9 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     reason: 'POST /activities; confirm no live client writer',
   },
   './routes/moic.js': {
-    kind: 'gap-pending',
-    reason: 'client use-moic.ts hits /api/moic; /moic-analysis page may be retired',
+    kind: 'permanent-superseded',
+    reason:
+      'superseded by fund-moic.js (/api/funds/:id/moic/rankings, on makeApp); its only callers useMOICCalculation/useMOICRanking are dead exports; /moic-analysis page retired (#997)',
   },
   './routes/lp-health.js': { kind: 'gap-pending', reason: 'GET /api/lp/health; verify caller' },
 };
@@ -202,7 +203,7 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 5;
+const GAP_PENDING_COUNT = 4;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -217,11 +218,11 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (moic) is Docker-only today', () => {
+  it('a known gap-pending router (lp-health) is Docker-only today', () => {
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
-    expect(docker.has('./routes/moic.js')).toBe(true);
-    expect(makeApp.has('./routes/moic.js')).toBe(false);
+    expect(docker.has('./routes/lp-health.js')).toBe(true);
+    expect(makeApp.has('./routes/lp-health.js')).toBe(false);
   });
 
   it('every Docker-only router is mounted on makeApp OR exempted (the #1032 guard)', () => {


### PR DESCRIPTION
## Summary

Route-mount-parity burn-down (#1036). The `moic` router is **superseded, not a prod gap** — reclassify `gap-pending` -> `permanent-superseded` and do **not** mount it.

### Verdict evidence
- The `moic` router serves `/api/moic/calculate` + `/api/moic/rank`. Its only client callers, `useMOICCalculation` / `useMOICRanking` (`client/src/hooks/use-moic.ts`), are **dead exports** — zero consumers anywhere in the codebase (verified by name-grep across all `.ts`/`.tsx`).
- The live MOIC path uses `useFundMoicRankingsV2` -> `/api/funds/:id/moic/rankings` -> `fund-moic.js`, which is **already mounted on makeApp** (`server/app.ts:20`). So prod MOIC works today.
- The `/moic-analysis` page was retired in #997.

### Changes (single file: `tests/unit/server/route-mount-parity.test.ts`)
- `moic` exemption: `gap-pending` -> `permanent-superseded` with a documented reason.
- `GAP_PENDING_COUNT`: 5 -> 4 (deliberate downward edit, in-diff per the R4 pin).
- Docker-only canary retargeted `moic` -> `lp-health` (still gap-pending, still Docker-only — verified in `server/routes.ts:134`, absent from `app.ts`).

### Scope guardrails
- No `app.ts` mount (router stays Docker-only), no surface/contract test, no `MAKEAPP_ROUTE_INVENTORY` (D6) entry — none apply when a router is *not* mounted on makeApp.
- Parity suite: 12/12 green locally.

### Remaining gap-pending tail (4)
`monte-carlo`, `performance-metrics`, `activities`, `lp-health` — each needs its own live-vs-superseded check before mount-or-reclassify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)