### PR TITLE
feat(reserves): facts-sourced reserve candidates behind flag-off-identical gate (Plan 5 wave 2)

### DIFF
--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -516,6 +516,20 @@ flags:
     expiresAt: null
     aliases: ['ENABLE_MARGINAL_RESERVE_MOIC']
 
+  enable_facts_sourced_reserve_inputs:
+    default: false
+    description: 'Gates eligibility-filtered reserve engine inputs sourced from actuals facts'
+    owner: 'analytics'
+    risk: high
+    exposeToClient: false
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: null
+    aliases: ['ENABLE_FACTS_SOURCED_RESERVE_INPUTS']
+
   enable_faults:
     default: false
     description: 'Enable fault injection for testing'

--- a/server/services/reserve-calculation-service.ts
+++ b/server/services/reserve-calculation-service.ts
@@ -1,12 +1,139 @@
 import { db } from '../db';
 import { fundSnapshots } from '@shared/schema';
 import { generateReserveSummary } from '@shared/core/reserves/ReserveEngine';
+import { isFlagEnabled } from '@shared/flags/getFlag';
+import type { ReserveInputTrustSummary } from '@shared/contracts/reserve-input-provenance.contract';
+import type { ReserveCompanyInput, ReserveSummary } from '@shared/types';
+import Decimal from '@shared/lib/decimal-config';
+import { logger } from '../lib/logger';
 import { resolveMoicActionability, toH9SnapshotColumns } from './fund-calculation-mode-service';
 import { markCalcRunCompletedIfReady } from './calc-run-tracking';
 import { buildReservePortfolioInputWithProvenance } from './reserve-input-builder';
+import {
+  buildFactsReserveCandidates,
+  type FactsReserveCandidate,
+} from './reserves/facts-reserve-input-adapter';
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
+const RESERVE_FACTS_CALCULATION_KEY = 'reserve_facts_inputs';
+
+type ReserveFactsCalculationMode = 'off' | 'shadow' | 'on';
+type FactsBasisMetadata = {
+  factsInputHash: string | null;
+  trustedForActivation: boolean;
+  mode: 'on';
+};
+
+async function resolveReserveFactsCalculationMode(
+  fundId: number
+): Promise<ReserveFactsCalculationMode> {
+  const mode = await db.query.fundCalculationModes.findFirst({
+    columns: { configuredMode: true, killSwitchActive: true },
+    where: (row, { and, eq }) =>
+      and(eq(row.fundId, fundId), eq(row.calculationKey, RESERVE_FACTS_CALCULATION_KEY)),
+  });
+  if (mode?.killSwitchActive) return 'off';
+  return mode?.configuredMode === 'shadow' || mode?.configuredMode === 'on'
+    ? mode.configuredMode
+    : 'off';
+}
+
+function eligibleInputs(candidates: readonly FactsReserveCandidate[]): ReserveCompanyInput[] {
+  return candidates
+    .filter((candidate) => candidate.status === 'eligible')
+    .map((candidate) => candidate.input);
+}
+
+function engineFedFactsInputsAreTrusted(candidates: readonly FactsReserveCandidate[]): boolean {
+  return candidates
+    .filter((candidate) => candidate.status === 'eligible')
+    .every((candidate) =>
+      [
+        candidate.input.provenance.invested,
+        candidate.input.provenance.ownership,
+        candidate.input.provenance.stage,
+      ].every((field) => field.status === 'observed' || field.status === 'approved_assumption')
+    );
+}
+
+function excludedCountsByReason(
+  candidates: readonly FactsReserveCandidate[]
+): Record<string, number> {
+  const counts = new Map<string, number>();
+  for (const candidate of candidates) {
+    if (candidate.status !== 'excluded') continue;
+    for (const reason of new Set(candidate.reasons)) {
+      counts.set(reason, (counts.get(reason) ?? 0) + 1);
+    }
+  }
+  return Object.fromEntries(
+    [...counts.entries()].sort(([left], [right]) => left.localeCompare(right))
+  );
+}
+
+function summaryValueDeltaPct(
+  legacySummary: ReserveSummary,
+  factsSummary: ReserveSummary
+): number | null {
+  if (!Number.isFinite(legacySummary.totalAllocation) || legacySummary.totalAllocation === 0) {
+    return null;
+  }
+  return new Decimal(factsSummary.totalAllocation)
+    .minus(legacySummary.totalAllocation)
+    .div(new Decimal(legacySummary.totalAllocation).abs())
+    .toDecimalPlaces(6)
+    .toNumber();
+}
+
+function logReserveFactsShadowEvent(event: Record<string, unknown>): void {
+  try {
+    logger.info(event, 'reserve facts inputs shadow comparison generated');
+  } catch {
+    return;
+  }
+}
+
+async function emitReserveFactsShadowComparison(input: {
+  fundId: number;
+  asOfDate: string;
+  legacyCompanyCount: number;
+  legacySummary: ReserveSummary;
+}): Promise<void> {
+  const startedAt = performance.now();
+  try {
+    const facts = await buildFactsReserveCandidates({
+      fundId: input.fundId,
+      asOfDate: input.asOfDate,
+    });
+    const factsPortfolio = eligibleInputs(facts.candidates);
+    const factsSummary = generateReserveSummary(input.fundId, factsPortfolio);
+    const excludedCounts = excludedCountsByReason(facts.candidates);
+    logReserveFactsShadowEvent({
+      eventName: 'reserve_facts_inputs_shadow',
+      fundId: input.fundId,
+      factsInputHash: facts.factsInputHash?.slice(0, 12) ?? null,
+      eligibleCount: factsPortfolio.length,
+      excludedCountsByReason: excludedCounts,
+      legacyCompanyCount: input.legacyCompanyCount,
+      summaryValueDeltaPct: summaryValueDeltaPct(input.legacySummary, factsSummary),
+      durationMs: performance.now() - startedAt,
+      warningCodes: Object.keys(excludedCounts).map((reason) => reason.toUpperCase()),
+    });
+  } catch {
+    logReserveFactsShadowEvent({
+      eventName: 'reserve_facts_inputs_shadow',
+      fundId: input.fundId,
+      factsInputHash: null,
+      eligibleCount: 0,
+      excludedCountsByReason: {},
+      legacyCompanyCount: input.legacyCompanyCount,
+      summaryValueDeltaPct: null,
+      durationMs: performance.now() - startedAt,
+      warningCodes: ['SHADOW_BUILD_FAILED'],
+    });
+  }
+}
 
 async function retryWithBackoff<T>(
   fn: () => Promise<T>,
@@ -57,15 +184,45 @@ export async function runReserveCalculation({
     throw new Error(`Fund ${fundId} not found`);
   }
 
-  const {
-    portfolio,
-    reserveInputTrustSummary,
-  } = await retryWithBackoff(() => buildReservePortfolioInputWithProvenance(fundId));
+  const reserveFactsFlagEnabled = isFlagEnabled('enable_facts_sourced_reserve_inputs');
+  const reserveFactsMode = reserveFactsFlagEnabled
+    ? await resolveReserveFactsCalculationMode(fundId)
+    : 'off';
+  let portfolio: ReserveCompanyInput[];
+  let reserveInputTrustSummary: ReserveInputTrustSummary;
+  let factsBasis: FactsBasisMetadata | undefined;
+  let factsInputsTrustedForActivation = true;
+
+  if (reserveFactsMode === 'on') {
+    const facts = await buildFactsReserveCandidates({
+      fundId,
+      asOfDate: new Date().toISOString().slice(0, 10),
+    });
+    portfolio = eligibleInputs(facts.candidates);
+    reserveInputTrustSummary = facts.trustSummary;
+    factsInputsTrustedForActivation =
+      facts.factsInputHash !== null &&
+      facts.trustSummary.trustedForActivation &&
+      engineFedFactsInputsAreTrusted(facts.candidates);
+    factsBasis = {
+      factsInputHash: facts.factsInputHash,
+      trustedForActivation: factsInputsTrustedForActivation,
+      mode: 'on',
+    };
+  } else {
+    const legacy = await retryWithBackoff(() => buildReservePortfolioInputWithProvenance(fundId));
+    portfolio = legacy.portfolio;
+    reserveInputTrustSummary = legacy.reserveInputTrustSummary;
+  }
 
   const reserves = generateReserveSummary(fundId, portfolio);
   // H9: stamp the actionability fingerprint onto the authoritative snapshot so
   // downstream reuse/cache/export can gate on it. Display reads are unaffected.
   const actionability = await resolveMoicActionability({ fundId });
+  const h9Columns = toH9SnapshotColumns(actionability);
+  if (reserveFactsMode === 'on' && !factsInputsTrustedForActivation) {
+    h9Columns.h9ActionabilityStatus = 'non_actionable';
+  }
 
   // ADR-022: authoritative-only writer. scenario_set_id intentionally omitted (defaults to NULL).
   const insertedSnapshots = await db
@@ -80,11 +237,12 @@ export async function runReserveCalculation({
       ...(runId != null && { runId }),
       ...(configId != null && { configId }),
       ...(configVersion != null && { configVersion }),
-      ...toH9SnapshotColumns(actionability),
+      ...h9Columns,
       metadata: {
         portfolioCount: portfolio.length,
         engineRuntime: performance.now() - startTime,
         reserveInputTrustSummary,
+        ...(factsBasis !== undefined && { factsBasis }),
       },
     })
     .returning();
@@ -96,6 +254,15 @@ export async function runReserveCalculation({
 
   if (runId != null) {
     await markCalcRunCompletedIfReady(runId);
+  }
+
+  if (reserveFactsMode === 'shadow') {
+    await emitReserveFactsShadowComparison({
+      fundId,
+      asOfDate: new Date().toISOString().slice(0, 10),
+      legacyCompanyCount: portfolio.length,
+      legacySummary: reserves,
+    });
   }
 
   return {

--- a/server/services/reserves/facts-reserve-input-adapter.ts
+++ b/server/services/reserves/facts-reserve-input-adapter.ts
@@ -1,0 +1,165 @@
+import {
+  FactsReserveCandidateSchema,
+  ReserveInputTrustSummarySchema,
+  type FactsReserveCandidate,
+  type FactsReserveCandidateExclusionReason,
+  type ReserveCompanyInputWithProvenance,
+  type ReserveInputSourceStatus,
+  type ReserveInputTrustSummary,
+} from '../../../shared/contracts/reserve-input-provenance.contract';
+import Decimal from '../../../shared/lib/decimal-config';
+import { buildFundCompanyActualsFacts } from '../fund-actuals/fund-company-actuals-facts-service';
+import { buildReservePortfolioInputWithProvenance } from '../reserve-input-builder';
+
+export type { FactsReserveCandidate } from '../../../shared/contracts/reserve-input-provenance.contract';
+
+type ReserveInputField = 'invested' | 'ownership' | 'stage' | 'sector';
+
+const REASON_ORDER: readonly FactsReserveCandidateExclusionReason[] = [
+  'missing_ownership',
+  'missing_stage',
+  'missing_sector',
+  'currency_blocked',
+  'facts_unavailable',
+];
+
+function isTrustedStatus(status: ReserveInputSourceStatus): boolean {
+  return status === 'observed' || status === 'approved_assumption';
+}
+
+function orderedReasons(
+  reasons: ReadonlySet<FactsReserveCandidateExclusionReason>
+): FactsReserveCandidateExclusionReason[] {
+  return REASON_ORDER.filter((reason) => reasons.has(reason));
+}
+
+function eligibleInputIsTrusted(input: ReserveCompanyInputWithProvenance): boolean {
+  return Object.values(input.provenance).every((field) => isTrustedStatus(field.status));
+}
+
+export async function buildFactsReserveCandidates(input: {
+  fundId: number;
+  asOfDate: string;
+}): Promise<{
+  candidates: FactsReserveCandidate[];
+  factsInputHash: string | null;
+  trustSummary: ReserveInputTrustSummary;
+}> {
+  const legacy = await buildReservePortfolioInputWithProvenance(input.fundId);
+  const facts = await buildFundCompanyActualsFacts(input).catch(() => null);
+  const factsByCompany = new Map(
+    (facts?.facts ?? []).map((fact) => [fact.companyId, fact] as const)
+  );
+  const defaultedOccurrences = new Set<string>();
+  const unavailableOccurrences = new Set<string>();
+  const defaultedFields = new Set<ReserveInputField>();
+  const unavailableFields = new Set<ReserveInputField>();
+
+  function countExcludedField(params: {
+    companyId: number;
+    field: ReserveInputField;
+    sourceStatus?: ReserveInputSourceStatus;
+  }): void {
+    const isDefaulted = params.sourceStatus === 'defaulted';
+    const occurrences = isDefaulted ? defaultedOccurrences : unavailableOccurrences;
+    const fields = isDefaulted ? defaultedFields : unavailableFields;
+    occurrences.add(`${params.companyId}:${params.field}`);
+    fields.add(params.field);
+  }
+
+  const candidates: FactsReserveCandidate[] = [...legacy.provenancePortfolio]
+    .sort((left, right) => left.id - right.id)
+    .map((company) => {
+      const fact = factsByCompany.get(company.id);
+      const reasons = new Set<FactsReserveCandidateExclusionReason>();
+      const factsUnavailable =
+        fact === undefined ||
+        fact.provenance.trustState === 'FAILED' ||
+        fact.provenance.trustState === 'UNAVAILABLE';
+      if (factsUnavailable) {
+        reasons.add('facts_unavailable');
+        countExcludedField({ companyId: company.id, field: 'invested' });
+      }
+      if (fact?.currencyStatus === 'mismatch_blocked') {
+        reasons.add('currency_blocked');
+        countExcludedField({ companyId: company.id, field: 'invested' });
+      }
+      if (
+        !isTrustedStatus(company.provenance.ownership.status) ||
+        !Number.isFinite(company.ownership) ||
+        company.ownership < 0 ||
+        company.ownership > 1
+      ) {
+        reasons.add('missing_ownership');
+        countExcludedField({
+          companyId: company.id,
+          field: 'ownership',
+          sourceStatus: company.provenance.ownership.status,
+        });
+      }
+      if (!isTrustedStatus(company.provenance.stage.status) || company.stage.trim().length === 0) {
+        reasons.add('missing_stage');
+        countExcludedField({
+          companyId: company.id,
+          field: 'stage',
+          sourceStatus: company.provenance.stage.status,
+        });
+      }
+      if (
+        !isTrustedStatus(company.provenance.sector.status) ||
+        company.sector.trim().length === 0
+      ) {
+        reasons.add('missing_sector');
+        countExcludedField({
+          companyId: company.id,
+          field: 'sector',
+          sourceStatus: company.provenance.sector.status,
+        });
+      }
+
+      if (reasons.size > 0 || !fact) {
+        return FactsReserveCandidateSchema.parse({
+          status: 'excluded',
+          companyId: company.id,
+          reasons: orderedReasons(reasons),
+          factsInputHash: fact?.inputHash ?? null,
+        });
+      }
+
+      return FactsReserveCandidateSchema.parse({
+        status: 'eligible',
+        companyId: company.id,
+        factsInputHash: fact.inputHash,
+        input: {
+          ...company,
+          invested: new Decimal(fact.initialInvestmentAmount)
+            .plus(fact.followOnInvestmentAmount)
+            .toNumber(),
+          provenance: {
+            ...company.provenance,
+            invested: {
+              status: 'observed',
+              source: 'fund_company_actuals_facts.initialInvestmentAmount+followOnInvestmentAmount',
+              reason: null,
+            },
+          },
+        },
+      });
+    });
+
+  const eligibleInputs = candidates
+    .filter((candidate) => candidate.status === 'eligible')
+    .map((candidate) => candidate.input);
+
+  return {
+    candidates,
+    factsInputHash: facts?.inputHash ?? null,
+    trustSummary: ReserveInputTrustSummarySchema.parse({
+      trustedForActivation: eligibleInputs.every(eligibleInputIsTrusted),
+      defaultedInputCount: defaultedOccurrences.size,
+      unavailableInputCount: unavailableOccurrences.size,
+      defaultedFields: [...defaultedFields].sort(),
+      unavailableFields: [...unavailableFields].sort(),
+    }),
+  };
+}

--- a/shared/contracts/reserve-input-provenance.contract.ts
+++ b/shared/contracts/reserve-input-provenance.contract.ts
@@ -40,9 +40,43 @@ export const ReserveInputTrustSummarySchema = z
   })
   .strict();
 
+export const FactsReserveCandidateExclusionReasonSchema = z.enum([
+  'missing_ownership',
+  'missing_stage',
+  'missing_sector',
+  'currency_blocked',
+  'facts_unavailable',
+]);
+
+export const FactsReserveCandidateSchema = z.discriminatedUnion('status', [
+  z
+    .object({
+      status: z.literal('eligible'),
+      companyId: z.number().int().positive(),
+      input: ReserveCompanyInputWithProvenanceSchema,
+      factsInputHash: z.string().regex(/^[a-f0-9]{64}$/),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal('excluded'),
+      companyId: z.number().int().positive(),
+      reasons: z.array(FactsReserveCandidateExclusionReasonSchema).min(1),
+      factsInputHash: z
+        .string()
+        .regex(/^[a-f0-9]{64}$/)
+        .nullable(),
+    })
+    .strict(),
+]);
+
 export type ReserveInputSourceStatus = z.infer<typeof ReserveInputSourceStatusSchema>;
 export type ReserveInputFieldProvenance = z.infer<typeof ReserveInputFieldProvenanceSchema>;
 export type ReserveCompanyInputWithProvenance = z.infer<
   typeof ReserveCompanyInputWithProvenanceSchema
 >;
 export type ReserveInputTrustSummary = z.infer<typeof ReserveInputTrustSummarySchema>;
+export type FactsReserveCandidateExclusionReason = z.infer<
+  typeof FactsReserveCandidateExclusionReasonSchema
+>;
+export type FactsReserveCandidate = z.infer<typeof FactsReserveCandidateSchema>;

--- a/shared/generated/flag-defaults.ts
+++ b/shared/generated/flag-defaults.ts
@@ -572,6 +572,22 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     expiresAt: null,
     aliases: ['ENABLE_MARGINAL_RESERVE_MOIC'],
   },
+  enable_facts_sourced_reserve_inputs: {
+    default: false,
+    description: 'Gates eligibility-filtered reserve engine inputs sourced from actuals facts',
+    owner: 'analytics',
+    risk: 'high',
+    exposeToClient: false,
+
+    environments: {
+      development: false,
+      staging: false,
+      production: false,
+    },
+    dependencies: [],
+    expiresAt: null,
+    aliases: ['ENABLE_FACTS_SOURCED_RESERVE_INPUTS'],
+  },
   enable_faults: {
     default: false,
     description: 'Enable fault injection for testing',
@@ -786,6 +802,7 @@ export const FLAG_DEFAULTS: FlagRecord = {
   require_auth: false,
   enable_portfolio_intelligence: false,
   enable_marginal_reserve_moic: false,
+  enable_facts_sourced_reserve_inputs: false,
   enable_faults: false,
   enable_wizard_step_general: false,
   enable_wizard_step_sectors: false,
@@ -874,6 +891,7 @@ export const FLAG_ALIASES: Record<string, FlagKey> = {
   ONBOARDING_TOUR: 'onboarding_tour',
   ENABLE_PORTFOLIO_INTELLIGENCE: 'enable_portfolio_intelligence',
   ENABLE_MARGINAL_RESERVE_MOIC: 'enable_marginal_reserve_moic',
+  ENABLE_FACTS_SOURCED_RESERVE_INPUTS: 'enable_facts_sourced_reserve_inputs',
   ENABLE_WIZARD_STEP_GENERAL: 'enable_wizard_step_general',
   ENABLE_WIZARD_STEP_SIZING: 'enable_wizard_step_sizing',
   ENABLE_WIZARD_STEP_SECTORS: 'enable_wizard_step_sizing',

--- a/shared/generated/flag-types.ts
+++ b/shared/generated/flag-types.ts
@@ -46,6 +46,7 @@ export type FlagKey =
   | 'require_auth'
   | 'enable_portfolio_intelligence'
   | 'enable_marginal_reserve_moic'
+  | 'enable_facts_sourced_reserve_inputs'
   | 'enable_faults'
   | 'enable_wizard_step_general'
   | 'enable_wizard_step_sectors'
@@ -113,6 +114,7 @@ export type ServerOnlyFlagKey =
   | 'require_auth'
   | 'enable_portfolio_intelligence'
   | 'enable_marginal_reserve_moic'
+  | 'enable_facts_sourced_reserve_inputs'
   | 'enable_faults';
 
 /**
@@ -196,6 +198,7 @@ export const ALL_FLAG_KEYS: readonly FlagKey[] = [
   'require_auth',
   'enable_portfolio_intelligence',
   'enable_marginal_reserve_moic',
+  'enable_facts_sourced_reserve_inputs',
   'enable_faults',
   'enable_wizard_step_general',
   'enable_wizard_step_sectors',

--- a/tests/unit/services/reserve-calculation-facts-inputs.test.ts
+++ b/tests/unit/services/reserve-calculation-facts-inputs.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MoicActionabilityResult } from '../../../server/services/fund-calculation-mode-service';
+import type { ReserveCompanyInputWithProvenance } from '../../../shared/contracts/reserve-input-provenance.contract';
+import type { ReserveSummary } from '../../../shared/types';
+import { FLAG_DEFAULTS, FLAG_DEFINITIONS } from '../../../shared/generated/flag-defaults';
+
+const {
+  buildFactsReserveCandidates,
+  buildReservePortfolioInputWithProvenance,
+  eventOrder,
+  generateReserveSummary,
+  isFlagEnabled,
+  loggerInfo,
+  modeFindFirst,
+  persistedSnapshots,
+  resolveMoicActionability,
+} = vi.hoisted(() => ({
+  buildFactsReserveCandidates: vi.fn(),
+  buildReservePortfolioInputWithProvenance: vi.fn(),
+  eventOrder: [] as string[],
+  generateReserveSummary: vi.fn(),
+  isFlagEnabled: vi.fn(),
+  loggerInfo: vi.fn(),
+  modeFindFirst: vi.fn(),
+  persistedSnapshots: [] as Record<string, unknown>[],
+  resolveMoicActionability: vi.fn(),
+}));
+
+vi.mock('../../../server/db', () => ({
+  db: {
+    query: {
+      fundConfigs: { findFirst: vi.fn(async () => ({ version: 3, isPublished: true })) },
+      funds: { findFirst: vi.fn(async () => ({ id: 7, size: '100000000' })) },
+      fundCalculationModes: { findFirst: modeFindFirst },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        persistedSnapshots.push(values);
+        eventOrder.push('persist');
+        return {
+          returning: vi.fn(async () => [
+            {
+              id: 101,
+              createdAt: new Date('2026-07-13T00:00:00.000Z'),
+              calcVersion: '1.0.0',
+            },
+          ]),
+        };
+      }),
+    })),
+  },
+}));
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
+  return { ...actual, resolveMoicActionability };
+});
+
+vi.mock('../../../server/services/reserve-input-builder', () => ({
+  buildReservePortfolioInputWithProvenance,
+}));
+
+vi.mock('../../../server/services/reserves/facts-reserve-input-adapter', () => ({
+  buildFactsReserveCandidates,
+}));
+
+vi.mock('@shared/core/reserves/ReserveEngine', () => ({ generateReserveSummary }));
+
+vi.mock('@shared/flags/getFlag', () => ({ isFlagEnabled }));
+
+vi.mock('../../../server/lib/logger', () => ({
+  logger: {
+    info: loggerInfo,
+    child: vi.fn(() => ({ info: loggerInfo, warn: vi.fn(), error: vi.fn() })),
+  },
+}));
+
+vi.mock('../../../server/services/calc-run-tracking', () => ({
+  markCalcRunCompletedIfReady: vi.fn(async () => undefined),
+}));
+
+import { runReserveCalculation } from '../../../server/services/reserve-calculation-service';
+
+const LEGACY_COMPANY: ReserveCompanyInputWithProvenance = {
+  id: 11,
+  invested: 100,
+  ownership: 0.15,
+  stage: 'Seed',
+  sector: 'SaaS',
+  provenance: {
+    invested: { status: 'observed', source: 'investments.amount', reason: null },
+    ownership: { status: 'defaulted', source: 'system_default_ownership', reason: 'legacy' },
+    stage: { status: 'observed', source: 'investments.round', reason: null },
+    sector: { status: 'observed', source: 'portfolio_companies.sector', reason: null },
+  },
+};
+
+const LEGACY_PORTFOLIO = [
+  {
+    id: LEGACY_COMPANY.id,
+    invested: LEGACY_COMPANY.invested,
+    ownership: LEGACY_COMPANY.ownership,
+    stage: LEGACY_COMPANY.stage,
+    sector: LEGACY_COMPANY.sector,
+  },
+];
+
+const LEGACY_TRUST_SUMMARY = {
+  trustedForActivation: false,
+  defaultedInputCount: 1,
+  unavailableInputCount: 0,
+  defaultedFields: ['ownership'] as const,
+  unavailableFields: [] as const,
+};
+
+const LEGACY_RESERVES: ReserveSummary = {
+  fundId: 7,
+  totalAllocation: 100,
+  avgConfidence: 0.5,
+  highConfidenceCount: 0,
+  allocations: [{ allocation: 100, confidence: 0.5, rationale: 'legacy' }],
+  generatedAt: new Date('2026-07-13T00:00:00.000Z'),
+};
+
+const FACTS_INPUT_HASH = 'd'.repeat(64);
+const FACTS_COMPANY: ReserveCompanyInputWithProvenance = {
+  id: 11,
+  invested: 125,
+  ownership: 0.2,
+  stage: 'Series A',
+  sector: 'SaaS',
+  provenance: {
+    invested: {
+      status: 'observed',
+      source: 'fund_company_actuals_facts.initialInvestmentAmount+followOnInvestmentAmount',
+      reason: null,
+    },
+    ownership: { status: 'observed', source: 'investments.ownership_percentage', reason: null },
+    stage: { status: 'approved_assumption', source: 'approved.stage', reason: null },
+    sector: { status: 'observed', source: 'portfolio_companies.sector', reason: null },
+  },
+};
+const FACTS_TRUST_SUMMARY = {
+  trustedForActivation: true,
+  defaultedInputCount: 0,
+  unavailableInputCount: 1,
+  defaultedFields: [] as const,
+  unavailableFields: ['ownership'] as const,
+};
+const FACTS_RESERVES: ReserveSummary = {
+  fundId: 7,
+  totalAllocation: 125,
+  avgConfidence: 0.6,
+  highConfidenceCount: 1,
+  allocations: [{ allocation: 125, confidence: 0.6, rationale: 'facts' }],
+  generatedAt: new Date('2026-07-13T00:00:00.000Z'),
+};
+
+function actionabilityResult(): MoicActionabilityResult {
+  return {
+    sourceFingerprintMatches: true,
+    actionability: 'actionable',
+    actionabilityStatus: 'actionable',
+    sourceFingerprint: {
+      moicSourceInputHash: 'moic-src-hash',
+      roundEvidenceInputHash: 'round-evidence-hash',
+      roundEvidenceAssumptionsHash: 'assumptions-hash',
+      fingerprintHash: 'fingerprint-hash',
+      policyVersion: 'h9-policy-v1',
+    },
+    acceptedReconciliationRunId: '42',
+  };
+}
+
+function withoutPersistenceTiming(values: Record<string, unknown>): Record<string, unknown> {
+  const { snapshotTime: _snapshotTime, metadata, ...snapshot } = values;
+  if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error('Expected reserve snapshot metadata');
+  }
+  const { engineRuntime: _engineRuntime, ...stableMetadata } = metadata as Record<string, unknown>;
+  return { ...snapshot, metadata: stableMetadata };
+}
+
+describe('runReserveCalculation facts-sourced inputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventOrder.length = 0;
+    persistedSnapshots.length = 0;
+    isFlagEnabled.mockReturnValue(false);
+    modeFindFirst.mockResolvedValue(undefined);
+    buildReservePortfolioInputWithProvenance.mockResolvedValue({
+      portfolio: LEGACY_PORTFOLIO,
+      provenancePortfolio: [LEGACY_COMPANY],
+      reserveInputTrustSummary: LEGACY_TRUST_SUMMARY,
+    });
+    generateReserveSummary.mockReturnValue(LEGACY_RESERVES);
+    resolveMoicActionability.mockResolvedValue(actionabilityResult());
+    buildFactsReserveCandidates.mockResolvedValue({
+      candidates: [
+        {
+          status: 'eligible',
+          companyId: 11,
+          input: FACTS_COMPANY,
+          factsInputHash: 'e'.repeat(64),
+        },
+        {
+          status: 'excluded',
+          companyId: 12,
+          reasons: ['missing_ownership', 'currency_blocked'],
+          factsInputHash: 'f'.repeat(64),
+        },
+      ],
+      factsInputHash: FACTS_INPUT_HASH,
+      trustSummary: FACTS_TRUST_SUMMARY,
+    });
+  });
+
+  it('registers the facts-sourced reserve flag as server-only and off in every environment', () => {
+    expect(FLAG_DEFAULTS.enable_facts_sourced_reserve_inputs).toBe(false);
+    expect(FLAG_DEFINITIONS.enable_facts_sourced_reserve_inputs).toMatchObject({
+      default: false,
+      owner: 'analytics',
+      exposeToClient: false,
+      environments: { development: false, staging: false, production: false },
+    });
+  });
+
+  it('preserves the pre-change return and persistence shape when the flag is off', async () => {
+    const result = await runReserveCalculation({ fundId: 7, correlationId: 'corr-parity' });
+
+    expect(result).toEqual({
+      fundId: 7,
+      snapshotId: 101,
+      reserves: LEGACY_RESERVES,
+      calculatedAt: new Date('2026-07-13T00:00:00.000Z'),
+      version: '1.0.0',
+    });
+    expect(generateReserveSummary).toHaveBeenCalledOnce();
+    expect(generateReserveSummary).toHaveBeenCalledWith(7, LEGACY_PORTFOLIO);
+    expect(persistedSnapshots).toHaveLength(1);
+    expect(persistedSnapshots[0]?.snapshotTime).toBeInstanceOf(Date);
+    expect(withoutPersistenceTiming(persistedSnapshots[0] ?? {})).toEqual({
+      fundId: 7,
+      type: 'RESERVE',
+      payload: LEGACY_RESERVES,
+      calcVersion: '1.0.0',
+      correlationId: 'corr-parity',
+      h9MoicSourceInputHash: 'moic-src-hash',
+      h9RoundEvidenceInputHash: 'round-evidence-hash',
+      h9RoundEvidenceAssumptionsHash: 'assumptions-hash',
+      h9FingerprintHash: 'fingerprint-hash',
+      h9PolicyVersion: 'h9-policy-v1',
+      h9ActionabilityStatus: 'actionable',
+      metadata: {
+        portfolioCount: 1,
+        reserveInputTrustSummary: LEGACY_TRUST_SUMMARY,
+      },
+    });
+    expect(modeFindFirst).not.toHaveBeenCalled();
+    expect(buildFactsReserveCandidates).not.toHaveBeenCalled();
+    expect(loggerInfo).not.toHaveBeenCalled();
+  });
+
+  it('uses the legacy path when the flag is on but no mode row exists', async () => {
+    isFlagEnabled.mockReturnValue(true);
+
+    const result = await runReserveCalculation({ fundId: 7, correlationId: 'corr-no-mode' });
+
+    expect(result.reserves).toEqual(LEGACY_RESERVES);
+    expect(modeFindFirst).toHaveBeenCalledOnce();
+    expect(buildFactsReserveCandidates).not.toHaveBeenCalled();
+    expect(generateReserveSummary).toHaveBeenCalledOnce();
+    expect(generateReserveSummary).toHaveBeenCalledWith(7, LEGACY_PORTFOLIO);
+  });
+
+  it('emits aggregate shadow telemetry without changing served values, persistence, or H9', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
+    buildFactsReserveCandidates.mockImplementation(async () => {
+      eventOrder.push('shadow');
+      return {
+        candidates: [
+          {
+            status: 'eligible',
+            companyId: 11,
+            input: FACTS_COMPANY,
+            factsInputHash: 'e'.repeat(64),
+          },
+          {
+            status: 'excluded',
+            companyId: 12,
+            reasons: ['missing_ownership', 'currency_blocked'],
+            factsInputHash: 'f'.repeat(64),
+          },
+        ],
+        factsInputHash: FACTS_INPUT_HASH,
+        trustSummary: FACTS_TRUST_SUMMARY,
+      };
+    });
+    generateReserveSummary.mockImplementation((_fundId, portfolio) =>
+      portfolio[0]?.invested === FACTS_COMPANY.invested ? FACTS_RESERVES : LEGACY_RESERVES
+    );
+
+    const result = await runReserveCalculation({ fundId: 7, correlationId: 'corr-shadow' });
+
+    expect(result.reserves).toEqual(LEGACY_RESERVES);
+    expect(eventOrder).toEqual(['persist', 'shadow']);
+    expect(generateReserveSummary).toHaveBeenNthCalledWith(1, 7, LEGACY_PORTFOLIO);
+    expect(generateReserveSummary).toHaveBeenNthCalledWith(2, 7, [FACTS_COMPANY]);
+    expect(persistedSnapshots[0]).toMatchObject({
+      payload: LEGACY_RESERVES,
+      h9MoicSourceInputHash: 'moic-src-hash',
+      h9FingerprintHash: 'fingerprint-hash',
+      h9ActionabilityStatus: 'actionable',
+      metadata: {
+        portfolioCount: 1,
+        reserveInputTrustSummary: LEGACY_TRUST_SUMMARY,
+      },
+    });
+    expect(persistedSnapshots[0]?.metadata).not.toHaveProperty('factsBasis');
+    expect(loggerInfo).toHaveBeenCalledOnce();
+    expect(loggerInfo.mock.calls[0]?.[0]).toEqual({
+      eventName: 'reserve_facts_inputs_shadow',
+      fundId: 7,
+      factsInputHash: FACTS_INPUT_HASH.slice(0, 12),
+      eligibleCount: 1,
+      excludedCountsByReason: { currency_blocked: 1, missing_ownership: 1 },
+      legacyCompanyCount: 1,
+      summaryValueDeltaPct: 0.25,
+      durationMs: expect.any(Number),
+      warningCodes: ['CURRENCY_BLOCKED', 'MISSING_OWNERSHIP'],
+    });
+    const serializedLog = JSON.stringify(loggerInfo.mock.calls);
+    expect(serializedLog).not.toContain('Company 11');
+    expect(serializedLog).not.toContain('invested');
+    expect(serializedLog).not.toContain('totalAllocation');
+  });
+
+  it('does not fail a persisted shadow calculation when facts telemetry cannot be logged', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
+    buildFactsReserveCandidates.mockRejectedValue(new Error('facts unavailable'));
+    loggerInfo.mockImplementation(() => {
+      throw new Error('telemetry unavailable');
+    });
+
+    await expect(
+      runReserveCalculation({ fundId: 7, correlationId: 'corr-shadow-log-failure' })
+    ).resolves.toMatchObject({ reserves: LEGACY_RESERVES });
+    expect(persistedSnapshots).toHaveLength(1);
+  });
+
+  it('returns to byte-identical legacy behavior on the run after the flag is disabled', async () => {
+    isFlagEnabled.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
+    generateReserveSummary.mockImplementation((_fundId, portfolio) =>
+      portfolio[0]?.invested === FACTS_COMPANY.invested ? FACTS_RESERVES : LEGACY_RESERVES
+    );
+
+    const baselineLegacyRun = await runReserveCalculation({
+      fundId: 7,
+      correlationId: 'corr-legacy',
+    });
+    const factsRun = await runReserveCalculation({ fundId: 7, correlationId: 'corr-on' });
+    const legacyRun = await runReserveCalculation({ fundId: 7, correlationId: 'corr-legacy' });
+
+    expect(factsRun.reserves).toEqual(FACTS_RESERVES);
+    expect(legacyRun).toEqual(baselineLegacyRun);
+    expect(persistedSnapshots).toHaveLength(3);
+    expect(withoutPersistenceTiming(persistedSnapshots[2] ?? {})).toEqual(
+      withoutPersistenceTiming(persistedSnapshots[0] ?? {})
+    );
+    expect(modeFindFirst).toHaveBeenCalledOnce();
+    expect(buildFactsReserveCandidates).toHaveBeenCalledOnce();
+    expect(buildReservePortfolioInputWithProvenance).toHaveBeenCalledTimes(2);
+    expect(generateReserveSummary).toHaveBeenLastCalledWith(7, LEGACY_PORTFOLIO);
+  });
+});

--- a/tests/unit/services/reserve-calculation-h9-stamp.test.ts
+++ b/tests/unit/services/reserve-calculation-h9-stamp.test.ts
@@ -3,9 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MoicActionabilityResult } from '../../../server/services/fund-calculation-mode-service';
 
 // Mock only resolveMoicActionability; keep the real toH9SnapshotColumns (pure mapper under test).
-const { resolveMoicActionability } = vi.hoisted(() => ({
-  resolveMoicActionability: vi.fn(),
-}));
+const { buildFactsReserveCandidates, isFlagEnabled, modeFindFirst, resolveMoicActionability } =
+  vi.hoisted(() => ({
+    buildFactsReserveCandidates: vi.fn(),
+    isFlagEnabled: vi.fn(),
+    modeFindFirst: vi.fn(),
+    resolveMoicActionability: vi.fn(),
+  }));
 
 vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
   const actual =
@@ -24,6 +28,7 @@ vi.mock('../../../server/db', () => ({
     query: {
       fundConfigs: { findFirst: vi.fn(async () => ({ version: 3, isPublished: true })) },
       funds: { findFirst: vi.fn(async () => ({ id: 7, size: '100000000' })) },
+      fundCalculationModes: { findFirst: modeFindFirst },
     },
     insert: vi.fn(() => ({
       values: vi.fn((values: Record<string, unknown>) => {
@@ -52,6 +57,12 @@ vi.mock('../../../server/services/reserve-input-builder', () => ({
   })),
 }));
 
+vi.mock('../../../server/services/reserves/facts-reserve-input-adapter', () => ({
+  buildFactsReserveCandidates,
+}));
+
+vi.mock('@shared/flags/getFlag', () => ({ isFlagEnabled }));
+
 vi.mock('@shared/core/reserves/ReserveEngine', () => ({
   generateReserveSummary: vi.fn(() => ({ ok: true })),
 }));
@@ -63,9 +74,7 @@ vi.mock('../../../server/services/calc-run-tracking', () => ({
 import { runReserveCalculation } from '../../../server/services/reserve-calculation-service';
 import { toH9SnapshotColumns } from '../../../server/services/fund-calculation-mode-service';
 
-function actionabilityResult(
-  status: 'actionable' | 'non_actionable'
-): MoicActionabilityResult {
+function actionabilityResult(status: 'actionable' | 'non_actionable'): MoicActionabilityResult {
   return {
     sourceFingerprintMatches: status === 'actionable',
     actionability: status,
@@ -106,6 +115,8 @@ describe('runReserveCalculation H9 stamp', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     delete captured.values;
+    isFlagEnabled.mockReturnValue(false);
+    modeFindFirst.mockResolvedValue(undefined);
   });
 
   it('stamps the resolved H9 fingerprint columns onto the authoritative reserve snapshot insert', async () => {
@@ -138,5 +149,107 @@ describe('runReserveCalculation H9 stamp', () => {
     await runReserveCalculation({ fundId: 7, correlationId: 'corr-2' });
 
     expect(captured.values?.h9ActionabilityStatus).toBe('non_actionable');
+  });
+
+  it('rechecks engine-fed facts provenance before retaining an actionable H9 stamp', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
+    buildFactsReserveCandidates.mockResolvedValue({
+      candidates: [
+        {
+          status: 'eligible',
+          companyId: 11,
+          factsInputHash: 'b'.repeat(64),
+          input: {
+            id: 11,
+            invested: 100,
+            ownership: 0.2,
+            stage: 'Series A',
+            sector: 'SaaS',
+            provenance: {
+              invested: {
+                status: 'defaulted',
+                source: 'invalid-test-fixture',
+                reason: 'must force non-actionable',
+              },
+              ownership: { status: 'observed', source: 'ownership', reason: null },
+              stage: { status: 'observed', source: 'stage', reason: null },
+              sector: { status: 'observed', source: 'sector', reason: null },
+            },
+          },
+        },
+      ],
+      factsInputHash: 'a'.repeat(64),
+      trustSummary: {
+        trustedForActivation: true,
+        defaultedInputCount: 0,
+        unavailableInputCount: 0,
+        defaultedFields: [],
+        unavailableFields: [],
+      },
+    });
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('actionable'));
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-facts-on' });
+
+    expect(captured.values).toMatchObject({
+      h9MoicSourceInputHash: 'moic-src-hash',
+      h9RoundEvidenceInputHash: 'round-evidence-hash',
+      h9RoundEvidenceAssumptionsHash: 'assumptions-hash',
+      h9FingerprintHash: 'fingerprint-hash',
+      h9PolicyVersion: 'h9-policy-v1',
+      h9ActionabilityStatus: 'non_actionable',
+      metadata: {
+        reserveInputTrustSummary: {
+          trustedForActivation: true,
+          defaultedInputCount: 0,
+          defaultedFields: [],
+        },
+        factsBasis: {
+          factsInputHash: 'a'.repeat(64),
+          trustedForActivation: false,
+          mode: 'on',
+        },
+      },
+    });
+  });
+
+  it('forces non-actionable H9 when on-mode facts evidence has no input hash', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
+    buildFactsReserveCandidates.mockResolvedValue({
+      candidates: [
+        {
+          status: 'excluded',
+          companyId: 11,
+          reasons: ['facts_unavailable'],
+          factsInputHash: null,
+        },
+      ],
+      factsInputHash: null,
+      trustSummary: {
+        trustedForActivation: true,
+        defaultedInputCount: 0,
+        unavailableInputCount: 1,
+        defaultedFields: [],
+        unavailableFields: ['invested'],
+      },
+    });
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('actionable'));
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-facts-unavailable' });
+
+    expect(captured.values).toMatchObject({
+      h9FingerprintHash: 'fingerprint-hash',
+      h9ActionabilityStatus: 'non_actionable',
+      metadata: {
+        portfolioCount: 0,
+        factsBasis: {
+          factsInputHash: null,
+          trustedForActivation: false,
+          mode: 'on',
+        },
+      },
+    });
   });
 });

--- a/tests/unit/services/reserves/facts-reserve-input-adapter.test.ts
+++ b/tests/unit/services/reserves/facts-reserve-input-adapter.test.ts
@@ -1,0 +1,378 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FundCompanyActualsFactsResponse } from '../../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import {
+  FactsReserveCandidateSchema,
+  type ReserveCompanyInputWithProvenance,
+} from '../../../../shared/contracts/reserve-input-provenance.contract';
+import type { ReservePortfolioInputWithTrust } from '../../../../server/services/reserve-input-builder';
+
+const { buildFundCompanyActualsFacts, buildReservePortfolioInputWithProvenance } = vi.hoisted(
+  () => ({
+    buildFundCompanyActualsFacts: vi.fn(),
+    buildReservePortfolioInputWithProvenance: vi.fn(),
+  })
+);
+
+vi.mock('../../../../server/services/fund-actuals/fund-company-actuals-facts-service', () => ({
+  buildFundCompanyActualsFacts,
+}));
+
+vi.mock('../../../../server/services/reserve-input-builder', () => ({
+  buildReservePortfolioInputWithProvenance,
+}));
+
+import { buildFactsReserveCandidates } from '../../../../server/services/reserves/facts-reserve-input-adapter';
+
+const FUND_FACTS_HASH = 'a'.repeat(64);
+const COMPANY_FACTS_HASH = 'b'.repeat(64);
+
+describe('FactsReserveCandidateSchema', () => {
+  it('accepts missing_sector as an additive exclusion reason', () => {
+    expect(
+      FactsReserveCandidateSchema.parse({
+        status: 'excluded',
+        companyId: 11,
+        reasons: ['missing_sector'],
+        factsInputHash: null,
+      })
+    ).toEqual({
+      status: 'excluded',
+      companyId: 11,
+      reasons: ['missing_sector'],
+      factsInputHash: null,
+    });
+  });
+});
+
+function field(
+  status: ReserveCompanyInputWithProvenance['provenance']['ownership']['status'],
+  source: string
+) {
+  return { status, source, reason: null };
+}
+
+function reserveCompany(
+  companyId: number,
+  overrides: Partial<ReserveCompanyInputWithProvenance> = {}
+): ReserveCompanyInputWithProvenance {
+  return {
+    id: companyId,
+    invested: 999,
+    ownership: 0.125,
+    stage: 'Series A',
+    sector: 'SaaS',
+    provenance: {
+      invested: field('observed', 'investments.amount'),
+      ownership: field('observed', 'investments.ownership_percentage'),
+      stage: field('approved_assumption', 'approved.stage'),
+      sector: field('observed', 'portfolio_companies.sector'),
+    },
+    ...overrides,
+  };
+}
+
+function legacyPortfolio(
+  provenancePortfolio: ReserveCompanyInputWithProvenance[]
+): ReservePortfolioInputWithTrust {
+  return {
+    portfolio: provenancePortfolio.map(({ id, invested, ownership, stage, sector }) => ({
+      id,
+      invested,
+      ownership,
+      stage,
+      sector,
+    })),
+    provenancePortfolio,
+    reserveInputTrustSummary: {
+      trustedForActivation: true,
+      defaultedInputCount: 0,
+      unavailableInputCount: 0,
+      defaultedFields: [],
+      unavailableFields: [],
+    },
+  };
+}
+
+function facts(
+  companyId: number,
+  overrides: Partial<FundCompanyActualsFactsResponse['facts'][number]> = {}
+): FundCompanyActualsFactsResponse {
+  return {
+    fundId: 7,
+    asOfDate: '2026-07-13',
+    inputHash: FUND_FACTS_HASH,
+    generatedAt: '2026-07-13T00:00:00.000Z',
+    facts: [
+      {
+        fundId: 7,
+        companyId,
+        companyName: `Company ${companyId}`,
+        investmentIds: [101],
+        activeRoundIds: [201],
+        approvedPlanningFmvMarkId: null,
+        planningFmvStatus: 'none',
+        initialInvestmentAmount: '100.250000',
+        followOnInvestmentAmount: '20.750000',
+        amountOnlyNonEquityAmount: '0.000000',
+        latestRoundDate: '2026-07-01',
+        latestRoundValuation: '1000.000000',
+        latestPlanningFmvDate: null,
+        latestPlanningFmvValue: null,
+        currency: 'USD',
+        currencyStatus: 'base_currency',
+        supersedeLineage: [{ roundId: 201, supersedesRoundId: null }],
+        warnings: [],
+        provenance: {
+          trustState: 'LIVE',
+          core: {
+            sourceKind: 'computed',
+            actionability: 'actionable',
+            sourceEngine: 'fund-company-actuals-facts',
+            engineVersion: 'fund-company-actuals-facts-v1',
+            inputHash: COMPANY_FACTS_HASH,
+            assumptionsHash: 'c'.repeat(64),
+            generatedAt: '2026-07-13T00:00:00.000Z',
+            isFinanciallyActionable: true,
+            warnings: [],
+          },
+          structuredWarnings: [],
+        },
+        inputHash: COMPANY_FACTS_HASH,
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function factsForCompanies(companyIds: number[]): FundCompanyActualsFactsResponse {
+  const response = facts(companyIds[0] ?? 1);
+  response.facts = companyIds.map((companyId) => facts(companyId).facts[0]!);
+  return response;
+}
+
+describe('buildFactsReserveCandidates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(
+      legacyPortfolio([reserveCompany(11)])
+    );
+    buildFundCompanyActualsFacts.mockResolvedValue(facts(11));
+  });
+
+  it('builds an eligible engine input from facts money and trusted builder fields', async () => {
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result).toMatchObject({
+      factsInputHash: FUND_FACTS_HASH,
+      candidates: [
+        {
+          status: 'eligible',
+          companyId: 11,
+          factsInputHash: COMPANY_FACTS_HASH,
+          input: {
+            id: 11,
+            invested: 121,
+            ownership: 0.125,
+            stage: 'Series A',
+            sector: 'SaaS',
+            provenance: {
+              invested: {
+                status: 'observed',
+                source:
+                  'fund_company_actuals_facts.initialInvestmentAmount+followOnInvestmentAmount',
+              },
+              ownership: { status: 'observed' },
+              stage: { status: 'approved_assumption' },
+              sector: { status: 'observed' },
+            },
+          },
+        },
+      ],
+      trustSummary: {
+        trustedForActivation: true,
+        defaultedInputCount: 0,
+        unavailableInputCount: 0,
+        defaultedFields: [],
+        unavailableFields: [],
+      },
+    });
+    expect(buildFundCompanyActualsFacts).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: '2026-07-13',
+    });
+  });
+
+  it('excludes missing ownership instead of substituting the legacy 15 percent default', async () => {
+    const company = reserveCompany(11, { ownership: 0.15 });
+    company.provenance.ownership = {
+      status: 'defaulted',
+      source: 'system_default_ownership',
+      reason: 'Missing ownership percentage uses 0.15 legacy default',
+    };
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(legacyPortfolio([company]));
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.candidates).toEqual([
+      {
+        status: 'excluded',
+        companyId: 11,
+        reasons: ['missing_ownership'],
+        factsInputHash: COMPANY_FACTS_HASH,
+      },
+    ]);
+  });
+
+  it('excludes a company whose stage provenance is not observed or approved', async () => {
+    const company = reserveCompany(11, { stage: 'seed' });
+    company.provenance.stage = field('estimated', 'estimated.stage');
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(legacyPortfolio([company]));
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.candidates[0]).toMatchObject({
+      status: 'excluded',
+      reasons: ['missing_stage'],
+    });
+  });
+
+  it('excludes a company whose sector provenance is not observed or approved', async () => {
+    const company = reserveCompany(11, { sector: 'unknown' });
+    company.provenance.sector = field('unavailable', 'missing.sector');
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(legacyPortfolio([company]));
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.candidates[0]).toMatchObject({
+      status: 'excluded',
+      reasons: ['missing_sector'],
+    });
+  });
+
+  it('excludes currency-blocked facts without converting raw money', async () => {
+    buildFundCompanyActualsFacts.mockResolvedValue(
+      facts(11, { currency: 'EUR', currencyStatus: 'mismatch_blocked' })
+    );
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.candidates[0]).toMatchObject({
+      status: 'excluded',
+      reasons: expect.arrayContaining(['currency_blocked']),
+    });
+  });
+
+  it('excludes every legacy company and clears the top-level hash when facts loading fails', async () => {
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(
+      legacyPortfolio([reserveCompany(12), reserveCompany(11)])
+    );
+    buildFundCompanyActualsFacts.mockRejectedValue(new Error('facts unavailable'));
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.factsInputHash).toBeNull();
+    expect(result.candidates).toEqual([
+      {
+        status: 'excluded',
+        companyId: 11,
+        reasons: ['facts_unavailable'],
+        factsInputHash: null,
+      },
+      {
+        status: 'excluded',
+        companyId: 12,
+        reasons: ['facts_unavailable'],
+        factsInputHash: null,
+      },
+    ]);
+  });
+
+  it('excludes missing and FAILED per-company facts', async () => {
+    const response = factsForCompanies([11]);
+    response.facts[0]!.provenance.trustState = 'FAILED';
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(
+      legacyPortfolio([reserveCompany(12), reserveCompany(11)])
+    );
+    buildFundCompanyActualsFacts.mockResolvedValue(response);
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.candidates).toEqual([
+      {
+        status: 'excluded',
+        companyId: 11,
+        reasons: ['facts_unavailable'],
+        factsInputHash: COMPANY_FACTS_HASH,
+      },
+      {
+        status: 'excluded',
+        companyId: 12,
+        reasons: ['facts_unavailable'],
+        factsInputHash: null,
+      },
+    ]);
+  });
+
+  it('sorts candidates by company id regardless of source order', async () => {
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(
+      legacyPortfolio([reserveCompany(12), reserveCompany(11)])
+    );
+    buildFundCompanyActualsFacts.mockResolvedValue(factsForCompanies([12, 11]));
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.candidates.map((candidate) => candidate.companyId)).toEqual([11, 12]);
+  });
+
+  it('counts excluded defaulted and unavailable fields without distrusting the eligible engine set', async () => {
+    const defaultedOwnership = reserveCompany(11);
+    defaultedOwnership.provenance.ownership = field('defaulted', 'system_default_ownership');
+    const estimatedStage = reserveCompany(12);
+    estimatedStage.provenance.stage = field('estimated', 'estimated.stage');
+    buildReservePortfolioInputWithProvenance.mockResolvedValue(
+      legacyPortfolio([defaultedOwnership, estimatedStage, reserveCompany(13), reserveCompany(14)])
+    );
+    const response = factsForCompanies([11, 12, 13, 14]);
+    response.facts.find((fact) => fact.companyId === 13)!.currencyStatus = 'mismatch_blocked';
+    buildFundCompanyActualsFacts.mockResolvedValue(response);
+
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+
+    expect(result.trustSummary).toEqual({
+      trustedForActivation: true,
+      defaultedInputCount: 1,
+      unavailableInputCount: 2,
+      defaultedFields: ['ownership'],
+      unavailableFields: ['invested', 'stage'],
+    });
+  });
+
+  it('never carries legacy default sources or reasons into an eligible candidate', async () => {
+    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+    const eligible = result.candidates.find((candidate) => candidate.status === 'eligible');
+
+    expect(eligible).toBeDefined();
+    const serialized = JSON.stringify(eligible);
+    expect(serialized).not.toContain('system_default');
+    expect(serialized.toLowerCase()).not.toContain('legacy default');
+  });
+
+  it('imports only the sanctioned facts and provenance-builder sources', async () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+    const source = await readFile(
+      path.join(repoRoot, 'server/services/reserves/facts-reserve-input-adapter.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain('buildFundCompanyActualsFacts');
+    expect(source).toContain('buildReservePortfolioInputWithProvenance');
+    expect(source).not.toMatch(/from ['"].*\/db['"]/);
+    expect(source).not.toMatch(/from ['"].*shared\/schema/);
+    expect(source).not.toMatch(/\b(investments|investmentRounds|valuationMarks)\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Plan 5 wave 2 (Tasks 5.3 + 5.4) — eligibility-gated reserve inputs sourced from actuals facts, shadow-first, flag off by default everywhere.

- **New adapter** `server/services/reserves/facts-reserve-input-adapter.ts`: `buildFactsReserveCandidates` assembles candidates from sanctioned sources only (`buildFundCompanyActualsFacts` for money/currency/trust + the provenance-tagged builder output for ownership/stage/sector). A field is eligible only when its provenance status is `observed` or `approved_assumption` — the legacy 0.15/'seed'/'unknown' defaults can never enter the facts path (source-level test pins no DB/schema imports; no legacy default strings in eligible outputs). Exclusion reasons: `missing_ownership`, `missing_stage`, `missing_sector` (additive enum member beyond the plan's four — the plan tests sector absence but omitted the reason; sector is engine-required and must not be fabricated), `currency_blocked`, `facts_unavailable`.
- **Flag** `enable_facts_sourced_reserve_inputs` (default false, all environments false, exposeToClient false) + regenerated flag files in the same commit.
- **Calculation service**: flag off (or kill switch active on the mode row) = the exact legacy code path. Flag on consults `fund_calculation_modes` (`calculationKey: 'reserve_facts_inputs'`, absent row = off). Shadow computes candidates + emits one structured comparison event (short hash, counts by reason, summary delta pct, duration — no company names, no raw money) strictly after the legacy result is persisted; shadow failures are swallowed into a `SHADOW_BUILD_FAILED` event and can never affect serving. Mode on feeds only eligible candidates to the engine, stamps `factsBasis` (facts hash + trust) into snapshot metadata alongside the existing trust summary (no new columns, no migration), and forces `h9ActionabilityStatus: 'non_actionable'` unless the facts hash exists, the trust summary is activation-trusted, and every engine-fed field is observed/approved — the existing actionability gate is only ever strengthened.

## Verification

- 24/24 tests green independently (12 adapter, 6 facts-inputs integration incl. flag-off parity and kill-switch restore, 6 H9-stamp with all pre-existing pins intact).
- `npm run check` 0 TS errors; ESLint clean on all changed files.
- No routes, no client code, no migrations, no phoenix truth-case surface touched; flag-off behavior byte-identical by construction (legacy branch is the unmodified original path).

Spec: `updog_restore_review_only_implementation_plans_2026-07-11.md` Plan 5 (line 1866) + CEO/eng amendments, executed via Hermes/Codex worktree lane, Claude-verified. Remaining Plan 5 wave: 5.5 UI disclosure (design decisions D-A..D-D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h