### PR TITLE
feat(allocations): plan-vs-actuals drift disclosure on latest reads (Plan 5 wave 1)

### DIFF
--- a/server/routes/allocations.ts
+++ b/server/routes/allocations.ts
@@ -30,6 +30,16 @@ import {
 import { setStageWarningHeaders } from '../middleware/deprecation-headers';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 import { storage } from '../storage';
+import { AllocationCompanyActualsDriftV1Schema } from '@shared/contracts/allocations/allocation-actuals-drift-v1.contract';
+import type { FundCompanyActualsFactsResponse } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import {
+  buildAllocationActualsDrift,
+  buildFailedAllocationActualsDrift,
+} from '../services/allocations/allocation-actuals-drift-service.js';
+import {
+  buildFundCompanyActualsFacts,
+  FundActualsFactsServiceError,
+} from '../services/fund-actuals/fund-company-actuals-facts-service.js';
 
 // Custom error type for HTTP status codes
 interface HttpError extends Error {
@@ -77,6 +87,57 @@ const ALLOCATION_ERROR_MAPPINGS = [
 
 const COMPANY_LIST_CURSOR_BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
 const CompanyListSortBySchema = z.enum(['exit_moic_desc', 'planned_reserves_desc', 'name_asc']);
+
+const LatestAllocationActualsDriftSummarySchema = z
+  .object({
+    facts_status: z.enum(['available', 'failed']),
+    drifted_company_count: z.number().int().nonnegative(),
+    material_company_count: z.number().int().nonnegative(),
+    degraded_company_count: z.number().int().nonnegative(),
+    facts_input_hash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    as_of_date: z.string().date(),
+  })
+  .strict();
+
+const LatestAllocationCompanySchema = z
+  .object({
+    company_id: z.number().int().positive(),
+    company_name: z.string(),
+    sector: z.string(),
+    stage: z.string(),
+    status: z.string(),
+    invested_amount_cents: z.number().int(),
+    planned_reserves_cents: z.number().int(),
+    deployed_reserves_cents: z.number().int(),
+    allocation_cap_cents: z.number().int().nullable(),
+    allocation_reason: z.string().nullable(),
+    allocation_version: z.number().int().nonnegative(),
+    last_allocation_at: z.string().datetime().nullable(),
+    allocation_facts_missing: z.boolean(),
+    missing_allocation_fields: z.array(z.string()),
+    actuals_drift: AllocationCompanyActualsDriftV1Schema,
+  })
+  .strict();
+
+const LatestAllocationResponseSchema = z
+  .object({
+    fund_id: z.number().int().positive(),
+    companies: z.array(LatestAllocationCompanySchema),
+    metadata: z
+      .object({
+        total_planned_cents: z.number().int(),
+        total_deployed_cents: z.number().int(),
+        companies_count: z.number().int().nonnegative(),
+        allocation_facts_missing_count: z.number().int().nonnegative(),
+        last_updated_at: z.string().datetime().nullable(),
+        actuals_drift_summary: LatestAllocationActualsDriftSummarySchema,
+      })
+      .strict(),
+  })
+  .strict();
 
 type CompanyListSortBy = z.infer<typeof CompanyListSortBySchema>;
 type CompanyListCursorKey = string | number | null;
@@ -168,33 +229,6 @@ const CompanyListQuerySchema = z
 // ============================================================================
 
 type _UpdateAllocationRequest = z.infer<typeof UpdateAllocationRequestSchema>;
-
-interface _LatestAllocationResponse {
-  fund_id: number;
-  companies: Array<{
-    company_id: number;
-    company_name: string;
-    sector: string;
-    stage: string;
-    status: string;
-    invested_amount_cents: number;
-    planned_reserves_cents: number;
-    deployed_reserves_cents: number;
-    allocation_cap_cents: number | null;
-    allocation_reason: string | null;
-    allocation_version: number;
-    last_allocation_at: string | null;
-    allocation_facts_missing: boolean;
-    missing_allocation_fields: string[];
-  }>;
-  metadata: {
-    total_planned_cents: number;
-    total_deployed_cents: number;
-    companies_count: number;
-    allocation_facts_missing_count: number;
-    last_updated_at: string | null;
-  };
-}
 
 interface _UpdateAllocationResponse {
   success: boolean;
@@ -319,6 +353,31 @@ function findAllocationErrorMapping(message: string): AllocationErrorMapping | u
 
 function allocationErrorMappingMessage(mapping: AllocationErrorMapping | undefined): string {
   return mapping?.message ?? DEFAULT_ALLOCATION_ERROR_MESSAGE;
+}
+
+async function loadAllocationActualsFacts(input: {
+  fundId: number;
+  asOfDate: string;
+  requestId: string;
+}): Promise<FundCompanyActualsFactsResponse | null> {
+  try {
+    return await buildFundCompanyActualsFacts({
+      fundId: input.fundId,
+      asOfDate: input.asOfDate,
+    });
+  } catch (error) {
+    logger.warn(
+      {
+        requestId: input.requestId,
+        fundId: input.fundId,
+        errorCode:
+          error instanceof FundActualsFactsServiceError ? error.code : 'unexpected_facts_error',
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'actuals facts unavailable for latest allocation read'
+    );
+    return null;
+  }
 }
 
 function parseActorUserId(req: Request): number | null {
@@ -864,8 +923,41 @@ router['get'](
         .where(eq(portfolioCompanies.fundId, fundId))
         .orderBy(asc(portfolioCompanies.id));
 
+      const asOfDate = new Date().toISOString().slice(0, 10);
+      const actualsFacts = await loadAllocationActualsFacts({
+        fundId,
+        asOfDate,
+        requestId: req.rid ?? 'unknown',
+      });
+      const factsByCompanyId = new Map(
+        actualsFacts?.facts.map((fact) => [fact.companyId, fact]) ?? []
+      );
+
       const companies = rows.map((row) => {
         const missingFields = missingAllocationFields(row);
+        const plannedReservesCents =
+          row.planned_reserves_cents != null ? Number(row.planned_reserves_cents) : 0;
+        const deployedReservesCents =
+          row.deployed_reserves_cents != null ? Number(row.deployed_reserves_cents) : 0;
+        const allocationVersion = row.allocation_version ?? 0;
+        const driftAllocationVersion = allocationVersion > 0 ? allocationVersion : 1;
+        const driftInput = {
+          allocation: {
+            companyId: row.company_id,
+            deployedReservesCents,
+            investmentAmount: row.invested_amount || '0',
+            allocationVersion: driftAllocationVersion,
+            lastAllocationAt: row.last_allocation_at,
+          },
+          asOfDate,
+        };
+        const actualsDrift =
+          actualsFacts === null
+            ? buildFailedAllocationActualsDrift(driftInput)
+            : buildAllocationActualsDrift({
+                ...driftInput,
+                fact: factsByCompanyId.get(row.company_id) ?? null,
+              });
 
         return {
           company_id: row.company_id,
@@ -874,17 +966,16 @@ router['get'](
           stage: row.stage,
           status: row.status,
           invested_amount_cents: Math.round(parseFloat(row.invested_amount || '0') * 100),
-          planned_reserves_cents:
-            row.planned_reserves_cents != null ? Number(row.planned_reserves_cents) : 0,
-          deployed_reserves_cents:
-            row.deployed_reserves_cents != null ? Number(row.deployed_reserves_cents) : 0,
+          planned_reserves_cents: plannedReservesCents,
+          deployed_reserves_cents: deployedReservesCents,
           allocation_cap_cents:
             row.allocation_cap_cents != null ? Number(row.allocation_cap_cents) : null,
           allocation_reason: row.allocation_reason,
-          allocation_version: row.allocation_version ?? 0,
+          allocation_version: allocationVersion,
           last_allocation_at: row.last_allocation_at ? row.last_allocation_at.toISOString() : null,
           allocation_facts_missing: missingFields.length > 0,
           missing_allocation_fields: missingFields,
+          actuals_drift: actualsDrift,
         };
       });
 
@@ -897,7 +988,7 @@ router['get'](
           .sort()
           .reverse()[0] || null;
 
-      return res.status(200).json({
+      const response = LatestAllocationResponseSchema.parse({
         fund_id: fundId,
         companies,
         metadata: {
@@ -907,8 +998,24 @@ router['get'](
           allocation_facts_missing_count: companies.filter((c) => c.allocation_facts_missing)
             .length,
           last_updated_at,
+          actuals_drift_summary: {
+            facts_status: actualsFacts === null ? 'failed' : 'available',
+            drifted_company_count: companies.filter((company) =>
+              company.actuals_drift.comparisons.some((comparison) => comparison.state === 'drifted')
+            ).length,
+            material_company_count: companies.filter((company) =>
+              company.actuals_drift.comparisons.some((comparison) => comparison.material)
+            ).length,
+            degraded_company_count: companies.filter(
+              (company) => company.actuals_drift.trustState !== 'LIVE'
+            ).length,
+            facts_input_hash: actualsFacts?.inputHash ?? null,
+            as_of_date: asOfDate,
+          },
         },
       });
+
+      return res.status(200).json(response);
     } catch (error) {
       logger.warn(
         {

--- a/server/services/allocations/allocation-actuals-drift-service.ts
+++ b/server/services/allocations/allocation-actuals-drift-service.ts
@@ -1,0 +1,196 @@
+import Decimal from '../../../shared/lib/decimal-config';
+import {
+  AllocationCompanyActualsDriftV1Schema,
+  type AllocationCompanyActualsDriftV1,
+  type AllocationDriftComparisonV1,
+} from '../../../shared/contracts/allocations/allocation-actuals-drift-v1.contract';
+import type { FundCompanyActualsFact } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+
+const CENTS_PER_UNIT = new Decimal(100);
+const MATERIALITY_ABSOLUTE_FLOOR_CENTS = new Decimal(100_000);
+const MATERIALITY_RELATIVE_RATE = new Decimal('0.01');
+const MAX_DECIMAL_PLACES = 6;
+
+type AllocationDriftBasis = AllocationDriftComparisonV1['basis'];
+type UnavailableReason = NonNullable<AllocationDriftComparisonV1['unavailableReason']>;
+
+export interface AllocationPlanRow {
+  companyId: number;
+  deployedReservesCents: number;
+  investmentAmount: string;
+  allocationVersion: number;
+  lastAllocationAt: Date | string | null;
+}
+
+interface ActualCents {
+  cents: Decimal;
+  subCentRemainder: string | null;
+}
+
+function decimalString(value: Decimal): string {
+  return value.toDecimalPlaces(MAX_DECIMAL_PLACES, Decimal.ROUND_HALF_UP).toString();
+}
+
+function integerCentString(value: Decimal): string {
+  return value.toFixed(0);
+}
+
+function dollarsToCents(value: string): Decimal {
+  return new Decimal(value).times(CENTS_PER_UNIT).toDecimalPlaces(0, Decimal.ROUND_DOWN);
+}
+
+function actualDollarsToCents(value: Decimal): ActualCents {
+  const exactCents = value.times(CENTS_PER_UNIT);
+  const cents = exactCents.toDecimalPlaces(0, Decimal.ROUND_DOWN);
+  const remainder = exactCents.minus(cents);
+
+  return {
+    cents,
+    subCentRemainder: remainder.isZero() ? null : decimalString(remainder),
+  };
+}
+
+function lastAllocationAt(value: AllocationPlanRow['lastAllocationAt']): string | null {
+  if (value === null) {
+    return null;
+  }
+  return (value instanceof Date ? value : new Date(value)).toISOString();
+}
+
+function planCentsForBasis(allocation: AllocationPlanRow, basis: AllocationDriftBasis): Decimal {
+  if (basis === 'deployed_reserves_vs_observed_follow_on') {
+    return new Decimal(allocation.deployedReservesCents.toString());
+  }
+  return dollarsToCents(allocation.investmentAmount);
+}
+
+function unavailableComparison(
+  allocation: AllocationPlanRow,
+  basis: AllocationDriftBasis,
+  unavailableReason: UnavailableReason
+): AllocationDriftComparisonV1 {
+  return {
+    basis,
+    state: 'unavailable',
+    planCents: integerCentString(planCentsForBasis(allocation, basis)),
+    actualCents: null,
+    deltaCents: null,
+    relativeDelta: null,
+    material: false,
+    subCentRemainder: null,
+    unavailableReason,
+  };
+}
+
+function comparison(
+  allocation: AllocationPlanRow,
+  basis: AllocationDriftBasis,
+  actual: ActualCents
+): AllocationDriftComparisonV1 {
+  const planCents = planCentsForBasis(allocation, basis);
+  const deltaCents = actual.cents.minus(planCents);
+  const relativeDelta = planCents.isZero() ? null : decimalString(deltaCents.div(planCents));
+  const materialityThreshold = Decimal.max(
+    MATERIALITY_ABSOLUTE_FLOOR_CENTS,
+    planCents.abs().times(MATERIALITY_RELATIVE_RATE)
+  );
+
+  return {
+    basis,
+    state: deltaCents.isZero() ? 'exact' : 'drifted',
+    planCents: integerCentString(planCents),
+    actualCents: integerCentString(actual.cents),
+    deltaCents: integerCentString(deltaCents),
+    relativeDelta,
+    material: deltaCents.abs().gte(materialityThreshold),
+    subCentRemainder: actual.subCentRemainder,
+    unavailableReason: null,
+  };
+}
+
+function unavailableDrift(input: {
+  allocation: AllocationPlanRow;
+  fact: FundCompanyActualsFact | null;
+  asOfDate: string;
+  reason: UnavailableReason;
+  trustState: AllocationCompanyActualsDriftV1['trustState'];
+}): AllocationCompanyActualsDriftV1 {
+  const { allocation, fact } = input;
+
+  return AllocationCompanyActualsDriftV1Schema.parse({
+    contractVersion: 'allocation-actuals-drift-v1',
+    companyId: allocation.companyId,
+    asOfDate: input.asOfDate,
+    allocationVersion: allocation.allocationVersion,
+    lastAllocationAt: lastAllocationAt(allocation.lastAllocationAt),
+    factsInputHash: fact?.inputHash ?? null,
+    trustState: input.trustState,
+    planningFmvStatus: fact?.planningFmvStatus ?? 'none',
+    currencyStatus: fact?.currencyStatus ?? 'unknown',
+    activeRoundIds: fact?.activeRoundIds ?? [],
+    supersedeLineage: fact?.supersedeLineage ?? [],
+    comparisons: [
+      unavailableComparison(allocation, 'deployed_reserves_vs_observed_follow_on', input.reason),
+      unavailableComparison(allocation, 'legacy_invested_vs_observed_total', input.reason),
+    ],
+    warnings: fact?.warnings ?? [],
+  });
+}
+
+export function buildAllocationActualsDrift(input: {
+  allocation: AllocationPlanRow;
+  fact: FundCompanyActualsFact | null;
+  asOfDate: string;
+}): AllocationCompanyActualsDriftV1 {
+  if (input.fact === null) {
+    return unavailableDrift({
+      ...input,
+      reason: 'facts_missing',
+      trustState: 'UNAVAILABLE',
+    });
+  }
+
+  if (input.fact.currencyStatus === 'mismatch_blocked') {
+    return unavailableDrift({
+      ...input,
+      reason: 'currency_blocked',
+      trustState: input.fact.provenance.trustState,
+    });
+  }
+
+  const observedFollowOn = actualDollarsToCents(new Decimal(input.fact.followOnInvestmentAmount));
+  const observedTotal = actualDollarsToCents(
+    new Decimal(input.fact.initialInvestmentAmount).plus(input.fact.followOnInvestmentAmount)
+  );
+
+  return AllocationCompanyActualsDriftV1Schema.parse({
+    contractVersion: 'allocation-actuals-drift-v1',
+    companyId: input.allocation.companyId,
+    asOfDate: input.asOfDate,
+    allocationVersion: input.allocation.allocationVersion,
+    lastAllocationAt: lastAllocationAt(input.allocation.lastAllocationAt),
+    factsInputHash: input.fact.inputHash,
+    trustState: input.fact.provenance.trustState,
+    planningFmvStatus: input.fact.planningFmvStatus,
+    currencyStatus: input.fact.currencyStatus,
+    activeRoundIds: input.fact.activeRoundIds,
+    supersedeLineage: input.fact.supersedeLineage,
+    comparisons: [
+      comparison(input.allocation, 'deployed_reserves_vs_observed_follow_on', observedFollowOn),
+      comparison(input.allocation, 'legacy_invested_vs_observed_total', observedTotal),
+    ],
+    warnings: input.fact.warnings,
+  });
+}
+
+export function buildFailedAllocationActualsDrift(input: {
+  allocation: AllocationPlanRow;
+  asOfDate: string;
+}): AllocationCompanyActualsDriftV1 {
+  return unavailableDrift({
+    ...input,
+    fact: null,
+    reason: 'facts_failed',
+    trustState: 'FAILED',
+  });
+}

--- a/shared/contracts/allocations/allocation-actuals-drift-v1.contract.ts
+++ b/shared/contracts/allocations/allocation-actuals-drift-v1.contract.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+import {
+  FundCompanyActualsCurrencyStatusSchema,
+  FundCompanyActualsPlanningFmvStatusSchema,
+  FundCompanyActualsSupersedeLineageSchema,
+} from '../fund-actuals/fund-company-actuals-fact.contract';
+import { DecimalStringSchema } from '../lp-reporting/cash-flow-event.contract';
+import { StructuredWarningSchema } from '../provenance-envelope.contract';
+
+const IntegerCentStringSchema = z.string().regex(/^-?\d+$/);
+
+export const AllocationDriftComparisonV1Schema = z
+  .object({
+    basis: z.enum(['deployed_reserves_vs_observed_follow_on', 'legacy_invested_vs_observed_total']),
+    state: z.enum(['exact', 'drifted', 'unavailable']),
+    planCents: IntegerCentStringSchema,
+    actualCents: IntegerCentStringSchema.nullable(),
+    deltaCents: IntegerCentStringSchema.nullable(),
+    relativeDelta: DecimalStringSchema.nullable(),
+    material: z.boolean(),
+    subCentRemainder: DecimalStringSchema.nullable(),
+    unavailableReason: z.enum(['currency_blocked', 'facts_failed', 'facts_missing']).nullable(),
+  })
+  .strict();
+
+export const AllocationCompanyActualsDriftV1Schema = z
+  .object({
+    contractVersion: z.literal('allocation-actuals-drift-v1'),
+    companyId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+    allocationVersion: z.number().int().positive(),
+    lastAllocationAt: z.string().datetime().nullable(),
+    factsInputHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    trustState: z.enum(['LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED']),
+    planningFmvStatus: FundCompanyActualsPlanningFmvStatusSchema,
+    currencyStatus: FundCompanyActualsCurrencyStatusSchema,
+    activeRoundIds: z.array(z.number().int().positive()),
+    supersedeLineage: z.array(FundCompanyActualsSupersedeLineageSchema),
+    comparisons: z.array(AllocationDriftComparisonV1Schema).length(2),
+    warnings: z.array(StructuredWarningSchema),
+  })
+  .strict();
+
+export type AllocationDriftComparisonV1 = z.infer<typeof AllocationDriftComparisonV1Schema>;
+export type AllocationCompanyActualsDriftV1 = z.infer<typeof AllocationCompanyActualsDriftV1Schema>;

--- a/tests/unit/contracts/allocation-actuals-drift-v1.contract.test.ts
+++ b/tests/unit/contracts/allocation-actuals-drift-v1.contract.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AllocationCompanyActualsDriftV1Schema,
+  AllocationDriftComparisonV1Schema,
+} from '../../../shared/contracts/allocations/allocation-actuals-drift-v1.contract';
+
+const SHA_256 = 'a'.repeat(64);
+
+function comparison() {
+  return {
+    basis: 'deployed_reserves_vs_observed_follow_on' as const,
+    state: 'exact' as const,
+    planCents: '100000',
+    actualCents: '100000',
+    deltaCents: '0',
+    relativeDelta: '0',
+    material: false,
+    subCentRemainder: null,
+    unavailableReason: null,
+  };
+}
+
+function drift() {
+  return {
+    contractVersion: 'allocation-actuals-drift-v1' as const,
+    companyId: 11,
+    asOfDate: '2026-07-11',
+    allocationVersion: 4,
+    lastAllocationAt: null,
+    factsInputHash: SHA_256,
+    trustState: 'LIVE' as const,
+    planningFmvStatus: 'active' as const,
+    currencyStatus: 'base_currency' as const,
+    activeRoundIds: [101],
+    supersedeLineage: [{ roundId: 101, supersedesRoundId: null }],
+    comparisons: [
+      comparison(),
+      {
+        ...comparison(),
+        basis: 'legacy_invested_vs_observed_total' as const,
+      },
+    ],
+    warnings: [],
+  };
+}
+
+describe('AllocationDriftComparisonV1Schema', () => {
+  it('accepts every comparison enum value', () => {
+    for (const basis of [
+      'deployed_reserves_vs_observed_follow_on',
+      'legacy_invested_vs_observed_total',
+    ] as const) {
+      expect(AllocationDriftComparisonV1Schema.safeParse({ ...comparison(), basis }).success).toBe(
+        true
+      );
+    }
+
+    for (const state of ['exact', 'drifted', 'unavailable'] as const) {
+      expect(AllocationDriftComparisonV1Schema.safeParse({ ...comparison(), state }).success).toBe(
+        true
+      );
+    }
+
+    for (const unavailableReason of [
+      'currency_blocked',
+      'facts_failed',
+      'facts_missing',
+    ] as const) {
+      expect(
+        AllocationDriftComparisonV1Schema.safeParse({ ...comparison(), unavailableReason }).success
+      ).toBe(true);
+    }
+  });
+
+  it('rejects unknown comparison fields', () => {
+    expect(
+      AllocationDriftComparisonV1Schema.safeParse({ ...comparison(), unexpected: true }).success
+    ).toBe(false);
+  });
+});
+
+describe('AllocationCompanyActualsDriftV1Schema', () => {
+  it('accepts every company-level enum value', () => {
+    for (const trustState of ['LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED'] as const) {
+      expect(
+        AllocationCompanyActualsDriftV1Schema.safeParse({ ...drift(), trustState }).success
+      ).toBe(true);
+    }
+
+    for (const planningFmvStatus of ['none', 'active', 'superseded', 'stale', 'blocked'] as const) {
+      expect(
+        AllocationCompanyActualsDriftV1Schema.safeParse({ ...drift(), planningFmvStatus }).success
+      ).toBe(true);
+    }
+
+    for (const currencyStatus of ['base_currency', 'mismatch_blocked', 'unknown'] as const) {
+      expect(
+        AllocationCompanyActualsDriftV1Schema.safeParse({ ...drift(), currencyStatus }).success
+      ).toBe(true);
+    }
+  });
+
+  it('rejects unknown company fields and comparison counts other than two', () => {
+    expect(
+      AllocationCompanyActualsDriftV1Schema.safeParse({ ...drift(), unexpected: true }).success
+    ).toBe(false);
+    expect(
+      AllocationCompanyActualsDriftV1Schema.safeParse({
+        ...drift(),
+        comparisons: [comparison()],
+      }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/routes/allocations-latest.test.ts
+++ b/tests/unit/routes/allocations-latest.test.ts
@@ -1,12 +1,22 @@
 import express from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FundCompanyActualsFact } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 
-const { dbMock, loggerWarnMock } = vi.hoisted(() => ({
+const {
+  applyAllocationUpdatesMock,
+  buildFundCompanyActualsFactsMock,
+  dbMock,
+  loggerWarnMock,
+  transactionMock,
+} = vi.hoisted(() => ({
+  applyAllocationUpdatesMock: vi.fn(),
+  buildFundCompanyActualsFactsMock: vi.fn(),
   dbMock: {
     select: vi.fn(),
   },
   loggerWarnMock: vi.fn(),
+  transactionMock: vi.fn(),
 }));
 
 vi.mock('../../../server/db', () => ({
@@ -14,7 +24,29 @@ vi.mock('../../../server/db', () => ({
 }));
 
 vi.mock('../../../server/db/pg-circuit', () => ({
-  transaction: vi.fn(),
+  transaction: transactionMock,
+}));
+
+vi.mock('../../../server/services/allocation-write-service.js', () => ({
+  applyAllocationUpdates: applyAllocationUpdatesMock,
+}));
+
+vi.mock(
+  '../../../server/services/fund-actuals/fund-company-actuals-facts-service.js',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('../../../server/services/fund-actuals/fund-company-actuals-facts-service')
+      >();
+    return {
+      ...actual,
+      buildFundCompanyActualsFacts: buildFundCompanyActualsFactsMock,
+    };
+  }
+);
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: vi.fn(async () => true),
 }));
 
 vi.mock('../../../server/lib/logger.js', () => ({
@@ -25,6 +57,49 @@ vi.mock('../../../server/lib/logger.js', () => ({
 }));
 
 import allocationsRouter from '../../../server/routes/allocations';
+
+const FACT_INPUT_HASH = 'a'.repeat(64);
+const RESPONSE_INPUT_HASH = 'c'.repeat(64);
+
+function actualsFact(overrides: Partial<FundCompanyActualsFact> = {}): FundCompanyActualsFact {
+  return {
+    fundId: 1,
+    companyId: 10,
+    companyName: 'TechCorp',
+    investmentIds: [20],
+    activeRoundIds: [30],
+    approvedPlanningFmvMarkId: 40,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '500000.000000',
+    followOnInvestmentAmount: '600000.000000',
+    amountOnlyNonEquityAmount: '0.000000',
+    latestRoundDate: '2026-07-01',
+    latestRoundValuation: '20000000.000000',
+    latestPlanningFmvDate: '2026-07-01',
+    latestPlanningFmvValue: '21000000.000000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [{ roundId: 30, supersedesRoundId: null }],
+    warnings: [],
+    provenance: {
+      trustState: 'LIVE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'actionable',
+        sourceEngine: 'rounds-to-model',
+        engineVersion: 'rounds-to-model-v1',
+        inputHash: FACT_INPUT_HASH,
+        assumptionsHash: 'b'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: true,
+        warnings: [],
+      },
+      structuredWarnings: [],
+    },
+    inputHash: FACT_INPUT_HASH,
+    ...overrides,
+  };
+}
 
 function makeApp() {
   const app = express();
@@ -54,6 +129,15 @@ function failingLimitChain(error: Error) {
 describe('latest allocations route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    buildFundCompanyActualsFactsMock.mockImplementation(
+      async (input: { fundId: number; asOfDate: string }) => ({
+        fundId: input.fundId,
+        asOfDate: input.asOfDate,
+        facts: [actualsFact({ fundId: input.fundId })],
+        inputHash: RESPONSE_INPUT_HASH,
+        generatedAt: '2026-07-13T00:00:00.000Z',
+      })
+    );
   });
 
   it('returns safe JSON instead of leaking database credential failures', async () => {
@@ -115,6 +199,44 @@ describe('latest allocations route', () => {
         companies_count: 1,
         last_updated_at: '2026-04-01T00:00:00.000Z',
       },
+    });
+    expect(buildFundCompanyActualsFactsMock).toHaveBeenCalledTimes(1);
+    expect(buildFundCompanyActualsFactsMock).toHaveBeenCalledWith({
+      fundId: 1,
+      asOfDate: res.body.metadata.actuals_drift_summary.as_of_date,
+    });
+    expect(res.body.companies[0].actuals_drift).toMatchObject({
+      contractVersion: 'allocation-actuals-drift-v1',
+      companyId: 10,
+      allocationVersion: 3,
+      factsInputHash: FACT_INPUT_HASH,
+      trustState: 'LIVE',
+      comparisons: [
+        {
+          basis: 'deployed_reserves_vs_observed_follow_on',
+          planCents: '50000000',
+          actualCents: '60000000',
+          deltaCents: '10000000',
+          state: 'drifted',
+          material: true,
+        },
+        {
+          basis: 'legacy_invested_vs_observed_total',
+          planCents: '125000000',
+          actualCents: '110000000',
+          deltaCents: '-15000000',
+          state: 'drifted',
+          material: true,
+        },
+      ],
+    });
+    expect(res.body.metadata.actuals_drift_summary).toEqual({
+      facts_status: 'available',
+      drifted_company_count: 1,
+      material_company_count: 1,
+      degraded_company_count: 0,
+      facts_input_hash: RESPONSE_INPUT_HASH,
+      as_of_date: res.body.metadata.actuals_drift_summary.as_of_date,
     });
   });
 
@@ -186,5 +308,61 @@ describe('latest allocations route', () => {
         allocation_facts_missing_count: 1,
       },
     });
+  });
+
+  it('degrades facts failures to unavailable drift without mutating allocation rows', async () => {
+    const sourceRows = [
+      {
+        company_id: 10,
+        company_name: 'TechCorp',
+        sector: 'AI',
+        stage: 'Series A',
+        status: 'active',
+        invested_amount: '1250000.00',
+        planned_reserves_cents: 200_000_000,
+        deployed_reserves_cents: 50_000_000,
+        allocation_cap_cents: null,
+        allocation_reason: 'Follow-on reserve',
+        allocation_version: 3,
+        last_allocation_at: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ];
+    const before = structuredClone(sourceRows);
+    dbMock.select
+      .mockReturnValueOnce(queryChain(Promise.resolve([{ id: 1 }])))
+      .mockReturnValueOnce(queryChain(Promise.resolve(sourceRows)));
+    buildFundCompanyActualsFactsMock.mockRejectedValueOnce(new Error('facts backend down'));
+
+    const res = await request(makeApp()).get('/api/funds/1/allocations/latest');
+
+    expect(res.status).toBe(200);
+    expect(sourceRows).toEqual(before);
+    expect(res.body.companies[0]).toMatchObject({
+      company_id: 10,
+      invested_amount_cents: 125_000_000,
+      planned_reserves_cents: 200_000_000,
+      deployed_reserves_cents: 50_000_000,
+      allocation_version: 3,
+      actuals_drift: {
+        factsInputHash: null,
+        trustState: 'FAILED',
+      },
+    });
+    expect(
+      res.body.companies[0].actuals_drift.comparisons.every(
+        (comparison: { state: string; unavailableReason: string }) =>
+          comparison.state === 'unavailable' && comparison.unavailableReason === 'facts_failed'
+      )
+    ).toBe(true);
+    expect(res.body.metadata.actuals_drift_summary).toEqual({
+      facts_status: 'failed',
+      drifted_company_count: 0,
+      material_company_count: 0,
+      degraded_company_count: 1,
+      facts_input_hash: null,
+      as_of_date: res.body.metadata.actuals_drift_summary.as_of_date,
+    });
+    expect(applyAllocationUpdatesMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/routes/allocations.contract.test.ts
+++ b/tests/unit/routes/allocations.contract.test.ts
@@ -1,7 +1,9 @@
 import express from 'express';
 import type { Request, Response } from 'express';
+import { join } from 'node:path';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FundCompanyActualsFact } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 
 type QueryChain = PromiseLike<unknown[]> & {
   from: ReturnType<typeof vi.fn>;
@@ -55,6 +57,10 @@ const storageState = vi.hoisted(() => ({
   getPortfolioCompanies: vi.fn(async (): Promise<unknown[]> => []),
 }));
 
+const factsState = vi.hoisted(() => ({
+  buildFundCompanyActualsFacts: vi.fn(),
+}));
+
 vi.mock('../../../server/db', () => ({ db: dbState.db }));
 
 vi.mock('../../../server/db/pg-circuit', () => ({
@@ -64,6 +70,20 @@ vi.mock('../../../server/db/pg-circuit', () => ({
 vi.mock('../../../server/services/allocation-write-service.js', () => ({
   applyAllocationUpdates: writeState.applyAllocationUpdates,
 }));
+
+vi.mock(
+  '../../../server/services/fund-actuals/fund-company-actuals-facts-service.js',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('../../../server/services/fund-actuals/fund-company-actuals-facts-service')
+      >();
+    return {
+      ...actual,
+      buildFundCompanyActualsFacts: factsState.buildFundCompanyActualsFacts,
+    };
+  }
+);
 
 vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
   enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
@@ -92,6 +112,49 @@ vi.mock('../../../server/storage', () => ({
 }));
 
 import allocationsRouter from '../../../server/routes/allocations';
+
+const FACT_INPUT_HASH = 'a'.repeat(64);
+const RESPONSE_INPUT_HASH = 'c'.repeat(64);
+
+function actualsFact(overrides: Partial<FundCompanyActualsFact> = {}): FundCompanyActualsFact {
+  return {
+    fundId: 1,
+    companyId: 11,
+    companyName: 'Alpha AI',
+    investmentIds: [21],
+    activeRoundIds: [31],
+    approvedPlanningFmvMarkId: 41,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '750000.000000',
+    followOnInvestmentAmount: '250000.000000',
+    amountOnlyNonEquityAmount: '0.000000',
+    latestRoundDate: '2026-07-01',
+    latestRoundValuation: '20000000.000000',
+    latestPlanningFmvDate: '2026-07-01',
+    latestPlanningFmvValue: '21000000.000000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [{ roundId: 31, supersedesRoundId: null }],
+    warnings: [],
+    provenance: {
+      trustState: 'LIVE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'actionable',
+        sourceEngine: 'rounds-to-model',
+        engineVersion: 'rounds-to-model-v1',
+        inputHash: FACT_INPUT_HASH,
+        assumptionsHash: 'b'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: true,
+        warnings: [],
+      },
+      structuredWarnings: [],
+    },
+    inputHash: FACT_INPUT_HASH,
+    ...overrides,
+  };
+}
 
 function makeApp() {
   const app = express();
@@ -125,6 +188,16 @@ function resetState() {
   storageState.kind = 'database';
   storageState.getPortfolioCompanies.mockReset();
   storageState.getPortfolioCompanies.mockResolvedValue([]);
+  factsState.buildFundCompanyActualsFacts.mockReset();
+  factsState.buildFundCompanyActualsFacts.mockImplementation(
+    async (input: { fundId: number; asOfDate: string }) => ({
+      fundId: input.fundId,
+      asOfDate: input.asOfDate,
+      facts: [actualsFact({ fundId: input.fundId })],
+      inputHash: RESPONSE_INPUT_HASH,
+      generatedAt: '2026-07-13T00:00:00.000Z',
+    })
+  );
 }
 
 function companyRow(overrides: Record<string, unknown> = {}) {
@@ -268,6 +341,7 @@ describe('allocations route contracts', () => {
     ]);
 
     const response = await request(makeApp()).get('/api/funds/1/allocations/latest');
+    const asOfDate = response.body.metadata.actuals_drift_summary.as_of_date;
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -288,6 +362,44 @@ describe('allocations route contracts', () => {
           last_allocation_at: '2026-01-01T00:00:00.000Z',
           allocation_facts_missing: false,
           missing_allocation_fields: [],
+          actuals_drift: {
+            contractVersion: 'allocation-actuals-drift-v1',
+            companyId: 11,
+            asOfDate,
+            allocationVersion: 3,
+            lastAllocationAt: '2026-01-01T00:00:00.000Z',
+            factsInputHash: FACT_INPUT_HASH,
+            trustState: 'LIVE',
+            planningFmvStatus: 'active',
+            currencyStatus: 'base_currency',
+            activeRoundIds: [31],
+            supersedeLineage: [{ roundId: 31, supersedesRoundId: null }],
+            comparisons: [
+              {
+                basis: 'deployed_reserves_vs_observed_follow_on',
+                state: 'exact',
+                planCents: '25000000',
+                actualCents: '25000000',
+                deltaCents: '0',
+                relativeDelta: '0',
+                material: false,
+                subCentRemainder: null,
+                unavailableReason: null,
+              },
+              {
+                basis: 'legacy_invested_vs_observed_total',
+                state: 'exact',
+                planCents: '100000000',
+                actualCents: '100000000',
+                deltaCents: '0',
+                relativeDelta: '0',
+                material: false,
+                subCentRemainder: null,
+                unavailableReason: null,
+              },
+            ],
+            warnings: [],
+          },
         },
       ],
       metadata: {
@@ -296,8 +408,37 @@ describe('allocations route contracts', () => {
         companies_count: 1,
         allocation_facts_missing_count: 0,
         last_updated_at: '2026-01-01T00:00:00.000Z',
+        actuals_drift_summary: {
+          facts_status: 'available',
+          drifted_company_count: 0,
+          material_company_count: 0,
+          degraded_company_count: 0,
+          facts_input_hash: RESPONSE_INPUT_HASH,
+          as_of_date: asOfDate,
+        },
       },
     });
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledWith({
+      fundId: 1,
+      asOfDate,
+    });
+  });
+
+  it('keeps the allocation read on the facts seam and strict response parser', async () => {
+    const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const routeSource = readFileSync(join(process.cwd(), 'server/routes/allocations.ts'), 'utf8');
+    const driftSource = readFileSync(
+      join(process.cwd(), 'server/services/allocations/allocation-actuals-drift-service.ts'),
+      'utf8'
+    );
+    const forbiddenFactsTables =
+      /investmentRounds|valuationMarks|investment_rounds|valuation_marks/;
+
+    expect(routeSource).toContain('buildFundCompanyActualsFacts');
+    expect(routeSource).toContain('LatestAllocationResponseSchema.parse');
+    expect(routeSource).not.toMatch(forbiddenFactsTables);
+    expect(driftSource).not.toMatch(forbiddenFactsTables);
   });
 
   it('POST /api/funds/:fundId/allocations rejects invalid body with current error envelope', async () => {

--- a/tests/unit/services/allocations/allocation-actuals-drift-service.test.ts
+++ b/tests/unit/services/allocations/allocation-actuals-drift-service.test.ts
@@ -1,0 +1,280 @@
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildAllocationActualsDrift,
+  type AllocationPlanRow,
+} from '../../../../server/services/allocations/allocation-actuals-drift-service';
+import type { FundCompanyActualsFact } from '../../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+
+const INPUT_HASH = 'a'.repeat(64);
+const ASSUMPTIONS_HASH = 'b'.repeat(64);
+
+function allocation(overrides: Partial<AllocationPlanRow> = {}): AllocationPlanRow {
+  return {
+    companyId: 11,
+    deployedReservesCents: 600_000,
+    investmentAmount: '10000.00',
+    allocationVersion: 4,
+    lastAllocationAt: null,
+    ...overrides,
+  };
+}
+
+function fact(overrides: Partial<FundCompanyActualsFact> = {}): FundCompanyActualsFact {
+  return {
+    fundId: 1,
+    companyId: 11,
+    companyName: 'Alpha AI',
+    investmentIds: [21],
+    activeRoundIds: [31],
+    approvedPlanningFmvMarkId: 41,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '4000.000000',
+    followOnInvestmentAmount: '6000.000000',
+    amountOnlyNonEquityAmount: '0.000000',
+    latestRoundDate: '2026-07-01',
+    latestRoundValuation: '20000000.000000',
+    latestPlanningFmvDate: '2026-07-01',
+    latestPlanningFmvValue: '21000000.000000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [{ roundId: 31, supersedesRoundId: null }],
+    warnings: [],
+    provenance: {
+      trustState: 'LIVE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'actionable',
+        sourceEngine: 'rounds-to-model',
+        engineVersion: 'rounds-to-model-v1',
+        inputHash: INPUT_HASH,
+        assumptionsHash: ASSUMPTIONS_HASH,
+        generatedAt: '2026-07-11T00:00:00.000Z',
+        isFinanciallyActionable: true,
+        warnings: [],
+      },
+      structuredWarnings: [],
+    },
+    inputHash: INPUT_HASH,
+    ...overrides,
+  };
+}
+
+function build(
+  allocationOverrides: Partial<AllocationPlanRow> = {},
+  factOverrides: Partial<FundCompanyActualsFact> = {}
+) {
+  return buildAllocationActualsDrift({
+    allocation: allocation(allocationOverrides),
+    fact: fact(factOverrides),
+    asOfDate: '2026-07-11',
+  });
+}
+
+describe('buildAllocationActualsDrift', () => {
+  it('emits exact comparisons when both actual totals match the plan cents', () => {
+    const result = build();
+
+    expect(result.comparisons).toEqual([
+      {
+        basis: 'deployed_reserves_vs_observed_follow_on',
+        state: 'exact',
+        planCents: '600000',
+        actualCents: '600000',
+        deltaCents: '0',
+        relativeDelta: '0',
+        material: false,
+        subCentRemainder: null,
+        unavailableReason: null,
+      },
+      {
+        basis: 'legacy_invested_vs_observed_total',
+        state: 'exact',
+        planCents: '1000000',
+        actualCents: '1000000',
+        deltaCents: '0',
+        relativeDelta: '0',
+        material: false,
+        subCentRemainder: null,
+        unavailableReason: null,
+      },
+    ]);
+  });
+
+  it('truncates actuals to cents and discloses the fractional-cent remainder', () => {
+    const result = build(
+      { deployedReservesCents: 100_000, investmentAmount: '1000.00' },
+      {
+        initialInvestmentAmount: '0.000000',
+        followOnInvestmentAmount: '1000.001234',
+      }
+    );
+
+    expect(result.comparisons[0]).toMatchObject({
+      actualCents: '100000',
+      deltaCents: '0',
+      state: 'exact',
+      subCentRemainder: '0.1234',
+    });
+    expect(result.comparisons[1]).toMatchObject({
+      actualCents: '100000',
+      subCentRemainder: '0.1234',
+    });
+  });
+
+  it('returns null relative delta when the plan side is zero', () => {
+    const result = build(
+      { deployedReservesCents: 0, investmentAmount: '0' },
+      {
+        initialInvestmentAmount: '0.000000',
+        followOnInvestmentAmount: '1.000000',
+      }
+    );
+
+    expect(result.comparisons[0]).toMatchObject({
+      deltaCents: '100',
+      relativeDelta: null,
+      state: 'drifted',
+    });
+  });
+
+  it('treats exactly 100,000 cents as material and 99,999 cents as immaterial', () => {
+    const atBoundary = build(
+      { deployedReservesCents: 10_000_000 },
+      { followOnInvestmentAmount: '101000.00' }
+    );
+    const belowBoundary = build(
+      { deployedReservesCents: 10_000_000 },
+      { followOnInvestmentAmount: '100999.99' }
+    );
+
+    expect(atBoundary.comparisons[0]).toMatchObject({ deltaCents: '100000', material: true });
+    expect(belowBoundary.comparisons[0]).toMatchObject({ deltaCents: '99999', material: false });
+  });
+
+  it('uses the greater of the absolute floor and one percent of plan value', () => {
+    const atRelativeBoundary = build(
+      { deployedReservesCents: 20_000_000 },
+      { followOnInvestmentAmount: '202000.00' }
+    );
+    const belowRelativeBoundary = build(
+      { deployedReservesCents: 20_000_000 },
+      { followOnInvestmentAmount: '201999.99' }
+    );
+    const belowAbsoluteFloor = build(
+      { deployedReservesCents: 5_000_000 },
+      { followOnInvestmentAmount: '50500.00' }
+    );
+
+    expect(atRelativeBoundary.comparisons[0]).toMatchObject({
+      deltaCents: '200000',
+      material: true,
+    });
+    expect(belowRelativeBoundary.comparisons[0]).toMatchObject({
+      deltaCents: '199999',
+      material: false,
+    });
+    expect(belowAbsoluteFloor.comparisons[0]).toMatchObject({
+      deltaCents: '50000',
+      material: false,
+    });
+  });
+
+  it('marks currency-blocked money unavailable rather than zero', () => {
+    const baseFact = fact();
+    const result = buildAllocationActualsDrift({
+      allocation: allocation(),
+      fact: {
+        ...baseFact,
+        currencyStatus: 'mismatch_blocked',
+        provenance: { ...baseFact.provenance, trustState: 'UNAVAILABLE' },
+      },
+      asOfDate: '2026-07-11',
+    });
+
+    expect(result.trustState).toBe('UNAVAILABLE');
+    for (const comparison of result.comparisons) {
+      expect(comparison).toMatchObject({
+        state: 'unavailable',
+        actualCents: null,
+        deltaCents: null,
+        relativeDelta: null,
+        material: false,
+        subCentRemainder: null,
+        unavailableReason: 'currency_blocked',
+      });
+    }
+  });
+
+  it('marks a missing fact unavailable', () => {
+    const result = buildAllocationActualsDrift({
+      allocation: allocation(),
+      fact: null,
+      asOfDate: '2026-07-11',
+    });
+
+    expect(result).toMatchObject({
+      factsInputHash: null,
+      trustState: 'UNAVAILABLE',
+      planningFmvStatus: 'none',
+      currencyStatus: 'unknown',
+      activeRoundIds: [],
+      supersedeLineage: [],
+      warnings: [],
+    });
+    expect(result.comparisons.every((item) => item.unavailableReason === 'facts_missing')).toBe(
+      true
+    );
+  });
+
+  it('passes the accepted plan truth case', () => {
+    expect(
+      buildAllocationActualsDrift({
+        allocation: {
+          companyId: 11,
+          deployedReservesCents: 1_000_000,
+          investmentAmount: '15000.00',
+          allocationVersion: 4,
+          lastAllocationAt: null,
+        },
+        fact: fact({
+          initialInvestmentAmount: '10000.00',
+          followOnInvestmentAmount: '12000.00',
+        }),
+        asOfDate: '2026-07-11',
+      })
+    ).toMatchObject({
+      comparisons: [
+        {
+          basis: 'deployed_reserves_vs_observed_follow_on',
+          planCents: '1000000',
+          actualCents: '1200000',
+          deltaCents: '200000',
+          material: true,
+        },
+        {
+          basis: 'legacy_invested_vs_observed_total',
+          planCents: '1500000',
+          actualCents: '2200000',
+          deltaCents: '700000',
+          material: true,
+        },
+      ],
+    });
+  });
+
+  it('uses Decimal.js without route, database, React, or raw facts-table imports', async () => {
+    const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const source = readFileSync(
+      join(process.cwd(), 'server/services/allocations/allocation-actuals-drift-service.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain('decimal-config');
+    expect(source).not.toContain("from 'decimal.js'");
+    expect(source).not.toMatch(/parseFloat|Math\./);
+    expect(source).not.toMatch(/server\/db|express|react/i);
+    expect(source).not.toMatch(/investmentRounds|valuationMarks|investment_rounds|valuation_marks/);
+  });
+});


### PR DESCRIPTION
## Summary

Plan 5 wave 1 (Tasks 5.1 + 5.2) of the trust-spine arc — allocation plan-vs-actuals drift, disclosure-only.

- **New contract** `shared/contracts/allocations/allocation-actuals-drift-v1.contract.ts`: strict per-company drift block with exactly two comparisons (`deployed_reserves_vs_observed_follow_on`, `legacy_invested_vs_observed_total`).
- **New pure service** `server/services/allocations/allocation-actuals-drift-service.ts`: Decimal.js arithmetic; materiality = `max(100,000 cents, 1% of plan-side)`; sub-cent facts truncated for the cents comparison with the remainder disclosed; zero-plan relative delta is `null`; currency-blocked money is `unavailable`, never zero; trust state taken from the fact's provenance envelope.
- **Extended read** `GET /api/funds/:fundId/allocations/latest`: one `buildFundCompanyActualsFacts` call per request; additive `actuals_drift` per company + `actuals_drift_summary` metadata; facts failure degrades to `facts_status:'failed'` with per-company FAILED/unavailable blocks while existing fields and HTTP 200 are preserved (ADR-028 disclose-not-block); final response parsed by a strict server-side Zod schema.

## Binding-decision compliance

- Drift computed at read time, never persisted; reads do not mutate allocation rows (tested).
- Every non-zero delta disclosed (`exact`/`drifted` by exact cent delta).
- Existing router/mount only — no manifest change; no reserve-engine input change anywhere in this PR.
- No direct `investment_rounds`/`valuation_marks` access — facts flow only through the sanctioned facts seam (source-level test).
- One deliberate strengthening vs the plan interface: `actuals_drift` is always present (failed facts produce disclosed unavailable blocks) rather than nullable, satisfying the exit-gate requirement that every row has a reproducible drift or disclosed-unavailable state.
- Nuance: rows with `allocation_version: 0` (never allocated) carry `allocationVersion: 1` inside the drift block to satisfy the positive-int contract; the top-level response field still reports the raw version.

## Verification

- 27/27 tests green across the four suites (contract, service, latest-route, route-contract), run independently post-implementation.
- `npm run check` (client/server/shared baseline) green: 0 TypeScript errors.
- ESLint clean on all 7 changed files.
- Truth case from the accepted plan passes verbatim; both materiality boundaries pinned.

Spec: `updog_restore_review_only_implementation_plans_2026-07-11.md` Plan 5 (line 1866), executed via Hermes/Codex worktree lane, Claude-verified. Remaining Plan 5 waves: 5.3/5.4 (facts-sourced reserve adapter + flag/H9), 5.5 (UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h