### PR TITLE
fix(schema): declare canonical column types across M6/M7 manifests (close type-drift blind spot)

### DIFF
--- a/scripts/prod-schema-manifests/06-h9-actionability.json
+++ b/scripts/prod-schema-manifests/06-h9-actionability.json
@@ -9,12 +9,28 @@
     {
       "name": "fund_snapshots",
       "columns": [
-        { "name": "h9_moic_source_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
-        { "name": "h9_fingerprint_hash", "nullable": true },
-        { "name": "h9_policy_version", "nullable": true },
-        { "name": "h9_actionability_status", "nullable": true }
+        {
+          "name": "h9_moic_source_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_assumptions_hash",
+          "type": "text",
+          "nullable": true
+        },
+        { "name": "h9_fingerprint_hash", "type": "text", "nullable": true },
+        { "name": "h9_policy_version", "type": "text", "nullable": true },
+        {
+          "name": "h9_actionability_status",
+          "type": "varchar",
+          "nullable": true
+        }
       ],
       "constraints": [
         "fund_snapshots_h9_actionability_status_check",
@@ -26,12 +42,28 @@
       "name": "fund_calculation_modes",
       "sharedTable": true,
       "columns": [
-        { "name": "h9_moic_source_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
-        { "name": "h9_fingerprint_hash", "nullable": true },
-        { "name": "h9_policy_version", "nullable": true },
-        { "name": "h9_actionability_status", "nullable": true }
+        {
+          "name": "h9_moic_source_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_assumptions_hash",
+          "type": "text",
+          "nullable": true
+        },
+        { "name": "h9_fingerprint_hash", "type": "text", "nullable": true },
+        { "name": "h9_policy_version", "type": "text", "nullable": true },
+        {
+          "name": "h9_actionability_status",
+          "type": "varchar",
+          "nullable": true
+        }
       ],
       "constraints": [
         "fund_calculation_modes_h9_actionability_status_check",
@@ -43,12 +75,28 @@
       "name": "lp_report_packages",
       "sharedTable": true,
       "columns": [
-        { "name": "h9_moic_source_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
-        { "name": "h9_fingerprint_hash", "nullable": true },
-        { "name": "h9_policy_version", "nullable": true },
-        { "name": "h9_actionability_status", "nullable": true }
+        {
+          "name": "h9_moic_source_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_assumptions_hash",
+          "type": "text",
+          "nullable": true
+        },
+        { "name": "h9_fingerprint_hash", "type": "text", "nullable": true },
+        { "name": "h9_policy_version", "type": "text", "nullable": true },
+        {
+          "name": "h9_actionability_status",
+          "type": "varchar",
+          "nullable": true
+        }
       ],
       "constraints": [
         "lp_report_packages_h9_actionability_status_check",
@@ -59,12 +107,28 @@
     {
       "name": "pacing_history",
       "columns": [
-        { "name": "h9_moic_source_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_input_hash", "nullable": true },
-        { "name": "h9_round_evidence_assumptions_hash", "nullable": true },
-        { "name": "h9_fingerprint_hash", "nullable": true },
-        { "name": "h9_policy_version", "nullable": true },
-        { "name": "h9_actionability_status", "nullable": true }
+        {
+          "name": "h9_moic_source_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_input_hash",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "h9_round_evidence_assumptions_hash",
+          "type": "text",
+          "nullable": true
+        },
+        { "name": "h9_fingerprint_hash", "type": "text", "nullable": true },
+        { "name": "h9_policy_version", "type": "text", "nullable": true },
+        {
+          "name": "h9_actionability_status",
+          "type": "varchar",
+          "nullable": true
+        }
       ],
       "constraints": [
         "pacing_history_h9_actionability_status_check",

--- a/scripts/prod-schema-manifests/07-allocation-scenarios.json
+++ b/scripts/prod-schema-manifests/07-allocation-scenarios.json
@@ -14,20 +14,28 @@
     {
       "name": "allocation_scenarios",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "name", "nullable": false },
-        { "name": "notes", "nullable": true },
-        { "name": "source_allocation_version", "nullable": true },
-        { "name": "company_count", "nullable": false },
+        { "name": "id", "type": "uuid", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "name", "type": "varchar", "nullable": false },
+        { "name": "notes", "type": "text", "nullable": true },
+        {
+          "name": "source_allocation_version",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "company_count", "type": "integer", "nullable": false },
         { "name": "total_planned_cents", "type": "bigint", "nullable": false },
-        { "name": "created_at", "nullable": false },
-        { "name": "updated_at", "nullable": false },
-        { "name": "last_applied_at", "nullable": true },
-        { "name": "last_applied_by", "nullable": true },
-        { "name": "last_applied_allocation_version", "nullable": true },
-        { "name": "last_synced_at", "nullable": true },
-        { "name": "last_synced_by", "nullable": true }
+        { "name": "created_at", "type": "timestamptz", "nullable": false },
+        { "name": "updated_at", "type": "timestamptz", "nullable": false },
+        { "name": "last_applied_at", "type": "timestamptz", "nullable": true },
+        { "name": "last_applied_by", "type": "text", "nullable": true },
+        {
+          "name": "last_applied_allocation_version",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "last_synced_at", "type": "timestamptz", "nullable": true },
+        { "name": "last_synced_by", "type": "text", "nullable": true }
       ],
       "constraints": ["allocation_scenarios_fund_id_fkey"],
       "indexes": ["allocation_scenarios_fund_updated_idx"]
@@ -35,13 +43,17 @@
     {
       "name": "allocation_scenario_items",
       "columns": [
-        { "name": "scenario_id", "nullable": false },
-        { "name": "company_id", "nullable": false },
-        { "name": "planned_reserves_cents", "nullable": false },
-        { "name": "allocation_cap_cents", "nullable": true },
-        { "name": "allocation_reason", "nullable": true },
-        { "name": "created_at", "nullable": false },
-        { "name": "updated_at", "nullable": false }
+        { "name": "scenario_id", "type": "uuid", "nullable": false },
+        { "name": "company_id", "type": "integer", "nullable": false },
+        {
+          "name": "planned_reserves_cents",
+          "type": "bigint",
+          "nullable": false
+        },
+        { "name": "allocation_cap_cents", "type": "bigint", "nullable": true },
+        { "name": "allocation_reason", "type": "text", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false },
+        { "name": "updated_at", "type": "timestamptz", "nullable": false }
       ],
       "constraints": [
         "allocation_scenario_items_scenario_id_fkey",
@@ -55,17 +67,25 @@
     {
       "name": "allocation_scenario_events",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "scenario_id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "event_type", "nullable": false },
-        { "name": "actor_user_id", "nullable": true },
-        { "name": "actor_label", "nullable": true },
-        { "name": "note", "nullable": true },
-        { "name": "source_allocation_version", "nullable": true },
-        { "name": "resulting_allocation_version", "nullable": true },
-        { "name": "change_summary_json", "nullable": false },
-        { "name": "created_at", "nullable": false }
+        { "name": "id", "type": "uuid", "nullable": false },
+        { "name": "scenario_id", "type": "uuid", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "event_type", "type": "varchar", "nullable": false },
+        { "name": "actor_user_id", "type": "integer", "nullable": true },
+        { "name": "actor_label", "type": "text", "nullable": true },
+        { "name": "note", "type": "text", "nullable": true },
+        {
+          "name": "source_allocation_version",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "resulting_allocation_version",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "change_summary_json", "type": "jsonb", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
       ],
       "constraints": [
         "allocation_scenario_events_scenario_id_fkey",
@@ -81,22 +101,38 @@
     {
       "name": "allocation_scenario_ic_decisions",
       "columns": [
-        { "name": "id", "nullable": false },
-        { "name": "scenario_id", "nullable": false },
-        { "name": "fund_id", "nullable": false },
-        { "name": "company_id", "nullable": false },
-        { "name": "decision_type", "nullable": false },
-        { "name": "decision_status", "nullable": false },
-        { "name": "rationale", "nullable": false },
-        { "name": "proposed_planned_reserves_cents", "nullable": true },
-        { "name": "final_planned_reserves_cents", "nullable": true },
-        { "name": "decided_by_user_id", "nullable": true },
-        { "name": "decided_by_label", "nullable": true },
-        { "name": "decided_at", "nullable": true },
-        { "name": "source_allocation_version", "nullable": true },
-        { "name": "live_allocation_version", "nullable": true },
-        { "name": "created_at", "nullable": false },
-        { "name": "updated_at", "nullable": false }
+        { "name": "id", "type": "uuid", "nullable": false },
+        { "name": "scenario_id", "type": "uuid", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "company_id", "type": "integer", "nullable": false },
+        { "name": "decision_type", "type": "varchar", "nullable": false },
+        { "name": "decision_status", "type": "varchar", "nullable": false },
+        { "name": "rationale", "type": "text", "nullable": false },
+        {
+          "name": "proposed_planned_reserves_cents",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "final_planned_reserves_cents",
+          "type": "bigint",
+          "nullable": true
+        },
+        { "name": "decided_by_user_id", "type": "integer", "nullable": true },
+        { "name": "decided_by_label", "type": "text", "nullable": true },
+        { "name": "decided_at", "type": "timestamptz", "nullable": true },
+        {
+          "name": "source_allocation_version",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "live_allocation_version",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "created_at", "type": "timestamptz", "nullable": false },
+        { "name": "updated_at", "type": "timestamptz", "nullable": false }
       ],
       "constraints": [
         "allocation_scenario_ic_decisions_scenario_id_fkey",


### PR DESCRIPTION
## Close the prod-schema type-drift blind spot (all M6/M7 columns)

Follow-up to #1075. The reconciler's `auditTable` only compares a column's TYPE when the manifest declares a `type`. After #1075 only `total_planned_cents` was typed (fixed reactively when the partial-drift proof caught it) — the other ~48 M6/M7 columns declared `name + nullable` only, so an unsafe type change (e.g. `bigint`/`timestamptz` → `text`) on any of them would audit `SKIP` (false clean) instead of `REFUSE-FOR-HUMAN`.

This declares the canonical type for **every** column in both manifests:
- M6 (H9): 24/24 columns typed (5×`text` + `varchar` per table), from migration 0018.
- M7 (allocation): 48/48 columns typed (`uuid`/`integer`/`bigint`/`text`/`varchar`/`timestamptz`/`jsonb`), from migration 0025.

### Type format
Types use the **normalized bare vocabulary** that `normalizeColumnType` (`scripts/reconcile-prod-schema.mjs`) produces — `varchar` (not `varchar(24)`/`character varying`), `timestamptz` (not `timestamp with time zone`), etc. Declaring a length modifier or long form would create a *false* mismatch and turn the clean-clone audit red; a grep proof confirms none slipped in.

### Verification
- `npm run check`: 0 new TypeScript errors.
- Every column typed (24/24, 48/48); zero length-modifier/long-form types.
- The clean-clone "every manifest audits clean (SKIP)" Testcontainers test is the real validation that the declared types match the live catalog — it runs on this PR (schema path).

Root cause was my Task 1.5 brief ("derive columns: name + nullable"), which omitted the type. Lesson logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
