### PR TITLE
fix(ops): use Neon HTTP driver in prod provisioning script

### DIFF
--- a/scripts/provision-prod-users.ts
+++ b/scripts/provision-prod-users.ts
@@ -1,5 +1,5 @@
 /**
- * Provision login users into a target Postgres (users table ONLY).
+ * Provision login users into a target Neon Postgres (users table ONLY).
  *
  * Why this exists (do NOT use scripts/seed-db.ts for prod):
  *   seed-db.ts upserts the login users idempotently, but then ALSO inserts a
@@ -10,6 +10,11 @@
  *
  * What it does: idempotent upsert (on username) of the shared seed identities
  *   (server/lib/seed-users.ts). Safe to re-run. No schema change.
+ *
+ * Driver: uses the Neon HTTP driver (HTTPS, matches prod on Vercel) rather than
+ *   importing the app's server/db, whose driver selection picks a WebSocket pool
+ *   for remote hosts -- that WS upgrade is commonly blocked on local networks.
+ *   HTTP over 443 is the reliable path for a one-off ops run.
  *
  * Credentials (ADR-034): reuses TEST_LOGIN_CREDENTIALS via buildSeedUsers().
  *   The passwords are committed in the repo -- acceptable ONLY because the
@@ -22,8 +27,9 @@
  * NEVER db:push / db:migrate against prod -- this is a data upsert only.
  */
 
+import { neon } from '@neondatabase/serverless';
+import { drizzle } from 'drizzle-orm/neon-http';
 import { sql } from 'drizzle-orm';
-import { db, closeDatabasePool } from '../server/db';
 import { users } from '@shared/schema';
 import { buildSeedUsers } from '../server/lib/seed-users';
 
@@ -35,6 +41,12 @@ async function provisionProdUsers(): Promise<number> {
     );
   }
 
+  const connectionString = process.env['DATABASE_URL'] ?? process.env['NEON_DATABASE_URL'];
+  if (!connectionString) {
+    throw new Error('DATABASE_URL (or NEON_DATABASE_URL) is required.');
+  }
+
+  const db = drizzle(neon(connectionString));
   const seedUsers = buildSeedUsers();
 
   for (const seedUser of seedUsers) {
@@ -45,7 +57,8 @@ async function provisionProdUsers(): Promise<number> {
   }
 
   // Verify the rows are present (count is idempotent across re-runs).
-  const [{ count }] = await db.select({ count: sql<number>`count(*)::int` }).from(users);
+  const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(users);
+  const count = row?.count ?? 0;
 
   console.log(
     `[DONE] Provisioned ${seedUsers.length} login user(s); users table now has ${count} row(s).`
@@ -54,12 +67,8 @@ async function provisionProdUsers(): Promise<number> {
 }
 
 provisionProdUsers()
-  .then(async () => {
-    await closeDatabasePool();
-    process.exit(0);
-  })
-  .catch(async (error: unknown) => {
+  .then(() => process.exit(0))
+  .catch((error: unknown) => {
     console.error('[FAIL] User provisioning failed:', error);
-    await closeDatabasePool();
     process.exit(1);
   });


### PR DESCRIPTION
## Why

Follow-up to #1069. The initial `scripts/provision-prod-users.ts` imported the app's `server/db`, whose driver selection (`shouldUseNodePostgresDriver`) returns true only for `localhost` — so remote Neon hosts fall through to the **neon-serverless WebSocket** pool. That WS upgrade fails on local networks:

```
All attempts to open a WebSocket to connect to the database failed ... fetch failed
```

So the one-off prod run couldn't connect.

## Fix

Switch the script to the **Neon HTTP driver** (`drizzle-orm/neon-http` over HTTPS/443) — the same transport prod uses on Vercel and the reliable path for a local ops run. The script is now self-contained (reads `DATABASE_URL` directly, no `server/db` boot-time storage policy). Behavior is otherwise identical: `PROVISION_PROD=1` gate, users-only idempotent upsert, row-count verify.

## Verified against prod

```
[DONE] Provisioned 5 login user(s); users table now has 5 row(s).
```

Prod `POST /api/auth/login` now returns **200 + token** for valid creds (`admin` / `admin-dev-2026`) — was `401 {"error":"invalid_credentials"}` for everyone. Wrong password still 401. This closes Task 7 item 2 (real prod login unblocked).

## Gates

- `npm run check` → 0 new TS errors
- Standalone tsc (`tsconfig.eslint.json`, covers `scripts/**`) → file clean
- Pre-commit + commit-msg hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)