### PR TITLE
feat(moic): marginal reserve MOIC shadow — inputs, route, rankings comparison (Plan 7 wave 2)

### DIFF
--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -502,6 +502,20 @@ flags:
     expiresAt: null
     aliases: ['ENABLE_PORTFOLIO_INTELLIGENCE']
 
+  enable_marginal_reserve_moic:
+    default: false
+    description: 'Gates shadow-only marginal reserve MOIC rankings for internal comparison'
+    owner: 'analytics'
+    risk: high
+    exposeToClient: false
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: null
+    aliases: ['ENABLE_MARGINAL_RESERVE_MOIC']
+
   enable_faults:
     default: false
     description: 'Enable fault injection for testing'

--- a/server/config/features.ts
+++ b/server/config/features.ts
@@ -17,6 +17,8 @@ export const FEATURES = {
   statGating: flag(process.env['ENABLE_STAT_GATING'], false),
   // Canonical declaration: flags/registry.yaml; intentionally enforced by this env var, not client flags.
   portfolioIntelligence: flag(process.env['ENABLE_PORTFOLIO_INTELLIGENCE'], false),
+  // Server-only shadow route; production remains fail-closed unless explicitly enabled.
+  marginalReserveMoic: flag(process.env['ENABLE_MARGINAL_RESERVE_MOIC'], false),
 };
 
 export type FeatureBag = typeof FEATURES;

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -28,7 +28,9 @@ type RoutePolicyDecision = Pick<
 >;
 
 type PortfolioIntelligenceRouteDecisionMap = {
-  [Route in PortfolioIntelligenceClassificationEntry as `${Route['method']} ${Route['path']}`]: RoutePolicyDecision;
+  [
+    Route in PortfolioIntelligenceClassificationEntry as `${Route['method']} ${Route['path']}`
+  ]: RoutePolicyDecision;
 };
 
 type PortfolioIntelligenceRouteKey = keyof PortfolioIntelligenceRouteDecisionMap & string;
@@ -705,6 +707,27 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     performanceBudgetMs: null,
     notes:
       'H9 source-fingerprint actionability is enforced in the route before candidate MOIC rankings can be served.',
+  },
+  {
+    id: 'api:get:/api/funds/:fundId/moic/marginal-rankings',
+    method: 'GET',
+    path: '/api/funds/:fundId/moic/marginal-rankings',
+    lifecycle: 'durable_crud',
+    governanceRef: '/fund-model-results/:fundId/moic-analysis',
+    surface: 'marginal-reserve-moic-shadow-api',
+    owner: 'analytics',
+    telemetryKey: 'api.route.api.funds.fundId.moic.marginal.rankings',
+    financialSurface: 'moic_reserves',
+    apiAuthBoundary: 'require_auth_and_fund_access',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'shadow_review_required',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+    staleBlocksExport: true,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+    notes:
+      'Server-only flag gates this non-persistent shadow ranking surface; investment-team review remains required.',
   },
   {
     id: 'api:get:/api/portfolio-overview',

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -45,7 +45,7 @@ import { FEATURES } from '../config/features.js';
 import { calculateMarginalReserveMoic } from '../../shared/core/moic/MarginalReserveMoic.js';
 import {
   MarginalReserveRankingsResponseV1Schema,
-  type MarginalReserveMoicResultV1,
+  type MarginalReserveRankingItemV1,
 } from '../../shared/contracts/marginal-reserve-moic-v1.contract.js';
 import { buildMarginalReserveMoicInputs } from '../services/moic/marginal-reserve-moic-input-service.js';
 
@@ -73,22 +73,22 @@ const MarginalRankingsQuerySchema = z
   })
   .strict();
 
-const MARGINAL_STATUS_ORDER: Readonly<Record<MarginalReserveMoicResultV1['status'], number>> = {
+const MARGINAL_STATUS_ORDER: Readonly<Record<MarginalReserveRankingItemV1['status'], number>> = {
   actionable: 0,
   indicative: 1,
   unavailable: 2,
 };
 
 function sortMarginalRankings(
-  rankings: MarginalReserveMoicResultV1[]
-): MarginalReserveMoicResultV1[] {
+  rankings: MarginalReserveRankingItemV1[]
+): MarginalReserveRankingItemV1[] {
   return [...rankings].sort((left, right) => {
     const statusOrder = MARGINAL_STATUS_ORDER[left.status] - MARGINAL_STATUS_ORDER[right.status];
     if (statusOrder !== 0) return statusOrder;
-    if (left.marginalMoic === null && right.marginalMoic !== null) return 1;
-    if (left.marginalMoic !== null && right.marginalMoic === null) return -1;
-    if (left.marginalMoic !== null && right.marginalMoic !== null) {
-      const moicOrder = new Decimal(right.marginalMoic).comparedTo(left.marginalMoic);
+    if (left.result.marginalMoic === null && right.result.marginalMoic !== null) return 1;
+    if (left.result.marginalMoic !== null && right.result.marginalMoic === null) return -1;
+    if (left.result.marginalMoic !== null && right.result.marginalMoic !== null) {
+      const moicOrder = new Decimal(right.result.marginalMoic).comparedTo(left.result.marginalMoic);
       if (moicOrder !== 0) return moicOrder;
     }
     return left.companyId - right.companyId;
@@ -167,10 +167,26 @@ router.get(
       fundId,
       asOfDate: parsedQuery.data.asOfDate,
     });
-    const rankings = sortMarginalRankings(inputs.ready.map(calculateMarginalReserveMoic));
+    const rankings = sortMarginalRankings(
+      inputs.ready.map((input) => {
+        const result = calculateMarginalReserveMoic(input);
+        const inputReadiness = input.readiness ?? { status: 'actionable' as const, reasons: [] };
+        return {
+          companyId: input.companyId,
+          status:
+            result.status === 'actionable' && inputReadiness.status === 'indicative'
+              ? 'indicative'
+              : result.status,
+          inputReadiness,
+          result,
+        };
+      })
+    );
     return res.json(
       MarginalReserveRankingsResponseV1Schema.parse({
         contractVersion: 'marginal-reserve-rankings-v1',
+        mode: 'shadow',
+        actionability: 'non_actionable_shadow',
         fundId,
         asOfDate: parsedQuery.data.asOfDate,
         factsInputHash: inputs.factsInputHash,

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
+import Decimal from '../../shared/lib/decimal-config.js';
 import { requireAuth, requireFundAccess, requireRole } from '../lib/auth/jwt.js';
 import {
   FundMoicRankingsResponseV2Schema,
@@ -16,9 +17,7 @@ import {
   getFundMoicRankingSources,
   summarizeMoicActualsProvenance,
 } from '../services/fund-moic-ranking-service.js';
-import {
-  buildFundCompanyActualsFacts,
-} from '../services/fund-actuals/fund-company-actuals-facts-service.js';
+import { buildFundCompanyActualsFacts } from '../services/fund-actuals/fund-company-actuals-facts-service.js';
 import {
   getLatestCompletedMoicReconciliation,
   MoicReconciliationConflictError,
@@ -42,6 +41,13 @@ import {
 } from '../services/fund-calculation-mode-service.js';
 import { invalidateH9Artifacts } from '../services/h9-artifact-invalidation-service';
 import { buildRoundsToModelEvidence } from '../services/rounds-to-model-evidence-service.js';
+import { FEATURES } from '../config/features.js';
+import { calculateMarginalReserveMoic } from '../../shared/core/moic/MarginalReserveMoic.js';
+import {
+  MarginalReserveRankingsResponseV1Schema,
+  type MarginalReserveMoicResultV1,
+} from '../../shared/contracts/marginal-reserve-moic-v1.contract.js';
+import { buildMarginalReserveMoicInputs } from '../services/moic/marginal-reserve-moic-input-service.js';
 
 const router = Router();
 
@@ -61,6 +67,33 @@ const ModeUpdateBodySchema = z
     acceptedReconciliationRunId: z.number().int().positive().nullable().optional(),
   })
   .strict();
+const MarginalRankingsQuerySchema = z
+  .object({
+    asOfDate: z.string().date(),
+  })
+  .strict();
+
+const MARGINAL_STATUS_ORDER: Readonly<Record<MarginalReserveMoicResultV1['status'], number>> = {
+  actionable: 0,
+  indicative: 1,
+  unavailable: 2,
+};
+
+function sortMarginalRankings(
+  rankings: MarginalReserveMoicResultV1[]
+): MarginalReserveMoicResultV1[] {
+  return [...rankings].sort((left, right) => {
+    const statusOrder = MARGINAL_STATUS_ORDER[left.status] - MARGINAL_STATUS_ORDER[right.status];
+    if (statusOrder !== 0) return statusOrder;
+    if (left.marginalMoic === null && right.marginalMoic !== null) return 1;
+    if (left.marginalMoic !== null && right.marginalMoic === null) return -1;
+    if (left.marginalMoic !== null && right.marginalMoic !== null) {
+      const moicOrder = new Decimal(right.marginalMoic).comparedTo(left.marginalMoic);
+      if (moicOrder !== 0) return moicOrder;
+    }
+    return left.companyId - right.companyId;
+  });
+}
 
 function routeHandler(
   handler: (req: Request, res: Response, next: NextFunction) => Promise<unknown>
@@ -109,6 +142,47 @@ function roundEvidenceSummary(coverage: {
     warningCodes: Object.keys(coverage.warningsByCode).sort(),
   };
 }
+
+router.get(
+  '/funds/:fundId/moic/marginal-rankings',
+  requireAuth(),
+  requireFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = parseFundId(req, res);
+    if (fundId === null) return;
+
+    if (!FEATURES.marginalReserveMoic) {
+      return res.status(404).json({ error: 'not_found' });
+    }
+
+    const parsedQuery = MarginalRankingsQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      return res.status(400).json({
+        error: 'invalid_as_of_date',
+        message: 'asOfDate must be provided as YYYY-MM-DD',
+      });
+    }
+
+    const inputs = await buildMarginalReserveMoicInputs({
+      fundId,
+      asOfDate: parsedQuery.data.asOfDate,
+    });
+    const rankings = sortMarginalRankings(inputs.ready.map(calculateMarginalReserveMoic));
+    return res.json(
+      MarginalReserveRankingsResponseV1Schema.parse({
+        contractVersion: 'marginal-reserve-rankings-v1',
+        fundId,
+        asOfDate: parsedQuery.data.asOfDate,
+        factsInputHash: inputs.factsInputHash,
+        assumptionsHash: inputs.assumptionsHash,
+        rankings,
+        unavailable: [...inputs.unavailable].sort(
+          (left, right) => left.companyId - right.companyId
+        ),
+      })
+    );
+  })
+);
 
 router.get(
   '/funds/:fundId/moic/rankings',

--- a/server/services/moic/marginal-reserve-moic-input-service.ts
+++ b/server/services/moic/marginal-reserve-moic-input-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from '../../db';
@@ -20,6 +20,7 @@ import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
 import Decimal from '../../../shared/lib/decimal-config';
 import { CANONICAL_STAGES, type CanonicalStage } from '../../../shared/schemas/stage';
 import { fundConfigs, funds, portfolioCompanies } from '../../../shared/schema';
+import { allocationScenarioIcDecisions } from '../../../shared/schema/allocation-scenarios';
 
 export const MARGINAL_RESERVE_ASSUMPTION_STALE_AFTER_DAYS = 120;
 
@@ -37,6 +38,17 @@ export interface MarginalReserveCompanySource {
   sector: string;
   currentOwnership: string | number | null;
   plannedReservesCents: number | bigint | null;
+  allocationVersion: number;
+}
+
+export interface MarginalReserveApprovedAllocationSource {
+  companyId: number;
+  decisionType: string;
+  decisionStatus: string;
+  finalPlannedReservesCents: number | bigint | null;
+  liveAllocationVersion: number | null;
+  decidedAt: Date | null;
+  updatedAt: Date;
 }
 
 export interface MarginalReservePublishedAssumptions {
@@ -47,9 +59,11 @@ export interface MarginalReservePublishedAssumptions {
 }
 
 export interface MarginalReserveInputSources {
+  sourceSnapshotDate: string;
   baseCurrency: string;
   facts: FundCompanyActualsFactsResponse;
   companies: readonly MarginalReserveCompanySource[];
+  approvedAllocations: readonly MarginalReserveApprovedAllocationSource[];
   publishedAssumptions: MarginalReservePublishedAssumptions | null;
 }
 
@@ -71,6 +85,7 @@ const STAGE_ALIASES: Readonly<Record<string, CanonicalStage>> = {
   growth: 'growth',
   latestage: 'late_stage',
 };
+const USD_PER_MILLION = new Decimal(1_000_000);
 
 function normalizedKey(value: string): string {
   return value
@@ -93,8 +108,8 @@ function currentOwnershipString(value: string | number | null): string | null {
   if (value === null || value === '') return null;
   try {
     const ownership = new Decimal(value);
-    if (!ownership.isFinite() || ownership.lt(0) || ownership.gt(100)) return null;
-    return (ownership.gt(1) ? ownership.div(100) : ownership).toString();
+    if (!ownership.isFinite() || ownership.lt(0) || ownership.gt(1)) return null;
+    return ownership.toString();
   } catch {
     return null;
   }
@@ -105,6 +120,10 @@ function assumptionIsStale(publishedAt: Date | null, asOfDate: string): boolean 
   const asOf = new Date(`${asOfDate}T00:00:00.000Z`).getTime();
   const ageDays = (asOf - publishedAt.getTime()) / 86_400_000;
   return ageDays > MARGINAL_RESERVE_ASSUMPTION_STALE_AFTER_DAYS;
+}
+
+function assumptionIsEffective(publishedAt: Date | null, asOfDate: string): boolean {
+  return publishedAt !== null && publishedAt.toISOString().slice(0, 10) <= asOfDate;
 }
 
 function profileForCompany(config: FundDraftWriteV1, sector: string) {
@@ -137,16 +156,14 @@ function followOnPolicyForCompany(
   return sectorCandidates.length === 1 ? (sectorCandidates[0] ?? null) : null;
 }
 
-function prospectiveStage(
+function prospectiveStages(
   config: FundDraftWriteV1,
   company: MarginalReserveCompanySource,
-  currentStage: CanonicalStage,
-  checkAmount: Decimal
-): MarginalReserveStageV1 | null {
+  currentStage: CanonicalStage
+): Array<Omit<MarginalReserveStageV1, 'withDecision' | 'withoutDecision'>> | null {
   const profile = profileForCompany(config, company.sector);
   if (!profile) return null;
-  const currentStageIndex = CANONICAL_STAGES.indexOf(currentStage);
-  const assumedStage = profile.stages
+  const orderedStages = profile.stages
     .map((stage) => ({ stage, canonical: canonicalStage(stage.name) }))
     .filter(
       (
@@ -157,44 +174,89 @@ function prospectiveStage(
     .sort(
       (left, right) =>
         CANONICAL_STAGES.indexOf(left.canonical) - CANONICAL_STAGES.indexOf(right.canonical)
-    )
-    .find((candidate) => CANONICAL_STAGES.indexOf(candidate.canonical) > currentStageIndex);
-  if (!assumedStage) return null;
+    );
+  const currentProfileIndex = orderedStages.findIndex(
+    (candidate) => candidate.canonical === currentStage
+  );
+  if (currentProfileIndex < 0) return null;
+  const assumedStages = orderedStages.slice(currentProfileIndex + 1);
+  if (assumedStages.length === 0) return null;
 
-  const roundSize = new Decimal(assumedStage.stage.roundSize);
-  const statedValuation = new Decimal(assumedStage.stage.valuation);
-  const preMoneyValuation =
-    assumedStage.stage.valuationType === 'post'
-      ? statedValuation.minus(roundSize)
-      : statedValuation;
-  const exitValuation = new Decimal(assumedStage.stage.exitValuation);
-  const graduationProbability = probabilityString(assumedStage.stage.graduationRate);
-  const exitProbability = probabilityString(assumedStage.stage.exitRate);
-  if (
-    !roundSize.gt(0) ||
-    !preMoneyValuation.gt(0) ||
-    !exitValuation.gt(0) ||
-    graduationProbability === null ||
-    exitProbability === null ||
-    new Decimal(graduationProbability).plus(exitProbability).gt(1) ||
-    !Number.isInteger(assumedStage.stage.monthsToGraduate) ||
-    assumedStage.stage.monthsToGraduate < 0 ||
-    !checkAmount.gt(0)
-  ) {
-    return null;
+  const stages: Array<Omit<MarginalReserveStageV1, 'withDecision' | 'withoutDecision'>> = [];
+  for (let index = 0; index < assumedStages.length; index += 1) {
+    const assumedStage = assumedStages[index];
+    const priorStage = orderedStages[currentProfileIndex + index];
+    if (!assumedStage || !priorStage) return null;
+    const roundSize = new Decimal(assumedStage.stage.roundSize).times(USD_PER_MILLION);
+    const statedValuation = new Decimal(assumedStage.stage.valuation).times(USD_PER_MILLION);
+    const preMoneyValuation =
+      assumedStage.stage.valuationType === 'post'
+        ? statedValuation.minus(roundSize)
+        : statedValuation;
+    const exitValuation = new Decimal(assumedStage.stage.exitValuation).times(USD_PER_MILLION);
+    const graduationProbability = probabilityString(assumedStage.stage.graduationRate);
+    const exitProbability = probabilityString(assumedStage.stage.exitRate);
+    if (
+      !roundSize.gt(0) ||
+      !preMoneyValuation.gt(0) ||
+      !exitValuation.gt(0) ||
+      graduationProbability === null ||
+      exitProbability === null ||
+      new Decimal(graduationProbability).plus(exitProbability).gt(1) ||
+      !Number.isInteger(priorStage.stage.monthsToGraduate) ||
+      priorStage.stage.monthsToGraduate <= 0
+    ) {
+      return null;
+    }
+    stages.push({
+      stage: assumedStage.canonical,
+      preMoneyValuation: preMoneyValuation.toString(),
+      roundSize: roundSize.toString(),
+      // V1 advances financing stages on the prior stage's approved graduation cadence.
+      monthsFromPriorStage: priorStage.stage.monthsToGraduate,
+      graduationProbability,
+      exitProbability,
+      exitValuation: exitValuation.toString(),
+    });
   }
+  return stages;
+}
 
-  return {
-    stage: assumedStage.canonical,
-    preMoneyValuation: preMoneyValuation.toString(),
-    roundSize: roundSize.toString(),
-    monthsFromPriorStage: assumedStage.stage.monthsToGraduate,
-    graduationProbability,
-    exitProbability,
-    exitValuation: exitValuation.toString(),
-    withDecision: { participate: true, checkAmount: checkAmount.toString() },
-    withoutDecision: { participate: false, checkAmount: '0' },
-  };
+function approvedCheckAmount(
+  policy: NonNullable<FundDraftWriteV1['capitalPlanAllocations']>[number] | null,
+  ownership: string | null,
+  stage: Omit<MarginalReserveStageV1, 'withDecision' | 'withoutDecision'>
+): Decimal | null {
+  if (!policy || policy.followOnParticipationPct <= 0 || ownership === null) return null;
+  if (policy.followOnStrategy === 'amount') {
+    const amount = new Decimal(policy.followOnAmount ?? 0);
+    return amount.gt(0) ? amount : null;
+  }
+  const maintainOwnershipCheck = new Decimal(stage.roundSize).times(ownership);
+  return maintainOwnershipCheck.gt(0) ? maintainOwnershipCheck : null;
+}
+
+function currentApprovedAllocation(
+  company: MarginalReserveCompanySource,
+  approvals: readonly MarginalReserveApprovedAllocationSource[],
+  asOfDate: string
+): MarginalReserveApprovedAllocationSource | null {
+  return (
+    [...approvals]
+      .sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime())
+      .find(
+        (approval) =>
+          approval.companyId === company.companyId &&
+          approval.decisionType === 'follow_on' &&
+          approval.decisionStatus === 'approved' &&
+          approval.decidedAt !== null &&
+          approval.decidedAt.toISOString().slice(0, 10) <= asOfDate &&
+          approval.liveAllocationVersion === company.allocationVersion &&
+          String(approval.finalPlannedReservesCents ?? '') ===
+            String(company.plannedReservesCents ?? '') &&
+          new Decimal(approval.finalPlannedReservesCents ?? 0).gt(0)
+      ) ?? null
+  );
 }
 
 function orderedReasons(
@@ -222,19 +284,38 @@ export function buildMarginalReserveMoicInputsFromSources(input: {
     ? FundDraftWriteV1Schema.safeParse(input.sources.publishedAssumptions.config)
     : null;
   const config = parsedConfig?.success ? parsedConfig.data : null;
-  const factsInputHash = input.sources.facts.inputHash;
+  const factsScopeMatches =
+    input.sources.facts.fundId === fundId &&
+    input.sources.facts.asOfDate === asOfDate &&
+    input.sources.facts.facts.every((fact) => fact.fundId === fundId);
+  const currentStateDateMatches = input.sources.sourceSnapshotDate === asOfDate;
+  const currentFactsRows = companies.map((company) => ({
+    companyId: company.companyId,
+    stage: company.stage,
+    currentStage: company.currentStage,
+    sector: company.sector,
+    currentOwnership: company.currentOwnership,
+  }));
+  const factsInputHash = canonicalSha256({
+    fundId,
+    asOfDate,
+    actualsFactsInputHash: input.sources.facts.inputHash,
+    sourceSnapshotDate: input.sources.sourceSnapshotDate,
+    baseCurrency: input.sources.baseCurrency,
+    currentCompanyFacts: currentFactsRows,
+  });
   const assumptionsHash = canonicalSha256({
     fundId,
-    baseCurrency: input.sources.baseCurrency,
     publishedAssumptions: input.sources.publishedAssumptions,
-    companies: companies.map((company) => ({
+    currentAllocations: companies.map((company) => ({
       companyId: company.companyId,
-      stage: company.stage,
-      currentStage: company.currentStage,
-      sector: company.sector,
-      currentOwnership: company.currentOwnership,
       plannedReservesCents: String(company.plannedReservesCents ?? ''),
+      allocationVersion: company.allocationVersion,
     })),
+    approvedAllocations: [...input.sources.approvedAllocations].sort(
+      (left, right) =>
+        left.companyId - right.companyId || right.updatedAt.getTime() - left.updatedAt.getTime()
+    ),
   });
   const ready: MarginalReserveMoicInputV1[] = [];
   const unavailable: MarginalReserveInputFailure[] = [];
@@ -242,20 +323,24 @@ export function buildMarginalReserveMoicInputsFromSources(input: {
   for (const company of companies) {
     const reasons: MarginalReserveInputReadinessReason[] = [];
     const fact = factsByCompany.get(company.companyId);
+    if (!factsScopeMatches) reasons.push('FACTS_SCOPE_MISMATCH');
+    if (!currentStateDateMatches) reasons.push('CURRENT_STATE_DATE_MISMATCH');
     if (!fact) reasons.push('MISSING_ACTUALS_FACTS');
     if (
       input.sources.baseCurrency !== 'USD' ||
-      !fact ||
-      fact.currencyStatus !== 'base_currency' ||
-      fact.currency !== 'USD'
+      fact?.currencyStatus === 'mismatch_blocked' ||
+      (fact !== undefined && fact.currency !== 'USD')
     ) {
       reasons.push('BLOCKED_CURRENCY');
     }
+    if (fact?.currencyStatus === 'unknown') reasons.push('UNKNOWN_CURRENCY');
 
     const ownership = currentOwnershipString(company.currentOwnership);
     if (ownership === null) reasons.push('MISSING_CURRENT_OWNERSHIP');
-    if (!config || !input.sources.publishedAssumptions) {
+    if (!config || !input.sources.publishedAssumptions?.publishedAt) {
       reasons.push('MISSING_PUBLISHED_ASSUMPTIONS');
+    } else if (!assumptionIsEffective(input.sources.publishedAssumptions.publishedAt, asOfDate)) {
+      reasons.push('ASSUMPTION_NOT_EFFECTIVE');
     }
 
     const currentStage = canonicalStage(company.currentStage ?? company.stage);
@@ -264,16 +349,41 @@ export function buildMarginalReserveMoicInputsFromSources(input: {
     if (!policy || policy.followOnParticipationPct <= 0) {
       reasons.push('MISSING_FOLLOW_ON_POLICY');
     }
+    const approvedAllocation = currentApprovedAllocation(
+      company,
+      input.sources.approvedAllocations,
+      asOfDate
+    );
+    if (!approvedAllocation) reasons.push('MISSING_APPROVED_ALLOCATION');
 
-    const checkAmount = new Decimal(company.plannedReservesCents ?? 0).div(100);
-    if (!checkAmount.gt(0)) reasons.push('MISSING_PLANNED_CHECK');
-    const stage =
-      config && currentStage && checkAmount.gt(0)
-        ? prospectiveStage(config, company, currentStage, checkAmount)
-        : null;
-    if (!stage) {
+    const stageTerms =
+      config && currentStage ? prospectiveStages(config, company, currentStage) : null;
+    if (!stageTerms) {
       reasons.push('MISSING_STAGE_ASSUMPTION');
-    } else if (checkAmount.gt(stage.roundSize)) {
+    }
+    const firstCheckAmount =
+      stageTerms?.[0] && approvedAllocation
+        ? approvedCheckAmount(policy, ownership, stageTerms[0])
+        : null;
+    const checkAmounts = stageTerms?.map((_stage, index) =>
+      index === 0 ? firstCheckAmount : new Decimal(0)
+    );
+    if (!checkAmounts || firstCheckAmount === null) {
+      reasons.push('MISSING_PLANNED_CHECK');
+    }
+    if (
+      firstCheckAmount &&
+      approvedAllocation &&
+      firstCheckAmount.gt(new Decimal(approvedAllocation.finalPlannedReservesCents ?? 0).div(100))
+    ) {
+      reasons.push('PLANNED_CHECK_EXCEEDS_APPROVED_ALLOCATION');
+    }
+    if (
+      stageTerms?.some((stage, index) => {
+        const checkAmount = checkAmounts?.[index];
+        return checkAmount !== null && checkAmount !== undefined && checkAmount.gt(stage.roundSize);
+      })
+    ) {
       reasons.push('PLANNED_CHECK_EXCEEDS_ROUND_SIZE');
     }
 
@@ -283,7 +393,9 @@ export function buildMarginalReserveMoicInputsFromSources(input: {
     if (
       blockingReasons.length > 0 ||
       ownership === null ||
-      !stage ||
+      !stageTerms ||
+      !checkAmounts ||
+      firstCheckAmount === null ||
       !input.sources.publishedAssumptions
     ) {
       unavailable.push(
@@ -304,7 +416,15 @@ export function buildMarginalReserveMoicInputsFromSources(input: {
         baseCurrency: 'USD',
         asOfDate,
         currentOwnership: ownership,
-        stages: [stage],
+        stages: stageTerms.map((stage, index) => {
+          const checkAmount = checkAmounts[index];
+          if (!checkAmount) throw new Error('Approved check path is incomplete');
+          return {
+            ...stage,
+            withDecision: { participate: checkAmount.gt(0), checkAmount: checkAmount.toString() },
+            withoutDecision: { participate: false, checkAmount: '0' },
+          };
+        }),
         factsInputHash,
         assumptionsHash,
         engineVersion: 'marginal-reserve-moic-v1',
@@ -322,7 +442,8 @@ async function loadMarginalReserveInputSources(input: {
   fundId: number;
   asOfDate: string;
 }): Promise<MarginalReserveInputSources> {
-  const [facts, fundRows, configRows, companyRows] = await Promise.all([
+  const sourceSnapshotDate = new Date().toISOString().slice(0, 10);
+  const [facts, fundRows, configRows, companyRows, approvedAllocations] = await Promise.all([
     buildFundCompanyActualsFacts(input),
     db
       .select({ baseCurrency: funds.baseCurrency })
@@ -347,10 +468,33 @@ async function loadMarginalReserveInputSources(input: {
         sector: portfolioCompanies.sector,
         currentOwnership: portfolioCompanies.ownershipCurrentPct,
         plannedReservesCents: portfolioCompanies.plannedReservesCents,
+        allocationVersion: portfolioCompanies.allocationVersion,
       })
       .from(portfolioCompanies)
       .where(eq(portfolioCompanies.fundId, input.fundId))
       .orderBy(asc(portfolioCompanies.id)),
+    db
+      .select({
+        companyId: allocationScenarioIcDecisions.companyId,
+        decisionType: allocationScenarioIcDecisions.decisionType,
+        decisionStatus: allocationScenarioIcDecisions.decisionStatus,
+        finalPlannedReservesCents: allocationScenarioIcDecisions.finalPlannedReservesCents,
+        liveAllocationVersion: allocationScenarioIcDecisions.liveAllocationVersion,
+        decidedAt: allocationScenarioIcDecisions.decidedAt,
+        updatedAt: allocationScenarioIcDecisions.updatedAt,
+      })
+      .from(allocationScenarioIcDecisions)
+      .where(
+        and(
+          eq(allocationScenarioIcDecisions.fundId, input.fundId),
+          eq(allocationScenarioIcDecisions.decisionType, 'follow_on'),
+          eq(allocationScenarioIcDecisions.decisionStatus, 'approved')
+        )
+      )
+      .orderBy(
+        asc(allocationScenarioIcDecisions.companyId),
+        desc(allocationScenarioIcDecisions.updatedAt)
+      ),
   ]);
   const fund = fundRows[0];
   if (!fund) {
@@ -361,7 +505,9 @@ async function loadMarginalReserveInputSources(input: {
     baseCurrency: fund.baseCurrency,
     facts,
     companies: companyRows,
+    approvedAllocations,
     publishedAssumptions: configRows[0] ?? null,
+    sourceSnapshotDate,
   };
 }
 

--- a/server/services/moic/marginal-reserve-moic-input-service.ts
+++ b/server/services/moic/marginal-reserve-moic-input-service.ts
@@ -1,0 +1,375 @@
+import { and, asc, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../../db';
+import { buildFundCompanyActualsFacts } from '../fund-actuals/fund-company-actuals-facts-service';
+import {
+  FundDraftWriteV1Schema,
+  type FundDraftWriteV1,
+} from '../../../shared/contracts/fund-draft-write-v1.contract';
+import type { FundCompanyActualsFactsResponse } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import {
+  MarginalReserveInputFailureSchema,
+  MarginalReserveMoicInputV1Schema,
+  type MarginalReserveInputFailure,
+  type MarginalReserveInputReadinessReason,
+  type MarginalReserveMoicInputV1,
+  type MarginalReserveStageV1,
+} from '../../../shared/contracts/marginal-reserve-moic-v1.contract';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import Decimal from '../../../shared/lib/decimal-config';
+import { CANONICAL_STAGES, type CanonicalStage } from '../../../shared/schemas/stage';
+import { fundConfigs, funds, portfolioCompanies } from '../../../shared/schema';
+
+export const MARGINAL_RESERVE_ASSUMPTION_STALE_AFTER_DAYS = 120;
+
+const BuildInputSchema = z
+  .object({
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+  })
+  .strict();
+
+export interface MarginalReserveCompanySource {
+  companyId: number;
+  stage: string | null;
+  currentStage: string | null;
+  sector: string;
+  currentOwnership: string | number | null;
+  plannedReservesCents: number | bigint | null;
+}
+
+export interface MarginalReservePublishedAssumptions {
+  configId: number;
+  version: number;
+  publishedAt: Date | null;
+  config: unknown;
+}
+
+export interface MarginalReserveInputSources {
+  baseCurrency: string;
+  facts: FundCompanyActualsFactsResponse;
+  companies: readonly MarginalReserveCompanySource[];
+  publishedAssumptions: MarginalReservePublishedAssumptions | null;
+}
+
+export interface MarginalReserveInputAssembly {
+  ready: MarginalReserveMoicInputV1[];
+  unavailable: MarginalReserveInputFailure[];
+  factsInputHash: string;
+  assumptionsHash: string;
+}
+
+const STAGE_ALIASES: Readonly<Record<string, CanonicalStage>> = {
+  preseed: 'pre_seed',
+  seed: 'seed',
+  seriesa: 'series_a',
+  seriesb: 'series_b',
+  seriesc: 'series_c',
+  seriesd: 'series_d',
+  seriesdplus: 'series_d',
+  growth: 'growth',
+  latestage: 'late_stage',
+};
+
+function normalizedKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function canonicalStage(value: string | null | undefined): CanonicalStage | null {
+  if (!value) return null;
+  return STAGE_ALIASES[normalizedKey(value)] ?? null;
+}
+
+function probabilityString(percent: number): string | null {
+  if (!Number.isFinite(percent) || percent < 0 || percent > 100) return null;
+  return new Decimal(percent).div(100).toString();
+}
+
+function currentOwnershipString(value: string | number | null): string | null {
+  if (value === null || value === '') return null;
+  try {
+    const ownership = new Decimal(value);
+    if (!ownership.isFinite() || ownership.lt(0) || ownership.gt(100)) return null;
+    return (ownership.gt(1) ? ownership.div(100) : ownership).toString();
+  } catch {
+    return null;
+  }
+}
+
+function assumptionIsStale(publishedAt: Date | null, asOfDate: string): boolean {
+  if (!publishedAt) return true;
+  const asOf = new Date(`${asOfDate}T00:00:00.000Z`).getTime();
+  const ageDays = (asOf - publishedAt.getTime()) / 86_400_000;
+  return ageDays > MARGINAL_RESERVE_ASSUMPTION_STALE_AFTER_DAYS;
+}
+
+function profileForCompany(config: FundDraftWriteV1, sector: string) {
+  const profiles = config.pipelineProfiles ?? [];
+  if (profiles.length === 1) return profiles[0] ?? null;
+  const sectorKey = normalizedKey(sector);
+  const matches = profiles.filter(
+    (profile) =>
+      normalizedKey(profile.id) === sectorKey || normalizedKey(profile.name) === sectorKey
+  );
+  return matches.length === 1 ? (matches[0] ?? null) : null;
+}
+
+function followOnPolicyForCompany(
+  config: FundDraftWriteV1,
+  company: MarginalReserveCompanySource,
+  currentStage: CanonicalStage
+) {
+  const sectorProfileId = config.sectorProfiles?.find(
+    (profile) => normalizedKey(profile.name) === normalizedKey(company.sector)
+  )?.id;
+  const sectorCandidates = (config.capitalPlanAllocations ?? []).filter(
+    (allocation) =>
+      allocation.sectorProfileId === undefined || allocation.sectorProfileId === sectorProfileId
+  );
+  const stageCandidates = sectorCandidates.filter(
+    (allocation) => canonicalStage(allocation.entryRound) === currentStage
+  );
+  if (stageCandidates.length === 1) return stageCandidates[0] ?? null;
+  return sectorCandidates.length === 1 ? (sectorCandidates[0] ?? null) : null;
+}
+
+function prospectiveStage(
+  config: FundDraftWriteV1,
+  company: MarginalReserveCompanySource,
+  currentStage: CanonicalStage,
+  checkAmount: Decimal
+): MarginalReserveStageV1 | null {
+  const profile = profileForCompany(config, company.sector);
+  if (!profile) return null;
+  const currentStageIndex = CANONICAL_STAGES.indexOf(currentStage);
+  const assumedStage = profile.stages
+    .map((stage) => ({ stage, canonical: canonicalStage(stage.name) }))
+    .filter(
+      (
+        candidate
+      ): candidate is { stage: (typeof profile.stages)[number]; canonical: CanonicalStage } =>
+        candidate.canonical !== null
+    )
+    .sort(
+      (left, right) =>
+        CANONICAL_STAGES.indexOf(left.canonical) - CANONICAL_STAGES.indexOf(right.canonical)
+    )
+    .find((candidate) => CANONICAL_STAGES.indexOf(candidate.canonical) > currentStageIndex);
+  if (!assumedStage) return null;
+
+  const roundSize = new Decimal(assumedStage.stage.roundSize);
+  const statedValuation = new Decimal(assumedStage.stage.valuation);
+  const preMoneyValuation =
+    assumedStage.stage.valuationType === 'post'
+      ? statedValuation.minus(roundSize)
+      : statedValuation;
+  const exitValuation = new Decimal(assumedStage.stage.exitValuation);
+  const graduationProbability = probabilityString(assumedStage.stage.graduationRate);
+  const exitProbability = probabilityString(assumedStage.stage.exitRate);
+  if (
+    !roundSize.gt(0) ||
+    !preMoneyValuation.gt(0) ||
+    !exitValuation.gt(0) ||
+    graduationProbability === null ||
+    exitProbability === null ||
+    new Decimal(graduationProbability).plus(exitProbability).gt(1) ||
+    !Number.isInteger(assumedStage.stage.monthsToGraduate) ||
+    assumedStage.stage.monthsToGraduate < 0 ||
+    !checkAmount.gt(0)
+  ) {
+    return null;
+  }
+
+  return {
+    stage: assumedStage.canonical,
+    preMoneyValuation: preMoneyValuation.toString(),
+    roundSize: roundSize.toString(),
+    monthsFromPriorStage: assumedStage.stage.monthsToGraduate,
+    graduationProbability,
+    exitProbability,
+    exitValuation: exitValuation.toString(),
+    withDecision: { participate: true, checkAmount: checkAmount.toString() },
+    withoutDecision: { participate: false, checkAmount: '0' },
+  };
+}
+
+function orderedReasons(
+  reasons: Iterable<MarginalReserveInputReadinessReason>
+): MarginalReserveInputReadinessReason[] {
+  return [...new Set(reasons)].sort();
+}
+
+export function buildMarginalReserveMoicInputsFromSources(input: {
+  fundId: number;
+  asOfDate: string;
+  sources: MarginalReserveInputSources;
+}): MarginalReserveInputAssembly {
+  const { fundId, asOfDate } = BuildInputSchema.parse({
+    fundId: input.fundId,
+    asOfDate: input.asOfDate,
+  });
+  const companies = [...input.sources.companies].sort(
+    (left, right) => left.companyId - right.companyId
+  );
+  const factsByCompany = new Map(
+    input.sources.facts.facts.map((fact) => [fact.companyId, fact] as const)
+  );
+  const parsedConfig = input.sources.publishedAssumptions
+    ? FundDraftWriteV1Schema.safeParse(input.sources.publishedAssumptions.config)
+    : null;
+  const config = parsedConfig?.success ? parsedConfig.data : null;
+  const factsInputHash = input.sources.facts.inputHash;
+  const assumptionsHash = canonicalSha256({
+    fundId,
+    baseCurrency: input.sources.baseCurrency,
+    publishedAssumptions: input.sources.publishedAssumptions,
+    companies: companies.map((company) => ({
+      companyId: company.companyId,
+      stage: company.stage,
+      currentStage: company.currentStage,
+      sector: company.sector,
+      currentOwnership: company.currentOwnership,
+      plannedReservesCents: String(company.plannedReservesCents ?? ''),
+    })),
+  });
+  const ready: MarginalReserveMoicInputV1[] = [];
+  const unavailable: MarginalReserveInputFailure[] = [];
+
+  for (const company of companies) {
+    const reasons: MarginalReserveInputReadinessReason[] = [];
+    const fact = factsByCompany.get(company.companyId);
+    if (!fact) reasons.push('MISSING_ACTUALS_FACTS');
+    if (
+      input.sources.baseCurrency !== 'USD' ||
+      !fact ||
+      fact.currencyStatus !== 'base_currency' ||
+      fact.currency !== 'USD'
+    ) {
+      reasons.push('BLOCKED_CURRENCY');
+    }
+
+    const ownership = currentOwnershipString(company.currentOwnership);
+    if (ownership === null) reasons.push('MISSING_CURRENT_OWNERSHIP');
+    if (!config || !input.sources.publishedAssumptions) {
+      reasons.push('MISSING_PUBLISHED_ASSUMPTIONS');
+    }
+
+    const currentStage = canonicalStage(company.currentStage ?? company.stage);
+    const policy =
+      config && currentStage ? followOnPolicyForCompany(config, company, currentStage) : null;
+    if (!policy || policy.followOnParticipationPct <= 0) {
+      reasons.push('MISSING_FOLLOW_ON_POLICY');
+    }
+
+    const checkAmount = new Decimal(company.plannedReservesCents ?? 0).div(100);
+    if (!checkAmount.gt(0)) reasons.push('MISSING_PLANNED_CHECK');
+    const stage =
+      config && currentStage && checkAmount.gt(0)
+        ? prospectiveStage(config, company, currentStage, checkAmount)
+        : null;
+    if (!stage) {
+      reasons.push('MISSING_STAGE_ASSUMPTION');
+    } else if (checkAmount.gt(stage.roundSize)) {
+      reasons.push('PLANNED_CHECK_EXCEEDS_ROUND_SIZE');
+    }
+
+    const blockingReasons = orderedReasons(
+      reasons.filter((reason) => reason !== 'STALE_ASSUMPTION')
+    );
+    if (
+      blockingReasons.length > 0 ||
+      ownership === null ||
+      !stage ||
+      !input.sources.publishedAssumptions
+    ) {
+      unavailable.push(
+        MarginalReserveInputFailureSchema.parse({
+          companyId: company.companyId,
+          reasons: blockingReasons,
+        })
+      );
+      continue;
+    }
+
+    const stale = assumptionIsStale(input.sources.publishedAssumptions.publishedAt, asOfDate);
+    ready.push(
+      MarginalReserveMoicInputV1Schema.parse({
+        contractVersion: 'marginal-reserve-moic-input-v1',
+        fundId,
+        companyId: company.companyId,
+        baseCurrency: 'USD',
+        asOfDate,
+        currentOwnership: ownership,
+        stages: [stage],
+        factsInputHash,
+        assumptionsHash,
+        engineVersion: 'marginal-reserve-moic-v1',
+        readiness: stale
+          ? { status: 'indicative', reasons: ['STALE_ASSUMPTION'] }
+          : { status: 'actionable', reasons: [] },
+      })
+    );
+  }
+
+  return { ready, unavailable, factsInputHash, assumptionsHash };
+}
+
+async function loadMarginalReserveInputSources(input: {
+  fundId: number;
+  asOfDate: string;
+}): Promise<MarginalReserveInputSources> {
+  const [facts, fundRows, configRows, companyRows] = await Promise.all([
+    buildFundCompanyActualsFacts(input),
+    db
+      .select({ baseCurrency: funds.baseCurrency })
+      .from(funds)
+      .where(eq(funds.id, input.fundId))
+      .limit(1),
+    db
+      .select({
+        configId: fundConfigs.id,
+        version: fundConfigs.version,
+        publishedAt: fundConfigs.publishedAt,
+        config: fundConfigs.config,
+      })
+      .from(fundConfigs)
+      .where(and(eq(fundConfigs.fundId, input.fundId), eq(fundConfigs.isPublished, true)))
+      .limit(1),
+    db
+      .select({
+        companyId: portfolioCompanies.id,
+        stage: portfolioCompanies.stage,
+        currentStage: portfolioCompanies.currentStage,
+        sector: portfolioCompanies.sector,
+        currentOwnership: portfolioCompanies.ownershipCurrentPct,
+        plannedReservesCents: portfolioCompanies.plannedReservesCents,
+      })
+      .from(portfolioCompanies)
+      .where(eq(portfolioCompanies.fundId, input.fundId))
+      .orderBy(asc(portfolioCompanies.id)),
+  ]);
+  const fund = fundRows[0];
+  if (!fund) {
+    throw new Error(`Fund ${input.fundId} was not found`);
+  }
+
+  return {
+    baseCurrency: fund.baseCurrency,
+    facts,
+    companies: companyRows,
+    publishedAssumptions: configRows[0] ?? null,
+  };
+}
+
+export async function buildMarginalReserveMoicInputs(input: {
+  fundId: number;
+  asOfDate: string;
+}): Promise<MarginalReserveInputAssembly> {
+  const parsed = BuildInputSchema.parse(input);
+  const sources = await loadMarginalReserveInputSources(parsed);
+  return buildMarginalReserveMoicInputsFromSources({ ...parsed, sources });
+}

--- a/server/services/moic/marginal-reserve-moic-shadow-service.ts
+++ b/server/services/moic/marginal-reserve-moic-shadow-service.ts
@@ -1,7 +1,7 @@
 import type { FundMoicRankingItemV1 } from '../../../shared/contracts/fund-moic-v1.contract';
 import type {
   MarginalReserveInputFailure,
-  MarginalReserveMoicResultV1,
+  MarginalReserveRankingItemV1,
 } from '../../../shared/contracts/marginal-reserve-moic-v1.contract';
 import Decimal from '../../../shared/lib/decimal-config';
 import { logger } from '../../lib/logger';
@@ -23,6 +23,16 @@ export interface MarginalReserveShadowAnnotation {
   plannedRanks: [number, number];
   marginalRanks: [number, number];
   annotation: string;
+  reviewedBy: string | null;
+  reviewerRole: 'investment_team' | null;
+  reviewedAt: string | null;
+}
+
+export interface MarginalReserveShadowAnnotationInput {
+  annotation: string;
+  reviewedBy: string;
+  reviewerRole: 'investment_team';
+  reviewedAt: string;
 }
 
 export interface MarginalReserveMoicShadowArtifact {
@@ -36,9 +46,9 @@ export interface MarginalReserveMoicShadowArtifact {
 export interface MarginalReserveMoicShadowInput {
   fundId: number;
   plannedRankings: readonly FundMoicRankingItemV1[];
-  marginalRankings: readonly MarginalReserveMoicResultV1[];
+  marginalRankings: readonly MarginalReserveRankingItemV1[];
   unavailable: readonly MarginalReserveInputFailure[];
-  annotationsByInversionId?: Readonly<Record<string, string>>;
+  annotationsByInversionId?: Readonly<Record<string, MarginalReserveShadowAnnotationInput>>;
 }
 
 interface ActionableRanking {
@@ -90,16 +100,19 @@ function plannedActionableRankings(
 }
 
 function marginalActionableRankings(
-  rankings: readonly MarginalReserveMoicResultV1[]
+  rankings: readonly MarginalReserveRankingItemV1[]
 ): ActionableRanking[] {
   const seen = new Set<number>();
   return [...rankings]
     .filter(
-      (ranking): ranking is MarginalReserveMoicResultV1 & { marginalMoic: string } =>
-        ranking.status === 'actionable' && ranking.marginalMoic !== null
+      (
+        ranking
+      ): ranking is MarginalReserveRankingItemV1 & {
+        result: MarginalReserveRankingItemV1['result'] & { marginalMoic: string };
+      } => ranking.status === 'actionable' && ranking.result.marginalMoic !== null
     )
     .sort((left, right) => {
-      const moicOrder = new Decimal(right.marginalMoic).comparedTo(left.marginalMoic);
+      const moicOrder = new Decimal(right.result.marginalMoic).comparedTo(left.result.marginalMoic);
       return moicOrder !== 0 ? moicOrder : left.companyId - right.companyId;
     })
     .filter((ranking) => {
@@ -110,7 +123,7 @@ function marginalActionableRankings(
     .map((ranking, index) => ({
       companyId: ranking.companyId,
       position: index + 1,
-      moic: new Decimal(ranking.marginalMoic),
+      moic: new Decimal(ranking.result.marginalMoic),
     }));
 }
 
@@ -202,6 +215,18 @@ function inversionId(inversion: RankInversion): string {
   return [...inversion.companyIds].sort((left, right) => left - right).join(':');
 }
 
+function validInvestmentTeamAnnotation(
+  annotation: MarginalReserveShadowAnnotationInput | undefined
+): annotation is MarginalReserveShadowAnnotationInput {
+  return Boolean(
+    annotation &&
+    annotation.annotation.trim() &&
+    annotation.reviewedBy.trim() &&
+    annotation.reviewerRole === 'investment_team' &&
+    !Number.isNaN(Date.parse(annotation.reviewedAt))
+  );
+}
+
 export function buildMarginalReserveMoicShadowArtifact(
   input: MarginalReserveMoicShadowInput
 ): MarginalReserveMoicShadowArtifact {
@@ -218,12 +243,17 @@ export function buildMarginalReserveMoicShadowArtifact(
     .filter((inversion) => inversion.companyIds.some((companyId) => topFiveIds.has(companyId)))
     .map((inversion) => {
       const id = inversionId(inversion);
+      const supplied = input.annotationsByInversionId?.[id];
+      const accepted = validInvestmentTeamAnnotation(supplied) ? supplied : null;
       return {
         inversionId: id,
         companyIds: inversion.companyIds,
         plannedRanks: inversion.plannedRanks,
         marginalRanks: inversion.marginalRanks,
-        annotation: input.annotationsByInversionId?.[id]?.trim() ?? '',
+        annotation: accepted?.annotation.trim() ?? '',
+        reviewedBy: accepted?.reviewedBy.trim() ?? null,
+        reviewerRole: accepted?.reviewerRole ?? null,
+        reviewedAt: accepted?.reviewedAt ?? null,
       };
     });
   const metrics: MarginalReserveShadowMetrics = {
@@ -245,7 +275,13 @@ export function buildMarginalReserveMoicShadowArtifact(
   return {
     artifactVersion: 'marginal-reserve-moic-shadow-v1',
     fundId: input.fundId,
-    status: annotations.every((annotation) => annotation.annotation.length > 0)
+    status: annotations.every(
+      (annotation) =>
+        annotation.annotation.length > 0 &&
+        annotation.reviewedBy !== null &&
+        annotation.reviewerRole === 'investment_team' &&
+        annotation.reviewedAt !== null
+    )
       ? 'approved'
       : 'annotation_required',
     metrics,

--- a/server/services/moic/marginal-reserve-moic-shadow-service.ts
+++ b/server/services/moic/marginal-reserve-moic-shadow-service.ts
@@ -1,0 +1,281 @@
+import type { FundMoicRankingItemV1 } from '../../../shared/contracts/fund-moic-v1.contract';
+import type {
+  MarginalReserveInputFailure,
+  MarginalReserveMoicResultV1,
+} from '../../../shared/contracts/marginal-reserve-moic-v1.contract';
+import Decimal from '../../../shared/lib/decimal-config';
+import { logger } from '../../lib/logger';
+
+export interface MarginalReserveShadowMetrics {
+  top_3_overlap: number;
+  top_5_overlap: number;
+  pairwise_rank_inversion_count: number;
+  companies_actionable_in_both: number;
+  companies_only_planned_actionable: number;
+  companies_only_marginal_actionable: number;
+  median_moic_ratio: string | null;
+  unavailable_reason_counts: Record<string, number>;
+}
+
+export interface MarginalReserveShadowAnnotation {
+  inversionId: string;
+  companyIds: [number, number];
+  plannedRanks: [number, number];
+  marginalRanks: [number, number];
+  annotation: string;
+}
+
+export interface MarginalReserveMoicShadowArtifact {
+  artifactVersion: 'marginal-reserve-moic-shadow-v1';
+  fundId: number;
+  status: 'approved' | 'annotation_required';
+  metrics: MarginalReserveShadowMetrics;
+  annotations: MarginalReserveShadowAnnotation[];
+}
+
+export interface MarginalReserveMoicShadowInput {
+  fundId: number;
+  plannedRankings: readonly FundMoicRankingItemV1[];
+  marginalRankings: readonly MarginalReserveMoicResultV1[];
+  unavailable: readonly MarginalReserveInputFailure[];
+  annotationsByInversionId?: Readonly<Record<string, string>>;
+}
+
+interface ActionableRanking {
+  companyId: number;
+  position: number;
+  moic: Decimal;
+}
+
+interface RankInversion {
+  companyIds: [number, number];
+  plannedRanks: [number, number];
+  marginalRanks: [number, number];
+}
+
+export interface MarginalReserveShadowLogger {
+  info(bindings: Record<string, unknown>, message: string): void;
+}
+
+function positiveCompanyId(value: string): number | null {
+  if (!/^[1-9]\d*$/.test(value)) return null;
+  const companyId = Number.parseInt(value, 10);
+  return Number.isSafeInteger(companyId) ? companyId : null;
+}
+
+function plannedActionableRankings(
+  rankings: readonly FundMoicRankingItemV1[]
+): ActionableRanking[] {
+  const seen = new Set<number>();
+  const ordered = [...rankings].sort((left, right) => {
+    const rankOrder = left.rank - right.rank;
+    if (rankOrder !== 0) return rankOrder;
+    const leftCompanyId = positiveCompanyId(left.investmentId);
+    const rightCompanyId = positiveCompanyId(right.investmentId);
+    return leftCompanyId !== null && rightCompanyId !== null
+      ? leftCompanyId - rightCompanyId
+      : left.investmentId.localeCompare(right.investmentId, 'en');
+  });
+  const actionable: ActionableRanking[] = [];
+  for (const ranking of ordered) {
+    const companyId = positiveCompanyId(ranking.investmentId);
+    const value = ranking.reservesMoic.value;
+    if (companyId === null || value === null || !Number.isFinite(value) || seen.has(companyId)) {
+      continue;
+    }
+    seen.add(companyId);
+    actionable.push({ companyId, position: actionable.length + 1, moic: new Decimal(value) });
+  }
+  return actionable;
+}
+
+function marginalActionableRankings(
+  rankings: readonly MarginalReserveMoicResultV1[]
+): ActionableRanking[] {
+  const seen = new Set<number>();
+  return [...rankings]
+    .filter(
+      (ranking): ranking is MarginalReserveMoicResultV1 & { marginalMoic: string } =>
+        ranking.status === 'actionable' && ranking.marginalMoic !== null
+    )
+    .sort((left, right) => {
+      const moicOrder = new Decimal(right.marginalMoic).comparedTo(left.marginalMoic);
+      return moicOrder !== 0 ? moicOrder : left.companyId - right.companyId;
+    })
+    .filter((ranking) => {
+      if (seen.has(ranking.companyId)) return false;
+      seen.add(ranking.companyId);
+      return true;
+    })
+    .map((ranking, index) => ({
+      companyId: ranking.companyId,
+      position: index + 1,
+      moic: new Decimal(ranking.marginalMoic),
+    }));
+}
+
+function overlapCount(
+  planned: readonly ActionableRanking[],
+  marginal: readonly ActionableRanking[],
+  limit: number
+): number {
+  const marginalTop = new Set(marginal.slice(0, limit).map((ranking) => ranking.companyId));
+  return planned.slice(0, limit).filter((ranking) => marginalTop.has(ranking.companyId)).length;
+}
+
+function rankInversions(
+  planned: readonly ActionableRanking[],
+  marginal: readonly ActionableRanking[]
+): RankInversion[] {
+  const marginalPosition = new Map(
+    marginal.map((ranking) => [ranking.companyId, ranking.position] as const)
+  );
+  const common = planned.filter((ranking) => marginalPosition.has(ranking.companyId));
+  const inversions: RankInversion[] = [];
+  for (let leftIndex = 0; leftIndex < common.length; leftIndex += 1) {
+    const left = common[leftIndex];
+    if (!left) continue;
+    for (let rightIndex = leftIndex + 1; rightIndex < common.length; rightIndex += 1) {
+      const right = common[rightIndex];
+      if (!right) continue;
+      const leftMarginalPosition = marginalPosition.get(left.companyId);
+      const rightMarginalPosition = marginalPosition.get(right.companyId);
+      if (
+        leftMarginalPosition === undefined ||
+        rightMarginalPosition === undefined ||
+        (left.position - right.position) * (leftMarginalPosition - rightMarginalPosition) >= 0
+      ) {
+        continue;
+      }
+      inversions.push({
+        companyIds: [left.companyId, right.companyId],
+        plannedRanks: [left.position, right.position],
+        marginalRanks: [leftMarginalPosition, rightMarginalPosition],
+      });
+    }
+  }
+  return inversions;
+}
+
+function medianMoicRatio(
+  planned: readonly ActionableRanking[],
+  marginal: readonly ActionableRanking[]
+): string | null {
+  const plannedByCompany = new Map(planned.map((ranking) => [ranking.companyId, ranking] as const));
+  const ratios = marginal
+    .map((ranking) => {
+      const plannedRanking = plannedByCompany.get(ranking.companyId);
+      return plannedRanking && plannedRanking.moic.gt(0)
+        ? ranking.moic.div(plannedRanking.moic)
+        : null;
+    })
+    .filter((ratio): ratio is Decimal => ratio !== null)
+    .sort((left, right) => left.comparedTo(right));
+  if (ratios.length === 0) return null;
+  const midpoint = Math.floor(ratios.length / 2);
+  const upper = ratios[midpoint];
+  if (!upper) return null;
+  if (ratios.length % 2 === 1) return upper.toFixed(6);
+  const lower = ratios[midpoint - 1];
+  return lower ? lower.plus(upper).div(2).toFixed(6) : null;
+}
+
+function unavailableReasonCounts(
+  unavailable: readonly MarginalReserveInputFailure[]
+): Record<string, number> {
+  const companiesByReason = new Map<string, Set<number>>();
+  for (const failure of unavailable) {
+    for (const reason of new Set(failure.reasons)) {
+      const companyIds = companiesByReason.get(reason) ?? new Set<number>();
+      companyIds.add(failure.companyId);
+      companiesByReason.set(reason, companyIds);
+    }
+  }
+  return Object.fromEntries(
+    [...companiesByReason.entries()]
+      .sort(([left], [right]) => left.localeCompare(right, 'en'))
+      .map(([reason, companyIds]) => [reason, companyIds.size])
+  );
+}
+
+function inversionId(inversion: RankInversion): string {
+  return [...inversion.companyIds].sort((left, right) => left - right).join(':');
+}
+
+export function buildMarginalReserveMoicShadowArtifact(
+  input: MarginalReserveMoicShadowInput
+): MarginalReserveMoicShadowArtifact {
+  const planned = plannedActionableRankings(input.plannedRankings);
+  const marginal = marginalActionableRankings(input.marginalRankings);
+  const plannedIds = new Set(planned.map((ranking) => ranking.companyId));
+  const marginalIds = new Set(marginal.map((ranking) => ranking.companyId));
+  const inversions = rankInversions(planned, marginal);
+  const topFiveIds = new Set([
+    ...planned.slice(0, 5).map((ranking) => ranking.companyId),
+    ...marginal.slice(0, 5).map((ranking) => ranking.companyId),
+  ]);
+  const annotations = inversions
+    .filter((inversion) => inversion.companyIds.some((companyId) => topFiveIds.has(companyId)))
+    .map((inversion) => {
+      const id = inversionId(inversion);
+      return {
+        inversionId: id,
+        companyIds: inversion.companyIds,
+        plannedRanks: inversion.plannedRanks,
+        marginalRanks: inversion.marginalRanks,
+        annotation: input.annotationsByInversionId?.[id]?.trim() ?? '',
+      };
+    });
+  const metrics: MarginalReserveShadowMetrics = {
+    top_3_overlap: overlapCount(planned, marginal, 3),
+    top_5_overlap: overlapCount(planned, marginal, 5),
+    pairwise_rank_inversion_count: inversions.length,
+    companies_actionable_in_both: [...plannedIds].filter((companyId) => marginalIds.has(companyId))
+      .length,
+    companies_only_planned_actionable: [...plannedIds].filter(
+      (companyId) => !marginalIds.has(companyId)
+    ).length,
+    companies_only_marginal_actionable: [...marginalIds].filter(
+      (companyId) => !plannedIds.has(companyId)
+    ).length,
+    median_moic_ratio: medianMoicRatio(planned, marginal),
+    unavailable_reason_counts: unavailableReasonCounts(input.unavailable),
+  };
+
+  return {
+    artifactVersion: 'marginal-reserve-moic-shadow-v1',
+    fundId: input.fundId,
+    status: annotations.every((annotation) => annotation.annotation.length > 0)
+      ? 'approved'
+      : 'annotation_required',
+    metrics,
+    annotations,
+  };
+}
+
+export function emitMarginalReserveMoicShadowComparison(
+  input: MarginalReserveMoicShadowInput,
+  log: MarginalReserveShadowLogger = logger
+): MarginalReserveMoicShadowArtifact {
+  const artifact = buildMarginalReserveMoicShadowArtifact(input);
+  const companyIds = [
+    ...new Set([
+      ...input.plannedRankings
+        .map((ranking) => positiveCompanyId(ranking.investmentId))
+        .filter((companyId): companyId is number => companyId !== null),
+      ...input.marginalRankings.map((ranking) => ranking.companyId),
+      ...input.unavailable.map((failure) => failure.companyId),
+    ]),
+  ].sort((left, right) => left - right);
+  log.info(
+    {
+      fundId: artifact.fundId,
+      status: artifact.status,
+      companyIds,
+      inversionIds: artifact.annotations.map((annotation) => annotation.inversionId),
+      metrics: artifact.metrics,
+    },
+    'marginal reserve MOIC shadow comparison generated'
+  );
+  return artifact;
+}

--- a/shared/contracts/marginal-reserve-moic-v1.contract.ts
+++ b/shared/contracts/marginal-reserve-moic-v1.contract.ts
@@ -41,6 +41,12 @@ export const MarginalReserveInputReadinessReasonSchema = z.enum([
   'PLANNED_CHECK_EXCEEDS_ROUND_SIZE',
   'BLOCKED_CURRENCY',
   'STALE_ASSUMPTION',
+  'ASSUMPTION_NOT_EFFECTIVE',
+  'CURRENT_STATE_DATE_MISMATCH',
+  'FACTS_SCOPE_MISMATCH',
+  'UNKNOWN_CURRENCY',
+  'MISSING_APPROVED_ALLOCATION',
+  'PLANNED_CHECK_EXCEEDS_APPROVED_ALLOCATION',
 ]);
 
 export const MarginalReserveInputReadinessSchema = z
@@ -196,7 +202,6 @@ export const MarginalReserveWarningCodeSchema = z.enum([
   'MIN_DENOMINATOR_FLOOR',
   'IMPLAUSIBLE_MAGNITUDE',
   'IRR_UNAVAILABLE',
-  'STALE_ASSUMPTION',
 ]);
 
 export const StructuredWarningSchema = z
@@ -242,7 +247,6 @@ export const StageContributionSchema = z
 export const MarginalReserveMoicResultV1Schema = z
   .object({
     contractVersion: z.literal('marginal-reserve-moic-result-v1'),
-    companyId: z.number().int().positive(),
     status: z.enum(['actionable', 'indicative', 'unavailable']),
     marginalMoic: DecimalStringSchema.nullable(),
     marginalIrr: DecimalStringSchema.nullable(),
@@ -261,9 +265,6 @@ export const MarginalReserveMoicResultV1Schema = z
     validateCanonicalStageOrder(value.stageContributions, ctx, 'stageContributions');
     const hasMagnitudeWarning = value.warnings.some(
       (warning) => warning.code === 'IMPLAUSIBLE_MAGNITUDE'
-    );
-    const hasStaleAssumptionWarning = value.warnings.some(
-      (warning) => warning.code === 'STALE_ASSUMPTION'
     );
     const exceedsMagnitudeThreshold =
       value.marginalMoic !== null && new Decimal(value.marginalMoic).gt(100);
@@ -285,14 +286,14 @@ export const MarginalReserveMoicResultV1Schema = z
         path: ['marginalMoic'],
       });
     }
-    if (value.status === 'indicative' && !exceedsMagnitudeThreshold && !hasStaleAssumptionWarning) {
+    if (value.status === 'indicative' && !exceedsMagnitudeThreshold) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Indicative results require a magnitude or stale-assumption warning',
+        message: 'Indicative results require marginalMoic above 100',
         path: ['marginalMoic'],
       });
     }
-    if (value.status === 'indicative' && exceedsMagnitudeThreshold && !hasMagnitudeWarning) {
+    if (value.status === 'indicative' && !hasMagnitudeWarning) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Indicative results require an IMPLAUSIBLE_MAGNITUDE warning',
@@ -313,10 +314,25 @@ export const MarginalReserveMoicResultV1Schema = z
         path: ['warnings'],
       });
     }
-    if (value.status === 'actionable' && hasStaleAssumptionWarning) {
+  });
+
+export const MarginalReserveRankingItemV1Schema = z
+  .object({
+    companyId: z.number().int().positive(),
+    status: z.enum(['actionable', 'indicative', 'unavailable']),
+    inputReadiness: MarginalReserveInputReadinessSchema,
+    result: MarginalReserveMoicResultV1Schema,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const expectedStatus =
+      value.result.status === 'actionable' && value.inputReadiness.status === 'indicative'
+        ? 'indicative'
+        : value.result.status;
+    if (value.status !== expectedStatus) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Stale assumptions cannot produce an actionable result',
+        message: 'Ranking status must reflect result status and input readiness',
         path: ['status'],
       });
     }
@@ -325,11 +341,13 @@ export const MarginalReserveMoicResultV1Schema = z
 export const MarginalReserveRankingsResponseV1Schema = z
   .object({
     contractVersion: z.literal('marginal-reserve-rankings-v1'),
+    mode: z.literal('shadow'),
+    actionability: z.literal('non_actionable_shadow'),
     fundId: z.number().int().positive(),
     asOfDate: z.string().date(),
     factsInputHash: Sha256Schema,
     assumptionsHash: Sha256Schema,
-    rankings: z.array(MarginalReserveMoicResultV1Schema),
+    rankings: z.array(MarginalReserveRankingItemV1Schema),
     unavailable: z.array(MarginalReserveInputFailureSchema),
   })
   .strict();
@@ -346,6 +364,7 @@ export type StructuredWarning = z.infer<typeof StructuredWarningSchema>;
 export type CounterfactualSummary = z.infer<typeof CounterfactualSummarySchema>;
 export type StageContribution = z.infer<typeof StageContributionSchema>;
 export type MarginalReserveMoicResultV1 = z.infer<typeof MarginalReserveMoicResultV1Schema>;
+export type MarginalReserveRankingItemV1 = z.infer<typeof MarginalReserveRankingItemV1Schema>;
 export type MarginalReserveRankingsResponseV1 = z.infer<
   typeof MarginalReserveRankingsResponseV1Schema
 >;

--- a/shared/contracts/marginal-reserve-moic-v1.contract.ts
+++ b/shared/contracts/marginal-reserve-moic-v1.contract.ts
@@ -31,6 +31,49 @@ export const ProbabilityDecimalStringSchema = DecimalStringSchema.refine(
   { message: 'Expected a decimal string between 0 and 1' }
 );
 
+export const MarginalReserveInputReadinessReasonSchema = z.enum([
+  'MISSING_ACTUALS_FACTS',
+  'MISSING_CURRENT_OWNERSHIP',
+  'MISSING_PUBLISHED_ASSUMPTIONS',
+  'MISSING_STAGE_ASSUMPTION',
+  'MISSING_FOLLOW_ON_POLICY',
+  'MISSING_PLANNED_CHECK',
+  'PLANNED_CHECK_EXCEEDS_ROUND_SIZE',
+  'BLOCKED_CURRENCY',
+  'STALE_ASSUMPTION',
+]);
+
+export const MarginalReserveInputReadinessSchema = z
+  .object({
+    status: z.enum(['actionable', 'indicative']),
+    reasons: z.array(MarginalReserveInputReadinessReasonSchema),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const hasStaleAssumption = value.reasons.includes('STALE_ASSUMPTION');
+    if (value.status === 'actionable' && value.reasons.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Actionable inputs cannot have readiness reasons',
+        path: ['reasons'],
+      });
+    }
+    if (value.status === 'indicative' && !hasStaleAssumption) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Indicative inputs require a stale-assumption reason',
+        path: ['reasons'],
+      });
+    }
+  });
+
+export const MarginalReserveInputFailureSchema = z
+  .object({
+    companyId: z.number().int().positive(),
+    reasons: z.array(MarginalReserveInputReadinessReasonSchema).min(1),
+  })
+  .strict();
+
 const ParticipationSchema = z
   .object({
     participate: z.boolean(),
@@ -79,9 +122,7 @@ export const MarginalReserveStageV1Schema = z
       });
     }
 
-    const probabilitySum = new Decimal(value.exitProbability).plus(
-      value.graduationProbability
-    );
+    const probabilitySum = new Decimal(value.exitProbability).plus(value.graduationProbability);
     if (probabilitySum.gt(1)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -132,14 +173,14 @@ export const MarginalReserveMoicInputV1Schema = z
     factsInputHash: Sha256Schema,
     assumptionsHash: Sha256Schema,
     engineVersion: z.literal('marginal-reserve-moic-v1'),
+    readiness: MarginalReserveInputReadinessSchema.optional(),
   })
   .strict()
   .superRefine((value, ctx) => {
     validateCanonicalStageOrder(value.stages, ctx, 'stages');
 
     const hasCapitalDifference = value.stages.some(
-      (stage) =>
-        !new Decimal(stage.withDecision.checkAmount).eq(stage.withoutDecision.checkAmount)
+      (stage) => !new Decimal(stage.withDecision.checkAmount).eq(stage.withoutDecision.checkAmount)
     );
     if (!hasCapitalDifference) {
       ctx.addIssue({
@@ -155,6 +196,7 @@ export const MarginalReserveWarningCodeSchema = z.enum([
   'MIN_DENOMINATOR_FLOOR',
   'IMPLAUSIBLE_MAGNITUDE',
   'IRR_UNAVAILABLE',
+  'STALE_ASSUMPTION',
 ]);
 
 export const StructuredWarningSchema = z
@@ -200,6 +242,7 @@ export const StageContributionSchema = z
 export const MarginalReserveMoicResultV1Schema = z
   .object({
     contractVersion: z.literal('marginal-reserve-moic-result-v1'),
+    companyId: z.number().int().positive(),
     status: z.enum(['actionable', 'indicative', 'unavailable']),
     marginalMoic: DecimalStringSchema.nullable(),
     marginalIrr: DecimalStringSchema.nullable(),
@@ -219,10 +262,16 @@ export const MarginalReserveMoicResultV1Schema = z
     const hasMagnitudeWarning = value.warnings.some(
       (warning) => warning.code === 'IMPLAUSIBLE_MAGNITUDE'
     );
+    const hasStaleAssumptionWarning = value.warnings.some(
+      (warning) => warning.code === 'STALE_ASSUMPTION'
+    );
     const exceedsMagnitudeThreshold =
       value.marginalMoic !== null && new Decimal(value.marginalMoic).gt(100);
 
-    if (value.status === 'unavailable' && (value.marginalMoic !== null || value.marginalIrr !== null)) {
+    if (
+      value.status === 'unavailable' &&
+      (value.marginalMoic !== null || value.marginalIrr !== null)
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Unavailable results cannot contain marginalMoic or marginalIrr',
@@ -236,14 +285,14 @@ export const MarginalReserveMoicResultV1Schema = z
         path: ['marginalMoic'],
       });
     }
-    if (value.status === 'indicative' && !exceedsMagnitudeThreshold) {
+    if (value.status === 'indicative' && !exceedsMagnitudeThreshold && !hasStaleAssumptionWarning) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Indicative results require marginalMoic above 100',
+        message: 'Indicative results require a magnitude or stale-assumption warning',
         path: ['marginalMoic'],
       });
     }
-    if (value.status === 'indicative' && !hasMagnitudeWarning) {
+    if (value.status === 'indicative' && exceedsMagnitudeThreshold && !hasMagnitudeWarning) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Indicative results require an IMPLAUSIBLE_MAGNITUDE warning',
@@ -264,12 +313,39 @@ export const MarginalReserveMoicResultV1Schema = z
         path: ['warnings'],
       });
     }
+    if (value.status === 'actionable' && hasStaleAssumptionWarning) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Stale assumptions cannot produce an actionable result',
+        path: ['status'],
+      });
+    }
   });
 
+export const MarginalReserveRankingsResponseV1Schema = z
+  .object({
+    contractVersion: z.literal('marginal-reserve-rankings-v1'),
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+    factsInputHash: Sha256Schema,
+    assumptionsHash: Sha256Schema,
+    rankings: z.array(MarginalReserveMoicResultV1Schema),
+    unavailable: z.array(MarginalReserveInputFailureSchema),
+  })
+  .strict();
+
 export type MarginalReserveStageV1 = z.infer<typeof MarginalReserveStageV1Schema>;
+export type MarginalReserveInputReadinessReason = z.infer<
+  typeof MarginalReserveInputReadinessReasonSchema
+>;
+export type MarginalReserveInputReadiness = z.infer<typeof MarginalReserveInputReadinessSchema>;
+export type MarginalReserveInputFailure = z.infer<typeof MarginalReserveInputFailureSchema>;
 export type MarginalReserveMoicInputV1 = z.infer<typeof MarginalReserveMoicInputV1Schema>;
 export type MarginalReserveWarningCode = z.infer<typeof MarginalReserveWarningCodeSchema>;
 export type StructuredWarning = z.infer<typeof StructuredWarningSchema>;
 export type CounterfactualSummary = z.infer<typeof CounterfactualSummarySchema>;
 export type StageContribution = z.infer<typeof StageContributionSchema>;
 export type MarginalReserveMoicResultV1 = z.infer<typeof MarginalReserveMoicResultV1Schema>;
+export type MarginalReserveRankingsResponseV1 = z.infer<
+  typeof MarginalReserveRankingsResponseV1Schema
+>;

--- a/shared/core/moic/MarginalReserveMoic.ts
+++ b/shared/core/moic/MarginalReserveMoic.ts
@@ -260,8 +260,10 @@ function calculateExpectedIrr(datedCashFlows: DatedDecimalCashFlow[]): Decimal |
 }
 
 function normalizeInputForHash(input: MarginalReserveMoicInputV1): unknown {
+  const hashInput = { ...input };
+  delete hashInput.readiness;
   return {
-    ...input,
+    ...hashInput,
     currentOwnership: formatMetric(new Decimal(input.currentOwnership)),
     stages: input.stages.map((stage) => ({
       ...stage,
@@ -308,12 +310,6 @@ export function calculateMarginalReserveMoic(
   );
 
   const warnings: StructuredWarning[] = [];
-  if (parsedInput.readiness?.status === 'indicative') {
-    warnings.push({
-      code: 'STALE_ASSUMPTION',
-      message: 'One or more approved assumptions are stale',
-    });
-  }
   let status: MarginalReserveMoicResultV1['status'];
   let marginalMoic: Decimal | null = null;
   let marginalIrr: Decimal | null = null;
@@ -332,12 +328,8 @@ export function calculateMarginalReserveMoic(
     });
   } else {
     marginalMoic = exactDeltaExpectedProceeds.div(exactDeltaExpectedCapital);
-    const exceedsMagnitudeThreshold = marginalMoic.gt(100);
-    status =
-      exceedsMagnitudeThreshold || parsedInput.readiness?.status === 'indicative'
-        ? 'indicative'
-        : 'actionable';
-    if (exceedsMagnitudeThreshold) {
+    status = marginalMoic.gt(100) ? 'indicative' : 'actionable';
+    if (status === 'indicative') {
       warnings.push({
         code: 'IMPLAUSIBLE_MAGNITUDE',
         message: 'Marginal MOIC exceeds 100x',
@@ -423,7 +415,6 @@ export function calculateMarginalReserveMoic(
 
   const resultWithoutHash: Omit<MarginalReserveMoicResultV1, 'resultHash'> = {
     contractVersion: 'marginal-reserve-moic-result-v1',
-    companyId: parsedInput.companyId,
     status,
     marginalMoic: marginalMoic === null ? null : formatMetric(marginalMoic),
     marginalIrr: marginalIrr === null ? null : formatMetric(marginalIrr),

--- a/shared/core/moic/MarginalReserveMoic.ts
+++ b/shared/core/moic/MarginalReserveMoic.ts
@@ -308,6 +308,12 @@ export function calculateMarginalReserveMoic(
   );
 
   const warnings: StructuredWarning[] = [];
+  if (parsedInput.readiness?.status === 'indicative') {
+    warnings.push({
+      code: 'STALE_ASSUMPTION',
+      message: 'One or more approved assumptions are stale',
+    });
+  }
   let status: MarginalReserveMoicResultV1['status'];
   let marginalMoic: Decimal | null = null;
   let marginalIrr: Decimal | null = null;
@@ -326,8 +332,12 @@ export function calculateMarginalReserveMoic(
     });
   } else {
     marginalMoic = exactDeltaExpectedProceeds.div(exactDeltaExpectedCapital);
-    status = marginalMoic.gt(100) ? 'indicative' : 'actionable';
-    if (status === 'indicative') {
+    const exceedsMagnitudeThreshold = marginalMoic.gt(100);
+    status =
+      exceedsMagnitudeThreshold || parsedInput.readiness?.status === 'indicative'
+        ? 'indicative'
+        : 'actionable';
+    if (exceedsMagnitudeThreshold) {
       warnings.push({
         code: 'IMPLAUSIBLE_MAGNITUDE',
         message: 'Marginal MOIC exceeds 100x',
@@ -413,6 +423,7 @@ export function calculateMarginalReserveMoic(
 
   const resultWithoutHash: Omit<MarginalReserveMoicResultV1, 'resultHash'> = {
     contractVersion: 'marginal-reserve-moic-result-v1',
+    companyId: parsedInput.companyId,
     status,
     marginalMoic: marginalMoic === null ? null : formatMetric(marginalMoic),
     marginalIrr: marginalIrr === null ? null : formatMetric(marginalIrr),

--- a/shared/generated/flag-defaults.ts
+++ b/shared/generated/flag-defaults.ts
@@ -556,6 +556,22 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     expiresAt: null,
     aliases: ['ENABLE_PORTFOLIO_INTELLIGENCE'],
   },
+  enable_marginal_reserve_moic: {
+    default: false,
+    description: 'Gates shadow-only marginal reserve MOIC rankings for internal comparison',
+    owner: 'analytics',
+    risk: 'high',
+    exposeToClient: false,
+
+    environments: {
+      development: false,
+      staging: false,
+      production: false,
+    },
+    dependencies: [],
+    expiresAt: null,
+    aliases: ['ENABLE_MARGINAL_RESERVE_MOIC'],
+  },
   enable_faults: {
     default: false,
     description: 'Enable fault injection for testing',
@@ -769,6 +785,7 @@ export const FLAG_DEFAULTS: FlagRecord = {
   demo_mode: false,
   require_auth: false,
   enable_portfolio_intelligence: false,
+  enable_marginal_reserve_moic: false,
   enable_faults: false,
   enable_wizard_step_general: false,
   enable_wizard_step_sectors: false,
@@ -856,6 +873,7 @@ export const FLAG_ALIASES: Record<string, FlagKey> = {
   UI_CATALOG: 'ui_catalog',
   ONBOARDING_TOUR: 'onboarding_tour',
   ENABLE_PORTFOLIO_INTELLIGENCE: 'enable_portfolio_intelligence',
+  ENABLE_MARGINAL_RESERVE_MOIC: 'enable_marginal_reserve_moic',
   ENABLE_WIZARD_STEP_GENERAL: 'enable_wizard_step_general',
   ENABLE_WIZARD_STEP_SIZING: 'enable_wizard_step_sizing',
   ENABLE_WIZARD_STEP_SECTORS: 'enable_wizard_step_sizing',

--- a/shared/generated/flag-types.ts
+++ b/shared/generated/flag-types.ts
@@ -45,6 +45,7 @@ export type FlagKey =
   | 'demo_mode'
   | 'require_auth'
   | 'enable_portfolio_intelligence'
+  | 'enable_marginal_reserve_moic'
   | 'enable_faults'
   | 'enable_wizard_step_general'
   | 'enable_wizard_step_sectors'
@@ -111,6 +112,7 @@ export type ServerOnlyFlagKey =
   | 'demo_mode'
   | 'require_auth'
   | 'enable_portfolio_intelligence'
+  | 'enable_marginal_reserve_moic'
   | 'enable_faults';
 
 /**
@@ -193,6 +195,7 @@ export const ALL_FLAG_KEYS: readonly FlagKey[] = [
   'demo_mode',
   'require_auth',
   'enable_portfolio_intelligence',
+  'enable_marginal_reserve_moic',
   'enable_faults',
   'enable_wizard_step_general',
   'enable_wizard_step_sectors',

--- a/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
+++ b/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   MIN_DELTA_CAPITAL_FLOOR,
   MarginalReserveMoicInputV1Schema,
+  MarginalReserveInputFailureSchema,
   MarginalReserveMoicResultV1Schema,
   MarginalReserveStageV1Schema,
 } from '@shared/contracts/marginal-reserve-moic-v1.contract';
@@ -44,6 +45,7 @@ function makeInput(overrides: Record<string, unknown> = {}) {
 function makeResult(overrides: Record<string, unknown> = {}) {
   return {
     contractVersion: 'marginal-reserve-moic-result-v1',
+    companyId: 2,
     status: 'actionable',
     marginalMoic: '5.000000',
     marginalIrr: null,
@@ -195,6 +197,33 @@ describe('MarginalReserveMoicInputV1Schema', () => {
       }).success
     ).toBe(false);
   });
+
+  it('represents stale assumptions as indicative input readiness', () => {
+    expect(
+      MarginalReserveMoicInputV1Schema.safeParse(
+        makeInput({
+          readiness: { status: 'indicative', reasons: ['STALE_ASSUMPTION'] },
+        })
+      ).success
+    ).toBe(true);
+    expect(
+      MarginalReserveMoicInputV1Schema.safeParse(
+        makeInput({ readiness: { status: 'actionable', reasons: ['STALE_ASSUMPTION'] } })
+      ).success
+    ).toBe(false);
+  });
+
+  it('requires explicit reasons for unavailable company inputs', () => {
+    expect(
+      MarginalReserveInputFailureSchema.parse({
+        companyId: 2,
+        reasons: ['MISSING_CURRENT_OWNERSHIP'],
+      })
+    ).toEqual({ companyId: 2, reasons: ['MISSING_CURRENT_OWNERSHIP'] });
+    expect(MarginalReserveInputFailureSchema.safeParse({ companyId: 2, reasons: [] }).success).toBe(
+      false
+    );
+  });
 });
 
 describe('MarginalReserveMoicResultV1Schema', () => {
@@ -226,9 +255,7 @@ describe('MarginalReserveMoicResultV1Schema', () => {
         makeResult({
           status: 'indicative',
           marginalMoic: '101.000000',
-          warnings: [
-            { code: 'IMPLAUSIBLE_MAGNITUDE', message: 'Marginal MOIC exceeds 100x' },
-          ],
+          warnings: [{ code: 'IMPLAUSIBLE_MAGNITUDE', message: 'Marginal MOIC exceeds 100x' }],
         })
       ).success
     ).toBe(true);
@@ -245,12 +272,22 @@ describe('MarginalReserveMoicResultV1Schema', () => {
         makeResult({
           status: 'indicative',
           marginalMoic: '100.000000',
-          warnings: [
-            { code: 'IMPLAUSIBLE_MAGNITUDE', message: 'Marginal MOIC exceeds 100x' },
-          ],
+          warnings: [{ code: 'IMPLAUSIBLE_MAGNITUDE', message: 'Marginal MOIC exceeds 100x' }],
         })
       ).success
     ).toBe(false);
+  });
+
+  it('accepts stale-assumption indicative results below 100x', () => {
+    expect(
+      MarginalReserveMoicResultV1Schema.safeParse(
+        makeResult({
+          status: 'indicative',
+          marginalMoic: '5.000000',
+          warnings: [{ code: 'STALE_ASSUMPTION', message: 'Approved assumptions are stale' }],
+        })
+      ).success
+    ).toBe(true);
   });
 });
 

--- a/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
+++ b/tests/unit/contracts/marginal-reserve-moic-v1.contract.test.ts
@@ -4,6 +4,7 @@ import {
   MarginalReserveMoicInputV1Schema,
   MarginalReserveInputFailureSchema,
   MarginalReserveMoicResultV1Schema,
+  MarginalReserveRankingItemV1Schema,
   MarginalReserveStageV1Schema,
 } from '@shared/contracts/marginal-reserve-moic-v1.contract';
 
@@ -45,7 +46,6 @@ function makeInput(overrides: Record<string, unknown> = {}) {
 function makeResult(overrides: Record<string, unknown> = {}) {
   return {
     contractVersion: 'marginal-reserve-moic-result-v1',
-    companyId: 2,
     status: 'actionable',
     marginalMoic: '5.000000',
     marginalIrr: null,
@@ -278,16 +278,32 @@ describe('MarginalReserveMoicResultV1Schema', () => {
     ).toBe(false);
   });
 
-  it('accepts stale-assumption indicative results below 100x', () => {
+  it('keeps stale readiness outside the strict V1 engine result', () => {
     expect(
       MarginalReserveMoicResultV1Schema.safeParse(
         makeResult({
           status: 'indicative',
           marginalMoic: '5.000000',
-          warnings: [{ code: 'STALE_ASSUMPTION', message: 'Approved assumptions are stale' }],
+          warnings: [],
         })
       ).success
+    ).toBe(false);
+    expect(
+      MarginalReserveRankingItemV1Schema.safeParse({
+        companyId: 2,
+        status: 'indicative',
+        inputReadiness: { status: 'indicative', reasons: ['STALE_ASSUMPTION'] },
+        result: makeResult(),
+      }).success
     ).toBe(true);
+    expect(
+      MarginalReserveRankingItemV1Schema.safeParse({
+        companyId: 2,
+        status: 'actionable',
+        inputReadiness: { status: 'indicative', reasons: ['STALE_ASSUMPTION'] },
+        result: makeResult(),
+      }).success
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/engines/marginal-reserve-moic.test.ts
+++ b/tests/unit/engines/marginal-reserve-moic.test.ts
@@ -210,15 +210,18 @@ describe('calculateMarginalReserveMoic', () => {
     expect(result.warnings.map((warning) => warning.code)).toContain('IMPLAUSIBLE_MAGNITUDE');
   });
 
-  it('downgrades a supported result when approved assumptions are stale', () => {
-    const input = baseInput();
-    input.readiness = { status: 'indicative', reasons: ['STALE_ASSUMPTION'] };
+  it('keeps source readiness from mutating the strict V1 engine result', () => {
+    const omittedReadiness = calculateMarginalReserveMoic(baseInput());
+    const actionableInput = baseInput();
+    actionableInput.readiness = { status: 'actionable', reasons: [] };
+    const staleInput = baseInput();
+    staleInput.readiness = { status: 'indicative', reasons: ['STALE_ASSUMPTION'] };
 
-    const result = calculateMarginalReserveMoic(input);
+    const actionableReadiness = calculateMarginalReserveMoic(actionableInput);
+    const staleReadiness = calculateMarginalReserveMoic(staleInput);
 
-    expect(result.status).toBe('indicative');
-    expect(result.marginalMoic).toBe('5.000000');
-    expect(result.warnings.map((warning) => warning.code)).toContain('STALE_ASSUMPTION');
+    expect(actionableReadiness).toEqual(omittedReadiness);
+    expect(staleReadiness).toEqual(omittedReadiness);
   });
 
   it('rejects an invalid probability sum before projection', () => {

--- a/tests/unit/engines/marginal-reserve-moic.test.ts
+++ b/tests/unit/engines/marginal-reserve-moic.test.ts
@@ -210,6 +210,17 @@ describe('calculateMarginalReserveMoic', () => {
     expect(result.warnings.map((warning) => warning.code)).toContain('IMPLAUSIBLE_MAGNITUDE');
   });
 
+  it('downgrades a supported result when approved assumptions are stale', () => {
+    const input = baseInput();
+    input.readiness = { status: 'indicative', reasons: ['STALE_ASSUMPTION'] };
+
+    const result = calculateMarginalReserveMoic(input);
+
+    expect(result.status).toBe('indicative');
+    expect(result.marginalMoic).toBe('5.000000');
+    expect(result.warnings.map((warning) => warning.code)).toContain('STALE_ASSUMPTION');
+  });
+
   it('rejects an invalid probability sum before projection', () => {
     const input = baseInput();
     input.stages[0]!.exitProbability = '0.6';

--- a/tests/unit/flags/marginal-reserve-moic-flag.test.ts
+++ b/tests/unit/flags/marginal-reserve-moic-flag.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CLIENT_FLAG_KEYS,
+  type FlagKey,
+  type ServerOnlyFlagKey,
+} from '../../../shared/generated/flag-types.js';
+import {
+  FLAG_ALIASES,
+  FLAG_DEFAULTS,
+  FLAG_DEFINITIONS,
+  resolveAlias,
+} from '../../../shared/generated/flag-defaults.js';
+
+const flagKey: FlagKey = 'enable_marginal_reserve_moic';
+const serverOnlyFlagKey: ServerOnlyFlagKey = flagKey;
+const environmentAlias = 'ENABLE_MARGINAL_RESERVE_MOIC';
+
+describe('enable_marginal_reserve_moic flag registration', () => {
+  it('defaults off in every environment and resolves its server alias', () => {
+    expect(FLAG_DEFAULTS[flagKey]).toBe(false);
+    expect(FLAG_DEFINITIONS[flagKey].environments).toEqual({
+      development: false,
+      staging: false,
+      production: false,
+    });
+    expect(FLAG_ALIASES[environmentAlias]).toBe(flagKey);
+    expect(resolveAlias(environmentAlias)).toBe(flagKey);
+  });
+
+  it('is server-only and absent from the client flag surface', () => {
+    expect(FLAG_DEFINITIONS[serverOnlyFlagKey]).toMatchObject({
+      default: false,
+      owner: 'analytics',
+      exposeToClient: false,
+    });
+    expect(CLIENT_FLAG_KEYS).not.toContain(flagKey);
+  });
+});

--- a/tests/unit/route-policy/canonical-moic-route.policy.test.ts
+++ b/tests/unit/route-policy/canonical-moic-route.policy.test.ts
@@ -16,6 +16,7 @@ import { verifyRoutePolicy } from '../../../scripts/verify-route-policy';
 const CANONICAL = '/fund-model-results/:fundId/moic-analysis';
 const ADMIN_INPUT_ROUTE = '/api/admin/funds/:fundId/moic-inputs/portfolio-companies/:companyId';
 const ADMIN_MODE_ROUTE = '/api/admin/funds/:fundId/calculation-modes/fund-moic-rankings';
+const MARGINAL_SHADOW_ROUTE = '/api/funds/:fundId/moic/marginal-rankings';
 
 const entry = (path: string): RouteGovernanceEntry => ({
   path,
@@ -116,6 +117,29 @@ describe('route-policy: canonical fund-model-results MOIC route', () => {
     expect(modeEntry ? EXPLICIT_API_ROUTE_POLICY_KEYS.has(routePolicyKey(modeEntry)) : false).toBe(
       true
     );
+  });
+
+  it('registers the marginal shadow route as a fund-scoped financial surface', () => {
+    const entry = API_ROUTE_POLICY_REGISTRY.find(
+      (candidate) => candidate.path === MARGINAL_SHADOW_ROUTE
+    );
+
+    expect(entry).toMatchObject({
+      id: 'api:get:/api/funds/:fundId/moic/marginal-rankings',
+      method: 'GET',
+      lifecycle: 'durable_crud',
+      governanceRef: CANONICAL,
+      surface: 'marginal-reserve-moic-shadow-api',
+      owner: 'analytics',
+      financialSurface: 'moic_reserves',
+      apiAuthBoundary: 'require_auth_and_fund_access',
+      fundScopeMode: 'route_param_fund_id',
+      workflowRequirement: 'shadow_review_required',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+      humanReviewRequired: true,
+    });
+    expect(entry ? EXPLICIT_API_ROUTE_POLICY_KEYS.has(routePolicyKey(entry)) : false).toBe(true);
   });
 
   it('allows scoped admin-only MOIC financial-control API entries in policy verification', () => {

--- a/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
@@ -1,0 +1,181 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MarginalReserveMoicInputV1 } from '../../../shared/contracts/marginal-reserve-moic-v1.contract';
+import { MarginalReserveRankingsResponseV1Schema } from '../../../shared/contracts/marginal-reserve-moic-v1.contract';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+
+const authState = vi.hoisted(() => ({
+  user: null as null | { id: number; role: string; fundIds: number[] },
+}));
+const featureState = vi.hoisted(() => ({ enabled: false }));
+const inputService = vi.hoisted(() => ({ build: vi.fn() }));
+
+vi.mock('../../../server/config/features', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/config/features')>();
+  const features = { ...actual.FEATURES };
+  Object.defineProperty(features, 'marginalReserveMoic', {
+    enumerable: true,
+    get: () => featureState.enabled,
+  });
+  return { ...actual, FEATURES: features };
+});
+
+vi.mock('../../../server/services/moic/marginal-reserve-moic-input-service', () => ({
+  buildMarginalReserveMoicInputs: inputService.build,
+}));
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
+      if (!authState.user) return res.sendStatus(401);
+      (req as Request & { user: unknown }).user = { ...authState.user };
+      next();
+    },
+  };
+});
+
+import fundMoicRouter from '../../../server/routes/fund-moic';
+
+function marginalInput(params: {
+  companyId: number;
+  exitValuation: string;
+  readiness?: MarginalReserveMoicInputV1['readiness'];
+}): MarginalReserveMoicInputV1 {
+  return {
+    contractVersion: 'marginal-reserve-moic-input-v1',
+    fundId: 1,
+    companyId: params.companyId,
+    baseCurrency: 'USD',
+    asOfDate: '2026-07-12',
+    currentOwnership: '0',
+    stages: [
+      {
+        stage: 'series_a',
+        preMoneyValuation: '8000000',
+        roundSize: '2000000',
+        monthsFromPriorStage: 12,
+        graduationProbability: '0',
+        exitProbability: '1',
+        exitValuation: params.exitValuation,
+        withDecision: { participate: true, checkAmount: '1000000' },
+        withoutDecision: { participate: false, checkAmount: '0' },
+      },
+    ],
+    factsInputHash: HASH_A,
+    assumptionsHash: HASH_B,
+    engineVersion: 'marginal-reserve-moic-v1',
+    readiness: params.readiness ?? { status: 'actionable', reasons: [] },
+  };
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', fundMoicRouter);
+  app.use((_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
+    res.status(500).json({ error: 'internal_error' })
+  );
+  return app;
+}
+
+function getRankings(path = '/api/funds/1/moic/marginal-rankings?asOfDate=2026-07-12') {
+  return request(buildApp()).get(path);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = { id: 101, role: 'admin', fundIds: [1] };
+  featureState.enabled = true;
+  inputService.build.mockResolvedValue({
+    ready: [
+      marginalInput({
+        companyId: 2,
+        exitValuation: '30000000',
+        readiness: { status: 'indicative', reasons: ['STALE_ASSUMPTION'] },
+      }),
+      marginalInput({ companyId: 1, exitValuation: '50000000' }),
+      marginalInput({ companyId: 4, exitValuation: '20000000' }),
+    ],
+    unavailable: [{ companyId: 3, reasons: ['MISSING_CURRENT_OWNERSHIP'] }],
+    factsInputHash: HASH_A,
+    assumptionsHash: HASH_B,
+  });
+});
+
+describe('marginal reserve MOIC shadow route', () => {
+  it('returns 404 without reading inputs when the server flag is off', async () => {
+    featureState.enabled = false;
+
+    const response = await getRankings();
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'not_found' });
+    expect(inputService.build).not.toHaveBeenCalled();
+  });
+
+  it('returns strict results sorted by status then descending marginal MOIC', async () => {
+    const response = await getRankings();
+
+    expect(response.status).toBe(200);
+    const parsed = MarginalReserveRankingsResponseV1Schema.parse(response.body);
+    expect(parsed.rankings.map((ranking) => [ranking.companyId, ranking.status])).toEqual([
+      [1, 'actionable'],
+      [4, 'actionable'],
+      [2, 'indicative'],
+    ]);
+    expect(parsed.unavailable).toEqual([{ companyId: 3, reasons: ['MISSING_CURRENT_OWNERSHIP'] }]);
+    expect(inputService.build).toHaveBeenCalledWith({ fundId: 1, asOfDate: '2026-07-12' });
+  });
+
+  it('requires authentication before any source read', async () => {
+    authState.user = null;
+
+    const response = await getRankings();
+
+    expect(response.status).toBe(401);
+    expect(inputService.build).not.toHaveBeenCalled();
+  });
+
+  it('rejects users without access to the requested fund', async () => {
+    authState.user = { id: 101, role: 'gp', fundIds: [2] };
+
+    const response = await getRankings();
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      error: 'Forbidden',
+      message: 'You do not have access to fund 1',
+    });
+    expect(inputService.build).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric fund ID with the sibling guard status', async () => {
+    const response = await getRankings(
+      '/api/funds/not-a-number/moic/marginal-rankings?asOfDate=2026-07-12'
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Bad Request', message: 'Invalid fund ID' });
+    expect(inputService.build).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/api/funds/1/moic/marginal-rankings',
+    '/api/funds/1/moic/marginal-rankings?asOfDate=07-12-2026',
+  ])('rejects a missing or invalid asOfDate: %s', async (path) => {
+    const response = await getRankings(path);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: 'invalid_as_of_date',
+      message: 'asOfDate must be provided as YYYY-MM-DD',
+    });
+    expect(inputService.build).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
@@ -124,12 +124,14 @@ describe('marginal reserve MOIC shadow route', () => {
 
     expect(response.status).toBe(200);
     const parsed = MarginalReserveRankingsResponseV1Schema.parse(response.body);
+    expect(parsed).toMatchObject({ mode: 'shadow', actionability: 'non_actionable_shadow' });
     expect(parsed.rankings.map((ranking) => [ranking.companyId, ranking.status])).toEqual([
       [1, 'actionable'],
       [4, 'actionable'],
       [2, 'indicative'],
     ]);
     expect(parsed.unavailable).toEqual([{ companyId: 3, reasons: ['MISSING_CURRENT_OWNERSHIP'] }]);
+    expect(parsed.rankings[0]?.result).not.toHaveProperty('companyId');
     expect(inputService.build).toHaveBeenCalledWith({ fundId: 1, asOfDate: '2026-07-12' });
   });
 

--- a/tests/unit/services/moic/marginal-reserve-moic-input-service.test.ts
+++ b/tests/unit/services/moic/marginal-reserve-moic-input-service.test.ts
@@ -88,26 +88,26 @@ function publishedConfig(overrides: Record<string, unknown> = {}) {
           {
             id: 'seed',
             name: 'Seed',
-            roundSize: 2000000,
-            valuation: 8000000,
+            roundSize: 2,
+            valuation: 8,
             valuationType: 'pre',
             esopPct: 10,
             graduationRate: 40,
             exitRate: 10,
-            exitValuation: 30000000,
+            exitValuation: 30,
             monthsToGraduate: 12,
             monthsToExit: 48,
           },
           {
             id: 'series-a',
             name: 'Series A',
-            roundSize: 5000000,
-            valuation: 20000000,
+            roundSize: 5,
+            valuation: 20,
             valuationType: 'pre',
             esopPct: 10,
             graduationRate: 30,
             exitRate: 20,
-            exitValuation: 75000000,
+            exitValuation: 75,
             monthsToGraduate: 18,
             monthsToExit: 48,
           },
@@ -122,6 +122,7 @@ function sources(
   overrides: Partial<MarginalReserveInputSources> = {}
 ): MarginalReserveInputSources {
   return {
+    sourceSnapshotDate: '2026-07-12',
     baseCurrency: 'USD',
     facts: facts(),
     companies: [
@@ -132,6 +133,18 @@ function sources(
         sector: 'SaaS',
         currentOwnership: '0.125',
         plannedReservesCents: 100_000_000,
+        allocationVersion: 3,
+      },
+    ],
+    approvedAllocations: [
+      {
+        companyId: 11,
+        decisionType: 'follow_on',
+        decisionStatus: 'approved',
+        finalPlannedReservesCents: 100_000_000,
+        liveAllocationVersion: 3,
+        decidedAt: new Date('2026-07-10T00:00:00.000Z'),
+        updatedAt: new Date('2026-07-10T00:00:00.000Z'),
       },
     ],
     publishedAssumptions: {
@@ -161,7 +174,7 @@ describe('marginal reserve MOIC input assembly', () => {
     expect(result.ready[0]).toMatchObject({
       companyId: 11,
       currentOwnership: '0.125',
-      factsInputHash: HASH,
+      factsInputHash: expect.stringMatching(/^[a-f0-9]{64}$/),
       readiness: { status: 'actionable', reasons: [] },
       stages: [
         {
@@ -192,12 +205,13 @@ describe('marginal reserve MOIC input assembly', () => {
             {
               id: 'series-a',
               name: 'Series A',
-              roundSize: 5000000,
-              valuation: 20000000,
+              roundSize: 5,
+              valuation: 20,
               valuationType: 'pre',
               esopPct: 10,
               graduationRate: 30,
-              exitRate: 20,
+              exitRate: 101,
+              exitValuation: 0,
               monthsToGraduate: 18,
               monthsToExit: 48,
             },
@@ -215,7 +229,7 @@ describe('marginal reserve MOIC input assembly', () => {
     });
 
     expect(result.ready).toEqual([]);
-    expect(result.unavailable[0]?.reasons).toContain('MISSING_PUBLISHED_ASSUMPTIONS');
+    expect(result.unavailable[0]?.reasons).toContain('MISSING_STAGE_ASSUMPTION');
   });
 
   it('returns every applicable readiness reason for unavailable companies', () => {
@@ -229,7 +243,8 @@ describe('marginal reserve MOIC input assembly', () => {
           currentStage: 'Seed',
           sector: 'SaaS',
           currentOwnership: null,
-          plannedReservesCents: 0,
+          plannedReservesCents: 100_000_000,
+          allocationVersion: 3,
         },
       ],
       publishedAssumptions: null,
@@ -254,23 +269,50 @@ describe('marginal reserve MOIC input assembly', () => {
   it('hashes facts and assumptions separately and deterministically', () => {
     const first = assemble();
     const same = assemble();
-    const changed = assemble({
+    const changedAssumption = assemble({
+      publishedAssumptions: {
+        configId: 7,
+        version: 4,
+        publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+        config: publishedConfig({
+          capitalPlanAllocations: [
+            {
+              id: 'saas-seed',
+              name: 'SaaS Seed',
+              sectorProfileId: 'saas',
+              entryRound: 'Seed',
+              capitalAllocationPct: 100,
+              initialCheckStrategy: 'amount',
+              initialCheckAmount: 500000,
+              followOnStrategy: 'amount',
+              followOnAmount: 2000000,
+              followOnParticipationPct: 100,
+              investmentHorizonMonths: 60,
+            },
+          ],
+        }),
+      },
+    });
+    const changedFact = assemble({
       companies: [
         {
           companyId: 11,
           stage: 'Seed',
           currentStage: 'Seed',
           sector: 'SaaS',
-          currentOwnership: '0.125',
-          plannedReservesCents: 200_000_000,
+          currentOwnership: '0.25',
+          plannedReservesCents: 100_000_000,
+          allocationVersion: 3,
         },
       ],
     });
 
     expect(first.factsInputHash).toBe(same.factsInputHash);
     expect(first.assumptionsHash).toBe(same.assumptionsHash);
-    expect(changed.factsInputHash).toBe(first.factsInputHash);
-    expect(changed.assumptionsHash).not.toBe(first.assumptionsHash);
+    expect(changedAssumption.factsInputHash).toBe(first.factsInputHash);
+    expect(changedAssumption.assumptionsHash).not.toBe(first.assumptionsHash);
+    expect(changedFact.factsInputHash).not.toBe(first.factsInputHash);
+    expect(changedFact.assumptionsHash).toBe(first.assumptionsHash);
   });
 
   it('marks ready inputs indicative when the published assumptions are stale', () => {
@@ -298,7 +340,119 @@ describe('marginal reserve MOIC input assembly', () => {
     expect(result.unavailable[0]?.reasons).toContain('BLOCKED_CURRENCY');
   });
 
+  it('reports unknown currency separately from an explicit mismatch block', () => {
+    const result = assemble({ facts: facts({ currencyStatus: 'unknown' }) });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('UNKNOWN_CURRENCY');
+    expect(result.unavailable[0]?.reasons).not.toContain('BLOCKED_CURRENCY');
+  });
+
+  it('does not mislabel missing facts as a known currency mismatch', () => {
+    const missingFacts = facts();
+    missingFacts.facts = [];
+    const result = assemble({ facts: missingFacts });
+
+    expect(result.unavailable[0]?.reasons).toContain('MISSING_ACTUALS_FACTS');
+    expect(result.unavailable[0]?.reasons).not.toContain('BLOCKED_CURRENCY');
+  });
+
+  it('builds the complete supported future stage path from approved assumptions', () => {
+    const config = publishedConfig();
+    const pipeline = config.pipelineProfiles?.[0];
+    if (!pipeline) throw new Error('Expected fixture pipeline');
+    pipeline.stages.push({
+      id: 'series-b',
+      name: 'Series B',
+      roundSize: 10,
+      valuation: 40,
+      valuationType: 'pre',
+      esopPct: 10,
+      graduationRate: 0,
+      exitRate: 100,
+      exitValuation: 150,
+      monthsToGraduate: 24,
+      monthsToExit: 36,
+    });
+    const result = assemble({
+      publishedAssumptions: {
+        configId: 7,
+        version: 3,
+        publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+        config,
+      },
+    });
+
+    expect(result.unavailable).toEqual([]);
+    expect(result.ready[0]?.stages.map((stage) => stage.stage)).toEqual(['series_a', 'series_b']);
+    expect(result.ready[0]?.stages.map((stage) => stage.withDecision.checkAmount)).toEqual([
+      '1000000',
+      '0',
+    ]);
+    expect(result.ready[0]?.stages.map((stage) => stage.monthsFromPriorStage)).toEqual([12, 18]);
+  });
+
   it('rejects a planned check that exceeds the approved prospective round size', () => {
+    const result = assemble({
+      publishedAssumptions: {
+        configId: 7,
+        version: 3,
+        publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+        config: publishedConfig({
+          capitalPlanAllocations: [
+            {
+              id: 'saas-seed',
+              name: 'SaaS Seed',
+              sectorProfileId: 'saas',
+              entryRound: 'Seed',
+              capitalAllocationPct: 100,
+              initialCheckStrategy: 'amount',
+              initialCheckAmount: 500000,
+              followOnStrategy: 'amount',
+              followOnAmount: 6000000,
+              followOnParticipationPct: 100,
+              investmentHorizonMonths: 60,
+            },
+          ],
+        }),
+      },
+    });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('PLANNED_CHECK_EXCEEDS_ROUND_SIZE');
+  });
+
+  it('fails closed when current portfolio state does not match the requested date', () => {
+    const result = assemble({ sourceSnapshotDate: '2026-07-13' });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('CURRENT_STATE_DATE_MISMATCH');
+  });
+
+  it('fails closed when assumptions were published after the requested date', () => {
+    const result = assemble({
+      publishedAssumptions: {
+        configId: 7,
+        version: 3,
+        publishedAt: new Date('2026-07-13T00:00:00.000Z'),
+        config: publishedConfig(),
+      },
+    });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('ASSUMPTION_NOT_EFFECTIVE');
+  });
+
+  it('fails closed when facts do not match the requested fund and date', () => {
+    const mismatchedFacts = facts();
+    mismatchedFacts.asOfDate = '2026-07-11';
+    const result = assemble({ facts: mismatchedFacts });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('FACTS_SCOPE_MISMATCH');
+  });
+
+  it('requires ownership to use the explicit fractional 0-to-1 contract', () => {
     const result = assemble({
       companies: [
         {
@@ -306,14 +460,22 @@ describe('marginal reserve MOIC input assembly', () => {
           stage: 'Seed',
           currentStage: 'Seed',
           sector: 'SaaS',
-          currentOwnership: '0.125',
-          plannedReservesCents: 600_000_000,
+          currentOwnership: '12.5',
+          plannedReservesCents: 100_000_000,
+          allocationVersion: 3,
         },
       ],
     });
 
     expect(result.ready).toEqual([]);
-    expect(result.unavailable[0]?.reasons).toContain('PLANNED_CHECK_EXCEEDS_ROUND_SIZE');
+    expect(result.unavailable[0]?.reasons).toContain('MISSING_CURRENT_OWNERSHIP');
+  });
+
+  it('requires a current approved company follow-on allocation', () => {
+    const result = assemble({ approvedAllocations: [] });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('MISSING_APPROVED_ALLOCATION');
   });
 
   it('does not import or query raw rounds or valuation marks', async () => {

--- a/tests/unit/services/moic/marginal-reserve-moic-input-service.test.ts
+++ b/tests/unit/services/moic/marginal-reserve-moic-input-service.test.ts
@@ -1,0 +1,331 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import type { FundCompanyActualsFactsResponse } from '../../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { canonicalSha256 } from '../../../../shared/lib/canonical-hash';
+import {
+  buildMarginalReserveMoicInputsFromSources,
+  type MarginalReserveInputSources,
+} from '../../../../server/services/moic/marginal-reserve-moic-input-service';
+
+const HASH = canonicalSha256({ facts: 'fixture' });
+
+function facts(
+  overrides: Partial<FundCompanyActualsFactsResponse['facts'][number]> = {}
+): FundCompanyActualsFactsResponse {
+  return {
+    fundId: 1,
+    asOfDate: '2026-07-12',
+    inputHash: HASH,
+    generatedAt: '2026-07-12T00:00:00.000Z',
+    facts: [
+      {
+        fundId: 1,
+        companyId: 11,
+        companyName: 'Fixture Company',
+        investmentIds: [101],
+        activeRoundIds: [201],
+        approvedPlanningFmvMarkId: null,
+        planningFmvStatus: 'none',
+        initialInvestmentAmount: '1000000',
+        followOnInvestmentAmount: '0',
+        amountOnlyNonEquityAmount: '0',
+        latestRoundDate: '2026-01-01',
+        latestRoundValuation: '999999999999',
+        latestPlanningFmvDate: null,
+        latestPlanningFmvValue: null,
+        currency: 'USD',
+        currencyStatus: 'base_currency',
+        supersedeLineage: [{ roundId: 201, supersedesRoundId: null }],
+        warnings: [],
+        provenance: {
+          trustState: 'LIVE',
+          sourceKind: 'db_actuals',
+          sourceRecordIds: ['company:11'],
+          asOf: '2026-07-12T00:00:00.000Z',
+          lastReconciledAt: null,
+          staleAfter: null,
+          warnings: [],
+        },
+        inputHash: canonicalSha256({ companyId: 11 }),
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function publishedConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    fundName: 'Fixture Fund',
+    stages: [
+      { id: 'seed', name: 'Seed', graduate: 40, exit: 10, months: 12 },
+      { id: 'series-a', name: 'Series A', graduate: 30, exit: 20, months: 18 },
+    ],
+    sectorProfiles: [{ id: 'saas', name: 'SaaS', targetPercentage: 100 }],
+    capitalPlanAllocations: [
+      {
+        id: 'saas-seed',
+        name: 'SaaS Seed',
+        sectorProfileId: 'saas',
+        entryRound: 'Seed',
+        capitalAllocationPct: 100,
+        initialCheckStrategy: 'amount',
+        initialCheckAmount: 500000,
+        followOnStrategy: 'amount',
+        followOnAmount: 1000000,
+        followOnParticipationPct: 100,
+        investmentHorizonMonths: 60,
+      },
+    ],
+    pipelineProfiles: [
+      {
+        id: 'default',
+        name: 'Default',
+        stages: [
+          {
+            id: 'seed',
+            name: 'Seed',
+            roundSize: 2000000,
+            valuation: 8000000,
+            valuationType: 'pre',
+            esopPct: 10,
+            graduationRate: 40,
+            exitRate: 10,
+            exitValuation: 30000000,
+            monthsToGraduate: 12,
+            monthsToExit: 48,
+          },
+          {
+            id: 'series-a',
+            name: 'Series A',
+            roundSize: 5000000,
+            valuation: 20000000,
+            valuationType: 'pre',
+            esopPct: 10,
+            graduationRate: 30,
+            exitRate: 20,
+            exitValuation: 75000000,
+            monthsToGraduate: 18,
+            monthsToExit: 48,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function sources(
+  overrides: Partial<MarginalReserveInputSources> = {}
+): MarginalReserveInputSources {
+  return {
+    baseCurrency: 'USD',
+    facts: facts(),
+    companies: [
+      {
+        companyId: 11,
+        stage: 'Seed',
+        currentStage: 'Seed',
+        sector: 'SaaS',
+        currentOwnership: '0.125',
+        plannedReservesCents: 100_000_000,
+      },
+    ],
+    publishedAssumptions: {
+      configId: 7,
+      version: 3,
+      publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+      config: publishedConfig(),
+    },
+    ...overrides,
+  };
+}
+
+function assemble(sourceOverrides: Partial<MarginalReserveInputSources> = {}) {
+  return buildMarginalReserveMoicInputsFromSources({
+    fundId: 1,
+    asOfDate: '2026-07-12',
+    sources: sources(sourceOverrides),
+  });
+}
+
+describe('marginal reserve MOIC input assembly', () => {
+  it('assembles from facts plus explicit ownership and published assumptions', () => {
+    const result = assemble();
+
+    expect(result.unavailable).toEqual([]);
+    expect(result.ready).toHaveLength(1);
+    expect(result.ready[0]).toMatchObject({
+      companyId: 11,
+      currentOwnership: '0.125',
+      factsInputHash: HASH,
+      readiness: { status: 'actionable', reasons: [] },
+      stages: [
+        {
+          stage: 'series_a',
+          preMoneyValuation: '20000000',
+          roundSize: '5000000',
+          exitValuation: '75000000',
+          withDecision: { participate: true, checkAmount: '1000000' },
+          withoutDecision: { participate: false, checkAmount: '0' },
+        },
+      ],
+    });
+  });
+
+  it('never reuses the latest actual round valuation as future exit value', () => {
+    const result = assemble({ facts: facts({ latestRoundValuation: '123456789012345' }) });
+
+    expect(result.ready[0]?.stages[0]?.exitValuation).toBe('75000000');
+  });
+
+  it('does not default missing approved probabilities or multiples', () => {
+    const invalidConfig = publishedConfig({
+      pipelineProfiles: [
+        {
+          id: 'default',
+          name: 'Default',
+          stages: [
+            {
+              id: 'series-a',
+              name: 'Series A',
+              roundSize: 5000000,
+              valuation: 20000000,
+              valuationType: 'pre',
+              esopPct: 10,
+              graduationRate: 30,
+              exitRate: 20,
+              monthsToGraduate: 18,
+              monthsToExit: 48,
+            },
+          ],
+        },
+      ],
+    });
+    const result = assemble({
+      publishedAssumptions: {
+        configId: 7,
+        version: 3,
+        publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+        config: invalidConfig,
+      },
+    });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('MISSING_PUBLISHED_ASSUMPTIONS');
+  });
+
+  it('returns every applicable readiness reason for unavailable companies', () => {
+    const result = assemble({
+      baseCurrency: 'EUR',
+      facts: facts({ currency: 'EUR', currencyStatus: 'mismatch_blocked' }),
+      companies: [
+        {
+          companyId: 11,
+          stage: 'Seed',
+          currentStage: 'Seed',
+          sector: 'SaaS',
+          currentOwnership: null,
+          plannedReservesCents: 0,
+        },
+      ],
+      publishedAssumptions: null,
+    });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable).toEqual([
+      {
+        companyId: 11,
+        reasons: expect.arrayContaining([
+          'BLOCKED_CURRENCY',
+          'MISSING_CURRENT_OWNERSHIP',
+          'MISSING_FOLLOW_ON_POLICY',
+          'MISSING_PLANNED_CHECK',
+          'MISSING_PUBLISHED_ASSUMPTIONS',
+          'MISSING_STAGE_ASSUMPTION',
+        ]),
+      },
+    ]);
+  });
+
+  it('hashes facts and assumptions separately and deterministically', () => {
+    const first = assemble();
+    const same = assemble();
+    const changed = assemble({
+      companies: [
+        {
+          companyId: 11,
+          stage: 'Seed',
+          currentStage: 'Seed',
+          sector: 'SaaS',
+          currentOwnership: '0.125',
+          plannedReservesCents: 200_000_000,
+        },
+      ],
+    });
+
+    expect(first.factsInputHash).toBe(same.factsInputHash);
+    expect(first.assumptionsHash).toBe(same.assumptionsHash);
+    expect(changed.factsInputHash).toBe(first.factsInputHash);
+    expect(changed.assumptionsHash).not.toBe(first.assumptionsHash);
+  });
+
+  it('marks ready inputs indicative when the published assumptions are stale', () => {
+    const result = assemble({
+      publishedAssumptions: {
+        configId: 7,
+        version: 3,
+        publishedAt: new Date('2025-01-01T00:00:00.000Z'),
+        config: publishedConfig(),
+      },
+    });
+
+    expect(result.ready[0]?.readiness).toEqual({
+      status: 'indicative',
+      reasons: ['STALE_ASSUMPTION'],
+    });
+  });
+
+  it('blocks currency mismatches instead of converting them', () => {
+    const result = assemble({
+      facts: facts({ currency: 'EUR', currencyStatus: 'mismatch_blocked' }),
+    });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('BLOCKED_CURRENCY');
+  });
+
+  it('rejects a planned check that exceeds the approved prospective round size', () => {
+    const result = assemble({
+      companies: [
+        {
+          companyId: 11,
+          stage: 'Seed',
+          currentStage: 'Seed',
+          sector: 'SaaS',
+          currentOwnership: '0.125',
+          plannedReservesCents: 600_000_000,
+        },
+      ],
+    });
+
+    expect(result.ready).toEqual([]);
+    expect(result.unavailable[0]?.reasons).toContain('PLANNED_CHECK_EXCEEDS_ROUND_SIZE');
+  });
+
+  it('does not import or query raw rounds or valuation marks', async () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+    const source = await readFile(
+      path.join(repoRoot, 'server/services/moic/marginal-reserve-moic-input-service.ts'),
+      'utf8'
+    );
+
+    expect(source).not.toContain('investmentRounds');
+    expect(source).not.toContain('valuationMarks');
+    expect(source).not.toContain('latestRoundValuation');
+    expect(source).toContain('buildFundCompanyActualsFacts');
+  });
+});

--- a/tests/unit/services/moic/marginal-reserve-moic-shadow-service.test.ts
+++ b/tests/unit/services/moic/marginal-reserve-moic-shadow-service.test.ts
@@ -1,0 +1,230 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FundMoicRankingItemV1 } from '../../../../shared/contracts/fund-moic-v1.contract';
+import type { MarginalReserveMoicInputV1 } from '../../../../shared/contracts/marginal-reserve-moic-v1.contract';
+import { calculateMarginalReserveMoic } from '../../../../shared/core/moic/MarginalReserveMoic';
+import {
+  buildMarginalReserveMoicShadowArtifact,
+  emitMarginalReserveMoicShadowComparison,
+  type MarginalReserveMoicShadowInput,
+} from '../../../../server/services/moic/marginal-reserve-moic-shadow-service';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+
+function planned(
+  companyId: number,
+  rank: number,
+  moic: number | null,
+  name = `Private Company ${companyId}`
+): FundMoicRankingItemV1 {
+  return {
+    rank,
+    investmentId: String(companyId),
+    investmentName: name,
+    reservesMoic: {
+      value: moic,
+      description: `private-description-${companyId}`,
+      formula: `private-formula-${companyId}`,
+    },
+  };
+}
+
+function marginal(
+  companyId: number,
+  moic: number,
+  readiness: MarginalReserveMoicInputV1['readiness'] = {
+    status: 'actionable',
+    reasons: [],
+  }
+) {
+  const input: MarginalReserveMoicInputV1 = {
+    contractVersion: 'marginal-reserve-moic-input-v1',
+    fundId: 1,
+    companyId,
+    baseCurrency: 'USD',
+    asOfDate: '2026-07-12',
+    currentOwnership: '0',
+    stages: [
+      {
+        stage: 'series_a',
+        preMoneyValuation: '8000000',
+        roundSize: '2000000',
+        monthsFromPriorStage: 12,
+        graduationProbability: '0',
+        exitProbability: '1',
+        exitValuation: String(moic * 10_000_000),
+        withDecision: { participate: true, checkAmount: '1000000' },
+        withoutDecision: { participate: false, checkAmount: '0' },
+      },
+    ],
+    factsInputHash: HASH_A,
+    assumptionsHash: HASH_B,
+    engineVersion: 'marginal-reserve-moic-v1',
+    readiness,
+  };
+  return calculateMarginalReserveMoic(input);
+}
+
+function fixture(
+  overrides: Partial<MarginalReserveMoicShadowInput> = {}
+): MarginalReserveMoicShadowInput {
+  return {
+    fundId: 1,
+    plannedRankings: [
+      planned(1, 1, 1),
+      planned(2, 2, 1),
+      planned(3, 3, 1),
+      planned(4, 4, 1),
+      planned(5, 5, 1),
+      planned(6, 6, 1),
+      planned(8, 7, null),
+    ],
+    marginalRankings: [
+      marginal(2, 10),
+      marginal(1, 9),
+      marginal(3, 8),
+      marginal(5, 7),
+      marginal(4, 6),
+      marginal(7, 5),
+      marginal(8, 4, { status: 'indicative', reasons: ['STALE_ASSUMPTION'] }),
+    ],
+    unavailable: [
+      { companyId: 9, reasons: ['BLOCKED_CURRENCY', 'BLOCKED_CURRENCY'] },
+      { companyId: 10, reasons: ['BLOCKED_CURRENCY', 'MISSING_CURRENT_OWNERSHIP'] },
+    ],
+    ...overrides,
+  };
+}
+
+describe('marginal reserve MOIC shadow comparison', () => {
+  it('emits overlap, inversion, actionability, and unavailable-reason metrics', () => {
+    const artifact = buildMarginalReserveMoicShadowArtifact(fixture());
+
+    expect(artifact.metrics).toEqual({
+      top_3_overlap: 3,
+      top_5_overlap: 5,
+      pairwise_rank_inversion_count: 2,
+      companies_actionable_in_both: 5,
+      companies_only_planned_actionable: 1,
+      companies_only_marginal_actionable: 1,
+      median_moic_ratio: '8.000000',
+      unavailable_reason_counts: {
+        BLOCKED_CURRENCY: 2,
+        MISSING_CURRENT_OWNERSHIP: 1,
+      },
+    });
+  });
+
+  it('creates empty top-five annotations that block approval', () => {
+    const artifact = buildMarginalReserveMoicShadowArtifact(fixture());
+
+    expect(artifact.status).toBe('annotation_required');
+    expect(artifact.annotations).toEqual([
+      {
+        inversionId: '1:2',
+        companyIds: [1, 2],
+        plannedRanks: [1, 2],
+        marginalRanks: [2, 1],
+        annotation: '',
+      },
+      {
+        inversionId: '4:5',
+        companyIds: [4, 5],
+        plannedRanks: [4, 5],
+        marginalRanks: [5, 4],
+        annotation: '',
+      },
+    ]);
+  });
+
+  it('approves only after every unexplained top-five inversion is annotated', () => {
+    const artifact = buildMarginalReserveMoicShadowArtifact(
+      fixture({
+        annotationsByInversionId: {
+          '1:2': 'Investment team prefers company 2 at the margin.',
+          '4:5': 'Known timing difference in the approved stage path.',
+        },
+      })
+    );
+
+    expect(artifact.status).toBe('approved');
+    expect(artifact.annotations.every((annotation) => annotation.annotation.length > 0)).toBe(true);
+  });
+
+  it('produces deterministic rankings and annotations from permuted fixture order', () => {
+    const original = fixture();
+    const permuted = fixture({
+      plannedRankings: [...original.plannedRankings].reverse(),
+      marginalRankings: [...original.marginalRankings].reverse(),
+      unavailable: [...original.unavailable].reverse(),
+    });
+
+    expect(buildMarginalReserveMoicShadowArtifact(permuted)).toEqual(
+      buildMarginalReserveMoicShadowArtifact(original)
+    );
+  });
+
+  it('calculates odd, even, and unavailable median MOIC ratios', () => {
+    const odd = buildMarginalReserveMoicShadowArtifact(
+      fixture({
+        plannedRankings: [planned(1, 1, 2), planned(2, 2, 4), planned(3, 3, 5)],
+        marginalRankings: [marginal(1, 2), marginal(2, 8), marginal(3, 20)],
+        unavailable: [],
+      })
+    );
+    const even = buildMarginalReserveMoicShadowArtifact(
+      fixture({
+        plannedRankings: [planned(1, 1, 2), planned(2, 2, 4)],
+        marginalRankings: [marginal(1, 2), marginal(2, 12)],
+        unavailable: [],
+      })
+    );
+    const none = buildMarginalReserveMoicShadowArtifact(
+      fixture({
+        plannedRankings: [planned(1, 1, 0), planned(2, 2, null)],
+        marginalRankings: [marginal(1, 2)],
+        unavailable: [],
+      })
+    );
+
+    expect(odd.metrics.median_moic_ratio).toBe('2.000000');
+    expect(even.metrics.median_moic_ratio).toBe('2.000000');
+    expect(none.metrics.median_moic_ratio).toBeNull();
+  });
+
+  it('logs IDs and aggregate metrics without names or raw result payloads', () => {
+    const log = { info: vi.fn() };
+
+    const artifact = emitMarginalReserveMoicShadowComparison(fixture(), log);
+
+    expect(log.info).toHaveBeenCalledTimes(1);
+    expect(log.info.mock.calls[0]?.[0]).toEqual({
+      fundId: 1,
+      status: artifact.status,
+      companyIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      inversionIds: ['1:2', '4:5'],
+      metrics: artifact.metrics,
+    });
+    const serializedLog = JSON.stringify(log.info.mock.calls);
+    expect(serializedLog).not.toContain('Private Company');
+    expect(serializedLog).not.toContain('private-description');
+    expect(serializedLog).not.toContain('deltaExpectedProceeds');
+    expect(serializedLog).not.toContain('stageContributions');
+  });
+
+  it('has no database imports or write methods', async () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+    const source = await readFile(
+      path.join(repoRoot, 'server/services/moic/marginal-reserve-moic-shadow-service.ts'),
+      'utf8'
+    );
+
+    expect(source).not.toMatch(/from ['"].*\/db['"]/);
+    expect(source).not.toMatch(/\.(insert|update|delete)\s*\(/);
+  });
+});

--- a/tests/unit/services/moic/marginal-reserve-moic-shadow-service.test.ts
+++ b/tests/unit/services/moic/marginal-reserve-moic-shadow-service.test.ts
@@ -5,7 +5,10 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { FundMoicRankingItemV1 } from '../../../../shared/contracts/fund-moic-v1.contract';
-import type { MarginalReserveMoicInputV1 } from '../../../../shared/contracts/marginal-reserve-moic-v1.contract';
+import type {
+  MarginalReserveMoicInputV1,
+  MarginalReserveRankingItemV1,
+} from '../../../../shared/contracts/marginal-reserve-moic-v1.contract';
 import { calculateMarginalReserveMoic } from '../../../../shared/core/moic/MarginalReserveMoic';
 import {
   buildMarginalReserveMoicShadowArtifact,
@@ -41,7 +44,7 @@ function marginal(
     status: 'actionable',
     reasons: [],
   }
-) {
+): MarginalReserveRankingItemV1 {
   const input: MarginalReserveMoicInputV1 = {
     contractVersion: 'marginal-reserve-moic-input-v1',
     fundId: 1,
@@ -67,7 +70,16 @@ function marginal(
     engineVersion: 'marginal-reserve-moic-v1',
     readiness,
   };
-  return calculateMarginalReserveMoic(input);
+  const result = calculateMarginalReserveMoic(input);
+  return {
+    companyId,
+    status:
+      result.status === 'actionable' && readiness.status === 'indicative'
+        ? 'indicative'
+        : result.status,
+    inputReadiness: readiness,
+    result,
+  };
 }
 
 function fixture(
@@ -131,6 +143,9 @@ describe('marginal reserve MOIC shadow comparison', () => {
         plannedRanks: [1, 2],
         marginalRanks: [2, 1],
         annotation: '',
+        reviewedBy: null,
+        reviewerRole: null,
+        reviewedAt: null,
       },
       {
         inversionId: '4:5',
@@ -138,6 +153,9 @@ describe('marginal reserve MOIC shadow comparison', () => {
         plannedRanks: [4, 5],
         marginalRanks: [5, 4],
         annotation: '',
+        reviewedBy: null,
+        reviewerRole: null,
+        reviewedAt: null,
       },
     ]);
   });
@@ -146,8 +164,18 @@ describe('marginal reserve MOIC shadow comparison', () => {
     const artifact = buildMarginalReserveMoicShadowArtifact(
       fixture({
         annotationsByInversionId: {
-          '1:2': 'Investment team prefers company 2 at the margin.',
-          '4:5': 'Known timing difference in the approved stage path.',
+          '1:2': {
+            annotation: 'Investment team prefers company 2 at the margin.',
+            reviewedBy: 'reviewer-1',
+            reviewerRole: 'investment_team',
+            reviewedAt: '2026-07-12T20:00:00.000Z',
+          },
+          '4:5': {
+            annotation: 'Known timing difference in the approved stage path.',
+            reviewedBy: 'reviewer-2',
+            reviewerRole: 'investment_team',
+            reviewedAt: '2026-07-12T20:05:00.000Z',
+          },
         },
       })
     );


### PR DESCRIPTION
## Summary

Plan 7 wave 2 (Tasks 7.5-7.7) on top of merged wave 1 (#1087, ADR-033). Shadow-only; no UI, no persistence, flag off everywhere.

- **7.5 Input service** (`server/services/moic/marginal-reserve-moic-input-service.ts`): assembles engine inputs ONLY from sanctioned sources — `buildFundCompanyActualsFacts` seam, published fund config stage assumptions, approved allocation/follow-on IC decisions, fund base currency. No raw rounds/marks reads, no invented defaults; per-company readiness reasons; separate facts/assumptions hashes; stale assumption -> indicative; blocked currency -> unavailable. Read-only (no insert/update/delete).
- **7.6 Shadow route** `GET /api/funds/:fundId/moic/marginal-rankings?asOfDate=` added INSIDE the existing `fund-moic` router (no new mount; D6 inventory unaffected). `requireAuth` + `requireFundAccess` + strict fundId 400; flag `enable_marginal_reserve_moic` (default/staging/production all FALSE, `exposeToClient: false`) -> 404 when off; response is contract-validated with `mode: shadow`, `actionability: non_actionable_shadow`; sorted by status then marginal MOIC (Decimal compare), companyId tiebreak. Route-policy registry entry added (financial).
- **7.7 Shadow comparison service** (`marginal-reserve-moic-shadow-service.ts`): top-3/top-5 overlap, pairwise inversions, actionability deltas, median MOIC ratio, unavailable-reason counts; logs carry company IDs + aggregate metrics only (no names/values — pinned by test); review artifact requires investment-team annotations for unexplained top-5 inversions; source-level test asserts no DB imports/writes (H9 gate).
- Lane self-review hardened production semantics: pipeline money persisted in millions, stage timing from prior stage's graduation cadence, fund-wide participation != company approval; `ready` now requires a current approved `follow_on` IC decision matching the live allocation (commit `2553f9f1`).
- Engine change is a 4-line hash seam: exclude new `readiness` metadata from input-hash normalization. Contract adds readiness schema with invariant refinements.

## Verification

- `npm run check`: 0 TypeScript errors (baseline clean)
- Targeted suites (contract, engine, input service, route behavior, flag, route-policy, shadow service): green
- `npm run phoenix:truth`: 282/282
- `npm run calc-gate`: 194 + 20 orphan checks, green

## Notes

- 7.8 UI deferred until calibration per plan; not in LP exports.
- Built via Hermes/Codex lane (gpt-5.6-sol), reviewed and verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h