### PR TITLE
fix(auth): close residual empty==unrestricted fund guards (complete 2.6 migration)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5765,7 +5765,7 @@ distinguish repairable additive gaps from states requiring an operator decision.
 
 ## ADR-036: Named Identities, Explicit Fund Grants, and jti Revocation (Plan 2)
 
-**Date:** 2026-07-11 **Status:** [IMPLEMENTED] Implemented **Decision:** Extend
+**Date:** 2026-07-12 **Status:** [IMPLEMENTED] Implemented **Decision:** Extend
 the ADR-034 Bearer contract with per-person identities (roles plus explicit fund
 grants) and make Bearer tokens individually revocable via a `jti` denylist,
 without introducing cookie sessions or CSRF. ADR-034's transport stays in force
@@ -5823,9 +5823,10 @@ actionable while keeping the Bearer transport.
   token has a `jti`.
 - Login now mints each active user's persisted role and, for non-admin/service
   identities, their explicit fund grants. Admin/service tokens intentionally
-  carry empty `fundIds` because those roles are unrestricted. Residual
-  `empty == unrestricted` logic remains in `requireFundAccess` and
-  `getVerifiedFundScope`; cookie sessions (D4) remain a deferred TODO.
+  carry empty `fundIds` because those roles are unrestricted.
+  `requireFundAccess` and `getVerifiedFundScope` are role-aware and fail closed
+  for non-admin callers with empty grants. Only cookie sessions and CSRF (D4)
+  remain deferred.
 
 **Implementation:** PR #1077 (migration 0031; tasks 2.1 schema, 2.2 external
 provisioning, `jti` minting, 2.4 revocation plus principal, and 2.6 fail-closed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,10 +72,10 @@ When reporting a vulnerability, please include:
 
 Plan 2 adds per-user roles and explicit fund grants to the ADR-034 Bearer
 contract. `enforceProvidedFundScope` fails closed: a non-admin identity with no
-grants receives 403. Legacy `requireFundAccess` and `getVerifiedFundScope`
-retain empty-as-unrestricted behavior. Login rejects inactive users and mints
-each active user's persisted role plus explicit grants for non-admin/service
-identities; admin/service roles remain unrestricted with empty `fundIds`. Tokens
+grants receives 403. `requireFundAccess` and `getVerifiedFundScope` use the same
+role-aware fail-closed contract; admin/service roles remain unrestricted with
+empty `fundIds`. Login rejects inactive users and mints each active user's
+persisted role plus explicit grants for non-admin/service identities. Tokens
 carry a `jti` and are individually revocable through the denylist on logout;
 per-request `is_active` checks make later user deactivation effective on the
 next verified request. Production identities come from an external, untracked

--- a/server/lib/auth/jwt.ts
+++ b/server/lib/auth/jwt.ts
@@ -17,6 +17,7 @@ import { parseFundIdParam } from '@shared/number';
 import { getConfig } from '../../config';
 import { authMetrics } from '../../telemetry';
 import { firstString } from '../request-values';
+import { resolveFundScope } from './fund-scope';
 import { principalFromUser } from './principal';
 
 export type JWTClaims = JwtPayload & {
@@ -167,13 +168,12 @@ function fundIdsFromClaims(value: unknown): number[] {
 }
 
 /**
- * JWT fund-scope contract:
- * - Missing or empty fundIds means unrestricted admin/service access.
- * - Non-empty fundIds restrict access to the listed fund IDs only.
+ * Legacy compatibility helper that preserves the historical
+ * empty-fundIds-is-unrestricted contract for direct consumers.
  *
- * Empty scope is privileged. Issuers must mint fundIds: [] only for trusted
- * admin or service identities, and every route helper must call this function
- * instead of reimplementing the empty-array branch locally.
+ * Do not use this helper in production authorization guards. Role-aware guards
+ * must resolve principalFromUser(...) through resolveFundScope(...), which
+ * denies anonymous and non-admin callers with empty grants.
  */
 export function hasFundAccess(fundIds: unknown, fundId: number): boolean {
   const result = parseFundIds(fundIds);
@@ -299,7 +299,7 @@ export const requireFundAccess = (req: Request, res: Response, next: NextFunctio
     });
   }
 
-  if (hasFundAccess(req.user?.fundIds, fundId)) {
+  if (resolveFundScope(principalFromUser(req.user), fundId) === 'allow') {
     return next();
   }
 

--- a/server/lib/auth/provided-fund-scope.ts
+++ b/server/lib/auth/provided-fund-scope.ts
@@ -87,9 +87,9 @@ function parseProvidedFundId(raw: unknown): number | null {
  * Middleware: read fundId from req.body or req.query and enforce fund scope via
  * enforceProvidedFundScope, which re-verifies the bearer token and builds its own
  * req.user. It deliberately never delegates to requireFundAccess: on the
- * registerRoutes surface global auth sets req.context (not req.user), so a guard
- * that reads req.user?.fundIds sees undefined and hasFundAccess(undefined, ...)
- * returns true -- a silent fail-open.
+ * registerRoutes surface global auth sets req.context (not req.user), so this
+ * middleware must verify the bearer token itself before making a role-aware
+ * fund-scope decision.
  */
 export function requireProvidedFundScopeFrom(source: 'body' | 'query') {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -120,8 +120,8 @@ export interface VerifiedFundScope {
  * enforceProvidedFundScope's no-token contract: throws outside development/test,
  * and in development/test falls back to the upstream user (or an unrestricted dev
  * bypass when none is present). Returns null only for an invalid or expired token
- * so the caller can respond 401. unrestricted === true means empty fundIds
- * (privileged admin/service scope).
+ * so the caller can respond 401. unrestricted === true means an admin/service
+ * role; a non-admin with empty grants is not unrestricted and is denied.
  */
 export async function getVerifiedFundScope(req: Request): Promise<VerifiedFundScope | null> {
   const token = bearerToken(req);
@@ -129,7 +129,9 @@ export async function getVerifiedFundScope(req: Request): Promise<VerifiedFundSc
     assertTokenRequiredOutsideDevelopment();
     if (req.user) {
       const fundIds = req.user.fundIds ?? [];
-      return { unrestricted: fundIds.length === 0, fundIds };
+      const principal = principalFromUser(req.user);
+      const unrestricted = principal.kind === 'admin' || principal.kind === 'service';
+      return { unrestricted, fundIds };
     }
     return { unrestricted: true, fundIds: [] };
   }
@@ -142,7 +144,9 @@ export async function getVerifiedFundScope(req: Request): Promise<VerifiedFundSc
       ...verifiedUser,
     };
     const fundIds = verifiedUser.fundIds ?? [];
-    return { unrestricted: fundIds.length === 0, fundIds };
+    const principal = principalFromUser(verifiedUser);
+    const unrestricted = principal.kind === 'admin' || principal.kind === 'service';
+    return { unrestricted, fundIds };
   } catch {
     return null;
   }

--- a/tests/unit/auth/providedFundScope.test.ts
+++ b/tests/unit/auth/providedFundScope.test.ts
@@ -489,13 +489,24 @@ describe('getVerifiedFundScope', () => {
     }
   });
 
-  it('maps an empty-scope token to unrestricted', async () => {
+  it('maps an admin token to unrestricted', async () => {
     setJwtEnv();
-    const token = signToken({ fundIds: [] });
+    const token = signToken({ role: 'admin', fundIds: [] });
     const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
 
     await expect(getVerifiedFundScope(makeRequest(`Bearer ${token}`))).resolves.toEqual({
       unrestricted: true,
+      fundIds: [],
+    });
+  });
+
+  it('maps a non-admin token with empty grants to restricted empty scope', async () => {
+    setJwtEnv();
+    const token = signToken({ role: 'analyst', fundIds: [] });
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+
+    await expect(getVerifiedFundScope(makeRequest(`Bearer ${token}`))).resolves.toEqual({
+      unrestricted: false,
       fundIds: [],
     });
   });
@@ -553,6 +564,46 @@ describe('getVerifiedFundScope', () => {
     await expect(getVerifiedFundScope(req)).resolves.toEqual({
       unrestricted: false,
       fundIds: [99],
+    });
+  });
+
+  it('treats an upstream admin as unrestricted when no token is present in test mode', async () => {
+    setJwtEnv();
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+    const req = makeRequest(undefined, {
+      id: 'upstream-admin',
+      sub: 'upstream-admin',
+      email: 'admin@example.com',
+      role: 'admin',
+      roles: ['admin'],
+      fundIds: [],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    });
+
+    await expect(getVerifiedFundScope(req)).resolves.toEqual({
+      unrestricted: true,
+      fundIds: [],
+    });
+  });
+
+  it('treats an upstream non-admin with empty grants as restricted in test mode', async () => {
+    setJwtEnv();
+    const { getVerifiedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+    const req = makeRequest(undefined, {
+      id: 'upstream-analyst',
+      sub: 'upstream-analyst',
+      email: 'analyst@example.com',
+      role: 'analyst',
+      roles: ['analyst'],
+      fundIds: [],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    });
+
+    await expect(getVerifiedFundScope(req)).resolves.toEqual({
+      unrestricted: false,
+      fundIds: [],
     });
   });
 

--- a/tests/unit/auth/requireFundAccess.test.ts
+++ b/tests/unit/auth/requireFundAccess.test.ts
@@ -51,16 +51,17 @@ describe('requireFundAccess Middleware', () => {
       expect(statusMock).not.toHaveBeenCalled();
     });
 
-    it('should grant access to any fund when user has empty fundIds array (admin)', () => {
+    it('should grant an admin access to any fund', () => {
       req.params = { fundId: '99999' };
       req.user = {
         id: 'admin-1',
         sub: 'admin-1',
         email: 'admin@example.com',
+        role: 'admin',
         roles: ['admin'],
         ip: '127.0.0.1',
         userAgent: 'test',
-        fundIds: [], // Empty array means admin access to all funds
+        fundIds: [],
       };
 
       requireFundAccess(req as Request, res as Response, next);
@@ -287,18 +288,17 @@ describe('requireFundAccess Middleware', () => {
   });
 
   describe('Edge Cases - Null/Undefined User', () => {
-    it('should treat undefined req.user as empty fundIds array (admin access)', () => {
+    it('should deny access when req.user is undefined', () => {
       req.params = { fundId: '123' };
-      req.user = undefined; // No user attached to request
+      req.user = undefined;
 
       requireFundAccess(req as Request, res as Response, next);
 
-      // With empty fundIds (from undefined user), it grants admin access
-      expect(next).toHaveBeenCalledOnce();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
     });
 
-    it('should treat user without fundIds property as empty array (admin access)', () => {
+    it('should deny a non-admin user without fund grants', () => {
       req.params = { fundId: '123' };
       req.user = {
         id: 'user-1',
@@ -307,17 +307,15 @@ describe('requireFundAccess Middleware', () => {
         roles: ['user'],
         ip: '127.0.0.1',
         userAgent: 'test',
-        // fundIds property is missing
       };
 
       requireFundAccess(req as Request, res as Response, next);
 
-      // With missing fundIds property, it defaults to [] and grants admin access
-      expect(next).toHaveBeenCalledOnce();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
     });
 
-    it('should handle user with null fundIds as empty array (admin access)', () => {
+    it('should deny a non-admin user with malformed null fund grants', () => {
       req.params = { fundId: '123' };
       req.user = {
         id: 'user-1',
@@ -326,14 +324,13 @@ describe('requireFundAccess Middleware', () => {
         roles: ['user'],
         ip: '127.0.0.1',
         userAgent: 'test',
-        fundIds: null as any, // Explicitly set to null
+        fundIds: null as unknown as number[],
       };
 
       requireFundAccess(req as Request, res as Response, next);
 
-      // null fundIds gets coerced to [] via || operator
-      expect(next).toHaveBeenCalledOnce();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/routes/fund-moic-admin-inputs.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-admin-inputs.behavior.test.ts
@@ -160,8 +160,8 @@ describe('fund MOIC admin input route - behavioral state machine', () => {
     expect(svc.updateFundMoicInputs).not.toHaveBeenCalled();
   });
 
-  it('403 for an admin without fund access, with zero service work', async () => {
-    authState.user = { id: 101, role: 'admin', fundIds: [999] };
+  it('403 for a non-admin without fund access, with zero service work', async () => {
+    authState.user = { id: 103, role: 'analyst', fundIds: [999] };
     const res = await put(1, 12, { key: 'k-access' });
 
     expect(res.status).toBe(403);

--- a/tests/unit/routes/fund-moic-mode.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-mode.behavior.test.ts
@@ -161,8 +161,8 @@ describe('fund MOIC calculation mode route - behavioral state machine', () => {
     expect(svc.updateFundMoicCalculationMode).not.toHaveBeenCalled();
   });
 
-  it('403 for an admin without fund access, with zero service work', async () => {
-    authState.user = { id: 101, role: 'admin', fundIds: [999] };
+  it('403 for a non-admin without fund access, with zero service work', async () => {
+    authState.user = { id: 103, role: 'analyst', fundIds: [999] };
     const res = await put(1, { key: 'm-access' });
 
     expect(res.status).toBe(403);

--- a/tests/unit/routes/fund-moic-reconciliations.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-reconciliations.behavior.test.ts
@@ -226,8 +226,8 @@ describe('fund MOIC reconciliation route - behavioral state machine', () => {
     expectZeroDownstream();
   });
 
-  it('403 for an admin WITHOUT fund access (isolates requireFundAccess), zero downstream', async () => {
-    authState.user = { id: 101, role: 'admin', fundIds: [999] };
+  it('403 for a non-admin WITHOUT fund access (isolates requireFundAccess), zero downstream', async () => {
+    authState.user = { id: 103, role: 'analyst', fundIds: [999] };
     const res = await post(1, 'key-403-access');
     expect(res.status).toBe(403);
     expect(res.body).toEqual({ error: 'Forbidden', message: 'You do not have access to fund 1' });


### PR DESCRIPTION
## Close the residual `empty == unrestricted` fund guards

Completes the Plan 2 Task 2.6 fail-closed migration. Task 2.6 made
`enforceProvidedFundScope` role-aware but deliberately scoped out its two sibling guards,
which still granted access on empty fund grants. This closes them.

### Changes

- **`requireFundAccess`** (`server/lib/auth/jwt.ts`): decides via
  `resolveFundScope(principalFromUser(req.user))` instead of `hasFundAccess`. Anonymous
  callers (no `req.user`) and non-admin callers with empty/missing/null `fundIds` now get
  **403** (previously granted admin-level access — a latent fail-open). `hasFundAccess` is kept
  with a "legacy — do not use in guards" note (may have test consumers).
- **`getVerifiedFundScope`** (`server/lib/auth/provided-fund-scope.ts`): `unrestricted` now
  means an **admin/service role**, not empty `fundIds`. A non-admin with empty grants is
  restricted (`fundIds: []`), so its three consumers (`activities`, `sse-events`,
  `company-fund-scope`) deny it **with no change on their side**. The dev no-token/no-user
  bypass is preserved.

### Prod-safety

Login mints each user's real role + grants (#1078), so admin/service identities stay
unrestricted; only non-admin empty-grant tokens (previously the fail-open) change. No behavior
change for existing admin identities.

### Blast radius (fixed by intent, not by weakening)

- Admin-token fund-SCOPING tests switch to non-admin (admin now bypasses scope by role — the
  same pattern as Task 2.6's deal-pipeline / funds-endpoint-snapshots): the 3
  `fund-moic-*.behavior.test.ts`.
- `requireFundAccess` undefined/missing/null-user cases now assert **403** (fail-open closed).
- `getVerifiedFundScope` tests assert role-based `unrestricted` in both branches.

### Verification

- `npm run check`: 0 new TypeScript errors.
- Full unit suite: **6457 passed / 0 regressions**.
- Branch is based on merged `main` (includes the CI teardown fixes), so CI runs from the fixed
  baseline.

### Residual after this PR

Only the deferred cookie-session / CSRF transport (decision D4) remains — noted in ADR-036.

Generated with Claude Code (https://claude.com/claude-code)
