### PR TITLE
chore(auth): D4 review follow-ups — drop redundant credentials:'include'; annotate ADR-036

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5773,6 +5773,12 @@ without introducing cookie sessions or CSRF. ADR-034's transport stays in force
 (HS256, 7-day, localStorage, no refresh). The cookie-session plus CSRF transport
 (decision D4) remains deferred.
 
+> **D4 deferral resolved (2026-07-12):** the deferred cookie-session + CSRF
+> transport (decision D4) was subsequently implemented in
+> [ADR-037](#adr-037-browser-httponly-jwt-cookie-and-signed-csrf-contract-d4),
+> which supersedes ADR-034's browser transport. The identity, fund-grant, and
+> jti-revocation model recorded here remains in force unchanged.
+
 ### Context
 
 ADR-034 shipped Bearer auth but deferred per-fund/non-admin scoping, left every

--- a/client/src/components/portfolio/tabs/hooks/useReserveIcPacketEvidence.ts
+++ b/client/src/components/portfolio/tabs/hooks/useReserveIcPacketEvidence.ts
@@ -4,9 +4,7 @@ import type { FundResultsReadV1 } from '@shared/contracts/fund-results-v1.contra
 import { useFundContext } from '@/contexts/FundContext';
 
 async function readJsonOrNull<T>(url: string): Promise<T | null> {
-  const response = await fetch(url, {
-    credentials: 'include',
-  });
+  const response = await fetch(url);
 
   if (response.status === 404) {
     return null;

--- a/client/src/hooks/lp-reporting/useLedgerImportCommit.ts
+++ b/client/src/hooks/lp-reporting/useLedgerImportCommit.ts
@@ -28,7 +28,6 @@ async function postLedgerImportCommit(
   const res = await fetch(`/api/funds/${fundId}/imports/ledger/commit`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(body),
   });
 

--- a/client/src/hooks/lp-reporting/useLedgerImportDryRun.ts
+++ b/client/src/hooks/lp-reporting/useLedgerImportDryRun.ts
@@ -31,7 +31,6 @@ async function postLedgerImportDryRun(
   const res = await fetch(`/api/funds/${fundId}/imports/ledger/dry-run`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(body),
   });
 

--- a/client/src/hooks/lp-reporting/useMetricsDryRun.ts
+++ b/client/src/hooks/lp-reporting/useMetricsDryRun.ts
@@ -226,7 +226,6 @@ async function postMetricsDryRun(
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify(body),
     },
     MetricRunDryRunResponseSchema,
@@ -245,7 +244,6 @@ async function postMetricRunCommit(
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify(body),
     },
     MetricRunCommitResponseSchema,
@@ -374,7 +372,6 @@ async function getLatestMetricRun(
   });
   const res = await fetch(`/api/funds/${fundId}/metric-runs/latest?${params.toString()}`, {
     method: 'GET',
-    credentials: 'include',
   });
 
   return readContractResponse(
@@ -390,7 +387,6 @@ async function getMetricRunDetail(
 ): Promise<MetricRunDetailResponse> {
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}`, {
     method: 'GET',
-    credentials: 'include',
   });
 
   return readContractResponse(
@@ -406,7 +402,6 @@ async function getMetricRunEvidenceList(
 ): Promise<MetricRunEvidenceListResponse> {
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/evidence-records`, {
     method: 'GET',
-    credentials: 'include',
   });
 
   return readContractResponse(
@@ -422,7 +417,6 @@ async function getMetricRunNarrativeList(
 ): Promise<NarrativeRunListResponse> {
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/narrative-runs`, {
     method: 'GET',
-    credentials: 'include',
   });
 
   return readContractResponse(
@@ -441,7 +435,6 @@ async function getMetricRunNarrativeDetail(
     `/api/funds/${fundId}/metric-runs/${metricRunId}/narrative-runs/${narrativeRunId}`,
     {
       method: 'GET',
-      credentials: 'include',
     }
   );
 
@@ -458,7 +451,6 @@ async function getMetricRunReportPackage(
 ): Promise<ReportPackageGetResponse> {
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/report-package`, {
     method: 'GET',
-    credentials: 'include',
   });
 
   return readContractResponse(
@@ -476,7 +468,6 @@ async function getMetricRunReportPackageRenderModel(
     `/api/funds/${fundId}/metric-runs/${metricRunId}/report-package/render-model`,
     {
       method: 'GET',
-      credentials: 'include',
     }
   );
 
@@ -495,7 +486,6 @@ async function getMetricRunReportPackageJsonExport(
     `/api/funds/${fundId}/metric-runs/${metricRunId}/report-package/export/json`,
     {
       method: 'GET',
-      credentials: 'include',
     }
   );
 
@@ -510,7 +500,6 @@ async function getMetricRunReportPackageStoredJsonExport(
     `/api/funds/${fundId}/metric-runs/${metricRunId}/report-package/exports/json`,
     {
       method: 'GET',
-      credentials: 'include',
     }
   );
 
@@ -529,7 +518,6 @@ async function getMetricRunReportPackageStoredJsonArtifact(
     `/api/funds/${fundId}/metric-runs/${metricRunId}/report-package/exports/json/artifact`,
     {
       method: 'GET',
-      credentials: 'include',
     }
   );
 
@@ -548,7 +536,6 @@ async function getMetricRunReportPackageStoredCsvExport(
     `/api/funds/${fundId}/metric-runs/${metricRunId}/report-package/exports/csv`,
     {
       method: 'GET',
-      credentials: 'include',
     }
   );
 
@@ -567,7 +554,6 @@ async function getMetricRunReportPackageStoredCsvArtifact(
     `/api/funds/${fundId}/metric-runs/${metricRunId}/report-package/exports/csv/artifact`,
     {
       method: 'GET',
-      credentials: 'include',
     }
   );
 
@@ -587,7 +573,6 @@ async function createMetricRunReportPackageStoredJsonExport(
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify({}),
     }
   );
@@ -608,7 +593,6 @@ async function createMetricRunReportPackageStoredCsvExport(
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify({}),
     }
   );
@@ -630,7 +614,6 @@ async function postMetricRunApprove(
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/approve`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(body),
   });
 
@@ -651,7 +634,6 @@ async function postMetricRunLock(
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/lock`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(body),
   });
 
@@ -672,7 +654,6 @@ async function postMetricRunEvidence(
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/evidence-records`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(body),
   });
 
@@ -693,7 +674,6 @@ async function postMetricRunNarrative(
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/narrative-runs`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(body),
   });
 
@@ -717,7 +697,6 @@ async function patchMetricRunNarrative(
     {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify(body),
     }
   );
@@ -742,7 +721,6 @@ async function postMetricRunNarrativeReview(
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify(body),
     }
   );
@@ -767,7 +745,6 @@ async function postMetricRunNarrativeApprove(
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify(body),
     }
   );
@@ -789,7 +766,6 @@ async function postMetricRunReportPackage(
   const res = await fetch(`/api/funds/${fundId}/metric-runs/${metricRunId}/report-package`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(body),
   });
 


### PR DESCRIPTION
## Summary

Two D4 (cookie-session + CSRF, #1080) review follow-ups:

- **Remove redundant `credentials: 'include'`** from the lp-reporting and
  reserve-IC-packet client hooks (`useMetricsDryRun` ×24, `useLedgerImportCommit`,
  `useLedgerImportDryRun`, `useReserveIcPacketEvidence`). Post-D4, the global
  fetch interceptor (`client/src/lib/install-auth-fetch.ts`) already attaches
  `credentials: 'include'` and the `X-CSRF-Token` header to every same-origin
  `/api/` request, so the per-hook flag is redundant.
- **Annotate ADR-036**: its deferred decision D4 is now resolved by ADR-037
  (which supersedes ADR-034's browser transport).

## Why it's safe

- All four hooks call same-origin `/api/funds/...`; the interceptor covers them
  (verified `contractFetch` forwards to the global `fetch`). Their POSTs still
  receive CSRF protection via the interceptor.
- Hook tests assert fetch **call counts**, not fetch options — unaffected.
- No behavior change in the browser.

## Validation

- `npm run check` — 0 new TypeScript errors
- `useMetricsDryRun` + `useImportCommit` hook tests: 46 passed
- Diff is exactly the credential-line removals + the ADR annotation (no logic,
  no prettier collateral)

## Context

Follow-up to the D4 prod smoke. The smoke verified the cookie/CSRF machinery is
live and enforcing in prod; it also surfaced an unrelated prod incident (Upstash
Redis quota exhausted -> login 500s), filed separately as #1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
