### PR TITLE
feat(trust): quarantine v2 reference screens from production bundle (Task 5)

### DIFF
--- a/client/src/app/app-router.tsx
+++ b/client/src/app/app-router.tsx
@@ -11,23 +11,15 @@ import {
   ADMIN_GATED_ROUTES,
   APP_ROUTES,
   ARCHIVED_PLACEHOLDER_ROUTES,
-  CashV2,
-  CompanyV2,
-  ExitsV2,
-  InsightsV2,
   LEGACY_REDIRECT_ROUTES,
   LP_INDEX_REDIRECT_PATH,
   LP_INDEX_REDIRECT_TARGET,
   LP_ROUTES,
   NotFound,
   PageLoadingFallback,
-  PartnersV2,
   PortalAccessDenied,
-  PortfolioV2,
   PUBLIC_ENTRY_ROUTES,
-  ScenariosV2,
   SharedDashboard,
-  TodayV2,
   UICatalog,
   type AppRouteEntry,
   type ArchivedPlaceholderRouteEntry,
@@ -169,34 +161,7 @@ function Router() {
   );
 }
 
-/**
- * Press On v2 reference screens render full-screen and supply their own chrome
- * (sidebar, command palette, topbar). They must bypass AppLayout so the existing
- * dashboard chrome doesn't double up on them.
- */
 export function AppRouter() {
-  const [location] = useLocation();
-  const isV2 = location.startsWith('/v2');
-
-  if (isV2) {
-    return (
-      <Suspense fallback={<PageLoadingFallback />}>
-        <Switch>
-          <Route path="/v2" component={() => <Redirect to="/v2/today" />} />
-          <Route path="/v2/today" component={TodayV2} />
-          <Route path="/v2/portfolio" component={PortfolioV2} />
-          <Route path="/v2/companies/:id" component={CompanyV2} />
-          <Route path="/v2/scenarios" component={ScenariosV2} />
-          <Route path="/v2/cash" component={CashV2} />
-          <Route path="/v2/exits" component={ExitsV2} />
-          <Route path="/v2/insights" component={InsightsV2} />
-          <Route path="/v2/partners" component={PartnersV2} />
-          <Route path="/v2/:rest*" component={() => <Redirect to="/v2/today" />} />
-        </Switch>
-      </Suspense>
-    );
-  }
-
   return (
     <AppLayout>
       <Router />

--- a/client/src/app/app-routes.tsx
+++ b/client/src/app/app-routes.tsx
@@ -67,16 +67,6 @@ export const UICatalog = React.lazy(() => import('@/pages/admin/ui-catalog'));
 // Portal pages (LP Portal scaffolding)
 export const PortalAccessDenied = React.lazy(() => import('@/pages/portal/access-denied'));
 
-// Press On Ventures v2 design philosophy reference screens (full-screen, bypasses AppLayout)
-export const TodayV2 = React.lazy(() => import('@/pages/v2/today'));
-export const PortfolioV2 = React.lazy(() => import('@/pages/v2/portfolio'));
-export const CompanyV2 = React.lazy(() => import('@/pages/v2/company'));
-export const ScenariosV2 = React.lazy(() => import('@/pages/v2/scenarios'));
-export const CashV2 = React.lazy(() => import('@/pages/v2/cash'));
-export const ExitsV2 = React.lazy(() => import('@/pages/v2/exits'));
-export const InsightsV2 = React.lazy(() => import('@/pages/v2/insights'));
-export const PartnersV2 = React.lazy(() => import('@/pages/v2/partners'));
-
 export interface AppRouteEntry extends AppRouteDefinition {
   component: React.ComponentType<Record<string, unknown>>;
 }

--- a/scripts/check-prod-bundle.mjs
+++ b/scripts/check-prod-bundle.mjs
@@ -21,6 +21,8 @@ export const QUARANTINED_MODULES = [
   'cash-management',
   'portfolio-analytics',
   'CapTables',
+  // Press On v2 mock-data reference screens: reference/dev only, never ship to prod.
+  'pages/v2/',
 ];
 
 /** Pure: return manifest entries whose key/src/file matches a forbidden substring. */

--- a/tests/unit/scripts/check-prod-bundle.test.mjs
+++ b/tests/unit/scripts/check-prod-bundle.test.mjs
@@ -62,3 +62,21 @@ describe('mock-route quarantine extension', () => {
     expect(hits.map((h) => h.needle).sort()).toEqual([...newlyQuarantined].sort());
   });
 });
+
+describe('v2 reference-screen quarantine', () => {
+  it('quarantines the pages/v2 reference screens', () => {
+    expect(QUARANTINED_MODULES).toContain('pages/v2/');
+  });
+
+  it('flags a v2 reference page in the manifest', () => {
+    const manifest = {
+      'client/src/pages/v2/today.tsx': {
+        file: 'assets/today-abc123.js',
+        src: 'client/src/pages/v2/today.tsx',
+        isDynamicEntry: true,
+      },
+    };
+    const hits = findForbiddenModules(manifest, QUARANTINED_MODULES);
+    expect(hits.map((h) => h.needle)).toContain('pages/v2/');
+  });
+});


### PR DESCRIPTION
## Task 5 — `/v2` production quarantine

Tranche 5 of the current-main sequential-trust program (follows #1058). Removes the
Press On **v2 mock-data reference screens** (`client/src/pages/v2/*`) from the production
bundle and arms a regression guard so they cannot be silently re-mounted. The v2 page
source files stay in the tree as design reference — they are simply no longer reachable
from the prod entrypoint.

### Changes
- **`client/src/app/app-routes.tsx`** — drop the 8 `@/pages/v2/*` `React.lazy` exports.
- **`client/src/app/app-router.tsx`** — remove the `isV2` `AppRouter` bypass; `/v2/*` now
  falls through to `NotFound` in prod. No dead imports left behind (`Suspense`/`Switch`/
  `Route`/`Redirect`/`useLocation`/`PageLoadingFallback` all still used elsewhere).
- **`scripts/check-prod-bundle.mjs`** — add the precise `'pages/v2/'` sentinel to
  `QUARANTINED_MODULES`.
- **`tests/unit/scripts/check-prod-bundle.test.mjs`** — regression test asserting the
  sentinel is armed and flags a v2 manifest entry.

### Correction to the original handoff spec
The handoff proposed sentinels `presson-v2` / `pages/v2` / `/v2/`. **`presson-v2` was
dropped deliberately**: `@/components/presson-v2/*` (AppShell, `Btn`/`ChartCard`/`Tag`
primitives, `presson-v2.css`) is *shared design infrastructure* imported by live prod
components — `investments/rounds-table.tsx`, `investments/new-round-dialog.tsx`,
`investments/investment-rounds-section.tsx` (the investment-rounds feature). Quarantining
`presson-v2` would make `build:verify` fail. The bare `/v2/` substring is redundant/broad.
The single precise sentinel `pages/v2/` targets exactly the reference screens.

### Verification (all local gates green)
- `npm run check` — 0 new TS errors (client/server/shared).
- ESLint on the 4 files — 0 errors.
- `npx vitest run tests/unit/scripts/check-prod-bundle.test.mjs` — 8/8.
- `npm run build` — green; `npm run build:verify` — `OK: no quarantined modules or stray
  source maps`. Manifest confirmed: 0 `pages/v2` entries.

### Acceptance
- `/v2/*` URLs → `NotFound` in the prod router (bypass removed).
- Re-adding any `@/pages/v2/*` import fails `build:verify` (guard armed).

Implemented via Hermes (codex owner lane); diff + gates verified in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
