### PR TITLE
refactor(moic): relocate dbToMOICInvestment to lib, drop superseded /api/moic route

### DIFF
--- a/server/lib/moic-mapper.ts
+++ b/server/lib/moic-mapper.ts
@@ -1,35 +1,13 @@
 /**
- * MOIC Calculator API Routes
+ * MOIC input mapper.
  *
- * Endpoints for portfolio MOIC calculations.
+ * Relocated from server/routes/moic.ts (#1036 burn-down): the /api/moic router
+ * was a superseded, uncalled Docker-only route and was removed, but this DB-row
+ * adapter is a live dependency of fund-moic-ranking-service (the on-makeApp
+ * /api/funds/:id/moic/rankings path), so it lives here as a plain lib helper.
  */
 
-import { Router } from 'express';
-import type { Request, Response } from 'express';
-import { z } from 'zod';
-import { asyncHandler } from '../middleware/async.js';
-import { MOICCalculator } from '../../shared/core/moic/MOICCalculator.js';
 import type { Investment as MOICInvestment } from '../../shared/core/moic/MOICCalculator.js';
-
-const router = Router();
-
-// Request validation schema
-const investmentSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  initialInvestment: z.number(),
-  followOnInvestment: z.number(),
-  currentValuation: z.number(),
-  projectedExitValue: z.number(),
-  exitProbability: z.number(),
-  plannedReserves: z.number(),
-  reserveExitMultiple: z.number(),
-  investmentDate: z.coerce.date(),
-});
-
-const moicCalculationSchema = z.object({
-  investments: z.array(investmentSchema),
-});
 
 /**
  * Canonical adapter: database portfolio company / investment row → MOIC input.
@@ -77,33 +55,3 @@ export function dbToMOICInvestment(row: {
     investmentDate: row.investmentDate ? new Date(row.investmentDate) : new Date(),
   };
 }
-
-/**
- * POST /api/moic/calculate
- * Calculate portfolio MOIC summary for given investments
- */
-router.post(
-  '/calculate',
-  asyncHandler(async (req: Request, res: Response) => {
-    const { investments } = moicCalculationSchema.parse(req.body);
-
-    const result = MOICCalculator.generatePortfolioSummary(investments);
-    res.json(result);
-  })
-);
-
-/**
- * POST /api/moic/rank
- * Rank investments by reserves MOIC
- */
-router.post(
-  '/rank',
-  asyncHandler(async (req: Request, res: Response) => {
-    const { investments } = moicCalculationSchema.parse(req.body);
-
-    const result = MOICCalculator.rankByReservesMOIC(investments);
-    res.json(result);
-  })
-);
-
-export default router;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -83,8 +83,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
     // Backtesting routes (Monte Carlo validation)
     { mountPath: '/api/backtesting', load: () => import('./routes/backtesting.js') },
     { mountPath: '/api', load: () => import('./routes/sensitivity.js') },
-    // MOIC Calculator routes
-    { mountPath: '/api/moic', load: () => import('./routes/moic.js') },
     // Fund-scoped MOIC follow-on rankings (authenticated, fund-scoped)
     { mountPath: '/api', load: () => import('./routes/fund-moic.js') },
     // Graduation Rate Engine routes

--- a/server/services/fund-moic-ranking-service.ts
+++ b/server/services/fund-moic-ranking-service.ts
@@ -1,7 +1,7 @@
 import { db } from '../db';
 import { MOICCalculator } from '../../shared/core/moic/MOICCalculator.js';
 import type { Investment as MOICInvestment } from '../../shared/core/moic/MOICCalculator.js';
-import { dbToMOICInvestment } from '../routes/moic.js';
+import { dbToMOICInvestment } from '../lib/moic-mapper.js';
 import type { FundMoicRankingsResponseV1 } from '../../shared/contracts/fund-moic-v1.contract.js';
 import { canonicalSha256 } from '../../shared/lib/canonical-hash';
 

--- a/tests/unit/server/route-mount-parity.test.ts
+++ b/tests/unit/server/route-mount-parity.test.ts
@@ -189,11 +189,6 @@ const DOCKER_ONLY_EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: stri
     reason:
       'activity feed read served by dashboard-summary (on makeApp) via recentActivities; RecentActivity component unrendered; no client caller/writer of /api/activities (only tests)',
   },
-  './routes/moic.js': {
-    kind: 'permanent-superseded',
-    reason:
-      'superseded by fund-moic.js (/api/funds/:id/moic/rankings, on makeApp); its only callers useMOICCalculation/useMOICRanking are dead exports; /moic-analysis page retired (#997)',
-  },
   './routes/lp-health.js': {
     kind: 'permanent-infra',
     reason: 'LP feature health check for load balancers/monitoring; no client caller',

--- a/tests/unit/services/fund-moic-ranking-service.test.ts
+++ b/tests/unit/services/fund-moic-ranking-service.test.ts
@@ -15,8 +15,8 @@ vi.mock('../../../server/db', () => ({
   },
 }));
 
-vi.mock('../../../server/routes/moic', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../server/routes/moic')>();
+vi.mock('../../../server/lib/moic-mapper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/moic-mapper')>();
 
   dbToMOICInvestment.mockImplementation(actual.dbToMOICInvestment);
 


### PR DESCRIPTION
## Summary

Removes the dead `/api/moic` route (option 3 of the moic follow-up: relocate the
live helper, then delete the router). Follows #1048 (moic reclassified
`permanent-superseded`) and #1049 (its client hooks removed).

`server/routes/moic.ts` could not be deleted outright: alongside the dead router
(`POST /calculate`, `/rank`) it hosted **`dbToMOICInvestment`**, a live DB-row →
MOIC adapter imported and called by `server/services/fund-moic-ranking-service.ts`
(the on-makeApp `/api/funds/:id/moic/rankings` path). So:

- **Relocate** `dbToMOICInvestment` (+ its `MOICInvestment` type import) into a new
  plain helper `server/lib/moic-mapper.ts` (git tracks it as a rename of `moic.ts`).
- **Repoint** the service import and the service test's `vi.mock` target to
  `server/lib/moic-mapper`.
- **Delete** `server/routes/moic.ts` (the dead router + validation schemas).
- **Remove** the `/api/moic` mount from `server/routes.ts`.
- **Remove** the now-stale `./routes/moic.js` exemption from the route-mount-parity
  guard (deleting the mount makes the exemption stale — the two are coupled).

## Verification

- `route-mount-parity` **12/12** + `fund-moic-ranking-service` **14/14** green.
- **Negative control**: re-adding the `moic.js` exemption (with the module gone
  from `routes.ts`) reddens the stale-exemption guard
  (`expected [ './routes/moic.js' ] to deeply equal []`), proving the coupling.
- `npm run check` (typecheck): clean, exit 0.
- No test/config asserts `/api/moic/calculate|rank`; no audit/inventory references
  the path. **No behavior change to the live MOIC rankings path.**

No auto-merge — awaiting CI + explicit go-ahead.