### PR TITLE
feat(moic): marginal next-dollar reserve MOIC — ADR, contract, engine, truth cases (Plan 7 wave 1)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5629,7 +5629,7 @@ Full draft with verified evidence: issue #1020 comment 4894518091 (amended
 
 ## ADR-033: Marginal Next-Dollar Reserve MOIC Model (expanded in docs/adr/)
 
-**Date:** 2026-07-10 **Status:** Proposed
+**Date:** 2026-07-10 **Status:** [ACCEPTED] Accepted 2026-07-12
 
 This ledger entry continues the DECISIONS.md sequence (...032 -> 033). To keep
 its evolving design in one place, the full ADR is authored as an expanded file
@@ -5637,11 +5637,18 @@ rather than inline here.
 
 - **Home:**
   [`docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md`](docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md)
-- **Summary:** the current planned-reserves MOIC path ranks planned reserves by
-  reserve exit multiple x exit probability; it is not a marginal next-dollar
-  opportunity-cost model (no incremental ownership, dilution, subsequent rounds,
-  staged probabilities, or delta expected proceeds). ADR-033 proposes that
-  model.
+- **Ratification (2026-07-12):** marginal return is the difference in expected
+  proceeds divided by the difference in all probability-weighted capital across
+  paired with-decision and baseline paths. Priced rounds dilute existing
+  ownership and add independently purchased ownership in each path.
+- **Safety amendment (2026-07-12):** no numeric result is returned when delta
+  expected capital is non-positive or below
+  `max(USD 1,000, 1% of path W expected capital)`. Results above 100x are
+  preserved but downgraded to indicative with a structured warning.
+- **Boundary decisions:** v1 is USD-only; does not infer SAFE/note conversion;
+  does not invent terminal liquidation; uses explicit staged probabilities and
+  timing; and requires canonical source/version/result hashes plus shadow
+  acceptance before production actionability.
 - **Implementation plan:** tracked in GitHub issue #1056, kept separate from the
   facts/provenance work in #1021.
 

--- a/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
+++ b/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
@@ -132,10 +132,10 @@ source/version/hash and shadow criteria are also met.
 Inputs and results use literal version identifiers. Facts and assumptions carry
 separate lower-case SHA-256 hashes. The engine validates and normalizes the
 input, preserves both source hashes, and computes the result hash from the
-canonical output payload excluding `resultHash`. Object keys are canonicalized;
-stage arrays retain their unique canonical stage order because order is model
-semantics. A changed fact, assumption, engine version, or ordered stage path
-therefore produces a distinguishable evidence record.
+canonical normalized input and output payloads, excluding `resultHash`. Object
+keys are canonicalized; stage arrays retain their unique canonical stage order
+because order is model semantics. A changed fact, assumption, engine version, or
+ordered stage path therefore produces a distinguishable evidence record.
 
 ### Shadow acceptance criteria
 

--- a/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
+++ b/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
@@ -28,6 +28,11 @@ and source assumptions:
 - path B is the baseline without that decision and has its own future
   participation choices.
 
+Version one holds financing terms, valuations, and the company outcome tree
+fixed between paths. "Independent" means participation and ownership evolve
+separately; it does not claim that the investment decision causally changes the
+company's graduation, failure, or exit probabilities.
+
 The marginal return is:
 
 ```text
@@ -115,7 +120,10 @@ floor = max(USD 1,000, 1% * E[capital_W])
 - `unavailable`: `deltaExpectedCapital <= 0`, or
   `0 < deltaExpectedCapital < floor`. MOIC and IRR are both `null`. The latter
   condition emits `MIN_DENOMINATOR_FLOOR`. A numeric MOIC is never returned
-  below the floor.
+  below the floor. Floor comparisons use full-precision Decimal values before
+  six-place result serialization. A displayed denominator can therefore round
+  to the floor while status remains `unavailable`; the structured warning is
+  authoritative at that boundary.
 - `indicative`: a supported numeric result whose marginal MOIC is greater than
   `100`. It emits `IMPLAUSIBLE_MAGNITUDE` and is not actionable without source
   review.

--- a/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
+++ b/docs/adr/ADR-033-marginal-next-dollar-reserve-moic.md
@@ -2,25 +2,208 @@
 
 ## Status
 
-Proposed
+Accepted (2026-07-12)
 
 ## Context
 
-The current planned-reserves MOIC path ranks existing planned reserves using reserve exit multiple and exit probability inputs. That is not a full marginal next-dollar opportunity-cost model because it does not derive incremental ownership, future dilution, subsequent rounds, staged probabilities, or delta expected proceeds.
+The planned-reserves MOIC path ranks existing planned reserves using reserve
+exit-multiple and exit-probability assumptions. It does not measure the return
+on the next reserve dollar because it does not isolate incremental ownership,
+future dilution and checks, staged outcomes, or the expected proceeds that are
+caused by a prospective decision.
+
+This ADR defines the version-one analytical contract. It does not activate a
+production route or user interface. Activation remains gated by shadow evidence
+and investment-team acceptance.
 
 ## Decision
 
-Keep #1021 scoped to facts/provenance integration. Model true marginal reserve return in a separate lane that calculates:
+### Paired counterfactual basis
+
+Every calculation projects two independent paths from the same current ownership
+and source assumptions:
+
+- path W includes the prospective reserve decision and its path-specific future
+  participation;
+- path B is the baseline without that decision and has its own future
+  participation choices.
+
+The marginal return is:
 
 ```text
-delta probability-weighted expected proceeds / delta reserve capital deployed
+deltaExpectedProceeds = E[proceeds_W] - E[proceeds_B]
+deltaExpectedCapital  = E[capital_W]  - E[capital_B]
+marginalReserveMoic   = deltaExpectedProceeds / deltaExpectedCapital
 ```
 
-The model must include prospective check size, round price, incremental ownership, future dilution, follow-on participation, staged exit/failure assumptions, and explicit expected-value weighting.
+The denominator is expected capital, not the nominal first check. It includes
+every probability-weighted future check that differs between the paths.
+
+### Probability tree
+
+At stage `s`, `reachProbability_s` is unconditional and equals the product of
+all prior conditional graduation probabilities. Exit, graduation, and failure
+are conditional on reaching the stage:
+
+```text
+conditionalFailureProbability_s =
+  1 - conditionalExitProbability_s - conditionalGraduationProbability_s
+```
+
+Each probability must be in `[0, 1]`, and exit plus graduation must not exceed
+one. Stage reach, exit, failure, expected capital, and expected proceeds are
+retained in the result so the expectation can be reconstructed.
+
+### Priced-round ownership
+
+For a priced round, `postMoney = preMoney + roundSize`, and each path updates
+ownership independently:
+
+```text
+existingOwnershipAfter =
+  existingOwnershipBefore * preMoney / postMoney
+incrementalOwnershipPurchased = fundCheck / postMoney
+ownershipAfter =
+  existingOwnershipAfter + incrementalOwnershipPurchased
+```
+
+A path with `participate = false` has a zero check and buys no incremental
+ownership, but its existing position is still diluted. Participation in one
+stage does not imply participation in any later stage. A participating check
+must be part of the modeled round size and cannot purchase more than the round.
+
+### SAFEs and convertible notes
+
+Version one does not invent conversion economics. A SAFE or convertible note is
+`unavailable` unless upstream source construction supplies either an explicitly
+approved conversion price or priced-equivalent ownership inputs that satisfy
+this priced-round contract. Instrument terms alone are insufficient.
+
+### Currency policy
+
+All valuations, round sizes, and checks must use the fund base currency. Version
+one accepts USD only because the absolute denominator floor is denominated in
+USD and no approved FX source is part of this contract. Non-USD or
+mixed-currency inputs are rejected upstream/at contract validation rather than
+silently converted.
+
+### Terminal and liquidation policy
+
+There is no automatic terminal liquidation. Expected proceeds include only
+explicit stage exits. A fund-end FMV or liquidation value may be included only
+when the source construction assumptions explicitly define that rule; it must be
+represented and disclosed separately before reaching this engine.
+
+### Timing and marginal IRR
+
+`asOfDate` is time zero. Each stage's `monthsFromPriorStage` advances both paths
+by the same cumulative number of months. Expected checks are negative marginal
+cash flows and expected exit proceeds are positive marginal cash flows at the
+corresponding stage time. Marginal IRR uses those delta expected cash flows and
+is `null` when there is no sign change, no unique bounded solution, or the MOIC
+itself is unavailable. A missing IRR does not invent a rate and does not by
+itself invalidate an otherwise supported marginal MOIC.
+
+### Denominator floor and actionability
+
+The minimum denominator is recomputed for each result:
+
+```text
+floor = max(USD 1,000, 1% * E[capital_W])
+```
+
+- `unavailable`: `deltaExpectedCapital <= 0`, or
+  `0 < deltaExpectedCapital < floor`. MOIC and IRR are both `null`. The latter
+  condition emits `MIN_DENOMINATOR_FLOOR`. A numeric MOIC is never returned
+  below the floor.
+- `indicative`: a supported numeric result whose marginal MOIC is greater than
+  `100`. It emits `IMPLAUSIBLE_MAGNITUDE` and is not actionable without source
+  review.
+- `actionable`: the denominator meets the floor, the result is at most `100`,
+  contract validation passes, and the accepted source and shadow gates below are
+  satisfied by the activating consumer.
+
+The pure engine can establish mathematical status but cannot prove production
+source acceptance. Consumers must not display `actionable` unless the accepted
+source/version/hash and shadow criteria are also met.
+
+### Source, version, and hash rules
+
+Inputs and results use literal version identifiers. Facts and assumptions carry
+separate lower-case SHA-256 hashes. The engine validates and normalizes the
+input, preserves both source hashes, and computes the result hash from the
+canonical output payload excluding `resultHash`. Object keys are canonicalized;
+stage arrays retain their unique canonical stage order because order is model
+semantics. A changed fact, assumption, engine version, or ordered stage path
+therefore produces a distinguishable evidence record.
+
+### Shadow acceptance criteria
+
+Production activation requires a shadow run over the accepted investment-team
+sample with all of the following recorded against exact hashes and versions:
+
+1. every result reconstructs from its stage contributions at six decimal places;
+2. no numeric result is emitted below its denominator floor;
+3. all results above `100x` are `indicative` with the required warning;
+4. source reviewers resolve every unsupported SAFE/note, currency, and terminal
+   value input without invented defaults;
+5. the investment team approves the paired scenarios and manually verifies the
+   anchor cases; and
+6. no unexplained result-hash drift remains across identical reruns.
+
+## Hand-worked example
+
+Assume current ownership is zero. At a certain-exit priced round, pre-money is
+USD 8,000,000, round size is USD 2,000,000, path W invests USD 1,000,000, and
+path B invests zero. There are no later rounds.
+
+```text
+postMoney = 8,000,000 + 2,000,000 = 10,000,000
+incremental ownership_W = 1,000,000 / 10,000,000 = 0.10
+incremental ownership_B = 0
+
+E[proceeds_W] = 1.00 reach * 1.00 exit * 0.10 * 50,000,000
+              = 5,000,000
+E[proceeds_B] = 0
+deltaExpectedProceeds = 5,000,000
+
+E[capital_W] = 1.00 * 1,000,000 = 1,000,000
+E[capital_B] = 0
+deltaExpectedCapital = 1,000,000
+
+floor = max(1,000, 0.01 * 1,000,000) = 10,000
+marginalReserveMoic = 5,000,000 / 1,000,000 = 5.000000
+status = actionable
+```
+
+If the only difference were a USD 500 check, the absolute USD 1,000 prong would
+apply. The result would be `unavailable` with `MIN_DENOMINATOR_FLOOR`, even if
+the computed ratio would otherwise be finite.
+
+## Rejected alternatives
+
+- **Nominal first check as denominator:** rejected because later path-specific
+  checks are part of the decision's expected capital cost.
+- **Single-path attribution:** rejected because dilution and future
+  participation can change the baseline; only paired paths isolate causation.
+- **Divide every positive denominator:** rejected because near-zero differences
+  generate unstable, falsely actionable magnitudes.
+- **Cap results at 100x:** rejected because it hides source/model risk. Preserve
+  the number, downgrade it to `indicative`, and warn.
+- **Infer SAFE/note conversion:** rejected because conversion economics require
+  approved terms and can materially alter ownership.
+- **Assume liquidation at fund end:** rejected because it invents proceeds not
+  present in the source construction assumptions.
+- **Convert currencies inside the engine:** rejected because no approved FX
+  source, date, or conversion policy belongs to this version.
 
 ## Consequences
 
-- Planned-reserves MOIC can be labeled assumption-based until this ADR is implemented.
-- #1021 cannot claim marginal next-dollar opportunity cost.
-- A missing exit probability or reserve exit multiple cannot silently become trusted input.
-- Investment-team calibration is required before production activation.
+- Planned-reserves MOIC remains a separate assumption-based ranking and cannot
+  be relabeled as marginal next-dollar return.
+- The new result is auditable through paired summaries, stage contributions,
+  source hashes, and a canonical result hash.
+- Some opportunities intentionally return `unavailable`; upstream source work,
+  not a fallback calculation, is required to make them modelable.
+- Investment-team calibration and shadow acceptance remain gates before any
+  production actionability claim.

--- a/shared/contracts/marginal-reserve-moic-v1.contract.ts
+++ b/shared/contracts/marginal-reserve-moic-v1.contract.ts
@@ -1,0 +1,252 @@
+import { z } from 'zod';
+import Decimal from '@shared/lib/decimal-config';
+import { CANONICAL_STAGES, CanonicalStageSchema } from '@shared/schemas/stage';
+import { DecimalStringSchema } from './lp-reporting/cash-flow-event.contract';
+
+/**
+ * The denominator floor has two prongs: an absolute USD 1,000 minimum and
+ * 1% of the with-decision path's total expected capital. The engine applies
+ * the greater amount for each result.
+ */
+export const MIN_DELTA_CAPITAL_FLOOR = {
+  absoluteUsd: '1000',
+  withDecisionExpectedCapitalRatio: '0.01',
+} as const;
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const CurrencyCodeSchema = z
+  .string()
+  .regex(/^[A-Z]{3}$/)
+  .refine((value) => value === 'USD', {
+    message: 'marginal-reserve-moic-v1 supports USD only',
+  });
+
+const NonnegativeDecimalStringSchema = DecimalStringSchema.refine(
+  (value) => new Decimal(value).gte(0),
+  { message: 'Expected a nonnegative decimal string' }
+);
+
+export const ProbabilityDecimalStringSchema = DecimalStringSchema.refine(
+  (value) => new Decimal(value).gte(0) && new Decimal(value).lte(1),
+  { message: 'Expected a decimal string between 0 and 1' }
+);
+
+const ParticipationSchema = z
+  .object({
+    participate: z.boolean(),
+    checkAmount: NonnegativeDecimalStringSchema,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const checkAmount = new Decimal(value.checkAmount);
+    if (value.participate && !checkAmount.gt(0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A participating path requires a positive checkAmount',
+        path: ['checkAmount'],
+      });
+    }
+    if (!value.participate && !checkAmount.isZero()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A non-participating path requires a zero checkAmount',
+        path: ['checkAmount'],
+      });
+    }
+  });
+
+export const MarginalReserveStageV1Schema = z
+  .object({
+    stage: CanonicalStageSchema,
+    preMoneyValuation: NonnegativeDecimalStringSchema,
+    roundSize: NonnegativeDecimalStringSchema,
+    monthsFromPriorStage: z.number().int().nonnegative(),
+    graduationProbability: ProbabilityDecimalStringSchema,
+    exitProbability: ProbabilityDecimalStringSchema,
+    exitValuation: NonnegativeDecimalStringSchema,
+    withDecision: ParticipationSchema,
+    withoutDecision: ParticipationSchema,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const preMoney = new Decimal(value.preMoneyValuation);
+    const roundSize = new Decimal(value.roundSize);
+    if (preMoney.plus(roundSize).lte(0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'preMoneyValuation plus roundSize must be positive',
+        path: ['roundSize'],
+      });
+    }
+
+    const probabilitySum = new Decimal(value.exitProbability).plus(
+      value.graduationProbability
+    );
+    if (probabilitySum.gt(1)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'exitProbability plus graduationProbability must not exceed 1',
+        path: ['exitProbability'],
+      });
+    }
+
+    for (const path of ['withDecision', 'withoutDecision'] as const) {
+      if (new Decimal(value[path].checkAmount).gt(roundSize)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'checkAmount cannot exceed roundSize',
+          path: [path, 'checkAmount'],
+        });
+      }
+    }
+  });
+
+function validateCanonicalStageOrder(
+  stages: ReadonlyArray<{ stage: z.infer<typeof CanonicalStageSchema> }>,
+  ctx: z.RefinementCtx,
+  collectionPath: 'stages' | 'stageContributions'
+): void {
+  let priorIndex = -1;
+  stages.forEach((stage, index) => {
+    const currentIndex = CANONICAL_STAGES.indexOf(stage.stage);
+    if (currentIndex <= priorIndex) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Stages must be unique and follow canonical stage order',
+        path: [collectionPath, index, 'stage'],
+      });
+    }
+    priorIndex = currentIndex;
+  });
+}
+
+export const MarginalReserveMoicInputV1Schema = z
+  .object({
+    contractVersion: z.literal('marginal-reserve-moic-input-v1'),
+    fundId: z.number().int().positive(),
+    companyId: z.number().int().positive(),
+    baseCurrency: CurrencyCodeSchema,
+    asOfDate: z.string().date(),
+    currentOwnership: ProbabilityDecimalStringSchema,
+    stages: z.array(MarginalReserveStageV1Schema).min(1),
+    factsInputHash: Sha256Schema,
+    assumptionsHash: Sha256Schema,
+    engineVersion: z.literal('marginal-reserve-moic-v1'),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    validateCanonicalStageOrder(value.stages, ctx, 'stages');
+
+    const hasCapitalDifference = value.stages.some(
+      (stage) =>
+        !new Decimal(stage.withDecision.checkAmount).eq(stage.withoutDecision.checkAmount)
+    );
+    if (!hasCapitalDifference) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one stage must differ in capital between counterfactual paths',
+        path: ['stages'],
+      });
+    }
+  });
+
+export const MarginalReserveWarningCodeSchema = z.enum([
+  'NON_POSITIVE_DELTA_CAPITAL',
+  'MIN_DENOMINATOR_FLOOR',
+  'IMPLAUSIBLE_MAGNITUDE',
+  'IRR_UNAVAILABLE',
+]);
+
+export const StructuredWarningSchema = z
+  .object({
+    code: MarginalReserveWarningCodeSchema,
+    message: z.string().min(1),
+  })
+  .strict();
+
+export const CounterfactualSummarySchema = z
+  .object({
+    expectedProceeds: DecimalStringSchema,
+    expectedCapital: DecimalStringSchema,
+    expectedOwnershipAtExit: DecimalStringSchema,
+  })
+  .strict();
+
+const CounterfactualStageContributionSchema = z
+  .object({
+    ownershipAfterRound: DecimalStringSchema,
+    expectedCapital: DecimalStringSchema,
+    expectedProceeds: DecimalStringSchema,
+    expectedOwnershipAtExit: DecimalStringSchema,
+  })
+  .strict();
+
+export const StageContributionSchema = z
+  .object({
+    stage: CanonicalStageSchema,
+    reachProbability: ProbabilityDecimalStringSchema,
+    conditionalExitProbability: ProbabilityDecimalStringSchema,
+    conditionalGraduationProbability: ProbabilityDecimalStringSchema,
+    conditionalFailureProbability: ProbabilityDecimalStringSchema,
+    unconditionalExitProbability: ProbabilityDecimalStringSchema,
+    unconditionalFailureProbability: ProbabilityDecimalStringSchema,
+    withDecision: CounterfactualStageContributionSchema,
+    withoutDecision: CounterfactualStageContributionSchema,
+    deltaExpectedProceeds: DecimalStringSchema,
+    deltaExpectedCapital: DecimalStringSchema,
+  })
+  .strict();
+
+export const MarginalReserveMoicResultV1Schema = z
+  .object({
+    contractVersion: z.literal('marginal-reserve-moic-result-v1'),
+    status: z.enum(['actionable', 'indicative', 'unavailable']),
+    marginalMoic: DecimalStringSchema.nullable(),
+    marginalIrr: DecimalStringSchema.nullable(),
+    deltaExpectedProceeds: DecimalStringSchema,
+    deltaExpectedCapital: DecimalStringSchema,
+    withDecision: CounterfactualSummarySchema,
+    withoutDecision: CounterfactualSummarySchema,
+    stageContributions: z.array(StageContributionSchema).min(1),
+    factsInputHash: Sha256Schema,
+    assumptionsHash: Sha256Schema,
+    resultHash: Sha256Schema,
+    warnings: z.array(StructuredWarningSchema),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    validateCanonicalStageOrder(value.stageContributions, ctx, 'stageContributions');
+
+    if (value.status === 'unavailable' && (value.marginalMoic !== null || value.marginalIrr !== null)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Unavailable results cannot contain marginalMoic or marginalIrr',
+        path: ['status'],
+      });
+    }
+    if (value.status !== 'unavailable' && value.marginalMoic === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Available results require marginalMoic',
+        path: ['marginalMoic'],
+      });
+    }
+    if (
+      value.status === 'indicative' &&
+      !value.warnings.some((warning) => warning.code === 'IMPLAUSIBLE_MAGNITUDE')
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Indicative results require an IMPLAUSIBLE_MAGNITUDE warning',
+        path: ['warnings'],
+      });
+    }
+  });
+
+export type MarginalReserveStageV1 = z.infer<typeof MarginalReserveStageV1Schema>;
+export type MarginalReserveMoicInputV1 = z.infer<typeof MarginalReserveMoicInputV1Schema>;
+export type MarginalReserveWarningCode = z.infer<typeof MarginalReserveWarningCodeSchema>;
+export type StructuredWarning = z.infer<typeof StructuredWarningSchema>;
+export type CounterfactualSummary = z.infer<typeof CounterfactualSummarySchema>;
+export type StageContribution = z.infer<typeof StageContributionSchema>;
+export type MarginalReserveMoicResultV1 = z.infer<typeof MarginalReserveMoicResultV1Schema>;

--- a/shared/contracts/marginal-reserve-moic-v1.contract.ts
+++ b/shared/contracts/marginal-reserve-moic-v1.contract.ts
@@ -216,6 +216,11 @@ export const MarginalReserveMoicResultV1Schema = z
   .strict()
   .superRefine((value, ctx) => {
     validateCanonicalStageOrder(value.stageContributions, ctx, 'stageContributions');
+    const hasMagnitudeWarning = value.warnings.some(
+      (warning) => warning.code === 'IMPLAUSIBLE_MAGNITUDE'
+    );
+    const exceedsMagnitudeThreshold =
+      value.marginalMoic !== null && new Decimal(value.marginalMoic).gt(100);
 
     if (value.status === 'unavailable' && (value.marginalMoic !== null || value.marginalIrr !== null)) {
       ctx.addIssue({
@@ -231,13 +236,31 @@ export const MarginalReserveMoicResultV1Schema = z
         path: ['marginalMoic'],
       });
     }
-    if (
-      value.status === 'indicative' &&
-      !value.warnings.some((warning) => warning.code === 'IMPLAUSIBLE_MAGNITUDE')
-    ) {
+    if (value.status === 'indicative' && !exceedsMagnitudeThreshold) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Indicative results require marginalMoic above 100',
+        path: ['marginalMoic'],
+      });
+    }
+    if (value.status === 'indicative' && !hasMagnitudeWarning) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Indicative results require an IMPLAUSIBLE_MAGNITUDE warning',
+        path: ['warnings'],
+      });
+    }
+    if (exceedsMagnitudeThreshold && value.status !== 'indicative') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Marginal MOIC above 100 must be indicative',
+        path: ['status'],
+      });
+    }
+    if (!exceedsMagnitudeThreshold && hasMagnitudeWarning) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'IMPLAUSIBLE_MAGNITUDE is valid only when marginalMoic is above 100',
         path: ['warnings'],
       });
     }

--- a/shared/core/moic/MarginalReserveMoic.ts
+++ b/shared/core/moic/MarginalReserveMoic.ts
@@ -1,0 +1,420 @@
+import Decimal from '@shared/lib/decimal-config';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+import {
+  MIN_DELTA_CAPITAL_FLOOR,
+  MarginalReserveMoicInputV1Schema,
+  MarginalReserveMoicResultV1Schema,
+  type MarginalReserveMoicInputV1,
+  type MarginalReserveMoicResultV1,
+  type MarginalReserveStageV1,
+  type StructuredWarning,
+} from '@shared/contracts/marginal-reserve-moic-v1.contract';
+
+const OUTPUT_DECIMAL_PLACES = 6;
+const ZERO = new Decimal(0);
+const ONE = new Decimal(1);
+
+type CounterfactualPath = 'withDecision' | 'withoutDecision';
+
+interface DecimalStageContribution {
+  ownershipAfterRound: Decimal;
+  expectedCapital: Decimal;
+  expectedProceeds: Decimal;
+  expectedOwnershipAtExit: Decimal;
+}
+
+interface ProjectedStage {
+  stage: MarginalReserveStageV1['stage'];
+  monthsFromAsOf: number;
+  reachProbability: Decimal;
+  conditionalExitProbability: Decimal;
+  conditionalGraduationProbability: Decimal;
+  conditionalFailureProbability: Decimal;
+  unconditionalExitProbability: Decimal;
+  unconditionalFailureProbability: Decimal;
+  contribution: DecimalStageContribution;
+}
+
+interface CounterfactualProjection {
+  expectedProceeds: Decimal;
+  expectedCapital: Decimal;
+  expectedOwnershipAtExit: Decimal;
+  stages: ProjectedStage[];
+}
+
+interface DatedDecimalCashFlow {
+  monthsFromAsOf: number;
+  amount: Decimal;
+}
+
+function roundMetric(value: Decimal): Decimal {
+  return value.toDecimalPlaces(OUTPUT_DECIMAL_PLACES, Decimal.ROUND_HALF_UP);
+}
+
+function formatMetric(value: Decimal): string {
+  return roundMetric(value).toFixed(OUTPUT_DECIMAL_PLACES);
+}
+
+function validateProbabilityTree(stage: MarginalReserveStageV1): void {
+  const exitProbability = new Decimal(stage.exitProbability);
+  const graduationProbability = new Decimal(stage.graduationProbability);
+  if (
+    exitProbability.lt(0) ||
+    exitProbability.gt(1) ||
+    graduationProbability.lt(0) ||
+    graduationProbability.gt(1) ||
+    exitProbability.plus(graduationProbability).gt(1)
+  ) {
+    throw new Error(`Invalid probability tree at stage ${stage.stage}`);
+  }
+}
+
+function ownershipAfterRound(
+  existingOwnershipBefore: Decimal,
+  preMoneyValuation: Decimal,
+  roundSize: Decimal,
+  fundCheck: Decimal
+): Decimal {
+  const postMoney = preMoneyValuation.plus(roundSize);
+  if (postMoney.lte(0)) {
+    throw new Error('Priced round post-money valuation must be positive');
+  }
+
+  const existingOwnershipAfter = existingOwnershipBefore.times(preMoneyValuation).div(postMoney);
+  const incrementalOwnershipPurchased = fundCheck.div(postMoney);
+  return existingOwnershipAfter.plus(incrementalOwnershipPurchased);
+}
+
+function projectCounterfactual(
+  input: MarginalReserveMoicInputV1,
+  path: CounterfactualPath
+): CounterfactualProjection {
+  let reachProbability = ONE;
+  let ownership = new Decimal(input.currentOwnership);
+  let monthsFromAsOf = 0;
+  const stages: ProjectedStage[] = [];
+
+  for (const stage of input.stages) {
+    validateProbabilityTree(stage);
+    monthsFromAsOf += stage.monthsFromPriorStage;
+
+    const exitProbability = new Decimal(stage.exitProbability);
+    const graduationProbability = new Decimal(stage.graduationProbability);
+    const failureProbability = ONE.minus(exitProbability).minus(graduationProbability);
+    const unconditionalExitProbability = reachProbability.times(exitProbability);
+    const unconditionalFailureProbability = reachProbability.times(failureProbability);
+    const decision = stage[path];
+    const checkAmount = decision.participate ? new Decimal(decision.checkAmount) : ZERO;
+
+    ownership = ownershipAfterRound(
+      ownership,
+      new Decimal(stage.preMoneyValuation),
+      new Decimal(stage.roundSize),
+      checkAmount
+    );
+
+    const expectedCapital = roundMetric(reachProbability.times(checkAmount));
+    const rawExpectedOwnershipAtExit = unconditionalExitProbability.times(ownership);
+    const expectedOwnershipAtExit = roundMetric(rawExpectedOwnershipAtExit);
+    const expectedProceeds = roundMetric(
+      rawExpectedOwnershipAtExit.times(new Decimal(stage.exitValuation))
+    );
+
+    stages.push({
+      stage: stage.stage,
+      monthsFromAsOf,
+      reachProbability,
+      conditionalExitProbability: exitProbability,
+      conditionalGraduationProbability: graduationProbability,
+      conditionalFailureProbability: failureProbability,
+      unconditionalExitProbability,
+      unconditionalFailureProbability,
+      contribution: {
+        ownershipAfterRound: ownership,
+        expectedCapital,
+        expectedProceeds,
+        expectedOwnershipAtExit,
+      },
+    });
+
+    reachProbability = reachProbability.times(graduationProbability);
+  }
+
+  return {
+    expectedProceeds: stages.reduce(
+      (total, stage) => total.plus(stage.contribution.expectedProceeds),
+      ZERO
+    ),
+    expectedCapital: stages.reduce(
+      (total, stage) => total.plus(stage.contribution.expectedCapital),
+      ZERO
+    ),
+    expectedOwnershipAtExit: stages.reduce(
+      (total, stage) => total.plus(stage.contribution.expectedOwnershipAtExit),
+      ZERO
+    ),
+    stages,
+  };
+}
+
+function decimalNpvAt(rate: Decimal, cashFlows: DatedDecimalCashFlow[]): Decimal | null {
+  const base = ONE.plus(rate);
+  if (base.lte(0)) {
+    return null;
+  }
+
+  return cashFlows.reduce((npv, cashFlow) => {
+    const years = new Decimal(cashFlow.monthsFromAsOf).div(12);
+    return npv.plus(cashFlow.amount.div(base.pow(years)));
+  }, ZERO);
+}
+
+function calculateExpectedIrr(datedCashFlows: DatedDecimalCashFlow[]): Decimal | null {
+  const aggregatedByMonth = new Map<number, Decimal>();
+  for (const cashFlow of datedCashFlows) {
+    aggregatedByMonth.set(
+      cashFlow.monthsFromAsOf,
+      (aggregatedByMonth.get(cashFlow.monthsFromAsOf) ?? ZERO).plus(cashFlow.amount)
+    );
+  }
+
+  const cashFlows = [...aggregatedByMonth.entries()]
+    .sort(([leftMonth], [rightMonth]) => leftMonth - rightMonth)
+    .map(([monthsFromAsOf, amount]) => ({ monthsFromAsOf, amount }))
+    .filter((cashFlow) => !cashFlow.amount.isZero());
+
+  if (
+    cashFlows.length < 2 ||
+    !cashFlows.some((cashFlow) => cashFlow.amount.lt(0)) ||
+    !cashFlows.some((cashFlow) => cashFlow.amount.gt(0))
+  ) {
+    return null;
+  }
+
+  let signChanges = 0;
+  for (let index = 1; index < cashFlows.length; index += 1) {
+    const prior = cashFlows[index - 1];
+    const current = cashFlows[index];
+    if (prior && current && prior.amount.isNegative() !== current.amount.isNegative()) {
+      signChanges += 1;
+    }
+  }
+  if (signChanges !== 1) {
+    return null;
+  }
+
+  let lower = new Decimal('-0.999999');
+  let upper = ONE;
+  let lowerNpv = decimalNpvAt(lower, cashFlows);
+  let upperNpv = decimalNpvAt(upper, cashFlows);
+  if (lowerNpv === null || upperNpv === null) {
+    return null;
+  }
+
+  const maximumUpperRate = new Decimal(1_000_000);
+  while (lowerNpv.times(upperNpv).gt(0) && upper.lt(maximumUpperRate)) {
+    upper = upper.times(2).plus(1);
+    upperNpv = decimalNpvAt(upper, cashFlows);
+    if (upperNpv === null) {
+      return null;
+    }
+  }
+  if (lowerNpv.times(upperNpv).gt(0)) {
+    return null;
+  }
+
+  const npvTolerance = new Decimal('0.0000001');
+  const rateTolerance = new Decimal('0.000000000001');
+  for (let iteration = 0; iteration < 256; iteration += 1) {
+    const midpoint = lower.plus(upper).div(2);
+    const midpointNpv = decimalNpvAt(midpoint, cashFlows);
+    if (midpointNpv === null) {
+      return null;
+    }
+    if (midpointNpv.abs().lte(npvTolerance) || upper.minus(lower).abs().lte(rateTolerance)) {
+      return midpoint;
+    }
+
+    if (lowerNpv.times(midpointNpv).lte(0)) {
+      upper = midpoint;
+      upperNpv = midpointNpv;
+    } else {
+      lower = midpoint;
+      lowerNpv = midpointNpv;
+    }
+  }
+
+  return null;
+}
+
+function normalizeInputForHash(input: MarginalReserveMoicInputV1): unknown {
+  return {
+    ...input,
+    currentOwnership: formatMetric(new Decimal(input.currentOwnership)),
+    stages: input.stages.map((stage) => ({
+      ...stage,
+      preMoneyValuation: formatMetric(new Decimal(stage.preMoneyValuation)),
+      roundSize: formatMetric(new Decimal(stage.roundSize)),
+      graduationProbability: formatMetric(new Decimal(stage.graduationProbability)),
+      exitProbability: formatMetric(new Decimal(stage.exitProbability)),
+      exitValuation: formatMetric(new Decimal(stage.exitValuation)),
+      withDecision: {
+        ...stage.withDecision,
+        checkAmount: formatMetric(new Decimal(stage.withDecision.checkAmount)),
+      },
+      withoutDecision: {
+        ...stage.withoutDecision,
+        checkAmount: formatMetric(new Decimal(stage.withoutDecision.checkAmount)),
+      },
+    })),
+  };
+}
+
+export function calculateMarginalReserveMoic(
+  input: MarginalReserveMoicInputV1
+): MarginalReserveMoicResultV1 {
+  const parsedInput = MarginalReserveMoicInputV1Schema.parse(input);
+  const withDecision = projectCounterfactual(parsedInput, 'withDecision');
+  const withoutDecision = projectCounterfactual(parsedInput, 'withoutDecision');
+  const deltaExpectedProceeds = withDecision.expectedProceeds.minus(
+    withoutDecision.expectedProceeds
+  );
+  const deltaExpectedCapital = withDecision.expectedCapital.minus(withoutDecision.expectedCapital);
+  const denominatorFloor = Decimal.max(
+    new Decimal(MIN_DELTA_CAPITAL_FLOOR.absoluteUsd),
+    withDecision.expectedCapital.times(MIN_DELTA_CAPITAL_FLOOR.withDecisionExpectedCapitalRatio)
+  );
+
+  const warnings: StructuredWarning[] = [];
+  let status: MarginalReserveMoicResultV1['status'];
+  let marginalMoic: Decimal | null = null;
+  let marginalIrr: Decimal | null = null;
+
+  if (deltaExpectedCapital.lte(0)) {
+    status = 'unavailable';
+    warnings.push({
+      code: 'NON_POSITIVE_DELTA_CAPITAL',
+      message: 'Delta expected capital must be positive',
+    });
+  } else if (deltaExpectedCapital.lt(denominatorFloor)) {
+    status = 'unavailable';
+    warnings.push({
+      code: 'MIN_DENOMINATOR_FLOOR',
+      message: `Delta expected capital is below the ${formatMetric(denominatorFloor)} floor`,
+    });
+  } else {
+    marginalMoic = deltaExpectedProceeds.div(deltaExpectedCapital);
+    status = marginalMoic.gt(100) ? 'indicative' : 'actionable';
+    if (status === 'indicative') {
+      warnings.push({
+        code: 'IMPLAUSIBLE_MAGNITUDE',
+        message: 'Marginal MOIC exceeds 100x',
+      });
+    }
+
+    const marginalCashFlows: DatedDecimalCashFlow[] = [];
+    for (let index = 0; index < parsedInput.stages.length; index += 1) {
+      const withStage = withDecision.stages[index];
+      const withoutStage = withoutDecision.stages[index];
+      if (!withStage || !withoutStage) {
+        throw new Error('Counterfactual stage projections are misaligned');
+      }
+
+      const capitalDelta = withStage.contribution.expectedCapital.minus(
+        withoutStage.contribution.expectedCapital
+      );
+      const proceedsDelta = withStage.contribution.expectedProceeds.minus(
+        withoutStage.contribution.expectedProceeds
+      );
+      if (!capitalDelta.isZero()) {
+        marginalCashFlows.push({
+          monthsFromAsOf: withStage.monthsFromAsOf,
+          amount: capitalDelta.negated(),
+        });
+      }
+      if (!proceedsDelta.isZero()) {
+        marginalCashFlows.push({
+          monthsFromAsOf: withStage.monthsFromAsOf,
+          amount: proceedsDelta,
+        });
+      }
+    }
+
+    marginalIrr = calculateExpectedIrr(marginalCashFlows);
+    if (marginalIrr === null) {
+      warnings.push({
+        code: 'IRR_UNAVAILABLE',
+        message: 'Marginal expected cash flows do not have one bounded IRR root',
+      });
+    }
+  }
+
+  const stageContributions = parsedInput.stages.map((stage, index) => {
+    const withStage = withDecision.stages[index];
+    const withoutStage = withoutDecision.stages[index];
+    if (!withStage || !withoutStage) {
+      throw new Error('Counterfactual stage projections are misaligned');
+    }
+
+    return {
+      stage: stage.stage,
+      reachProbability: formatMetric(withStage.reachProbability),
+      conditionalExitProbability: formatMetric(withStage.conditionalExitProbability),
+      conditionalGraduationProbability: formatMetric(withStage.conditionalGraduationProbability),
+      conditionalFailureProbability: formatMetric(withStage.conditionalFailureProbability),
+      unconditionalExitProbability: formatMetric(withStage.unconditionalExitProbability),
+      unconditionalFailureProbability: formatMetric(withStage.unconditionalFailureProbability),
+      withDecision: {
+        ownershipAfterRound: formatMetric(withStage.contribution.ownershipAfterRound),
+        expectedCapital: formatMetric(withStage.contribution.expectedCapital),
+        expectedProceeds: formatMetric(withStage.contribution.expectedProceeds),
+        expectedOwnershipAtExit: formatMetric(withStage.contribution.expectedOwnershipAtExit),
+      },
+      withoutDecision: {
+        ownershipAfterRound: formatMetric(withoutStage.contribution.ownershipAfterRound),
+        expectedCapital: formatMetric(withoutStage.contribution.expectedCapital),
+        expectedProceeds: formatMetric(withoutStage.contribution.expectedProceeds),
+        expectedOwnershipAtExit: formatMetric(withoutStage.contribution.expectedOwnershipAtExit),
+      },
+      deltaExpectedProceeds: formatMetric(
+        withStage.contribution.expectedProceeds.minus(withoutStage.contribution.expectedProceeds)
+      ),
+      deltaExpectedCapital: formatMetric(
+        withStage.contribution.expectedCapital.minus(withoutStage.contribution.expectedCapital)
+      ),
+    };
+  });
+
+  const resultWithoutHash: Omit<MarginalReserveMoicResultV1, 'resultHash'> = {
+    contractVersion: 'marginal-reserve-moic-result-v1',
+    status,
+    marginalMoic: marginalMoic === null ? null : formatMetric(marginalMoic),
+    marginalIrr: marginalIrr === null ? null : formatMetric(marginalIrr),
+    deltaExpectedProceeds: formatMetric(deltaExpectedProceeds),
+    deltaExpectedCapital: formatMetric(deltaExpectedCapital),
+    withDecision: {
+      expectedProceeds: formatMetric(withDecision.expectedProceeds),
+      expectedCapital: formatMetric(withDecision.expectedCapital),
+      expectedOwnershipAtExit: formatMetric(withDecision.expectedOwnershipAtExit),
+    },
+    withoutDecision: {
+      expectedProceeds: formatMetric(withoutDecision.expectedProceeds),
+      expectedCapital: formatMetric(withoutDecision.expectedCapital),
+      expectedOwnershipAtExit: formatMetric(withoutDecision.expectedOwnershipAtExit),
+    },
+    stageContributions,
+    factsInputHash: parsedInput.factsInputHash,
+    assumptionsHash: parsedInput.assumptionsHash,
+    warnings,
+  };
+
+  const result: MarginalReserveMoicResultV1 = {
+    ...resultWithoutHash,
+    resultHash: canonicalSha256({
+      input: normalizeInputForHash(parsedInput),
+      output: resultWithoutHash,
+    }),
+  };
+
+  return MarginalReserveMoicResultV1Schema.parse(result);
+}

--- a/shared/core/moic/MarginalReserveMoic.ts
+++ b/shared/core/moic/MarginalReserveMoic.ts
@@ -36,6 +36,9 @@ interface ProjectedStage {
 }
 
 interface CounterfactualProjection {
+  exactExpectedProceeds: Decimal;
+  exactExpectedCapital: Decimal;
+  exactExpectedOwnershipAtExit: Decimal;
   expectedProceeds: Decimal;
   expectedCapital: Decimal;
   expectedOwnershipAtExit: Decimal;
@@ -113,12 +116,9 @@ function projectCounterfactual(
       checkAmount
     );
 
-    const expectedCapital = roundMetric(reachProbability.times(checkAmount));
-    const rawExpectedOwnershipAtExit = unconditionalExitProbability.times(ownership);
-    const expectedOwnershipAtExit = roundMetric(rawExpectedOwnershipAtExit);
-    const expectedProceeds = roundMetric(
-      rawExpectedOwnershipAtExit.times(new Decimal(stage.exitValuation))
-    );
+    const expectedCapital = reachProbability.times(checkAmount);
+    const expectedOwnershipAtExit = unconditionalExitProbability.times(ownership);
+    const expectedProceeds = expectedOwnershipAtExit.times(new Decimal(stage.exitValuation));
 
     stages.push({
       stage: stage.stage,
@@ -141,16 +141,28 @@ function projectCounterfactual(
   }
 
   return {
-    expectedProceeds: stages.reduce(
+    exactExpectedProceeds: stages.reduce(
       (total, stage) => total.plus(stage.contribution.expectedProceeds),
       ZERO
     ),
-    expectedCapital: stages.reduce(
+    exactExpectedCapital: stages.reduce(
       (total, stage) => total.plus(stage.contribution.expectedCapital),
       ZERO
     ),
-    expectedOwnershipAtExit: stages.reduce(
+    exactExpectedOwnershipAtExit: stages.reduce(
       (total, stage) => total.plus(stage.contribution.expectedOwnershipAtExit),
+      ZERO
+    ),
+    expectedProceeds: stages.reduce(
+      (total, stage) => total.plus(roundMetric(stage.contribution.expectedProceeds)),
+      ZERO
+    ),
+    expectedCapital: stages.reduce(
+      (total, stage) => total.plus(roundMetric(stage.contribution.expectedCapital)),
+      ZERO
+    ),
+    expectedOwnershipAtExit: stages.reduce(
+      (total, stage) => total.plus(roundMetric(stage.contribution.expectedOwnershipAtExit)),
       ZERO
     ),
     stages,
@@ -276,13 +288,23 @@ export function calculateMarginalReserveMoic(
   const parsedInput = MarginalReserveMoicInputV1Schema.parse(input);
   const withDecision = projectCounterfactual(parsedInput, 'withDecision');
   const withoutDecision = projectCounterfactual(parsedInput, 'withoutDecision');
-  const deltaExpectedProceeds = withDecision.expectedProceeds.minus(
+  const exactDeltaExpectedProceeds = withDecision.exactExpectedProceeds.minus(
+    withoutDecision.exactExpectedProceeds
+  );
+  const exactDeltaExpectedCapital = withDecision.exactExpectedCapital.minus(
+    withoutDecision.exactExpectedCapital
+  );
+  const displayedDeltaExpectedProceeds = withDecision.expectedProceeds.minus(
     withoutDecision.expectedProceeds
   );
-  const deltaExpectedCapital = withDecision.expectedCapital.minus(withoutDecision.expectedCapital);
+  const displayedDeltaExpectedCapital = withDecision.expectedCapital.minus(
+    withoutDecision.expectedCapital
+  );
   const denominatorFloor = Decimal.max(
     new Decimal(MIN_DELTA_CAPITAL_FLOOR.absoluteUsd),
-    withDecision.expectedCapital.times(MIN_DELTA_CAPITAL_FLOOR.withDecisionExpectedCapitalRatio)
+    withDecision.exactExpectedCapital.times(
+      MIN_DELTA_CAPITAL_FLOOR.withDecisionExpectedCapitalRatio
+    )
   );
 
   const warnings: StructuredWarning[] = [];
@@ -290,20 +312,20 @@ export function calculateMarginalReserveMoic(
   let marginalMoic: Decimal | null = null;
   let marginalIrr: Decimal | null = null;
 
-  if (deltaExpectedCapital.lte(0)) {
+  if (exactDeltaExpectedCapital.lte(0)) {
     status = 'unavailable';
     warnings.push({
       code: 'NON_POSITIVE_DELTA_CAPITAL',
       message: 'Delta expected capital must be positive',
     });
-  } else if (deltaExpectedCapital.lt(denominatorFloor)) {
+  } else if (exactDeltaExpectedCapital.lt(denominatorFloor)) {
     status = 'unavailable';
     warnings.push({
       code: 'MIN_DENOMINATOR_FLOOR',
-      message: `Delta expected capital is below the ${formatMetric(denominatorFloor)} floor`,
+      message: `Unrounded delta expected capital is below the ${formatMetric(denominatorFloor)} floor`,
     });
   } else {
-    marginalMoic = deltaExpectedProceeds.div(deltaExpectedCapital);
+    marginalMoic = exactDeltaExpectedProceeds.div(exactDeltaExpectedCapital);
     status = marginalMoic.gt(100) ? 'indicative' : 'actionable';
     if (status === 'indicative') {
       warnings.push({
@@ -377,10 +399,14 @@ export function calculateMarginalReserveMoic(
         expectedOwnershipAtExit: formatMetric(withoutStage.contribution.expectedOwnershipAtExit),
       },
       deltaExpectedProceeds: formatMetric(
-        withStage.contribution.expectedProceeds.minus(withoutStage.contribution.expectedProceeds)
+        roundMetric(withStage.contribution.expectedProceeds).minus(
+          roundMetric(withoutStage.contribution.expectedProceeds)
+        )
       ),
       deltaExpectedCapital: formatMetric(
-        withStage.contribution.expectedCapital.minus(withoutStage.contribution.expectedCapital)
+        roundMetric(withStage.contribution.expectedCapital).minus(
+          roundMetric(withoutStage.contribution.expectedCapital)
+        )
       ),
     };
   });
@@ -390,8 +416,8 @@ export function calculateMarginalReserveMoic(
     status,
     marginalMoic: marginalMoic === null ? null : formatMetric(marginalMoic),
     marginalIrr: marginalIrr === null ? null : formatMetric(marginalIrr),
-    deltaExpectedProceeds: formatMetric(deltaExpectedProceeds),
-    deltaExpectedCapital: formatMetric(deltaExpectedCapital),
+    deltaExpectedProceeds: formatMetric(displayedDeltaExpectedProceeds),
+    deltaExpectedCapital: formatMetric(displayedDeltaExpectedCapital),
     withDecision: {
       expectedProceeds: formatMetric(withDecision.expectedProceeds),
       expectedCapital: formatMetric(withDecision.expectedCapital),

--- a/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
+++ b/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MIN_DELTA_CAPITAL_FLOOR,
+  MarginalReserveMoicInputV1Schema,
+  MarginalReserveMoicResultV1Schema,
+  MarginalReserveStageV1Schema,
+} from '@shared/contracts/marginal-reserve-moic-v1.contract';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const HASH_C = 'c'.repeat(64);
+
+function makeStage(overrides: Record<string, unknown> = {}) {
+  return {
+    stage: 'seed',
+    preMoneyValuation: '8000000',
+    roundSize: '2000000',
+    monthsFromPriorStage: 0,
+    graduationProbability: '0',
+    exitProbability: '1',
+    exitValuation: '50000000',
+    withDecision: { participate: true, checkAmount: '1000000' },
+    withoutDecision: { participate: false, checkAmount: '0' },
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    contractVersion: 'marginal-reserve-moic-input-v1',
+    fundId: 1,
+    companyId: 2,
+    baseCurrency: 'USD',
+    asOfDate: '2026-07-12',
+    currentOwnership: '0',
+    stages: [makeStage()],
+    factsInputHash: HASH_A,
+    assumptionsHash: HASH_B,
+    engineVersion: 'marginal-reserve-moic-v1',
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Record<string, unknown> = {}) {
+  return {
+    contractVersion: 'marginal-reserve-moic-result-v1',
+    status: 'actionable',
+    marginalMoic: '5.000000',
+    marginalIrr: null,
+    deltaExpectedProceeds: '5000000.000000',
+    deltaExpectedCapital: '1000000.000000',
+    withDecision: {
+      expectedProceeds: '5000000.000000',
+      expectedCapital: '1000000.000000',
+      expectedOwnershipAtExit: '0.100000',
+    },
+    withoutDecision: {
+      expectedProceeds: '0.000000',
+      expectedCapital: '0.000000',
+      expectedOwnershipAtExit: '0.000000',
+    },
+    stageContributions: [
+      {
+        stage: 'seed',
+        reachProbability: '1.000000',
+        conditionalExitProbability: '1.000000',
+        conditionalGraduationProbability: '0.000000',
+        conditionalFailureProbability: '0.000000',
+        unconditionalExitProbability: '1.000000',
+        unconditionalFailureProbability: '0.000000',
+        withDecision: {
+          ownershipAfterRound: '0.100000',
+          expectedCapital: '1000000.000000',
+          expectedProceeds: '5000000.000000',
+          expectedOwnershipAtExit: '0.100000',
+        },
+        withoutDecision: {
+          ownershipAfterRound: '0.000000',
+          expectedCapital: '0.000000',
+          expectedProceeds: '0.000000',
+          expectedOwnershipAtExit: '0.000000',
+        },
+        deltaExpectedProceeds: '5000000.000000',
+        deltaExpectedCapital: '1000000.000000',
+      },
+    ],
+    factsInputHash: HASH_A,
+    assumptionsHash: HASH_B,
+    resultHash: HASH_C,
+    warnings: [{ code: 'IRR_UNAVAILABLE', message: 'No marginal IRR root exists' }],
+    ...overrides,
+  };
+}
+
+describe('MarginalReserveMoicInputV1Schema', () => {
+  it('accepts a strict, ordered priced-round counterfactual', () => {
+    expect(MarginalReserveMoicInputV1Schema.parse(makeInput())).toEqual(makeInput());
+  });
+
+  it('rejects numbers, NaN, and Infinity in decimal-string fields', () => {
+    for (const invalid of [1, Number.NaN, Number.POSITIVE_INFINITY, 'NaN', 'Infinity']) {
+      const parsed = MarginalReserveStageV1Schema.safeParse(
+        makeStage({ preMoneyValuation: invalid })
+      );
+      expect(parsed.success).toBe(false);
+    }
+  });
+
+  it('rejects probabilities outside bounds and exit plus graduation above one', () => {
+    expect(
+      MarginalReserveStageV1Schema.safeParse(makeStage({ exitProbability: '1.000001' })).success
+    ).toBe(false);
+    expect(
+      MarginalReserveStageV1Schema.safeParse(makeStage({ graduationProbability: '-0.1' })).success
+    ).toBe(false);
+    expect(
+      MarginalReserveStageV1Schema.safeParse(
+        makeStage({ exitProbability: '0.6', graduationProbability: '0.400001' })
+      ).success
+    ).toBe(false);
+  });
+
+  it('rejects negative valuations, round sizes, and checks', () => {
+    expect(
+      MarginalReserveStageV1Schema.safeParse(makeStage({ preMoneyValuation: '-1' })).success
+    ).toBe(false);
+    expect(MarginalReserveStageV1Schema.safeParse(makeStage({ roundSize: '-1' })).success).toBe(
+      false
+    );
+    expect(
+      MarginalReserveStageV1Schema.safeParse(
+        makeStage({ withDecision: { participate: true, checkAmount: '-1' } })
+      ).success
+    ).toBe(false);
+  });
+
+  it('enforces participation/check consistency and priced-round capacity', () => {
+    expect(
+      MarginalReserveStageV1Schema.safeParse(
+        makeStage({ withDecision: { participate: false, checkAmount: '1' } })
+      ).success
+    ).toBe(false);
+    expect(
+      MarginalReserveStageV1Schema.safeParse(
+        makeStage({ withDecision: { participate: true, checkAmount: '0' } })
+      ).success
+    ).toBe(false);
+    expect(
+      MarginalReserveStageV1Schema.safeParse(
+        makeStage({ withDecision: { participate: true, checkAmount: '2000000.000001' } })
+      ).success
+    ).toBe(false);
+  });
+
+  it('requires unique stages in canonical order', () => {
+    const duplicate = makeInput({ stages: [makeStage(), makeStage()] });
+    const reversed = makeInput({
+      stages: [makeStage({ stage: 'series_a' }), makeStage({ stage: 'seed' })],
+    });
+
+    expect(MarginalReserveMoicInputV1Schema.safeParse(duplicate).success).toBe(false);
+    expect(MarginalReserveMoicInputV1Schema.safeParse(reversed).success).toBe(false);
+  });
+
+  it('requires at least one capital difference between paths', () => {
+    const sameCapital = makeInput({
+      stages: [
+        makeStage({
+          withDecision: { participate: true, checkAmount: '1000000' },
+          withoutDecision: { participate: true, checkAmount: '1000000.000000' },
+        }),
+      ],
+    });
+
+    expect(MarginalReserveMoicInputV1Schema.safeParse(sameCapital).success).toBe(false);
+  });
+
+  it('rejects non-USD inputs until an approved FX policy exists', () => {
+    expect(
+      MarginalReserveMoicInputV1Schema.safeParse(makeInput({ baseCurrency: 'EUR' })).success
+    ).toBe(false);
+    expect(
+      MarginalReserveMoicInputV1Schema.safeParse(makeInput({ baseCurrency: 'usd' })).success
+    ).toBe(false);
+  });
+
+  it('is strict at every object boundary', () => {
+    expect(
+      MarginalReserveMoicInputV1Schema.safeParse(makeInput({ unexpected: true })).success
+    ).toBe(false);
+    expect(
+      MarginalReserveMoicInputV1Schema.safeParse({
+        ...makeInput(),
+        stages: [makeStage({ withDecision: { participate: true, checkAmount: '1', extra: 1 } })],
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('MarginalReserveMoicResultV1Schema', () => {
+  it('accepts auditable paired summaries and stage contributions', () => {
+    expect(MarginalReserveMoicResultV1Schema.parse(makeResult())).toEqual(makeResult());
+  });
+
+  it('requires unavailable results to suppress MOIC and IRR', () => {
+    expect(
+      MarginalReserveMoicResultV1Schema.safeParse(
+        makeResult({ status: 'unavailable', marginalMoic: '5.000000' })
+      ).success
+    ).toBe(false);
+    expect(
+      MarginalReserveMoicResultV1Schema.safeParse(
+        makeResult({ status: 'unavailable', marginalMoic: null, marginalIrr: null })
+      ).success
+    ).toBe(true);
+  });
+
+  it('requires the structured magnitude warning for indicative results', () => {
+    expect(
+      MarginalReserveMoicResultV1Schema.safeParse(
+        makeResult({ status: 'indicative', marginalMoic: '101.000000', warnings: [] })
+      ).success
+    ).toBe(false);
+    expect(
+      MarginalReserveMoicResultV1Schema.safeParse(
+        makeResult({
+          status: 'indicative',
+          marginalMoic: '101.000000',
+          warnings: [
+            { code: 'IMPLAUSIBLE_MAGNITUDE', message: 'Marginal MOIC exceeds 100x' },
+          ],
+        })
+      ).success
+    ).toBe(true);
+  });
+});
+
+describe('MIN_DELTA_CAPITAL_FLOOR', () => {
+  it('documents both binding floor prongs as exact decimal strings', () => {
+    expect(MIN_DELTA_CAPITAL_FLOOR).toEqual({
+      absoluteUsd: '1000',
+      withDecisionExpectedCapitalRatio: '0.01',
+    });
+  });
+});

--- a/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
+++ b/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
@@ -233,6 +233,25 @@ describe('MarginalReserveMoicResultV1Schema', () => {
       ).success
     ).toBe(true);
   });
+
+  it('enforces the 100x indicative threshold in both directions', () => {
+    expect(
+      MarginalReserveMoicResultV1Schema.safeParse(
+        makeResult({ status: 'actionable', marginalMoic: '101.000000' })
+      ).success
+    ).toBe(false);
+    expect(
+      MarginalReserveMoicResultV1Schema.safeParse(
+        makeResult({
+          status: 'indicative',
+          marginalMoic: '100.000000',
+          warnings: [
+            { code: 'IMPLAUSIBLE_MAGNITUDE', message: 'Marginal MOIC exceeds 100x' },
+          ],
+        })
+      ).success
+    ).toBe(false);
+  });
 });
 
 describe('MIN_DELTA_CAPITAL_FLOOR', () => {

--- a/tests/unit/engines/marginal-reserve-moic.test.ts
+++ b/tests/unit/engines/marginal-reserve-moic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ZodError } from 'zod';
+import Decimal from '@shared/lib/decimal-config';
 import { calculateMarginalReserveMoic } from '@shared/core/moic/MarginalReserveMoic';
 import type { MarginalReserveMoicInputV1 } from '@shared/contracts/marginal-reserve-moic-v1.contract';
 
@@ -261,12 +262,12 @@ describe('calculateMarginalReserveMoic', () => {
 
     const result = calculateMarginalReserveMoic(input);
     const capitalSum = result.stageContributions.reduce(
-      (sum, stage) => sum + Number(stage.deltaExpectedCapital),
-      0
+      (sum, stage) => sum.plus(stage.deltaExpectedCapital),
+      new Decimal(0)
     );
     const proceedsSum = result.stageContributions.reduce(
-      (sum, stage) => sum + Number(stage.deltaExpectedProceeds),
-      0
+      (sum, stage) => sum.plus(stage.deltaExpectedProceeds),
+      new Decimal(0)
     );
 
     expect(capitalSum.toFixed(6)).toBe(result.deltaExpectedCapital);

--- a/tests/unit/engines/marginal-reserve-moic.test.ts
+++ b/tests/unit/engines/marginal-reserve-moic.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import { ZodError } from 'zod';
+import { calculateMarginalReserveMoic } from '@shared/core/moic/MarginalReserveMoic';
+import type { MarginalReserveMoicInputV1 } from '@shared/contracts/marginal-reserve-moic-v1.contract';
+
+const FACTS_HASH = 'a'.repeat(64);
+const ASSUMPTIONS_HASH = 'b'.repeat(64);
+
+function baseInput(): MarginalReserveMoicInputV1 {
+  return {
+    contractVersion: 'marginal-reserve-moic-input-v1',
+    fundId: 1,
+    companyId: 2,
+    baseCurrency: 'USD',
+    asOfDate: '2026-07-12',
+    currentOwnership: '0',
+    stages: [
+      {
+        stage: 'seed',
+        preMoneyValuation: '8000000',
+        roundSize: '2000000',
+        monthsFromPriorStage: 0,
+        graduationProbability: '0',
+        exitProbability: '1',
+        exitValuation: '50000000',
+        withDecision: { participate: true, checkAmount: '1000000' },
+        withoutDecision: { participate: false, checkAmount: '0' },
+      },
+    ],
+    factsInputHash: FACTS_HASH,
+    assumptionsHash: ASSUMPTIONS_HASH,
+    engineVersion: 'marginal-reserve-moic-v1',
+  };
+}
+
+describe('calculateMarginalReserveMoic', () => {
+  it('calculates a certain exit with no later dilution', () => {
+    const result = calculateMarginalReserveMoic(baseInput());
+
+    expect(result.status).toBe('actionable');
+    expect(result.deltaExpectedProceeds).toBe('5000000.000000');
+    expect(result.deltaExpectedCapital).toBe('1000000.000000');
+    expect(result.marginalMoic).toBe('5.000000');
+    expect(result.marginalIrr).toBeNull();
+    expect(result.withDecision.expectedOwnershipAtExit).toBe('0.100000');
+    expect(result.warnings.map((warning) => warning.code)).toEqual(['IRR_UNAVAILABLE']);
+  });
+
+  it('weights proceeds by a 50% conditional exit probability', () => {
+    const input = baseInput();
+    input.stages[0]!.exitProbability = '0.5';
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.deltaExpectedProceeds).toBe('2500000.000000');
+    expect(result.deltaExpectedCapital).toBe('1000000.000000');
+    expect(result.marginalMoic).toBe('2.500000');
+    expect(result.stageContributions[0]?.unconditionalExitProbability).toBe('0.500000');
+  });
+
+  it('dilutes both paths at a later non-participated round', () => {
+    const input = baseInput();
+    input.stages[0]!.exitProbability = '0';
+    input.stages[0]!.graduationProbability = '1';
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '8000000',
+      roundSize: '2000000',
+      monthsFromPriorStage: 12,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '50000000',
+      withDecision: { participate: false, checkAmount: '0' },
+      withoutDecision: { participate: false, checkAmount: '0' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.stageContributions[1]?.withDecision.ownershipAfterRound).toBe('0.080000');
+    expect(result.deltaExpectedProceeds).toBe('4000000.000000');
+    expect(result.marginalMoic).toBe('4.000000');
+    expect(result.marginalIrr).toBe('3.000000');
+  });
+
+  it('models future pro-rata participation independently in the with-decision path', () => {
+    const input = baseInput();
+    input.stages[0]!.exitProbability = '0';
+    input.stages[0]!.graduationProbability = '1';
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '8000000',
+      roundSize: '2000000',
+      monthsFromPriorStage: 12,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '50000000',
+      withDecision: { participate: true, checkAmount: '200000' },
+      withoutDecision: { participate: false, checkAmount: '0' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.stageContributions[1]?.withDecision.ownershipAfterRound).toBe('0.100000');
+    expect(result.deltaExpectedCapital).toBe('1200000.000000');
+    expect(result.deltaExpectedProceeds).toBe('5000000.000000');
+    expect(result.marginalMoic).toBe('4.166667');
+  });
+
+  it('includes all probability-weighted future check differences in capital', () => {
+    const input = baseInput();
+    input.stages[0]!.exitProbability = '0';
+    input.stages[0]!.graduationProbability = '0.5';
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '10000000',
+      roundSize: '2000000',
+      monthsFromPriorStage: 12,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '60000000',
+      withDecision: { participate: true, checkAmount: '1000000' },
+      withoutDecision: { participate: true, checkAmount: '500000' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.stageContributions[1]?.reachProbability).toBe('0.500000');
+    expect(result.stageContributions[1]?.deltaExpectedCapital).toBe('250000.000000');
+    expect(result.deltaExpectedCapital).toBe('1250000.000000');
+  });
+
+  it('incurs the reached-stage check when the company fails at that stage', () => {
+    const input = baseInput();
+    input.stages[0]!.exitProbability = '0';
+    input.stages[0]!.graduationProbability = '0';
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.stageContributions[0]?.conditionalFailureProbability).toBe('1.000000');
+    expect(result.deltaExpectedCapital).toBe('1000000.000000');
+    expect(result.deltaExpectedProceeds).toBe('0.000000');
+    expect(result.marginalMoic).toBe('0.000000');
+  });
+
+  it('returns unavailable when the only nominal capital difference is unreachable', () => {
+    const input = baseInput();
+    input.stages[0]!.withDecision = { participate: false, checkAmount: '0' };
+    input.stages[0]!.withoutDecision = { participate: false, checkAmount: '0' };
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '10000000',
+      roundSize: '1000000',
+      monthsFromPriorStage: 12,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '50000000',
+      withDecision: { participate: true, checkAmount: '1000000' },
+      withoutDecision: { participate: false, checkAmount: '0' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.status).toBe('unavailable');
+    expect(result.marginalMoic).toBeNull();
+    expect(result.marginalIrr).toBeNull();
+    expect(result.deltaExpectedCapital).toBe('0.000000');
+    expect(result.warnings.map((warning) => warning.code)).toEqual(['NON_POSITIVE_DELTA_CAPITAL']);
+  });
+
+  it('applies the absolute denominator floor to a small positive delta', () => {
+    const input = baseInput();
+    input.stages[0]!.withDecision.checkAmount = '500';
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.deltaExpectedCapital).toBe('500.000000');
+    expect(result.status).toBe('unavailable');
+    expect(result.marginalMoic).toBeNull();
+    expect(result.marginalIrr).toBeNull();
+    expect(result.warnings.map((warning) => warning.code)).toEqual(['MIN_DENOMINATOR_FLOOR']);
+  });
+
+  it('applies the one-percent with-decision-capital floor prong', () => {
+    const input = baseInput();
+    input.stages[0]!.withDecision.checkAmount = '1000000';
+    input.stages[0]!.withoutDecision = { participate: true, checkAmount: '995000' };
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.deltaExpectedCapital).toBe('5000.000000');
+    expect(result.status).toBe('unavailable');
+    expect(result.warnings[0]?.message).toContain('10000.000000 floor');
+  });
+
+  it('downgrades a computed result above 100x to indicative', () => {
+    const input = baseInput();
+    input.stages[0] = {
+      ...input.stages[0]!,
+      preMoneyValuation: '0',
+      roundSize: '1000',
+      exitValuation: '200000',
+      withDecision: { participate: true, checkAmount: '1000' },
+    };
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.status).toBe('indicative');
+    expect(result.marginalMoic).toBe('200.000000');
+    expect(result.warnings.map((warning) => warning.code)).toContain('IMPLAUSIBLE_MAGNITUDE');
+  });
+
+  it('rejects an invalid probability sum before projection', () => {
+    const input = baseInput();
+    input.stages[0]!.exitProbability = '0.6';
+    input.stages[0]!.graduationProbability = '0.5';
+
+    expect(() => calculateMarginalReserveMoic(input)).toThrow(ZodError);
+  });
+
+  it('rejects non-USD input rather than inventing FX conversion', () => {
+    const input = baseInput();
+    Object.assign(input, { baseCurrency: 'EUR' });
+
+    expect(() => calculateMarginalReserveMoic(input)).toThrow(ZodError);
+  });
+
+  it('produces a deterministic hash from normalized input and output', () => {
+    const compact = baseInput();
+    const fixed = baseInput();
+    fixed.currentOwnership = '0.000000';
+    fixed.stages[0]!.preMoneyValuation = '8000000.000000';
+    fixed.stages[0]!.roundSize = '2000000.000000';
+    fixed.stages[0]!.graduationProbability = '0.000000';
+    fixed.stages[0]!.exitProbability = '1.000000';
+    fixed.stages[0]!.exitValuation = '50000000.000000';
+    fixed.stages[0]!.withDecision.checkAmount = '1000000.000000';
+    fixed.stages[0]!.withoutDecision.checkAmount = '0.000000';
+
+    const compactResult = calculateMarginalReserveMoic(compact);
+    const fixedResult = calculateMarginalReserveMoic(fixed);
+
+    expect(compactResult.resultHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(fixedResult.resultHash).toBe(compactResult.resultHash);
+  });
+
+  it('makes stage deltas sum exactly to top-level deltas', () => {
+    const input = baseInput();
+    input.stages[0]!.exitProbability = '0';
+    input.stages[0]!.graduationProbability = '0.5';
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '10000000',
+      roundSize: '2000000',
+      monthsFromPriorStage: 18,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '60000000',
+      withDecision: { participate: true, checkAmount: '1000000' },
+      withoutDecision: { participate: true, checkAmount: '500000' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+    const capitalSum = result.stageContributions.reduce(
+      (sum, stage) => sum + Number(stage.deltaExpectedCapital),
+      0
+    );
+    const proceedsSum = result.stageContributions.reduce(
+      (sum, stage) => sum + Number(stage.deltaExpectedProceeds),
+      0
+    );
+
+    expect(capitalSum.toFixed(6)).toBe(result.deltaExpectedCapital);
+    expect(proceedsSum.toFixed(6)).toBe(result.deltaExpectedProceeds);
+  });
+});

--- a/tests/unit/truth-cases/marginal-reserve-moic-truth-cases.test.ts
+++ b/tests/unit/truth-cases/marginal-reserve-moic-truth-cases.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import fc from 'fast-check';
+import Decimal from '@shared/lib/decimal-config';
 import { calculateMarginalReserveMoic } from '@shared/core/moic/MarginalReserveMoic';
 import type { MarginalReserveMoicInputV1 } from '@shared/contracts/marginal-reserve-moic-v1.contract';
 
 const FACTS_HASH = '1'.repeat(64);
 const ASSUMPTIONS_HASH = '2'.repeat(64);
+
+function requireMarginalMoic(
+  result: ReturnType<typeof calculateMarginalReserveMoic>
+): Decimal {
+  if (result.marginalMoic === null) {
+    throw new Error('Expected a numeric marginal MOIC');
+  }
+  return new Decimal(result.marginalMoic);
+}
 
 function anchorInput(): MarginalReserveMoicInputV1 {
   return {
@@ -134,6 +144,41 @@ describe('marginal reserve MOIC truth cases', () => {
     expect(result.marginalIrr).toBeNull();
     expect(result.warnings.map((warning) => warning.code)).toContain('MIN_DENOMINATOR_FLOOR');
   });
+
+  it('uses unrounded expected capital when enforcing the denominator floor', () => {
+    // Stage-two reach = 0.999999 and check = 1,000.001, so the exact expected
+    // delta capital is 999.999999999. It serializes to 1,000.000000 at six
+    // places but remains below the exact USD 1,000 policy floor.
+    const input = anchorInput();
+    input.stages[0] = {
+      ...input.stages[0]!,
+      exitProbability: '0.000001',
+      graduationProbability: '0.999999',
+      exitValuation: '0',
+      withDecision: { participate: false, checkAmount: '0' },
+    };
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '1000000',
+      roundSize: '2000',
+      monthsFromPriorStage: 12,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '25000000',
+      withDecision: { participate: true, checkAmount: '1000.001' },
+      withoutDecision: { participate: false, checkAmount: '0' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.deltaExpectedCapital).toBe('1000.000000');
+    expect(result.status).toBe('unavailable');
+    expect(result.marginalMoic).toBeNull();
+    expect(result.marginalIrr).toBeNull();
+    expect(result.warnings.map((warning) => warning.code)).toEqual([
+      'MIN_DENOMINATOR_FLOOR',
+    ]);
+  });
 });
 
 describe('marginal reserve MOIC properties', () => {
@@ -151,7 +196,7 @@ describe('marginal reserve MOIC properties', () => {
           const lower = calculateMarginalReserveMoic(lowerInput);
           const higher = calculateMarginalReserveMoic(higherInput);
 
-          expect(Number(higher.marginalMoic)).toBeGreaterThanOrEqual(Number(lower.marginalMoic));
+          expect(requireMarginalMoic(higher).gte(requireMarginalMoic(lower))).toBe(true);
         }
       ),
       { numRuns: 50 }
@@ -200,9 +245,9 @@ describe('marginal reserve MOIC properties', () => {
           const lessDilution = calculateWithLaterRound(firstRoundSize);
           const moreDilution = calculateWithLaterRound(firstRoundSize + extraDilution);
 
-          expect(Number(moreDilution.marginalMoic)).toBeLessThanOrEqual(
-            Number(lessDilution.marginalMoic)
-          );
+          expect(
+            requireMarginalMoic(moreDilution).lte(requireMarginalMoic(lessDilution))
+          ).toBe(true);
         }
       ),
       { numRuns: 50 }

--- a/tests/unit/truth-cases/marginal-reserve-moic-truth-cases.test.ts
+++ b/tests/unit/truth-cases/marginal-reserve-moic-truth-cases.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import { calculateMarginalReserveMoic } from '@shared/core/moic/MarginalReserveMoic';
+import type { MarginalReserveMoicInputV1 } from '@shared/contracts/marginal-reserve-moic-v1.contract';
+
+const FACTS_HASH = '1'.repeat(64);
+const ASSUMPTIONS_HASH = '2'.repeat(64);
+
+function anchorInput(): MarginalReserveMoicInputV1 {
+  return {
+    contractVersion: 'marginal-reserve-moic-input-v1',
+    fundId: 7,
+    companyId: 11,
+    baseCurrency: 'USD',
+    asOfDate: '2026-07-12',
+    currentOwnership: '0',
+    stages: [
+      {
+        stage: 'seed',
+        preMoneyValuation: '8000000',
+        roundSize: '2000000',
+        monthsFromPriorStage: 0,
+        graduationProbability: '0',
+        exitProbability: '1',
+        exitValuation: '50000000',
+        withDecision: { participate: true, checkAmount: '1000000' },
+        withoutDecision: { participate: false, checkAmount: '0' },
+      },
+    ],
+    factsInputHash: FACTS_HASH,
+    assumptionsHash: ASSUMPTIONS_HASH,
+    engineVersion: 'marginal-reserve-moic-v1',
+  };
+}
+
+describe('marginal reserve MOIC truth cases', () => {
+  it('anchor: a USD 1m check at USD 10m post-money returns exactly 5.0x', () => {
+    // Post-money = 8m + 2m = 10m.
+    // Incremental ownership = 1m / 10m = 10%.
+    // Certain proceeds = 10% * 50m = 5m.
+    // Marginal MOIC = 5m / 1m = 5.000000.
+    const result = calculateMarginalReserveMoic(anchorInput());
+
+    expect(result.status).toBe('actionable');
+    expect(result.deltaExpectedProceeds).toBe('5000000.000000');
+    expect(result.deltaExpectedCapital).toBe('1000000.000000');
+    expect(result.marginalMoic).toBe('5.000000');
+  });
+
+  it('weights the anchor at a 25% exit probability to exactly 1.25x', () => {
+    // Expected proceeds = 25% * 10% ownership * 50m = 1.25m.
+    // Expected capital is still the reached-stage 1m check.
+    // Marginal MOIC = 1.25m / 1m = 1.250000.
+    const input = anchorInput();
+    input.stages[0]!.exitProbability = '0.25';
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.deltaExpectedProceeds).toBe('1250000.000000');
+    expect(result.deltaExpectedCapital).toBe('1000000.000000');
+    expect(result.marginalMoic).toBe('1.250000');
+  });
+
+  it('applies a later 20% dilution to reduce the certain-exit anchor to 4.0x', () => {
+    // Seed check buys 10%. A later 8m pre / 2m round with no participation
+    // retains 8m / 10m = 80%, so ownership becomes 8%.
+    // Certain proceeds = 8% * 50m = 4m; capital remains 1m; MOIC = 4.0x.
+    const input = anchorInput();
+    input.stages[0]!.exitProbability = '0';
+    input.stages[0]!.graduationProbability = '1';
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '8000000',
+      roundSize: '2000000',
+      monthsFromPriorStage: 12,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '50000000',
+      withDecision: { participate: false, checkAmount: '0' },
+      withoutDecision: { participate: false, checkAmount: '0' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.stageContributions[1]?.withDecision.ownershipAfterRound).toBe('0.080000');
+    expect(result.deltaExpectedProceeds).toBe('4000000.000000');
+    expect(result.deltaExpectedCapital).toBe('1000000.000000');
+    expect(result.marginalMoic).toBe('4.000000');
+  });
+
+  it('moves both numerator and denominator for a probability-weighted future pro-rata check', () => {
+    // Seed: 1m buys 10%; 50% exits at 20m, contributing 1.0m proceeds.
+    // The other 50% reaches Series A. A 200k pro-rata check preserves 10%:
+    //   future expected capital = 50% * 200k = 100k
+    //   future expected proceeds = 50% * 10% * 50m = 2.5m
+    // Totals: delta proceeds = 3.5m; delta capital = 1.1m;
+    // marginal MOIC = 3.5m / 1.1m = 3.181818.
+    const input = anchorInput();
+    input.stages[0]!.exitProbability = '0.5';
+    input.stages[0]!.graduationProbability = '0.5';
+    input.stages[0]!.exitValuation = '20000000';
+    input.stages.push({
+      stage: 'series_a',
+      preMoneyValuation: '8000000',
+      roundSize: '2000000',
+      monthsFromPriorStage: 12,
+      graduationProbability: '0',
+      exitProbability: '1',
+      exitValuation: '50000000',
+      withDecision: { participate: true, checkAmount: '200000' },
+      withoutDecision: { participate: false, checkAmount: '0' },
+    });
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.stageContributions[1]?.withDecision.expectedCapital).toBe('100000.000000');
+    expect(result.stageContributions[1]?.withDecision.expectedProceeds).toBe('2500000.000000');
+    expect(result.deltaExpectedProceeds).toBe('3500000.000000');
+    expect(result.deltaExpectedCapital).toBe('1100000.000000');
+    expect(result.marginalMoic).toBe('3.181818');
+  });
+
+  it('never emits a numeric MOIC for a USD 500 denominator', () => {
+    // Delta capital = 500, below max(USD 1,000, 1% * 500) = USD 1,000.
+    // The mathematical ratio is deliberately suppressed as unavailable.
+    const input = anchorInput();
+    input.stages[0]!.withDecision.checkAmount = '500';
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.deltaExpectedCapital).toBe('500.000000');
+    expect(result.status).toBe('unavailable');
+    expect(result.marginalMoic).toBeNull();
+    expect(result.marginalIrr).toBeNull();
+    expect(result.warnings.map((warning) => warning.code)).toContain('MIN_DENOMINATOR_FLOOR');
+  });
+});
+
+describe('marginal reserve MOIC properties', () => {
+  it('higher exit value cannot lower marginal MOIC in a linear one-round case', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1_000_000, max: 100_000_000 }),
+        fc.integer({ min: 1, max: 100_000_000 }),
+        (lowerExitValue, increase) => {
+          const lowerInput = anchorInput();
+          lowerInput.stages[0]!.exitValuation = lowerExitValue.toString();
+          const higherInput = anchorInput();
+          higherInput.stages[0]!.exitValuation = (lowerExitValue + increase).toString();
+
+          const lower = calculateMarginalReserveMoic(lowerInput);
+          const higher = calculateMarginalReserveMoic(higherInput);
+
+          expect(Number(higher.marginalMoic)).toBeGreaterThanOrEqual(Number(lower.marginalMoic));
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  it('higher check at the same price preserves per-dollar MOIC in a linear no-cap case', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1_000, max: 2_000_000 }), (checkAmount) => {
+        const input = anchorInput();
+        input.stages[0]!.withDecision.checkAmount = checkAmount.toString();
+
+        const result = calculateMarginalReserveMoic(input);
+
+        expect(result.status).toBe('actionable');
+        expect(result.marginalMoic).toBe('5.000000');
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('more dilution cannot increase marginal MOIC without other changes', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 4_000_000 }),
+        fc.integer({ min: 1, max: 4_000_000 }),
+        (firstRoundSize, extraDilution) => {
+          const calculateWithLaterRound = (roundSize: number) => {
+            const input = anchorInput();
+            input.stages[0]!.exitProbability = '0';
+            input.stages[0]!.graduationProbability = '1';
+            input.stages.push({
+              stage: 'series_a',
+              preMoneyValuation: '8000000',
+              roundSize: roundSize.toString(),
+              monthsFromPriorStage: 12,
+              graduationProbability: '0',
+              exitProbability: '1',
+              exitValuation: '50000000',
+              withDecision: { participate: false, checkAmount: '0' },
+              withoutDecision: { participate: false, checkAmount: '0' },
+            });
+            return calculateMarginalReserveMoic(input);
+          };
+
+          const lessDilution = calculateWithLaterRound(firstRoundSize);
+          const moreDilution = calculateWithLaterRound(firstRoundSize + extraDilution);
+
+          expect(Number(moreDilution.marginalMoic)).toBeLessThanOrEqual(
+            Number(lessDilution.marginalMoic)
+          );
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Plan 7 wave 1 (Tasks 7.1-7.4, CEO-reviewed 2026-07-11 with amendments applied). Executed via a Hermes/Codex lane; reviewed, verified, and the final invariant-tightening pass committed by Claude.

- **ADR-033 ratified** (Proposed -> Accepted): paired-counterfactual basis, expected-capital denominator, priced-round ownership, probability tree, SAFE/terminal/currency/IRR policies, actionability rules, hand-worked example, rejected alternatives. `DECISIONS.md` entry added.
- **Contract** `shared/contracts/marginal-reserve-moic-v1.contract.ts`: strict Zod schemas (decimal strings only), enumerated warning codes, bidirectional invariants (moic > 100 <=> indicative + IMPLAUSIBLE_MAGNITUDE).
- **Engine** `shared/core/moic/MarginalReserveMoic.ts`: pure Decimal paired-counterfactual projection, canonical input/result hashing, deterministic six-place serialization.
- **Amendment (CRITICAL GAP) baked in**: `MIN_DELTA_CAPITAL_FLOOR = max($1,000, 1% of E[capital_W])` — `deltaExpectedCapital` in `(0, floor)` returns `unavailable` + `MIN_DENOMINATOR_FLOOR`, never a numeric MOIC; magnitude > 100x downgrades to `indicative` + `IMPLAUSIBLE_MAGNITUDE`.
- **Truth cases** in the `phoenix:truth` glob with hand-worked fixtures (5.0x anchor, 1.25x weighted, 4.0x dilution, pro-rata both-sides case, floor case) plus fast-check monotonicity properties.

Server route/shadow service (7.5-7.7) and UI (7.8) are deliberately wave 2 — no route, flag, or client changes here.

## Verification (run in the lane worktree)

- `npm run check` — 0 new TypeScript errors
- New suites: 37/37 (contract 264 lines, engine 276, truth 256)
- `npm run phoenix:truth` — 282/282 (+9 new cases)
- `npm run calc-gate` — fully green (194 + 20 orphans)

## Merge sequencing

Do not merge until release run 29217597973 completes (expected_sha pinning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h