### PR TITLE
docs(adr): declare DECISIONS.md the ADR ledger home-of-record (#1055)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-07-04
+last_updated: 2026-07-10
 owner: Core Team
 review_cadence: P90D
 ---
@@ -9,6 +9,16 @@ review_cadence: P90D
 
 This file documents key architectural and technical decisions made during the
 development of the Press On Ventures fund modeling platform.
+
+> **Ledger home-of-record.** This file is the primary, chronological ADR ledger
+> for the platform (ADR-009 onward). The `docs/adr/` directory is a **separate,
+> standalone collection of expanded ADRs with its own independent numbering** —
+> a `docs/adr/ADR-NNN` file does NOT correspond to the same-numbered entry here
+> (e.g. `ADR-018` here is "Phase 3C Truthful Rich Results"; `docs/adr/ADR-018`
+> is "Stage Normalization"). Cite `docs/adr/` entries by file path and title,
+> never by number alone. The sole shared number is **ADR-033**, which continues
+> this ledger's sequence but is authored as a full file under `docs/adr/` (see
+> the ADR-033 entry below).
 
 ## Table of Contents
 
@@ -36,6 +46,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-030: Trust Blending Keyed by the Provenance Envelope (PRD #1020 D2)](#adr-030-trust-blending-keyed-by-the-provenance-envelope-prd-1020-d2)
 - [ADR-031: Dual-Forecast Response Contract and Invalidation Seam (PRD #1020 D3)](#adr-031-dual-forecast-response-contract-and-invalidation-seam-prd-1020-d3)
 - [ADR-032: Currency Blocks Contribute No Facts-Derived Money (PRD #1020 D4)](#adr-032-currency-blocks-contribute-no-facts-derived-money-prd-1020-d4)
+- [ADR-033: Marginal Next-Dollar Reserve MOIC Model (expanded in docs/adr/)](#adr-033-marginal-next-dollar-reserve-moic-model-expanded-in-docsadr)
 
 ---
 
@@ -5609,3 +5620,23 @@ rewrite when it lands.
 
 Full draft with verified evidence: issue #1020 comment 4894518091 (amended
 2026-07-06).
+
+---
+
+## ADR-033: Marginal Next-Dollar Reserve MOIC Model (expanded in docs/adr/)
+
+**Date:** 2026-07-10 **Status:** Proposed
+
+This ledger entry continues the DECISIONS.md sequence (...032 -> 033). To keep
+its evolving design in one place, the full ADR is authored as an expanded file
+rather than inline here.
+
+- **Home:**
+  [`docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md`](docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md)
+- **Summary:** the current planned-reserves MOIC path ranks planned reserves by
+  reserve exit multiple x exit probability; it is not a marginal next-dollar
+  opportunity-cost model (no incremental ownership, dilution, subsequent rounds,
+  staged probabilities, or delta expected proceeds). ADR-033 proposes that
+  model.
+- **Implementation plan:** tracked in GitHub issue #1056, kept separate from the
+  facts/provenance work in #1021.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-04-18
+last_updated: 2026-07-10
 ---
 
 # Architecture Decision Records (ADRs)
@@ -8,35 +8,48 @@ last_updated: 2026-04-18
 This directory contains Architecture Decision Records for the Updog Fund
 Management Platform.
 
-## Routing Note
+## Routing Note — home-of-record
 
-`docs/adr/` is a standalone ADR collection. `DECISIONS.md` also contains ADRs,
-including separate ADR-017/018/019 entries on unrelated topics. Cite ADRs from
-this directory by file path and title, not by number alone.
+`DECISIONS.md` (repo root) is the **home-of-record** for the platform's running,
+chronological ADR ledger (ADR-009 onward). This directory, `docs/adr/`, is a
+**standalone collection of expanded ADRs with its own independent numbering** —
+a number here does NOT correspond to the same-numbered entry in `DECISIONS.md`
+(e.g. `ADR-018` here is "Stage Normalization"; `ADR-018` in `DECISIONS.md` is
+"Phase 3C Truthful Rich Results"). Always cite an entry in this directory by
+**file path and title**, never by number alone.
+
+No stub files are backfilled for `DECISIONS.md` ADR-024..032 — doing so would
+falsely imply the two numberings align. The one shared number is **ADR-033**
+(Marginal Next-Dollar Reserve MOIC), which continues the `DECISIONS.md` sequence
+but is authored as a full file here; `DECISIONS.md` carries its ledger entry and
+this file is the deep-dive.
 
 ## Index
 
-| ADR                                               | Title                                                        | Status      |
-| ------------------------------------------------- | ------------------------------------------------------------ | ----------- |
-| [0001](0001-evaluator-metrics.md)                 | Evaluator Metrics for AI Agents                              | Accepted    |
-| [0002](0002-token-budgeting.md)                   | Token Budgeting Strategy                                     | Accepted    |
-| [0003](0003-streaming-architecture.md)            | Streaming Architecture for Long-Running Operations           | Accepted    |
-| [004](ADR-004-waterfall-names.md)                 | Waterfall Distribution Names                                 | Accepted    |
-| [005](ADR-005-xirr-excel-parity.md)               | XIRR Excel Parity                                            | Accepted    |
-| [006](ADR-006-fee-calculation-standards.md)       | Fee Calculation Standards                                    | Accepted    |
-| [007](ADR-007-exit-recycling-policy.md)           | Exit Recycling Policy                                        | Accepted    |
-| [008](ADR-008-capital-allocation-policy.md)       | Capital Allocation Policy                                    | Accepted    |
-| [009](ADR-009-RESERVED.md)                        | Reserved                                                     | Reserved    |
-| [013](ADR-013-scenario-comparison-activation.md)  | Scenario Comparison Activation                               | Superseded  |
-| [014](ADR-014-snapshot-governance.md)             | Snapshot Governance                                          | Accepted    |
-| [015](ADR-015-XIRR-BOUNDED-RATES.md)              | XIRR Bounded Rate Strategy                                   | Accepted    |
-| [017](ADR-017-monte-carlo-validation-strategy.md) | Monte Carlo Validation Strategy                              | Accepted    |
-| [018](ADR-018-stage-normalization-v2.md)          | Typed Stage Normalization & Statistical Monte Carlo Testing  | Implemented |
-| [019](ADR-019-mem0-integration.md)                | mem0 Integration for AI Agent Memory Management              | Proposed    |
-| [020](ADR-020-analysis-cohort-boundary.md)        | Analysis Cohort Boundary                                     | Accepted    |
-| [021](ADR-021-runtime-authority.md)               | Runtime Authority for Contract-Integrity Work                | Accepted    |
-| [022](ADR-022-fund-scenario-architecture.md)      | Fund-Results Scenario Architecture                           | Implemented |
-| [023](ADR-023-investment-event-persistence.md)    | Investment Event Persistence Backbone (Rounds First Tranche) | Accepted    |
+| ADR                                                 | Title                                                        | Status      |
+| --------------------------------------------------- | ------------------------------------------------------------ | ----------- |
+| [0001](0001-evaluator-metrics.md)                   | Evaluator Metrics for AI Agents                              | Accepted    |
+| [0002](0002-token-budgeting.md)                     | Token Budgeting Strategy                                     | Accepted    |
+| [0003](0003-streaming-architecture.md)              | Streaming Architecture for Long-Running Operations           | Accepted    |
+| [004](ADR-004-waterfall-names.md)                   | Waterfall Distribution Names                                 | Accepted    |
+| [005](ADR-005-xirr-excel-parity.md)                 | XIRR Excel Parity                                            | Accepted    |
+| [006](ADR-006-fee-calculation-standards.md)         | Fee Calculation Standards                                    | Accepted    |
+| [007](ADR-007-exit-recycling-policy.md)             | Exit Recycling Policy                                        | Accepted    |
+| [008](ADR-008-capital-allocation-policy.md)         | Capital Allocation Policy                                    | Accepted    |
+| [009](ADR-009-RESERVED.md)                          | Reserved                                                     | Reserved    |
+| [010](ADR-010-xirr-day-count-and-bounds.md)         | XIRR Day-Count and Bounds Reconciliation                     | Accepted    |
+| [011](ADR-011-decimal-string-api-convention.md)     | Decimal-String API Convention for Money Fields               | Accepted    |
+| [013](ADR-013-scenario-comparison-activation.md)    | Scenario Comparison Activation                               | Superseded  |
+| [014](ADR-014-snapshot-governance.md)               | Snapshot Governance                                          | Accepted    |
+| [015](ADR-015-XIRR-BOUNDED-RATES.md)                | XIRR Bounded Rate Strategy                                   | Accepted    |
+| [017](ADR-017-monte-carlo-validation-strategy.md)   | Monte Carlo Validation Strategy                              | Accepted    |
+| [018](ADR-018-stage-normalization-v2.md)            | Typed Stage Normalization & Statistical Monte Carlo Testing  | Implemented |
+| [019](ADR-019-mem0-integration.md)                  | mem0 Integration for AI Agent Memory Management              | Proposed    |
+| [020](ADR-020-analysis-cohort-boundary.md)          | Analysis Cohort Boundary                                     | Accepted    |
+| [021](ADR-021-runtime-authority.md)                 | Runtime Authority for Contract-Integrity Work                | Accepted    |
+| [022](ADR-022-fund-scenario-architecture.md)        | Fund-Results Scenario Architecture                           | Implemented |
+| [023](ADR-023-investment-event-persistence.md)      | Investment Event Persistence Backbone (Rounds First Tranche) | Accepted    |
+| [033](ADR-033-marginal-next-dollar-reserve-moic.md) | Marginal Next-Dollar Reserve MOIC Model                      | Proposed    |
 
 ## What is an ADR?
 


### PR DESCRIPTION
## #1055 — Reconcile the ADR ledger

`DECISIONS.md` and `docs/adr/` carried **independent, colliding ADR numbers** (e.g. `ADR-018`
is "Phase 3C Truthful Rich Results" in DECISIONS.md but "Stage Normalization" in docs/adr), and
`docs/adr/README.md`'s index was **missing `ADR-010`, `ADR-011`, and `ADR-033`** — the
"off-by-many" folder-glob trap the issue names.

### Decision (option b)
`DECISIONS.md` is the **primary chronological ADR ledger (home-of-record)**; `docs/adr/` is a
**standalone collection of expanded ADRs with its own independent numbering**. No stub files are
backfilled for `DECISIONS.md` ADR-024..032 — that would falsely imply the numberings align.
`ADR-033` is the one shared number: it continues the `DECISIONS.md` sequence but is authored as a
full file under `docs/adr/`.

### Changes
- **`docs/adr/README.md`** — authoritative home-of-record routing note; index backfilled with
  `ADR-010`/`011`/`033` (now 22 rows == 22 files); `last_updated` bumped.
- **`DECISIONS.md`** — home-of-record note; `ADR-033` ledger pointer entry (TOC + section) closing
  the `032 -> 033` sequence without forking the evolving ADR-033 content (that lives in #1056).

### Verification
- `npx prettier --check` — clean (both files).
- `npm run docs:routing:check:ci` — PASS (in sync).
- No new files added (inventory unchanged); no `docs/_generated` regen bundled.

Closes #1055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)