### PR TITLE
feat(auth): POST /api/auth/login (Bearer) + user seed (Task 7 PR-7b-i)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "ajv": "8.20.0",
         "ajv-formats": "^3.0.1",
         "baseline-browser-mapping": "2.10.42",
+        "bcryptjs": "3.0.3",
         "body-parser": "^2.3.0",
         "bullmq": "5.79.2",
         "chalk": "^5.6.2",
@@ -11204,6 +11205,15 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "ajv": "8.20.0",
     "ajv-formats": "^3.0.1",
     "baseline-browser-mapping": "2.10.42",
+    "bcryptjs": "3.0.3",
     "body-parser": "^2.3.0",
     "bullmq": "5.79.2",
     "chalk": "^5.6.2",

--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */ // Database seeding utilities
 
 import { db } from '../server/db';
-import { funds, portfolioCompanies, investments, fundMetrics, activities } from '@shared/schema';
+import {
+  funds,
+  portfolioCompanies,
+  investments,
+  fundMetrics,
+  activities,
+  users,
+} from '@shared/schema';
+import { buildSeedUsers } from '../server/lib/seed-users';
 
 // Self-executing script when run directly
 if (import.meta.url === `file://${process.argv[1]!}`) {
@@ -20,6 +28,17 @@ export async function seedDatabase() {
   console.log('[SEED] Seeding database with sample data...');
 
   try {
+    // Seed test-only login users (idempotent upsert on username). Shared source:
+    // server/lib/seed-users.ts. Consumed by POST /api/auth/login.
+    const seedUsers = buildSeedUsers();
+    for (const seedUser of seedUsers) {
+      await db
+        .insert(users)
+        .values(seedUser)
+        .onConflictDoUpdate({ target: users.username, set: { password: seedUser.password } });
+    }
+    console.log('[DONE] Seeded login users:', seedUsers.length);
+
     // Insert sample fund
     const fundData = {
       name: 'Press On Ventures Fund I',

--- a/server/app.ts
+++ b/server/app.ts
@@ -54,6 +54,7 @@ import { cspDirectives, securityHeaders } from './config/csp.js';
 import { requireAuth } from './lib/auth/jwt.js';
 import { isPublicApiPath } from './lib/public-api-boundary.js';
 import { errorHandler } from './errors.js';
+import authRouter from './routes/auth.js';
 
 export function makeApp() {
   const app = express();
@@ -198,6 +199,10 @@ export function makeApp() {
 
     return requireApiAuth(req, res, next);
   });
+
+  // Auth: login endpoint. Router self-defines /api/auth/login; mounted at the bare
+  // root AFTER the /api guard, which lets it through via isPublicApiPath(POST /auth/login).
+  app.use(authRouter);
 
   // Feature flags API
   app.use('/api/flags', flagsRouter);

--- a/server/lib/auth/credentials.ts
+++ b/server/lib/auth/credentials.ts
@@ -1,0 +1,22 @@
+import bcrypt from 'bcryptjs';
+import type { User } from '@shared/schema';
+import { storage } from '../../storage';
+
+/**
+ * Verify a username/password pair against the user store.
+ *
+ * Returns the matching user iff the username exists AND the password matches the
+ * stored bcrypt hash; otherwise null. The uniform null result (unknown user vs.
+ * bad password) is what lets the login route return an identical 401 for both,
+ * avoiding user enumeration.
+ *
+ * Lives in the auth lib (not the route) so the route stays free of direct
+ * persistence access — see .baselines/route-persistence-imports.json.
+ */
+export async function verifyCredentials(username: string, password: string): Promise<User | null> {
+  const user = await storage.getUserByUsername(username);
+  if (!user || !(await bcrypt.compare(password, user.password))) {
+    return null;
+  }
+  return user;
+}

--- a/server/lib/public-api-boundary.ts
+++ b/server/lib/public-api-boundary.ts
@@ -32,5 +32,10 @@ export function isPublicApiPath(method: string, mountRelativePath: string): bool
     return true;
   }
 
+  // Login must be reachable without a prior token. Path is mount-relative to /api.
+  if (normalizedMethod === 'POST' && normalizedPath === '/auth/login') {
+    return true;
+  }
+
   return false;
 }

--- a/server/lib/seed-users.ts
+++ b/server/lib/seed-users.ts
@@ -1,0 +1,26 @@
+import bcrypt from 'bcryptjs';
+import type { InsertUser } from '@shared/schema';
+
+/**
+ * TEST-ONLY login credentials for the internal ~5-person team. These are NOT
+ * production identities. Single source of truth consumed by both MemStorage
+ * (server/storage.ts, dev/tests) and scripts/seed-db.ts (Postgres).
+ */
+export const TEST_LOGIN_CREDENTIALS: ReadonlyArray<{ username: string; password: string }> = [
+  { username: 'admin', password: 'admin-dev-2026' },
+  { username: 'partner', password: 'partner-dev-2026' },
+  { username: 'analyst', password: 'analyst-dev-2026' },
+  { username: 'operator', password: 'operator-dev-2026' },
+  { username: 'viewer', password: 'viewer-dev-2026' },
+];
+
+// Low cost factor: throwaway test creds, not real secrets. Hashing runs once at
+// MemStorage construction / seed time.
+const SEED_BCRYPT_COST = 8;
+
+export function buildSeedUsers(): InsertUser[] {
+  return TEST_LOGIN_CREDENTIALS.map(({ username, password }) => ({
+    username,
+    password: bcrypt.hashSync(password, SEED_BCRYPT_COST),
+  }));
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,6 +61,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   await mountDefaultRoutes(app, [
     // Health and metrics routes
     { mountPath: '/', load: () => import('./routes/health.js') },
+    // Auth: login endpoint (router self-defines /api/auth/login). Parity with makeApp.
+    { mountPath: '/', load: () => import('./routes/auth.js') },
     { mountPath: '/api', load: () => import('./routes/dashboard-summary.js') },
     { mountPath: '/api', load: () => import('./routes/investments.js') },
     { mountPath: '/api', load: () => import('./routes/portfolio-companies.js') },

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,0 +1,41 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { verifyCredentials } from '../lib/auth/credentials';
+import { signToken } from '../lib/auth/jwt';
+
+const loginSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+const authRouter = Router();
+
+// Self-defines the FULL /api/auth/login path so it can be mounted at the bare root
+// on both surfaces (makeApp + registerRoutes). Made public in
+// server/lib/public-api-boundary.ts so the global /api auth guard lets it through.
+authRouter.post('/api/auth/login', async (req: Request, res: Response) => {
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'invalid_request' });
+  }
+
+  const { username, password } = parsed.data;
+  const user = await verifyCredentials(username, password);
+
+  // Uniform 401 for unknown-user and bad-password: no user enumeration.
+  if (!user) {
+    return res.status(401).json({ error: 'invalid_credentials' });
+  }
+
+  // Internal tool: every identity is admin (empty fundIds = unrestricted scope).
+  const token = signToken({
+    sub: String(user.id),
+    email: user.username,
+    role: 'admin',
+    fundIds: [],
+  });
+
+  return res.json({ token });
+});
+
+export default authRouter;

--- a/server/routes/metrics-rum.guard.ts
+++ b/server/routes/metrics-rum.guard.ts
@@ -148,8 +148,16 @@ export const rumLimiter = rateLimit({
  * Privacy guard to strip PII from RUM payloads
  */
 export function rumPrivacyGuard(req: Request, res: Response, next: NextFunction) {
-  // Set no-store cache control
+  // Set no-store cache control (applies to every response; keep unconditional).
   res.setHeader('Cache-Control', 'no-store');
+
+  // Only mutate RUM beacon payloads. This guard runs on metricsRumRouter, which is
+  // mounted at the bare root, so without this gate it strips password/token/email/
+  // userName (and lowercased `username`) from EVERY request body — e.g. it empties
+  // POST /api/auth/login. Mirrors the isRumRequest gate in rumOriginGuard/rumSamplingGuard.
+  if (!isRumRequest(req)) {
+    return next();
+  }
 
   // Strip accidental PII fields from body
   const body = getRumBody(req);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -27,6 +27,7 @@ import {
   getStorageConfigurationError,
   resolveStorageBootMode,
 } from './storage-runtime-policy';
+import { buildSeedUsers } from './lib/seed-users';
 
 // Round and performance case types (simplified versions without schema definition)
 export interface InvestmentRound {
@@ -346,6 +347,15 @@ export class MemStorage implements IStorage {
     };
     this.fundMetrics.set(1, sampleMetrics);
     this.currentMetricsId = 2;
+
+    // Seed test-only login users so POST /api/auth/login works under MemStorage
+    // (ALLOW_MEMORY_STORAGE=1 dev + unit tests). Source: server/lib/seed-users.ts.
+    const seedUsers = buildSeedUsers();
+    seedUsers.forEach((seedUser, index) => {
+      const id = index + 1;
+      this.users.set(id, { ...seedUser, id });
+    });
+    this.currentUserId = seedUsers.length + 1;
   }
 
   // User methods

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -126,6 +126,9 @@ const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string
   metricsRouter: { kind: 'non-table' },
   metricsRumRouter: { kind: 'non-table' },
   installRumIngressGuards: { kind: 'non-table' },
+  // Login endpoint. Reads the `users` table via verifyCredentials -> storage.getUserByUsername.
+  // `users` is not in C1_MOUNTED_TABLES, so other-table (same posture as fundsRouter).
+  authRouter: { kind: 'other-table' },
 };
 
 function migrationSql(): string {

--- a/tests/unit/routes/auth-login.test.ts
+++ b/tests/unit/routes/auth-login.test.ts
@@ -1,0 +1,81 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+import type { Express } from 'express';
+
+let makeApp: typeof import('../../../server/app').makeApp;
+let storage: typeof import('../../../server/storage').storage;
+let verifyAccessTokenAsync: typeof import('../../../server/lib/auth/jwt').verifyAccessTokenAsync;
+let app: Express;
+
+const TEST_USERNAME = 'analyst';
+const TEST_PASSWORD = 'analyst-dev-2026';
+
+const mockUser = () => ({
+  id: 3,
+  username: TEST_USERNAME,
+  password: bcrypt.hashSync(TEST_PASSWORD, 8),
+});
+
+describe('POST /api/auth/login', () => {
+  beforeAll(async () => {
+    makeApp = (await import('../../../server/app')).makeApp;
+    ({ storage } = await import('../../../server/storage'));
+    ({ verifyAccessTokenAsync } = await import('../../../server/lib/auth/jwt'));
+    app = makeApp();
+  });
+
+  it('is reachable without a token (public path; 401 from handler, not the /api guard)', async () => {
+    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(undefined);
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'nobody', password: 'x' });
+    expect(res.status).not.toBe(415);
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid_credentials' });
+  });
+
+  it('unknown user -> 401 invalid_credentials', async () => {
+    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(undefined);
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'ghost', password: 'nope' });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid_credentials' });
+  });
+
+  it('bad password -> 401 (no enumeration difference vs unknown user)', async () => {
+    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(mockUser());
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: TEST_USERNAME, password: 'wrong' });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid_credentials' });
+  });
+
+  it('malformed body -> 400 invalid_request', async () => {
+    const res = await request(app).post('/api/auth/login').send({ username: '' });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'invalid_request' });
+  });
+
+  it('good creds -> 200 with a verifiable admin token (fundIds [], 7d expiry)', async () => {
+    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(mockUser());
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: TEST_USERNAME, password: TEST_PASSWORD });
+    expect(res.status).toBe(200);
+    expect(typeof res.body.token).toBe('string');
+
+    const claims = await verifyAccessTokenAsync(res.body.token);
+    expect(claims.sub).toBe('3');
+    expect(claims.email).toBe(TEST_USERNAME);
+    expect(claims.role).toBe('admin');
+    expect(claims.fundIds).toEqual([]);
+    expect(claims.exp).toBeDefined();
+    expect(claims.iat).toBeDefined();
+    if (claims.exp && claims.iat) {
+      expect(claims.exp - claims.iat).toBe(7 * 24 * 60 * 60);
+    }
+  });
+});


### PR DESCRIPTION
## Task 7 PR-7b-i — Login endpoint + user seed

Server slice of PR-7b. Adds `POST /api/auth/login` (username + password -> Bearer JWT) plus
test-user seeding. Client-side token storage is deferred to PR-7b-ii. Scale context: internal
~5-person tool, KISS — security *correctness* (fail-closed, no enumeration), production
hardening dropped.

### What
- **`server/routes/auth.ts`** — `POST /api/auth/login`. Zod-validated body; malformed -> `400
  invalid_request`. Uniform `401 invalid_credentials` for both unknown-user and bad-password
  (no user enumeration). On success mints an HS256 7-day admin token via the existing
  `signToken` (`{ sub, email, role: 'admin', fundIds: [] }`). Mounted on **both** `makeApp`
  (Vercel/prod) and `registerRoutes` (Docker) surfaces.
- **`server/lib/auth/credentials.ts`** — `verifyCredentials()` (storage lookup + `bcrypt.compare`).
  Keeps the route off a direct `storage` import so it passes the `route-persistence-imports`
  guard; also makes the login test a clean single-spy.
- **`server/lib/seed-users.ts`** — single source of truth for 5 test users, bcrypt-hashed.
  Seeded into **both** the `MemStorage` constructor (so `ALLOW_MEMORY_STORAGE=1` dev + unit
  tests can log in) and `scripts/seed-db.ts` (idempotent upsert on `username` for Postgres).
- **`server/lib/public-api-boundary.ts`** — `POST /auth/login` is public (reachable before a
  token) on both surfaces.

### Root-cause fix (bonus, repo-wide)
`fix(rum)`: `rumPrivacyGuard` now early-returns on `!isRumRequest(req)` (matching its sibling
guards). It is registered via `metricsRumRouter.use(...)` on a router mounted at the **bare
root**, so it ran on **every** request and deleted body fields named
`password`/`token`/`email`/`userName` (and lowercased `username`) — silently emptying the login
POST body, and latently breaking any endpoint with those field names. The global
`Cache-Control: no-store` is kept unconditional (tests depend on it).

### Decisions (become ADR-034)
- **A** — reuse the existing `users` table (bcrypt hash in the existing `password` column). No
  migration.
- **B** — single **7-day** access JWT. No refresh, rotation, or CSRF.
- **C** — client stores the token in localStorage — **deferred to PR-7b-ii** (not in this PR).

### Test credentials (TEST-ONLY — not production identities)
`admin`, `partner`, `analyst`, `operator`, `viewer` — each with password `<username>-dev-2026`
(e.g. `analyst` / `analyst-dev-2026`). Defined in `server/lib/seed-users.ts`.

### Tests / gates (all green locally)
- `tests/unit/routes/auth-login.test.ts` (server/node project): public reachability (not 401 from
  the global guard, not 415), unknown-user -> 401, bad-password -> 401, malformed -> 400,
  good creds -> 200 with a token that round-trips through `verifyAccessTokenAsync` carrying
  `role:'admin'`, `fundIds:[]`, 7-day expiry.
- `authRouter` classified in `MAKEAPP_ROUTE_INVENTORY` (D6 mount-parity guard).
- Local: `npm run check` (0 new TS errors), `npm run lint` (+ guardrails), full **server** unit
  suite **502 files / 6561 tests pass** (incl. #1065's `server-no-client-import`,
  `route-policy-coverage`, `canonical-moic-route.policy`), `npm run build` + `build:verify`.
- Rebased onto `#1065` (Task 8 Slice 1) — conflict-free.

### Deps
`bcryptjs@3.0.3` (pure JS — no native builds on Vercel/Windows; ships its own types, so no
`@types/bcryptjs`).

### Not in scope
Fund-scope route migration (all tokens are admin -> no-op until per-fund restriction lands);
client localStorage wiring (PR-7b-ii); ADR-034 write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
