### PR TITLE
Prevent Vercel auth imports from crashing before auth runs

### DIFF
--- a/docs/superpowers/plans/2026-07-07-shares-makeapp-mount.md
+++ b/docs/superpowers/plans/2026-07-07-shares-makeapp-mount.md
@@ -1,0 +1,284 @@
+# Shares makeApp Mount (issue #1036 burn-down) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mount BOTH `shares` routers on the `makeApp`/Vercel production surface so `/api/shares` (management) and `/api/public/shares` (anonymous public snapshot) stop 404-ing in prod — with the public boundary staying anonymous by construction.
+
+**Architecture:** `server/routes.ts` (Docker-only) already mounts BOTH `./routes/shares.js` routers (`app.use('/api/shares', sharesRouter)` + `app.use('/api/public/shares', publicSharesRouter)`, routes.ts:145-148); `server/app.ts` (the live Vercel `makeApp` surface) mounts neither, so the client's share calls 404 in prod (real callers: `client/src/pages/dashboard-modern.tsx:161` mgmt; `client/src/pages/shared-dashboard.tsx:88,115` public). We add a single import + both mounts to `app.ts`. NO router modification and NO new middleware gate is needed:
+- **Management** (`sharesRouter`) self-gates per-handler via `requireAuthenticatedUser` (shares.ts:146, reads `req.context?.userId ?? req.user?.id`) + `canManageFund` (shares.ts:155, checks `req.context` OR `req.user.fundIds`). On makeApp the global `/api` auth (app.ts:188-194) 401s unauthenticated callers first; `requireAuth` populates `req.user` (`userFromClaims`, jwt.ts:160-180: `id=sub`, `fundIds` from claims), so the handler auth clears. Cross-surface-safe.
+- **Public** (`publicSharesRouter`) MUST stay anonymous. The global `/api` auth middleware calls `isPublicApiPath(req.method, req.path)` (app.ts:189) and, when true, bypasses `requireAuth`. `isPublicApiPath` (public-api-boundary.ts:19-36) already whitelists exactly `GET /public/shares/:id` (line 27) and `POST /public/shares/:id/verify` (line 31) on the `/api`-stripped path — so mounting at `/api/public/shares` lets those two routes bypass auth. This bypass is the load-bearing risk and is PROVEN in the surface test, not assumed.
+
+The route-mount-parity guard's ledger and the D6 migrations inventory are updated in the same PR.
+
+**Tech Stack:** TypeScript, Express, Zod, Vitest (server project, Node env), supertest, `jsonwebtoken` (HS256 via `signToken`).
+
+**Decision record (from the multi-model debate scrutiny — codex/kimi/agy + claude, 2026-07-07; synthesis: `.claude/artifacts/shares-makeapp-debate.md`):**
+- **[Crux] The naive public assertion `GET /api/public/shares/<id> -> NOT 401` is VACUOUS.** Trace unmounted: no token -> `isPublicApiPath` true -> auth bypass (app.ts:189) -> falls through every `/api` router -> makeApp catch-all `404 { error: 'not_found' }` (app.ts:283). 404 != 401, so "NOT 401" is GREEN even when the public router is NEVER mounted. All four debate lanes converged on this. It MUST be replaced.
+- **The public proof is `POST /api/public/shares/<id>/verify` `.send({})` -> `400 { error: 'Validation error' }`.** `.send({})` sets Content-Type application/json (clears the 415 guard, app.ts:119-130) -> bypass (boundary.ts:31) -> `VerifyPasskeySchema.parse({})` throws a ZodError BEFORE `findShare` (shares.ts:706 precedes 707) -> `400 { error: 'Validation error' }` (shares.ts:721-724). Deterministic and DB-INDEPENDENT. `expect(status).toBe(400)` discriminates BOTH failure modes: unmounted -> 404 (400!=404); broken `isPublicApiPath` -> 401 (400!=401). Assert the BODY (`error: 'Validation error'`), not only the status, so a 400 from another path cannot pass.
+- **Keep the GET assertion too** (agy): (d) proves only the POST route exists; the GET route could be missing from the router. (c) `GET /api/public/shares/<id>` no token -> `status !== 401` (bypass worked) AND `body` not `{ error: 'not_found' }` (mount worked). Robust to BOTH mounted outcomes: 404 `{ error: 'Share not found' }` (shares.ts:683) OR a DB-stub 500 (REFL-037 — `findShare` hits the real `db` under ALLOW_MEMORY_STORAGE). Do NOT hard-pin 404.
+- **Mgmt reachability (a):** `GET /api/shares?fundId=1` with a fund-1 token (role:user, fundIds:[1]) -> `expect([401,404]).not.toContain(status)`. Mounted: `requireAuthenticatedUser` passes (id from sub) + `canManageFund` true (fundIds.includes(1), shares.ts:160) -> 200 or DB-stub 500; unmounted -> catch-all 404. Discriminates the mgmt mount.
+- **Mgmt auth boundary (b):** `GET /api/shares` no token -> 401. This is the PRE-EXISTING global `/api` boundary (app.ts:188-194; `res.sendStatus(401)` jwt.ts:230) — it returns 401 whether or not shares is mounted. LABEL it as a boundary sanity check, NOT proof of the mount (mirrors timeline's 401-honesty note).
+- **No new cross-fund exposure** (unlike timeline's `/events/latest`): management is fund-scoped via `canManageFund`; public is snapshot-only with its own rate limiters (shares.ts:63-87) + passkey. The mount is additive; no gate to add.
+- **Parity is by MODULE PATH:** the route-mount-parity guard scans `./routes/shares.js` (one import line satisfies it regardless of the two named exports). The D6 inventory scans IMPORT IDENTIFIERS (`parseImportClauseIdentifiers`, migrations.test.ts:156-182), so BOTH `sharesRouter` and `publicSharesRouter` need entries. The import MUST be single-line (D6 regex has no `s` flag, migrations.test.ts:142).
+
+---
+
+## Preconditions
+
+- [ ] **Step 0: Baseline re-verified (DONE this session)**
+
+Clean tree; `HEAD` at `45d8269b` (timeline #1039 squash) or later; branch `feat/1036-burndown-shares-makeapp-mount` created. `GAP_PENDING_COUNT = 11`; canary = `shares` (still Docker-only). All shares touchpoints re-verified against current main.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `server/app.ts` | makeApp prod surface; import + mount BOTH shares routers | Modify |
+| `tests/unit/routes/shares-makeapp-surface.contract.test.ts` | makeApp mount proof: mgmt reachability (a) + boundary (b) + public GET bypass (c) + public verify 400 (d) | Create |
+| `tests/unit/server/route-mount-parity.test.ts` | Parity ledger; drop shares exemption, 11->10, retarget canary to capital-allocation | Modify |
+| `tests/unit/mount-parity-migrations.test.ts` | D6 inventory; classify `sharesRouter` + `publicSharesRouter` as `other-table` | Modify |
+
+Commit boundaries:
+- **Commit 1** = Task 1 (surface test + both mounts + parity ledger + D6 inventory, atomic; suite green).
+- Task 2 = negative controls + verification + PR (Claude-owned, no code changes).
+
+---
+
+## Task 1: Mount both shares routers on makeApp + surface proof + parity ledger
+
+**Files:**
+- Create: `tests/unit/routes/shares-makeapp-surface.contract.test.ts`
+- Modify: `server/app.ts` (import after `import timelineRouter from './routes/timeline.js';`; mount after `app.use('/api/timeline', timelineRouter);`)
+- Modify: `tests/unit/server/route-mount-parity.test.ts` (exemption block, `GAP_PENDING_COUNT`, canary `it`)
+- Modify: `tests/unit/mount-parity-migrations.test.ts` (`MAKEAPP_ROUTE_INVENTORY`)
+
+- [ ] **Step 1: Create the makeApp surface contract test (RED first)**
+
+Create `tests/unit/routes/shares-makeapp-surface.contract.test.ts`. Copy the env/auth harness VERBATIM from `tests/unit/routes/timeline-makeapp-surface.contract.test.ts` lines 1-104 (the imports, `ENV_KEYS`, `saveEnv`, `restoreEnv`, `configureTestAuthEnv`, `makeAppWithTestAuth`, `authorizationHeader`, `nonAdminAuthorizationHeader` — all local functions, copy them). Then replace the `describe(...)` body with:
+
+```typescript
+describe('shares makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // (a) Management mount + reachability. A fund-1 token clears the global /api auth
+  // boundary AND the handler's own requireAuthenticatedUser + canManageFund into the
+  // service. Mounted -> 200 (empty list) or a DB-stub 500 (REFL-037); never 401/404.
+  // When NOT mounted the same request falls to the makeApp catch-all 404 { error:
+  // 'not_found' } -> 404 is the mount RED.
+  it('mounts the shares management router on the production makeApp API surface', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/shares?fundId=1')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+
+    expect([401, 404]).not.toContain(res.status);
+  }, 30_000);
+
+  // (b) Management auth boundary. NOTE: this 401 comes from the PRE-EXISTING global
+  // /api auth boundary (app.ts:188-194), NOT from the mount -- GET /api/shares returns
+  // 401 with no token whether or not shares is mounted. It is a boundary sanity check,
+  // not proof of the mount. (a)/(c)/(d) are the mount proofs.
+  it('401s an unauthenticated GET /api/shares at the pre-existing global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/shares?fundId=1');
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  // (c) Public GET mount + anonymous bypass. isPublicApiPath whitelists GET
+  // /public/shares/:id (public-api-boundary.ts:27) so the global /api auth bypasses
+  // (status !== 401 proves the bypass). Mounted -> the router's own 404 { error:
+  // 'Share not found' } (shares.ts:683) or a DB-stub 500 -- NEITHER is the catch-all
+  // { error: 'not_found' }. When NOT mounted the bypassed request falls to the catch-all
+  // 404 { error: 'not_found' } -> body.error === 'not_found' is the mount RED. Do NOT
+  // hard-pin 404: the mounted outcome may be 404 OR 500.
+  it('reaches the public shares GET handler anonymously (mount + isPublicApiPath bypass)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/public/shares/nonexistent-share-id');
+
+    expect(res.status).not.toBe(401);
+    expect(res.body).not.toMatchObject({ error: 'not_found' });
+  }, 30_000);
+
+  // (d) PRIMARY public proof. POST .send({}) sets application/json (clears the 415
+  // guard at app.ts:119-130). isPublicApiPath whitelists POST /public/shares/:id/verify
+  // (public-api-boundary.ts:31) -> auth bypass -> VerifyPasskeySchema.parse({}) throws a
+  // ZodError BEFORE findShare (shares.ts:706 precedes 707) -> 400 { error: 'Validation
+  // error' } (shares.ts:721-724). Deterministic + DB-INDEPENDENT. expect(400) discriminates
+  // BOTH failures: unmounted -> 404 not_found (400!=404); broken isPublicApiPath -> 401
+  // (400!=401). The body assertion pins it to the Zod path (a 415 would be status 415
+  // with error 'unsupported_media_type').
+  it('reaches the public verify handler anonymously and 400s an empty body (load-bearing public proof)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .post('/api/public/shares/nonexistent-share-id/verify')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Validation error' });
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Run the surface test to verify it FAILS (negative control #1 — mount RED)**
+
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/shares-makeapp-surface.contract.test.ts
+```
+Expected: FAIL — (a) gets `404 { error: 'not_found' }` (shares not mounted) so `[401,404]` contains it; (c) `body.error === 'not_found'`; (d) gets `404`, not `400`. (b) passes vacuously (global `/api` boundary 401 regardless) — which is exactly why (b) is a boundary check, not mount proof. PASTE the failing output; a missing RED here => BLOCKED.
+
+- [ ] **Step 3: Import and mount BOTH routers in app.ts**
+
+In `server/app.ts`, add the import immediately after `import timelineRouter from './routes/timeline.js';` (keep it SINGLE-LINE — the D6 identifier regex has no `s` flag):
+
+```typescript
+import { sharesRouter, publicSharesRouter } from './routes/shares.js';
+```
+
+Add both mounts immediately after `app.use('/api/timeline', timelineRouter);`, matching the Docker mount paths and placed AFTER the global `/api` auth boundary (app.ts:188-194) so the public bypass works:
+
+```typescript
+  // Shares API (#1036 burn-down). Mounted here so the Vercel/makeApp surface matches
+  // the Docker routes.ts mount; without it /api/shares and /api/public/shares 404 in
+  // prod. Management self-gates per-handler (requireAuthenticatedUser + canManageFund);
+  // the public routes stay anonymous via isPublicApiPath (GET /public/shares/:id and
+  // POST /public/shares/:id/verify bypass the global /api auth).
+  app.use('/api/shares', sharesRouter);
+  app.use('/api/public/shares', publicSharesRouter);
+```
+
+- [ ] **Step 4: Run the surface test to verify it PASSES**
+
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/shares-makeapp-surface.contract.test.ts
+```
+Expected: PASS — 4 tests. PASTE the green output.
+
+- [ ] **Step 5: Run the parity guards to observe the expected failures**
+
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+```
+Expected: FAIL — `route-mount-parity`: the canary "shares is Docker-only today" now fails (`makeApp.has('./routes/shares.js')` is `true`) and the stale-exemption check flags `./routes/shares.js`; `mount-parity-migrations`: the D6 inventory guard fails on the unclassified `sharesRouter` and `publicSharesRouter`. PASTE the output.
+
+- [ ] **Step 6: Update the parity ledger**
+
+In `tests/unit/server/route-mount-parity.test.ts`:
+
+(a) DELETE the shares exemption block:
+```typescript
+  './routes/shares.js': {
+    kind: 'gap-pending',
+    reason: 'client dashboard-modern.tsx hits /api/shares',
+  },
+```
+
+(b) Change the gap-pending pin from `11` to `10`:
+```typescript
+const GAP_PENDING_COUNT = 10;
+```
+
+(c) Retarget the Docker-only canary from `shares` to `capital-allocation` (the `it('a known gap-pending router (shares) is Docker-only today', ...)` block):
+```typescript
+  it('a known gap-pending router (capital-allocation) is Docker-only today', () => {
+    const docker = extractRouteModulePaths(routesSrc);
+    const makeApp = extractRouteModulePaths(appSrc);
+    expect(docker.has('./routes/capital-allocation.js')).toBe(true);
+    expect(makeApp.has('./routes/capital-allocation.js')).toBe(false);
+  });
+```
+
+- [ ] **Step 7: Classify BOTH routers in the migrations inventory**
+
+In `tests/unit/mount-parity-migrations.test.ts`, add to `MAKEAPP_ROUTE_INVENTORY` (alongside the other `other-table` entries, e.g. after the `timelineRouter: { kind: 'other-table' }` block):
+
+```typescript
+  // Shares management + anonymous public snapshot. Reads/writes shares, shareAnalytics,
+  // and share snapshots -- none are in C1_MOUNTED_TABLES.
+  sharesRouter: { kind: 'other-table' },
+  publicSharesRouter: { kind: 'other-table' },
+```
+
+- [ ] **Step 8: Run the parity guards to verify they PASS**
+
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+```
+Expected: PASS — all parity assertions green; gap-pending count is 10. PASTE the output. DO NOT COMMIT (Claude reviews + commits).
+
+---
+
+## Task 2: Negative controls, full verification, and PR (Claude-owned)
+
+**Files:** none modified (verification only). Reverts via Edit, NEVER `git checkout --` (uncommitted Task 1 work is present).
+
+- [ ] **Step 1: Negative control A — drop only the public mount (keep isPublicApiPath)**
+
+Comment out `app.use('/api/public/shares', publicSharesRouter);` only (Edit). Run the surface test.
+Expected: FAIL — (d) returns `404 { error: 'not_found' }` (400!=404) and (c) `body.error === 'not_found'`. Proves the test catches a MISSING public mount. Restore; re-run -> PASS.
+
+- [ ] **Step 2: Negative control B — break the public boundary (keep the mount)**
+
+Temporarily make `isPublicApiPath` NOT match public shares (Edit `server/lib/public-api-boundary.ts` — e.g. change the GET regex to `/^\/public\/shares-BROKEN\/[^/]+$/` and the POST regex likewise). Run the surface test.
+Expected: FAIL — (d) returns `401` (400!=401) and (c) `status === 401`. Proves the test catches a BROKEN public boundary (a mount alone is not enough). Restore both regexes; re-run -> PASS. NOTE: dropping the mount does NOT yield 401 (bypass intact -> 404); breaking the boundary is a DIFFERENT failure requiring this separate control.
+
+- [ ] **Step 3: Negative control C — drop the management mount**
+
+Comment out `app.use('/api/shares', sharesRouter);` only (Edit). Run the surface test.
+Expected: FAIL — (a) returns `404 { error: 'not_found' }`. Proves the mgmt-mount coverage. Restore; re-run -> PASS.
+
+- [ ] **Step 4: Negative control D — remove the import (parity RED)**
+
+Temporarily remove the `import { sharesRouter, publicSharesRouter } ...` line AND both mounts (Edit). Run `route-mount-parity.test.ts`.
+Expected: FAIL — `findUnexemptedDockerOnly` flags `./routes/shares.js` (Docker-only, exemption already deleted). Restore all lines; re-run -> PASS.
+
+- [ ] **Step 5: Typecheck and lint**
+
+```powershell
+npm run check
+npm run lint
+```
+Expected: both PASS with no new errors.
+
+- [ ] **Step 6: Run the full affected server suite once**
+
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/shares-makeapp-surface.contract.test.ts tests/unit/routes/shares.contract.test.ts tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+```
+Expected: PASS — all four files green (the pre-existing `shares.contract.test.ts` still passes — it constructs the router directly, unaffected by the mount).
+
+- [ ] **Step 7: Commit, push (BACKGROUND), open PR (NO auto-merge)**
+
+```bash
+git add server/app.ts tests/unit/routes/shares-makeapp-surface.contract.test.ts tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+git commit -m "feat(routes): mount shares routers on makeApp; burn down gap-pending 11->10 (#1036)"
+```
+Push in the background (the pre-push doc-freshness hook scans ~645 md files and blows the 2-min foreground cap). Then `gh pr create --base main` (see PR body below). Do NOT arm auto-merge.
+
+PR body MUST include: route inventory (TWO mounts: `/api/shares` mgmt + `/api/public/shares` anonymous); real client callers (`dashboard-modern.tsx:161`, `shared-dashboard.tsx:88,115`); the auth model (mgmt self-gates via `requireAuthenticatedUser`+`canManageFund`, cross-surface-safe; public stays anonymous via `isPublicApiPath` whitelist — no new gate); the discrimination note (the load-bearing public proof is the `/verify` 400 — DB-independent — plus the GET body check; the `GET /api/shares` 401 only exercises the pre-existing global `/api` boundary and is NOT cited as mount proof); local verification output; ALL FOUR negative-control RED proofs (A public-mount, B broken-boundary, C mgmt-mount, D parity-import); diff scope; gap-pending 11->10 + canary retargeted shares->capital-allocation. Non-goals: no auto-merge, no unrelated cleanup, no docs/session artifacts, no dependency changes.
+
+- [ ] **Step 8: Publication proof (do NOT arm auto-merge)**
+
+```bash
+gh pr view <new-pr> --json statusCheckRollup,headRefOid,baseRefOid,mergeStateStatus,reviewDecision,state
+gh workflow run ci-unified.yml --ref feat/1036-burndown-shares-makeapp-mount -f run_full_suite=true
+```
+This PR touches only `server/**` + `tests/**` (no `migrations/**` or `shared/schema/**`), so the new contract tests are NOT auto-run on the PR — dispatch the full suite and cite it. R6 CI proof from the unit-fast job log: `test:unit` primary ran, `--project=server`, `--bail=1`, no `test:quick` fallback, unit-fast green, live `statusCheckRollup`. Do not claim dot-reporter logs contain specific test filenames.
+
+---
+
+## Notes / risks (not tasks)
+
+- **REFL-037 (DB on makeApp surface):** the public GET and mgmt GET reach the real `db` under ALLOW_MEMORY_STORAGE, so their status may be 404/200 OR a DB-driven 500. That is why (c)/(a) assert NON-membership of failure statuses / NON-`not_found` body rather than a hard 200/404. Only (d) is fully deterministic (Zod 400 before any DB).
+- **REFL-001 (frozen config):** the surface harness sets JWT/env BEFORE importing `makeApp` and calls `vi.resetModules()` in `beforeEach` (copied from the timeline harness). Do not reorder.
+- **415 guard interaction:** `.send({})` in supertest sets Content-Type application/json, so the makeApp 415 guard (app.ts:119-130) passes and the request reaches the Zod parse. A body-less `.post(...)` with no `.send` would 415 instead — always `.send({})`.
+- **Rate limiters:** `publicShareReadLimiter`/`publicShareVerifyLimiter` (shares.ts:63-87) key on `req.params.shareId`; first request per id passes (max 60 / max 5). Pre-existing infra, shared with routes already on makeApp; no change needed.
+- **Docs governance:** this plan lives under `docs/superpowers/plans/` but is LEFT UNTRACKED (matching the timeline plan) to avoid the "Validate Discovery Routing" gate on new `docs/**/*.md`. Do not `git add` it.

--- a/docs/superpowers/plans/2026-07-07-timeline-makeapp-mount.md
+++ b/docs/superpowers/plans/2026-07-07-timeline-makeapp-mount.md
@@ -1,0 +1,446 @@
+# Timeline makeApp Mount (issue #1036 burn-down) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mount the `timeline` router on the `makeApp`/Vercel production surface so `/api/timeline` stops 404-ing in prod, and gate the cross-fund `GET /api/timeline/events/latest` behind admin auth — cross-surface-safe.
+
+**Architecture:** `server/routes.ts` (Docker-only) already mounts `./routes/timeline.js` at `/api/timeline`; `server/app.ts` (the live Vercel `makeApp` surface) does not, so the client's timeline calls 404 in prod. We add the mount to `app.ts` and — because mounting newly exposes the all-funds `/events/latest` endpoint on prod — gate that one route with route-local `requireAuth(), requireRole('admin')` (the established `server/routes/fund-moic.ts:185-189` convention; self-applying `requireAuth()` keeps it safe on both surfaces because Docker/`registerRoutes` populates `req.context`, not `req.user`). The route-mount-parity guard's ledger is updated in the same PR.
+
+**Tech Stack:** TypeScript, Express, Zod, Vitest (server project, Node env), supertest, `jsonwebtoken` (HS256 via `signToken`).
+
+**Decision record (from the multi-model debate scrutiny — codex/kimi/agy + claude, 2026-07-07; synthesis: `.claude/artifacts/timeline-makeapp-debate.md`):**
+- `useLatestEvents` (`client/src/hooks/useTimelineData.ts:165`) has ZERO call sites, so admin-gating `/events/latest` is security hardening, not feature restoration. EVIDENCE (cite in PR body): `git grep -n 'useLatestEvents'` returns only the definition at `useTimelineData.ts:165` — no importers/callers. The line reference proves existence; the grep proves non-use.
+- Option A (route-local `requireAuth()+requireRole('admin')` in the shared router) chosen over Option B (gate only at the app.ts mount) for robustness: defense-in-depth on both surfaces + convention consistency (`server/routes/fund-moic.ts:185-189`).
+- Auth-proof honesty: the new makeApp-surface test uses REAL signed tokens (avoiding the REFL-001 frozen-config trap — `server/config/index.ts` snapshots `process.env` at import). But only the **403** (signed non-admin) assertion proves the NEW route-local admin gate. The **401** (no token) assertion only exercises the PRE-EXISTING global `/api` auth boundary (`server/app.ts:187`), which returns 401 whether or not timeline is mounted and independent of the route-local `requireAuth()` — do NOT cite it as proof of the new auth work.
+- Coverage boundary: the makeApp-surface test proves MOUNT (400 on bad fundId) + the admin GATE (403) + fund-scoped REACHABILITY (an authenticated `/:fundId` clears auth+scope into the service). It does NOT assert a 200 body — the eager default service (`timeline.ts:334-343`, REFL-037) runs the real DB on the makeApp surface; the functional 200 read is proven in `timeline.contract.test.ts` via `createTimelineRouter(mockService)`.
+- Cross-surface: adding route-local `requireAuth()` makes `/events/latest` return 401 on the Docker/registerRoutes surface (which populates `req.context`, not `req.user`). Safe because `useLatestEvents` has zero callers; the four fund-scoped routes are unchanged (they use `enforceProvidedFundScope`, which re-verifies the bearer token itself and builds `req.user.fundIds` from claims — `provided-fund-scope.ts:42-57`).
+- Middleware order: `requireAuth()+requireRole('admin')` run BEFORE `timelineReadLimiter` so an authz decision wins over a 429 and rate-limit state is not leaked to unauthorized callers. This is safe: tokens are HS256 (cheap synchronous HMAC — `jwt.ts:72-74,303`), and makeApp already throttles unauthenticated floods at the global 60/min limiter (`app.ts:141`) BEFORE `/api` auth runs. (The cited `fund-moic.ts:185-189` convention has no route-local limiter, so it does not by itself establish auth-before-limiter ordering.)
+
+---
+
+## Preconditions
+
+- [ ] **Step 0: Re-verify baseline before branching**
+
+Run:
+```bash
+git fetch
+git status --short
+git rev-parse --short HEAD
+```
+Expected: clean tree; `HEAD` at `458094e9` (the PR #1038 route-mount-parity guard squash) or later. Then:
+```bash
+git switch -c feat/1036-burndown-timeline-makeapp-mount
+```
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `server/routes/timeline.ts` | Timeline router; add admin gate to `/events/latest` only | Modify |
+| `server/app.ts` | makeApp prod surface; import + mount timeline | Modify |
+| `tests/unit/routes/timeline.contract.test.ts` | Router-factory contract; add `/events/latest` authz + service-call coverage | Modify |
+| `tests/unit/api/time-travel-api.test.ts` | Response-format tests; inject admin so `/events/latest` format tests still pass | Modify |
+| `tests/unit/routes/timeline-makeapp-surface.contract.test.ts` | makeApp mount reachability (400) + fund-scoped reachability + admin-gate (403); the 401 only exercises the pre-existing global `/api` boundary | Create |
+| `tests/unit/server/route-mount-parity.test.ts` | Parity ledger; drop timeline exemption, 12→11, retarget canary | Modify |
+| `tests/unit/mount-parity-migrations.test.ts` | D6 inventory; classify `timelineRouter` | Modify |
+
+Commit boundaries (each leaves the suite green):
+- **Commit 1** = Task 1 (router gate + both existing test files updated atomically).
+- **Commit 2** = Task 2 (makeApp mount + surface test + parity ledger, atomic).
+- Task 3 = negative controls + verification + PR.
+
+---
+
+## Task 1: Admin-gate `/events/latest` in the shared router
+
+**Files:**
+- Modify: `server/routes/timeline.ts` (import near line 22; route at lines 302-323)
+- Test: `tests/unit/routes/timeline.contract.test.ts`
+- Test: `tests/unit/api/time-travel-api.test.ts:38-53,455-540`
+
+- [ ] **Step 1: Add the failing authz contract tests (factory + mocked auth)**
+
+In `tests/unit/routes/timeline.contract.test.ts`, add a hoisted auth state and a `jwt` mock at the top of the mock block (immediately after the existing `vi.mock('../../../server/lib/auth/provided-fund-scope', ...)` at line 16), so `createTimelineRouter` picks up mocked `requireAuth`/`requireRole`:
+
+```typescript
+const authState = vi.hoisted(() => ({
+  user: { id: '1', role: 'admin', roles: ['admin'], fundIds: [] } as
+    | { id: string; role: string; roles: string[]; fundIds: number[] }
+    | null,
+}));
+
+vi.mock('../../../server/lib/auth/jwt', () => ({
+  requireAuth: () => (req: Request, _res: Response, next: () => void) => {
+    (req as unknown as { user: unknown }).user = authState.user;
+    next();
+  },
+  requireRole:
+    (role: string) => (req: Request, res: Response, next: () => void) => {
+      const user = (req as unknown as { user?: { role?: string } }).user;
+      if (!user || user.role !== role) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+      }
+      next();
+    },
+}));
+```
+
+Reset `authState.user` to admin in the existing `beforeEach` (after line 79 `service = makeService();`):
+
+```typescript
+    authState.user = { id: '1', role: 'admin', roles: ['admin'], fundIds: [] };
+```
+
+Then append two tests inside the `describe('timeline route contracts', ...)` block (after line 149):
+
+```typescript
+  it('GET /events/latest rejects a non-admin before reading events', async () => {
+    authState.user = { id: '9', role: 'user', roles: ['user'], fundIds: [] };
+    const res = await request(makeApp(service)).get('/api/timeline/events/latest');
+    expect(res.status).toBe(403);
+    expect(service.getLatestEvents).not.toHaveBeenCalled();
+  });
+
+  it('GET /events/latest returns events for an admin', async () => {
+    const res = await request(makeApp(service)).get('/api/timeline/events/latest?limit=5');
+    expect(res.status).toBe(200);
+    expect(service.getLatestEvents).toHaveBeenCalledWith(5, undefined);
+  });
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/timeline.contract.test.ts
+```
+Expected: FAIL — the non-admin test gets `200` (no gate yet) and `getLatestEvents` is called; the mocked `jwt` module is unused by the router.
+
+- [ ] **Step 3: Add the admin gate to the router**
+
+In `server/routes/timeline.ts`, add the import immediately after line 22 (`import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';`). Use NO `.js` extension to match this file's import style (every relative import in `timeline.ts` is extensionless) so the test's `vi.mock('../../../server/lib/auth/jwt')` resolves to the same module:
+
+```typescript
+import { requireAuth, requireRole } from '../lib/auth/jwt';
+```
+
+Change the `/events/latest` route (currently lines 302-311) so the guard runs BEFORE the rate limiter and validation (authz boundary must win over a malformed 400):
+
+```typescript
+  router.get(
+    '/events/latest',
+    requireAuth(),
+    requireRole('admin'),
+    timelineReadLimiter,
+    validateRequest({
+      query: z.object({
+        limit: z.coerce.number().int().min(1).max(100).default(20),
+        eventTypes: z.array(z.string()).optional(),
+      }),
+    }),
+    asyncHandler(async (req, res) => {
+```
+
+Leave the handler body and the four fund-scoped routes unchanged.
+
+- [ ] **Step 4: Run the contract tests to verify they pass**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/timeline.contract.test.ts
+```
+Expected: PASS — 7 tests (5 pre-existing fund-scope + 2 new).
+
+- [ ] **Step 5: Repair the response-format tests (they now hit the gate)**
+
+`tests/unit/api/time-travel-api.test.ts` mounts the default router on a bare app with no auth; its 3 `/events/latest` tests (455-540) will now `401`. Add a `jwt` mock so the injected user is admin — this file tests response FORMAT, not auth (the real auth boundary is proven in Task 2). Insert after the existing `vi.mock('../../../server/db', ...)` block (ends line 94):
+
+```typescript
+// Inject an admin user so the /events/latest admin gate passes; this file
+// verifies response format only. The real auth boundary (401/403) is proven in
+// tests/unit/routes/timeline-makeapp-surface.contract.test.ts with real tokens.
+vi.mock('../../../server/lib/auth/jwt', () => ({
+  requireAuth: () => (req: any, _res: any, next: any) => {
+    req.user = { id: '1', role: 'admin', roles: ['admin'], fundIds: [] };
+    next();
+  },
+  requireRole: (role: string) => (req: any, res: any, next: any) =>
+    req.user?.role === role ? next() : res.sendStatus(403),
+}));
+```
+
+- [ ] **Step 6: Run the format tests to verify they pass**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/api/time-travel-api.test.ts
+```
+Expected: PASS — the 3 `/events/latest` tests return `200` again; fund-scoped tests unaffected (those routes have no `requireAuth`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/routes/timeline.ts tests/unit/routes/timeline.contract.test.ts tests/unit/api/time-travel-api.test.ts
+git commit -m "feat(timeline): admin-gate /events/latest before makeApp mount (#1036)"
+```
+
+---
+
+## Task 2: Mount timeline on makeApp + surface proof + parity ledger
+
+**Files:**
+- Create: `tests/unit/routes/timeline-makeapp-surface.contract.test.ts`
+- Modify: `server/app.ts` (import near line 20; mount near line 234)
+- Modify: `tests/unit/server/route-mount-parity.test.ts:197-200,230,245-250`
+- Modify: `tests/unit/mount-parity-migrations.test.ts` (MAKEAPP_ROUTE_INVENTORY, lines 40-113)
+
+- [ ] **Step 1: Create the makeApp surface contract test (negative control first)**
+
+Create `tests/unit/routes/timeline-makeapp-surface.contract.test.ts`. Copy the env/auth harness verbatim from `tests/unit/routes/dashboard-summary-makeapp-surface.contract.test.ts` (lines 1-94: `ENV_KEYS`, `saveEnv`, `restoreEnv`, `configureTestAuthEnv`, `makeAppWithTestAuth`, `authorizationHeader`) — these are local functions, not exports, so copy them. Add a non-admin variant of the header. Then the body:
+
+```typescript
+async function nonAdminAuthorizationHeader() {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'route-surface-nonadmin@example.com',
+    role: 'user',
+    fundIds: [1],
+  })}`;
+}
+
+describe('timeline makeApp surface', () => {
+  beforeEach(() => {
+    saveEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('mounts the timeline router on the production makeApp API surface', async () => {
+    // Non-numeric fundId reaches the mounted /:fundId handler's own guard:
+    // parseTimelineFundId rejects it -> 400 { error: 'Invalid fund ID' } before
+    // any DB access. When NOT mounted, the same request falls through to the
+    // makeApp catch-all 404 { error: 'not_found' } (the mount-parity defect).
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/timeline/abc')
+      .set('Authorization', await authorizationHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'Invalid fund ID' });
+  }, 30_000);
+
+  // NOTE: this 401 comes from the PRE-EXISTING global /api auth boundary
+  // (app.ts:187), NOT from the route-local requireAuth() this PR adds -- it would
+  // 401 even if timeline were unmounted. It is a boundary sanity check, not proof
+  // of the new admin gate. The 403 test below is the proof of the new gate.
+  it('401s an unauthenticated /events/latest at the pre-existing global /api boundary', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app).get('/api/timeline/events/latest');
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  it('rejects a signed non-admin /events/latest with 403 (proves the new route-local admin gate)', async () => {
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/timeline/events/latest')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+    expect(res.status).toBe(403);
+  }, 30_000);
+
+  it('lets an authenticated fund-scoped GET /api/timeline/:fundId clear auth+scope into the service', async () => {
+    // The mount exists to fix the CLIENT's fund-scoped timeline reads (useTimelineData),
+    // so prove one actually reaches the service on makeApp. A signed token scoped to fund 1
+    // (role is irrelevant here -- the /:fundId routes use enforceProvidedFundScope, not
+    // requireRole). Assert the status is NOT 401/403/404: 404 => not mounted, 401 => global
+    // auth rejected the token, 403 => fund-scope denied. Any other status (200, or a DB-driven
+    // 500 from the eager default service / REFL-037) proves the request cleared the mount, the
+    // /api auth boundary, AND the fund-scope gate. We deliberately do NOT assert 200:
+    // timeline.ts:334-343 injects the real DB on this surface (REFL-037); the 200 body is
+    // covered by timeline.contract.test.ts via createTimelineRouter(mockService).
+    const app = await makeAppWithTestAuth();
+    const res = await request(app)
+      .get('/api/timeline/1')
+      .set('Authorization', await nonAdminAuthorizationHeader());
+
+    expect([401, 403, 404]).not.toContain(res.status);
+  }, 30_000);
+});
+```
+
+Prepend the same imports the dashboard file uses:
+```typescript
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+```
+
+- [ ] **Step 2: Run the surface test to verify the mount assertion fails (negative control #1)**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/timeline-makeapp-surface.contract.test.ts
+```
+Expected: FAIL — the mount test and the fund-scoped reachability test both get `404 { error: 'not_found' }` (timeline not mounted on makeApp yet), so `[401,403,404]` contains the status and the reachability assertion fails; the 403 admin-gate test also fails (404, not 403). The 401 test passes vacuously (the global `/api` auth boundary returns 401 whether or not timeline is mounted) — which is exactly why it is not proof of the new gate.
+
+- [ ] **Step 3: Import and mount timeline in app.ts**
+
+In `server/app.ts`, add the import immediately after line 20 (`import fundMoicRouter from './routes/fund-moic.js';`):
+
+```typescript
+import timelineRouter from './routes/timeline.js';
+```
+
+Add the mount immediately after line 234 (`app.use('/api', fundMoicRouter);`), matching the Docker mount path `/api/timeline` and placed after the global `/api` auth (line 187):
+
+```typescript
+  // Timeline / time-travel API (#1036 burn-down). Mounted here so the
+  // Vercel/makeApp surface matches the Docker routes.ts mount; without it the
+  // client's /api/timeline calls 404 in prod. /events/latest self-gates with
+  // requireAuth()+requireRole('admin') inside the router (cross-surface safe).
+  app.use('/api/timeline', timelineRouter);
+```
+
+- [ ] **Step 4: Run the surface test to verify it passes**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/timeline-makeapp-surface.contract.test.ts
+```
+Expected: PASS — 400 reachability, 401 no-token, 403 non-admin.
+
+- [ ] **Step 5: Run the parity guard to observe the expected failures**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+```
+Expected: FAIL — `route-mount-parity`: the canary "timeline is Docker-only today" now fails (`makeApp.has('./routes/timeline.js')` is `true`) and the stale-exemption check flags `./routes/timeline.js`; `mount-parity-migrations`: the D6 inventory guard fails on the unclassified `timelineRouter`.
+
+- [ ] **Step 6: Update the parity ledger**
+
+In `tests/unit/server/route-mount-parity.test.ts`:
+
+(a) DELETE the timeline exemption block (lines 197-200):
+```typescript
+  './routes/timeline.js': {
+    kind: 'gap-pending',
+    reason: 'client useTimelineData hits /api/timeline heavily -- likely real 404',
+  },
+```
+
+(b) Change the gap-pending pin (line 230) from `12` to `11`:
+```typescript
+const GAP_PENDING_COUNT = 11;
+```
+
+(c) Retarget the Docker-only canary (lines 245-250) from `timeline` to `shares`:
+```typescript
+  it('a known gap-pending router (shares) is Docker-only today', () => {
+    const docker = extractRouteModulePaths(routesSrc);
+    const makeApp = extractRouteModulePaths(appSrc);
+    expect(docker.has('./routes/shares.js')).toBe(true);
+    expect(makeApp.has('./routes/shares.js')).toBe(false);
+  });
+```
+
+- [ ] **Step 7: Classify the router in the migrations inventory**
+
+In `tests/unit/mount-parity-migrations.test.ts`, add to `MAKEAPP_ROUTE_INVENTORY` (alongside the other `other-table` entries, e.g. after line 86 `fundMetricsRouter: { kind: 'other-table' },`):
+
+```typescript
+  // TimeTravelAnalyticsService reads fund_events, fund_snapshots, funds; also
+  // funds in POST /:fundId/snapshot. None are in C1_MOUNTED_TABLES.
+  timelineRouter: { kind: 'other-table' },
+```
+
+- [ ] **Step 8: Run the parity guard to verify it passes**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+```
+Expected: PASS — all parity assertions green; gap-pending count is 11.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/app.ts tests/unit/routes/timeline-makeapp-surface.contract.test.ts tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+git commit -m "feat(routes): mount timeline router on makeApp; burn down gap-pending 12->11 (#1036)"
+```
+
+---
+
+## Task 3: Negative controls, full verification, and PR
+
+**Files:** none modified (verification only)
+
+- [ ] **Step 1: Negative control — remove only the mount (keep the import)**
+
+Temporarily comment out `app.use('/api/timeline', timelineRouter);` in `server/app.ts` (use Edit, not `git checkout`). Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/timeline-makeapp-surface.contract.test.ts
+```
+Expected: FAIL — the mount test returns makeApp `404 { error: 'not_found' }`. Restore the line and re-run; expected PASS.
+
+- [ ] **Step 2: Negative control — remove import + mount after the exemption is gone**
+
+Temporarily remove BOTH the `import timelineRouter ...` and the `app.use('/api/timeline', ...)` lines (Edit). Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/server/route-mount-parity.test.ts
+```
+Expected: FAIL — `findUnexemptedDockerOnly` flags `./routes/timeline.js` (Docker-only, no exemption). Restore both lines and re-run; expected PASS.
+
+- [ ] **Step 3: Typecheck and lint**
+
+Run:
+```powershell
+npm run check
+npm run lint
+```
+Expected: both PASS with no new errors.
+
+- [ ] **Step 4: Run the full affected server suite once**
+
+Run:
+```powershell
+$env:TZ='UTC'; npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/routes/timeline.contract.test.ts tests/unit/api/time-travel-api.test.ts tests/unit/routes/timeline-makeapp-surface.contract.test.ts tests/unit/server/route-mount-parity.test.ts tests/unit/mount-parity-migrations.test.ts
+```
+Expected: PASS — all five files green.
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin feat/1036-burndown-timeline-makeapp-mount
+gh pr create --base main --title "feat(routes): mount timeline router on makeApp (#1036 burn-down)" --body "<see PR body requirements below>"
+```
+
+PR body MUST include: route inventory (5 routes; `/events/latest` is the only all-funds route); the auth decision (route-local `requireAuth()+requireRole('admin')` per the `fund-moic.ts:185-189` convention; cross-surface-safe; `git grep -n 'useLatestEvents'` shows only the `useTimelineData.ts:165` definition => zero callers => hardening); the auth-proof labeling (the **403** proves the new gate; the **401** only exercises the pre-existing global `/api` boundary at `app.ts:187` and is NOT cited as proof of the new work; the fund-scoped reachability test proves an authenticated `/:fundId` clears auth+scope; no makeApp 200 body assertion, by REFL-037); the Docker-surface behavior note (`/events/latest` now 401s on the registerRoutes surface — safe, zero callers); the middleware-order note (auth-before-limiter is intentional and safe — HS256 HMAC + global 60/min limiter at `app.ts:141`); local verification output; BOTH negative-control red proofs (Step 1 and Step 2); diff scope; and the gap-pending 12->11 note. Non-goals: no auto-merge, no unrelated cleanup, no docs/session artifacts, no dependency changes.
+
+- [ ] **Step 6: Publication proof (do NOT arm auto-merge)**
+
+Run:
+```bash
+gh pr view <new-pr> --json statusCheckRollup,headRefOid,baseRefOid,mergeStateStatus,reviewDecision,state
+```
+Because this PR touches only `server/**` + `tests/**` (no `migrations/**` or `shared/schema/**`), the new integration/contract tests are NOT auto-run on the PR — dispatch a full run and cite it:
+```bash
+gh workflow run ci-unified.yml --ref feat/1036-burndown-timeline-makeapp-mount -f run_full_suite=true
+```
+R6 CI proof must show: no `test:quick` fallback header/path, the server glob executed, `--bail=1`, unit-fast green, and a live `statusCheckRollup`. Do not claim dot-reporter logs contain specific test filenames.
+
+---
+
+## Notes / risks (not tasks)
+
+- **REFL-010 (trust proxy):** timeline's `timelineReadLimiter`/`timelineWriteLimiter` key on `req.ip`. This is pre-existing infra shared with `flagsRouter` etc. already on makeApp; no change needed here, but if prod rate-limiting misbehaves post-deploy, verify `app.set('trust proxy', ...)` on the makeApp surface.
+- **REFL-037 (eager service):** `timeline.ts` instantiates its default service at import (lines 334-343). That is why the "admin 200 + calls `getLatestEvents`" assertion lives in `timeline.contract.test.ts` via `createTimelineRouter(mockService)`, and the makeApp-surface test asserts only reachability + the DB-free auth boundary. Do NOT try to assert a service call through `makeApp`. (The eager service constructor only stores `db`/`cache` refs — `time-travel-analytics.ts:123-128` — so the import itself is cold-start-safe; DB access happens when a handler runs.)
+- **Middleware order (debate finding, adjudicated):** the admin guard runs BEFORE `timelineReadLimiter` on `/events/latest`. Intentional (authz wins over a 429; no rate-limit-state leak to unauthorized callers) and safe — HS256 tokens verify via a cheap synchronous HMAC (`server/lib/auth/jwt.ts:72-74,303`), and makeApp already throttles unauthenticated floods at the global 60/min limiter (`server/app.ts:141`) before `/api` auth runs. The `agy` lane argued for limiter-first on an RS256/JWKS CPU-exhaustion premise; that premise does not hold for this HS256 codebase (the RS256 path is conditional, key-cached, and self-caps at `jwksRequestsPerMinute: 10`), so the order is kept. Full scrutiny: `.claude/artifacts/timeline-makeapp-debate.md`.
+- **Docs governance:** this plan file lives under `docs/superpowers/plans/` (tracked). If committed, run `npm run docs:routing:generate` after `git add` so "Validate Discovery Routing" does not fail on a new `docs/**/*.md`. It is not required for the code change.
+- **`any` in tests:** the `jwt` mock in `time-travel-api.test.ts` uses `any` to match that file's existing quarantined mock style; `timeline.contract.test.ts` uses typed `Request`/`Response` to match its style.

--- a/docs/superpowers/plans/2026-07-08-client-api-auth-model-decision.md
+++ b/docs/superpowers/plans/2026-07-08-client-api-auth-model-decision.md
@@ -1,0 +1,147 @@
+# Client → /api Auth Model — Decision & Scoping Doc
+
+Status: **DRAFT / STEP 0 RESOLVED: CASE B + runtime blocker** (see Step 0)
+Date: 2026-07-08
+Owner: (GP / solo dev)
+Related: route-mount-parity burn-down #1036 (PRs #1038–#1050); memory topic `project_route_mount_parity_guard_1036`
+
+---
+
+## 1. Why this doc exists
+
+The #1036 burn-down mounted 7 previously Docker-only routers onto the prod
+`makeApp` surface (timeline, shares, capital-allocation, liquidity, graduation,
+portfolio-companies, portfolio-overview). Those mounts close the *silent 404*
+class — but they only convert prod `404 → 401`, **not** `404 → 200`, because of a
+deeper gap: **there is no working first-party end-to-end auth flow in this repo.**
+
+This doc frames the decision, gates it on the one fact the repo cannot answer,
+and lays out the auth-model options so implementation (if needed) can start from a
+chosen design rather than a guess.
+
+## 2. Verified current state (traced 2026-07-08)
+
+| Seam | Fact | Source |
+|---|---|---|
+| Server gate | `requireAuth` accepts **only** `Authorization: Bearer <jwt>`; no token → `401`. Never reads a cookie. | `server/lib/auth/jwt.ts:218-221` |
+| Verify side | `verifyAccessTokenAsync` supports HS256 **and** RS256. Works; exercised by tests. | `server/lib/auth/jwt.ts` |
+| Token issuance | `signToken` exists but has **zero production callers**. No `/login` route, no `res.cookie`, no session middleware anywhere in `server/` or `api/`. | repo-wide grep |
+| Client | `queryClient.ts` sends `credentials:'include'` (cookies) and stores **no** token (all `localStorage` is non-auth caches). | `client/src/lib/queryClient.ts:71,102` |
+| Edge | `api/[...slug].ts` just calls `makeApp()`; no edge auth injection/verification. | `api/[...slug].ts:20-26` |
+| External IdP | None (no Clerk/Auth0/Supabase/NextAuth/etc. in `package.json`). | `package.json` |
+| Config | `REQUIRE_AUTH` defaults `true`. Only user-injection path is `assignDevelopmentUser`, gated to `NODE_ENV=development && !REQUIRE_AUTH` (the local-dev bypass). | `server/config/index.ts:207`, `jwt.ts:223` |
+| Fund scope | Downstream authz (`enforceProvidedFundScope`, `requireAnyRole`) is already built and correct — it just sits *behind* the missing front door. | burn-down PRs |
+
+**Net:** the app can *verify* a JWT (and tests mint them via `scopedAuthorizationHeader`), but nothing *issues* one to a real browser, and the browser holds none. The "front door" (login → credential → attach on every request) does not exist.
+
+## 3. Step 0 — production auth setting
+
+The repo cannot tell us how prod actually behaves. Get **one fact** before anything else:
+
+```
+vercel env ls           # or the Vercel dashboard → Project → Settings → Environment Variables
+```
+
+Look for `REQUIRE_AUTH` (and any auth/deployment-protection proxy in front of the app).
+
+### Result captured 2026-07-09
+
+Command:
+
+```
+vercel env ls production --no-color
+```
+
+Result: production env listed `ALLOWED_ORIGINS`, `ENABLE_QUEUES`, `CLIENT_URL`,
+`CORS_ORIGIN`, `METRICS_KEY`, `HEALTH_KEY`, `JWT_SECRET`, `SESSION_SECRET`,
+`REDIS_URL`, `DATABASE_URL_UNPOOLED`, `DATABASE_URL`, and `VITE_API_BASE_URL`;
+it did **not** list `REQUIRE_AUTH`.
+
+Code consequence: `server/config/index.ts` defaults `REQUIRE_AUTH` to `true`, so
+prod is **not** Case A. Treat the auth-model decision as **Case B** unless a
+separate perimeter/proxy is proven to inject a browser credential.
+
+Runtime wrinkle: unauthenticated probes to `/api/flags`, `/api/version`,
+`/api/timeline/1?limit=1`, and `/api/public/shares/not-a-real-share/verify`
+returned `500`, not the expected guarded-route `401`/public-route response.
+Vercel runtime logs for `/api/flags` showed:
+
+```
+Failed to initialize Express app: Error [ERR_REQUIRE_ESM]: require() of ES Module
+/var/task/node_modules/jose/dist/webapi/index.js from
+/var/task/node_modules/jwks-rsa/src/utils.js not supported.
+```
+
+Action before auth-feature work: fix the serverless import crash, redeploy, then
+re-probe a guarded route such as `/api/timeline/1` without a token. Expected
+post-fix behavior is `401` for guarded `/api` routes, confirming the browser
+still has no credential path. Do not use `/api/flags` as the auth probe; it is
+intentionally public via `isPublicApiPath`.
+
+- **Case A — `REQUIRE_AUTH=0` (or unset→but default is true, so must be explicitly 0):**
+  The burn-down mounts are **already reachable** in prod (`404 → 200`). There is **no `401` gap to fix**. Action: close this item; write a 3-line REFL/ADR recording "prod runs REQUIRE_AUTH=0; the `/api` Bearer gate is inert in prod" so no future session re-chases it. **Stop here.**
+- **Case B — `REQUIRE_AUTH=1`:**
+  The browser genuinely cannot reach guarded `/api` routes and never could. This is a **net-new auth feature**, not a wiring fix. Proceed to §4.
+
+> Do **not** write code before this fact is known. Building either direction against an unknown prod config is the anti-pattern this doc exists to prevent.
+
+## 4. Case B — auth-model options
+
+Downstream authz already exists; the decision is only **how a browser proves identity on every `/api` call.** Three coherent models:
+
+### Option 1 — First-party cookie session (server-issued, httpOnly)
+- Add a `/api/auth/login` (+ `/logout`, `/me`) that verifies credentials and sets an **httpOnly, Secure, SameSite** session cookie (a JWT or an opaque session id).
+- Teach `requireAuth` to accept the cookie **in addition to** `Bearer` (keep Bearer for tests/service-to-service).
+- The client already sends `credentials:'include'` → **zero client fetch changes**.
+- Cost: build login/logout/me + credential store (who are the users? password? magic link? invite?), **CSRF protection** (cookies are auto-sent → need same-site + CSRF token or double-submit), cookie rotation/expiry.
+- Best when: the app owns its users and you want minimal client churn.
+
+### Option 2 — Bearer + client token store
+- `/api/auth/login` returns a JWT; client stores it (in-memory + refresh, or `localStorage`) and attaches `Authorization: Bearer` on every request (via `apiRequest` + `getQueryFn`).
+- `requireAuth` stays exactly as-is (already Bearer-only) → **zero server gate changes**.
+- Cost: build login + **refresh-token rotation**, touch **every** client fetch path to attach the header (raw-fetch hooks + shared `apiRequest`), XSS-exposure of a readable token (mitigate with short-lived access + httpOnly refresh cookie — which reintroduces Option 1's cookie work).
+- Best when: you also need non-browser API clients (mobile, CLI, partners).
+
+### Option 3 — External IdP (Auth0 / Clerk / Vercel deployment protection)
+- Delegate identity to a provider; the app verifies provider-issued tokens (RS256 path already supported by `verifyAccessTokenAsync`).
+- Cost: vendor + config + mapping provider claims → `req.user` (role/fund scope); least *code*, most *integration/ops*.
+- Best when: you want SSO/enterprise login and don't want to own credential storage.
+
+### Non-negotiable constraints (all options)
+1. **Do NOT** route a hook through `apiRequest` and call it fixed — cookies ≠ Bearer; documented non-fix (memory `project_secondary_surface_lp_paused` / systemic client-auth finding).
+2. **Do NOT** ship half a session system (cookie without CSRF, or token without rotation) — worse than none.
+3. Reuse `verifyAccessTokenAsync` (HS256/RS256) and `enforceProvidedFundScope`/`requireAnyRole` — do not fork the authz side.
+4. Mind `isPublicApiPath` (`public-api-boundary.ts`) — the shares `/api/public/*` anonymous bypass must stay intact and not become an auth hole (REFL-013 substring-matching risk).
+5. Vercel: set `trust proxy` correctly if any auth/rate-limit reads client IP (REFL-010).
+6. `REQUIRE_AUTH` default stays `true`; the dev bypass (`assignDevelopmentUser`) must remain dev-only.
+
+## 5. Recommendation
+
+- **Step 0 result is Case B.** Production does not define `REQUIRE_AUTH`, and
+  the repo default is `true`; do not pursue Case A unless a future env check
+  shows production explicitly set to `REQUIRE_AUTH=0`.
+- For the auth-feature design, default to **Option 1 (cookie session)** —
+  smallest client blast radius (the client is already cookie-ready), and this
+  is an internal tool that owns its (small) user set, so full IdP is overkill.
+  Escalate to Option 3 only if SSO/enterprise login is a real requirement.
+- Treat Option 2 as a fallback only if a non-browser API client appears.
+
+## 6. Rough scope (Case B / Option 1)
+
+Milestone-sized, sequence:
+1. Credential model decision (password vs magic-link vs invite-only) + user store.
+2. `/api/auth/{login,logout,me}` + httpOnly cookie issuance/rotation + CSRF.
+3. `requireAuth` accepts cookie ∨ Bearer (add cookie branch, keep Bearer).
+4. Client `/login` UI + `useAuth`/session bootstrap + 401 → redirect.
+5. E2E: unauthenticated → login → the 7 burn-down routes now `200`.
+6. ADR in `DECISIONS.md`; REFL for the auth boundary.
+
+**Not** a one-PR fix. Warrants `superpowers:brainstorm` on the credential model before coding.
+
+## 7. Open questions (for the human)
+- **Prod `REQUIRE_AUTH` value?** Resolved 2026-07-09: not present in production
+  `vercel env ls`; repo default is `true`. Reconfirm only after deployment/env
+  changes.
+- Who are the users, and how do they authenticate today (if at all)? Is there an existing SSO/IdP expectation for Press On Ventures?
+- Is any non-browser client (mobile/CLI/partner) in scope? (Bearer vs cookie.)
+- Is login even desired in-app, or is access controlled entirely by Vercel deployment protection / network perimeter?

--- a/server/lib/auth/jwt.ts
+++ b/server/lib/auth/jwt.ts
@@ -33,29 +33,41 @@ function getJwtConfig() {
 
 // JWKS client singleton for RS256 (lazy initialized)
 type JwksClientInstance = import('jwks-rsa').JwksClient;
-type JwksClientFactory = (options: import('jwks-rsa').Options) => JwksClientInstance;
+type JwksClientOptions = import('jwks-rsa').Options;
+type JwksClientFactory = (options: JwksClientOptions) => JwksClientInstance;
+type JwksRsaModule = {
+  default?: JwksClientFactory;
+} & JwksClientFactory;
 
-let jwksClientInstance: JwksClientInstance | null = null;
+let jwksClientPromise: Promise<JwksClientInstance> | null = null;
 
-async function getJwksClient(): Promise<JwksClientInstance> {
-  const cfg = getJwtConfig();
-  if (!jwksClientInstance && cfg.JWT_JWKS_URL) {
-    const jwksRsaModule = (await import('jwks-rsa')) as unknown as {
-      default?: JwksClientFactory;
-    } & JwksClientFactory;
-    const createJwksClient = jwksRsaModule.default ?? jwksRsaModule;
-    jwksClientInstance = createJwksClient({
-      jwksUri: cfg.JWT_JWKS_URL,
-      cache: true,
-      cacheMaxAge: 600000, // 10 minutes
-      rateLimit: true,
-      jwksRequestsPerMinute: 10,
-    });
+async function createJwksClient(jwksUri: string): Promise<JwksClientInstance> {
+  const jwksRsaModule = (await import('jwks-rsa')) as unknown as JwksRsaModule;
+  const createJwksClientInstance = jwksRsaModule.default ?? jwksRsaModule;
+  return createJwksClientInstance({
+    jwksUri,
+    cache: true,
+    cacheMaxAge: 600000, // 10 minutes
+    rateLimit: true,
+    jwksRequestsPerMinute: 10,
+  });
+}
+
+function getJwksClient(): Promise<JwksClientInstance> {
+  if (jwksClientPromise) {
+    return jwksClientPromise;
   }
-  if (!jwksClientInstance) {
+
+  const cfg = getJwtConfig();
+  if (!cfg.JWT_JWKS_URL) {
     throw new Error('JWKS client not initialized - JWT_JWKS_URL required for RS256');
   }
-  return jwksClientInstance;
+
+  jwksClientPromise = createJwksClient(cfg.JWT_JWKS_URL).catch((err: unknown) => {
+    jwksClientPromise = null;
+    throw err;
+  });
+  return jwksClientPromise;
 }
 
 /**

--- a/server/lib/auth/jwt.ts
+++ b/server/lib/auth/jwt.ts
@@ -11,7 +11,6 @@
 
 import type { Algorithm, JwtPayload } from 'jsonwebtoken';
 import jwt from 'jsonwebtoken';
-import jwksClient from 'jwks-rsa';
 import type { Request, Response, NextFunction } from 'express';
 import { parseFundIdParam } from '@shared/number';
 import { getConfig } from '../../config';
@@ -33,12 +32,19 @@ function getJwtConfig() {
 }
 
 // JWKS client singleton for RS256 (lazy initialized)
-let jwksClientInstance: jwksClient.JwksClient | null = null;
+type JwksClientInstance = import('jwks-rsa').JwksClient;
+type JwksClientFactory = (options: import('jwks-rsa').Options) => JwksClientInstance;
 
-function getJwksClient(): jwksClient.JwksClient {
+let jwksClientInstance: JwksClientInstance | null = null;
+
+async function getJwksClient(): Promise<JwksClientInstance> {
   const cfg = getJwtConfig();
   if (!jwksClientInstance && cfg.JWT_JWKS_URL) {
-    jwksClientInstance = jwksClient({
+    const jwksRsaModule = (await import('jwks-rsa')) as unknown as {
+      default?: JwksClientFactory;
+    } & JwksClientFactory;
+    const createJwksClient = jwksRsaModule.default ?? jwksRsaModule;
+    jwksClientInstance = createJwksClient({
       jwksUri: cfg.JWT_JWKS_URL,
       cache: true,
       cacheMaxAge: 600000, // 10 minutes
@@ -56,7 +62,7 @@ function getJwksClient(): jwksClient.JwksClient {
  * Get signing key from JWKS endpoint for RS256 verification
  */
 async function getSigningKey(kid: string): Promise<string> {
-  const client = getJwksClient();
+  const client = await getJwksClient();
   const key = await client.getSigningKey(kid);
   return key.getPublicKey();
 }

--- a/tests/unit/bootstrap/import-smoke.test.ts
+++ b/tests/unit/bootstrap/import-smoke.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
 
 /**
@@ -29,6 +31,12 @@ describe('import-smoke: side-effect-free module loading', () => {
     expect(typeof mod.verifyAccessTokenAsync).toBe('function');
     expect(typeof mod.signToken).toBe('function');
     expect(typeof mod.requireAuth).toBe('function');
+  });
+
+  it('lib/auth/jwt does not statically import jwks-rsa', async () => {
+    const source = await readFile(resolve(process.cwd(), 'server/lib/auth/jwt.ts'), 'utf8');
+
+    expect(source).not.toMatch(/^import(?!\s+type\b)[^;]*['"]jwks-rsa['"];?/m);
   });
 
   it('lib/secure-context exports types and functions without DB access', async () => {


### PR DESCRIPTION
The production serverless bundle was failing during Express app initialization because jwks-rsa loaded jose through a CommonJS require path before any request reached requireAuth. The auth model still needs a separate Case B decision, but the immediate runtime blocker is to keep the JWKS client off the top-level HS256 import path.

The committed plan drafts preserve the route-mount and auth-model evidence that led to this fix, including the production REQUIRE_AUTH check and the correct guarded repro path.

Constraint: Vercel serverless production uses HS256 today, while jwks-rsa 4.1.0 can crash on cold import through jose ESM interop

Rejected: Build a browser login/session feature in this commit | Step 0 makes that a separate net-new auth feature

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Keep jwks-rsa off the top-level auth import path unless RS256 production is explicitly re-proven

Tested: npx tsc -p tsconfig.server.json --noEmit --pretty false

Tested: npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/bootstrap/import-smoke.test.ts tests/unit/auth/requireAuth.test.ts

Tested: node scripts/build-vercel-api.mjs

Tested: Local generated Vercel bundle GET /api/timeline/1 returned 401 without a bearer token

Not-tested: Live Vercel redeploy and production re-probe

Not-tested: RS256 JWKS runtime branch