### PR TITLE
fix(auth): attach Bearer to same-origin /api/* via global fetch interceptor (#1072)

### DIFF
--- a/client/src/lib/install-auth-fetch.ts
+++ b/client/src/lib/install-auth-fetch.ts
@@ -1,0 +1,60 @@
+/**
+ * Global fetch interceptor: attaches the Bearer auth token to same-origin /api/*
+ * requests. Fixes the prod gap where hooks calling fetch('/api/...') raw bypass
+ * queryClient's apiRequest/getQueryFn wrappers and 401 at the global /api auth
+ * boundary (requireAuth, Bearer-only; ADR-034). Installed in all environments.
+ *
+ * Scope guards:
+ * - Same-origin AND path starts with /api/ -> never leaks the token cross-origin.
+ * - Only when a token exists (getToken()).
+ * - Never overrides an Authorization header the caller already set, so
+ *   apiRequest/getQueryFn (which set it explicitly) are untouched.
+ */
+import { getToken } from './auth-token';
+
+type AuthFetchWindow = Window & {
+  __auth_fetch_installed?: boolean;
+};
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function isSameOriginApi(url: string): boolean {
+  try {
+    const resolved = new URL(url, window.location.origin);
+    return resolved.origin === window.location.origin && resolved.pathname.startsWith('/api/');
+  } catch {
+    return false;
+  }
+}
+
+function hasAuthHeader(input: RequestInfo | URL, init?: RequestInit): boolean {
+  const source = init?.headers ?? (input instanceof Request ? input.headers : undefined);
+  return new Headers(source).has('Authorization');
+}
+
+export function installAuthFetch(): void {
+  if (typeof window === 'undefined') return;
+
+  const authFetchWindow = window as AuthFetchWindow;
+  if (authFetchWindow.__auth_fetch_installed) return;
+  authFetchWindow.__auth_fetch_installed = true;
+
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    if (isSameOriginApi(getRequestUrl(input)) && !hasAuthHeader(input, init)) {
+      const token = getToken();
+      if (token) {
+        const headers = new Headers(
+          init?.headers ?? (input instanceof Request ? input.headers : undefined)
+        );
+        headers.set('Authorization', `Bearer ${token}`);
+        init = { ...init, headers };
+      }
+    }
+    return originalFetch(input, init);
+  };
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,6 +6,11 @@ import './styles/brand-tokens.css'; // Phase 1: Brand consistency (Inter/Poppins
 import { installFetchTap } from './debug/fetch-tap';
 import { checkEmergencyRollback } from './debug/emergency-rollback';
 import { bootstrapMonitoring } from './monitoring/bootstrap';
+import { installAuthFetch } from './lib/install-auth-fetch';
+
+// Attach Bearer token to same-origin /api/* requests (all envs). Fixes prod 401s
+// on hooks that call fetch('/api/...') raw and bypass apiRequest/getQueryFn (#1072).
+installAuthFetch();
 
 if (import.meta.env.DEV) {
   installFetchTap();

--- a/tests/unit/install-auth-fetch.test.ts
+++ b/tests/unit/install-auth-fetch.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getToken } from '@/lib/auth-token';
+import { installAuthFetch } from '@/lib/install-auth-fetch';
+
+vi.mock('@/lib/auth-token', () => ({ getToken: vi.fn() }));
+
+type AuthFetchWindow = Window & { __auth_fetch_installed?: boolean };
+
+const mockGetToken = vi.mocked(getToken);
+
+describe('installAuthFetch', () => {
+  let originalFetch: typeof window.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    window.fetch = fetchMock as typeof window.fetch;
+    mockGetToken.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    delete (window as AuthFetchWindow).__auth_fetch_installed;
+    vi.restoreAllMocks();
+  });
+
+  function lastInit(): RequestInit | undefined {
+    return fetchMock.mock.calls.at(-1)?.[1] as RequestInit | undefined;
+  }
+  function authOf(init: RequestInit | undefined): string | null {
+    return new Headers(init?.headers).get('Authorization');
+  }
+
+  it('attaches Bearer to same-origin /api/* when a token exists', async () => {
+    mockGetToken.mockReturnValue('tok123');
+    installAuthFetch();
+    await window.fetch('/api/funds/1/metrics');
+    expect(authOf(lastInit())).toBe('Bearer tok123');
+  });
+
+  it('does not attach when no token is present', async () => {
+    mockGetToken.mockReturnValue(null);
+    installAuthFetch();
+    await window.fetch('/api/funds/1/metrics');
+    expect(authOf(lastInit())).toBeNull();
+  });
+
+  it('does not override an Authorization header the caller already set', async () => {
+    mockGetToken.mockReturnValue('tok123');
+    installAuthFetch();
+    await window.fetch('/api/funds/1/metrics', { headers: { Authorization: 'Bearer caller' } });
+    expect(authOf(lastInit())).toBe('Bearer caller');
+  });
+
+  it('does not attach to non-/api same-origin requests', async () => {
+    mockGetToken.mockReturnValue('tok123');
+    installAuthFetch();
+    await window.fetch('/assets/app.js');
+    expect(authOf(lastInit())).toBeNull();
+  });
+
+  it('does not attach to cross-origin /api requests (token-leak guard)', async () => {
+    mockGetToken.mockReturnValue('tok123');
+    installAuthFetch();
+    await window.fetch('https://evil.example.com/api/funds/1');
+    expect(authOf(lastInit())).toBeNull();
+  });
+
+  it('preserves existing headers while adding Authorization', async () => {
+    mockGetToken.mockReturnValue('tok123');
+    installAuthFetch();
+    await window.fetch('/api/funds/1/metrics', { headers: { 'Content-Type': 'application/json' } });
+    const headers = new Headers(lastInit()?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer tok123');
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('installs once (idempotent) and returns the original response', async () => {
+    mockGetToken.mockReturnValue('tok123');
+    installAuthFetch();
+    installAuthFetch();
+    const res = await window.fetch('/api/funds/1/metrics');
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Fixes the prod-only bug (#1072) where the fund-scoped UI broadly **401s**: ~60 client
data-fetching hooks call `fetch('/api/...')` **raw**, bypassing `queryClient`'s `apiRequest` /
`getQueryFn` wrappers that attach `Authorization: Bearer <updog.authToken>`.

## Root cause

The gap is the **global `/api` auth boundary** (`server/lib/auth/jwt.ts` `requireAuth`, mounted at
`server/app.ts`), which is **Bearer-only with no cookie/session fallback** — not just
`enforceProvidedFundScope`. So *every* non-public `/api` call without the header 401s in prod
(everything except health / flags / `public/shares` / `auth/login` per `isPublicApiPath`).
Introduced by the Task-7 Bearer cutover (#1066/#1067); invisible in dev because dev-auth
auto-injects the user.

## Fix (client-only; server Bearer requirement unchanged, per ADR-034)

A **global fetch interceptor** installed at bootstrap in all envs
(`client/src/lib/install-auth-fetch.ts`, wired in `client/src/main.tsx`), mirroring the existing
`installFetchTap` pattern. It attaches `Authorization: Bearer <token>` to **same-origin `/api/*`**
requests when a token exists and no `Authorization` header is already present.

- No-ops on `apiRequest` / `getQueryFn` (they set the header explicitly).
- Never attaches cross-origin — **token-leak guard** (tested).
- Harmless on the public `/api/public/shares/*` routes.
- One module + one bootstrap call fixes every raw-fetch site (and future ones) while preserving each
  hook's existing response / streaming / branching logic — no per-hook rewrites, no risk to the
  streaming (`useAgentStream`) or dry-run/commit (`lp-reporting`) hooks.

## Tests

`tests/unit/install-auth-fetch.test.ts` (jsdom) — 7 cases: attach on same-origin `/api/*`,
no-token skip, no-override of a caller-set header, non-`/api` skip, cross-origin token-leak guard,
header preservation, idempotent install. All green; `npm run check` clean (0 new TS errors).

## Verification

- [x] Unit: 7/7 pass.
- [ ] In-browser prod (post-deploy): login `admin`, load `/portfolio?tab=reserve-planning`, confirm
  `metrics` / `allocations/latest` / `allocation-scenarios` return **200** and the tab renders.

Implemented via Hermes (codex worker-executor); reviewed + tested by Claude.

Closes #1072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
