### PR TITLE
ci: probe staged RUM origin with the canonical production origin

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -146,6 +146,7 @@ jobs:
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          RUM_ALLOWED_ORIGIN: ${{ vars.PRODUCTION_URL }}
         run: |
           : "${PRODUCTION_URL:?PRODUCTION_URL is required}"
           : "${HEALTH_KEY:?HEALTH_KEY is required}"
@@ -153,6 +154,7 @@ jobs:
           : "${PROD_SMOKE_USERNAME:?PROD_SMOKE_USERNAME is required}"
           : "${PROD_SMOKE_PASSWORD:?PROD_SMOKE_PASSWORD is required}"
           : "${VERCEL_AUTOMATION_BYPASS_SECRET:?VERCEL_AUTOMATION_BYPASS_SECRET is required}"
+          : "${RUM_ALLOWED_ORIGIN:?RUM_ALLOWED_ORIGIN is required}"
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
@@ -165,6 +167,7 @@ jobs:
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          RUM_ALLOWED_ORIGIN: ${{ vars.PRODUCTION_URL }}
         run: npx playwright test tests/smoke/production-boundaries.spec.ts --project=production --reporter=line
 
   promote:

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -150,10 +150,14 @@ describe('required CI fails closed', () => {
       '${{ needs.validate-deployment.outputs.deployment_url }}'
     );
     expect(stagedSmokeStep?.env).toHaveProperty('VERCEL_AUTOMATION_BYPASS_SECRET');
+    // Staged smoke probes RUM origin layers with the canonical production
+    // origin — the ephemeral staged URL is correctly not allow-listed.
+    expect(stagedSmokeStep?.env?.RUM_ALLOWED_ORIGIN).toBe('${{ vars.PRODUCTION_URL }}');
     const stagedCredentialGuard = stagedSmoke?.steps?.find(
       (step) => step.name === 'Require non-skippable smoke credentials'
     );
     expect(stagedCredentialGuard?.run).toContain('VERCEL_AUTOMATION_BYPASS_SECRET is required');
+    expect(stagedCredentialGuard?.run).toContain('RUM_ALLOWED_ORIGIN is required');
 
     const postPromotionSmoke = releaseWorkflow.jobs?.['post-promotion-smoke'];
     expect(JSON.stringify(postPromotionSmoke?.steps ?? [])).not.toContain(

--- a/tests/smoke/production-boundaries.spec.ts
+++ b/tests/smoke/production-boundaries.spec.ts
@@ -7,6 +7,7 @@ const HEALTH_KEY = process.env.HEALTH_KEY ?? '';
 const METRICS_KEY = process.env.METRICS_KEY ?? '';
 const PROD_SMOKE_USERNAME = process.env.PROD_SMOKE_USERNAME ?? '';
 const PROD_SMOKE_PASSWORD = process.env.PROD_SMOKE_PASSWORD ?? '';
+const RUM_ALLOWED_ORIGIN = process.env.RUM_ALLOWED_ORIGIN ?? '';
 const RUM_BODY = {
   name: 'LCP',
   value: 123,
@@ -38,6 +39,14 @@ async function expectJsonObject(response: APIResponse): Promise<JsonObject> {
 
 function productionOrigin(): string {
   return new URL(PRODUCTION_URL).origin;
+}
+
+// Origin used to probe the RUM allow-list layers. Against a staged deployment
+// the deployment's own ephemeral *.vercel.app origin is correctly NOT in the
+// allow-list, so staged runs pass the canonical production origin via
+// RUM_ALLOWED_ORIGIN — probing the exact allow-list the promoted domain uses.
+function rumProbeOrigin(): string {
+  return RUM_ALLOWED_ORIGIN ? new URL(RUM_ALLOWED_ORIGIN).origin : productionOrigin();
 }
 
 test.describe('production boundary smoke', () => {
@@ -149,7 +158,7 @@ test.describe('production boundary smoke', () => {
   test('rum lookalike origin is rejected', async ({ request }) => {
     const response = await request.post(`${PRODUCTION_URL}/api/metrics/rum`, {
       headers: {
-        Origin: `${productionOrigin()}.evil.example`,
+        Origin: `${rumProbeOrigin()}.evil.example`,
       },
       data: RUM_BODY,
     });
@@ -170,14 +179,14 @@ test.describe('production boundary smoke', () => {
   test('rum exact origin is not origin-blocked', async ({ request }) => {
     const response = await request.post(`${PRODUCTION_URL}/api/metrics/rum`, {
       headers: {
-        Origin: productionOrigin(),
+        Origin: rumProbeOrigin(),
       },
       data: RUM_BODY,
     });
 
     expectNotSpaRewrite(response);
 
-    // The exact deployed origin must never be rejected by any origin layer
+    // The canonical allowed origin must never be rejected by any origin layer
     // (strict-CORS perimeter or rumOriginGuard). Non-403 schema/validation
     // responses are acceptable; verified live as 204 on 2026-06-12.
     expect(response.status()).not.toBe(403);


### PR DESCRIPTION
## Summary

Release run 29215506423 (first post-#1085 dispatch) reached staged smoke with the Vercel protection bypass working — 9/10 specs passed, promote correctly skipped. The single failure, `rum exact origin is not origin-blocked`, is an environment mismatch, not an app regression: the spec derives its `Origin` header from `PRODUCTION_URL`, which in the staged job is the ephemeral `*.vercel.app` deployment URL. That origin is correctly absent from the RUM/CORS allow-lists (`RUM_ORIGIN_ALLOWLIST` / strict-CORS perimeter), so the app 403s it by design.

## Fix

- `tests/smoke/production-boundaries.spec.ts`: both RUM origin probes now prefer `RUM_ALLOWED_ORIGIN` when set (exact-origin probe and the `.evil.example` lookalike base), falling back to the `PRODUCTION_URL` origin — post-promotion behavior unchanged.
- `.github/workflows/release-production.yml`: staged-smoke passes `RUM_ALLOWED_ORIGIN: ${{ vars.PRODUCTION_URL }}` (`https://updog-restore.vercel.app`, Production environment var) and the non-skippable credential guard hard-requires it.
- `tests/regressions/ci-fail-closed.test.ts`: pins the new env wiring and guard line (7/7 passing locally).

This probes the exact allow-list configuration the promoted domain will serve, since staged production deployments run with production env vars. The post-promotion smoke stays bypass-free and canonical-origin-based by design.

## Verification

- `npx cross-env TZ=UTC vitest run tests/regressions/ci-fail-closed.test.ts --project=server` — 7/7 green.
- After merge: re-dispatch `release-production.yml` at the new main head with its fresh staged deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h