### PR TITLE
feat(scenarios): actuals-backed case seed contract and read-only seed suggestions (Plan 8 wave 1)

### DIFF
--- a/server/routes/scenario-analysis.ts
+++ b/server/routes/scenario-analysis.ts
@@ -6,10 +6,13 @@
  */
 
 import { Router } from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { z } from 'zod';
 import { db } from '../db';
+import { Sha256Schema } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { ScenarioCaseSeedV1Schema } from '@shared/contracts/scenarios/scenario-case-seed-v1.contract';
 import { scenarios, scenarioCases, scenarioAuditLogs } from '@shared/schema';
+import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
 import { eq, and } from 'drizzle-orm';
 import {
   calculateWeightedSummary,
@@ -18,10 +21,15 @@ import {
   addMOICToCases,
 } from '@shared/utils/scenario-math';
 import type { ScenarioAnalysisResponse, ScenarioCase } from '@shared/types/scenario';
-import { requireAuth } from '../lib/auth/jwt';
+import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
 import { firstString } from '../lib/request-values';
 import { createRouteLogger } from '../lib/route-logger.js';
 import { enforceCompanyFundScope } from '../lib/auth/company-fund-scope';
+import {
+  buildFundCompanyActualsFacts,
+  FundActualsFactsServiceError,
+} from '../services/fund-actuals/fund-company-actuals-facts-service';
+import { buildScenarioCaseSeed } from '../services/scenarios/scenario-case-seed-service';
 
 const routeLog = createRouteLogger('scenario-analysis');
 
@@ -72,6 +80,54 @@ const ReserveSuggestionsSchema = z.object({
   scenario_id: z.string(),
 });
 
+const ScenarioSeedQuerySchema = z
+  .object({
+    asOfDate: z.string().date().optional(),
+  })
+  .strict();
+
+const ScenarioSeedResponseSchema = z.discriminatedUnion('factsStatus', [
+  z
+    .object({
+      fundId: z.number().int().positive(),
+      asOfDate: z.string().date(),
+      factsStatus: z.literal('available'),
+      factsInputHash: Sha256Schema,
+      seeds: z.array(ScenarioCaseSeedV1Schema),
+    })
+    .strict(),
+  z
+    .object({
+      fundId: z.number().int().positive(),
+      asOfDate: z.string().date(),
+      factsStatus: z.literal('failed'),
+      factsInputHash: z.null(),
+      seeds: z.array(ScenarioCaseSeedV1Schema).max(0),
+    })
+    .strict(),
+]);
+
+function failedScenarioSeedResponse(fundId: number, asOfDate: string) {
+  return ScenarioSeedResponseSchema.parse({
+    fundId,
+    asOfDate,
+    factsStatus: 'failed',
+    factsInputHash: null,
+    seeds: [],
+  });
+}
+
+function validateScenarioSeedFundId(req: Request, res: Response, next: NextFunction) {
+  const parsed = FundIdParamSchema.safeParse(req.params);
+  if (!parsed.success) {
+    return res.status(400).json({
+      error: 'invalid_fund_id',
+      message: 'Fund ID must be a positive integer',
+    });
+  }
+  next();
+}
+
 // ============================================================================
 // Middleware: User tracking for audit
 // ============================================================================
@@ -114,6 +170,55 @@ async function auditLog(params: {
 // ============================================================================
 // Scenario CRUD (Deal-Level)
 // ============================================================================
+
+router['get'](
+  '/funds/:fundId/scenario-analysis/seeds',
+  requireAuth(),
+  validateScenarioSeedFundId,
+  requireFundAccess,
+  async (req: Request, res: Response) => {
+    const { fundId } = FundIdParamSchema.parse(req.params);
+    const parsedQuery = ScenarioSeedQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      return res.status(400).json({
+        error: 'invalid_as_of_date',
+        message: 'asOfDate must be YYYY-MM-DD when provided',
+      });
+    }
+    const asOfDate = parsedQuery.data.asOfDate ?? new Date().toISOString().slice(0, 10);
+
+    let facts: Awaited<ReturnType<typeof buildFundCompanyActualsFacts>>;
+    try {
+      facts = await buildFundCompanyActualsFacts({ fundId, asOfDate });
+    } catch (error: unknown) {
+      if (error instanceof FundActualsFactsServiceError && error.status === 404) {
+        return res.status(404).json({ error: error.code, message: error.message });
+      }
+      routeLog.error('Scenario seed facts load failed:', error);
+      return res.json(failedScenarioSeedResponse(fundId, asOfDate));
+    }
+
+    if (facts.fundId !== fundId || facts.asOfDate !== asOfDate) {
+      routeLog.error(
+        'Scenario seed facts scope mismatch:',
+        new Error(
+          `Requested fund ${fundId} as of ${asOfDate}, received fund ${facts.fundId} as of ${facts.asOfDate}`
+        )
+      );
+      return res.json(failedScenarioSeedResponse(fundId, asOfDate));
+    }
+
+    return res.json(
+      ScenarioSeedResponseSchema.parse({
+        fundId,
+        asOfDate,
+        factsStatus: 'available',
+        factsInputHash: facts.inputHash,
+        seeds: facts.facts.map((fact) => buildScenarioCaseSeed({ fundId, fact, asOfDate })),
+      })
+    );
+  }
+);
 
 /**
  * GET /api/companies/:companyId/scenarios/:scenarioId

--- a/server/services/scenarios/scenario-case-seed-service.ts
+++ b/server/services/scenarios/scenario-case-seed-service.ts
@@ -1,0 +1,90 @@
+import type { FundCompanyActualsFact } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import {
+  ScenarioCaseSeedV1Schema,
+  type ScenarioCaseSeedV1,
+} from '../../../shared/contracts/scenarios/scenario-case-seed-v1.contract';
+
+function buildObservedMoneyField(
+  fact: FundCompanyActualsFact,
+  value: string,
+  source: string
+): ScenarioCaseSeedV1['fields']['investment'] {
+  if (fact.currencyStatus !== 'base_currency') {
+    return { status: 'unavailable', value: null, reason: 'currency_blocked' };
+  }
+  if (fact.provenance.trustState === 'FAILED') {
+    return { status: 'unavailable', value: null, reason: 'facts_unavailable' };
+  }
+  if (fact.provenance.trustState === 'UNAVAILABLE') {
+    return { status: 'unavailable', value: null, reason: 'facts_unavailable' };
+  }
+  if (fact.activeRoundIds.length === 0) {
+    return { status: 'unavailable', value: null, reason: 'source_missing' };
+  }
+  return { status: 'seeded', value, source };
+}
+
+function buildFmvField(fact: FundCompanyActualsFact): ScenarioCaseSeedV1['fields']['fmv'] {
+  if (fact.currencyStatus !== 'base_currency') {
+    return { status: 'unavailable', value: null, reason: 'currency_blocked' };
+  }
+  if (fact.provenance.trustState === 'FAILED') {
+    return { status: 'unavailable', value: null, reason: 'facts_unavailable' };
+  }
+  if (fact.provenance.trustState === 'UNAVAILABLE') {
+    return { status: 'unavailable', value: null, reason: 'facts_unavailable' };
+  }
+  if (fact.planningFmvStatus === 'stale') {
+    return { status: 'unavailable', value: null, reason: 'fmv_stale' };
+  }
+  if (fact.planningFmvStatus !== 'active' || fact.latestPlanningFmvValue === null) {
+    return { status: 'unavailable', value: null, reason: 'no_active_fmv' };
+  }
+  return {
+    status: 'seeded',
+    value: fact.latestPlanningFmvValue,
+    source: 'facts.latestPlanningFmvValue',
+  };
+}
+
+export function buildScenarioCaseSeed(input: {
+  fundId: number;
+  fact: FundCompanyActualsFact;
+  asOfDate: string;
+}): ScenarioCaseSeedV1 {
+  if (input.fundId !== input.fact.fundId) {
+    throw new Error(`Fact fund ${input.fact.fundId} does not match requested fund ${input.fundId}`);
+  }
+
+  return ScenarioCaseSeedV1Schema.parse({
+    contractVersion: 'scenario-case-seed-v1',
+    fundId: input.fundId,
+    companyId: input.fact.companyId,
+    asOfDate: input.asOfDate,
+    factsInputHash: input.fact.inputHash,
+    trustState: input.fact.provenance.trustState,
+    currencyStatus: input.fact.currencyStatus,
+    fields: {
+      investment: buildObservedMoneyField(
+        input.fact,
+        input.fact.initialInvestmentAmount,
+        'facts.initialInvestmentAmount'
+      ),
+      followOns: buildObservedMoneyField(
+        input.fact,
+        input.fact.followOnInvestmentAmount,
+        'facts.followOnInvestmentAmount'
+      ),
+      fmv: buildFmvField(input.fact),
+      exitValuation: {
+        value: null,
+        status: 'user_required',
+        marketReference:
+          input.fact.provenance.trustState === 'FAILED' ? null : input.fact.latestRoundValuation,
+      },
+      probability: { value: null, status: 'user_required' },
+      ownershipAtExit: { value: null, status: 'user_required' },
+    },
+    warnings: input.fact.warnings,
+  });
+}

--- a/shared/contracts/fund-actuals/fund-company-actuals-fact.contract.ts
+++ b/shared/contracts/fund-actuals/fund-company-actuals-fact.contract.ts
@@ -1,13 +1,10 @@
 import { z } from 'zod';
 
 import { DecimalStringSchema } from '../lp-reporting/cash-flow-event.contract';
-import {
-  ProvenanceEnvelopeSchema,
-  StructuredWarningSchema,
-} from '../provenance-envelope.contract';
+import { ProvenanceEnvelopeSchema, StructuredWarningSchema } from '../provenance-envelope.contract';
 
 const PositiveIdSchema = z.number().int().positive();
-const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+export const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 const IsoDateSchema = z.string().date();
 const CurrencyCodeSchema = z.string().regex(/^[A-Z]{3}$/);
 
@@ -79,9 +76,5 @@ export type FundCompanyActualsPlanningFmvStatus = z.infer<
 export type FundCompanyActualsCurrencyStatus = z.infer<
   typeof FundCompanyActualsCurrencyStatusSchema
 >;
-export type FundCompanyActualsFact = z.infer<
-  typeof FundCompanyActualsFactSchema
->;
-export type FundCompanyActualsFactsResponse = z.infer<
-  typeof FundCompanyActualsFactsResponseSchema
->;
+export type FundCompanyActualsFact = z.infer<typeof FundCompanyActualsFactSchema>;
+export type FundCompanyActualsFactsResponse = z.infer<typeof FundCompanyActualsFactsResponseSchema>;

--- a/shared/contracts/scenarios/scenario-case-seed-v1.contract.ts
+++ b/shared/contracts/scenarios/scenario-case-seed-v1.contract.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+
+import {
+  FundCompanyActualsCurrencyStatusSchema,
+  Sha256Schema,
+} from '../fund-actuals/fund-company-actuals-fact.contract';
+import { DecimalStringSchema } from '../lp-reporting/cash-flow-event.contract';
+import { StructuredWarningSchema } from '../provenance-envelope.contract';
+
+export const SeededFieldSchema = z.discriminatedUnion('status', [
+  z
+    .object({
+      status: z.literal('seeded'),
+      value: DecimalStringSchema,
+      source: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal('unavailable'),
+      value: z.null(),
+      reason: z.enum(['currency_blocked', 'facts_unavailable', 'source_missing']),
+    })
+    .strict(),
+]);
+
+export const SeededNullableFieldSchema = z.discriminatedUnion('status', [
+  z
+    .object({
+      status: z.literal('seeded'),
+      value: DecimalStringSchema,
+      source: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal('unavailable'),
+      value: z.null(),
+      reason: z.enum(['currency_blocked', 'facts_unavailable', 'no_active_fmv', 'fmv_stale']),
+    })
+    .strict(),
+]);
+
+export const UserRequiredFieldSchema = z
+  .object({
+    value: z.null(),
+    status: z.literal('user_required'),
+  })
+  .strict();
+
+export const ScenarioCaseSeedV1Schema = z
+  .object({
+    contractVersion: z.literal('scenario-case-seed-v1'),
+    fundId: z.number().int().positive(),
+    companyId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+    factsInputHash: Sha256Schema,
+    trustState: z.enum(['LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED']),
+    currencyStatus: FundCompanyActualsCurrencyStatusSchema,
+    fields: z
+      .object({
+        investment: SeededFieldSchema,
+        followOns: SeededFieldSchema,
+        fmv: SeededNullableFieldSchema,
+        exitValuation: z
+          .object({
+            value: z.null(),
+            status: z.literal('user_required'),
+            marketReference: DecimalStringSchema.nullable(),
+          })
+          .strict(),
+        probability: UserRequiredFieldSchema,
+        ownershipAtExit: UserRequiredFieldSchema,
+      })
+      .strict(),
+    warnings: z.array(StructuredWarningSchema),
+  })
+  .strict()
+  .superRefine((seed, context) => {
+    const monetaryFields = ['investment', 'followOns', 'fmv'] as const;
+
+    if (seed.currencyStatus !== 'base_currency') {
+      for (const fieldName of monetaryFields) {
+        const field = seed.fields[fieldName];
+        if (field.status !== 'unavailable' || field.reason !== 'currency_blocked') {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['fields', fieldName],
+            message: 'Non-base-currency facts cannot seed monetary fields',
+          });
+        }
+      }
+    }
+
+    if (seed.trustState === 'UNAVAILABLE' || seed.trustState === 'FAILED') {
+      for (const fieldName of monetaryFields) {
+        if (seed.fields[fieldName].status === 'seeded') {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['fields', fieldName],
+            message: `${seed.trustState} facts cannot seed monetary fields`,
+          });
+        }
+      }
+    }
+
+    if (seed.trustState === 'FAILED' && seed.fields.exitValuation.marketReference !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fields', 'exitValuation', 'marketReference'],
+        message: 'Failed facts cannot disclose a market reference',
+      });
+    }
+  });
+
+export type ScenarioCaseSeedV1 = z.infer<typeof ScenarioCaseSeedV1Schema>;

--- a/tests/unit/contracts/scenario-case-seed-v1.contract.test.ts
+++ b/tests/unit/contracts/scenario-case-seed-v1.contract.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ScenarioCaseSeedV1Schema,
+  SeededFieldSchema,
+  SeededNullableFieldSchema,
+  UserRequiredFieldSchema,
+} from '../../../shared/contracts/scenarios/scenario-case-seed-v1.contract';
+
+function makeSeed() {
+  return {
+    contractVersion: 'scenario-case-seed-v1',
+    fundId: 10,
+    companyId: 101,
+    asOfDate: '2026-07-13',
+    factsInputHash: 'a'.repeat(64),
+    trustState: 'LIVE',
+    currencyStatus: 'base_currency',
+    fields: {
+      investment: {
+        status: 'seeded',
+        value: '500000.000000',
+        source: 'facts.initialInvestmentAmount',
+      },
+      followOns: {
+        status: 'seeded',
+        value: '250000.000000',
+        source: 'facts.followOnInvestmentAmount',
+      },
+      fmv: {
+        status: 'seeded',
+        value: '14000000.000000',
+        source: 'facts.latestPlanningFmvValue',
+      },
+      exitValuation: {
+        value: null,
+        status: 'user_required',
+        marketReference: '12000000.000000',
+      },
+      probability: { value: null, status: 'user_required' },
+      ownershipAtExit: { value: null, status: 'user_required' },
+    },
+    warnings: [],
+  };
+}
+
+function withoutSeededMoney(seed = makeSeed()) {
+  return {
+    ...seed,
+    fields: {
+      ...seed.fields,
+      investment: { status: 'unavailable', value: null, reason: 'facts_unavailable' },
+      followOns: { status: 'unavailable', value: null, reason: 'facts_unavailable' },
+      fmv: { status: 'unavailable', value: null, reason: 'facts_unavailable' },
+    },
+  };
+}
+
+function withCurrencyBlockedMoney(seed = makeSeed()) {
+  return {
+    ...seed,
+    fields: {
+      ...seed.fields,
+      investment: { status: 'unavailable', value: null, reason: 'currency_blocked' },
+      followOns: { status: 'unavailable', value: null, reason: 'currency_blocked' },
+      fmv: { status: 'unavailable', value: null, reason: 'currency_blocked' },
+    },
+  };
+}
+
+describe('ScenarioCaseSeedV1Schema', () => {
+  it('accepts an actuals-backed seed with user-required forecast inputs', () => {
+    const seed = makeSeed();
+
+    expect(ScenarioCaseSeedV1Schema.parse(seed)).toEqual(seed);
+  });
+
+  it.each(['LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED'] as const)(
+    'accepts the %s trust state',
+    (trustState) => {
+      const seed =
+        trustState === 'UNAVAILABLE' || trustState === 'FAILED' ? withoutSeededMoney() : makeSeed();
+      if (trustState === 'FAILED') {
+        seed.fields.exitValuation.marketReference = null;
+      }
+
+      expect(ScenarioCaseSeedV1Schema.safeParse({ ...seed, trustState }).success).toBe(true);
+    }
+  );
+
+  it.each(['base_currency', 'mismatch_blocked', 'unknown'] as const)(
+    'accepts the %s currency state',
+    (currencyStatus) => {
+      const seed = currencyStatus === 'base_currency' ? makeSeed() : withCurrencyBlockedMoney();
+
+      expect(ScenarioCaseSeedV1Schema.safeParse({ ...seed, currencyStatus }).success).toBe(true);
+    }
+  );
+
+  it('rejects seeded money for unavailable trust or blocked currency', () => {
+    expect(
+      ScenarioCaseSeedV1Schema.safeParse({ ...makeSeed(), trustState: 'UNAVAILABLE' }).success
+    ).toBe(false);
+    expect(
+      ScenarioCaseSeedV1Schema.safeParse({ ...makeSeed(), currencyStatus: 'mismatch_blocked' })
+        .success
+    ).toBe(false);
+  });
+
+  it('rejects a facts-derived market reference on a failed seed', () => {
+    expect(
+      ScenarioCaseSeedV1Schema.safeParse({
+        ...withoutSeededMoney(),
+        trustState: 'FAILED',
+      }).success
+    ).toBe(false);
+  });
+
+  it.each(['currency_blocked', 'facts_unavailable', 'source_missing'] as const)(
+    'accepts the %s required-money unavailability reason',
+    (reason) => {
+      expect(
+        SeededFieldSchema.safeParse({ status: 'unavailable', value: null, reason }).success
+      ).toBe(true);
+    }
+  );
+
+  it.each(['currency_blocked', 'facts_unavailable', 'no_active_fmv', 'fmv_stale'] as const)(
+    'accepts the %s nullable-money unavailability reason',
+    (reason) => {
+      expect(
+        SeededNullableFieldSchema.safeParse({ status: 'unavailable', value: null, reason }).success
+      ).toBe(true);
+    }
+  );
+
+  it('rejects unknown keys at every reusable object boundary', () => {
+    expect(ScenarioCaseSeedV1Schema.safeParse({ ...makeSeed(), extra: true }).success).toBe(false);
+    expect(
+      SeededFieldSchema.safeParse({
+        status: 'seeded',
+        value: '1.000000',
+        source: 'facts.initialInvestmentAmount',
+        extra: true,
+      }).success
+    ).toBe(false);
+    expect(
+      SeededNullableFieldSchema.safeParse({
+        status: 'unavailable',
+        value: null,
+        reason: 'no_active_fmv',
+        extra: true,
+      }).success
+    ).toBe(false);
+    expect(
+      UserRequiredFieldSchema.safeParse({
+        value: null,
+        status: 'user_required',
+        extra: true,
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects numeric money and invalid enum values', () => {
+    expect(
+      SeededFieldSchema.safeParse({
+        status: 'seeded',
+        value: 500000,
+        source: 'facts.initialInvestmentAmount',
+      }).success
+    ).toBe(false);
+    expect(ScenarioCaseSeedV1Schema.safeParse({ ...makeSeed(), trustState: 'STALE' }).success).toBe(
+      false
+    );
+    expect(
+      ScenarioCaseSeedV1Schema.safeParse({ ...makeSeed(), currencyStatus: 'converted' }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -1,11 +1,39 @@
 import express from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  FundCompanyActualsFactSchema,
+  type FundCompanyActualsFact,
+} from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 
 const fundScopeState = vi.hoisted(() => ({
   enforceCompanyFundScope: vi.fn(async (_req: Request, _res: Response, _companyId: number) => true),
 }));
+
+const fundAccessState = vi.hoisted(() => ({
+  requireFundAccess: vi.fn((_req: Request, _res: Response, next: NextFunction) => next()),
+}));
+
+const factsState = vi.hoisted(() => {
+  class FundActualsFactsServiceError extends Error {
+    readonly status: number;
+    readonly code: string;
+
+    constructor(status: number, code: string, message: string) {
+      super(message);
+      this.name = 'FundActualsFactsServiceError';
+      this.status = status;
+      this.code = code;
+    }
+  }
+
+  return {
+    buildFundCompanyActualsFacts: vi.fn(),
+    FundActualsFactsServiceError,
+  };
+});
 
 // Chain-safe db stub: every builder method is a spy; terminal awaits resolve to
 // empty/benign values so a neutered guard (negative control) falls through to a
@@ -23,12 +51,17 @@ const dbState = vi.hoisted(() => {
   const deleteChain: Record<string, unknown> = {};
   deleteChain['where'] = vi.fn(async () => undefined);
 
+  const updateChain: Record<string, unknown> = {};
+  updateChain['set'] = vi.fn(() => updateChain);
+  updateChain['where'] = vi.fn(async () => undefined);
+
   const select = vi.fn(() => selectChain);
   const insert = vi.fn(() => insertChain);
+  const update = vi.fn(() => updateChain);
   const remove = vi.fn(() => deleteChain);
   const transaction = vi.fn(async () => undefined);
   const findFirst = vi.fn(async () => undefined);
-  return { select, insert, remove, transaction, findFirst };
+  return { select, insert, update, remove, transaction, findFirst };
 });
 
 vi.mock('../../../server/lib/auth/company-fund-scope', () => ({
@@ -37,12 +70,19 @@ vi.mock('../../../server/lib/auth/company-fund-scope', () => ({
 
 vi.mock('../../../server/lib/auth/jwt', () => ({
   requireAuth: () => (_req: Request, _res: Response, next: () => void) => next(),
+  requireFundAccess: fundAccessState.requireFundAccess,
+}));
+
+vi.mock('../../../server/services/fund-actuals/fund-company-actuals-facts-service', () => ({
+  buildFundCompanyActualsFacts: factsState.buildFundCompanyActualsFacts,
+  FundActualsFactsServiceError: factsState.FundActualsFactsServiceError,
 }));
 
 vi.mock('../../../server/db', () => ({
   db: {
     select: dbState.select,
     insert: dbState.insert,
+    update: dbState.update,
     delete: dbState.remove,
     transaction: dbState.transaction,
     query: { scenarios: { findFirst: dbState.findFirst } },
@@ -75,10 +115,118 @@ function resetState() {
   fundScopeState.enforceCompanyFundScope.mockResolvedValue(true);
   dbState.select.mockClear();
   dbState.insert.mockClear();
+  dbState.update.mockClear();
   dbState.remove.mockClear();
   dbState.transaction.mockClear();
   dbState.findFirst.mockClear();
+  fundAccessState.requireFundAccess.mockReset();
+  fundAccessState.requireFundAccess.mockImplementation(
+    (_req: Request, _res: Response, next: NextFunction) => next()
+  );
+  factsState.buildFundCompanyActualsFacts.mockReset();
 }
+
+function denyFundAccessOnce() {
+  fundAccessState.requireFundAccess.mockImplementationOnce(
+    (_req: Request, res: Response, _next: NextFunction) => {
+      res.status(403).json({ error: 'Forbidden' });
+    }
+  );
+}
+
+function makeFact(overrides: Partial<FundCompanyActualsFact> = {}): FundCompanyActualsFact {
+  return FundCompanyActualsFactSchema.parse({
+    fundId: 7,
+    companyId: 101,
+    companyName: 'Acme Robotics',
+    investmentIds: [201],
+    activeRoundIds: [301],
+    approvedPlanningFmvMarkId: 401,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '500000.000000',
+    followOnInvestmentAmount: '250000.000000',
+    amountOnlyNonEquityAmount: '0.000000',
+    latestRoundDate: '2025-02-01',
+    latestRoundValuation: '12000000.000000',
+    latestPlanningFmvDate: '2026-06-01',
+    latestPlanningFmvValue: '14000000.000000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [],
+    warnings: [],
+    provenance: {
+      trustState: 'LIVE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'actionable',
+        sourceEngine: 'fund-company-actuals-facts',
+        engineVersion: 'fund-company-actuals-facts-v1',
+        inputHash: 'a'.repeat(64),
+        assumptionsHash: 'b'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: true,
+        warnings: [],
+      },
+      structuredWarnings: [],
+    },
+    inputHash: 'c'.repeat(64),
+    ...overrides,
+  });
+}
+
+function makeBlockedFact(): FundCompanyActualsFact {
+  const warning = {
+    code: 'CURRENCY_MISMATCH_BLOCK',
+    severity: 'blocking',
+    message: 'The source currency does not match the fund base currency.',
+    source: 'company:102',
+  } as const;
+
+  return makeFact({
+    companyId: 102,
+    companyName: 'Blocked Robotics',
+    currency: 'EUR',
+    currencyStatus: 'mismatch_blocked',
+    planningFmvStatus: 'blocked',
+    warnings: [warning],
+    provenance: {
+      trustState: 'UNAVAILABLE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'quarantined',
+        sourceEngine: 'fund-company-actuals-facts',
+        engineVersion: 'fund-company-actuals-facts-v1',
+        inputHash: 'd'.repeat(64),
+        assumptionsHash: 'e'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        quarantineReason: 'currency_mismatch',
+        warnings: [],
+      },
+      structuredWarnings: [warning],
+    },
+    inputHash: 'f'.repeat(64),
+  });
+}
+
+function factsResponse(asOfDate = '2026-07-13') {
+  return {
+    fundId: 7,
+    asOfDate,
+    facts: [makeFact(), makeBlockedFact()],
+    inputHash: '9'.repeat(64),
+    generatedAt: '2026-07-13T00:00:00.000Z',
+  };
+}
+
+function expectNoScenarioWrites() {
+  expect(dbState.insert).not.toHaveBeenCalled();
+  expect(dbState.update).not.toHaveBeenCalled();
+  expect(dbState.remove).not.toHaveBeenCalled();
+  expect(dbState.transaction).not.toHaveBeenCalled();
+}
+
+afterEach(() => vi.useRealTimers());
 
 describe('scenario-analysis route fund-scope contracts', () => {
   beforeEach(() => resetState());
@@ -165,5 +313,146 @@ describe('scenario-analysis route fund-scope contracts', () => {
     expect(res.body).toMatchObject({ error: 'Invalid company ID' });
     expect(fundScopeState.enforceCompanyFundScope).not.toHaveBeenCalled();
     expect(dbState.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('scenario-analysis actuals-backed seed suggestions', () => {
+  beforeEach(() => resetState());
+
+  it('rejects a non-canonical fundId before the fund guard or facts service', async () => {
+    const res = await request(makeApp()).get('/api/funds/01/scenario-analysis/seeds');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid_fund_id' });
+    expect(fundAccessState.requireFundAccess).not.toHaveBeenCalled();
+    expect(factsState.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+  });
+
+  it('denies cross-fund access before loading facts', async () => {
+    denyFundAccessOnce();
+
+    const res = await request(makeApp()).get('/api/funds/7/scenario-analysis/seeds');
+
+    expect(res.status).toBe(403);
+    expect(factsState.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expectNoScenarioWrites();
+  });
+
+  it('rejects malformed or extra query values before loading facts', async () => {
+    const malformed = await request(makeApp()).get(
+      '/api/funds/7/scenario-analysis/seeds?asOfDate=2026-7-1'
+    );
+    const extra = await request(makeApp()).get(
+      '/api/funds/7/scenario-analysis/seeds?asOfDate=2026-07-01&extra=true'
+    );
+
+    expect(malformed.status).toBe(400);
+    expect(extra.status).toBe(400);
+    expect(factsState.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+  });
+
+  it('returns every company seed and performs no scenario writes', async () => {
+    factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce(factsResponse('2026-07-01'));
+
+    const res = await request(makeApp()).get(
+      '/api/funds/7/scenario-analysis/seeds?asOfDate=2026-07-01'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      fundId: 7,
+      asOfDate: '2026-07-01',
+      factsStatus: 'available',
+      factsInputHash: '9'.repeat(64),
+    });
+    expect(res.body.seeds).toHaveLength(2);
+    expect(res.body.seeds[0].fields.investment).toMatchObject({
+      status: 'seeded',
+      value: '500000.000000',
+    });
+    expect(res.body.seeds[1].fields.investment).toMatchObject({
+      status: 'unavailable',
+      reason: 'currency_blocked',
+    });
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: '2026-07-01',
+    });
+    expect(res.headers['cache-control']).toBeUndefined();
+    expectNoScenarioWrites();
+  });
+
+  it.each([
+    ['fund ID', { fundId: 8 }],
+    ['as-of date', { asOfDate: '2026-07-12' }],
+  ] as const)(
+    'fails closed when the facts %s does not match the request',
+    async (_label, drift) => {
+      factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce({
+        ...factsResponse('2026-07-13'),
+        ...drift,
+      });
+
+      const res = await request(makeApp()).get(
+        '/api/funds/7/scenario-analysis/seeds?asOfDate=2026-07-13'
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        fundId: 7,
+        asOfDate: '2026-07-13',
+        factsStatus: 'failed',
+        factsInputHash: null,
+        seeds: [],
+      });
+      expectNoScenarioWrites();
+    }
+  );
+
+  it('defaults asOfDate to the current UTC date', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-13T23:59:59.000-07:00'));
+    factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce(factsResponse('2026-07-14'));
+
+    const res = await request(makeApp()).get('/api/funds/7/scenario-analysis/seeds');
+
+    expect(res.status).toBe(200);
+    expect(res.body.asOfDate).toBe('2026-07-14');
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: '2026-07-14',
+    });
+  });
+
+  it('propagates a facts-service fund-not-found response', async () => {
+    factsState.buildFundCompanyActualsFacts.mockRejectedValueOnce(
+      new factsState.FundActualsFactsServiceError(404, 'fund_not_found', 'Fund 7 was not found')
+    );
+
+    const res = await request(makeApp()).get('/api/funds/7/scenario-analysis/seeds');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'fund_not_found', message: 'Fund 7 was not found' });
+    expectNoScenarioWrites();
+  });
+
+  it('discloses a non-404 facts failure without returning partial seeds', async () => {
+    factsState.buildFundCompanyActualsFacts.mockRejectedValueOnce(
+      new Error('database unavailable')
+    );
+
+    const res = await request(makeApp()).get('/api/funds/7/scenario-analysis/seeds');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      fundId: 7,
+      asOfDate: '2026-07-13',
+      factsStatus: 'failed',
+      factsInputHash: null,
+      seeds: [],
+    });
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expectNoScenarioWrites();
   });
 });

--- a/tests/unit/services/scenarios/scenario-case-seed-service.test.ts
+++ b/tests/unit/services/scenarios/scenario-case-seed-service.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  FundCompanyActualsFactSchema,
+  type FundCompanyActualsFact,
+} from '../../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { buildScenarioCaseSeed } from '../../../../server/services/scenarios/scenario-case-seed-service';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const HASH_C = 'c'.repeat(64);
+const GENERATED_AT = '2026-07-13T00:00:00.000Z';
+
+function makePartialProvenance(
+  warning: FundCompanyActualsFact['warnings'][number]
+): FundCompanyActualsFact['provenance'] {
+  return {
+    trustState: 'PARTIAL',
+    core: {
+      sourceKind: 'computed',
+      actionability: 'input_only',
+      sourceEngine: 'fund-company-actuals-facts',
+      engineVersion: 'fund-company-actuals-facts-v1',
+      inputHash: HASH_A,
+      assumptionsHash: HASH_B,
+      generatedAt: GENERATED_AT,
+      isFinanciallyActionable: false,
+      warnings: [],
+    },
+    structuredWarnings: [warning],
+  };
+}
+
+function makeUnavailableProvenance(
+  warning: FundCompanyActualsFact['warnings'][number]
+): FundCompanyActualsFact['provenance'] {
+  return {
+    trustState: 'UNAVAILABLE',
+    core: {
+      sourceKind: 'computed',
+      actionability: 'quarantined',
+      sourceEngine: 'fund-company-actuals-facts',
+      engineVersion: 'fund-company-actuals-facts-v1',
+      inputHash: HASH_A,
+      assumptionsHash: HASH_B,
+      generatedAt: GENERATED_AT,
+      isFinanciallyActionable: false,
+      quarantineReason: 'currency_mismatch',
+      warnings: [],
+    },
+    structuredWarnings: [warning],
+  };
+}
+
+function makeFailedProvenance(
+  warning: FundCompanyActualsFact['warnings'][number]
+): FundCompanyActualsFact['provenance'] {
+  return {
+    trustState: 'FAILED',
+    core: {
+      sourceKind: 'prototype_blocked',
+      actionability: 'non_actionable',
+      generatedAt: GENERATED_AT,
+      isFinanciallyActionable: false,
+      quarantineReason: 'round_adapter_failed',
+      warnings: [],
+    },
+    structuredWarnings: [warning],
+  };
+}
+
+function makeLiveFact(overrides: Partial<FundCompanyActualsFact> = {}) {
+  return FundCompanyActualsFactSchema.parse({
+    fundId: 10,
+    companyId: 101,
+    companyName: 'Acme Robotics',
+    investmentIds: [201, 202],
+    activeRoundIds: [21, 22],
+    approvedPlanningFmvMarkId: 301,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '500000.000000',
+    followOnInvestmentAmount: '250000.000000',
+    amountOnlyNonEquityAmount: '0.000000',
+    latestRoundDate: '2025-02-01',
+    latestRoundValuation: '12000000.000000',
+    latestPlanningFmvDate: '2026-06-01',
+    latestPlanningFmvValue: '14000000.000000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [],
+    warnings: [],
+    provenance: {
+      trustState: 'LIVE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'actionable',
+        sourceEngine: 'fund-company-actuals-facts',
+        engineVersion: 'fund-company-actuals-facts-v1',
+        inputHash: HASH_A,
+        assumptionsHash: HASH_B,
+        generatedAt: GENERATED_AT,
+        isFinanciallyActionable: true,
+        warnings: [],
+      },
+      structuredWarnings: [],
+    },
+    inputHash: HASH_C,
+    ...overrides,
+  });
+}
+
+describe('buildScenarioCaseSeed', () => {
+  it('maps usable LIVE facts into seed suggestions without forecasting user inputs', () => {
+    const seed = buildScenarioCaseSeed({
+      fundId: 10,
+      fact: makeLiveFact(),
+      asOfDate: '2026-07-13',
+    });
+
+    expect(seed.fields).toEqual({
+      investment: {
+        status: 'seeded',
+        value: '500000.000000',
+        source: 'facts.initialInvestmentAmount',
+      },
+      followOns: {
+        status: 'seeded',
+        value: '250000.000000',
+        source: 'facts.followOnInvestmentAmount',
+      },
+      fmv: {
+        status: 'seeded',
+        value: '14000000.000000',
+        source: 'facts.latestPlanningFmvValue',
+      },
+      exitValuation: {
+        value: null,
+        status: 'user_required',
+        marketReference: '12000000.000000',
+      },
+      probability: { value: null, status: 'user_required' },
+      ownershipAtExit: { value: null, status: 'user_required' },
+    });
+  });
+
+  it('keeps usable PARTIAL actuals while disclosing a stale FMV as unavailable', () => {
+    const warning = {
+      code: 'PLANNING_FMV_STALE',
+      severity: 'warning',
+      message: 'The approved planning FMV mark is stale.',
+      source: 'company:101',
+    } as const;
+    const fact = makeLiveFact({
+      planningFmvStatus: 'stale',
+      warnings: [warning],
+      provenance: makePartialProvenance(warning),
+    });
+
+    const seed = buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' });
+
+    expect(seed.trustState).toBe('PARTIAL');
+    expect(seed.fields.investment.status).toBe('seeded');
+    expect(seed.fields.followOns.status).toBe('seeded');
+    expect(seed.fields.fmv).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'fmv_stale',
+    });
+  });
+
+  it.each(['none', 'superseded', 'blocked'] as const)(
+    'does not seed a %s planning FMV',
+    (planningFmvStatus) => {
+      const warning = {
+        code: 'PLANNING_FMV_MISSING',
+        severity: 'warning',
+        message: 'No active planning FMV is available.',
+        source: 'company:101',
+      } as const;
+      const fact = makeLiveFact({
+        planningFmvStatus,
+        warnings: [warning],
+        provenance: makePartialProvenance(warning),
+      });
+
+      const seed = buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' });
+
+      expect(seed.fields.fmv).toEqual({
+        status: 'unavailable',
+        value: null,
+        reason: 'no_active_fmv',
+      });
+    }
+  );
+
+  it('blocks every monetary seed when the fact currency does not match the fund', () => {
+    const warning = {
+      code: 'CURRENCY_MISMATCH_BLOCK',
+      severity: 'blocking',
+      message: 'The source currency does not match the fund base currency.',
+      source: 'company:101',
+    } as const;
+    const fact = makeLiveFact({
+      planningFmvStatus: 'blocked',
+      currency: 'EUR',
+      currencyStatus: 'mismatch_blocked',
+      warnings: [warning],
+      provenance: makeUnavailableProvenance(warning),
+    });
+
+    const seed = buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' });
+
+    expect(seed.fields.investment).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'currency_blocked',
+    });
+    expect(seed.fields.followOns).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'currency_blocked',
+    });
+    expect(seed.fields.fmv).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'currency_blocked',
+    });
+    expect(seed.fields.exitValuation).toEqual({
+      value: null,
+      status: 'user_required',
+      marketReference: '12000000.000000',
+    });
+  });
+
+  it('returns a fully unavailable seed for a FAILED company fact', () => {
+    const warning = {
+      code: 'ROUND_ADAPTER_FAILED',
+      severity: 'blocking',
+      message: 'The round adapter failed for this company.',
+      source: 'company:101',
+    } as const;
+    const fact = makeLiveFact({
+      warnings: [warning],
+      provenance: makeFailedProvenance(warning),
+    });
+
+    const seed = buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' });
+
+    expect(seed.trustState).toBe('FAILED');
+    expect(seed.fields.investment).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'facts_unavailable',
+    });
+    expect(seed.fields.followOns).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'facts_unavailable',
+    });
+    expect(seed.fields.fmv).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'facts_unavailable',
+    });
+    expect(seed.fields.exitValuation).toEqual({
+      value: null,
+      status: 'user_required',
+      marketReference: null,
+    });
+  });
+
+  it('rejects a fact from a different fund', () => {
+    const fact = makeLiveFact({ fundId: 11 });
+
+    expect(() => buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' })).toThrow(
+      'Fact fund 11 does not match requested fund 10'
+    );
+  });
+
+  it('does not fabricate observed money when the fact has no active round source', () => {
+    const fact = makeLiveFact({
+      investmentIds: [],
+      activeRoundIds: [],
+      initialInvestmentAmount: '0.000000',
+      followOnInvestmentAmount: '0.000000',
+    });
+
+    const seed = buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' });
+
+    expect(seed.fields.investment).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'source_missing',
+    });
+    expect(seed.fields.followOns).toEqual({
+      status: 'unavailable',
+      value: null,
+      reason: 'source_missing',
+    });
+    expect(seed.fields.fmv.status).toBe('seeded');
+  });
+
+  it('preserves observed zero sums when an amount-only round supplies the fact source', () => {
+    const fact = makeLiveFact({
+      activeRoundIds: [21],
+      initialInvestmentAmount: '0.000000',
+      followOnInvestmentAmount: '0.000000',
+      amountOnlyNonEquityAmount: '100000.000000',
+    });
+
+    const seed = buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' });
+
+    expect(seed.fields.investment).toEqual({
+      status: 'seeded',
+      value: '0.000000',
+      source: 'facts.initialInvestmentAmount',
+    });
+    expect(seed.fields.followOns).toEqual({
+      status: 'seeded',
+      value: '0.000000',
+      source: 'facts.followOnInvestmentAmount',
+    });
+  });
+
+  it('treats an unknown currency as blocked for every monetary seed', () => {
+    const warning = {
+      code: 'PLANNING_FMV_MISSING',
+      severity: 'warning',
+      message: 'No active planning FMV is available.',
+      source: 'company:101',
+    } as const;
+    const fact = makeLiveFact({
+      planningFmvStatus: 'none',
+      currencyStatus: 'unknown',
+      warnings: [warning],
+      provenance: makePartialProvenance(warning),
+    });
+
+    const seed = buildScenarioCaseSeed({ fundId: 10, fact, asOfDate: '2026-07-13' });
+
+    expect(seed.fields.investment).toMatchObject({
+      status: 'unavailable',
+      reason: 'currency_blocked',
+    });
+    expect(seed.fields.followOns).toMatchObject({
+      status: 'unavailable',
+      reason: 'currency_blocked',
+    });
+    expect(seed.fields.fmv).toMatchObject({
+      status: 'unavailable',
+      reason: 'currency_blocked',
+    });
+  });
+
+  it('is deterministic, preserves the fact hash, and never promotes a market reference', () => {
+    const input = { fundId: 10, fact: makeLiveFact(), asOfDate: '2026-07-13' };
+
+    const first = buildScenarioCaseSeed(input);
+    const second = buildScenarioCaseSeed(input);
+
+    expect(second).toEqual(first);
+    expect(first.factsInputHash).toBe(HASH_C);
+    expect(first.fields.exitValuation).toEqual({
+      value: null,
+      status: 'user_required',
+      marketReference: '12000000.000000',
+    });
+    expect(first.fields.probability).toEqual({ value: null, status: 'user_required' });
+    expect(first.fields.ownershipAtExit).toEqual({ value: null, status: 'user_required' });
+    expect(JSON.stringify(first).match(/12000000\.000000/g)).toHaveLength(1);
+  });
+
+  it('keeps the pure assembler isolated from routes, persistence, and source tables', async () => {
+    const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const source = actualFs.readFileSync(
+      new URL(
+        '../../../../server/services/scenarios/scenario-case-seed-service.ts',
+        import.meta.url
+      ),
+      'utf8'
+    );
+    const importTargets = [...source.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((match) => match[1]);
+
+    expect(importTargets).toEqual([
+      '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract',
+      '../../../shared/contracts/scenarios/scenario-case-seed-v1.contract',
+    ]);
+    for (const forbidden of [
+      'server/db',
+      'express',
+      'drizzle',
+      'investment_rounds',
+      'valuation_marks',
+    ]) {
+      expect(source).not.toContain(forbidden);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Plan 8 wave 1 (Tasks 8.1 + 8.2) of the trust-spine arc — scenario case seeds from recorded portfolio facts, read-only.

- **New contract** `shared/contracts/scenarios/scenario-case-seed-v1.contract.ts`: strict per-company seed with per-field seeded/unavailable status (`SeededFieldSchema` discriminated unions), machine-readable reasons, and permanently `user_required` probability/ownership fields.
- **New pure service** `server/services/scenarios/scenario-case-seed-service.ts`: binding field map enforced — investment/follow-ons from observed facts; FMV seeded only when Planning FMV is `active` AND base-currency (`fmv_stale` / `no_active_fmv` / `currency_blocked` reasons otherwise); non-base currency blocks ALL monetary seeds; latest round valuation appears only as `exitValuation.marketReference`, never in a value slot; exit valuation is never auto-seeded; trust state from the fact's provenance envelope with per-field gating (PARTIAL seeds only usable fields).
- **New read-only route** `GET /api/funds/:fundId/scenario-analysis/seeds?asOfDate=YYYY-MM-DD` on the existing scenario-analysis router (existing mount, no manifest surface change): strict fundId check (400) -> `requireFundAccess` (403) -> single `buildFundCompanyActualsFacts` call; strict discriminated-union response parsed server-side; fund-not-found propagates 404; any other facts failure returns a disclosed `factsStatus:'failed'` envelope with HTTP 200 (ADR-028); defensive facts scope-mismatch check. Returns ALL companies including fully-unavailable seeds. No caching, no writes.
- `Sha256Schema` in the fund-actuals contract gains an `export` keyword (plus prettier formatting) — zero behavior change.

## Binding-decision compliance

- Seeds are point-in-time suggestions; nothing is persisted in this wave (provenance table + snapshot-at-creation binding come in wave 2 with the migration, claiming the next free journal index at exec time).
- No probability/ownership defaults anywhere; no fabricated values — unavailable fields carry `value: null` + reason.
- Trust mapping: LIVE seeds observed money + active FMV; PARTIAL per-field; UNAVAILABLE/currency-blocked seeds no money; facts FAILED -> failed envelope.

## Verification

- 48/48 tests green across the three suites (19 contract, 13 service, 16 route incl. 400/403/404/failed-envelope paths), run independently post-implementation.
- Mount-parity + route-policy guard suites green (30/30) with the new route in place.
- `npm run check` (client/server/shared baseline) green: 0 TypeScript errors. ESLint clean on all changed files.
- Rebased onto main after #1097 (disjoint file sets, clean rebase).

Spec: `updog_restore_review_only_implementation_plans_2026-07-11.md` Plan 8 (line 3118), executed via Hermes/Codex worktree lane, Claude-verified. Remaining Plan 8 waves: 8.3 (provenance migration/persistence), 8.4 (seed picker UI), 8.5 (scenario hash), 8.6-8.8 (Monte Carlo adapter/parity/profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h