### PR TITLE
feat(schema): prod-schema reconciler coverage for H9 + allocation scenarios (Plan 1 PRs 1A-1E)

### DIFF
--- a/migrations/0029_h9_actionability_reconcile_drift.sql
+++ b/migrations/0029_h9_actionability_reconcile_drift.sql
@@ -1,0 +1,244 @@
+-- @drift-patch
+-- Migration: 0029_h9_actionability_reconcile_drift
+-- Reason: M6 production schema reconciliation needs a replay-safe restatement
+-- of the journaled H9 actionability columns and constraints from 0018 so
+-- databases that missed that migration can converge without base-table DDL or
+-- data mutation.
+-- Purpose: reconcile-covered, additive, guarded H9 actionability DDL.
+-- Replay safety: IF EXISTS / IF NOT EXISTS column changes plus pg_constraint guards.
+
+ALTER TABLE IF EXISTS "fund_snapshots"
+  ADD COLUMN IF NOT EXISTS "h9_moic_source_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_assumptions_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_fingerprint_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_policy_version" text,
+  ADD COLUMN IF NOT EXISTS "h9_actionability_status" varchar(24);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.fund_snapshots') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.fund_snapshots'::regclass
+         AND conname = 'fund_snapshots_h9_actionability_status_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "fund_snapshots"
+      ADD CONSTRAINT "fund_snapshots_h9_actionability_status_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" IN (
+          'actionable',
+          'input_only',
+          'non_actionable',
+          'quarantined',
+          'unknown_legacy'
+        )
+      );
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.fund_snapshots') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.fund_snapshots'::regclass
+         AND conname = 'fund_snapshots_h9_actionable_fingerprint_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "fund_snapshots"
+      ADD CONSTRAINT "fund_snapshots_h9_actionable_fingerprint_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" <> 'actionable'
+        OR (
+          "h9_moic_source_input_hash" IS NOT NULL
+          AND "h9_round_evidence_input_hash" IS NOT NULL
+          AND "h9_round_evidence_assumptions_hash" IS NOT NULL
+          AND "h9_fingerprint_hash" IS NOT NULL
+          AND "h9_policy_version" IS NOT NULL
+        )
+      );
+  END IF;
+END
+$$;
+--> statement-breakpoint
+ALTER TABLE IF EXISTS "fund_calculation_modes"
+  ADD COLUMN IF NOT EXISTS "h9_moic_source_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_assumptions_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_fingerprint_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_policy_version" text,
+  ADD COLUMN IF NOT EXISTS "h9_actionability_status" varchar(24);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.fund_calculation_modes') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.fund_calculation_modes'::regclass
+         AND conname = 'fund_calculation_modes_h9_actionability_status_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "fund_calculation_modes"
+      ADD CONSTRAINT "fund_calculation_modes_h9_actionability_status_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" IN (
+          'actionable',
+          'input_only',
+          'non_actionable',
+          'quarantined',
+          'unknown_legacy'
+        )
+      );
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.fund_calculation_modes') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.fund_calculation_modes'::regclass
+         AND conname = 'fund_calculation_modes_h9_actionable_fingerprint_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "fund_calculation_modes"
+      ADD CONSTRAINT "fund_calculation_modes_h9_actionable_fingerprint_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" <> 'actionable'
+        OR (
+          "h9_moic_source_input_hash" IS NOT NULL
+          AND "h9_round_evidence_input_hash" IS NOT NULL
+          AND "h9_round_evidence_assumptions_hash" IS NOT NULL
+          AND "h9_fingerprint_hash" IS NOT NULL
+          AND "h9_policy_version" IS NOT NULL
+        )
+      );
+  END IF;
+END
+$$;
+--> statement-breakpoint
+ALTER TABLE IF EXISTS "lp_report_packages"
+  ADD COLUMN IF NOT EXISTS "h9_moic_source_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_assumptions_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_fingerprint_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_policy_version" text,
+  ADD COLUMN IF NOT EXISTS "h9_actionability_status" varchar(24);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.lp_report_packages') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.lp_report_packages'::regclass
+         AND conname = 'lp_report_packages_h9_actionability_status_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "lp_report_packages"
+      ADD CONSTRAINT "lp_report_packages_h9_actionability_status_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" IN (
+          'actionable',
+          'input_only',
+          'non_actionable',
+          'quarantined',
+          'unknown_legacy'
+        )
+      );
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.lp_report_packages') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.lp_report_packages'::regclass
+         AND conname = 'lp_report_packages_h9_actionable_fingerprint_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "lp_report_packages"
+      ADD CONSTRAINT "lp_report_packages_h9_actionable_fingerprint_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" <> 'actionable'
+        OR (
+          "h9_moic_source_input_hash" IS NOT NULL
+          AND "h9_round_evidence_input_hash" IS NOT NULL
+          AND "h9_round_evidence_assumptions_hash" IS NOT NULL
+          AND "h9_fingerprint_hash" IS NOT NULL
+          AND "h9_policy_version" IS NOT NULL
+        )
+      );
+  END IF;
+END
+$$;
+--> statement-breakpoint
+ALTER TABLE IF EXISTS "pacing_history"
+  ADD COLUMN IF NOT EXISTS "h9_moic_source_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_input_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_round_evidence_assumptions_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_fingerprint_hash" text,
+  ADD COLUMN IF NOT EXISTS "h9_policy_version" text,
+  ADD COLUMN IF NOT EXISTS "h9_actionability_status" varchar(24);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.pacing_history') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.pacing_history'::regclass
+         AND conname = 'pacing_history_h9_actionability_status_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "pacing_history"
+      ADD CONSTRAINT "pacing_history_h9_actionability_status_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" IN (
+          'actionable',
+          'input_only',
+          'non_actionable',
+          'quarantined',
+          'unknown_legacy'
+        )
+      );
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.pacing_history') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.pacing_history'::regclass
+         AND conname = 'pacing_history_h9_actionable_fingerprint_check'
+     ) THEN
+    ALTER TABLE IF EXISTS "pacing_history"
+      ADD CONSTRAINT "pacing_history_h9_actionable_fingerprint_check"
+      CHECK (
+        "h9_actionability_status" IS NULL
+        OR "h9_actionability_status" <> 'actionable'
+        OR (
+          "h9_moic_source_input_hash" IS NOT NULL
+          AND "h9_round_evidence_input_hash" IS NOT NULL
+          AND "h9_round_evidence_assumptions_hash" IS NOT NULL
+          AND "h9_fingerprint_hash" IS NOT NULL
+          AND "h9_policy_version" IS NOT NULL
+        )
+      );
+  END IF;
+END
+$$;

--- a/migrations/0030_allocation_scenarios_reconcile_drift.sql
+++ b/migrations/0030_allocation_scenarios_reconcile_drift.sql
@@ -1,0 +1,479 @@
+-- @drift-patch
+-- Reason: restate 0025 allocation-scenario tables as an additive, replay-safe drift patch that creates missing tables and repairs partial tables without modifying data.
+-- Purpose: idempotent reconcile-covered restatement of 0025; create-if-absent plus guarded column repair, constraints, and indexes.
+
+CREATE TABLE IF NOT EXISTS "allocation_scenarios" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "fund_id" integer NOT NULL,
+  "name" varchar(120) NOT NULL,
+  "notes" text,
+  "source_allocation_version" integer,
+  "company_count" integer NOT NULL DEFAULT 0,
+  "total_planned_cents" bigint NOT NULL DEFAULT 0,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "last_applied_at" timestamp with time zone,
+  "last_applied_by" text,
+  "last_applied_allocation_version" integer,
+  "last_synced_at" timestamp with time zone,
+  "last_synced_by" text
+);
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "id" uuid DEFAULT gen_random_uuid();
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "fund_id" integer NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "name" varchar(120) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "notes" text;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "source_allocation_version" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "company_count" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "total_planned_cents" bigint NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "last_applied_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "last_applied_by" text;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "last_applied_allocation_version" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "last_synced_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenarios" ADD COLUMN IF NOT EXISTS "last_synced_by" text;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenarios') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenarios'::regclass
+         AND conname = 'allocation_scenarios_fund_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenarios"
+      ADD CONSTRAINT "allocation_scenarios_fund_id_fkey"
+      FOREIGN KEY ("fund_id") REFERENCES "funds"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "allocation_scenarios_fund_updated_idx" ON "allocation_scenarios" ("fund_id", "updated_at" DESC, "id" DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "allocation_scenario_items" (
+  "scenario_id" uuid NOT NULL,
+  "company_id" integer NOT NULL,
+  "planned_reserves_cents" bigint NOT NULL DEFAULT 0,
+  "allocation_cap_cents" bigint,
+  "allocation_reason" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  PRIMARY KEY ("scenario_id", "company_id")
+);
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_items" ADD COLUMN IF NOT EXISTS "scenario_id" uuid NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_items" ADD COLUMN IF NOT EXISTS "company_id" integer NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_items" ADD COLUMN IF NOT EXISTS "planned_reserves_cents" bigint NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_items" ADD COLUMN IF NOT EXISTS "allocation_cap_cents" bigint;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_items" ADD COLUMN IF NOT EXISTS "allocation_reason" text;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_items" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_items" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_items') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_items'::regclass
+         AND conname = 'allocation_scenario_items_scenario_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_items"
+      ADD CONSTRAINT "allocation_scenario_items_scenario_id_fkey"
+      FOREIGN KEY ("scenario_id") REFERENCES "allocation_scenarios"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_items') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_items'::regclass
+         AND conname = 'allocation_scenario_items_company_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_items"
+      ADD CONSTRAINT "allocation_scenario_items_company_id_fkey"
+      FOREIGN KEY ("company_id") REFERENCES "portfoliocompanies"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_items') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_items'::regclass
+         AND conname = 'allocation_scenario_items_non_negative_planned'
+     ) THEN
+    ALTER TABLE "allocation_scenario_items"
+      ADD CONSTRAINT "allocation_scenario_items_non_negative_planned"
+      CHECK ("planned_reserves_cents" >= 0);
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_items') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_items'::regclass
+         AND conname = 'allocation_scenario_items_non_negative_cap'
+     ) THEN
+    ALTER TABLE "allocation_scenario_items"
+      ADD CONSTRAINT "allocation_scenario_items_non_negative_cap"
+      CHECK ("allocation_cap_cents" IS NULL OR "allocation_cap_cents" >= 0);
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_items') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_items'::regclass
+         AND conname = 'allocation_scenario_items_cap_gte_planned'
+     ) THEN
+    ALTER TABLE "allocation_scenario_items"
+      ADD CONSTRAINT "allocation_scenario_items_cap_gte_planned"
+      CHECK ("allocation_cap_cents" IS NULL OR "allocation_cap_cents" >= "planned_reserves_cents");
+  END IF;
+END
+$$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "allocation_scenario_items_scenario_idx" ON "allocation_scenario_items" ("scenario_id", "company_id");
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "allocation_scenario_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "scenario_id" uuid NOT NULL,
+  "fund_id" integer NOT NULL,
+  "event_type" varchar(32) NOT NULL,
+  "actor_user_id" integer,
+  "actor_label" text,
+  "note" text,
+  "source_allocation_version" integer,
+  "resulting_allocation_version" integer,
+  "change_summary_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "id" uuid DEFAULT gen_random_uuid();
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "scenario_id" uuid NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "fund_id" integer NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "event_type" varchar(32) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "actor_user_id" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "actor_label" text;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "note" text;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "source_allocation_version" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "resulting_allocation_version" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "change_summary_json" jsonb NOT NULL DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_events') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_events'::regclass
+         AND conname = 'allocation_scenario_events_scenario_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_events"
+      ADD CONSTRAINT "allocation_scenario_events_scenario_id_fkey"
+      FOREIGN KEY ("scenario_id") REFERENCES "allocation_scenarios"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_events') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_events'::regclass
+         AND conname = 'allocation_scenario_events_fund_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_events"
+      ADD CONSTRAINT "allocation_scenario_events_fund_id_fkey"
+      FOREIGN KEY ("fund_id") REFERENCES "funds"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_events') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_events'::regclass
+         AND conname = 'allocation_scenario_events_actor_user_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_events"
+      ADD CONSTRAINT "allocation_scenario_events_actor_user_id_fkey"
+      FOREIGN KEY ("actor_user_id") REFERENCES "users"("id");
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_events') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_events'::regclass
+         AND conname = 'allocation_scenario_events_type_check'
+     ) THEN
+    ALTER TABLE "allocation_scenario_events"
+      ADD CONSTRAINT "allocation_scenario_events_type_check"
+      CHECK ("event_type" IN ('applied', 'synced'));
+  END IF;
+END
+$$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "allocation_scenario_events_scenario_created_idx" ON "allocation_scenario_events" ("scenario_id", "created_at" DESC, "id" DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "allocation_scenario_events_fund_created_idx" ON "allocation_scenario_events" ("fund_id", "created_at" DESC, "id" DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "allocation_scenario_ic_decisions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "scenario_id" uuid NOT NULL,
+  "fund_id" integer NOT NULL,
+  "company_id" integer NOT NULL,
+  "decision_type" varchar(32) NOT NULL,
+  "decision_status" varchar(32) NOT NULL DEFAULT 'draft',
+  "rationale" text NOT NULL,
+  "proposed_planned_reserves_cents" bigint,
+  "final_planned_reserves_cents" bigint,
+  "decided_by_user_id" integer,
+  "decided_by_label" text,
+  "decided_at" timestamp with time zone,
+  "source_allocation_version" integer,
+  "live_allocation_version" integer,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "id" uuid DEFAULT gen_random_uuid();
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "scenario_id" uuid NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "fund_id" integer NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "company_id" integer NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "decision_type" varchar(32) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "decision_status" varchar(32) NOT NULL DEFAULT 'draft';
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "rationale" text NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "proposed_planned_reserves_cents" bigint;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "final_planned_reserves_cents" bigint;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "decided_by_user_id" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "decided_by_label" text;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "decided_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "source_allocation_version" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "live_allocation_version" integer;
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "allocation_scenario_ic_decisions" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_scenario_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_scenario_id_fkey"
+      FOREIGN KEY ("scenario_id") REFERENCES "allocation_scenarios"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_fund_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_fund_id_fkey"
+      FOREIGN KEY ("fund_id") REFERENCES "funds"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_company_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_company_id_fkey"
+      FOREIGN KEY ("company_id") REFERENCES "portfoliocompanies"("id") ON DELETE CASCADE;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_decided_by_user_id_fkey'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_decided_by_user_id_fkey"
+      FOREIGN KEY ("decided_by_user_id") REFERENCES "users"("id");
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_unique_company'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_unique_company"
+      UNIQUE ("scenario_id", "company_id");
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_type_check'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_type_check"
+      CHECK ("decision_type" IN ('follow_on', 'defer', 'cut_reserve', 'no_action'));
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_status_check'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_status_check"
+      CHECK ("decision_status" IN ('draft', 'proposed', 'approved', 'rejected'));
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_proposed_non_negative'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_proposed_non_negative"
+      CHECK ("proposed_planned_reserves_cents" IS NULL OR "proposed_planned_reserves_cents" >= 0);
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF to_regclass('public.allocation_scenario_ic_decisions') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conrelid = 'public.allocation_scenario_ic_decisions'::regclass
+         AND conname = 'allocation_scenario_ic_decisions_final_non_negative'
+     ) THEN
+    ALTER TABLE "allocation_scenario_ic_decisions"
+      ADD CONSTRAINT "allocation_scenario_ic_decisions_final_non_negative"
+      CHECK ("final_planned_reserves_cents" IS NULL OR "final_planned_reserves_cents" >= 0);
+  END IF;
+END
+$$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "allocation_scenario_ic_decisions_scenario_idx" ON "allocation_scenario_ic_decisions" ("scenario_id", "company_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "allocation_scenario_ic_decisions_fund_idx" ON "allocation_scenario_ic_decisions" ("fund_id", "scenario_id", "updated_at" DESC, "id" DESC);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1783790526019,
       "tag": "0029_h9_actionability_reconcile_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1783791316672,
+      "tag": "0030_allocation_scenarios_reconcile_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1783022913852,
       "tag": "0028_operator_seam_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1783790526019,
+      "tag": "0029_h9_actionability_reconcile_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/06-h9-actionability.json
+++ b/scripts/prod-schema-manifests/06-h9-actionability.json
@@ -1,0 +1,76 @@
+{
+  "name": "M6-h9-actionability",
+  "order": 6,
+  "description": "H9 actionability columns/constraints on existing persistence tables (drift-covered).",
+  "missingTablePolicy": "existing_table_required",
+  "sqlFiles": ["migrations/0029_h9_actionability_reconcile_drift.sql"],
+  "allowedCreateTables": [],
+  "expectedTables": [
+    {
+      "name": "fund_snapshots",
+      "columns": [
+        { "name": "h9_moic_source_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
+        { "name": "h9_fingerprint_hash", "nullable": true },
+        { "name": "h9_policy_version", "nullable": true },
+        { "name": "h9_actionability_status", "nullable": true }
+      ],
+      "constraints": [
+        "fund_snapshots_h9_actionability_status_check",
+        "fund_snapshots_h9_actionable_fingerprint_check"
+      ],
+      "indexes": []
+    },
+    {
+      "name": "fund_calculation_modes",
+      "sharedTable": true,
+      "columns": [
+        { "name": "h9_moic_source_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
+        { "name": "h9_fingerprint_hash", "nullable": true },
+        { "name": "h9_policy_version", "nullable": true },
+        { "name": "h9_actionability_status", "nullable": true }
+      ],
+      "constraints": [
+        "fund_calculation_modes_h9_actionability_status_check",
+        "fund_calculation_modes_h9_actionable_fingerprint_check"
+      ],
+      "indexes": []
+    },
+    {
+      "name": "lp_report_packages",
+      "sharedTable": true,
+      "columns": [
+        { "name": "h9_moic_source_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
+        { "name": "h9_fingerprint_hash", "nullable": true },
+        { "name": "h9_policy_version", "nullable": true },
+        { "name": "h9_actionability_status", "nullable": true }
+      ],
+      "constraints": [
+        "lp_report_packages_h9_actionability_status_check",
+        "lp_report_packages_h9_actionable_fingerprint_check"
+      ],
+      "indexes": []
+    },
+    {
+      "name": "pacing_history",
+      "columns": [
+        { "name": "h9_moic_source_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_input_hash", "nullable": true },
+        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
+        { "name": "h9_fingerprint_hash", "nullable": true },
+        { "name": "h9_policy_version", "nullable": true },
+        { "name": "h9_actionability_status", "nullable": true }
+      ],
+      "constraints": [
+        "pacing_history_h9_actionability_status_check",
+        "pacing_history_h9_actionable_fingerprint_check"
+      ],
+      "indexes": []
+    }
+  ]
+}

--- a/scripts/prod-schema-manifests/07-allocation-scenarios.json
+++ b/scripts/prod-schema-manifests/07-allocation-scenarios.json
@@ -1,0 +1,118 @@
+{
+  "name": "M7-allocation-scenarios",
+  "order": 7,
+  "description": "Live allocation-scenario planning/events/IC-decision tables (drift-covered).",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0030_allocation_scenarios_reconcile_drift.sql"],
+  "allowedCreateTables": [
+    "allocation_scenarios",
+    "allocation_scenario_items",
+    "allocation_scenario_events",
+    "allocation_scenario_ic_decisions"
+  ],
+  "expectedTables": [
+    {
+      "name": "allocation_scenarios",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "name", "nullable": false },
+        { "name": "notes", "nullable": true },
+        { "name": "source_allocation_version", "nullable": true },
+        { "name": "company_count", "nullable": false },
+        { "name": "total_planned_cents", "nullable": false },
+        { "name": "created_at", "nullable": false },
+        { "name": "updated_at", "nullable": false },
+        { "name": "last_applied_at", "nullable": true },
+        { "name": "last_applied_by", "nullable": true },
+        { "name": "last_applied_allocation_version", "nullable": true },
+        { "name": "last_synced_at", "nullable": true },
+        { "name": "last_synced_by", "nullable": true }
+      ],
+      "constraints": ["allocation_scenarios_fund_id_fkey"],
+      "indexes": ["allocation_scenarios_fund_updated_idx"]
+    },
+    {
+      "name": "allocation_scenario_items",
+      "columns": [
+        { "name": "scenario_id", "nullable": false },
+        { "name": "company_id", "nullable": false },
+        { "name": "planned_reserves_cents", "nullable": false },
+        { "name": "allocation_cap_cents", "nullable": true },
+        { "name": "allocation_reason", "nullable": true },
+        { "name": "created_at", "nullable": false },
+        { "name": "updated_at", "nullable": false }
+      ],
+      "constraints": [
+        "allocation_scenario_items_scenario_id_fkey",
+        "allocation_scenario_items_company_id_fkey",
+        "allocation_scenario_items_non_negative_planned",
+        "allocation_scenario_items_non_negative_cap",
+        "allocation_scenario_items_cap_gte_planned"
+      ],
+      "indexes": ["allocation_scenario_items_scenario_idx"]
+    },
+    {
+      "name": "allocation_scenario_events",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "scenario_id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "event_type", "nullable": false },
+        { "name": "actor_user_id", "nullable": true },
+        { "name": "actor_label", "nullable": true },
+        { "name": "note", "nullable": true },
+        { "name": "source_allocation_version", "nullable": true },
+        { "name": "resulting_allocation_version", "nullable": true },
+        { "name": "change_summary_json", "nullable": false },
+        { "name": "created_at", "nullable": false }
+      ],
+      "constraints": [
+        "allocation_scenario_events_scenario_id_fkey",
+        "allocation_scenario_events_fund_id_fkey",
+        "allocation_scenario_events_actor_user_id_fkey",
+        "allocation_scenario_events_type_check"
+      ],
+      "indexes": [
+        "allocation_scenario_events_scenario_created_idx",
+        "allocation_scenario_events_fund_created_idx"
+      ]
+    },
+    {
+      "name": "allocation_scenario_ic_decisions",
+      "columns": [
+        { "name": "id", "nullable": false },
+        { "name": "scenario_id", "nullable": false },
+        { "name": "fund_id", "nullable": false },
+        { "name": "company_id", "nullable": false },
+        { "name": "decision_type", "nullable": false },
+        { "name": "decision_status", "nullable": false },
+        { "name": "rationale", "nullable": false },
+        { "name": "proposed_planned_reserves_cents", "nullable": true },
+        { "name": "final_planned_reserves_cents", "nullable": true },
+        { "name": "decided_by_user_id", "nullable": true },
+        { "name": "decided_by_label", "nullable": true },
+        { "name": "decided_at", "nullable": true },
+        { "name": "source_allocation_version", "nullable": true },
+        { "name": "live_allocation_version", "nullable": true },
+        { "name": "created_at", "nullable": false },
+        { "name": "updated_at", "nullable": false }
+      ],
+      "constraints": [
+        "allocation_scenario_ic_decisions_scenario_id_fkey",
+        "allocation_scenario_ic_decisions_fund_id_fkey",
+        "allocation_scenario_ic_decisions_company_id_fkey",
+        "allocation_scenario_ic_decisions_decided_by_user_id_fkey",
+        "allocation_scenario_ic_decisions_unique_company",
+        "allocation_scenario_ic_decisions_type_check",
+        "allocation_scenario_ic_decisions_status_check",
+        "allocation_scenario_ic_decisions_proposed_non_negative",
+        "allocation_scenario_ic_decisions_final_non_negative"
+      ],
+      "indexes": [
+        "allocation_scenario_ic_decisions_scenario_idx",
+        "allocation_scenario_ic_decisions_fund_idx"
+      ]
+    }
+  ]
+}

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -25,11 +25,31 @@ export const RECONCILE_LOCK_ID = 20260628;
 export const ACTION_SKIP = 'SKIP';
 export const ACTION_APPLY_MISSING_DDL = 'APPLY-MISSING-DDL';
 export const ACTION_REFUSE_FOR_HUMAN = 'REFUSE-FOR-HUMAN';
+export const MISSING_TABLE_POLICY_CREATE_OR_REPAIR = 'create_or_repair';
+export const MISSING_TABLE_POLICY_EXISTING_REQUIRED = 'existing_table_required';
+
+/** @typedef {'create_or_repair' | 'existing_table_required'} MissingTablePolicy */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SAFE_IDENTIFIER_PATTERN = /^[a-z_][a-z0-9_]*$/;
 const FORBIDDEN_SQL_PATTERN = /\b(?:neon_auth|drizzle_migrations)\b/i;
 const MIGRATION_MARKER_PATTERN = /^\s*--\s*@(generated|drift-patch)\b/m;
+const KNOWN_MANIFEST_KEYS = new Set([
+  'name',
+  'order',
+  'description',
+  'sqlFiles',
+  'allowedCreateTables',
+  'expectedTables',
+  'dropObjects',
+  'missingTablePolicy',
+  'manifestPath',
+]);
+const MISSING_TABLE_POLICIES = new Set([
+  MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
+  MISSING_TABLE_POLICY_EXISTING_REQUIRED,
+]);
+const warnedMissingTablePolicyManifests = new Set();
 
 export class ReconcileError extends Error {
   constructor(message, details = {}) {
@@ -141,6 +161,59 @@ export function manifestChecksum(manifest, sqlFiles) {
   );
 }
 
+function manifestLabel(manifest) {
+  return String(manifest?.manifestPath ?? manifest?.name ?? '<unknown>');
+}
+
+function validateManifestKeys(manifest) {
+  for (const key of Object.keys(manifest ?? {})) {
+    if (!KNOWN_MANIFEST_KEYS.has(key)) {
+      throw new ReconcileError(`Manifest ${manifestLabel(manifest)} has unsupported top-level key ${key}`, {
+        kind: 'unknown-manifest-key',
+        manifest: manifestLabel(manifest),
+        key,
+      });
+    }
+  }
+}
+
+function validateMissingTablePolicyValue(manifest) {
+  if (manifest?.missingTablePolicy === undefined) {
+    return;
+  }
+  if (!MISSING_TABLE_POLICIES.has(manifest.missingTablePolicy)) {
+    throw new ReconcileError(
+      `Manifest ${manifestLabel(manifest)} has invalid missingTablePolicy ${String(manifest.missingTablePolicy)}`,
+      {
+        kind: 'invalid-missing-table-policy',
+        manifest: manifestLabel(manifest),
+        missingTablePolicy: manifest.missingTablePolicy,
+      }
+    );
+  }
+}
+
+function validateManifest(manifest) {
+  validateManifestKeys(manifest);
+  validateMissingTablePolicyValue(manifest);
+}
+
+function resolveMissingTablePolicy(manifest) {
+  validateManifest(manifest);
+  if (manifest?.missingTablePolicy !== undefined) {
+    return manifest.missingTablePolicy;
+  }
+
+  const label = manifestLabel(manifest);
+  if (!warnedMissingTablePolicyManifests.has(label)) {
+    warnedMissingTablePolicyManifests.add(label);
+    console.warn(
+      `Manifest ${label} has no missingTablePolicy; defaulting to ${MISSING_TABLE_POLICY_CREATE_OR_REPAIR} (deprecated)`
+    );
+  }
+  return MISSING_TABLE_POLICY_CREATE_OR_REPAIR;
+}
+
 export function statementHashes(sqlFiles, extraStatements = []) {
   return [
     ...sqlFiles.flatMap((file) =>
@@ -159,6 +232,7 @@ export function statementHashes(sqlFiles, extraStatements = []) {
 }
 
 export function validateDropObjects(manifest) {
+  validateManifest(manifest);
   for (const drop of manifest.dropObjects ?? []) {
     if (drop.kind !== 'index' && drop.kind !== 'constraint') {
       throw new ReconcileError(
@@ -209,6 +283,7 @@ export function dropStatements(manifest) {
 }
 
 export function validateManifestSql(manifest, sqlFiles) {
+  validateManifest(manifest);
   const allowedCreates = new Set([
     ...(manifest.allowedCreateTables ?? []),
     ...(manifest.expectedTables ?? []).map((table) => table.name),
@@ -256,12 +331,14 @@ export function extractCreateTableNames(sql) {
 }
 
 export async function auditManifest(client, manifest) {
+  const missingTablePolicy = resolveMissingTablePolicy(manifest);
   const expectedTables = manifest.expectedTables ?? [];
   const dropObjects = manifest.dropObjects ?? [];
   const tableNames = expectedTables.map((table) => table.name);
   if (tableNames.length === 0 && dropObjects.length === 0) {
     return {
       manifest: manifest.name,
+      missingTablePolicy,
       action: ACTION_SKIP,
       objects: [],
     };
@@ -284,6 +361,7 @@ export async function auditManifest(client, manifest) {
           columns: columns.get(expectedTable.name) ?? new Map(),
           constraints,
           indexes,
+          missingTablePolicy,
         })
       );
     }
@@ -295,6 +373,7 @@ export async function auditManifest(client, manifest) {
 
   return {
     manifest: manifest.name,
+    missingTablePolicy,
     action: summarizeAction(objects.map((object) => object.action)),
     objects,
   };
@@ -351,8 +430,11 @@ async function loadPresentDropConstraints(client, constraintDrops) {
   return new Set(result.rows.map((row) => row.conname));
 }
 
-export function decideObjectAction({ tablePresent, deltas, populated }) {
+export function decideObjectAction({ tablePresent, deltas, populated, missingTablePolicy }) {
   if (!tablePresent) {
+    if (missingTablePolicy === MISSING_TABLE_POLICY_EXISTING_REQUIRED) {
+      return ACTION_REFUSE_FOR_HUMAN;
+    }
     return ACTION_APPLY_MISSING_DDL;
   }
 
@@ -377,7 +459,9 @@ export function formatAuditReport({ identity, privilegePrecheck, audits, apply }
   ];
 
   for (const audit of audits) {
-    lines.push(`${audit.manifest}: ${audit.action}`);
+    lines.push(
+      `${audit.manifest}: ${audit.action} (missingTablePolicy=${audit.missingTablePolicy ?? MISSING_TABLE_POLICY_CREATE_OR_REPAIR})`
+    );
     for (const object of audit.objects) {
       const deltaSummary =
         object.deltas.length === 0
@@ -559,17 +643,31 @@ export async function runReconcileCli({ argv = process.argv.slice(2), env = proc
   }
 }
 
-async function auditTable({ client, expectedTable, tablePresent, columns, constraints, indexes }) {
+async function auditTable({
+  client,
+  expectedTable,
+  tablePresent,
+  columns,
+  constraints,
+  indexes,
+  missingTablePolicy,
+}) {
   const deltas = [];
 
   if (!tablePresent) {
     deltas.push({ kind: 'missing-table', name: expectedTable.name, additiveSafe: true });
+    const action = decideObjectAction({
+      tablePresent,
+      deltas,
+      populated: false,
+      missingTablePolicy,
+    });
     return {
       table: expectedTable.name,
       present: false,
       populated: false,
       deltas,
-      action: ACTION_APPLY_MISSING_DDL,
+      action,
     };
   }
 
@@ -631,7 +729,7 @@ async function auditTable({ client, expectedTable, tablePresent, columns, constr
   const populated =
     deltas.some((delta) => delta.additiveSafe === false) &&
     (await hasRows(client, expectedTable.name));
-  const action = decideObjectAction({ tablePresent, deltas, populated });
+  const action = decideObjectAction({ tablePresent, deltas, populated, missingTablePolicy });
 
   return {
     table: expectedTable.name,

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -62,6 +62,22 @@ const LP_CORE_MANIFEST_TABLES = [
   'report_templates',
   'lp_audit_log',
 ] as const;
+// M6 (06-h9-actionability): H9 actionability columns live on these existing tables.
+// fund_calculation_modes + lp_report_packages are also owned by M2/M4 (sharedTable),
+// so the manifest union now contains them twice - compare as a Set.
+const H9_MANIFEST_TABLES = [
+  'fund_snapshots',
+  'fund_calculation_modes',
+  'lp_report_packages',
+  'pacing_history',
+] as const;
+// M7 (07-allocation-scenarios): live allocation scenario tables are manifest-owned.
+const ALLOCATION_SCENARIO_MANIFEST_TABLES = [
+  'allocation_scenarios',
+  'allocation_scenario_items',
+  'allocation_scenario_events',
+  'allocation_scenario_ic_decisions',
+] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
   'flags_state',
@@ -676,8 +692,14 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
       )
       .map(pgIdentifier);
 
-    expect([...expectedTables].sort()).toEqual(
-      [...C1_MOUNTED_TABLES, ...SEAM_MANIFEST_TABLES, ...LP_CORE_MANIFEST_TABLES].sort()
+    expect(new Set(expectedTables)).toEqual(
+      new Set([
+        ...C1_MOUNTED_TABLES,
+        ...SEAM_MANIFEST_TABLES,
+        ...LP_CORE_MANIFEST_TABLES,
+        ...H9_MANIFEST_TABLES,
+        ...ALLOCATION_SCENARIO_MANIFEST_TABLES,
+      ])
     );
 
     const migratedTables = await publicTables(pool!, expectedTables);
@@ -786,116 +808,105 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     // alert_evaluation_executions, job_outbox.dedupe_key, idx_job_outbox_job_type_dedupe, performance_alerts_open_incident_unique, backtest_results.scenario_comparison_summary are in BOTH the journal and shape source -> proven by the sentinel intersection diff above; asserting them here would be vacuous (the journal pre-supplies them).
   });
 
-  it(
-    'smoke-runs the s8.1 operator-seam audit script against the journal clone',
-    async () => {
-      expect(postgres).toBeDefined();
-      const outPath = path.join(
-        os.tmpdir(),
-        `s81-audit-smoke-${process.pid}-${Date.now()}.json`
-      );
+  it('smoke-runs the s8.1 operator-seam audit script against the journal clone', async () => {
+    expect(postgres).toBeDefined();
+    const outPath = path.join(os.tmpdir(), `s81-audit-smoke-${process.pid}-${Date.now()}.json`);
 
-      await execFileAsync('node', ['scripts/audit-prod-operator-seam.mjs', '--out', outPath], {
-        cwd: process.cwd(),
-        env: { ...process.env, DATABASE_URL: postgres!.getConnectionUri() },
-      });
+    await execFileAsync('node', ['scripts/audit-prod-operator-seam.mjs', '--out', outPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, DATABASE_URL: postgres!.getConnectionUri() },
+    });
 
-      const artifact = JSON.parse(await readFile(outPath, 'utf8')) as {
-        completed: boolean;
-        query_count: number;
-        results: {
-          old_global_indexes: Array<{ index_name: string; absent?: boolean }>;
-          scoped_indexes: Array<{
-            index_name: string;
-            absent?: boolean;
-            is_valid?: boolean;
-            is_ready?: boolean;
-          }>;
-          fund_snapshot_fks: Array<{ constraint_name: string; absent?: boolean }>;
-          outbox_status_checks: Array<{ constraint_name: string }>;
-          orphan_counts: {
-            fund_snapshots_run_id_orphans: number;
-            fund_snapshots_config_id_orphans: number;
-          };
-          row_counts: Record<string, number>;
+    const artifact = JSON.parse(await readFile(outPath, 'utf8')) as {
+      completed: boolean;
+      query_count: number;
+      results: {
+        old_global_indexes: Array<{ index_name: string; absent?: boolean }>;
+        scoped_indexes: Array<{
+          index_name: string;
+          absent?: boolean;
+          is_valid?: boolean;
+          is_ready?: boolean;
+        }>;
+        fund_snapshot_fks: Array<{ constraint_name: string; absent?: boolean }>;
+        outbox_status_checks: Array<{ constraint_name: string }>;
+        orphan_counts: {
+          fund_snapshots_run_id_orphans: number;
+          fund_snapshots_config_id_orphans: number;
         };
+        row_counts: Record<string, number>;
       };
+    };
 
-      // Positive control on the detection queries, pinned to post-0028 DB-A truth:
-      // the three old GLOBAL idempotency indexes are DROPPED by 0028 (the script
-      // must report them absent, not error), while the scoped indexes (0024),
-      // fund_snapshots FKs (0002), and job_outbox_status_check (0005) remain
-      // present. This proves detection in BOTH directions before an operator
-      // session relies on it.
-      expect(artifact.completed).toBe(true);
-      expect(artifact.query_count).toBeGreaterThan(0);
-      expect(
-        artifact.results.old_global_indexes
-          .filter((entry) => entry.absent)
-          .map((entry) => entry.index_name)
-          .sort()
-      ).toEqual([
-        'forecast_snapshots_idempotency_unique_idx',
-        'investment_lots_idempotency_unique_idx',
-        'reserve_allocations_idempotency_unique_idx',
-      ]);
-      expect(
-        artifact.results.scoped_indexes.filter(
-          (entry) => entry.absent || !entry.is_valid || !entry.is_ready
-        )
-      ).toEqual([]);
-      const foundFks = artifact.results.fund_snapshot_fks
-        .filter((entry) => !entry.absent)
-        .map((entry) => entry.constraint_name)
-        .sort();
-      expect(foundFks).toEqual([
-        'fund_snapshots_config_id_fundconfigs_id_fk',
-        'fund_snapshots_run_id_calc_runs_id_fk',
-      ]);
-      expect(
-        artifact.results.outbox_status_checks.map((entry) => entry.constraint_name)
-      ).toContain('job_outbox_status_check');
-      expect(artifact.results.orphan_counts.fund_snapshots_run_id_orphans).toBe(0);
-      expect(artifact.results.orphan_counts.fund_snapshots_config_id_orphans).toBe(0);
-      expect(Object.keys(artifact.results.row_counts)).toHaveLength(7);
-    },
-    60_000
-  );
+    // Positive control on the detection queries, pinned to post-0028 DB-A truth:
+    // the three old GLOBAL idempotency indexes are DROPPED by 0028 (the script
+    // must report them absent, not error), while the scoped indexes (0024),
+    // fund_snapshots FKs (0002), and job_outbox_status_check (0005) remain
+    // present. This proves detection in BOTH directions before an operator
+    // session relies on it.
+    expect(artifact.completed).toBe(true);
+    expect(artifact.query_count).toBeGreaterThan(0);
+    expect(
+      artifact.results.old_global_indexes
+        .filter((entry) => entry.absent)
+        .map((entry) => entry.index_name)
+        .sort()
+    ).toEqual([
+      'forecast_snapshots_idempotency_unique_idx',
+      'investment_lots_idempotency_unique_idx',
+      'reserve_allocations_idempotency_unique_idx',
+    ]);
+    expect(
+      artifact.results.scoped_indexes.filter(
+        (entry) => entry.absent || !entry.is_valid || !entry.is_ready
+      )
+    ).toEqual([]);
+    const foundFks = artifact.results.fund_snapshot_fks
+      .filter((entry) => !entry.absent)
+      .map((entry) => entry.constraint_name)
+      .sort();
+    expect(foundFks).toEqual([
+      'fund_snapshots_config_id_fundconfigs_id_fk',
+      'fund_snapshots_run_id_calc_runs_id_fk',
+    ]);
+    expect(artifact.results.outbox_status_checks.map((entry) => entry.constraint_name)).toContain(
+      'job_outbox_status_check'
+    );
+    expect(artifact.results.orphan_counts.fund_snapshots_run_id_orphans).toBe(0);
+    expect(artifact.results.orphan_counts.fund_snapshots_config_id_orphans).toBe(0);
+    expect(Object.keys(artifact.results.row_counts)).toHaveLength(7);
+  }, 60_000);
 
-  it(
-    'every manifest audits clean (SKIP) against the journal clone',
-    async () => {
-      expect(pool).toBeDefined();
-      const manifests = await loadManifests();
-      const failures: Array<{
-        manifest: string;
-        table: string;
-        action: string;
-        deltas: unknown[];
-      }> = [];
+  it('every manifest audits clean (SKIP) against the journal clone', async () => {
+    expect(pool).toBeDefined();
+    const manifests = await loadManifests();
+    const failures: Array<{
+      manifest: string;
+      table: string;
+      action: string;
+      deltas: unknown[];
+    }> = [];
 
-      for (const manifest of manifests) {
-        const audit = await auditManifest(pool!, manifest);
-        expect(audit.action, `${audit.manifest} manifest-level action`).toBe(ACTION_SKIP);
-        for (const object of audit.objects) {
-          if (object.deltas.length > 0 || object.action !== ACTION_SKIP) {
-            failures.push({
-              manifest: audit.manifest,
-              table: object.table,
-              action: object.action,
-              deltas: object.deltas,
-            });
-          }
+    for (const manifest of manifests) {
+      const audit = await auditManifest(pool!, manifest);
+      expect(audit.action, `${audit.manifest} manifest-level action`).toBe(ACTION_SKIP);
+      for (const object of audit.objects) {
+        if (object.deltas.length > 0 || object.action !== ACTION_SKIP) {
+          failures.push({
+            manifest: audit.manifest,
+            table: object.table,
+            action: object.action,
+            deltas: object.deltas,
+          });
         }
       }
+    }
 
-      // Declaration-vs-catalog agreement: the replayed journal materializes
-      // every manifest table/constraint/index (and 0028 already dropped the
-      // seam dropObjects targets), so any delta here is a WRONG MANIFEST
-      // DECLARATION - the bug class that rolled back the first slice-4
-      // operator apply (company_overrides.canonical_sector_id nullability).
-      expect(failures).toEqual([]);
-    },
-    120_000
-  );
+    // Declaration-vs-catalog agreement: the replayed journal materializes
+    // every manifest table/constraint/index (and 0028 already dropped the
+    // seam dropObjects targets), so any delta here is a WRONG MANIFEST
+    // DECLARATION - the bug class that rolled back the first slice-4
+    // operator apply (company_overrides.canonical_sector_id nullability).
+    expect(failures).toEqual([]);
+  }, 120_000);
 });

--- a/tests/unit/migration-drift-patches.test.ts
+++ b/tests/unit/migration-drift-patches.test.ts
@@ -4,21 +4,64 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const repoRoot = process.cwd();
-const migrationTag = '0029_h9_actionability_reconcile_drift';
-const migrationPath = path.join(repoRoot, 'migrations', `${migrationTag}.sql`);
+const h9MigrationTag = '0029_h9_actionability_reconcile_drift';
+const allocationScenarioMigrationTag = '0030_allocation_scenarios_reconcile_drift';
 const journalPath = path.join(repoRoot, 'migrations', 'meta', '_journal.json');
+const allocationScenarioTables = [
+  'allocation_scenarios',
+  'allocation_scenario_items',
+  'allocation_scenario_events',
+  'allocation_scenario_ic_decisions',
+] as const;
+const allocationScenarioIndexNames = [
+  'allocation_scenarios_fund_updated_idx',
+  'allocation_scenario_items_scenario_idx',
+  'allocation_scenario_events_scenario_created_idx',
+  'allocation_scenario_events_fund_created_idx',
+  'allocation_scenario_ic_decisions_scenario_idx',
+  'allocation_scenario_ic_decisions_fund_idx',
+] as const;
+const allocationScenarioConstraintNames = [
+  'allocation_scenarios_fund_id_fkey',
+  'allocation_scenario_items_scenario_id_fkey',
+  'allocation_scenario_items_company_id_fkey',
+  'allocation_scenario_items_non_negative_planned',
+  'allocation_scenario_items_non_negative_cap',
+  'allocation_scenario_items_cap_gte_planned',
+  'allocation_scenario_events_scenario_id_fkey',
+  'allocation_scenario_events_fund_id_fkey',
+  'allocation_scenario_events_actor_user_id_fkey',
+  'allocation_scenario_events_type_check',
+  'allocation_scenario_ic_decisions_scenario_id_fkey',
+  'allocation_scenario_ic_decisions_fund_id_fkey',
+  'allocation_scenario_ic_decisions_company_id_fkey',
+  'allocation_scenario_ic_decisions_decided_by_user_id_fkey',
+  'allocation_scenario_ic_decisions_unique_company',
+  'allocation_scenario_ic_decisions_type_check',
+  'allocation_scenario_ic_decisions_status_check',
+  'allocation_scenario_ic_decisions_proposed_non_negative',
+  'allocation_scenario_ic_decisions_final_non_negative',
+] as const;
+
+type JournalEntry = {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+};
 
 describe('H9 reconcile drift patch migration', () => {
   it('marks 0029 as a drift patch on the first line', () => {
-    expect(fs.existsSync(migrationPath)).toBe(true);
+    expect(fs.existsSync(migrationPath(h9MigrationTag))).toBe(true);
 
-    const firstLine = readMigrationSql().split(/\r?\n/, 1)[0];
+    const firstLine = readMigrationSql(h9MigrationTag).split(/\r?\n/, 1)[0];
 
     expect(firstLine).toBe('-- @drift-patch');
   });
 
   it('uses replay-safe guards for table and column changes', () => {
-    const sql = readMigrationSql();
+    const sql = readMigrationSql(h9MigrationTag);
     const alterTableIfExists = sql.match(/\bALTER\s+TABLE\s+IF\s+EXISTS\b/gi) ?? [];
     const bareAlterTable = sql.match(/\bALTER\s+TABLE\b(?!\s+IF\s+EXISTS\b)/gi) ?? [];
     const addColumnIfNotExists = sql.match(/\bADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\b/gi) ?? [];
@@ -31,7 +74,7 @@ describe('H9 reconcile drift patch migration', () => {
   });
 
   it('guards all constraint additions inside pg_constraint-aware DO blocks', () => {
-    const sql = readMigrationSql();
+    const sql = readMigrationSql(h9MigrationTag);
     const doBlocks = sql.match(/DO\s+\$\$[\s\S]*?END\s*\$\$;/gi) ?? [];
     const addConstraintBlocks = doBlocks.filter((block) => /\bADD\s+CONSTRAINT\b/i.test(block));
     const topLevelSql = sql.replace(/DO\s+\$\$[\s\S]*?END\s*\$\$;/gi, '');
@@ -45,7 +88,7 @@ describe('H9 reconcile drift patch migration', () => {
   });
 
   it('does not include destructive or base-table operations', () => {
-    const sql = readMigrationSql();
+    const sql = readMigrationSql(h9MigrationTag);
 
     expect(sql).not.toMatch(/\bDROP\s+/i);
     expect(sql).not.toMatch(/\bRENAME\s+/i);
@@ -53,28 +96,119 @@ describe('H9 reconcile drift patch migration', () => {
   });
 
   it('journals 0029 at idx 30', () => {
-    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
-      entries: Array<{
-        idx: number;
-        version: string;
-        when: number;
-        tag: string;
-        breakpoints: boolean;
-      }>;
-    };
-    const entries = journal.entries.filter((entry) => entry.tag === migrationTag);
+    const entries = readJournalEntries().filter((entry) => entry.tag === h9MigrationTag);
 
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       idx: 30,
       version: '7',
-      tag: migrationTag,
+      tag: h9MigrationTag,
       breakpoints: true,
     });
     expect(entries[0]?.when).toBeGreaterThan(1783022913852);
   });
 });
 
-function readMigrationSql(): string {
-  return fs.readFileSync(migrationPath, 'utf8');
+describe('Allocation scenario reconcile drift patch migration', () => {
+  it('marks 0030 as a drift patch on the first line', () => {
+    expect(fs.existsSync(migrationPath(allocationScenarioMigrationTag))).toBe(true);
+
+    const firstLine = readMigrationSql(allocationScenarioMigrationTag).split(/\r?\n/, 1)[0];
+
+    expect(firstLine).toBe('-- @drift-patch');
+  });
+
+  it('uses replay-safe guards for table, column, and index changes', () => {
+    const sql = readMigrationSql(allocationScenarioMigrationTag);
+    const createTableIfNotExists = sql.match(/\bCREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\b/gi) ?? [];
+    const bareCreateTable = sql.match(/\bCREATE\s+TABLE\b(?!\s+IF\s+NOT\s+EXISTS\b)/gi) ?? [];
+    const addColumnIfNotExists = sql.match(/\bADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\b/gi) ?? [];
+    const bareAddColumn = sql.match(/\bADD\s+COLUMN\b(?!\s+IF\s+NOT\s+EXISTS\b)/gi) ?? [];
+    const createIndexIfNotExists = sql.match(/\bCREATE\s+INDEX\s+IF\s+NOT\s+EXISTS\b/gi) ?? [];
+    const bareCreateIndex = sql.match(/\bCREATE\s+INDEX\b(?!\s+IF\s+NOT\s+EXISTS\b)/gi) ?? [];
+
+    expect(createTableIfNotExists).toHaveLength(allocationScenarioTables.length);
+    expect(bareCreateTable).toEqual([]);
+    expect(addColumnIfNotExists).toHaveLength(48);
+    expect(bareAddColumn).toEqual([]);
+    expect(createIndexIfNotExists).toHaveLength(allocationScenarioIndexNames.length);
+    expect(bareCreateIndex).toEqual([]);
+
+    for (const table of allocationScenarioTables) {
+      expect(sql).toMatch(new RegExp(`CREATE\\s+TABLE\\s+IF\\s+NOT\\s+EXISTS\\s+"${table}"`, 'i'));
+    }
+
+    for (const indexName of allocationScenarioIndexNames) {
+      expect(sql).toContain(`CREATE INDEX IF NOT EXISTS "${indexName}"`);
+    }
+  });
+
+  it('guards all constraint additions inside pg_constraint-aware DO blocks', () => {
+    const sql = readMigrationSql(allocationScenarioMigrationTag);
+    const doBlocks = sql.match(/DO\s+\$\$[\s\S]*?END\s*\$\$;/gi) ?? [];
+    const addConstraintBlocks = doBlocks.filter((block) => /\bADD\s+CONSTRAINT\b/i.test(block));
+    const topLevelSql = sql.replace(/DO\s+\$\$[\s\S]*?END\s*\$\$;/gi, '');
+
+    expect(addConstraintBlocks).toHaveLength(allocationScenarioConstraintNames.length);
+    expect(topLevelSql).not.toMatch(/\bADD\s+CONSTRAINT\b/i);
+
+    for (const block of addConstraintBlocks) {
+      expect(block).toMatch(/\bNOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+pg_constraint\b/i);
+    }
+
+    for (const constraintName of allocationScenarioConstraintNames) {
+      expect(
+        addConstraintBlocks.some(
+          (block) => block.includes(`"${constraintName}"`) || block.includes(`'${constraintName}'`)
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('does not include destructive operations or the intentionally omitted dead table', () => {
+    const sql = readMigrationSql(allocationScenarioMigrationTag);
+
+    expect(sql).not.toMatch(/\bDROP\s+/i);
+    expect(sql).not.toMatch(/\bRENAME\s+/i);
+    expect(sql).not.toContain('allocation_scenario_decisions');
+  });
+
+  it('references all four live allocation scenario tables', () => {
+    const sql = readMigrationSql(allocationScenarioMigrationTag);
+
+    for (const table of allocationScenarioTables) {
+      expect(sql).toContain(`"${table}"`);
+    }
+  });
+
+  it('journals 0030 at idx 31', () => {
+    const entries = readJournalEntries().filter(
+      (entry) => entry.tag === allocationScenarioMigrationTag
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      idx: 31,
+      version: '7',
+      tag: allocationScenarioMigrationTag,
+      breakpoints: true,
+    });
+    expect(entries[0]?.when).toBeGreaterThan(1783790526019);
+  });
+});
+
+function migrationPath(tag: string): string {
+  return path.join(repoRoot, 'migrations', `${tag}.sql`);
+}
+
+function readMigrationSql(tag: string): string {
+  return fs.readFileSync(migrationPath(tag), 'utf8');
+}
+
+function readJournalEntries(): JournalEntry[] {
+  const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
+    entries: JournalEntry[];
+  };
+
+  return journal.entries;
 }

--- a/tests/unit/migration-drift-patches.test.ts
+++ b/tests/unit/migration-drift-patches.test.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const migrationTag = '0029_h9_actionability_reconcile_drift';
+const migrationPath = path.join(repoRoot, 'migrations', `${migrationTag}.sql`);
+const journalPath = path.join(repoRoot, 'migrations', 'meta', '_journal.json');
+
+describe('H9 reconcile drift patch migration', () => {
+  it('marks 0029 as a drift patch on the first line', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+
+    const firstLine = readMigrationSql().split(/\r?\n/, 1)[0];
+
+    expect(firstLine).toBe('-- @drift-patch');
+  });
+
+  it('uses replay-safe guards for table and column changes', () => {
+    const sql = readMigrationSql();
+    const alterTableIfExists = sql.match(/\bALTER\s+TABLE\s+IF\s+EXISTS\b/gi) ?? [];
+    const bareAlterTable = sql.match(/\bALTER\s+TABLE\b(?!\s+IF\s+EXISTS\b)/gi) ?? [];
+    const addColumnIfNotExists = sql.match(/\bADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\b/gi) ?? [];
+    const bareAddColumn = sql.match(/\bADD\s+COLUMN\b(?!\s+IF\s+NOT\s+EXISTS\b)/gi) ?? [];
+
+    expect(alterTableIfExists).toHaveLength(12);
+    expect(bareAlterTable).toEqual([]);
+    expect(addColumnIfNotExists).toHaveLength(24);
+    expect(bareAddColumn).toEqual([]);
+  });
+
+  it('guards all constraint additions inside pg_constraint-aware DO blocks', () => {
+    const sql = readMigrationSql();
+    const doBlocks = sql.match(/DO\s+\$\$[\s\S]*?END\s*\$\$;/gi) ?? [];
+    const addConstraintBlocks = doBlocks.filter((block) => /\bADD\s+CONSTRAINT\b/i.test(block));
+    const topLevelSql = sql.replace(/DO\s+\$\$[\s\S]*?END\s*\$\$;/gi, '');
+
+    expect(addConstraintBlocks).toHaveLength(8);
+    expect(topLevelSql).not.toMatch(/\bADD\s+CONSTRAINT\b/i);
+
+    for (const block of addConstraintBlocks) {
+      expect(block).toMatch(/\bNOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+pg_constraint\b/i);
+    }
+  });
+
+  it('does not include destructive or base-table operations', () => {
+    const sql = readMigrationSql();
+
+    expect(sql).not.toMatch(/\bDROP\s+/i);
+    expect(sql).not.toMatch(/\bRENAME\s+/i);
+    expect(sql).not.toMatch(/\bCREATE\s+TABLE\b/i);
+  });
+
+  it('journals 0029 at idx 30', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
+      entries: Array<{
+        idx: number;
+        version: string;
+        when: number;
+        tag: string;
+        breakpoints: boolean;
+      }>;
+    };
+    const entries = journal.entries.filter((entry) => entry.tag === migrationTag);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      idx: 30,
+      version: '7',
+      tag: migrationTag,
+      breakpoints: true,
+    });
+    expect(entries[0]?.when).toBeGreaterThan(1783022913852);
+  });
+});
+
+function readMigrationSql(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -39,6 +39,8 @@ const expectedJournaledDriftPatchFiles = [
   '0026_reserve_decisions_index_resync_drift.sql',
   '0027_investment_rounds_journal_drift.sql',
   '0028_operator_seam_drift.sql',
+  '0029_h9_actionability_reconcile_drift.sql',
+  '0030_allocation_scenarios_reconcile_drift.sql',
 ].sort();
 
 afterEach(() => {

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { readJournaledMigrationFiles } from '../../scripts/migration-ledger';
 
 const APP_SOURCE_FILE = path.resolve(process.cwd(), 'server', 'app.ts');
+const PROD_SCHEMA_MANIFEST_DIR = path.resolve(process.cwd(), 'scripts', 'prod-schema-manifests');
 
 const C1_MOUNTED_TABLES = [
   'cohort_definitions',
@@ -36,6 +37,16 @@ const C1_MOUNTED_TABLES = [
 ] as const;
 
 type MountKind = 'c1' | 'non-table' | 'other-table';
+
+interface ProdSchemaExpectedTable {
+  name: string;
+  sharedTable?: boolean;
+}
+
+interface ProdSchemaManifest {
+  name: string;
+  expectedTables?: ProdSchemaExpectedTable[];
+}
 
 const MAKEAPP_ROUTE_INVENTORY: Record<string, { kind: MountKind; tables?: string[] }> = {
   reservesV1Router: { kind: 'other-table' },
@@ -149,6 +160,19 @@ function makeAppSource(): string {
   return fs.readFileSync(APP_SOURCE_FILE, 'utf8');
 }
 
+function loadProdSchemaManifestFiles(): Array<{ file: string; manifest: ProdSchemaManifest }> {
+  return fs
+    .readdirSync(PROD_SCHEMA_MANIFEST_DIR)
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => ({
+      file,
+      manifest: JSON.parse(
+        fs.readFileSync(path.join(PROD_SCHEMA_MANIFEST_DIR, file), 'utf8')
+      ) as ProdSchemaManifest,
+    }));
+}
+
 function extractMakeAppRouteImportIdentifiers(appSource: string): string[] {
   const identifiers = new Set<string>();
   const importPattern = /^\s*import\s+(.+?)\s+from\s+['"](\.\/routes\/[^'"]+)['"];?/gm;
@@ -194,6 +218,46 @@ function parseImportClauseIdentifiers(importClause: string): string[] {
 }
 
 describe('makeApp mount parity with journaled migrations', () => {
+  it('every C1 mounted table is covered by at least one prod-schema manifest expectedTables', () => {
+    const manifests = loadProdSchemaManifestFiles();
+    const covered = new Set<string>();
+
+    for (const { manifest } of manifests) {
+      for (const table of manifest.expectedTables ?? []) {
+        covered.add(table.name);
+      }
+    }
+
+    const missing = C1_MOUNTED_TABLES.filter((tableName) => !covered.has(tableName));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('no table is owned by more than one manifest unless marked sharedTable', () => {
+    const manifests = loadProdSchemaManifestFiles();
+    const ownership = new Map<string, string[]>();
+
+    for (const { file, manifest } of manifests) {
+      const ownedTableNames = new Set(
+        (manifest.expectedTables ?? [])
+          .filter((table) => table.sharedTable !== true)
+          .map((table) => table.name)
+      );
+
+      for (const tableName of [...ownedTableNames].sort()) {
+        const owners = ownership.get(tableName) ?? [];
+        owners.push(file);
+        ownership.set(tableName, owners);
+      }
+    }
+
+    const collisions = [...ownership.entries()]
+      .filter(([, files]) => files.length > 1)
+      .map(([tableName, files]) => `${tableName} in ${files.join(',')}`);
+
+    expect(collisions).toEqual([]);
+  });
+
   it('has CREATE TABLE coverage for every C1 mounted table', () => {
     const sql = migrationSql();
     const missingCreateTables = C1_MOUNTED_TABLES.filter(

--- a/tests/unit/mount-parity-migrations.test.ts
+++ b/tests/unit/mount-parity-migrations.test.ts
@@ -36,6 +36,14 @@ const C1_MOUNTED_TABLES = [
   'investment_round_model_overrides',
 ] as const;
 
+// These mounted rounds tables are intentionally flag-gated and not
+// prod-reconciled. They remain covered by the journal/mount-parity CREATE TABLE
+// assertion below, but they are outside the prod manifest set by design.
+const C1_TABLES_EXEMPT_FROM_MANIFEST = new Set([
+  'investment_rounds',
+  'investment_round_model_overrides',
+]);
+
 type MountKind = 'c1' | 'non-table' | 'other-table';
 
 interface ProdSchemaExpectedTable {
@@ -228,7 +236,9 @@ describe('makeApp mount parity with journaled migrations', () => {
       }
     }
 
-    const missing = C1_MOUNTED_TABLES.filter((tableName) => !covered.has(tableName));
+    const missing = C1_MOUNTED_TABLES.filter(
+      (tableName) => !covered.has(tableName) && !C1_TABLES_EXEMPT_FROM_MANIFEST.has(tableName)
+    );
 
     expect(missing).toEqual([]);
   });
@@ -267,9 +277,9 @@ describe('makeApp mount parity with journaled migrations', () => {
     expect(missingCreateTables).toEqual([]);
   });
 
-  it('keeps the formerly deferred rounds tables inside the C1 parity set (exemption retired)', () => {
-    // Journal coverage itself is asserted by the C1 parity test above; this pin
-    // guards against a silent re-exemption of either table.
+  it('keeps the manifest-exempt rounds tables inside the C1 parity set', () => {
+    // Journal coverage itself is asserted by the C1 parity test above; only the
+    // prod manifest coverage assertion exempts these dormant, flag-gated tables.
     expect(C1_MOUNTED_TABLES).toContain('investment_rounds');
     expect(C1_MOUNTED_TABLES).toContain('investment_round_model_overrides');
   });

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -81,13 +81,15 @@ function namesSurvivingSql(sqlFiles: string[]): Set<string> {
 describe('prod-schema manifest sentinels', () => {
   const manifests = loadManifestFiles();
 
-  it('finds the four PR-1 manifests plus the s8.1 operator-seam manifest', () => {
+  it('finds the four PR-1 manifests, the operator-seam manifest, and the H9 + allocation-scenario manifests', () => {
     expect(manifests.map((entry) => entry.file)).toEqual([
       '01-cohort.json',
       '02-fund-moic.json',
       '03-operating-tasks.json',
       '04-lp-reporting.json',
       '05-operator-seam.json',
+      '06-h9-actionability.json',
+      '07-allocation-scenarios.json',
     ]);
   });
 
@@ -97,6 +99,21 @@ describe('prod-schema manifest sentinels', () => {
         expect(fs.existsSync(path.join(repoRoot, sqlFile)), `${file} -> ${sqlFile}`).toBe(true);
       }
     }
+  });
+
+  it('every manifest SQL file begins with a -- @generated or -- @drift-patch marker', () => {
+    const offenders: string[] = [];
+
+    for (const { file, manifest } of manifests) {
+      for (const sqlFile of manifest.sqlFiles ?? []) {
+        const sql = fs.readFileSync(path.join(repoRoot, sqlFile), 'utf8');
+        if (!/^--\s*@(generated|drift-patch)\b/m.test(sql)) {
+          offenders.push(`${file} -> ${sqlFile}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
   });
 
   it('every sentinel name SURVIVES the manifest own SQL sequence (63-byte aware)', () => {

--- a/tests/unit/reconcile-prod-schema.test.ts
+++ b/tests/unit/reconcile-prod-schema.test.ts
@@ -1,15 +1,16 @@
-
 // Default import on purpose: node-setup.ts vi.mock('fs') stubs the NAMED
 // readFileSync export, but its ...actual spread preserves `default` as the
 // real fs module - same pattern as the sibling ledger/sentinel tests.
 import fs from 'node:fs';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   ACTION_APPLY_MISSING_DDL,
   ACTION_REFUSE_FOR_HUMAN,
   ACTION_SKIP,
+  MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
+  MISSING_TABLE_POLICY_EXISTING_REQUIRED,
   ReconcileError,
   assertApplyConfirmation,
   assertDirectDatabaseUrl,
@@ -161,7 +162,10 @@ function createMockClient(options: MockClientOptions = {}) {
         return { rows: [], rowCount: 0 };
       }
 
-      if (text.includes('CREATE TABLE IF NOT EXISTS') || text.includes('CREATE UNIQUE INDEX IF NOT EXISTS')) {
+      if (
+        text.includes('CREATE TABLE IF NOT EXISTS') ||
+        text.includes('CREATE UNIQUE INDEX IF NOT EXISTS')
+      ) {
         return { rows: [], rowCount: 0 };
       }
 
@@ -184,6 +188,7 @@ function createMockClient(options: MockClientOptions = {}) {
 
 const manifest = {
   name: 'fixture',
+  missingTablePolicy: MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
   expectedTables: [
     {
       name: 'tasks',
@@ -299,6 +304,7 @@ describe('reconcile-prod-schema shape decisions', () => {
     const audit = await auditManifest(client, manifest);
 
     expect(audit.action).toBe(ACTION_SKIP);
+    expect(audit.missingTablePolicy).toBe(MISSING_TABLE_POLICY_CREATE_OR_REPAIR);
     expect(audit.objects[0]?.deltas).toEqual([]);
   });
 
@@ -367,6 +373,7 @@ describe('reconcile-prod-schema shape decisions', () => {
     });
 
     expect(output.join('')).toContain('Audit-only mode');
+    expect(output.join('')).toContain('missingTablePolicy=create_or_repair');
     expect(
       client.calls.some((call) => /\bBEGIN\b|INSERT INTO|CREATE TABLE|COMMIT/.test(call.text))
     ).toBe(false);
@@ -390,9 +397,85 @@ describe('reconcile-prod-schema shape decisions', () => {
   });
 });
 
+describe('missing-table policy', () => {
+  it('refuses a missing base table for existing_table_required', () => {
+    expect(
+      decideObjectAction({
+        tablePresent: false,
+        deltas: [],
+        populated: false,
+        missingTablePolicy: MISSING_TABLE_POLICY_EXISTING_REQUIRED,
+      })
+    ).toBe(ACTION_REFUSE_FOR_HUMAN);
+  });
+
+  it('applies an additive create for create_or_repair', () => {
+    expect(
+      decideObjectAction({
+        tablePresent: false,
+        deltas: [],
+        populated: false,
+        missingTablePolicy: MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
+      })
+    ).toBe(ACTION_APPLY_MISSING_DDL);
+  });
+
+  it('defaults absent policy to create_or_repair with a deprecation warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const audit = await auditManifest(createMockClient(), {
+        name: 'missing-policy-fixture',
+        expectedTables: [{ name: 'tasks', columns: [] }],
+      });
+
+      expect(
+        decideObjectAction({
+          tablePresent: false,
+          deltas: [],
+          populated: false,
+        })
+      ).toBe(ACTION_APPLY_MISSING_DDL);
+      expect(audit.missingTablePolicy).toBe(MISSING_TABLE_POLICY_CREATE_OR_REPAIR);
+      expect(audit.action).toBe(ACTION_APPLY_MISSING_DDL);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing-policy-fixture'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('defaulting to create_or_repair'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('rejects an unknown policy value', async () => {
+    await expect(
+      auditManifest(createMockClient(), {
+        name: 'bad-policy-fixture',
+        missingTablePolicy: 'nonsense',
+        expectedTables: [],
+      })
+    ).rejects.toMatchObject({
+      details: { kind: 'invalid-missing-table-policy' },
+    });
+  });
+
+  it('rejects an unknown manifest key', () => {
+    expect(() =>
+      validateManifestSql(
+        {
+          name: 'bad-key-fixture',
+          missingTablePolicy: MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
+          expectedTables: [],
+          unexpectedKey: true,
+        },
+        []
+      )
+    ).toThrow(ReconcileError);
+  });
+});
+
 describe('reconcile-prod-schema dropObjects path (s8.1 slice 3.5)', () => {
   const dropManifest = {
     name: 'seam-fixture',
+    missingTablePolicy: MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
     dropObjects: [
       {
         kind: 'index',
@@ -456,9 +539,7 @@ describe('reconcile-prod-schema dropObjects path (s8.1 slice 3.5)', () => {
       { kind: 'index', name: `x${'y'.repeat(70)}`, reason: 'r', reverseSql: 's' },
     ];
     for (const drop of bad) {
-      expect(() => validateDropObjects({ name: 'm', dropObjects: [drop] })).toThrow(
-        ReconcileError
-      );
+      expect(() => validateDropObjects({ name: 'm', dropObjects: [drop] })).toThrow(ReconcileError);
     }
     expect(() => validateDropObjects(dropManifest)).not.toThrow();
   });


### PR DESCRIPTION
## Plan 1 (PRs 1A–1E): production-schema reconciler coverage for H9 + allocation scenarios

Closes the coverage gap behind the live `allocation_scenarios` 500 and the latent H9 write-path drift (#1071 class). Additive and review-gated: **no production apply is introduced here** (the protected audit/apply workflow is Task 1.7, a follow-up).

Executed one task at a time (red → green → refactor), Hermes/Codex as implementer, reviewed + verified locally after each.

### Commits
- **1A `bc93d84d`** `test(schema)` — failing coverage tests: pins that C1-mounted allocation-scenario tables + the H9 manifest set are absent from prod-schema manifest `expectedTables`, and that manifests 06/07 don't exist. (Intentionally RED at this commit.)
- **1B `288dfc18`** `feat(schema)` — reconciler `missingTablePolicy`: `existing_table_required` refuses a missing base table for human review; `create_or_repair` applies additive DDL. Absent policy defaults to `create_or_repair` with a deprecation warning; unknown policy/keys rejected. 27 unit tests.
- **1C `9bb75b41`** `fix(schema)` — migration `0029` (`-- @drift-patch`): replay-safe restatement of the 0018 H9 columns/constraints (`ALTER TABLE IF EXISTS` / `ADD COLUMN IF NOT EXISTS` / guarded `DO $$`) for `fund_snapshots`, `fund_calculation_modes`, `lp_report_packages`, `pacing_history`. Historical 0018 untouched.
- **1D `24dbf738`** `fix(schema)` — migration `0030` (`-- @drift-patch`): idempotently creates/repairs the four allocation-scenario tables (`CREATE TABLE IF NOT EXISTS` + per-column `ADD COLUMN IF NOT EXISTS` + guarded FK/CHECK/UNIQUE + `CREATE INDEX IF NOT EXISTS`), FK targets + `ON DELETE` preserved from 0025. Dead `allocation_scenario_decisions` excluded.
- **1E `b2443f1c`** `feat(schema)` — manifests **M6** (`existing_table_required`, H9 on the four tables; `fund_calculation_modes` + `lp_report_packages` marked `sharedTable` since 02/04 already own them) and **M7** (`create_or_repair`, the four allocation tables). The 1A assertions are now green.

### Design decision (please confirm on review)
The C1-coverage test required every mounted C1 table to appear in a prod manifest. `investment_rounds` + `investment_round_model_overrides` are intentionally flag-gated / not reconciled to production (design non-goal), so they are **documented-exempt** from prod-manifest coverage (`C1_TABLES_EXEMPT_FROM_MANIFEST` in `tests/unit/mount-parity-migrations.test.ts`). They remain covered by the journal/CREATE-TABLE parity test.

### Verification (local)
- `npm run check`: 0 TypeScript errors throughout.
- Schema unit surface green: `reconcile-prod-schema` (27), `migration-drift-patches` (11), `prod-schema-manifest-sentinels` (7), `mount-parity-migrations` (6), + preflight/ga-checklist — 58 tests, 0 failures.
- Migrations are additive/replay-safe by construction (unit-asserted); the live partial-drift Testcontainers proof is Task 1.6.

### Not in this PR (Plan 1 follow-ups)
- 1.6 partial-drift Testcontainers proof · 1.7 protected production audit/apply workflow · 1.8 release-gate wiring + close #1071.

Migrations touch `migrations/**`, so CI auto-runs the full schema test lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
