### PR TITLE
test(routes): reclassify final 4 gap-pending routers, close #1036 burn-down

### DIFF
--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -175,23 +175,29 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     reason: 'extracted into dedicated modules (routes.ts)',
   },
   './routes/monte-carlo.js': {
-    kind: 'gap-pending',
-    reason: 'no client caller found; MC may run via BullMQ -- verify then reclassify',
+    kind: 'permanent-serverless-incompatible',
+    reason:
+      'no client caller (client MC runs in a web worker, analytics.worker.ts); server API is BullMQ-queued + SSE (/jobs/:id/stream) + heavy multi-thousand-run sim, unfit for Vercel functions',
   },
   './routes/performance-metrics.js': {
-    kind: 'gap-pending',
-    reason: 'no client caller found; verify internal-only then reclassify',
+    kind: 'permanent-infra',
+    reason:
+      'dev-dashboard/monitoring; reads the in-process performance-monitor EventEmitter (per-invocation-meaningless on serverless) + SSE /realtime; no client caller',
   },
   './routes/activities.js': {
-    kind: 'gap-pending',
-    reason: 'POST /activities; confirm no live client writer',
+    kind: 'permanent-superseded',
+    reason:
+      'activity feed read served by dashboard-summary (on makeApp) via recentActivities; RecentActivity component unrendered; no client caller/writer of /api/activities (only tests)',
   },
   './routes/moic.js': {
     kind: 'permanent-superseded',
     reason:
       'superseded by fund-moic.js (/api/funds/:id/moic/rankings, on makeApp); its only callers useMOICCalculation/useMOICRanking are dead exports; /moic-analysis page retired (#997)',
   },
-  './routes/lp-health.js': { kind: 'gap-pending', reason: 'GET /api/lp/health; verify caller' },
+  './routes/lp-health.js': {
+    kind: 'permanent-infra',
+    reason: 'LP feature health check for load balancers/monitoring; no client caller',
+  },
 };
 
 // gap-pending pin (R4): exact count of gap-pending exemptions, pinned to the committed
@@ -203,7 +209,13 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
 // forbid raising this number. The exact pin is the strongest available substitute: it
 // removes the 12->11->12 slack a `<=` ceiling allowed (a silent re-add after a burn-down
 // passes a ceiling but fails this pin until the constant is edited back up, in view).
-const GAP_PENDING_COUNT = 4;
+//
+// BURN-DOWN COMPLETE (#1036): reached 0. The final four (monte-carlo, performance-metrics,
+// activities, lp-health) were each traced to zero live client callers and reclassified to
+// permanent-* rather than mounted (see their exemption reasons). A future Docker-only router
+// must now either mount on makeApp or land a permanent-* exemption -- this pin stays at 0 and
+// any new gap-pending entry forces a deliberate, diff-visible bump here.
+const GAP_PENDING_COUNT = 0;
 
 // -- Real-source parity assertions (the actual guard) -------------------------
 describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
@@ -218,7 +230,10 @@ describe('route-mount-parity: routes.ts <-> makeApp (real sources)', () => {
     expect(makeApp.has('./routes/funds.js')).toBe(true);
   });
 
-  it('a known gap-pending router (lp-health) is Docker-only today', () => {
+  it('a permanent Docker-only router (lp-health) is seen as Docker-only, not on makeApp', () => {
+    // Canary that the extractor still distinguishes the two surfaces now that the gap-pending
+    // burn-down reached zero: lp-health stays intentionally Docker-only (permanent-infra), so a
+    // real Docker-only module is still read as present in routes.ts and absent from makeApp.
     const docker = extractRouteModulePaths(routesSrc);
     const makeApp = extractRouteModulePaths(appSrc);
     expect(docker.has('./routes/lp-health.js')).toBe(true);


### PR DESCRIPTION
## Summary

Closes the route-mount-parity (#1036) burn-down. The gap-pending **tail of 4**
(`monte-carlo`, `performance-metrics`, `activities`, `lp-health`) was each traced
route -> hook -> component -> app-route, and **every one has zero live client
callers** — so all four are reclassified `permanent-*` rather than mounted on
`makeApp` (the moic reclassification recipe, #1047). `GAP_PENDING_COUNT 4 -> 0`.

Single-file, **test-only** change (`route-mount-parity.test.ts`). No `app.ts`
mount, no `MAKEAPP_ROUTE_INVENTORY` (D6) entry, no surface contract test.

## Per-router live-vs-superseded evidence

| Router | API | Evidence (zero live client caller) | New kind |
|---|---|---|---|
| `monte-carlo` | `/api/monte-carlo/*` | Client Monte Carlo runs entirely in a **web worker** (`analytics.worker.ts` / `useWorkerAnalytics`). Server API is BullMQ-queued (`simulation-queue`) + SSE (`/jobs/:id/stream`) + heavy multi-thousand-run sim. Only server-internal refs (`enhanced-audit` path config, `portfolio-intelligence` scenario map — itself permanent-infra) + a **registerRoutes-surface** test. | `permanent-serverless-incompatible` |
| `performance-metrics` | `/api/performance/{summary,alerts,operations,realtime,simulate,monte-carlo}` | File header: *"for development dashboard and monitoring systems."* Reads the **in-process** `performance-monitor` EventEmitter (per-invocation-meaningless on serverless) + SSE `/realtime`. No client caller. | `permanent-infra` |
| `activities` | `GET/POST /api/activities` | The activity-feed **read** is served by `dashboard-summary` (on `makeApp`) via `recentActivities`. `RecentActivity` component is **unrendered/unimported**. `createActivity` has no client or server-internal caller. `/api/activities` appears **only in tests**. | `permanent-superseded` |
| `lp-health` | `GET /api/lp/health` | Health check *"used by load balancers and monitoring systems."* LP **feature** routers (`lp-api`, `lp-capital-calls`, …) are already on `makeApp`; this is monitoring infra. No client caller. | `permanent-infra` |

## Framing (systemic client-auth caveat)

This is **parity / 404-gap ledger closure**, not "features restored." Independently
of this PR, no client code sends `Authorization: Bearer` to `/api` (raw-fetch hooks
and `apiRequest` send cookies), so a mount would only convert prod `404 -> 401`.
Since none of these four have a client caller at all, mounting them would add
inert, auth-gated endpoints — reclassification is the correct close.

## Verification

- Targeted run: **12/12 green** (`TZ=UTC vitest run tests/unit/server/route-mount-parity.test.ts`).
- **Negative control** (pin has teeth): reverting one kind-flip (`activities` -> `gap-pending`) while holding `GAP_PENDING_COUNT = 0` reddens the pin (`AssertionError: expected 1 to be +0`); restored and re-green.
- `findStaleExemptions` unaffected — all four remain in `routes.ts` and absent from `app.ts`.
- lp-health canary relabeled; assertions (`docker=true`, `makeApp=false`) still hold since it stays Docker-only.

Do **not** auto-merge — awaiting full CI (incl. the `CI Gate Status` aggregator + R6 unit-fast proof) and explicit go-ahead.