### PR TITLE
ci: provision browser for full release proof

### DIFF
--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
 
+      - name: Install Playwright Chromium for browser proof
+        run: npx playwright install --with-deps chromium
+
       - name: Run full DB-backed release proof
         env:
           CI: 'true'

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -114,6 +114,7 @@ describe('required CI fails closed', () => {
 
     const fullWorkflow = await readWorkflow('release-proof.yml');
     const fullScripts = allRunScripts(fullWorkflow).join('\n');
+    expect(fullScripts).toContain('npx playwright install --with-deps chromium');
     expect(fullScripts).toContain('npm run release:check');
     expect(fullScripts).not.toContain('release:check -- --skip-db');
 


### PR DESCRIPTION
## Outcome

Installs Chromium in the reusable full DB-backed release workflow before `npm run release:check`.

## Why

The first live `release-production.yml` dispatch correctly stopped before promotion because `release-proof.yml` invoked the cookie-session Playwright proof without provisioning its browser. The dispatch was cancelled while production remained on the prior deployment.

## Proof

- Fail-closed regression: red before, green after.
- actionlint 1.7.12: pass.
- Pre-push TypeScript baseline and targeted regression: pass.
- No production promotion occurred; staged merge deployment remains ready.