### PR TITLE
ci(schema): Plan 1 finish — partial-drift proof, protected apply workflow, release gate (1.6-1.8)

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -171,6 +171,7 @@ schema:
   - 'scripts/db-push.mjs'
   - 'scripts/db-push-core.mjs'
   - 'drizzle.config.ts'
+  - '.github/workflows/prod-schema-reconcile.yml'
 
 pr_security:
   - 'package.json'
@@ -285,6 +286,7 @@ test_quarantine:
 # workflow, and this filter file itself (so edits to this group must run the
 # proof they gate). Keep in sync with the vitest include list.
 schema_tests:
+  - 'migrations/**'
   - 'tests/helpers/apply-investment-round-constraints.ts'
   - 'tests/integration/migrations/**'
   - 'server/migrations/**'
@@ -301,4 +303,7 @@ schema_tests:
   - 'tests/integration/prod-schema-clone.test.ts'
   - 'tests/integration/investment-scenario-capability.test.ts'
   - 'scripts/audit-prod-operator-seam.mjs'
+  - 'scripts/reconcile-prod-schema.mjs'
   - 'scripts/prod-schema-manifests/**'
+  - 'tests/integration/prod-schema-reconcile-partial-drift.test.ts'
+  - '.github/workflows/prod-schema-reconcile.yml'

--- a/.github/workflows/prod-schema-reconcile.yml
+++ b/.github/workflows/prod-schema-reconcile.yml
@@ -1,0 +1,231 @@
+name: Production Schema Reconcile
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Audit production or apply additive-safe reconciliation
+        type: choice
+        options:
+          - audit
+          - apply
+        default: audit
+      expected_sha:
+        description: Full commit SHA expected to be checked out
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-schema-reconcile
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile Production Schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production-schema
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify expected commit SHA
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          if [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "Production reconciliation must run from the default branch."
+            exit 1
+          fi
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ] || [ "$GITHUB_SHA" != "$EXPECTED_SHA" ]; then
+            echo "Checked-out SHA does not match expected_sha."
+            exit 1
+          fi
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.19.0'
+          cache: 'npm'
+
+      - name: Align npm with packageManager
+        run: npm install -g npm@10.9.2
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Run pre-apply audit
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          mkdir -p reports
+          set +e
+          node scripts/reconcile-prod-schema.mjs > reports/pre-apply-audit.raw 2>&1
+          STATUS=$?
+          set -e
+          sed -E \
+            -e 's/^Target database: .* user=.*/Target database: [REDACTED] user=[REDACTED]/' \
+            -e 's#postgres(ql)?://[^[:space:]]+#[REDACTED_DATABASE_URL]#g' \
+            reports/pre-apply-audit.raw > reports/pre-apply-audit.txt
+          rm reports/pre-apply-audit.raw
+          exit "$STATUS"
+
+      - name: Require additive-safe apply decision
+        if: inputs.mode == 'apply'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const manifestDir = 'scripts/prod-schema-manifests';
+          const manifests = fs
+            .readdirSync(manifestDir)
+            .filter((file) => file.endsWith('.json'))
+            .map((file) => JSON.parse(fs.readFileSync(path.join(manifestDir, file), 'utf8')));
+          const report = fs.readFileSync('reports/pre-apply-audit.txt', 'utf8');
+          const decisionPattern =
+            /^([^\s:][^:]*): (SKIP|APPLY-MISSING-DDL|REFUSE-FOR-HUMAN) \(missingTablePolicy=[^)]+\)$/gm;
+          const decisions = [...report.matchAll(decisionPattern)].map((match) => ({
+            manifest: match[1],
+            action: match[2],
+          }));
+
+          const fail = (message) => {
+            console.error(message);
+            process.exit(1);
+          };
+          if (
+            decisions.length !== manifests.length ||
+            manifests.some(
+              ({ name }) => decisions.filter((decision) => decision.manifest === name).length !== 1
+            )
+          ) {
+            fail('Pre-apply audit did not contain exactly one recognized decision per manifest.');
+          }
+          if (decisions.some(({ action }) => action === 'REFUSE-FOR-HUMAN')) {
+            fail('Pre-apply audit requires human review; apply is blocked.');
+          }
+          if (!decisions.some(({ action }) => action === 'APPLY-MISSING-DDL')) {
+            fail('Pre-apply audit did not report additive-safe work to apply.');
+          }
+
+          const applyingManifests = new Set(
+            decisions
+              .filter(({ action }) => action === 'APPLY-MISSING-DDL')
+              .map(({ manifest }) => manifest)
+          );
+          const destructiveSqlPattern = /\b(?:DROP|TRUNCATE)\b|\bDELETE\s+FROM\b/i;
+          const destructiveSqlFiles = manifests
+            .filter(({ name }) => applyingManifests.has(name))
+            .flatMap((manifest) => manifest.sqlFiles ?? [])
+            .filter((file) => {
+              const sql = fs
+                .readFileSync(file, 'utf8')
+                .replace(/--.*$/gm, '')
+                .replace(/\/\*[\s\S]*?\*\//g, '');
+              return destructiveSqlPattern.test(sql);
+            });
+          if (destructiveSqlFiles.length > 0) {
+            fail('Pre-apply audit selected manifest SQL containing destructive statements.');
+          }
+
+          const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const dropDecisions = manifests.flatMap((manifest) =>
+            (manifest.dropObjects ?? []).map((drop) => {
+              const objectLabel = drop.table ?? drop.name;
+              const dropDecisionPattern = new RegExp(
+                `^  ${escapeRegExp(objectLabel)}: (SKIP \\(shape-ok\\)|APPLY-MISSING-DDL \\(${escapeRegExp(drop.name)}\\))$`,
+                'gm'
+              );
+              const matches = [...report.matchAll(dropDecisionPattern)];
+              if (matches.length !== 1) {
+                fail('Pre-apply audit did not contain exactly one recognized decision per dropObject.');
+              }
+              return matches[0][1].startsWith('APPLY-MISSING-DDL') ? 'APPLY' : 'SKIP';
+            })
+          );
+          if (dropDecisions.includes('APPLY')) {
+            fail('Pre-apply audit contains destructive dropObjects; apply is blocked.');
+          }
+          NODE
+
+      - name: Apply additive-safe reconciliation
+        id: apply
+        if: inputs.mode == 'apply'
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          set +e
+          node scripts/reconcile-prod-schema.mjs --apply --yes > reports/apply.raw 2>&1
+          STATUS=$?
+          set -e
+          sed -E \
+            -e 's/^Target database: .* user=.*/Target database: [REDACTED] user=[REDACTED]/' \
+            -e 's#postgres(ql)?://[^[:space:]]+#[REDACTED_DATABASE_URL]#g' \
+            reports/apply.raw > reports/apply.txt
+          rm reports/apply.raw
+          exit "$STATUS"
+
+      - name: Run post-apply audit
+        id: post_audit
+        if: ${{ !cancelled() && inputs.mode == 'apply' && (steps.apply.outcome == 'success' || steps.apply.outcome == 'failure') }}
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          set +e
+          node scripts/reconcile-prod-schema.mjs > reports/post-apply-audit.raw 2>&1
+          STATUS=$?
+          set -e
+          sed -E \
+            -e 's/^Target database: .* user=.*/Target database: [REDACTED] user=[REDACTED]/' \
+            -e 's#postgres(ql)?://[^[:space:]]+#[REDACTED_DATABASE_URL]#g' \
+            reports/post-apply-audit.raw > reports/post-apply-audit.txt
+          rm reports/post-apply-audit.raw
+          exit "$STATUS"
+
+      - name: Require clean post-apply audit
+        if: ${{ !cancelled() && inputs.mode == 'apply' && (steps.post_audit.outcome == 'success' || steps.post_audit.outcome == 'failure') }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const manifestDir = 'scripts/prod-schema-manifests';
+          const manifests = fs
+            .readdirSync(manifestDir)
+            .filter((file) => file.endsWith('.json'))
+            .map((file) => JSON.parse(fs.readFileSync(path.join(manifestDir, file), 'utf8')));
+          const report = fs.readFileSync('reports/post-apply-audit.txt', 'utf8');
+          const decisionPattern =
+            /^([^\s:][^:]*): (SKIP|APPLY-MISSING-DDL|REFUSE-FOR-HUMAN) \(missingTablePolicy=[^)]+\)$/gm;
+          const decisions = [...report.matchAll(decisionPattern)].map((match) => ({
+            manifest: match[1],
+            action: match[2],
+          }));
+          const complete =
+            decisions.length === manifests.length &&
+            manifests.every(
+              ({ name }) =>
+                decisions.filter(
+                  (decision) => decision.manifest === name && decision.action === 'SKIP'
+                ).length === 1
+            );
+          if (!complete) {
+            console.error('Post-apply audit did not report exactly one clean decision per manifest.');
+            process.exit(1);
+          }
+          NODE
+
+      - name: Upload redacted reconciliation reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: prod-schema-reconcile-${{ github.run_id }}-${{ inputs.mode }}
+          path: reports/*.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -48,6 +48,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-032: Currency Blocks Contribute No Facts-Derived Money (PRD #1020 D4)](#adr-032-currency-blocks-contribute-no-facts-derived-money-prd-1020-d4)
 - [ADR-033: Marginal Next-Dollar Reserve MOIC Model (expanded in docs/adr/)](#adr-033-marginal-next-dollar-reserve-moic-model-expanded-in-docsadr)
 - [ADR-034: Browser Auth Contract (Bearer HS256, 7-Day Token, localStorage, Task 7)](#adr-034-browser-auth-contract-bearer-hs256-7-day-token-localstorage-task-7)
+- [ADR-035: Ordered Manifests as the Executable Production Schema Contract](#adr-035-ordered-manifests-as-the-executable-production-schema-contract)
 
 ---
 
@@ -5709,3 +5710,52 @@ PR-7b-i #1066 (`POST /api/auth/login` + bcrypt user seed in
 `server/lib/seed-users.ts`), PR-7b-ii #1067 (client localStorage token + Bearer
 attach in `apiRequest` / `getQueryFn` + `/login` page + logout + PROD-only route
 gate).
+
+---
+
+## ADR-035: Ordered Manifests as the Executable Production Schema Contract
+
+**Date:** 2026-07-11 **Status:** [IMPLEMENTED] Implemented **Decision:** Treat
+the ordered `scripts/prod-schema-manifests` set as the executable production
+schema contract. Audit is the default; apply is available only through the
+protected production-schema workflow and only for additive-safe reconciliation.
+
+### Context
+
+Production can carry partial drift that a clean journal replay or a final-shape
+comparison does not repair. Historical journaled migrations are immutable, so
+production reconciliation needs an ordered, replay-safe contract that can
+distinguish repairable additive gaps from states requiring an operator decision.
+
+### Decision
+
+- `create_or_repair` manifests may create missing tables or repair additive
+  shape gaps. `existing_table_required` manifests refuse when their base table
+  is absent, and non-additive drift refuses for human review.
+- Schema drift is closed with new replay-safe `@drift-patch` migrations. Never
+  edit a historical journaled migration to make current production converge.
+- `release:check` proves manifest/reconciler coverage in its static server
+  surface and partial-drift repair in its DB-backed Testcontainers surface.
+- Production audit and apply remain separate deployment gates in the protected
+  `.github/workflows/prod-schema-reconcile.yml` workflow. An authenticated
+  deployed smoke remains a separate post-deployment gate.
+
+### Alternatives Considered
+
+- **Treat journal replay as the complete production contract:** rejected because
+  it cannot repair a database that has only part of a later schema surface.
+- **Edit historical migrations to match production:** rejected because it makes
+  replay depend on when the migration was consumed and destroys ledger
+  immutability.
+- **Run production apply inside `release:check`:** rejected because local
+  release proof must not mutate production or bypass the protected environment
+  gate.
+
+### Consequences
+
+- Manifest coverage and partial-drift repair now block full local release proof.
+- `--skip-db` remains diagnostic-only because it omits the partial-drift proof.
+- A full release still requires an audit reporting exactly one `SKIP` decision
+  per manifest and an authenticated deployed smoke. Audit workflow success alone
+  does not prove clean schema state, and a green `release:check` does not claim
+  either deployment result.

--- a/docs/BUILD_READINESS.md
+++ b/docs/BUILD_READINESS.md
@@ -50,7 +50,7 @@ Authoritative product surface:
 npm run check
 npm run validate:core
 npm run build && npm run build:verify
-npm run release:check   # canonical release gate (Docker/WSL2; --skip-db for a fast subset)
+npm run release:check   # canonical release gate (Docker/WSL2; --skip-db is diagnostic only)
 ```
 
 `npm run build:verify` executes `scripts/check-prod-bundle.mjs`; it must fail if
@@ -60,7 +60,20 @@ emitted without `VITE_SOURCEMAP=true`.
 `npm run release:check` (`scripts/release-check.mjs`) is the authoritative
 end-to-end release gate — build, typecheck, prod-bundle verifier, and a
 Testcontainers Postgres proof. CI green is baseline health, not release proof;
-it needs Docker (WSL2 on Windows), and `--skip-db` runs the non-DB subset.
+it needs Docker (WSL2 on Windows). The `--skip-db` subset is diagnostic only and
+is not release proof.
+
+## Production Schema Audit Gate
+
+The production schema audit is a separate deployment gate run through the
+protected `.github/workflows/prod-schema-reconcile.yml` workflow dispatch and
+its `production-schema` environment. The workflow defaults to audit; apply is
+explicitly gated and is not part of `release:check`.
+
+A full release requires a green, non-skipped `release:check` (including the
+DB-backed partial-drift reconciliation proof), a clean production schema audit
+(exactly one `SKIP` decision per manifest; workflow success alone is
+insufficient), and an authenticated smoke against the deployed application.
 
 ## Surface Status
 

--- a/scripts/prod-schema-manifests/07-allocation-scenarios.json
+++ b/scripts/prod-schema-manifests/07-allocation-scenarios.json
@@ -20,7 +20,7 @@
         { "name": "notes", "nullable": true },
         { "name": "source_allocation_version", "nullable": true },
         { "name": "company_count", "nullable": false },
-        { "name": "total_planned_cents", "nullable": false },
+        { "name": "total_planned_cents", "type": "bigint", "nullable": false },
         { "name": "created_at", "nullable": false },
         { "name": "updated_at", "nullable": false },
         { "name": "last_applied_at", "nullable": true },

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -25,6 +25,10 @@ const serverSurfaceTests = [
   'tests/unit/routes/backtesting.contract.test.ts',
   'tests/unit/queues/resolve-fund-id.test.ts',
   'tests/unit/routes/lp-api.contract.test.ts',
+  'tests/unit/prod-schema-manifest-sentinels.test.ts',
+  'tests/unit/mount-parity-migrations.test.ts',
+  'tests/unit/reconcile-prod-schema.test.ts',
+  'tests/unit/migration-drift-patches.test.ts',
   'tests/regressions/ci-unified-playwright-install.test.ts',
   'tests/unit/scripts/db-push.test.mjs',
 ];
@@ -33,12 +37,14 @@ const releaseOwnedPaths = [
   'docs/release',
   'migrations',
   'shared/migrations',
+  'scripts/prod-schema-manifests',
   'scripts/release-check.mjs',
   'scripts/db-push.mjs',
   'scripts/db-push-core.mjs',
   'tests/integration/fund-lifecycle-db.test.ts',
   'tests/integration/migration-drift.test.ts',
   'tests/integration/prod-schema-clone.test.ts',
+  'tests/integration/prod-schema-reconcile-partial-drift.test.ts',
   'vitest.config.testcontainers.ts',
 ];
 
@@ -111,6 +117,11 @@ if (skipDbProof) {
     name: 'Production schema clone proof',
     command:
       'cross-env TZ=UTC vitest run -c vitest.config.testcontainers.ts tests/integration/prod-schema-clone.test.ts',
+  });
+  steps.push({
+    name: 'Production partial-drift reconciliation proof',
+    command:
+      'cross-env TZ=UTC vitest run -c vitest.config.testcontainers.ts tests/integration/prod-schema-reconcile-partial-drift.test.ts',
   });
 }
 

--- a/tests/integration/prod-schema-reconcile-partial-drift.test.ts
+++ b/tests/integration/prod-schema-reconcile-partial-drift.test.ts
@@ -1,0 +1,201 @@
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  ACTION_APPLY_MISSING_DDL,
+  ACTION_REFUSE_FOR_HUMAN,
+  ACTION_SKIP,
+  auditManifest,
+  loadManifests,
+  splitSqlStatements,
+} from '../../scripts/reconcile-prod-schema.mjs';
+import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
+
+const STARTUP_TIMEOUT_MS = 90_000;
+const TEST_TIMEOUT_MS = 60_000;
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
+
+interface ManifestTable {
+  readonly name: string;
+}
+
+interface Manifest {
+  readonly name: string;
+  readonly sqlFiles: readonly string[];
+  readonly expectedTables?: readonly ManifestTable[];
+}
+
+let postgres: StartedPostgreSqlContainer | undefined;
+let pool: Pool | undefined;
+let h9Manifest: Manifest | undefined;
+let allocationManifest: Manifest | undefined;
+
+function requirePool(): Pool {
+  if (!pool) {
+    throw new Error('Postgres pool has not been initialized');
+  }
+  return pool;
+}
+
+function requireManifest(manifest: Manifest | undefined, tableName: string): Manifest {
+  if (!manifest) {
+    throw new Error(`Manifest containing ${tableName} was not loaded`);
+  }
+  return manifest;
+}
+
+function findManifest(manifests: readonly Manifest[], tableName: string): Manifest {
+  return requireManifest(
+    manifests.find((manifest) =>
+      manifest.expectedTables?.some((table) => table.name === tableName)
+    ),
+    tableName
+  );
+}
+
+async function applyManifest(activePool: Pool, manifest: Manifest): Promise<void> {
+  for (const sqlFile of manifest.sqlFiles) {
+    const sql = await readFile(path.resolve(REPO_ROOT, sqlFile), 'utf8');
+    for (const statement of splitSqlStatements(sql)) {
+      await activePool.query(statement);
+    }
+  }
+}
+
+describe.skipIf(skipIfNoDocker)('prod schema partial-drift reconciliation', () => {
+  beforeAll(async () => {
+    postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+      .withDatabase('test_db')
+      .withUsername('test_user')
+      .withPassword('test_password')
+      .withStartupTimeout(STARTUP_TIMEOUT_MS)
+      .start();
+
+    const connectionString = postgres.getConnectionUri();
+    await runMigrationsWithConnectionString(connectionString);
+    pool = new Pool({ connectionString, max: 1 });
+
+    const manifests = (await loadManifests()) as Manifest[];
+    h9Manifest = findManifest(manifests, 'pacing_history');
+    allocationManifest = findManifest(manifests, 'allocation_scenarios');
+  }, STARTUP_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await pool?.end();
+    await postgres?.stop();
+  });
+
+  it(
+    'clean journal clone audits SKIP for M6 and M7',
+    async () => {
+      const activePool = requirePool();
+
+      const h9Audit = await auditManifest(
+        activePool,
+        requireManifest(h9Manifest, 'fund_calculation_modes')
+      );
+      const allocationAudit = await auditManifest(
+        activePool,
+        requireManifest(allocationManifest, 'allocation_scenarios')
+      );
+
+      expect(h9Audit.action).toBe(ACTION_SKIP);
+      expect(allocationAudit.action).toBe(ACTION_SKIP);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'partial allocation drift repairs additively',
+    async () => {
+      const activePool = requirePool();
+      const manifest = requireManifest(allocationManifest, 'allocation_scenarios');
+
+      await activePool.query('DROP TABLE IF EXISTS allocation_scenario_items CASCADE');
+      await activePool.query(
+        'ALTER TABLE allocation_scenarios DROP COLUMN IF EXISTS last_synced_at'
+      );
+      await activePool.query('DROP INDEX IF EXISTS allocation_scenario_events_fund_created_idx');
+
+      expect((await auditManifest(activePool, manifest)).action).toBe(ACTION_APPLY_MISSING_DDL);
+
+      await applyManifest(activePool, manifest);
+      expect((await auditManifest(activePool, manifest)).action).toBe(ACTION_SKIP);
+
+      await applyManifest(activePool, manifest);
+      expect((await auditManifest(activePool, manifest)).action).toBe(ACTION_SKIP);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'partial H9 drift repairs additively',
+    async () => {
+      const activePool = requirePool();
+      const manifest = requireManifest(h9Manifest, 'fund_calculation_modes');
+
+      await activePool.query(
+        'ALTER TABLE fund_calculation_modes DROP COLUMN IF EXISTS h9_policy_version'
+      );
+
+      expect((await auditManifest(activePool, manifest)).action).toBe(ACTION_APPLY_MISSING_DDL);
+
+      await applyManifest(activePool, manifest);
+      expect((await auditManifest(activePool, manifest)).action).toBe(ACTION_SKIP);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'missing H9 base table refuses for human (existing_table_required)',
+    async () => {
+      const activePool = requirePool();
+      const manifest = requireManifest(h9Manifest, 'pacing_history');
+
+      await activePool.query('DROP TABLE IF EXISTS pacing_history CASCADE');
+
+      expect((await auditManifest(activePool, manifest)).action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    'non-additive type change on a populated table does not auto-apply',
+    async () => {
+      const activePool = requirePool();
+      const manifest = requireManifest(allocationManifest, 'allocation_scenarios');
+
+      await activePool.query(`
+        WITH inserted_fund AS (
+          INSERT INTO funds (name, size, management_fee, carry_percentage, vintage_year)
+          VALUES ('Partial drift proof fund', 1000000, 0.02, 0.20, 2026)
+          RETURNING id
+        )
+        INSERT INTO allocation_scenarios (fund_id, name)
+        SELECT id, 'Partial drift proof scenario'
+        FROM inserted_fund
+      `);
+      await activePool.query(`
+        ALTER TABLE allocation_scenarios
+        ALTER COLUMN total_planned_cents TYPE text USING total_planned_cents::text
+      `);
+
+      expect((await auditManifest(activePool, manifest)).action).toBe(ACTION_REFUSE_FOR_HUMAN);
+
+      const typeResult = await activePool.query<{ data_type: string }>(`
+        SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'allocation_scenarios'
+          AND column_name = 'total_planned_cents'
+      `);
+      expect(typeResult.rows).toEqual([{ data_type: 'text' }]);
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/vitest.config.testcontainers.ts
+++ b/vitest.config.testcontainers.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'tests/integration/fund-lifecycle-db.test.ts',
       'tests/integration/migration-drift.test.ts',
       'tests/integration/prod-schema-clone.test.ts',
+      'tests/integration/prod-schema-reconcile-partial-drift.test.ts',
       'tests/integration/migrations/investment-rounds-schema.test.ts',
       'tests/integration/migrations/investments-id-fund-unique.test.ts',
       'tests/integration/investment-scenario-capability.test.ts',


### PR DESCRIPTION
## Plan 1 finish (Tasks 1.6–1.8): partial-drift proof, protected apply workflow, release gate

Completes the Plan 1 production-schema reconciliation arc on top of #1074 (which landed the coverage tests, reconciler policy, drift patches 0029/0030, and manifests M6/M7). Additive and review-gated: **no production apply happens in this PR** — it makes the protected apply *workflow* available and proves the reconciler heals drift.

Authored in two parallel Hermes/Codex lanes (1.6 ∥ 1.7), assembled here, then 1.8.

### Commits
- **1.6 `de0162e4`** `test(schema)` — Testcontainers proof the reconciler heals a #1071-shaped partial drift **additively**: clean journal clone audits `SKIP` for M6/M7; dropping allocation tables/columns/indexes → `APPLY-MISSING-DDL`, applying 0030 → `SKIP` (idempotent on re-apply); dropping an H9 column → `APPLY` then `SKIP`; dropping the `pacing_history` base table → `REFUSE-FOR-HUMAN` (`existing_table_required`); a non-additive type change on a populated table → `REFUSE`. Added to the testcontainers config include.
- **1.7 `7d139498`** `ci(schema)` — `workflow_dispatch`-only production audit/apply workflow behind a protected `production-schema` environment. Audits by default; apply requires `mode=apply` + a clean audit, runs `--apply --yes`, then a post-apply audit that must be clean. SHA guard (checkout must equal `expected_sha`). Reads `DATABASE_URL` (direct, non-pooler) from an environment secret; `contents: read` only; concurrency `prod-schema-reconcile`; redacted artifacts. Destructive-SQL guard strips comments before scanning (avoids false positives).
- **1.8 `d9905765`** `ci(schema)` — `release:check` now proves manifest coverage in the static `--skip-db` lane (4 schema unit suites added to the server surface lock) and partial-drift repair in the DB-backed lane (new testcontainers step); new release-owned files tracked; `--skip-db` stays diagnostic-only. `BUILD_READINESS.md` documents the production schema audit + authenticated smoke as **separate** deployment gates. **ADR-035** records ordered manifests as the executable production schema contract.

### Verification
- `npm run check`: 0 new TypeScript errors across all three commits.
- Pre-push schema unit surface green; workflow + path-filters YAML validated; `release-check.mjs` syntax checked.
- The partial-drift Testcontainers proof runs live in CI (label `test:integration` requested on this PR so the Testcontainers lane exercises it).

### #1071
This provides the protected reconcile workflow and the drift proof. Per the plan, **#1071 is closed only after M6/M7 + the workflow have actually run a clean production audit/apply** — a deployment step, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
