### PR TITLE
feat(trust): reserve input + MOIC facts provenance (sequential-trust Tasks 0-4)

### DIFF
--- a/client/src/hooks/use-moic.ts
+++ b/client/src/hooks/use-moic.ts
@@ -10,6 +10,9 @@ import {
   type FundMoicRankingsResponseV2,
 } from '@shared/contracts/fund-moic-v2.contract';
 
+export type FundMoicActualsProvenanceSummary =
+  FundMoicRankingsResponseV2['actualsProvenanceSummary'];
+
 export type FundMoicRankingsHookError = Error & {
   code?: 'CONTRACT_PARSE_ERROR';
   status?: number;

--- a/client/src/pages/fund-model-results-moic-analysis.tsx
+++ b/client/src/pages/fund-model-results-moic-analysis.tsx
@@ -20,6 +20,7 @@ type FundIdParseResult =
 
 type FundMoicRankingV2 = FundMoicRankingsResponseV2['rankings'][number];
 type LatestReconciliationV2 = FundMoicRankingsResponseV2['latestReconciliation'];
+type ActualsProvenanceSummaryV2 = FundMoicRankingsResponseV2['actualsProvenanceSummary'];
 
 const ACTIVATION_BLOCKER_LABELS: Record<string, string> = {
   accepted_reconciliation_required: 'Accepted reconciliation required',
@@ -83,6 +84,20 @@ function formatUnreconciledEdits(hasUnreconciledEdits: boolean): string {
 
 function formatBlockingCount(count: number, label: string): string {
   return count > 0 ? `${count} blocking (${label})` : '0';
+}
+
+function formatFactsInputHash(summary: ActualsProvenanceSummaryV2): string {
+  return summary.factsInputHash ?? 'unavailable';
+}
+
+function formatFactsTrust(summary: ActualsProvenanceSummaryV2): string {
+  const counts = summary.trustStateCounts;
+  return [
+    `LIVE ${counts.LIVE}`,
+    `PARTIAL ${counts.PARTIAL}`,
+    `UNAVAILABLE ${counts.UNAVAILABLE}`,
+    `FAILED ${counts.FAILED}`,
+  ].join(', ');
 }
 
 function formatMappedCode(code: string, labels: Record<string, string>): string {
@@ -210,6 +225,7 @@ function ProvenanceStrip({ data }: { data: FundMoicRankingsResponseV2 }) {
     data.moicInputSummary.activationBlockingDefaultedExitProbabilityCount;
   const reserveMultipleCount =
     data.moicInputSummary.activationBlockingDefaultedReserveExitMultipleCount;
+  const actualsSummary = data.actualsProvenanceSummary;
 
   return (
     <Card className="border-beige-200 bg-pov-white">
@@ -219,6 +235,24 @@ function ProvenanceStrip({ data }: { data: FundMoicRankingsResponseV2 }) {
           <p className="font-semibold text-pov-charcoal">
             {formatRankingsSource(data.provenance.mode)}
           </p>
+        </div>
+
+        <div className="grid gap-3 rounded-md border border-beige-200 bg-pov-gray p-3 md:grid-cols-4">
+          <StatusField
+            label="Facts status"
+            value={actualsSummary.factsStatus}
+            tone={actualsSummary.factsStatus === 'failed' ? 'warning' : 'default'}
+          />
+          <StatusField label="Facts input hash" value={formatFactsInputHash(actualsSummary)} />
+          <StatusField
+            label="Facts trust"
+            value={formatFactsTrust(actualsSummary)}
+            tone={actualsSummary.trustStateCounts.FAILED > 0 ? 'warning' : 'default'}
+          />
+          <StatusField
+            label="Defaulted economic inputs"
+            value={String(actualsSummary.defaultedEconomicInputCount)}
+          />
         </div>
 
         {data.modePreview.killSwitchActive ? (

--- a/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
+++ b/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
@@ -1,0 +1,26 @@
+# ADR-033: Marginal Next-Dollar Reserve MOIC Model
+
+## Status
+
+Proposed
+
+## Context
+
+The current planned-reserves MOIC path ranks existing planned reserves using reserve exit multiple and exit probability inputs. That is not a full marginal next-dollar opportunity-cost model because it does not derive incremental ownership, future dilution, subsequent rounds, staged probabilities, or delta expected proceeds.
+
+## Decision
+
+Keep #1021 scoped to facts/provenance integration. Model true marginal reserve return in a separate lane that calculates:
+
+```text
+delta probability-weighted expected proceeds / delta reserve capital deployed
+```
+
+The model must include prospective check size, round price, incremental ownership, future dilution, follow-on participation, staged exit/failure assumptions, and explicit expected-value weighting.
+
+## Consequences
+
+- Planned-reserves MOIC can be labeled assumption-based until this ADR is implemented.
+- #1021 cannot claim marginal next-dollar opportunity cost.
+- A missing exit probability or reserve exit multiple cannot silently become trusted input.
+- Investment-team calibration is required before production activation.

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -6,12 +6,19 @@ import {
   FundMoicRankingsResponseV2Schema,
   type FundMoicRankingsResponseV2,
 } from '../../shared/contracts/fund-moic-v2.contract.js';
+import { logger } from '../lib/logger.js';
 import { FundIdParamSchema } from '../../shared/schemas/portfolio-route.js';
 import {
   assessMoicMateriality,
   MOIC_MATERIALITY_EPSILON,
 } from '../services/fund-moic-materiality.js';
-import { getFundMoicRankingSources } from '../services/fund-moic-ranking-service.js';
+import {
+  getFundMoicRankingSources,
+  summarizeMoicActualsProvenance,
+} from '../services/fund-moic-ranking-service.js';
+import {
+  buildFundCompanyActualsFacts,
+} from '../services/fund-actuals/fund-company-actuals-facts-service.js';
 import {
   getLatestCompletedMoicReconciliation,
   MoicReconciliationConflictError,
@@ -135,6 +142,49 @@ router.get(
       getLatestCompletedMoicReconciliation(fundId),
       buildRoundsToModelEvidence({ fundId }),
     ]);
+    // TODO(perf): this loads the full company-actuals facts corpus (~6 queries + hash in
+    // fund-company-actuals-facts-service) only to tally trustState counts; per-company facts
+    // are not used in ranking values. MOIC analysis is a low-frequency GP page today, so ship
+    // as-is, but memoize per (fundId, asOfDate) or expose a count-only facts helper if this page
+    // becomes polled or the corpus grows. Tracked as a separate low-priority GitHub perf issue.
+    const actualsAsOfDate = new Date().toISOString().slice(0, 10);
+    const sourceCompanyCount = sources.legacy.provenance.sourceRecordCount;
+    let actualsProvenanceSummary: ReturnType<typeof summarizeMoicActualsProvenance>;
+
+    try {
+      const actualsFacts = await buildFundCompanyActualsFacts({
+        fundId,
+        asOfDate: actualsAsOfDate,
+      });
+      actualsProvenanceSummary = summarizeMoicActualsProvenance({
+        factsStatus: 'available',
+        factsInputHash: actualsFacts.inputHash,
+        trustStates: actualsFacts.facts.map((fact) => fact.provenance.trustState),
+        defaultedEconomicInputCount:
+          sources.moicInputSummary.defaultedExitProbabilityCount +
+          sources.moicInputSummary.defaultedReserveExitMultipleCount,
+      });
+    } catch (error) {
+      // Disclosed to the client via warnings, but not silent server-side: operators need the reason.
+      logger.warn(
+        {
+          fundId,
+          asOfDate: actualsAsOfDate,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'fund-moic v2 actuals facts load failed; returning UNAVAILABLE provenance summary'
+      );
+      actualsProvenanceSummary = summarizeMoicActualsProvenance({
+        factsStatus: 'failed',
+        factsInputHash: null,
+        trustStates: Array.from({ length: sourceCompanyCount }, () => 'UNAVAILABLE'),
+        defaultedEconomicInputCount:
+          sources.moicInputSummary.defaultedExitProbabilityCount +
+          sources.moicInputSummary.defaultedReserveExitMultipleCount,
+        warnings: ['actuals_facts_failed'],
+      });
+    }
+
     const modePreview = await resolveFundCalculationMode({ fundId, sources });
     const actionability = await resolveMoicActionability({ fundId, sources, evidence });
     const usingCandidateRankings =
@@ -174,6 +224,7 @@ router.get(
       },
       modePreview,
       moicInputSummary: sources.moicInputSummary,
+      actualsProvenanceSummary,
       roundEvidenceSummary: roundEvidenceSummary(evidence.coverage),
       generatedAt: new Date().toISOString(),
     };

--- a/server/services/fund-moic-ranking-service.ts
+++ b/server/services/fund-moic-ranking-service.ts
@@ -25,6 +25,28 @@ export interface FundMoicRankingSources {
   moicSourceInputHash: string;
 }
 
+export function summarizeMoicActualsProvenance(input: {
+  factsStatus: 'available' | 'failed';
+  factsInputHash: string | null;
+  trustStates: Array<'LIVE' | 'PARTIAL' | 'UNAVAILABLE' | 'FAILED'>;
+  defaultedEconomicInputCount: number;
+  warnings?: Array<'actuals_facts_failed'>;
+}) {
+  return {
+    factsStatus: input.factsStatus,
+    factsInputHash: input.factsInputHash,
+    companyCount: input.trustStates.length,
+    trustStateCounts: {
+      LIVE: input.trustStates.filter((state) => state === 'LIVE').length,
+      PARTIAL: input.trustStates.filter((state) => state === 'PARTIAL').length,
+      UNAVAILABLE: input.trustStates.filter((state) => state === 'UNAVAILABLE').length,
+      FAILED: input.trustStates.filter((state) => state === 'FAILED').length,
+    },
+    defaultedEconomicInputCount: input.defaultedEconomicInputCount,
+    warnings: input.warnings ?? [],
+  };
+}
+
 type PortfolioCompanyMoicSourceRow = {
   id: number;
   fundId?: number | null;

--- a/server/services/fund-scenario-reserve-calculation-service.ts
+++ b/server/services/fund-scenario-reserve-calculation-service.ts
@@ -11,7 +11,8 @@ import {
   FUND_SCENARIOS_CONTRACT_VERSION,
   SCENARIO_INPUT_HASH_VERSION,
 } from '@shared/lib/scenarios/scenario-input-envelope';
-import { buildReservePortfolioInputForClient } from './reserve-input-builder';
+import { buildReservePortfolioInputForClientWithProvenance } from './reserve-input-builder';
+import type { ReserveInputTrustSummary } from '../../shared/contracts/reserve-input-provenance.contract';
 import { buildScenarioReserveSummary } from './fund-scenario-reserve-summary';
 import {
   FUND_SCENARIO_CALC_VERSION,
@@ -38,7 +39,9 @@ type ReserveScenarioVariant = Extract<
   FundScenarioCalculationPayloadV1['variants'][number],
   { overrideType: 'reserve_allocation' }
 >;
-type ReserveScenarioPortfolio = Awaited<ReturnType<typeof buildReservePortfolioInputForClient>>;
+type ReserveScenarioPortfolio = Awaited<
+  ReturnType<typeof buildReservePortfolioInputForClientWithProvenance>
+>['portfolio'];
 
 interface SourceConfigRow {
   id: number;
@@ -73,6 +76,7 @@ interface ReserveScenarioCalculationData {
   variants: ReserveScenarioVariant[];
   warningCount: number;
   payload: FundScenarioCalculationPayloadV1;
+  reserveInputTrustSummary: ReserveInputTrustSummary;
 }
 
 export interface ReserveScenarioCalculationIdentity {
@@ -473,7 +477,8 @@ async function buildReserveScenarioCalculationData(
   input: RunReserveScenarioCalculationInput,
   context: ReserveScenarioRunContext
 ): Promise<ReserveScenarioCalculationData> {
-  const portfolio = await buildReservePortfolioInputForClient(client, input.fundId);
+  const { portfolio, reserveInputTrustSummary } =
+    await buildReservePortfolioInputForClientWithProvenance(client, input.fundId);
   const fundSizeCents = await loadFundSizeCents(client, input.fundId);
   const variants = buildReserveScenarioVariants({
     fundId: input.fundId,
@@ -490,7 +495,7 @@ async function buildReserveScenarioCalculationData(
     variants,
   });
 
-  return { portfolio, variants, warningCount, payload };
+  return { portfolio, variants, warningCount, payload, reserveInputTrustSummary };
 }
 
 async function persistReserveScenarioCalculation(
@@ -510,6 +515,7 @@ async function persistReserveScenarioCalculation(
     variantCount: data.variants.length,
     companyCount: data.portfolio.length,
     warningCount: data.warningCount,
+    reserveInputTrustSummary: data.reserveInputTrustSummary,
   });
 
   await recordCalculatedReserveScenarioEvent(client, input, {

--- a/server/services/fund-scenario-reserve-snapshot-store.ts
+++ b/server/services/fund-scenario-reserve-snapshot-store.ts
@@ -6,6 +6,8 @@ import {
   type FundScenarioCalculationResponseV1,
   type FundScenarioResultStalenessStateV1,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
+import { canonicalSha256 } from '../../shared/lib/canonical-hash';
+import type { ReserveInputTrustSummary } from '../../shared/contracts/reserve-input-provenance.contract';
 import { createHttpError } from './fund-scenario-set-service.js';
 
 export const ASYNC_RESERVE_TIMEOUT_MS = 300_000;
@@ -69,6 +71,7 @@ export interface ReserveScenarioSnapshotInput {
   variantCount: number;
   companyCount: number;
   warningCount: number;
+  reserveInputTrustSummary: ReserveInputTrustSummary;
 }
 
 function parseJsonPayload(value: unknown): unknown {
@@ -90,6 +93,11 @@ function responseFromSnapshot(row: SnapshotRow): FundScenarioCalculationResponse
 }
 
 function reserveScenarioSnapshotMetadata(input: ReserveScenarioSnapshotInput) {
+  const reserveInputTrustSummaryHash = canonicalSha256({
+    kind: 'reserve_input_trust_summary',
+    summary: input.reserveInputTrustSummary,
+  });
+
   return {
     input_hash: input.inputHash,
     calculation_mode: 'async_reserve_allocation',
@@ -98,6 +106,8 @@ function reserveScenarioSnapshotMetadata(input: ReserveScenarioSnapshotInput) {
     company_count: input.companyCount,
     warning_count: input.warningCount,
     override_type: 'reserve_allocation',
+    reserve_input_trust_summary: input.reserveInputTrustSummary,
+    reserve_input_trust_summary_hash: reserveInputTrustSummaryHash,
   };
 }
 

--- a/server/services/reserve-calculation-service.ts
+++ b/server/services/reserve-calculation-service.ts
@@ -3,7 +3,7 @@ import { fundSnapshots } from '@shared/schema';
 import { generateReserveSummary } from '@shared/core/reserves/ReserveEngine';
 import { resolveMoicActionability, toH9SnapshotColumns } from './fund-calculation-mode-service';
 import { markCalcRunCompletedIfReady } from './calc-run-tracking';
-import { buildReservePortfolioInput } from './reserve-input-builder';
+import { buildReservePortfolioInputWithProvenance } from './reserve-input-builder';
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
@@ -57,7 +57,10 @@ export async function runReserveCalculation({
     throw new Error(`Fund ${fundId} not found`);
   }
 
-  const portfolio = await retryWithBackoff(() => buildReservePortfolioInput(fundId));
+  const {
+    portfolio,
+    reserveInputTrustSummary,
+  } = await retryWithBackoff(() => buildReservePortfolioInputWithProvenance(fundId));
 
   const reserves = generateReserveSummary(fundId, portfolio);
   // H9: stamp the actionability fingerprint onto the authoritative snapshot so
@@ -81,6 +84,7 @@ export async function runReserveCalculation({
       metadata: {
         portfolioCount: portfolio.length,
         engineRuntime: performance.now() - startTime,
+        reserveInputTrustSummary,
       },
     })
     .returning();

--- a/server/services/reserve-input-builder.ts
+++ b/server/services/reserve-input-builder.ts
@@ -1,6 +1,10 @@
 import type { PoolClient } from 'pg';
 import { db } from '../db';
 import type { ReserveCompanyInput } from '@shared/types';
+import type {
+  ReserveCompanyInputWithProvenance,
+  ReserveInputTrustSummary,
+} from '../../shared/contracts/reserve-input-provenance.contract';
 
 interface InvestmentPortfolioRow {
   id: number;
@@ -31,61 +35,175 @@ function toNumber(value: string | number | null | undefined, fallback = 0): numb
   return fallback;
 }
 
-function investmentRowToPortfolio(row: InvestmentPortfolioRow): ReserveCompanyInput {
+export interface ReservePortfolioInputWithTrust {
+  portfolio: ReserveCompanyInput[];
+  provenancePortfolio: ReserveCompanyInputWithProvenance[];
+  reserveInputTrustSummary: ReserveInputTrustSummary;
+}
+
+export function buildReservePortfolioInputWithProvenanceFromRows(input: {
+  investments: InvestmentPortfolioRow[];
+  companies: PortfolioCompanyRow[];
+}): ReserveCompanyInputWithProvenance[] {
+  if (input.investments.length > 0) {
+    return input.investments.map(investmentRowToPortfolioWithProvenance);
+  }
+  return input.companies.map(companyRowToPortfolioWithProvenance);
+}
+
+export function buildReserveInputTrustSummary(
+  portfolio: ReserveCompanyInputWithProvenance[]
+): ReserveInputTrustSummary {
+  const fields = portfolio.flatMap((company) => Object.entries(company.provenance));
+  const defaultedFields = fields
+    .filter(([, provenance]) => provenance.status === 'defaulted')
+    .map(([field]) => field as 'invested' | 'ownership' | 'stage' | 'sector');
+  const unavailableFields = fields
+    .filter(([, provenance]) => provenance.status === 'unavailable')
+    .map(([field]) => field as 'invested' | 'ownership' | 'stage' | 'sector');
+
   return {
-    id: row.company_id ?? row.id,
-    invested: toNumber(row.amount),
-    ownership: toNumber(row.ownership_percentage, 0.15),
-    stage: row.round ?? 'seed',
-    sector: row.sector ?? 'unknown',
+    trustedForActivation: defaultedFields.length === 0 && unavailableFields.length === 0,
+    defaultedInputCount: defaultedFields.length,
+    unavailableInputCount: unavailableFields.length,
+    defaultedFields: [...new Set(defaultedFields)].sort(),
+    unavailableFields: [...new Set(unavailableFields)].sort(),
   };
 }
 
-function companyRowToPortfolio(row: PortfolioCompanyRow): ReserveCompanyInput {
+function fieldProvenance(
+  status: 'observed' | 'approved_assumption' | 'estimated' | 'defaulted' | 'unavailable',
+  source: string,
+  reason: string | null
+) {
+  return { status, source, reason };
+}
+
+function investmentRowToPortfolioWithProvenance(
+  row: InvestmentPortfolioRow
+): ReserveCompanyInputWithProvenance {
+  const ownershipMissing = row.ownership_percentage == null;
+  const stageMissing = row.round == null || row.round.trim().length === 0;
+  const sectorMissing = row.sector == null || row.sector.trim().length === 0;
+
+  return {
+    id: row.company_id ?? row.id,
+    invested: toNumber(row.amount),
+    ownership: ownershipMissing ? 0.15 : toNumber(row.ownership_percentage),
+    stage: row.round != null && row.round.trim().length > 0 ? row.round : 'seed',
+    sector: row.sector != null && row.sector.trim().length > 0 ? row.sector : 'unknown',
+    provenance: {
+      invested: fieldProvenance('observed', 'investments.amount', null),
+      ownership: ownershipMissing
+        ? fieldProvenance('defaulted', 'system_default_ownership', 'Missing ownership percentage uses 0.15 legacy default')
+        : fieldProvenance('observed', 'investments.ownership_percentage', null),
+      stage: stageMissing
+        ? fieldProvenance('defaulted', 'system_default_stage', 'Missing round uses seed legacy default')
+        : fieldProvenance('observed', 'investments.round', null),
+      sector: sectorMissing
+        ? fieldProvenance('defaulted', 'system_default_sector', 'Missing sector uses unknown legacy default')
+        : fieldProvenance('observed', 'portfolio_companies.sector', null),
+    },
+  };
+}
+
+function companyRowToPortfolioWithProvenance(
+  row: PortfolioCompanyRow
+): ReserveCompanyInputWithProvenance {
+  const investedMissing = row.investment_amount == null;
+  const stageMissing = row.stage == null || row.stage.trim().length === 0;
+  const sectorMissing = row.sector == null || row.sector.trim().length === 0;
+
   return {
     id: row.id,
     invested: toNumber(row.investment_amount),
     ownership: 0.15,
-    stage: row.stage ?? 'seed',
-    sector: row.sector ?? 'unknown',
+    stage: row.stage != null && row.stage.trim().length > 0 ? row.stage : 'seed',
+    sector: row.sector != null && row.sector.trim().length > 0 ? row.sector : 'unknown',
+    provenance: {
+      invested: investedMissing
+        ? fieldProvenance('defaulted', 'system_default_invested', 'Missing investment amount uses 0 legacy default')
+        : fieldProvenance('observed', 'portfolio_companies.investment_amount', null),
+      ownership: fieldProvenance('defaulted', 'system_default_ownership', 'portfolioCompanies rows do not provide actuals-grade ownership; legacy fallback is 0.15'),
+      stage: stageMissing
+        ? fieldProvenance('defaulted', 'system_default_stage', 'Missing stage uses seed legacy default')
+        : fieldProvenance('observed', 'portfolio_companies.stage', null),
+      sector: sectorMissing
+        ? fieldProvenance('defaulted', 'system_default_sector', 'Missing sector uses unknown legacy default')
+        : fieldProvenance('observed', 'portfolio_companies.sector', null),
+    },
   };
 }
 
-export async function buildReservePortfolioInput(fundId: number): Promise<ReserveCompanyInput[]> {
+function toLegacyReservePortfolio(
+  provenancePortfolio: ReserveCompanyInputWithProvenance[]
+): ReserveCompanyInput[] {
+  return provenancePortfolio.map(({ id, invested, ownership, stage, sector }) => ({
+    id,
+    invested,
+    ownership,
+    stage,
+    sector,
+  }));
+}
+
+function buildReservePortfolioInputWithTrustFromRows(input: {
+  investments: InvestmentPortfolioRow[];
+  companies: PortfolioCompanyRow[];
+}): ReservePortfolioInputWithTrust {
+  const provenancePortfolio = buildReservePortfolioInputWithProvenanceFromRows(input);
+  return {
+    portfolio: toLegacyReservePortfolio(provenancePortfolio),
+    provenancePortfolio,
+    reserveInputTrustSummary: buildReserveInputTrustSummary(provenancePortfolio),
+  };
+}
+
+export async function buildReservePortfolioInputWithProvenance(
+  fundId: number
+): Promise<ReservePortfolioInputWithTrust> {
   const investments = await db.query.investments.findMany({
     where: (inv, { eq }) => eq(inv.fundId, fundId),
-    with: {
-      company: true,
-    },
+    with: { company: true },
   });
 
   if (investments.length > 0) {
-    return investments.map((inv) => ({
-      id: inv.companyId || inv.id,
-      invested: toNumber(inv.amount),
-      ownership: inv.ownershipPercentage ? toNumber(inv.ownershipPercentage) : 0.15,
-      stage: inv.round || 'seed',
-      sector: getInvestmentSector(inv),
-    }));
+    return buildReservePortfolioInputWithTrustFromRows({
+      investments: investments.map((inv) => ({
+        id: inv.id,
+        company_id: inv.companyId ?? null,
+        amount: inv.amount,
+        ownership_percentage: inv.ownershipPercentage ?? null,
+        round: inv.round ?? null,
+        sector: getInvestmentSector(inv),
+      })),
+      companies: [],
+    });
   }
 
   const portfolioCompanies = await db.query.portfolioCompanies.findMany({
     where: (companies, { eq }) => eq(companies.fundId, fundId),
   });
 
-  return portfolioCompanies.map((company) => ({
-    id: company.id,
-    invested: toNumber(company.investmentAmount),
-    ownership: 0.15,
-    stage: company.stage,
-    sector: company.sector,
-  }));
+  return buildReservePortfolioInputWithTrustFromRows({
+    investments: [],
+    companies: portfolioCompanies.map((company) => ({
+      id: company.id,
+      investment_amount: company.investmentAmount,
+      stage: company.stage,
+      sector: company.sector,
+    })),
+  });
 }
 
-export async function buildReservePortfolioInputForClient(
+export async function buildReservePortfolioInput(fundId: number): Promise<ReserveCompanyInput[]> {
+  return (await buildReservePortfolioInputWithProvenance(fundId)).portfolio;
+}
+
+export async function buildReservePortfolioInputForClientWithProvenance(
   client: PoolClient,
   fundId: number
-): Promise<ReserveCompanyInput[]> {
+): Promise<ReservePortfolioInputWithTrust> {
   const investments = await client.query<InvestmentPortfolioRow>(
     `SELECT
        i.id,
@@ -102,7 +220,10 @@ export async function buildReservePortfolioInputForClient(
   );
 
   if (investments.rows.length > 0) {
-    return investments.rows.map(investmentRowToPortfolio);
+    return buildReservePortfolioInputWithTrustFromRows({
+      investments: investments.rows,
+      companies: [],
+    });
   }
 
   const companies = await client.query<PortfolioCompanyRow>(
@@ -113,5 +234,15 @@ export async function buildReservePortfolioInputForClient(
     [fundId]
   );
 
-  return companies.rows.map(companyRowToPortfolio);
+  return buildReservePortfolioInputWithTrustFromRows({
+    investments: [],
+    companies: companies.rows,
+  });
+}
+
+export async function buildReservePortfolioInputForClient(
+  client: PoolClient,
+  fundId: number
+): Promise<ReserveCompanyInput[]> {
+  return (await buildReservePortfolioInputForClientWithProvenance(client, fundId)).portfolio;
 }

--- a/shared/contracts/fund-moic-v2.contract.ts
+++ b/shared/contracts/fund-moic-v2.contract.ts
@@ -40,6 +40,24 @@ const MoicInputSummarySchema = z
   })
   .strict();
 
+const ActualsProvenanceSummarySchema = z
+  .object({
+    factsStatus: z.enum(['available', 'failed']),
+    factsInputHash: z.string().min(1).nullable(),
+    companyCount: z.number().int().nonnegative(),
+    trustStateCounts: z
+      .object({
+        LIVE: z.number().int().nonnegative(),
+        PARTIAL: z.number().int().nonnegative(),
+        UNAVAILABLE: z.number().int().nonnegative(),
+        FAILED: z.number().int().nonnegative(),
+      })
+      .strict(),
+    defaultedEconomicInputCount: z.number().int().nonnegative(),
+    warnings: z.array(z.enum(['actuals_facts_failed'])),
+  })
+  .strict();
+
 export const FundMoicRankingsResponseV2Schema = z
   .object({
     contractVersion: z.literal('2.1.0'),
@@ -66,6 +84,7 @@ export const FundMoicRankingsResponseV2Schema = z
       .strict(),
     modePreview: ModePreviewSchema,
     moicInputSummary: MoicInputSummarySchema,
+    actualsProvenanceSummary: ActualsProvenanceSummarySchema,
     roundEvidenceSummary: z
       .object({
         activeRoundCount: z.number().int().nonnegative(),

--- a/shared/contracts/reserve-input-provenance.contract.ts
+++ b/shared/contracts/reserve-input-provenance.contract.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { ReserveCompanyInputSchema } from '../types';
+
+export const ReserveInputSourceStatusSchema = z.enum([
+  'observed',
+  'approved_assumption',
+  'estimated',
+  'defaulted',
+  'unavailable',
+]);
+
+export const ReserveInputFieldProvenanceSchema = z
+  .object({
+    status: ReserveInputSourceStatusSchema,
+    source: z.string().min(1),
+    reason: z.string().min(1).nullable(),
+  })
+  .strict();
+
+export const ReserveCompanyInputProvenanceSchema = z
+  .object({
+    invested: ReserveInputFieldProvenanceSchema,
+    ownership: ReserveInputFieldProvenanceSchema,
+    stage: ReserveInputFieldProvenanceSchema,
+    sector: ReserveInputFieldProvenanceSchema,
+  })
+  .strict();
+
+export const ReserveCompanyInputWithProvenanceSchema = ReserveCompanyInputSchema.extend({
+  provenance: ReserveCompanyInputProvenanceSchema,
+}).strict();
+
+export const ReserveInputTrustSummarySchema = z
+  .object({
+    trustedForActivation: z.boolean(),
+    defaultedInputCount: z.number().int().nonnegative(),
+    unavailableInputCount: z.number().int().nonnegative(),
+    defaultedFields: z.array(z.enum(['invested', 'ownership', 'stage', 'sector'])),
+    unavailableFields: z.array(z.enum(['invested', 'ownership', 'stage', 'sector'])),
+  })
+  .strict();
+
+export type ReserveInputSourceStatus = z.infer<typeof ReserveInputSourceStatusSchema>;
+export type ReserveInputFieldProvenance = z.infer<typeof ReserveInputFieldProvenanceSchema>;
+export type ReserveCompanyInputWithProvenance = z.infer<
+  typeof ReserveCompanyInputWithProvenanceSchema
+>;
+export type ReserveInputTrustSummary = z.infer<typeof ReserveInputTrustSummarySchema>;

--- a/tests/unit/contract/fund-moic-v2.contract.test.ts
+++ b/tests/unit/contract/fund-moic-v2.contract.test.ts
@@ -52,6 +52,14 @@ const makeValidV2 = (): FundMoicRankingsResponseV2 => ({
     defaultedReserveExitMultipleCount: 0,
     activationBlockingDefaultedReserveExitMultipleCount: 0,
   },
+  actualsProvenanceSummary: {
+    factsStatus: 'available',
+    factsInputHash: 'facts-hash',
+    companyCount: 1,
+    trustStateCounts: { LIVE: 1, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 },
+    defaultedEconomicInputCount: 1,
+    warnings: [],
+  },
   roundEvidenceSummary: { activeRoundCount: 0, activeOverrideCount: 0, warningCodes: [] },
   generatedAt: '2026-06-24T00:00:00.000Z',
 });
@@ -72,6 +80,7 @@ describe('FundMoicRankingsResponseV2 contract — allowlist', () => {
         'materiality',
         'modePreview',
         'moicInputSummary',
+        'actualsProvenanceSummary',
         'provenance',
         'rankings',
         'roundEvidenceSummary',
@@ -141,6 +150,23 @@ describe('FundMoicRankingsResponseV2 contract — allowlist', () => {
     );
   });
 
+  it('pins the EXACT actualsProvenanceSummary key set', () => {
+    const parsed = FundMoicRankingsResponseV2Schema.parse(makeValidV2());
+    expect(Object.keys(parsed.actualsProvenanceSummary).sort()).toEqual(
+      [
+        'companyCount',
+        'defaultedEconomicInputCount',
+        'factsInputHash',
+        'factsStatus',
+        'trustStateCounts',
+        'warnings',
+      ].sort()
+    );
+    expect(Object.keys(parsed.actualsProvenanceSummary.trustStateCounts).sort()).toEqual(
+      ['FAILED', 'LIVE', 'PARTIAL', 'UNAVAILABLE'].sort()
+    );
+  });
+
   it('pins the EXACT roundEvidenceSummary key set', () => {
     const parsed = FundMoicRankingsResponseV2Schema.parse(makeValidV2());
     expect(Object.keys(parsed.roundEvidenceSummary).sort()).toEqual(
@@ -157,6 +183,11 @@ describe('FundMoicRankingsResponseV2 contract — forbidden-field rejection', ()
 
   it('rejects monetary leakage smuggled at top level', () => {
     const bad = { ...makeValidV2(), totalReservesUsd: 1_000_000 };
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects raw actuals facts rows smuggled at top level', () => {
+    const bad = { ...makeValidV2(), actualsFacts: [{ companyId: 1, trustState: 'LIVE' }] };
     expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
   });
 
@@ -178,6 +209,20 @@ describe('FundMoicRankingsResponseV2 contract — forbidden-field rejection', ()
     const bad = makeValidV2();
     // @ts-expect-error injecting a forbidden key
     bad.roundEvidenceSummary.roundIds = ['r1', 'r2'];
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects raw monetary values on actualsProvenanceSummary', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error injecting a forbidden key
+    bad.actualsProvenanceSummary.totalCurrentValuationCents = 1_000_000_00;
+    expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects per-company actuals leakage on actualsProvenanceSummary', () => {
+    const bad = makeValidV2();
+    // @ts-expect-error injecting a forbidden key
+    bad.actualsProvenanceSummary.companies = [{ companyId: 1, trustState: 'LIVE' }];
     expect(FundMoicRankingsResponseV2Schema.safeParse(bad).success).toBe(false);
   });
 

--- a/tests/unit/contract/reserve-input-provenance.contract.test.ts
+++ b/tests/unit/contract/reserve-input-provenance.contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ReserveCompanyInputWithProvenanceSchema,
+  ReserveInputTrustSummarySchema,
+} from '../../../shared/contracts/reserve-input-provenance.contract';
+
+describe('reserve input provenance contract', () => {
+  it('accepts observed reserve inputs with per-field provenance', () => {
+    const parsed = ReserveCompanyInputWithProvenanceSchema.parse({
+      id: 101,
+      invested: 500000,
+      ownership: 0.12,
+      stage: 'series_a',
+      sector: 'SaaS',
+      provenance: {
+        invested: { status: 'observed', source: 'investment_amount', reason: null },
+        ownership: { status: 'observed', source: 'ownership_percentage', reason: null },
+        stage: { status: 'observed', source: 'round', reason: null },
+        sector: { status: 'observed', source: 'portfolio_company_sector', reason: null },
+      },
+    });
+
+    expect(parsed.provenance.ownership.status).toBe('observed');
+  });
+
+  it('labels defaulted ownership and stage as untrusted for activation', () => {
+    const parsed = ReserveInputTrustSummarySchema.parse({
+      trustedForActivation: false,
+      defaultedInputCount: 2,
+      unavailableInputCount: 0,
+      defaultedFields: ['ownership', 'stage'],
+      unavailableFields: [],
+    });
+
+    expect(parsed.trustedForActivation).toBe(false);
+  });
+});

--- a/tests/unit/hooks/use-moic-v2.test.tsx
+++ b/tests/unit/hooks/use-moic-v2.test.tsx
@@ -47,6 +47,14 @@ function makeV2Response(fundId: number): FundMoicRankingsResponseV2 {
       defaultedReserveExitMultipleCount: 0,
       activationBlockingDefaultedReserveExitMultipleCount: 0,
     },
+    actualsProvenanceSummary: {
+      factsStatus: 'available',
+      factsInputHash: 'facts-hash',
+      companyCount: 1,
+      trustStateCounts: { LIVE: 1, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 },
+      defaultedEconomicInputCount: 0,
+      warnings: [],
+    },
     roundEvidenceSummary: { activeRoundCount: 0, activeOverrideCount: 0, warningCodes: [] },
     generatedAt: '2026-06-24T00:00:00.000Z',
   };
@@ -88,6 +96,13 @@ describe('useFundMoicRankingsV2', () => {
 
     expect(result.current.data?.contractVersion).toBe('2.1.0');
     expect(result.current.data?.materiality.status).toBe('not_run');
+    expect(result.current.data?.actualsProvenanceSummary).toMatchObject({
+      factsStatus: 'available',
+      factsInputHash: 'facts-hash',
+      trustStateCounts: { LIVE: 1, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 },
+      defaultedEconomicInputCount: 0,
+    });
+    expect(JSON.stringify(result.current.data)).not.toMatch(/marginal next-dollar/i);
     expect(fetchSpy).toHaveBeenCalledWith('/api/funds/5/moic/rankings?contract=v2', {
       credentials: 'include',
     });

--- a/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
+++ b/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
@@ -78,6 +78,14 @@ const canonicalFixture = {
     defaultedReserveExitMultipleCount: 3,
     activationBlockingDefaultedReserveExitMultipleCount: 3,
   },
+  actualsProvenanceSummary: {
+    factsStatus: 'available',
+    factsInputHash: 'facts-hash',
+    companyCount: 4,
+    trustStateCounts: { LIVE: 2, PARTIAL: 1, UNAVAILABLE: 1, FAILED: 0 },
+    defaultedEconomicInputCount: 5,
+    warnings: [],
+  },
   roundEvidenceSummary: {
     activeRoundCount: 3,
     activeOverrideCount: 1,
@@ -157,6 +165,17 @@ describe('FundModelResultsMoicAnalysisPage', () => {
     expect(screen.getByText('Created: 2026-06-24T00:00:00.000Z')).toBeInTheDocument();
     expect(screen.getByText('Inputs changed')).toBeInTheDocument();
     expect(screen.getByText('Fingerprint changed')).toBeInTheDocument();
+    expect(screen.getByText('Facts status')).toBeInTheDocument();
+    expect(screen.getByText('available')).toBeInTheDocument();
+    expect(screen.getByText('Facts input hash')).toBeInTheDocument();
+    expect(screen.getByText('facts-hash')).toBeInTheDocument();
+    expect(screen.getByText('Facts trust')).toBeInTheDocument();
+    expect(
+      screen.getByText('LIVE 2, PARTIAL 1, UNAVAILABLE 1, FAILED 0')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Defaulted economic inputs')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.queryByText(/marginal next-dollar/i)).not.toBeInTheDocument();
     expect(screen.getByText('Acme Corp')).toBeInTheDocument();
   });
 
@@ -202,6 +221,14 @@ describe('FundModelResultsMoicAnalysisPage', () => {
     fixture.roundEvidenceSummary.warningCodes = [];
     fixture.latestReconciliation = null;
     fixture.materiality.status = 'not_run';
+    fixture.actualsProvenanceSummary.factsStatus = 'failed';
+    fixture.actualsProvenanceSummary.factsInputHash = null;
+    fixture.actualsProvenanceSummary.trustStateCounts = {
+      LIVE: 0,
+      PARTIAL: 0,
+      UNAVAILABLE: 1,
+      FAILED: 0,
+    };
 
     mockHook({
       data: FundMoicRankingsResponseV2Schema.parse(fixture),
@@ -214,6 +241,8 @@ describe('FundModelResultsMoicAnalysisPage', () => {
     expect(screen.getByText('Not run')).toBeInTheDocument();
     expect(screen.getAllByText('0')).toHaveLength(2);
     expect(screen.getAllByText('None').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('unavailable')).toBeInTheDocument();
     expect(screen.getByText('No reconciliation recorded')).toBeInTheDocument();
   });
 

--- a/tests/unit/routes/fund-moic-route-contract.test.ts
+++ b/tests/unit/routes/fund-moic-route-contract.test.ts
@@ -37,6 +37,24 @@ describe('fund-moic route contract', () => {
     expect(source).toContain('FundMoicRankingsResponseV2Schema.parse');
   });
 
+  it('reports companyCount from facts on success and from source record count on failure', async () => {
+    const source = await readRepoFile('server/routes/fund-moic.ts');
+    expect(source).toContain('buildFundCompanyActualsFacts({');
+    expect(source).toContain('asOfDate: actualsAsOfDate');
+    expect(source).toContain("factsStatus: 'available'");
+    expect(source).toContain(
+      'trustStates: actualsFacts.facts.map((fact) => fact.provenance.trustState)'
+    );
+    expect(source).toContain(
+      'const sourceCompanyCount = sources.legacy.provenance.sourceRecordCount'
+    );
+    expect(source).toContain("factsStatus: 'failed'");
+    expect(source).toContain(
+      "trustStates: Array.from({ length: sourceCompanyCount }, () => 'UNAVAILABLE')"
+    );
+    expect(source).toContain("warnings: ['actuals_facts_failed']");
+  });
+
   it('exposes the admin reconciliation POST with role + idempotency guards', async () => {
     const source = await readRepoFile('server/routes/fund-moic.ts');
     expect(source).toContain('/admin/funds/:fundId/moic/reconciliations');

--- a/tests/unit/services/fund-moic-actionability-service.test.ts
+++ b/tests/unit/services/fund-moic-actionability-service.test.ts
@@ -21,7 +21,10 @@ vi.mock('../../../server/services/rounds-to-model-evidence-service', () => ({
   buildRoundsToModelEvidence,
 }));
 
-import { createMoicActionabilityResolver } from '../../../server/services/fund-calculation-mode-service';
+import {
+  createMoicActionabilityResolver,
+  resolveFundCalculationMode,
+} from '../../../server/services/fund-calculation-mode-service';
 
 type ReconciliationRow = {
   id: number;
@@ -118,6 +121,12 @@ function makeDatabase(rows: ReconciliationRow[]) {
   };
 }
 
+function makeModeDatabase() {
+  return {
+    execute: vi.fn(async () => ({ rows: [] })),
+  };
+}
+
 function hasResolve(value: unknown): value is { resolve: ResolveByParams } {
   return (
     typeof value === 'object' &&
@@ -211,5 +220,27 @@ describe('fund MOIC actionability resolver', () => {
     expect(early.sourceFingerprint?.fingerprintHash).toBe(
       late.sourceFingerprint?.fingerprintHash
     );
+  });
+
+  it('keeps defaulted exit probability and reserve multiple blockers visible', async () => {
+    const sources = {
+      ...sourceBundle,
+      moicInputSummary: {
+        ...sourceBundle.moicInputSummary,
+        defaultedExitProbabilityCount: 1,
+        activationBlockingDefaultedExitProbabilityCount: 1,
+        defaultedReserveExitMultipleCount: 1,
+        activationBlockingDefaultedReserveExitMultipleCount: 1,
+      },
+    };
+    const preview = await resolveFundCalculationMode({
+      fundId: 7,
+      database: makeModeDatabase() as never,
+      now,
+      sources: sources as never,
+    });
+
+    expect(preview.blockers).toContain('exit_probability_source_incomplete');
+    expect(preview.blockers).toContain('reserve_exit_multiple_source_incomplete');
   });
 });

--- a/tests/unit/services/fund-moic-ranking-service.test.ts
+++ b/tests/unit/services/fund-moic-ranking-service.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../../server/lib/moic-mapper', async (importOriginal) => {
 import {
   buildMoicRankingSourcesFromCompanies,
   buildMoicRankingsFromInvestments,
+  summarizeMoicActualsProvenance,
 } from '../../../server/services/fund-moic-ranking-service';
 import { FundMoicRankingsResponseV1Schema } from '../../../shared/contracts/fund-moic-v1.contract';
 import type { Investment } from '../../../shared/core/moic/MOICCalculator';
@@ -216,6 +217,27 @@ describe('fund MOIC ranking service', () => {
     expect(result.moicInputSummary.activationBlockingDefaultedReserveExitMultipleCount).toBe(0);
   });
 
+  it('keeps candidate rankings on facts/provenance integration and does not claim marginal next-dollar MOIC', () => {
+    const result = buildMoicRankingSourcesFromCompanies(10, [
+      {
+        id: 1,
+        fundId: 10,
+        name: 'Acme',
+        investmentAmount: 500_000,
+        currentValuation: 1_500_000,
+        plannedReservesCents: 300_000_00,
+        exitMoicBps: 25000,
+        exitProbability: null,
+        investmentDate: new Date('2022-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    expect(result.moicInputSummary.defaultedExitProbabilityCount).toBe(1);
+    expect(result.legacy.provenance.calculation).toBe('reserves_moic_rankings');
+    expect(result.legacy.provenance.metricBasis).toBe('planned_reserves');
+    expect(JSON.stringify(result)).not.toMatch(/marginal|next-dollar|incremental ownership/i);
+  });
+
   it('falls missing reserve multiples back to 1x and blocks activation without double-counting probability', () => {
     const result = buildMoicRankingSourcesFromCompanies(10, [
       {
@@ -321,5 +343,22 @@ describe('fund MOIC ranking service', () => {
       r.rankings.map((x) => [x.investmentId, x.rank, x.reservesMoic.value]);
 
     expect(project(after)).toEqual(project(before));
+  });
+
+  it('counts trust states and preserves warnings', () => {
+    const summary = summarizeMoicActualsProvenance({
+      factsStatus: 'available',
+      factsInputHash: 'h',
+      trustStates: ['LIVE', 'LIVE', 'PARTIAL', 'UNAVAILABLE'],
+      defaultedEconomicInputCount: 3,
+    });
+    expect(summary.companyCount).toBe(4);
+    expect(summary.trustStateCounts).toEqual({
+      LIVE: 2,
+      PARTIAL: 1,
+      UNAVAILABLE: 1,
+      FAILED: 0,
+    });
+    expect(summary.warnings).toEqual([]);
   });
 });

--- a/tests/unit/services/fund-scenario-reserve-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-reserve-calculation-service.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createReserveScenarioInputHash } from '../../../server/services/fund-scenario-reserve-calculation-service';
+import { persistReserveScenarioSnapshot } from '../../../server/services/fund-scenario-reserve-snapshot-store';
+import type { FundScenarioCalculationPayloadV1 } from '../../../shared/contracts/fund-scenario-sets-v1.contract';
 
 describe('fund scenario reserve calculation service', () => {
   it('creates a stable input hash regardless of equivalent variant ordering', () => {
@@ -48,5 +50,103 @@ describe('fund scenario reserve calculation service', () => {
 
     expect(first).toBe(second);
     expect(first).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('stamps reserve input trust summary metadata on scenario snapshots', async () => {
+    const reservePayload: FundScenarioCalculationPayloadV1 = {
+      version: 'fund-scenarios-v1',
+      calculationMode: 'async_reserve_allocation',
+      fundId: 1,
+      scenarioSetId: '11111111-1111-4111-8111-111111111111',
+      sourceConfigId: 2,
+      sourceConfigVersion: 3,
+      staleness: {
+        state: 'CURRENT',
+        sourceConfigVersion: 3,
+        currentPublishedConfigVersion: 3,
+      },
+      calculatedAt: '2026-05-29T00:00:00.000Z',
+      variants: [
+        {
+          variantId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          scenarioSetId: '11111111-1111-4111-8111-111111111111',
+          name: 'Reserve variant',
+          overrideType: 'reserve_allocation',
+          reserve: {
+            fundId: 1,
+            totalBaseAllocationCents: 0,
+            totalScenarioAllocationCents: 1000,
+            totalAllocationDeltaCents: 1000,
+            avgConfidence: 1,
+            highConfidenceCount: 1,
+            allocations: [
+              {
+                companyId: 1,
+                baseAllocationCents: 0,
+                plannedReservesCents: 1000,
+                maxAllocationCents: null,
+                scenarioAllocationCents: 1000,
+                allocationDeltaCents: 1000,
+                capApplied: false,
+                confidence: 1,
+                rationale: 'unit test',
+              },
+            ],
+            warnings: [],
+            generatedAt: '2026-05-29T00:00:00.000Z',
+          },
+        },
+      ],
+    };
+    let capturedScenarioSnapshotMetadata:
+      | ({ reserve_input_trust_summary_hash?: string } & Record<string, unknown>)
+      | undefined;
+    const queryMock = vi.fn(async (_sql: string, values: unknown[]) => {
+      capturedScenarioSnapshotMetadata = values[4] as {
+        reserve_input_trust_summary_hash?: string;
+      } & Record<string, unknown>;
+      return {
+        rows: [
+          {
+            id: 202,
+            payload: reservePayload,
+            correlation_id: '11111111-1111-4111-8111-111111111113',
+            created_at: new Date(),
+            snapshot_time: new Date(),
+          },
+        ],
+      };
+    });
+
+    await persistReserveScenarioSnapshot(
+      { query: queryMock } as never,
+      {
+        fundId: 1,
+        scenarioSetId: '11111111-1111-4111-8111-111111111111',
+        sourceConfigId: 2,
+        sourceConfigVersion: 3,
+        correlationId: '11111111-1111-4111-8111-111111111113',
+        payload: reservePayload,
+        inputHash: 'b'.repeat(64),
+        variantCount: 1,
+        companyCount: 1,
+        warningCount: 0,
+        reserveInputTrustSummary: {
+          trustedForActivation: false,
+          defaultedInputCount: 2,
+          unavailableInputCount: 0,
+          defaultedFields: ['ownership', 'stage'],
+          unavailableFields: [],
+        },
+      }
+    );
+
+    expect(capturedScenarioSnapshotMetadata).toMatchObject({
+      reserve_input_trust_summary: {
+        trustedForActivation: false,
+        defaultedFields: ['ownership', 'stage'],
+      },
+    });
+    expect(capturedScenarioSnapshotMetadata!.reserve_input_trust_summary_hash).toMatch(/^[a-f0-9]{64}$/);
   });
 });

--- a/tests/unit/services/fund-scenario-retention.test.ts
+++ b/tests/unit/services/fund-scenario-retention.test.ts
@@ -152,6 +152,13 @@ const reserveSnapshotInput = {
   variantCount: 1,
   companyCount: 1,
   warningCount: 0,
+  reserveInputTrustSummary: {
+    trustedForActivation: true,
+    defaultedInputCount: 0,
+    unavailableInputCount: 0,
+    defaultedFields: [],
+    unavailableFields: [],
+  },
 };
 
 const calculationIdentity = {

--- a/tests/unit/services/reserve-calculation-h9-stamp.test.ts
+++ b/tests/unit/services/reserve-calculation-h9-stamp.test.ts
@@ -39,7 +39,17 @@ vi.mock('../../../server/db', () => ({
 }));
 
 vi.mock('../../../server/services/reserve-input-builder', () => ({
-  buildReservePortfolioInput: vi.fn(async () => []),
+  buildReservePortfolioInputWithProvenance: vi.fn(async () => ({
+    portfolio: [],
+    provenancePortfolio: [],
+    reserveInputTrustSummary: {
+      trustedForActivation: false,
+      defaultedInputCount: 2,
+      unavailableInputCount: 0,
+      defaultedFields: ['ownership', 'stage'],
+      unavailableFields: [],
+    },
+  })),
 }));
 
 vi.mock('@shared/core/reserves/ReserveEngine', () => ({
@@ -112,6 +122,13 @@ describe('runReserveCalculation H9 stamp', () => {
       h9FingerprintHash: 'fingerprint-hash',
       h9PolicyVersion: 'h9-policy-v1',
       h9ActionabilityStatus: 'actionable',
+    });
+    expect(captured.values?.metadata).toMatchObject({
+      reserveInputTrustSummary: {
+        trustedForActivation: false,
+        defaultedInputCount: 2,
+        defaultedFields: ['ownership', 'stage'],
+      },
     });
   });
 

--- a/tests/unit/services/reserve-input-builder.provenance.test.ts
+++ b/tests/unit/services/reserve-input-builder.provenance.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { ReserveCompanyInputSchema } from '../../../shared/types';
+import {
+  buildReserveInputTrustSummary,
+  buildReservePortfolioInputWithProvenanceFromRows,
+} from '../../../server/services/reserve-input-builder';
+
+describe('reserve input builder provenance', () => {
+  it('preserves observed investment ownership and stage', () => {
+    const portfolio = buildReservePortfolioInputWithProvenanceFromRows({
+      investments: [
+        {
+          id: 1,
+          company_id: 101,
+          amount: '500000',
+          ownership_percentage: '0.12',
+          round: 'series_a',
+          sector: 'SaaS',
+        },
+      ],
+      companies: [],
+    });
+
+    expect(portfolio[0]).toMatchObject({
+      id: 101,
+      invested: 500000,
+      ownership: 0.12,
+      stage: 'series_a',
+      provenance: {
+        ownership: { status: 'observed' },
+        stage: { status: 'observed' },
+      },
+    });
+  });
+
+  it('labels missing ownership and stage defaults and marks the summary untrusted', () => {
+    const portfolio = buildReservePortfolioInputWithProvenanceFromRows({
+      investments: [
+        {
+          id: 1,
+          company_id: 101,
+          amount: '500000',
+          ownership_percentage: null,
+          round: null,
+          sector: 'SaaS',
+        },
+      ],
+      companies: [],
+    });
+    const summary = buildReserveInputTrustSummary(portfolio);
+
+    expect(portfolio[0]?.provenance.ownership.status).toBe('defaulted');
+    expect(portfolio[0]?.provenance.stage.status).toBe('defaulted');
+    expect(summary).toMatchObject({
+      trustedForActivation: false,
+      defaultedInputCount: 2,
+      defaultedFields: ['ownership', 'stage'],
+    });
+  });
+
+  it('defaults the portfolio-companies fallback branch and labels each field', () => {
+    // Covers companyRowToPortfolioWithProvenance (investments empty -> companies path).
+    const portfolio = buildReservePortfolioInputWithProvenanceFromRows({
+      investments: [],
+      companies: [{ id: 101, investment_amount: '500000', stage: null, sector: null }],
+    });
+
+    expect(portfolio[0]).toMatchObject({
+      id: 101,
+      invested: 500000,
+      ownership: 0.15,
+      stage: 'seed',
+      sector: 'unknown',
+      provenance: {
+        ownership: { status: 'defaulted' },
+        stage: { status: 'defaulted' },
+        sector: { status: 'defaulted' },
+      },
+    });
+  });
+
+  it('REGRESSION: buildReservePortfolioInput fallback now emits schema-valid defaults, not null', () => {
+    // Pins the authoritative Drizzle-path behavior change (C1): the portfolio-companies
+    // fallback previously emitted raw null stage/sector (schema-invalid). The unified path
+    // must emit 'seed'/'unknown', which the reserve engine accepts and provenance marks defaulted.
+    const legacy = buildReservePortfolioInputWithProvenanceFromRows({
+      investments: [],
+      companies: [{ id: 101, investment_amount: '500000', stage: null, sector: null }],
+    }).map(({ id, invested, ownership, stage, sector }) => ({ id, invested, ownership, stage, sector }));
+
+    expect(legacy[0]?.stage).toBe('seed');
+    expect(legacy[0]?.sector).toBe('unknown');
+    expect(legacy[0]?.stage).not.toBeNull();
+    // Guard: the emitted shape must satisfy ReserveCompanyInputSchema (stage/sector .min(1)).
+    expect(() => ReserveCompanyInputSchema.parse(legacy[0])).not.toThrow();
+  });
+});


### PR DESCRIPTION
# Current-Main Sequential Trust (Tasks 0-4)

Executes Tasks 0-4 of the reviewed trust-handoff (`docs/superpowers/plans/2026-07-10-current-main-sequential-trust-EXECUTION-HANDOFF.md`).
Code edits dispatched via Hermes (codex production lane); reviewed and gated by Claude.

## Required fields

- **Execution branch or worktree name:** `codex/current-main-sequential-trust-handoff`
- **A gate decision for #1020:** closed-complete. Evidence: `rg` shows server facts integration (metrics-aggregator.ts 55 matches) + full `dual-forecast-response.contract.ts` + client disclosure (dashboard 21 matches); vitest server 26/26 + client 73/73 green (negative-path Zod/not-found logs are covered assertions).
- **Production smoke issue URL, if #1020 closed:** `https://github.com/nikhillinit/Updog_restore/issues/1057`
- **Marginal MOIC issue URL:** `https://github.com/nikhillinit/Updog_restore/issues/1056`
- **ADR number selected for marginal MOIC:** ADR-033 (DECISIONS.md head = ADR-032)
- **Perf issue URL (v2 MOIC facts load):** `https://github.com/nikhillinit/Updog_restore/issues/1054`
- **ADR-ledger issue URL:** `https://github.com/nikhillinit/Updog_restore/issues/1055`

## Tasks

- **Task 0** — Intake + branch. Base SHA `79c37b6b` verified against origin/main; issues #1020-1023/#1013 OPEN at intake.
- **Task 1** — #1020 dual-forecast closeout (soft gate A1): implementation-complete, close + production-smoke follow-up.
- **Task 2 (B1)** — Reserve input provenance. New `reserve-input-provenance.contract.ts`; unified both builder entrypoints through one provenance converter (deleted orphaned converters, C2); stamps `reserveInputTrustSummary` on authoritative snapshots and `reserve_input_trust_summary` + `_hash` on scenario snapshots. C1 latent-bug fix (portfolio-companies fallback null -> 'seed'/'unknown') pinned by regression test + phoenix:truth. `createReserveScenarioInputHash` unchanged.
- **Task 3 (B2)** — MOIC facts/provenance (#1021, additive only). `actualsProvenanceSummary` on v2 contract + route via the facts seam; `logger.warn` on facts failure (C3); companyCount success/failure seam (P1); MOIC page disclosure. No marginal-MOIC math.
- **Task 4** — Marginal next-dollar MOIC split into ADR-033 + separate issue; #1021 stays facts/provenance-only.

## Gates (run by reviewer)

- `npm run check`: 0 new TypeScript errors
- B1 vitest: reserve-input-provenance.contract + reserve-input-builder.provenance (incl C1 regression) + reserve-calculation-h9-stamp + fund-scenario-reserve-calculation-service + fund-scenario-retention = 15 pass
- `npm run phoenix:truth`: 273 pass (ER truth 20/20)
- B2 vitest: server 76 pass (fund-moic-ranking-service incl. #1021 guard + summarize counting, fund-moic-actionability-service, fund-moic-route-contract incl. companyCount seam, fund-moic-v2.contract + B1 files); client 13 pass (fund-model-results-moic-analysis, use-moic-v2)
- Final bundle (all green): `npm run lint` (+ financial-placeholder / round-derived-claim guardrails), `npm run check` (0 new), server vitest 76/76, client vitest 13/13, `npm run phoenix:truth` 273/273

Not release-ready: Tasks 5-8 (/v2 quarantine, CI fallback removal, auth contract, shared manifest) are separate plans; release-truth (`release:check`) waits for those.

## Prerequisite issues filed

- Perf (v2 MOIC facts load): `https://github.com/nikhillinit/Updog_restore/issues/1054`
- ADR-ledger reconcile: `https://github.com/nikhillinit/Updog_restore/issues/1055`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
