### PR TITLE
feat(auth): fail-closed RequestPrincipal + resolveFundScope primitives (Task 7 PR-7a)

### DIFF
--- a/server/lib/auth/fund-scope.ts
+++ b/server/lib/auth/fund-scope.ts
@@ -1,0 +1,21 @@
+import type { RequestPrincipal } from './principal';
+
+export type ScopeDecision = 'allow' | 'deny';
+
+/**
+ * Pure, fail-closed fund-scope resolution. `admin`/`service` allow any fund; a
+ * `user` principal allows only funds in its explicit fundIds; `anonymous` (or
+ * any unresolved principal) DENIES. There is no `undefined -> allow` path and no
+ * `empty-fundIds -> unrestricted` path.
+ */
+export function resolveFundScope(principal: RequestPrincipal, fundId: number): ScopeDecision {
+  switch (principal.kind) {
+    case 'admin':
+    case 'service':
+      return 'allow';
+    case 'user':
+      return principal.fundIds.includes(fundId) ? 'allow' : 'deny';
+    case 'anonymous':
+      return 'deny';
+  }
+}

--- a/server/lib/auth/principal.ts
+++ b/server/lib/auth/principal.ts
@@ -1,0 +1,34 @@
+/**
+ * Task 7 (Bearer contract): a typed, fail-closed representation of the
+ * authenticated caller, derived from the already-verified `req.user`.
+ *
+ * Admin/service are keyed on an EXPLICIT role, not the legacy
+ * "empty fundIds == unrestricted" convention -- so a non-privileged token with
+ * empty fundIds resolves to a `user` principal with no fund access (deny),
+ * closing that footgun.
+ *
+ * Additive: NOT yet wired into route guards. Routes migrate to
+ * `resolveFundScope()` in follow-up tranches (PR-7b onward).
+ */
+export type RequestPrincipal =
+  | { readonly kind: 'admin' }
+  | { readonly kind: 'service' }
+  | { readonly kind: 'user'; readonly userId: string; readonly fundIds: readonly number[] }
+  | { readonly kind: 'anonymous' };
+
+export function principalFromUser(user: Express.User | undefined): RequestPrincipal {
+  if (!user) {
+    return { kind: 'anonymous' };
+  }
+  if (user.role === 'admin') {
+    return { kind: 'admin' };
+  }
+  if (user.role === 'service') {
+    return { kind: 'service' };
+  }
+  return {
+    kind: 'user',
+    userId: user.id ?? user.sub,
+    fundIds: user.fundIds ?? [],
+  };
+}

--- a/tests/unit/auth/fund-scope.test.ts
+++ b/tests/unit/auth/fund-scope.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { principalFromUser } from '../../../server/lib/auth/principal';
+import { resolveFundScope } from '../../../server/lib/auth/fund-scope';
+
+const user = (over: Partial<Express.User> = {}): Express.User =>
+  ({
+    id: 'u1',
+    sub: 'u1',
+    email: 'u1@example.com',
+    roles: [],
+    fundIds: [],
+    ip: 'x',
+    userAgent: 'x',
+    ...over,
+  }) as Express.User;
+
+describe('principalFromUser', () => {
+  it('maps an absent user to anonymous', () => {
+    expect(principalFromUser(undefined)).toEqual({ kind: 'anonymous' });
+  });
+
+  it('maps role=admin to an admin principal', () => {
+    expect(principalFromUser(user({ role: 'admin' }))).toEqual({ kind: 'admin' });
+  });
+
+  it('maps role=service to a service principal', () => {
+    expect(principalFromUser(user({ role: 'service' }))).toEqual({ kind: 'service' });
+  });
+
+  it('maps a non-privileged user to a scoped user principal', () => {
+    expect(principalFromUser(user({ role: 'analyst', fundIds: [1, 2] }))).toEqual({
+      kind: 'user',
+      userId: 'u1',
+      fundIds: [1, 2],
+    });
+  });
+});
+
+describe('resolveFundScope (fail-closed acceptance matrix)', () => {
+  it('denies an anonymous principal (no fail-open)', () => {
+    expect(resolveFundScope({ kind: 'anonymous' }, 1)).toBe('deny');
+  });
+
+  it('allows admin for any fund', () => {
+    expect(resolveFundScope({ kind: 'admin' }, 42)).toBe('allow');
+  });
+
+  it('allows service for any fund', () => {
+    expect(resolveFundScope({ kind: 'service' }, 42)).toBe('allow');
+  });
+
+  it('allows a user for a fund in scope', () => {
+    expect(resolveFundScope({ kind: 'user', userId: 'u1', fundIds: [1, 2] }, 2)).toBe('allow');
+  });
+
+  it('denies a user for a fund out of scope', () => {
+    expect(resolveFundScope({ kind: 'user', userId: 'u1', fundIds: [1, 2] }, 3)).toBe('deny');
+  });
+
+  it('denies a non-privileged user with empty fundIds (empty != unrestricted)', () => {
+    expect(resolveFundScope({ kind: 'user', userId: 'u1', fundIds: [] }, 1)).toBe('deny');
+  });
+});


### PR DESCRIPTION
## Task 7 PR-7a — fail-closed fund-scope primitives

First increment of Task 7 (browser auth contract = **Bearer**, chosen after resolving the STOP-gate
via `vercel env ls production`: prod verifies HS256 Bearer JWTs; ADR-034 lands with the implementation).

**Additive and behavior-preserving** — these primitives are **not yet wired into any route**, so there
is no runtime change. They establish the canonical fail-closed model that route migration (follow-ups)
will adopt.

### Changes
- **`server/lib/auth/principal.ts`** — `RequestPrincipal` discriminated union (`admin | service | user | anonymous`)
  + `principalFromUser()`. admin/service are keyed on an **explicit role**, closing the legacy
  "empty fundIds == unrestricted" footgun: a non-privileged token with empty fundIds becomes a `user`
  principal with **no** fund access.
- **`server/lib/auth/fund-scope.ts`** — pure `resolveFundScope(principal, fundId) -> 'allow' | 'deny'`.
  admin/service allow any fund; user allows only in-scope funds; **anonymous denies**. No `undefined -> allow`,
  no `empty-fundIds -> unrestricted`.
- **`tests/unit/auth/fund-scope.test.ts`** — the fail-closed acceptance matrix at the function level (10 cases,
  incl. `anonymous -> deny` and `empty-fundIds -> deny`).

### Why scoped this way
The current enforcement (`enforceProvidedFundScope` + `company-fund-scope`, 20+ call sites) is already
fail-closed **in prod** by a documented "empty fundIds = unrestricted" JWT contract. The high-value, low-risk
first step is to (a) encode the *explicit* fail-closed model as pure, unit-tested primitives, and (b) sequence
the risky 20-route migration + the DB-backed HTTP acceptance-matrix integration test as follow-ups.

### Verification
- `npx vitest run tests/unit/auth/fund-scope.test.ts` — 10/10.
- `npm run check` — 0 new TS errors.
- ESLint — clean.

### Follow-ups (tracked)
Migrate the `enforceProvidedFundScope` call sites onto these primitives; add the DB-backed HTTP
acceptance matrix; land ADR-034; build the login endpoint (PR-7b) + client Bearer attach (PR-7c).

Implemented via Hermes (codex owner lane); test location corrected in review; diff + gates verified in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)