### PR TITLE
ci: send Vercel protection bypass in staged smoke only

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -145,12 +145,14 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           : "${PRODUCTION_URL:?PRODUCTION_URL is required}"
           : "${HEALTH_KEY:?HEALTH_KEY is required}"
           : "${METRICS_KEY:?METRICS_KEY is required}"
           : "${PROD_SMOKE_USERNAME:?PROD_SMOKE_USERNAME is required}"
           : "${PROD_SMOKE_PASSWORD:?PROD_SMOKE_PASSWORD is required}"
+          : "${VERCEL_AUTOMATION_BYPASS_SECRET:?VERCEL_AUTOMATION_BYPASS_SECRET is required}"
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
@@ -162,6 +164,7 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: npx playwright test tests/smoke/production-boundaries.spec.ts --project=production --reporter=line
 
   promote:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -144,6 +144,13 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         baseURL: process.env.PROD_URL || process.env.BASE_URL,
+        ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+          ? {
+              extraHTTPHeaders: {
+                'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+              },
+            }
+          : {}),
       },
     },
 

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -149,6 +149,16 @@ describe('required CI fails closed', () => {
     expect(stagedSmokeStep?.env?.PRODUCTION_URL).toBe(
       '${{ needs.validate-deployment.outputs.deployment_url }}'
     );
+    expect(stagedSmokeStep?.env).toHaveProperty('VERCEL_AUTOMATION_BYPASS_SECRET');
+    const stagedCredentialGuard = stagedSmoke?.steps?.find(
+      (step) => step.name === 'Require non-skippable smoke credentials'
+    );
+    expect(stagedCredentialGuard?.run).toContain('VERCEL_AUTOMATION_BYPASS_SECRET is required');
+
+    const postPromotionSmoke = releaseWorkflow.jobs?.['post-promotion-smoke'];
+    expect(JSON.stringify(postPromotionSmoke?.steps ?? [])).not.toContain(
+      'VERCEL_AUTOMATION_BYPASS_SECRET'
+    );
 
     const identityScripts = allRunScripts({
       jobs: { identity: releaseWorkflow.jobs?.['validate-deployment'] ?? {} },


### PR DESCRIPTION
## Outcome

The staged production smoke can reach the application through Vercel Deployment Protection, while the post-promotion smoke remains bypass-free and keeps proving the public perimeter.

## Why

Release-production run 29212022259 passed five stages (proof, schema audit, deployment identity) and then failed the Authenticated Staged Production Smoke with 9/10 tests down: the staged `*.vercel.app` URL is behind Vercel Deployment Protection, so every request received the platform's 401/`text/html` SSO wall and never reached the app. Promotion was correctly skipped (fail-closed held); production was untouched.

## What

- `release-production.yml` (staged-smoke job only): `VERCEL_AUTOMATION_BYPASS_SECRET` hard-required in the credential guard and passed to the smoke step. Post-promotion smoke deliberately untouched.
- `playwright.config.ts` (production project): env-gated `extraHTTPHeaders` sending `x-vercel-protection-bypass` only when the secret is set.
- `tests/regressions/ci-fail-closed.test.ts`: pins the guard text, the staged-smoke env key, and the ABSENCE of the bypass anywhere in the post-promotion-smoke job.

## Proof

- Regression suite red before, green after (7/7 via targeted vitest, verified independently of the implementation lane).
- TypeScript baseline: 0 new errors. Lint: pass.

## Before merge/dispatch

Requires one-time setup (not in this PR): generate the Protection Bypass for Automation secret in Vercel (Project Settings -> Deployment Protection) and add it as `VERCEL_AUTOMATION_BYPASS_SECRET` to the GitHub `Production` environment. The staged smoke fails closed until it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)