### PR TITLE
feat(auth): mint per-user roles + fund grants at login (Plan 2 follow-up)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-07-11
+last_updated: 2026-07-12
 owner: Core Team
 review_cadence: P90D
 ---
@@ -5821,10 +5821,11 @@ actionable while keeping the Bearer transport.
 - The `jti` transition is handled by `JWT_SECRET` rotation (a Plan 0 operation):
   pre-rotation tokens have no `jti` and skip the denylist; after rotation every
   token has a `jti`.
-- Residual `empty == unrestricted` logic remains in `requireFundAccess` and
-  `getVerifiedFundScope` (latent because login still mints admin/empty for every
-  user); wiring real per-user roles and grants into the login token is a
-  follow-up. Cookie sessions (D4) remain a deferred TODO.
+- Login now mints each active user's persisted role and, for non-admin/service
+  identities, their explicit fund grants. Admin/service tokens intentionally
+  carry empty `fundIds` because those roles are unrestricted. Residual
+  `empty == unrestricted` logic remains in `requireFundAccess` and
+  `getVerifiedFundScope`; cookie sessions (D4) remain a deferred TODO.
 
 **Implementation:** PR #1077 (migration 0031; tasks 2.1 schema, 2.2 external
 provisioning, `jti` minting, 2.4 revocation plus principal, and 2.6 fail-closed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-07-11
+last_updated: 2026-07-12
 ---
 
 # Security Policy
@@ -73,13 +73,14 @@ When reporting a vulnerability, please include:
 Plan 2 adds per-user roles and explicit fund grants to the ADR-034 Bearer
 contract. `enforceProvidedFundScope` fails closed: a non-admin identity with no
 grants receives 403. Legacy `requireFundAccess` and `getVerifiedFundScope`
-retain empty-as-unrestricted behavior, and login still mints admin/empty claims;
-wiring persisted roles and grants into login remains follow-up work. Tokens
+retain empty-as-unrestricted behavior. Login rejects inactive users and mints
+each active user's persisted role plus explicit grants for non-admin/service
+identities; admin/service roles remain unrestricted with empty `fundIds`. Tokens
 carry a `jti` and are individually revocable through the denylist on logout;
-per-request `is_active` checks make user deactivation effective on the next
-verified request. Production identities come from an external, untracked file,
-reject repository-defined dev passwords, and use bcrypt cost 12. Cookie sessions
-and CSRF remain deferred; see ADR-034 and ADR-036 in
+per-request `is_active` checks make later user deactivation effective on the
+next verified request. Production identities come from an external, untracked
+file, reject repository-defined dev passwords, and use bcrypt cost 12. Cookie
+sessions and CSRF remain deferred; see ADR-034 and ADR-036 in
 [DECISIONS.md](DECISIONS.md).
 
 ### Security Headers Configuration

--- a/docs/BUILD_READINESS.md
+++ b/docs/BUILD_READINESS.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-07-11
+last_updated: 2026-07-12
 ---
 
 # Build Readiness Verification Report
@@ -31,8 +31,8 @@ Authoritative product surface:
 - Compass is unmounted and experimental, not part of build readiness
 - Plan 2's identity slice is implemented: the ADR-034 Bearer transport now has
   `jti` revocation, per-user roles and explicit fund grants, and external
-  production provisioning. Login still mints admin/empty tokens pending the
-  follow-up that wires persisted roles and grants into claims; see ADR-036.
+  production provisioning. Login rejects inactive users and mints persisted
+  roles plus explicit grants for non-admin/service identities; see ADR-036.
 - Investment round create/list/read routes enforce fund scope through the parent
   investment before returning round data
 - LP dashboard/profile widget routes are mounted in both active server surfaces

--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -28,16 +28,8 @@ export async function seedDatabase() {
   console.log('[SEED] Seeding database with sample data...');
 
   try {
-    // Seed test-only login users (idempotent upsert on username). Shared source:
-    // server/lib/seed-users.ts. Consumed by POST /api/auth/login.
-    const seedUsers = buildSeedUsers();
-    for (const seedUser of seedUsers) {
-      await db
-        .insert(users)
-        .values(seedUser)
-        .onConflictDoUpdate({ target: users.username, set: { password: seedUser.password } });
-    }
-    console.log('[DONE] Seeded login users:', seedUsers.length);
+    const loginUsersSeeded = await seedLoginUsers();
+    console.log('[DONE] Seeded login users:', loginUsersSeeded);
 
     // Insert sample fund
     const fundData = {
@@ -210,4 +202,21 @@ export async function seedDatabase() {
     console.error('[FAIL] Error seeding database:', error);
     throw error;
   }
+}
+
+export async function seedLoginUsers(): Promise<number> {
+  // Seed test-only login users (idempotent upsert on username). Shared source:
+  // server/lib/seed-users.ts. Consumed by POST /api/auth/login.
+  const seedUsers = buildSeedUsers();
+  for (const seedUser of seedUsers) {
+    await db
+      .insert(users)
+      .values(seedUser)
+      .onConflictDoUpdate({
+        target: users.username,
+        set: { password: seedUser.password, role: seedUser.role },
+      });
+  }
+
+  return seedUsers.length;
 }

--- a/server/lib/auth/credentials.ts
+++ b/server/lib/auth/credentials.ts
@@ -20,3 +20,7 @@ export async function verifyCredentials(username: string, password: string): Pro
   }
   return user;
 }
+
+export async function getUserFundGrants(userId: number): Promise<number[]> {
+  return storage.getUserFundGrants(userId);
+}

--- a/server/lib/seed-users.ts
+++ b/server/lib/seed-users.ts
@@ -1,17 +1,21 @@
 import bcrypt from 'bcryptjs';
-import type { InsertUser } from '@shared/schema';
+import type { InsertUser, UserRole } from '@shared/schema';
 
 /**
  * TEST-ONLY login credentials for the internal ~5-person team. These are NOT
  * production identities. Single source of truth consumed by both MemStorage
  * (server/storage.ts, dev/tests) and scripts/seed-db.ts (Postgres).
  */
-export const TEST_LOGIN_CREDENTIALS: ReadonlyArray<{ username: string; password: string }> = [
-  { username: 'admin', password: 'admin-dev-2026' },
-  { username: 'partner', password: 'partner-dev-2026' },
-  { username: 'analyst', password: 'analyst-dev-2026' },
-  { username: 'operator', password: 'operator-dev-2026' },
-  { username: 'viewer', password: 'viewer-dev-2026' },
+export const TEST_LOGIN_CREDENTIALS: ReadonlyArray<{
+  username: string;
+  password: string;
+  role: UserRole;
+}> = [
+  { username: 'admin', password: 'admin-dev-2026', role: 'admin' },
+  { username: 'partner', password: 'partner-dev-2026', role: 'partner' },
+  { username: 'analyst', password: 'analyst-dev-2026', role: 'analyst' },
+  { username: 'operator', password: 'operator-dev-2026', role: 'operator' },
+  { username: 'viewer', password: 'viewer-dev-2026', role: 'viewer' },
 ];
 
 export const DEV_SEED_PASSWORDS: ReadonlySet<string> = new Set(
@@ -23,8 +27,9 @@ export const DEV_SEED_PASSWORDS: ReadonlySet<string> = new Set(
 const SEED_BCRYPT_COST = 8;
 
 export function buildSeedUsers(): InsertUser[] {
-  return TEST_LOGIN_CREDENTIALS.map(({ username, password }) => ({
+  return TEST_LOGIN_CREDENTIALS.map(({ username, password, role }) => ({
     username,
     password: bcrypt.hashSync(password, SEED_BCRYPT_COST),
+    role,
   }));
 }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
-import { verifyCredentials } from '../lib/auth/credentials';
+import { getUserFundGrants, verifyCredentials } from '../lib/auth/credentials';
 import { signToken } from '../lib/auth/jwt';
 import { revokeToken } from '../lib/auth/revocation';
 import { getAuthToken } from '../lib/headers-helper';
@@ -25,17 +25,19 @@ authRouter.post('/api/auth/login', async (req: Request, res: Response) => {
   const { username, password } = parsed.data;
   const user = await verifyCredentials(username, password);
 
-  // Uniform 401 for unknown-user and bad-password: no user enumeration.
-  if (!user) {
+  // Uniform 401 for unknown-user, bad-password, and inactive users: no user enumeration.
+  if (!user || !user.isActive) {
     return res.status(401).json({ error: 'invalid_credentials' });
   }
 
-  // Internal tool: every identity is admin (empty fundIds = unrestricted scope).
+  const role = user.role;
+  const fundIds = role === 'admin' || role === 'service' ? [] : await getUserFundGrants(user.id);
+
   const token = signToken({
     sub: String(user.id),
     email: user.username,
-    role: 'admin',
-    fundIds: [],
+    role,
+    fundIds,
   });
 
   return res.json({ token });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5,6 +5,7 @@ import {
   fundMetrics,
   activities,
   users,
+  userFundGrants,
   fundConfigs,
   type Fund,
   type FundConfig as StoredFundConfig,
@@ -84,6 +85,7 @@ export interface IStorage {
   // User methods
   getUser(_id: number): Promise<User | undefined>;
   getUserByUsername(_username: string): Promise<User | undefined>;
+  getUserFundGrants(_userId: number): Promise<number[]>;
   createUser(_user: InsertUser): Promise<User>;
 
   // Fund methods
@@ -381,6 +383,10 @@ export class MemStorage implements IStorage {
     return Array.from(this.users.values()).find((user) => user.username === username);
   }
 
+  async getUserFundGrants(_userId: number): Promise<number[]> {
+    return [];
+  }
+
   async createUser(insertUser: InsertUser): Promise<User> {
     const id = this.currentUserId++;
     const user = materializeMemoryUser(insertUser, id);
@@ -590,6 +596,16 @@ export class DatabaseStorage implements IStorage {
   async getUserByUsername(username: string): Promise<User | undefined> {
     const [user] = await db.select().from(users).where(eq(users.username, username));
     return user || undefined;
+  }
+
+  async getUserFundGrants(userId: number): Promise<number[]> {
+    const grants = await db
+      .select({ fundId: userFundGrants.fundId })
+      .from(userFundGrants)
+      .where(eq(userFundGrants.userId, userId))
+      .orderBy(userFundGrants.fundId);
+
+    return grants.map(({ fundId }) => fundId);
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {

--- a/tests/unit/routes/auth-login.test.ts
+++ b/tests/unit/routes/auth-login.test.ts
@@ -1,7 +1,8 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import bcrypt from 'bcryptjs';
 import type { Express } from 'express';
+import type { User } from '@shared/schema';
 
 let makeApp: typeof import('../../../server/app').makeApp;
 let storage: typeof import('../../../server/storage').storage;
@@ -11,10 +12,16 @@ let app: Express;
 const TEST_USERNAME = 'analyst';
 const TEST_PASSWORD = 'analyst-dev-2026';
 
-const mockUser = () => ({
+const mockUser = (overrides: Partial<User> = {}): User => ({
   id: 3,
   username: TEST_USERNAME,
   password: bcrypt.hashSync(TEST_PASSWORD, 8),
+  role: 'analyst',
+  isActive: true,
+  passwordUpdatedAt: new Date('2026-07-11T00:00:00.000Z'),
+  createdAt: new Date('2026-07-11T00:00:00.000Z'),
+  updatedAt: new Date('2026-07-11T00:00:00.000Z'),
+  ...overrides,
 });
 
 describe('POST /api/auth/login', () => {
@@ -23,6 +30,10 @@ describe('POST /api/auth/login', () => {
     ({ storage } = await import('../../../server/storage'));
     ({ verifyAccessTokenAsync } = await import('../../../server/lib/auth/jwt'));
     app = makeApp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('is reachable without a token (public path; 401 from handler, not the /api guard)', async () => {
@@ -59,8 +70,9 @@ describe('POST /api/auth/login', () => {
     expect(res.body).toEqual({ error: 'invalid_request' });
   });
 
-  it('good creds -> 200 with a verifiable admin token (fundIds [], 7d expiry)', async () => {
-    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(mockUser());
+  it('admin creds -> 200 with an unrestricted admin token (fundIds [], 7d expiry)', async () => {
+    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(mockUser({ role: 'admin' }));
+    const getGrants = vi.spyOn(storage, 'getUserFundGrants');
     const res = await request(app)
       .post('/api/auth/login')
       .send({ username: TEST_USERNAME, password: TEST_PASSWORD });
@@ -72,10 +84,39 @@ describe('POST /api/auth/login', () => {
     expect(claims.email).toBe(TEST_USERNAME);
     expect(claims.role).toBe('admin');
     expect(claims.fundIds).toEqual([]);
+    expect(getGrants).not.toHaveBeenCalled();
     expect(claims.exp).toBeDefined();
     expect(claims.iat).toBeDefined();
     if (claims.exp && claims.iat) {
       expect(claims.exp - claims.iat).toBe(7 * 24 * 60 * 60);
     }
+  });
+
+  it('non-admin creds -> 200 with the persisted role and explicit fund grants', async () => {
+    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(mockUser());
+    const getGrants = vi.spyOn(storage, 'getUserFundGrants').mockResolvedValue([1, 2]);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: TEST_USERNAME, password: TEST_PASSWORD });
+
+    expect(res.status).toBe(200);
+    const claims = await verifyAccessTokenAsync(res.body.token);
+    expect(claims.role).toBe('analyst');
+    expect(claims.fundIds).toEqual([1, 2]);
+    expect(getGrants).toHaveBeenCalledWith(3);
+  });
+
+  it('inactive user with valid credentials -> 401 invalid_credentials', async () => {
+    vi.spyOn(storage, 'getUserByUsername').mockResolvedValue(mockUser({ isActive: false }));
+    const getGrants = vi.spyOn(storage, 'getUserFundGrants');
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: TEST_USERNAME, password: TEST_PASSWORD });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid_credentials' });
+    expect(getGrants).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/scripts/seed-db-identity-upsert.test.ts
+++ b/tests/unit/scripts/seed-db-identity-upsert.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = vi.hoisted(() => {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn(() => ({ onConflictDoUpdate }));
+  const insert = vi.fn(() => ({ values }));
+
+  return { insert, onConflictDoUpdate, values };
+});
+
+vi.mock('../../../server/db', () => ({ db: dbMock }));
+
+import { users } from '@shared/schema';
+import { TEST_LOGIN_CREDENTIALS } from '../../../server/lib/seed-users';
+import { seedLoginUsers } from '../../../scripts/seed-db';
+
+describe('seedLoginUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('upserts each seed password and role on username conflicts', async () => {
+    await expect(seedLoginUsers()).resolves.toBe(TEST_LOGIN_CREDENTIALS.length);
+
+    expect(dbMock.insert).toHaveBeenCalledTimes(TEST_LOGIN_CREDENTIALS.length);
+    expect(dbMock.values).toHaveBeenCalledTimes(TEST_LOGIN_CREDENTIALS.length);
+    expect(dbMock.onConflictDoUpdate).toHaveBeenCalledTimes(TEST_LOGIN_CREDENTIALS.length);
+
+    TEST_LOGIN_CREDENTIALS.forEach((credential, index) => {
+      expect(dbMock.onConflictDoUpdate).toHaveBeenNthCalledWith(index + 1, {
+        target: users.username,
+        set: {
+          password: expect.any(String),
+          role: credential.role,
+        },
+      });
+    });
+  });
+});

--- a/tests/unit/server/storage-user-identity.test.ts
+++ b/tests/unit/server/storage-user-identity.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { MemStorage } from '../../../server/storage';
+import { TEST_LOGIN_CREDENTIALS } from '../../../server/lib/seed-users';
+
+describe('MemStorage user identity support', () => {
+  it('returns an empty explicit grant list for in-memory users', async () => {
+    const storage = new MemStorage();
+
+    await expect(storage.getUserFundGrants(1)).resolves.toEqual([]);
+  });
+
+  it('materializes each dev seed user with its declared role', async () => {
+    const storage = new MemStorage();
+
+    for (const credential of TEST_LOGIN_CREDENTIALS) {
+      const user = await storage.getUserByUsername(credential.username);
+      expect(user?.role).toBe(credential.role);
+    }
+  });
+});


### PR DESCRIPTION
## Activate the Plan 2 identity model at login

Follow-up to #1077 (Plan 2, merged). Plan 2 added per-user roles, explicit fund grants, and
jti revocation, but `POST /api/auth/login` still minted a hardcoded `role:'admin', fundIds:[]`
token for every user — so the identity model was inert. This wires the persisted role and
real grants into the login token.

### Changes

- **Login** (`server/routes/auth.ts`): reject inactive users with the same
  `401 invalid_credentials` (no enumeration); mint `role = user.role`; `fundIds = []` for
  admin/service (unrestricted by role) else the user's explicit `user_fund_grants`. Grant
  loading goes through a `credentials.ts` wrapper so the route keeps no direct persistence
  import (`.baselines/route-persistence-imports.json`).
- **Storage** (`server/storage.ts`): new `getUserFundGrants(userId)` on `IStorage` —
  `DatabaseStorage` queries `user_fund_grants`; `MemStorage` returns `[]` (dev seed users carry
  no grants; the admin seed user is unrestricted by role).
- **Seed users** (`server/lib/seed-users.ts`, `scripts/seed-db.ts`): each seed identity gets
  its real role (username = role); `buildSeedUsers` and the seed-db upsert persist/refresh
  role, keeping the `admin` dev login unrestricted. `seed-db` extracts a testable
  `seedLoginUsers()`.
- **Docs** (ADR-036 / SECURITY.md / BUILD_READINESS.md): the "login still mints admin/empty"
  caveat is resolved.

Now consistent end-to-end with Task 2.6's role-aware `resolveFundScope`.

### Prod-safety

Provisioned prod users (from the Task 2.2 external identity file) carry real roles + grants, so
admins get unrestricted tokens and scoped users get their funds. No behavior change for
existing admin identities.

### Verification

- `npm run check`: 0 new TypeScript errors.
- `auth-login` (7) + `seed-db-identity-upsert` (1) + `storage-user-identity` (2) = 10 pass —
  proves admin → unrestricted, non-admin → persisted role + grants `[1,2]`, inactive → 401
  no-enumeration.
- Full unit suite: **6454 passed / 0 regressions**.
- Branch is based on merged `main` (includes #1077 and the CI teardown fixes), so CI runs from
  the fixed baseline.

### Residual (not in this PR)

- `requireFundAccess` / `getVerifiedFundScope` still carry the legacy `empty == unrestricted`
  logic (latent).
- Cookie-session / CSRF transport (decision D4) remains deferred.

Generated with Claude Code (https://claude.com/claude-code)
