### PR TITLE
feat(scenarios): immutable case seed provenance persistence (Plan 8 wave 2)

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -312,4 +312,5 @@ schema_tests:
   - 'scripts/reconcile-prod-schema.mjs'
   - 'scripts/prod-schema-manifests/**'
   - 'tests/integration/prod-schema-reconcile-partial-drift.test.ts'
+  - 'tests/integration/scenarios/scenario-case-seed-persistence.test.ts'
   - '.github/workflows/prod-schema-reconcile.yml'

--- a/migrations/0032_scenario_case_seed_provenance.sql
+++ b/migrations/0032_scenario_case_seed_provenance.sql
@@ -1,0 +1,166 @@
+-- @drift-patch
+-- Reason: add immutable scenario-case seed provenance and fund-scoped idempotency without backfilling existing cases.
+
+CREATE TABLE IF NOT EXISTS "scenario_case_seed_provenance" (
+  "scenario_case_id" uuid NOT NULL,
+  "fund_id" integer NOT NULL,
+  "company_id" integer NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "facts_input_hash" char(64) NOT NULL,
+  "facts_as_of_date" date NOT NULL,
+  "seeded_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "trust_state" varchar(16) NOT NULL,
+  "currency_status" varchar(24) NOT NULL,
+  "seeded_investment" decimal(15,6) NOT NULL,
+  "seeded_follow_ons" decimal(15,6) NOT NULL,
+  "seeded_fmv" decimal(15,6),
+  "investment_source" varchar(64) NOT NULL,
+  "follow_ons_source" varchar(64) NOT NULL,
+  "fmv_source" varchar(64),
+  "latest_round_valuation_reference" decimal(15,6),
+  "latest_round_date_reference" date,
+  CONSTRAINT "scenario_case_seed_provenance_pkey" PRIMARY KEY ("scenario_case_id"),
+  CONSTRAINT "scenario_case_seed_provenance_scenario_case_id_fkey"
+    FOREIGN KEY ("scenario_case_id") REFERENCES "scenario_cases"("id") ON DELETE CASCADE,
+  CONSTRAINT "scenario_case_seed_provenance_fund_id_fkey"
+    FOREIGN KEY ("fund_id") REFERENCES "funds"("id") ON DELETE CASCADE,
+  CONSTRAINT "scenario_case_seed_provenance_company_id_fkey"
+    FOREIGN KEY ("company_id") REFERENCES "portfoliocompanies"("id") ON DELETE CASCADE,
+  CONSTRAINT "scenario_case_seed_provenance_fund_idempotency_key_unique"
+    UNIQUE ("fund_id", "idempotency_key"),
+  CONSTRAINT "scenario_case_seed_provenance_trust_state_check"
+    CHECK ("trust_state" IN ('LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED')),
+  CONSTRAINT "scenario_case_seed_provenance_currency_status_check"
+    CHECK ("currency_status" IN ('base_currency', 'mismatch_blocked', 'unknown'))
+);
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "scenario_case_id" uuid NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "fund_id" integer NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "company_id" integer NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "idempotency_key" text NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "facts_input_hash" char(64) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "facts_as_of_date" date NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "seeded_at" timestamp with time zone NOT NULL DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "trust_state" varchar(16) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "currency_status" varchar(24) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "seeded_investment" decimal(15,6) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "seeded_follow_ons" decimal(15,6) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "seeded_fmv" decimal(15,6);
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "investment_source" varchar(64) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "follow_ons_source" varchar(64) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "fmv_source" varchar(64);
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "latest_round_valuation_reference" decimal(15,6);
+--> statement-breakpoint
+ALTER TABLE "scenario_case_seed_provenance" ADD COLUMN IF NOT EXISTS "latest_round_date_reference" date;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'scenario_case_seed_provenance_pkey'
+      AND conrelid = 'public.scenario_case_seed_provenance'::regclass
+  ) THEN
+    ALTER TABLE "scenario_case_seed_provenance"
+      ADD CONSTRAINT "scenario_case_seed_provenance_pkey"
+      PRIMARY KEY ("scenario_case_id");
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'scenario_case_seed_provenance_scenario_case_id_fkey'
+      AND conrelid = 'public.scenario_case_seed_provenance'::regclass
+  ) THEN
+    ALTER TABLE "scenario_case_seed_provenance"
+      ADD CONSTRAINT "scenario_case_seed_provenance_scenario_case_id_fkey"
+      FOREIGN KEY ("scenario_case_id") REFERENCES "scenario_cases"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'scenario_case_seed_provenance_fund_id_fkey'
+      AND conrelid = 'public.scenario_case_seed_provenance'::regclass
+  ) THEN
+    ALTER TABLE "scenario_case_seed_provenance"
+      ADD CONSTRAINT "scenario_case_seed_provenance_fund_id_fkey"
+      FOREIGN KEY ("fund_id") REFERENCES "funds"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'scenario_case_seed_provenance_company_id_fkey'
+      AND conrelid = 'public.scenario_case_seed_provenance'::regclass
+  ) THEN
+    ALTER TABLE "scenario_case_seed_provenance"
+      ADD CONSTRAINT "scenario_case_seed_provenance_company_id_fkey"
+      FOREIGN KEY ("company_id") REFERENCES "portfoliocompanies"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'scenario_case_seed_provenance_fund_idempotency_key_unique'
+      AND conrelid = 'public.scenario_case_seed_provenance'::regclass
+  ) THEN
+    ALTER TABLE "scenario_case_seed_provenance"
+      ADD CONSTRAINT "scenario_case_seed_provenance_fund_idempotency_key_unique"
+      UNIQUE ("fund_id", "idempotency_key");
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'scenario_case_seed_provenance_trust_state_check'
+      AND conrelid = 'public.scenario_case_seed_provenance'::regclass
+  ) THEN
+    ALTER TABLE "scenario_case_seed_provenance"
+      ADD CONSTRAINT "scenario_case_seed_provenance_trust_state_check"
+      CHECK ("trust_state" IN ('LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED'));
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'scenario_case_seed_provenance_currency_status_check'
+      AND conrelid = 'public.scenario_case_seed_provenance'::regclass
+  ) THEN
+    ALTER TABLE "scenario_case_seed_provenance"
+      ADD CONSTRAINT "scenario_case_seed_provenance_currency_status_check"
+      CHECK ("currency_status" IN ('base_currency', 'mismatch_blocked', 'unknown'));
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "scenario_case_seed_provenance_fund_idx"
+  ON "scenario_case_seed_provenance" ("fund_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "scenario_case_seed_provenance_company_idx"
+  ON "scenario_case_seed_provenance" ("company_id");

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1783806971283,
       "tag": "0031_user_identity_grants_revocation",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1783968904128,
+      "tag": "0032_scenario_case_seed_provenance",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/08-scenario-case-seed-provenance.json
+++ b/scripts/prod-schema-manifests/08-scenario-case-seed-provenance.json
@@ -1,0 +1,53 @@
+{
+  "name": "scenario-case-seed-provenance",
+  "order": 8,
+  "description": "Immutable snapshots of the facts and overrides used to create scenario cases.",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0032_scenario_case_seed_provenance.sql"],
+  "allowedCreateTables": ["scenario_case_seed_provenance"],
+  "expectedTables": [
+    {
+      "name": "scenario_case_seed_provenance",
+      "columns": [
+        { "name": "scenario_case_id", "type": "uuid", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "company_id", "type": "integer", "nullable": false },
+        { "name": "idempotency_key", "type": "text", "nullable": false },
+        { "name": "facts_input_hash", "type": "character", "nullable": false },
+        { "name": "facts_as_of_date", "type": "date", "nullable": false },
+        { "name": "seeded_at", "type": "timestamptz", "nullable": false },
+        { "name": "trust_state", "type": "varchar", "nullable": false },
+        { "name": "currency_status", "type": "varchar", "nullable": false },
+        { "name": "seeded_investment", "type": "numeric", "nullable": false },
+        { "name": "seeded_follow_ons", "type": "numeric", "nullable": false },
+        { "name": "seeded_fmv", "type": "numeric", "nullable": true },
+        { "name": "investment_source", "type": "varchar", "nullable": false },
+        { "name": "follow_ons_source", "type": "varchar", "nullable": false },
+        { "name": "fmv_source", "type": "varchar", "nullable": true },
+        {
+          "name": "latest_round_valuation_reference",
+          "type": "numeric",
+          "nullable": true
+        },
+        {
+          "name": "latest_round_date_reference",
+          "type": "date",
+          "nullable": true
+        }
+      ],
+      "constraints": [
+        "scenario_case_seed_provenance_pkey",
+        "scenario_case_seed_provenance_scenario_case_id_fkey",
+        "scenario_case_seed_provenance_fund_id_fkey",
+        "scenario_case_seed_provenance_company_id_fkey",
+        "scenario_case_seed_provenance_fund_idempotency_key_unique",
+        "scenario_case_seed_provenance_trust_state_check",
+        "scenario_case_seed_provenance_currency_status_check"
+      ],
+      "indexes": [
+        "scenario_case_seed_provenance_fund_idx",
+        "scenario_case_seed_provenance_company_idx"
+      ]
+    }
+  ]
+}

--- a/server/services/scenarios/scenario-case-seed-persistence-service.ts
+++ b/server/services/scenarios/scenario-case-seed-persistence-service.ts
@@ -1,0 +1,385 @@
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '../../db';
+import type { ScenarioCaseSeedV1 } from '../../../shared/contracts/scenarios/scenario-case-seed-v1.contract';
+import {
+  scenarioCaseSeedProvenance,
+  type ScenarioCaseSeedProvenance,
+} from '../../../shared/schema/scenario-case-seed-provenance';
+import {
+  scenarioAuditLogs,
+  scenarioCases,
+  scenarios,
+  type ScenarioCase,
+} from '../../../shared/schema/scenario';
+
+const PROVENANCE_IDEMPOTENCY_CONSTRAINT =
+  'scenario_case_seed_provenance_fund_idempotency_key_unique';
+
+export type ScenarioCaseSeedPersistenceErrorCode =
+  | 'scenario_not_found'
+  | 'scenario_locked'
+  | 'version_conflict'
+  | 'missing_required_override'
+  | 'company_mismatch'
+  | 'idempotency_conflict';
+
+export class ScenarioCaseSeedPersistenceError extends Error {
+  readonly status: number;
+  readonly code: ScenarioCaseSeedPersistenceErrorCode;
+  readonly details?: unknown;
+
+  constructor(
+    status: number,
+    code: ScenarioCaseSeedPersistenceErrorCode,
+    message: string,
+    details?: unknown
+  ) {
+    super(message);
+    this.name = 'ScenarioCaseSeedPersistenceError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface ScenarioCaseSeedOverrides {
+  caseName: string;
+  probability: string;
+  exitValuation?: string;
+  monthsToExit?: number | null;
+  ownershipAtExit?: string | null;
+  investment?: string;
+  followOns?: string;
+  fmv?: string | null;
+}
+
+export interface ScenarioMutationActor {
+  userId: string | null;
+}
+
+export interface CreatedScenarioCase {
+  case: ScenarioCase;
+  provenance: ScenarioCaseSeedProvenance;
+  replayed: boolean;
+}
+
+interface SeededCaseValues {
+  investment: string;
+  investmentSource: string;
+  followOns: string;
+  followOnsSource: string;
+  fmv: string | null;
+  fmvSource: string | null;
+}
+
+function missingRequiredOverride(field: string): ScenarioCaseSeedPersistenceError {
+  return new ScenarioCaseSeedPersistenceError(
+    422,
+    'missing_required_override',
+    `A user override is required for ${field}.`,
+    { field }
+  );
+}
+
+function requireTextOverride(value: string | null | undefined, field: string): string {
+  const trimmed = value?.trim() ?? '';
+  if (trimmed.length === 0) {
+    throw missingRequiredOverride(field);
+  }
+  return trimmed;
+}
+
+function resolveRequiredSeedField(
+  field: ScenarioCaseSeedV1['fields']['investment'],
+  override: string | undefined,
+  fieldName: 'investment' | 'followOns'
+): { value: string; source: string } {
+  if (override !== undefined) {
+    return { value: requireTextOverride(override, fieldName), source: 'user_override' };
+  }
+  if (field.status === 'seeded') {
+    return { value: field.value, source: field.source };
+  }
+  throw missingRequiredOverride(fieldName);
+}
+
+function composeSeededCaseValues(
+  seed: ScenarioCaseSeedV1,
+  overrides: ScenarioCaseSeedOverrides
+): SeededCaseValues {
+  const investment = resolveRequiredSeedField(
+    seed.fields.investment,
+    overrides.investment,
+    'investment'
+  );
+  const followOns = resolveRequiredSeedField(
+    seed.fields.followOns,
+    overrides.followOns,
+    'followOns'
+  );
+
+  let fmv: string | null = null;
+  let fmvSource: string | null = null;
+  if (Object.prototype.hasOwnProperty.call(overrides, 'fmv') && overrides.fmv !== undefined) {
+    fmv = overrides.fmv;
+    fmvSource = 'user_override';
+  } else if (seed.fields.fmv.status === 'seeded') {
+    fmv = seed.fields.fmv.value;
+    fmvSource = seed.fields.fmv.source;
+  } else {
+    throw missingRequiredOverride('fmv');
+  }
+
+  return {
+    investment: investment.value,
+    investmentSource: investment.source,
+    followOns: followOns.value,
+    followOnsSource: followOns.source,
+    fmv,
+    fmvSource,
+  };
+}
+
+function isProvenanceIdempotencyViolation(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') {
+    return false;
+  }
+  const candidate = error as { code?: unknown; constraint?: unknown; message?: unknown };
+  return (
+    candidate.code === '23505' &&
+    (candidate.constraint === PROVENANCE_IDEMPOTENCY_CONSTRAINT ||
+      (typeof candidate.message === 'string' &&
+        candidate.message.includes(PROVENANCE_IDEMPOTENCY_CONSTRAINT)))
+  );
+}
+
+function assertReplayMatchesScenario(
+  scenarioCase: Pick<ScenarioCase, 'scenarioId'>,
+  scenarioId: string,
+  idempotencyKey: string
+): void {
+  if (scenarioCase.scenarioId !== scenarioId) {
+    throw new ScenarioCaseSeedPersistenceError(
+      409,
+      'idempotency_conflict',
+      'The idempotency key is already associated with a different scenario.',
+      { idempotencyKey, scenarioId }
+    );
+  }
+}
+
+async function loadReplayAfterUniqueViolation(input: {
+  fundId: number;
+  scenarioId: string;
+  idempotencyKey: string;
+}): Promise<CreatedScenarioCase> {
+  const provenanceRows = await db
+    .select()
+    .from(scenarioCaseSeedProvenance)
+    .where(
+      and(
+        eq(scenarioCaseSeedProvenance.fundId, input.fundId),
+        eq(scenarioCaseSeedProvenance.idempotencyKey, input.idempotencyKey)
+      )
+    )
+    .limit(1);
+  const provenance = provenanceRows[0];
+  if (!provenance) {
+    throw new Error('Idempotent scenario case create won the unique race but was not readable.');
+  }
+
+  const caseRows = await db
+    .select()
+    .from(scenarioCases)
+    .where(eq(scenarioCases.id, provenance.scenarioCaseId))
+    .limit(1);
+  const existingCase = caseRows[0];
+  if (!existingCase) {
+    throw new Error(
+      `Seed provenance references missing scenario case ${provenance.scenarioCaseId}.`
+    );
+  }
+  assertReplayMatchesScenario(existingCase, input.scenarioId, input.idempotencyKey);
+
+  return { case: existingCase, provenance, replayed: true };
+}
+
+export async function createScenarioCaseFromSeed(input: {
+  scenarioId: string;
+  expectedScenarioVersion: number;
+  seed: ScenarioCaseSeedV1;
+  overrides: ScenarioCaseSeedOverrides;
+  actor: ScenarioMutationActor;
+  idempotencyKey: string;
+}): Promise<CreatedScenarioCase> {
+  try {
+    return await db.transaction(async (tx) => {
+      const parentRows = await tx
+        .select()
+        .from(scenarios)
+        .where(eq(scenarios.id, input.scenarioId))
+        .limit(1)
+        .for('update');
+      const parent = parentRows[0];
+
+      if (!parent) {
+        throw new ScenarioCaseSeedPersistenceError(
+          404,
+          'scenario_not_found',
+          `Scenario ${input.scenarioId} was not found.`
+        );
+      }
+      if (parent.lockedAt !== null) {
+        throw new ScenarioCaseSeedPersistenceError(
+          409,
+          'scenario_locked',
+          `Scenario ${input.scenarioId} is locked.`
+        );
+      }
+      const hasExpectedVersion = parent.version === input.expectedScenarioVersion;
+      if (parent.companyId !== input.seed.companyId) {
+        throw new ScenarioCaseSeedPersistenceError(
+          422,
+          'company_mismatch',
+          `Scenario ${input.scenarioId} belongs to company ${parent.companyId}, not ${input.seed.companyId}.`,
+          {
+            scenarioCompanyId: parent.companyId,
+            seedCompanyId: input.seed.companyId,
+          }
+        );
+      }
+
+      const existingProvenanceRows = await tx
+        .select()
+        .from(scenarioCaseSeedProvenance)
+        .where(
+          and(
+            eq(scenarioCaseSeedProvenance.fundId, input.seed.fundId),
+            eq(scenarioCaseSeedProvenance.idempotencyKey, input.idempotencyKey)
+          )
+        )
+        .limit(1);
+      const existingProvenance = existingProvenanceRows[0];
+      if (existingProvenance) {
+        const existingCaseRows = await tx
+          .select()
+          .from(scenarioCases)
+          .where(eq(scenarioCases.id, existingProvenance.scenarioCaseId))
+          .limit(1);
+        const existingCase = existingCaseRows[0];
+        if (!existingCase) {
+          throw new Error(
+            `Seed provenance references missing scenario case ${existingProvenance.scenarioCaseId}.`
+          );
+        }
+        assertReplayMatchesScenario(existingCase, input.scenarioId, input.idempotencyKey);
+        return {
+          case: existingCase,
+          provenance: existingProvenance,
+          replayed: true,
+        };
+      }
+      if (!hasExpectedVersion) {
+        throw new ScenarioCaseSeedPersistenceError(
+          409,
+          'version_conflict',
+          `Scenario ${input.scenarioId} has version ${parent.version}, not ${input.expectedScenarioVersion}.`,
+          {
+            expectedVersion: input.expectedScenarioVersion,
+            actualVersion: parent.version,
+          }
+        );
+      }
+
+      const caseName = requireTextOverride(input.overrides.caseName, 'caseName');
+      const probability = requireTextOverride(input.overrides.probability, 'probability');
+      const seededValues = composeSeededCaseValues(input.seed, input.overrides);
+      const now = new Date();
+
+      const createdCaseRows = await tx
+        .insert(scenarioCases)
+        .values({
+          scenarioId: input.scenarioId,
+          caseName,
+          probability,
+          investment: seededValues.investment,
+          followOns: seededValues.followOns,
+          exitProceeds: '0',
+          exitValuation:
+            input.overrides.exitValuation === undefined
+              ? '0'
+              : requireTextOverride(input.overrides.exitValuation, 'exitValuation'),
+          monthsToExit: input.overrides.monthsToExit ?? null,
+          ownershipAtExit:
+            input.overrides.ownershipAtExit == null
+              ? null
+              : requireTextOverride(input.overrides.ownershipAtExit, 'ownershipAtExit'),
+          fmv: seededValues.fmv,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      const createdCase = createdCaseRows[0];
+      if (!createdCase) {
+        throw new Error('Scenario case insert did not return a row.');
+      }
+
+      const provenanceRows = await tx
+        .insert(scenarioCaseSeedProvenance)
+        .values({
+          scenarioCaseId: createdCase.id,
+          fundId: input.seed.fundId,
+          companyId: input.seed.companyId,
+          idempotencyKey: input.idempotencyKey,
+          factsInputHash: input.seed.factsInputHash,
+          factsAsOfDate: input.seed.asOfDate,
+          trustState: input.seed.trustState,
+          currencyStatus: input.seed.currencyStatus,
+          seededInvestment: seededValues.investment,
+          seededFollowOns: seededValues.followOns,
+          seededFmv: seededValues.fmv,
+          investmentSource: seededValues.investmentSource,
+          followOnsSource: seededValues.followOnsSource,
+          fmvSource: seededValues.fmvSource,
+          latestRoundValuationReference: input.seed.fields.exitValuation.marketReference,
+          latestRoundDateReference: null,
+        })
+        .returning();
+      const provenance = provenanceRows[0];
+      if (!provenance) {
+        throw new Error('Scenario case seed provenance insert did not return a row.');
+      }
+
+      await tx
+        .update(scenarios)
+        .set({ version: parent.version + 1, updatedAt: now })
+        .where(eq(scenarios.id, input.scenarioId));
+
+      await tx.insert(scenarioAuditLogs).values({
+        userId: input.actor.userId,
+        entityType: 'scenario_case',
+        entityId: createdCase.id,
+        action: 'CREATE',
+        diff: {
+          source: input.seed.contractVersion,
+          factsInputHash: input.seed.factsInputHash,
+          factsAsOfDate: input.seed.asOfDate,
+          caseName,
+        },
+        timestamp: now,
+      });
+
+      return { case: createdCase, provenance, replayed: false };
+    });
+  } catch (error) {
+    if (isProvenanceIdempotencyViolation(error)) {
+      return loadReplayAfterUniqueViolation({
+        fundId: input.seed.fundId,
+        scenarioId: input.scenarioId,
+        idempotencyKey: input.idempotencyKey,
+      });
+    }
+    throw error;
+  }
+}

--- a/shared/lib/data-boundaries.ts
+++ b/shared/lib/data-boundaries.ts
@@ -59,6 +59,7 @@ export const SIMULATION_ONLY_TABLES = [
   'portfolio_scenarios',
   'scenarios',
   'scenario_cases',
+  'scenario_case_seed_provenance',
   'scenario_audit_logs',
 
   // Strategy modeling

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -33,6 +33,7 @@ import {
 export * from './schema/fund';
 export * from './schema/portfolio';
 export * from './schema/scenario';
+export * from './schema/scenario-case-seed-provenance';
 export * from './schema/shares';
 export * from './schema/allocation-scenarios';
 export * from './schema/user';
@@ -2150,10 +2151,7 @@ export const backtestResults = pgTable(
       };
       modelQualityScore: number;
       calibrationStatus:
-        | 'well-calibrated'
-        | 'under-predicting'
-        | 'over-predicting'
-        | 'insufficient-data';
+        'well-calibrated' | 'under-predicting' | 'over-predicting' | 'insufficient-data';
       incalculableMetrics: string[];
     }>(),
 

--- a/shared/schema/index.ts
+++ b/shared/schema/index.ts
@@ -16,6 +16,7 @@
 export * from './fund';
 export * from './portfolio';
 export * from './scenario';
+export * from './scenario-case-seed-provenance';
 export * from './shares';
 export * from './user';
 export * from './lp-reporting-evidence';

--- a/shared/schema/scenario-case-seed-provenance.ts
+++ b/shared/schema/scenario-case-seed-provenance.ts
@@ -1,0 +1,85 @@
+import { sql } from 'drizzle-orm';
+import {
+  char,
+  check,
+  date,
+  decimal,
+  foreignKey,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  unique,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { funds } from './fund';
+import { portfolioCompanies } from './portfolio';
+import { scenarioCases } from './scenario';
+
+export const scenarioCaseSeedProvenance = pgTable(
+  'scenario_case_seed_provenance',
+  {
+    scenarioCaseId: uuid('scenario_case_id').notNull(),
+    fundId: integer('fund_id').notNull(),
+    companyId: integer('company_id').notNull(),
+    idempotencyKey: text('idempotency_key').notNull(),
+    factsInputHash: char('facts_input_hash', { length: 64 }).notNull(),
+    factsAsOfDate: date('facts_as_of_date').notNull(),
+    seededAt: timestamp('seeded_at', { withTimezone: true }).notNull().defaultNow(),
+    trustState: varchar('trust_state', { length: 16 }).notNull(),
+    currencyStatus: varchar('currency_status', { length: 24 }).notNull(),
+    seededInvestment: decimal('seeded_investment', { precision: 15, scale: 6 }).notNull(),
+    seededFollowOns: decimal('seeded_follow_ons', { precision: 15, scale: 6 }).notNull(),
+    seededFmv: decimal('seeded_fmv', { precision: 15, scale: 6 }),
+    investmentSource: varchar('investment_source', { length: 64 }).notNull(),
+    followOnsSource: varchar('follow_ons_source', { length: 64 }).notNull(),
+    fmvSource: varchar('fmv_source', { length: 64 }),
+    latestRoundValuationReference: decimal('latest_round_valuation_reference', {
+      precision: 15,
+      scale: 6,
+    }),
+    latestRoundDateReference: date('latest_round_date_reference'),
+  },
+  (table) => ({
+    primaryKey: primaryKey({
+      name: 'scenario_case_seed_provenance_pkey',
+      columns: [table.scenarioCaseId],
+    }),
+    scenarioCaseFk: foreignKey({
+      name: 'scenario_case_seed_provenance_scenario_case_id_fkey',
+      columns: [table.scenarioCaseId],
+      foreignColumns: [scenarioCases.id],
+    }).onDelete('cascade'),
+    fundFk: foreignKey({
+      name: 'scenario_case_seed_provenance_fund_id_fkey',
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+    }).onDelete('cascade'),
+    companyFk: foreignKey({
+      name: 'scenario_case_seed_provenance_company_id_fkey',
+      columns: [table.companyId],
+      foreignColumns: [portfolioCompanies.id],
+    }).onDelete('cascade'),
+    fundIdempotencyUnique: unique('scenario_case_seed_provenance_fund_idempotency_key_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    trustStateCheck: check(
+      'scenario_case_seed_provenance_trust_state_check',
+      sql`${table.trustState} IN ('LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED')`
+    ),
+    currencyStatusCheck: check(
+      'scenario_case_seed_provenance_currency_status_check',
+      sql`${table.currencyStatus} IN ('base_currency', 'mismatch_blocked', 'unknown')`
+    ),
+    fundIdx: index('scenario_case_seed_provenance_fund_idx')['on'](table.fundId),
+    companyIdx: index('scenario_case_seed_provenance_company_idx')['on'](table.companyId),
+  })
+);
+
+export type ScenarioCaseSeedProvenance = typeof scenarioCaseSeedProvenance.$inferSelect;
+export type NewScenarioCaseSeedProvenance = typeof scenarioCaseSeedProvenance.$inferInsert;

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -78,6 +78,7 @@ const ALLOCATION_SCENARIO_MANIFEST_TABLES = [
   'allocation_scenario_events',
   'allocation_scenario_ic_decisions',
 ] as const;
+const SCENARIO_CASE_SEED_PROVENANCE_MANIFEST_TABLES = ['scenario_case_seed_provenance'] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
   'flags_state',
@@ -699,6 +700,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...LP_CORE_MANIFEST_TABLES,
         ...H9_MANIFEST_TABLES,
         ...ALLOCATION_SCENARIO_MANIFEST_TABLES,
+        ...SCENARIO_CASE_SEED_PROVENANCE_MANIFEST_TABLES,
       ])
     );
 

--- a/tests/integration/scenarios/scenario-case-seed-persistence.test.ts
+++ b/tests/integration/scenarios/scenario-case-seed-persistence.test.ts
@@ -1,0 +1,298 @@
+/**
+ * @group integration
+ * @group testcontainers
+ *
+ * Real-Postgres proof for immutable scenario-case seed provenance.
+ *
+ * Supported modes:
+ *   1. TEST_DATABASE_URL=postgres://... (disposable test database)
+ *   2. RUN_DOCKER_PHASE0_TEST=1 (local Docker)
+ *   3. Main Testcontainers CI (Docker is provisioned by the workflow)
+ */
+
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { combinedSchema } from '../../../server/db-schema';
+import type { ScenarioCaseSeedV1 } from '../../../shared/contracts/scenarios/scenario-case-seed-v1.contract';
+import { runMigrationsWithConnectionString } from '../../helpers/testcontainers-migration';
+
+const STARTUP_TIMEOUT_MS = 120_000;
+const cloudDbUrl = process.env.TEST_DATABASE_URL;
+const useCloudDb = Boolean(cloudDbUrl);
+const useDocker = process.env.RUN_DOCKER_PHASE0_TEST === '1' || process.env.CI === 'true';
+const skipTest = !useCloudDb && !useDocker;
+
+const originalEnv = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  NEON_DATABASE_URL: process.env.NEON_DATABASE_URL,
+  USE_REAL_DB_IN_VITEST: process.env.USE_REAL_DB_IN_VITEST,
+};
+
+let container: import('@testcontainers/postgresql').StartedPostgreSqlContainer | null = null;
+let adminPool: Pool;
+let modulePool: Pool;
+let connectionString: string;
+let persistenceModule: typeof import('../../../server/services/scenarios/scenario-case-seed-persistence-service');
+
+function restoreEnvironment(): void {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function resetSchema(): Promise<void> {
+  await adminPool.query('DROP EXTENSION IF EXISTS vector CASCADE');
+  await adminPool.query('DROP EXTENSION IF EXISTS pgcrypto CASCADE');
+  await adminPool.query('DROP SCHEMA IF EXISTS public CASCADE');
+  await adminPool.query('CREATE SCHEMA public');
+  await adminPool.query('GRANT ALL ON SCHEMA public TO public');
+  await adminPool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public');
+  try {
+    await adminPool.query('CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public');
+  } catch {
+    // Some TEST_DATABASE_URL providers do not expose pgvector.
+  }
+}
+
+async function seedParent(options: { locked?: boolean } = {}): Promise<{
+  fundId: number;
+  companyId: number;
+  scenarioId: string;
+}> {
+  const fundResult = await adminPool.query<{ id: number }>(`
+    INSERT INTO funds (name, size, management_fee, carry_percentage, vintage_year, engine_results)
+    VALUES ('Seed provenance fund', 100000000, 0.02, 0.20, 2026, '{}'::jsonb)
+    RETURNING id
+  `);
+  const fundId = fundResult.rows[0]!.id;
+
+  const companyResult = await adminPool.query<{ id: number }>(
+    `
+      INSERT INTO portfoliocompanies (
+        fund_id, name, sector, stage, investment_amount, current_valuation, status
+      )
+      VALUES ($1, 'Seeded company', 'Software', 'Series A', 125000, 900000, 'active')
+      RETURNING id
+    `,
+    [fundId]
+  );
+  const companyId = companyResult.rows[0]!.id;
+
+  const scenarioResult = await adminPool.query<{ id: string }>(
+    `
+      INSERT INTO scenarios (company_id, name, version, locked_at)
+      VALUES ($1, 'Seeded scenario', 1, $2)
+      RETURNING id
+    `,
+    [companyId, options.locked ? new Date('2026-07-13T12:00:00.000Z') : null]
+  );
+
+  return { fundId, companyId, scenarioId: scenarioResult.rows[0]!.id };
+}
+
+function makeSeed(fundId: number, companyId: number): ScenarioCaseSeedV1 {
+  return {
+    contractVersion: 'scenario-case-seed-v1',
+    fundId,
+    companyId,
+    asOfDate: '2026-07-13',
+    factsInputHash: 'b'.repeat(64),
+    trustState: 'LIVE',
+    currencyStatus: 'base_currency',
+    fields: {
+      investment: {
+        status: 'seeded',
+        value: '125000.123456',
+        source: 'facts.initialInvestmentAmount',
+      },
+      followOns: {
+        status: 'seeded',
+        value: '50000.654321',
+        source: 'facts.followOnInvestmentAmount',
+      },
+      fmv: {
+        status: 'seeded',
+        value: '900000.111111',
+        source: 'facts.latestPlanningFmvValue',
+      },
+      exitValuation: {
+        status: 'user_required',
+        value: null,
+        marketReference: '1500000.000000',
+      },
+      probability: { status: 'user_required', value: null },
+      ownershipAtExit: { status: 'user_required', value: null },
+    },
+    warnings: [],
+  };
+}
+
+function createInput(parent: { fundId: number; companyId: number; scenarioId: string }) {
+  return {
+    scenarioId: parent.scenarioId,
+    expectedScenarioVersion: 1,
+    seed: makeSeed(parent.fundId, parent.companyId),
+    overrides: {
+      caseName: 'Base case',
+      probability: '0.50000000',
+      exitValuation: '2000000.000000',
+      monthsToExit: 36,
+      ownershipAtExit: '0.1000',
+    },
+    actor: { userId: 'integration-user' },
+    idempotencyKey: 'integration-seed-case',
+  };
+}
+
+async function persistedRows(scenarioId: string): Promise<{
+  cases: Record<string, unknown>[];
+  provenance: Record<string, unknown>[];
+}> {
+  const cases = await adminPool.query<Record<string, unknown>>(
+    'SELECT * FROM scenario_cases WHERE scenario_id = $1 ORDER BY id',
+    [scenarioId]
+  );
+  const provenance = await adminPool.query<Record<string, unknown>>(
+    `
+      SELECT p.*
+      FROM scenario_case_seed_provenance p
+      JOIN scenario_cases c ON c.id = p.scenario_case_id
+      WHERE c.scenario_id = $1
+      ORDER BY p.scenario_case_id
+    `,
+    [scenarioId]
+  );
+  return { cases: cases.rows, provenance: provenance.rows };
+}
+
+describe.skipIf(skipTest)('scenario case seed persistence', () => {
+  beforeAll(async () => {
+    if (useCloudDb) {
+      connectionString = cloudDbUrl!;
+      adminPool = new Pool({ connectionString, max: 1 });
+    } else {
+      const { PostgreSqlContainer } = await import('@testcontainers/postgresql');
+      container = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+        .withDatabase('test_db')
+        .withUsername('test_user')
+        .withPassword('test_password')
+        .start();
+      connectionString = container.getConnectionUri();
+      adminPool = new Pool({ connectionString, max: 1 });
+    }
+
+    await resetSchema();
+    await runMigrationsWithConnectionString(connectionString);
+
+    vi.resetModules();
+    process.env.USE_REAL_DB_IN_VITEST = '1';
+    process.env.DATABASE_URL = connectionString;
+    delete process.env.NEON_DATABASE_URL;
+
+    modulePool = new Pool({ connectionString, max: 2 });
+    const moduleDb = drizzle(modulePool, { schema: combinedSchema });
+    vi.doMock('../../../server/db', () => ({ db: moduleDb, pool: modulePool }));
+    persistenceModule =
+      await import('../../../server/services/scenarios/scenario-case-seed-persistence-service');
+  }, STARTUP_TIMEOUT_MS);
+
+  afterAll(async () => {
+    vi.doUnmock('../../../server/db');
+    await modulePool?.end();
+    await adminPool?.end();
+    await container?.stop();
+    restoreEnvironment();
+  }, STARTUP_TIMEOUT_MS);
+
+  beforeEach(async () => {
+    await adminPool.query(`
+      TRUNCATE TABLE funds RESTART IDENTITY CASCADE
+    `);
+  });
+
+  it('commits the case and provenance together and increments the parent once', async () => {
+    const parent = await seedParent();
+    const result = await persistenceModule.createScenarioCaseFromSeed(createInput(parent));
+    const rows = await persistedRows(parent.scenarioId);
+    const scenario = await adminPool.query<{ version: number }>(
+      'SELECT version FROM scenarios WHERE id = $1',
+      [parent.scenarioId]
+    );
+
+    expect(result.replayed).toBe(false);
+    expect(rows.cases).toHaveLength(1);
+    expect(rows.provenance).toHaveLength(1);
+    expect(rows.provenance[0]?.scenario_case_id).toBe(rows.cases[0]?.id);
+    expect(scenario.rows[0]?.version).toBe(2);
+  });
+
+  it('rolls back both rows when a later write in the transaction fails', async () => {
+    const parent = await seedParent();
+    const input = createInput(parent);
+    input.actor.userId = 'x'.repeat(256);
+
+    await expect(persistenceModule.createScenarioCaseFromSeed(input)).rejects.toBeDefined();
+    await expect(persistedRows(parent.scenarioId)).resolves.toEqual({ cases: [], provenance: [] });
+  });
+
+  it('leaves both rows absent when the parent scenario is locked', async () => {
+    const parent = await seedParent({ locked: true });
+
+    await expect(
+      persistenceModule.createScenarioCaseFromSeed(createInput(parent))
+    ).rejects.toMatchObject({ code: 'scenario_locked' });
+    await expect(persistedRows(parent.scenarioId)).resolves.toEqual({ cases: [], provenance: [] });
+  });
+
+  it('returns the same case on retry without another insert or version bump', async () => {
+    const parent = await seedParent();
+    const input = createInput(parent);
+    const created = await persistenceModule.createScenarioCaseFromSeed(input);
+    const replay = await persistenceModule.createScenarioCaseFromSeed(input);
+    const rows = await persistedRows(parent.scenarioId);
+    const scenario = await adminPool.query<{ version: number }>(
+      'SELECT version FROM scenarios WHERE id = $1',
+      [parent.scenarioId]
+    );
+
+    expect(replay.replayed).toBe(true);
+    expect(replay.case.id).toBe(created.case.id);
+    expect(rows.cases).toHaveLength(1);
+    expect(rows.provenance).toHaveLength(1);
+    expect(scenario.rows[0]?.version).toBe(2);
+  });
+
+  it('does not change the case or provenance when later company facts change', async () => {
+    const parent = await seedParent();
+    await persistenceModule.createScenarioCaseFromSeed(createInput(parent));
+    const before = await persistedRows(parent.scenarioId);
+
+    await adminPool.query('UPDATE portfoliocompanies SET current_valuation = $1 WHERE id = $2', [
+      '2500000.00',
+      parent.companyId,
+    ]);
+
+    await expect(persistedRows(parent.scenarioId)).resolves.toEqual(before);
+  });
+
+  it('allows a user case edit without mutating provenance', async () => {
+    const parent = await seedParent();
+    const created = await persistenceModule.createScenarioCaseFromSeed(createInput(parent));
+    const before = await persistedRows(parent.scenarioId);
+
+    await adminPool.query(
+      'UPDATE scenario_cases SET investment = $1, updated_at = now() WHERE id = $2',
+      ['175000.00', created.case.id]
+    );
+    const after = await persistedRows(parent.scenarioId);
+
+    expect(after.cases[0]?.investment).toBe('175000.00');
+    expect(after.provenance).toEqual(before.provenance);
+  });
+});

--- a/tests/integration/schema-isolation.test.ts
+++ b/tests/integration/schema-isolation.test.ts
@@ -48,6 +48,7 @@ describe('Schema Isolation - Data Boundaries', () => {
       expect(SIMULATION_ONLY_TABLES).toContain('monte_carlo_simulations');
       expect(SIMULATION_ONLY_TABLES).toContain('backtest_results');
       expect(SIMULATION_ONLY_TABLES).toContain('scenarios');
+      expect(SIMULATION_ONLY_TABLES).toContain('scenario_case_seed_provenance');
     });
 
     it('should not retain retired saved-comparison table names', () => {

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -42,6 +42,7 @@ const expectedJournaledDriftPatchFiles = [
   '0029_h9_actionability_reconcile_drift.sql',
   '0030_allocation_scenarios_reconcile_drift.sql',
   '0031_user_identity_grants_revocation.sql',
+  '0032_scenario_case_seed_provenance.sql',
 ].sort();
 
 afterEach(() => {

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -81,7 +81,7 @@ function namesSurvivingSql(sqlFiles: string[]): Set<string> {
 describe('prod-schema manifest sentinels', () => {
   const manifests = loadManifestFiles();
 
-  it('finds the four PR-1 manifests, the operator-seam manifest, and the H9 + allocation-scenario manifests', () => {
+  it('finds the four PR-1 manifests and all additive production manifests through scenario seed provenance', () => {
     expect(manifests.map((entry) => entry.file)).toEqual([
       '01-cohort.json',
       '02-fund-moic.json',
@@ -90,6 +90,7 @@ describe('prod-schema manifest sentinels', () => {
       '05-operator-seam.json',
       '06-h9-actionability.json',
       '07-allocation-scenarios.json',
+      '08-scenario-case-seed-provenance.json',
     ]);
   });
 

--- a/tests/unit/services/scenarios/scenario-case-seed-persistence.test.ts
+++ b/tests/unit/services/scenarios/scenario-case-seed-persistence.test.ts
@@ -1,0 +1,549 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ScenarioCaseSeedV1 } from '../../../../shared/contracts/scenarios/scenario-case-seed-v1.contract';
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    transaction: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../server/db', () => ({ db: mockDb }));
+
+import type { ScenarioCaseSeedPersistenceError } from '../../../../server/services/scenarios/scenario-case-seed-persistence-service';
+import { createScenarioCaseFromSeed } from '../../../../server/services/scenarios/scenario-case-seed-persistence-service';
+
+const seed: ScenarioCaseSeedV1 = {
+  contractVersion: 'scenario-case-seed-v1',
+  fundId: 7,
+  companyId: 11,
+  asOfDate: '2026-07-13',
+  factsInputHash: 'a'.repeat(64),
+  trustState: 'LIVE',
+  currencyStatus: 'base_currency',
+  fields: {
+    investment: {
+      status: 'seeded',
+      value: '125000.123456',
+      source: 'facts.initialInvestmentAmount',
+    },
+    followOns: {
+      status: 'seeded',
+      value: '50000.654321',
+      source: 'facts.followOnInvestmentAmount',
+    },
+    fmv: {
+      status: 'seeded',
+      value: '900000.111111',
+      source: 'facts.latestPlanningFmvValue',
+    },
+    exitValuation: {
+      status: 'user_required',
+      value: null,
+      marketReference: '1500000.000000',
+    },
+    probability: { status: 'user_required', value: null },
+    ownershipAtExit: { status: 'user_required', value: null },
+  },
+  warnings: [],
+};
+
+function makeSelectQueue(...rowsByCall: unknown[][]) {
+  const pendingRows = [...rowsByCall];
+  const select = vi.fn(() => {
+    const rows = pendingRows.shift() ?? [];
+    const result = Object.assign(Promise.resolve(rows), {
+      for: vi.fn().mockResolvedValue(rows),
+    });
+    const limit = vi.fn(() => result);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    return { from };
+  });
+  return { select };
+}
+
+function makeInsertQueue(...returnRowsByCall: unknown[][]) {
+  const pendingRows = [...returnRowsByCall];
+  const insertedValues: unknown[] = [];
+  const insert = vi.fn(() => ({
+    values: vi.fn((values: unknown) => {
+      insertedValues.push(values);
+      return {
+        returning: vi.fn().mockResolvedValue(pendingRows.shift() ?? []),
+      };
+    }),
+  }));
+  return { insert, insertedValues };
+}
+
+function makeUpdate() {
+  const updatedValues: unknown[] = [];
+  const where = vi.fn().mockResolvedValue(undefined);
+  const update = vi.fn(() => ({
+    set: vi.fn((values: unknown) => {
+      updatedValues.push(values);
+      return { where };
+    }),
+  }));
+  return { update, updatedValues };
+}
+
+describe('createScenarioCaseFromSeed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a locked parent before any write', async () => {
+    const parentSelect = makeSelectQueue([
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        companyId: seed.companyId,
+        version: 3,
+        lockedAt: new Date('2026-07-13T12:00:00.000Z'),
+      },
+    ]);
+    const tx = {
+      select: parentSelect.select,
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+    mockDb.transaction.mockImplementation(
+      async (operation: (transaction: typeof tx) => Promise<unknown>) => operation(tx)
+    );
+
+    const result = createScenarioCaseFromSeed({
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      expectedScenarioVersion: 3,
+      seed,
+      overrides: { caseName: 'Base case', probability: '0.50000000' },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-1',
+    });
+
+    await expect(result).rejects.toMatchObject<Partial<ScenarioCaseSeedPersistenceError>>({
+      code: 'scenario_locked',
+    });
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale expected scenario version before any write', async () => {
+    const parentSelect = makeSelectQueue([
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        companyId: seed.companyId,
+        version: 4,
+        lockedAt: null,
+      },
+    ]);
+    const tx = {
+      select: parentSelect.select,
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+    mockDb.transaction.mockImplementation(
+      async (operation: (transaction: typeof tx) => Promise<unknown>) => operation(tx)
+    );
+
+    const result = createScenarioCaseFromSeed({
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      expectedScenarioVersion: 3,
+      seed,
+      overrides: { caseName: 'Base case', probability: '0.50000000' },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-1',
+    });
+
+    await expect(result).rejects.toMatchObject<Partial<ScenarioCaseSeedPersistenceError>>({
+      code: 'version_conflict',
+    });
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a seed for a different portfolio company before any write', async () => {
+    const parentSelect = makeSelectQueue([
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        companyId: 99,
+        version: 3,
+        lockedAt: null,
+      },
+    ]);
+    const tx = {
+      select: parentSelect.select,
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+    mockDb.transaction.mockImplementation(
+      async (operation: (transaction: typeof tx) => Promise<unknown>) => operation(tx)
+    );
+
+    const result = createScenarioCaseFromSeed({
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      expectedScenarioVersion: 3,
+      seed,
+      overrides: { caseName: 'Base case', probability: '0.50000000' },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-1',
+    });
+
+    await expect(result).rejects.toMatchObject<Partial<ScenarioCaseSeedPersistenceError>>({
+      code: 'company_mismatch',
+    });
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unavailable required seed field without a user override', async () => {
+    const unavailableInvestmentSeed: ScenarioCaseSeedV1 = {
+      ...seed,
+      fields: {
+        ...seed.fields,
+        investment: {
+          status: 'unavailable',
+          value: null,
+          reason: 'source_missing',
+        },
+      },
+    };
+    const selectQueue = makeSelectQueue(
+      [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          companyId: seed.companyId,
+          version: 3,
+          lockedAt: null,
+        },
+      ],
+      []
+    );
+    const tx = {
+      select: selectQueue.select,
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+    mockDb.transaction.mockImplementation(
+      async (operation: (transaction: typeof tx) => Promise<unknown>) => operation(tx)
+    );
+
+    const result = createScenarioCaseFromSeed({
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      expectedScenarioVersion: 3,
+      seed: unavailableInvestmentSeed,
+      overrides: { caseName: 'Base case', probability: '0.50000000' },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-1',
+    });
+
+    await expect(result).rejects.toMatchObject<Partial<ScenarioCaseSeedPersistenceError>>({
+      code: 'missing_required_override',
+    });
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing case for an idempotent retry without writing or bumping version', async () => {
+    const existingCase = {
+      id: '00000000-0000-4000-8000-000000000010',
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      caseName: 'Base case',
+      description: null,
+      probability: '0.50000000',
+      investment: '125000.12',
+      followOns: '50000.65',
+      exitProceeds: '0.00',
+      exitValuation: '0.00',
+      monthsToExit: null,
+      ownershipAtExit: null,
+      fmv: '900000.11',
+      createdAt: new Date('2026-07-13T12:00:00.000Z'),
+      updatedAt: new Date('2026-07-13T12:00:00.000Z'),
+    };
+    const existingProvenance = {
+      scenarioCaseId: existingCase.id,
+      fundId: seed.fundId,
+      companyId: seed.companyId,
+      idempotencyKey: 'seed-case-1',
+      factsInputHash: seed.factsInputHash,
+      factsAsOfDate: seed.asOfDate,
+      seededAt: new Date('2026-07-13T12:00:00.000Z'),
+      trustState: seed.trustState,
+      currencyStatus: seed.currencyStatus,
+      seededInvestment: '125000.123456',
+      seededFollowOns: '50000.654321',
+      seededFmv: '900000.111111',
+      investmentSource: 'facts.initialInvestmentAmount',
+      followOnsSource: 'facts.followOnInvestmentAmount',
+      fmvSource: 'facts.latestPlanningFmvValue',
+      latestRoundValuationReference: '1500000.000000',
+      latestRoundDateReference: null,
+    };
+    const selectQueue = makeSelectQueue(
+      [
+        {
+          id: existingCase.scenarioId,
+          companyId: seed.companyId,
+          version: 4,
+          lockedAt: null,
+        },
+      ],
+      [existingProvenance],
+      [existingCase]
+    );
+    const tx = {
+      select: selectQueue.select,
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+    mockDb.transaction.mockImplementation(
+      async (operation: (transaction: typeof tx) => Promise<unknown>) => operation(tx)
+    );
+
+    const result = await createScenarioCaseFromSeed({
+      scenarioId: existingCase.scenarioId,
+      expectedScenarioVersion: 3,
+      seed,
+      overrides: { caseName: 'Ignored retry body', probability: '0.25000000' },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-1',
+    });
+
+    expect(result).toEqual({
+      case: existingCase,
+      provenance: existingProvenance,
+      replayed: true,
+    });
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it('maps seeded, overridden, and user-required values into the case and immutable provenance', async () => {
+    const createdCase = {
+      id: '00000000-0000-4000-8000-000000000010',
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      caseName: 'Upside case',
+      description: null,
+      probability: '0.30000000',
+      investment: '125000.12',
+      followOns: '75000.00',
+      exitProceeds: '0.00',
+      exitValuation: '2000000.00',
+      monthsToExit: 36,
+      ownershipAtExit: '0.1000',
+      fmv: '900000.11',
+      createdAt: new Date('2026-07-13T12:00:00.000Z'),
+      updatedAt: new Date('2026-07-13T12:00:00.000Z'),
+    };
+    const createdProvenance = {
+      scenarioCaseId: createdCase.id,
+      fundId: seed.fundId,
+      companyId: seed.companyId,
+      idempotencyKey: 'seed-case-2',
+      factsInputHash: seed.factsInputHash,
+      factsAsOfDate: seed.asOfDate,
+      seededAt: new Date('2026-07-13T12:00:00.000Z'),
+      trustState: seed.trustState,
+      currencyStatus: seed.currencyStatus,
+      seededInvestment:
+        seed.fields.investment.status === 'seeded' ? seed.fields.investment.value : '',
+      seededFollowOns: '75000.000000',
+      seededFmv: seed.fields.fmv.status === 'seeded' ? seed.fields.fmv.value : null,
+      investmentSource:
+        seed.fields.investment.status === 'seeded' ? seed.fields.investment.source : '',
+      followOnsSource: 'user_override',
+      fmvSource: seed.fields.fmv.status === 'seeded' ? seed.fields.fmv.source : null,
+      latestRoundValuationReference: seed.fields.exitValuation.marketReference,
+      latestRoundDateReference: null,
+    };
+    const selectQueue = makeSelectQueue(
+      [
+        {
+          id: createdCase.scenarioId,
+          companyId: seed.companyId,
+          version: 3,
+          lockedAt: null,
+        },
+      ],
+      []
+    );
+    const insertQueue = makeInsertQueue([createdCase], [createdProvenance], []);
+    const update = makeUpdate();
+    const tx = {
+      select: selectQueue.select,
+      insert: insertQueue.insert,
+      update: update.update,
+    };
+    mockDb.transaction.mockImplementation(
+      async (operation: (transaction: typeof tx) => Promise<unknown>) => operation(tx)
+    );
+
+    const result = await createScenarioCaseFromSeed({
+      scenarioId: createdCase.scenarioId,
+      expectedScenarioVersion: 3,
+      seed,
+      overrides: {
+        caseName: '  Upside case  ',
+        probability: '0.30000000',
+        followOns: '75000.000000',
+        exitValuation: '2000000.000000',
+        monthsToExit: 36,
+        ownershipAtExit: '0.1000',
+      },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-2',
+    });
+
+    expect(result).toEqual({ case: createdCase, provenance: createdProvenance, replayed: false });
+    expect(insertQueue.insertedValues[0]).toMatchObject({
+      scenarioId: createdCase.scenarioId,
+      caseName: 'Upside case',
+      probability: '0.30000000',
+      investment: '125000.123456',
+      followOns: '75000.000000',
+      exitProceeds: '0',
+      exitValuation: '2000000.000000',
+      monthsToExit: 36,
+      ownershipAtExit: '0.1000',
+      fmv: '900000.111111',
+    });
+    expect(insertQueue.insertedValues[1]).toEqual({
+      scenarioCaseId: createdCase.id,
+      fundId: seed.fundId,
+      companyId: seed.companyId,
+      idempotencyKey: 'seed-case-2',
+      factsInputHash: seed.factsInputHash,
+      factsAsOfDate: seed.asOfDate,
+      trustState: seed.trustState,
+      currencyStatus: seed.currencyStatus,
+      seededInvestment: '125000.123456',
+      seededFollowOns: '75000.000000',
+      seededFmv: '900000.111111',
+      investmentSource: 'facts.initialInvestmentAmount',
+      followOnsSource: 'user_override',
+      fmvSource: 'facts.latestPlanningFmvValue',
+      latestRoundValuationReference: '1500000.000000',
+      latestRoundDateReference: null,
+    });
+    expect(update.update).toHaveBeenCalledTimes(1);
+    expect(update.updatedValues).toEqual([
+      expect.objectContaining({ version: 4, updatedAt: expect.any(Date) }),
+    ]);
+    expect(insertQueue.insertedValues[2]).toMatchObject({
+      userId: 'user-17',
+      entityType: 'scenario_case',
+      entityId: createdCase.id,
+      action: 'CREATE',
+    });
+  });
+
+  it('re-reads the winning case after a provenance idempotency race', async () => {
+    const existingCase = {
+      id: '00000000-0000-4000-8000-000000000010',
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      caseName: 'Base case',
+      description: null,
+      probability: '0.50000000',
+      investment: '125000.12',
+      followOns: '50000.65',
+      exitProceeds: '0.00',
+      exitValuation: '0.00',
+      monthsToExit: null,
+      ownershipAtExit: null,
+      fmv: '900000.11',
+      createdAt: new Date('2026-07-13T12:00:00.000Z'),
+      updatedAt: new Date('2026-07-13T12:00:00.000Z'),
+    };
+    const existingProvenance = {
+      scenarioCaseId: existingCase.id,
+      fundId: seed.fundId,
+      companyId: seed.companyId,
+      idempotencyKey: 'seed-case-race',
+      factsInputHash: seed.factsInputHash,
+      factsAsOfDate: seed.asOfDate,
+      seededAt: new Date('2026-07-13T12:00:00.000Z'),
+      trustState: seed.trustState,
+      currencyStatus: seed.currencyStatus,
+      seededInvestment: '125000.123456',
+      seededFollowOns: '50000.654321',
+      seededFmv: '900000.111111',
+      investmentSource: 'facts.initialInvestmentAmount',
+      followOnsSource: 'facts.followOnInvestmentAmount',
+      fmvSource: 'facts.latestPlanningFmvValue',
+      latestRoundValuationReference: '1500000.000000',
+      latestRoundDateReference: null,
+    };
+    const selectQueue = makeSelectQueue([existingProvenance], [existingCase]);
+    mockDb.select.mockImplementation(selectQueue.select);
+    mockDb.transaction.mockRejectedValue({
+      code: '23505',
+      constraint: 'scenario_case_seed_provenance_fund_idempotency_key_unique',
+    });
+
+    const result = await createScenarioCaseFromSeed({
+      scenarioId: existingCase.scenarioId,
+      expectedScenarioVersion: 3,
+      seed,
+      overrides: { caseName: 'Base case', probability: '0.50000000' },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-race',
+    });
+
+    expect(result).toEqual({
+      case: existingCase,
+      provenance: existingProvenance,
+      replayed: true,
+    });
+  });
+
+  it('rejects an idempotency key that belongs to a different scenario', async () => {
+    const existingProvenance = {
+      scenarioCaseId: '00000000-0000-4000-8000-000000000099',
+      fundId: seed.fundId,
+      companyId: seed.companyId,
+      idempotencyKey: 'seed-case-cross-scenario',
+    };
+    const selectQueue = makeSelectQueue(
+      [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          companyId: seed.companyId,
+          version: 4,
+          lockedAt: null,
+        },
+      ],
+      [existingProvenance],
+      [
+        {
+          id: existingProvenance.scenarioCaseId,
+          scenarioId: '00000000-0000-4000-8000-000000000002',
+        },
+      ]
+    );
+    const tx = {
+      select: selectQueue.select,
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+    mockDb.transaction.mockImplementation(
+      async (operation: (transaction: typeof tx) => Promise<unknown>) => operation(tx)
+    );
+
+    const result = createScenarioCaseFromSeed({
+      scenarioId: '00000000-0000-4000-8000-000000000001',
+      expectedScenarioVersion: 3,
+      seed,
+      overrides: { caseName: 'Base case', probability: '0.50000000' },
+      actor: { userId: 'user-17' },
+      idempotencyKey: 'seed-case-cross-scenario',
+    });
+
+    await expect(result).rejects.toMatchObject<Partial<ScenarioCaseSeedPersistenceError>>({
+      code: 'idempotency_conflict',
+    });
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.testcontainers.ts
+++ b/vitest.config.testcontainers.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       'tests/integration/migrations/investment-rounds-schema.test.ts',
       'tests/integration/migrations/investments-id-fund-unique.test.ts',
       'tests/integration/investment-scenario-capability.test.ts',
+      'tests/integration/scenarios/scenario-case-seed-persistence.test.ts',
       // DISABLED: Pre-existing issues - fix in separate PRs
       // 'tests/integration/ScenarioMatrixCache.integration.test.ts', // bucket allocation validation
       // 'tests/integration/cache-monitoring.integration.test.ts', // server/db.ts imports database-mock


### PR DESCRIPTION
## Summary

Plan 8 wave 2 (Task 8.3) — snapshot-at-creation seed provenance, persisted atomically with the case it seeded.

- **Migration** `migrations/0032_scenario_case_seed_provenance.sql` (journal idx 33): one-to-one table keyed by `scenario_case_id` (PK = FK -> `scenario_cases(id)` CASCADE), FKs to `funds`/`portfoliocompanies`, CHECK constraints on trust/currency enums, fully replay-safe additive idiom (IF NOT EXISTS + guarded DO $$ blocks), timestamptz throughout, all constraint names under the 63-byte limit.
- **Two justified additions vs the plan's table spec** (called out per the CEO amendments' spirit): `idempotency_key text NOT NULL` + `UNIQUE(fund_id, idempotency_key)` — required by the plan's own "retry returns the same case" integration assertion, mirroring the `reconciliation_runs` fund-scoped idempotency precedent (migration 0017).
- **Drizzle schema** `shared/schema/scenario-case-seed-provenance.ts` (+ barrel exports) shape-equivalent to the SQL; table registered in `SIMULATION_ONLY_TABLES` data boundaries.
- **Typed M8 manifest** `scripts/prod-schema-manifests/08-scenario-case-seed-provenance.json` — every column carries a `type` (keeps type-drift detection effective).
- **Persistence service** `createScenarioCaseFromSeed`: single transaction with `SELECT ... FOR UPDATE` on the parent scenario; ordered guards — scenario_not_found -> **scenario_locked (new guard; nothing checked `lockedAt` before this PR)** -> company_mismatch -> idempotent replay short-circuit (returns the existing case with no insert and no version bump; checked before the version guard so post-success retries succeed) -> version_conflict -> required-override validation (probability/caseName are NOT NULL; user_required fields never seeded from facts) -> case insert + provenance insert + exactly-one parent version bump + audit log. Unique-constraint race (23505) resolves to replay-or-`idempotency_conflict`. Provenance rows have no update path — immutable by construction; existing cases are never backfilled.
- Guard-suite updates are additive-only: manifest sentinel list gains `08-*`, migration ledger gains `0032`, prod-schema-clone expected tables gain the new table, schema-isolation asserts containment, testcontainers config registers the new integration test.

## Verification

- 29/29 green independently: 8 persistence unit tests (locked-before-write, version conflict, company mismatch, idempotent replay, override validation, provenance immutability mapping) + manifest sentinels + migration ledger + mount-parity.
- `npm run check` 0 TS errors; ESLint clean.
- No routes/client/Monte Carlo/envelope files touched. The service is intentionally not route-wired yet — wave 3 (Task 8.4 seed picker) exposes it.
- Schema-touching PR: CI auto-runs the full suite; the new integration test (transaction atomicity, rollback, locked, retry, facts-change immunity, user-edit divergence) runs in the gated DB lanes — will confirm on the post-merge main run as well.
- NEVER run against prod: journaled additive migration only; production apply goes through the protected reconcile workflow (M8 manifest included for it).

Spec: `updog_restore_review_only_implementation_plans_2026-07-11.md` Plan 8 (line 3118) + amendments, executed via Hermes/Codex worktree lane, Claude-verified. Remaining Plan 8 waves: 8.4 picker + route exposure, 8.5 scenario hash, 8.6-8.8 Monte Carlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h