### PR TITLE
feat(auth): client Bearer token wiring + login page (Task 7 PR-7b-ii)

### DIFF
--- a/client/src/app/app-layout.tsx
+++ b/client/src/app/app-layout.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'wouter';
 import { Menu, X } from 'lucide-react';
 import Sidebar from '@/components/layout/sidebar';
+import { getToken, clearToken } from '@/lib/auth-token';
 import {
   getActiveNavigationId,
   getFooterNavigationItems,
@@ -90,9 +91,7 @@ function MobileNavigationItem({
   const href = resolveNavigationHref(item, navigationContext);
   const isActive = activeModule === item.id;
   const isDisabled = !isNavigationItemEnabled(item, navigationContext);
-  const disabledReasonId = isDisabled
-    ? `mobile-navigation-disabled-reason-${item.id}`
-    : undefined;
+  const disabledReasonId = isDisabled ? `mobile-navigation-disabled-reason-${item.id}` : undefined;
 
   if (!href || isDisabled) {
     return <DisabledMobileNavigationItem item={item} disabledReasonId={disabledReasonId} />;
@@ -165,10 +164,27 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [isMobileNavigationOpen, setIsMobileNavigationOpen] = useState(false);
   const activeModule = getActiveNavigationId(location);
   const isFundSetupRoute = location.startsWith('/fund-setup');
+  const handleLogout = () => {
+    clearToken();
+    if (typeof window !== 'undefined') {
+      window.location.assign('/login');
+    }
+  };
 
   return (
     <div className="flex min-h-screen flex-col overflow-x-hidden bg-pov-gray font-poppins text-charcoal">
       {isFundSetupRoute ? <FundConstructionKpiHeader /> : <DynamicFundHeader />}
+      {getToken() && (
+        <div className="flex justify-end border-b border-beige-200 bg-pov-white px-4 py-1">
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="text-sm text-charcoal/70 transition-colors hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-beige focus-visible:ring-offset-2"
+          >
+            Log out
+          </button>
+        </div>
+      )}
       <MobileNavigationToggle
         isOpen={isMobileNavigationOpen}
         onToggle={() => setIsMobileNavigationOpen((isOpen) => !isOpen)}

--- a/client/src/app/app-router.tsx
+++ b/client/src/app/app-router.tsx
@@ -5,8 +5,10 @@ import { LPProvider } from '@/contexts/LPContext';
 import { useFundContext } from '@/contexts/FundContext';
 import { resolveRouteControlFlag } from '@/app/route-control-flags';
 import { requiresFundContextRecovery } from '@/lib/fund-routes';
+import { getToken } from '@/lib/auth-token';
 import { queryClient } from '@/lib/queryClient';
 import { AppLayout } from '@/app/app-layout';
+import LoginPage from '@/pages/login';
 import {
   ADMIN_GATED_ROUTES,
   APP_ROUTES,
@@ -162,6 +164,18 @@ function Router() {
 }
 
 export function AppRouter() {
+  const [location] = useLocation();
+
+  // Public login route renders chrome-free (no AppLayout / fund-context queries).
+  if (location === '/login') {
+    return <LoginPage />;
+  }
+
+  // Prod requires a Bearer token; dev keeps the server dev-bypass (tokenless).
+  if (import.meta.env.PROD && !getToken()) {
+    return <Redirect to="/login" />;
+  }
+
   return (
     <AppLayout>
       <Router />

--- a/client/src/hooks/useLogin.ts
+++ b/client/src/hooks/useLogin.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiRequest, type ApiError } from '@/lib/queryClient';
+import { setToken } from '@/lib/auth-token';
+
+interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+interface LoginResponse {
+  token: string;
+}
+
+/** POST /api/auth/login -> store JWT in localStorage and refetch authed data. */
+export function useLogin() {
+  const queryClient = useQueryClient();
+
+  return useMutation<LoginResponse, ApiError, LoginRequest>({
+    mutationFn: (credentials) => apiRequest<LoginResponse>('POST', '/api/auth/login', credentials),
+    onSuccess: (data) => {
+      setToken(data.token);
+      void queryClient.invalidateQueries();
+    },
+  });
+}

--- a/client/src/lib/auth-token.ts
+++ b/client/src/lib/auth-token.ts
@@ -1,0 +1,33 @@
+/**
+ * Single source of truth for the browser auth token (localStorage).
+ * XSS-exfiltration risk accepted for internal-tool scale (decision C, ADR-034).
+ * `typeof window` guarded for SSR/test safety.
+ */
+const TOKEN_KEY = 'updog.authToken';
+
+export function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setToken(token: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(TOKEN_KEY, token);
+  } catch {
+    /* ignore quota/security errors */
+  }
+}
+
+export function clearToken(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,6 @@
 import type { QueryFunction } from '@tanstack/react-query';
 import { QueryClient } from '@tanstack/react-query';
+import { getToken, clearToken } from './auth-token';
 
 /**
  * Structured API error that preserves server response details.
@@ -41,6 +42,20 @@ interface ApiRequestOptions {
   headers?: Record<string, string>;
 }
 
+function authHeaders(): Record<string, string> {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** On an unexpected 401, drop the (expired/invalid) token and bounce to /login.
+ *  Guarded so it never loops when already on the login page. */
+function handleUnauthorized(): void {
+  clearToken();
+  if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+    window.location.assign('/login');
+  }
+}
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
@@ -66,6 +81,7 @@ export async function apiRequest<TResponse = unknown>(
     method,
     headers: {
       'Content-Type': 'application/json',
+      ...authHeaders(),
       ...requestOptions.headers,
     },
     credentials: 'include',
@@ -78,6 +94,9 @@ export async function apiRequest<TResponse = unknown>(
   const response = await fetch(url, options);
 
   if (!response.ok) {
+    if (response.status === 401 && url !== '/api/auth/login') {
+      handleUnauthorized();
+    }
     type ErrorBody = {
       message?: string;
       error?: string;
@@ -100,10 +119,14 @@ export function getQueryFn<T>(options: { on401: UnauthorizedBehavior }): QueryFu
   return async ({ queryKey }) => {
     const res = await fetch(queryKey.join('/') as string, {
       credentials: 'include',
+      headers: { ...authHeaders() },
     });
 
-    if (options.on401 === 'returnNull' && res.status === 401) {
-      return null;
+    if (res.status === 401) {
+      if (options.on401 === 'returnNull') {
+        return null;
+      }
+      handleUnauthorized();
     }
 
     await throwIfResNotOk(res);

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,79 @@
+import { useState, type FormEvent } from 'react';
+import { useLocation } from 'wouter';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useLogin } from '@/hooks/useLogin';
+
+export default function LoginPage() {
+  const [, navigate] = useLocation();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const login = useLogin();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    login.mutate({ username, password }, { onSuccess: () => navigate('/') });
+  };
+
+  const errorMessage =
+    login.error != null
+      ? login.error.status === 401
+        ? 'Invalid username or password.'
+        : 'Sign-in failed. Please try again.'
+      : null;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-pov-gray px-4 font-poppins text-charcoal">
+      <Card className="w-full max-w-md border-beige-200">
+        <CardHeader>
+          <CardTitle className="text-charcoal">Sign in</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username" className="text-charcoal">
+                Username
+              </Label>
+              <Input
+                id="username"
+                name="username"
+                autoComplete="username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-charcoal">
+                Password
+              </Label>
+              <Input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+              />
+            </div>
+            {errorMessage && (
+              <p role="alert" className="text-sm text-error-dark">
+                {errorMessage}
+              </p>
+            )}
+            <Button
+              type="submit"
+              disabled={login.isPending}
+              className="w-full bg-pov-charcoal text-pov-white hover:bg-charcoal-700"
+            >
+              {login.isPending ? 'Signing in...' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/tests/unit/auth-token.test.tsx
+++ b/tests/unit/auth-token.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getToken, setToken, clearToken } from '@/lib/auth-token';
+
+describe('auth-token', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns null when no token is stored', () => {
+    expect(getToken()).toBeNull();
+  });
+
+  it('stores and reads a token', () => {
+    setToken('abc');
+    expect(getToken()).toBe('abc');
+  });
+
+  it('clears a stored token', () => {
+    setToken('abc');
+    clearToken();
+    expect(getToken()).toBeNull();
+  });
+});

--- a/tests/unit/login-page.test.tsx
+++ b/tests/unit/login-page.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import LoginPage from '@/pages/login';
+import { getToken, clearToken } from '@/lib/auth-token';
+
+const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
+vi.mock('wouter', () => ({
+  useLocation: () => ['/login', navigateMock],
+}));
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return React.createElement(QueryClientProvider, { client: qc }, ui);
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    navigateMock.mockClear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearToken();
+  });
+
+  it('submits, stores the token, and redirects home', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ token: 'jwt-home' }),
+      } as Response)
+    );
+    render(wrap(React.createElement(LoginPage)));
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'admin-dev-2026' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => expect(getToken()).toBe('jwt-home'));
+    expect(navigateMock).toHaveBeenCalledWith('/');
+  });
+});

--- a/tests/unit/queryClient-bearer.test.tsx
+++ b/tests/unit/queryClient-bearer.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { apiRequest, getQueryFn } from '@/lib/queryClient';
+import { setToken, clearToken } from '@/lib/auth-token';
+
+function mockFetch(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response);
+}
+
+describe('queryClient Bearer injection', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearToken();
+  });
+
+  it('apiRequest attaches Authorization when a token is set', async () => {
+    setToken('tok123');
+    const fetchMock = mockFetch({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    await apiRequest('GET', '/api/x');
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((options.headers as Record<string, string>).Authorization).toBe('Bearer tok123');
+  });
+
+  it('apiRequest omits Authorization when no token is set', async () => {
+    const fetchMock = mockFetch({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    await apiRequest('GET', '/api/x');
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((options.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('getQueryFn attaches Authorization when a token is set', async () => {
+    setToken('tok456');
+    const fetchMock = mockFetch({ data: 1 });
+    vi.stubGlobal('fetch', fetchMock);
+    await getQueryFn({ on401: 'returnNull' })({ queryKey: ['/api/y'] } as never);
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((options.headers as Record<string, string>).Authorization).toBe('Bearer tok456');
+  });
+
+  it('getQueryFn omits Authorization when no token is set', async () => {
+    const fetchMock = mockFetch({ data: 1 });
+    vi.stubGlobal('fetch', fetchMock);
+    await getQueryFn({ on401: 'returnNull' })({ queryKey: ['/api/y'] } as never);
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((options.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('getQueryFn returns null on a 401 when on401 is returnNull', async () => {
+    const fetchMock = mockFetch({}, 401);
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await getQueryFn({ on401: 'returnNull' })({ queryKey: ['/api/y'] } as never);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/useLogin.test.tsx
+++ b/tests/unit/useLogin.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useLogin } from '@/hooks/useLogin';
+import { getToken, clearToken } from '@/lib/auth-token';
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('useLogin', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearToken();
+  });
+
+  it('stores the token on a successful login', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ token: 'jwt-xyz' }),
+      } as Response)
+    );
+    const { result } = renderHook(() => useLogin(), { wrapper: makeWrapper() });
+    result.current.mutate({ username: 'admin', password: 'admin-dev-2026' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getToken()).toBe('jwt-xyz');
+  });
+
+  it('surfaces a 401 as an error and stores no token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({ error: 'invalid_credentials' }),
+        text: async () => '{"error":"invalid_credentials"}',
+      } as Response)
+    );
+    const { result } = renderHook(() => useLogin(), { wrapper: makeWrapper() });
+    result.current.mutate({ username: 'admin', password: 'wrong' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.status).toBe(401);
+    expect(getToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Task 7 PR-7b-ii — client token wiring (localStorage + Bearer)

Closes the systemic client-auth gap: the client sent **cookies, not a Bearer header**, so every authenticated `/api` request 401s in prod. This stores the login JWT in localStorage and attaches `Authorization: Bearer <token>` on **both** fetch paths.

### Changes
**New**
- `client/src/lib/auth-token.ts` — SSR-guarded localStorage token (single source of truth)
- `client/src/hooks/useLogin.ts` — `POST /api/auth/login` -> `setToken` + invalidate queries
- `client/src/pages/login.tsx` — chrome-free login page (DESIGN charcoal / `presson.*` tokens, v3.1.1)
- `tests/unit/{auth-token,queryClient-bearer,useLogin,login-page}.test.tsx` — 11 tests

**Edited**
- `client/src/lib/queryClient.ts` — inject Bearer in `apiRequest` **and** `getQueryFn` (the default query fn, previously header-less); on 401 clear token + redirect `/login`, loop-guarded and excluding the login endpoint
- `client/src/app/app-router.tsx` — PROD-only auth gate; `/login` public; dev stays tokenless (server dev-bypass preserved)
- `client/src/app/app-layout.tsx` — token-gated logout control

### Behavior
- Valid login -> JWT in localStorage -> every subsequent `/api` request (mutations + all GET queries) carries the Bearer.
- 401 -> token cleared + redirect to `/login`. Logout clears the token.
- Dev still works tokenless (`import.meta.env.PROD` gate + server dev-bypass).

### Decision context (ADR-034)
Bearer HS256, single **7-day** token, **no** refresh / rotation / CSRF. Decision C: token in localStorage (XSS-exfiltration accepted for internal ~5-person scale). KISS/YAGNI.

### Gates (run locally, all green)
- `npm run check` — 0 new TS errors, no `any`
- `npm run lint` — eslint + all guardrails pass
- client vitest (4 files) — **11/11 pass**
- `npm run build` + `npm run build:verify` — pass, no quarantined modules

### Caveat
Prod end-to-end login still needs users seeded in prod Postgres (`seed-db` is dev-only; separate provisioning, out of scope here). PR-7b-ii is client-only — no server route mounts.

---
Generated with [Claude Code](https://claude.com/claude-code) (no-emoji per repo policy)

https://claude.ai/code/session_01KXTy8uQxo3NCWfsi13jGSi