### PR TITLE
ci(smoke): stop masking e2e smoke test failures (Task 6)

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -252,7 +252,16 @@ jobs:
               npm run test:integration
               ;;
             e2e)
-              npm run test:e2e:smoke || npm run test:smoke
+              # Selector/preflight problems may fall back to the self-contained
+              # smoke harness, but once the smoke tests actually run, a test
+              # FAILURE must fail the job (no masking fallback). `--list` loads
+              # the smoke project without running tests, so it isolates a
+              # selector/preflight failure from a real test failure.
+              if npm run test:e2e:smoke -- --list >/dev/null 2>&1; then
+                npm run test:e2e:smoke
+              else
+                npm run test:smoke
+              fi
               ;;
             validate-core)
               npm run validate:core

--- a/tests/unit/ci-workflow-regression.test.ts
+++ b/tests/unit/ci-workflow-regression.test.ts
@@ -396,3 +396,23 @@ describe('CI Workflow Regression - Fix #4', () => {
     });
   });
 });
+
+describe('CI e2e smoke: no test-failure masking (Task 6)', () => {
+  const workflowPath = path.join(process.cwd(), '.github/workflows/ci-unified.yml');
+
+  it('does not mask a smoke test failure with an unconditional fallback', async () => {
+    const content = await fs.readFile(workflowPath, 'utf-8');
+    // The naive "A || B" retries via a different harness and can green a real
+    // test failure. It must be gone.
+    expect(content).not.toContain('npm run test:e2e:smoke || npm run test:smoke');
+  });
+
+  it('gates the fallback behind a selector/preflight probe', async () => {
+    const content = await fs.readFile(workflowPath, 'utf-8');
+    // Preflight probe decides whether the smoke project is runnable here; only
+    // then does the real run happen, and its failure propagates.
+    expect(content).toContain('test:e2e:smoke -- --list');
+    // The self-contained fallback stays available for preflight failures.
+    expect(content).toContain('npm run test:smoke');
+  });
+});


### PR DESCRIPTION
## Task 6 — CI e2e smoke: remove test-failure masking

Tranche 6 of the current-main sequential-trust program (follows #1058; parallel to #1060).

The e2e matrix group in `ci-unified.yml` ran `npm run test:e2e:smoke || npm run test:smoke`.
The unconditional `||` **masks a real smoke test failure**: a failing test in `test:e2e:smoke`
(exit 1) triggers the fallback harness, which can green the job.

### Fix
Playwright returns exit 1 for both "test failed" and "couldn't select/load", so we can't branch
on the real run's exit code. Instead, gate the fallback behind a `playwright --list` preflight
probe (loads the smoke project without running tests):
- probe succeeds -> run `test:e2e:smoke` for real; a failure **propagates** (no `||`).
- probe fails (selector/preflight) -> fall back to the self-contained `test:smoke` harness.

### Changes
- **`.github/workflows/ci-unified.yml`** — replace the masking `||` with a `--list`-gated `if/else`.
- **`tests/unit/ci-workflow-regression.test.ts`** — lock the pattern: naive `||` gone, `--list`
  probe present, `test:smoke` fallback retained.

### Verification
- `npx vitest run tests/unit/ci-workflow-regression.test.ts` — 22/22 (2 new).
- YAML validity — parses, 13 jobs.
- ESLint on the test file — clean.
- `npm run check` N/A: the YAML and the test file are outside the tsconfig client/server/shared projects.

Implemented via Hermes (codex owner lane); diff + gates verified in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)