### PR TITLE
feat(allocations): plan-vs-actuals drift disclosure UI (Plan 5 wave 3 — final)

### DIFF
--- a/client/src/components/portfolio/tabs/AllocationActualsDisclosure.tsx
+++ b/client/src/components/portfolio/tabs/AllocationActualsDisclosure.tsx
@@ -1,0 +1,305 @@
+import { Button } from '@/components/ui/button';
+import type {
+  AllocationCompanyActualsDriftV1,
+  AllocationDriftComparisonV1,
+} from '@shared/contracts/allocations/allocation-actuals-drift-v1.contract';
+
+interface AllocationActualsDisclosureProps {
+  drift: AllocationCompanyActualsDriftV1;
+  companyName: string;
+}
+
+const BASIS_LABELS: Record<AllocationDriftComparisonV1['basis'], string> = {
+  deployed_reserves_vs_observed_follow_on: 'Deployed reserves vs observed follow-on',
+  legacy_invested_vs_observed_total: 'Legacy invested vs observed total',
+};
+
+const UNAVAILABLE_REASON_LABELS: Record<
+  NonNullable<AllocationDriftComparisonV1['unavailableReason']>,
+  string
+> = {
+  currency_blocked: 'currency blocked',
+  facts_failed: 'facts failed',
+  facts_missing: 'facts missing',
+};
+
+function formatCentString(value: string | null): string {
+  if (value === null) {
+    return 'Unavailable';
+  }
+
+  const cents = BigInt(value);
+  const isNegative = cents < 0n;
+  const absoluteCents = isNegative ? -cents : cents;
+  const dollars = absoluteCents / 100n;
+  const remainder = (absoluteCents % 100n).toString().padStart(2, '0');
+
+  return `${isNegative ? '-' : ''}$${dollars.toLocaleString('en-US')}.${remainder}`;
+}
+
+function formatRelativeDelta(value: string | null): string {
+  if (value === null) {
+    return 'Unavailable';
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    maximumFractionDigits: 2,
+  }).format(Number(value));
+}
+
+function ComparisonState({ comparison }: { comparison: AllocationDriftComparisonV1 }) {
+  if (comparison.state === 'unavailable') {
+    const label = comparison.unavailableReason
+      ? UNAVAILABLE_REASON_LABELS[comparison.unavailableReason]
+      : 'unavailable';
+
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-charcoal-500">
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+        />
+        <span>{label}</span>
+      </span>
+    );
+  }
+
+  if (comparison.material) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs font-medium text-pov-charcoal">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-warning" />
+        <span>material drift</span>
+      </span>
+    );
+  }
+
+  if (comparison.state === 'drifted') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-charcoal-500">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-warning" />
+        <span>drift disclosed</span>
+      </span>
+    );
+  }
+
+  return <span className="text-xs font-medium text-pov-charcoal">exact</span>;
+}
+
+function EvidenceState({
+  label,
+  caveated = false,
+  unavailable = false,
+}: {
+  label: string;
+  caveated?: boolean;
+  unavailable?: boolean;
+}) {
+  if (unavailable) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-charcoal-500">
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+        />
+        <span>{label}</span>
+      </span>
+    );
+  }
+
+  if (caveated) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-charcoal-500">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-warning" />
+        <span>{label}</span>
+      </span>
+    );
+  }
+
+  return <span className="font-medium text-pov-charcoal">{label}</span>;
+}
+
+function unavailableFactsReason(drift: AllocationCompanyActualsDriftV1): string | null {
+  if (drift.trustState === 'FAILED') {
+    return drift.warnings[0]?.message ?? 'facts failed';
+  }
+
+  if (drift.trustState === 'UNAVAILABLE') {
+    return drift.currencyStatus === 'mismatch_blocked' ? 'currency blocked' : 'facts unavailable';
+  }
+
+  return null;
+}
+
+export function AllocationActualsDisclosure({
+  drift,
+  companyName,
+}: AllocationActualsDisclosureProps) {
+  const factsUnavailableReason = unavailableFactsReason(drift);
+  const factsInputHash = drift.factsInputHash;
+  const trustIsUnavailable = drift.trustState === 'UNAVAILABLE' || drift.trustState === 'FAILED';
+  const trustIsCaveated = drift.trustState === 'PARTIAL';
+  const currencyLabel =
+    drift.currencyStatus === 'mismatch_blocked'
+      ? 'currency blocked'
+      : drift.currencyStatus.replace('_', ' ');
+
+  return (
+    <section
+      aria-label={`${companyName} plan versus actual details`}
+      className="space-y-4 border-y border-beige-200 bg-pov-gray/40 px-4 py-4 text-sm text-charcoal-500"
+    >
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+        <div>
+          <h3 className="font-semibold text-pov-charcoal">Plan vs actual</h3>
+          <p className="text-xs text-charcoal-500">{companyName}</p>
+        </div>
+        <p className="text-xs text-charcoal-500">As of {drift.asOfDate}</p>
+      </div>
+
+      {factsUnavailableReason ? (
+        <p className="flex items-center gap-1.5 text-sm text-charcoal-500">
+          <span
+            aria-hidden="true"
+            className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+          />
+          <span>Facts unavailable: {factsUnavailableReason}</span>
+        </p>
+      ) : null}
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[720px] border-collapse text-left">
+          <thead>
+            <tr className="border-b border-beige-200 text-xs text-charcoal-500">
+              <th className="px-2 py-2 font-medium">Comparison basis</th>
+              <th className="px-2 py-2 text-right font-medium">Plan</th>
+              <th className="px-2 py-2 text-right font-medium">Actual</th>
+              <th className="px-2 py-2 text-right font-medium">Delta</th>
+              <th className="px-2 py-2 text-right font-medium">Relative delta</th>
+              <th className="px-2 py-2 font-medium">State</th>
+            </tr>
+          </thead>
+          <tbody>
+            {drift.comparisons.map((comparison) => (
+              <tr key={comparison.basis} className="border-b border-beige-200/70 last:border-b-0">
+                <th className="px-2 py-3 font-medium text-pov-charcoal">
+                  {BASIS_LABELS[comparison.basis]}
+                  {comparison.subCentRemainder !== null ? (
+                    <span className="mt-1 block text-xs font-normal text-charcoal-500">
+                      sub-cent remainder: {comparison.subCentRemainder}
+                    </span>
+                  ) : null}
+                </th>
+                <td className="px-2 py-3 text-right">
+                  <span className="tabular-nums text-pov-charcoal">
+                    {formatCentString(comparison.planCents)}
+                  </span>
+                </td>
+                <td className="px-2 py-3 text-right">
+                  <span className="tabular-nums">{formatCentString(comparison.actualCents)}</span>
+                </td>
+                <td className="px-2 py-3 text-right">
+                  <span className="tabular-nums">{formatCentString(comparison.deltaCents)}</span>
+                </td>
+                <td className="px-2 py-3 text-right">
+                  <span className="tabular-nums">
+                    {formatRelativeDelta(comparison.relativeDelta)}
+                  </span>
+                </td>
+                <td className="px-2 py-3">
+                  <ComparisonState comparison={comparison} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="space-y-3 border-t border-beige-200 pt-3" aria-label="Actuals evidence">
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          <div>
+            <div className="text-xs uppercase text-charcoal-500">Source</div>
+            <div className="text-pov-charcoal">Live fund company actuals facts</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase text-charcoal-500">Trust state</div>
+            <EvidenceState
+              label={drift.trustState}
+              caveated={trustIsCaveated}
+              unavailable={trustIsUnavailable}
+            />
+          </div>
+          <div>
+            <div className="text-xs uppercase text-charcoal-500">Planning FMV status</div>
+            <EvidenceState
+              label={drift.planningFmvStatus.replace('_', ' ')}
+              caveated={
+                drift.planningFmvStatus === 'stale' || drift.planningFmvStatus === 'blocked'
+              }
+              unavailable={drift.planningFmvStatus === 'none'}
+            />
+          </div>
+          <div>
+            <div className="text-xs uppercase text-charcoal-500">Currency status</div>
+            <EvidenceState
+              label={currencyLabel}
+              caveated={drift.currencyStatus === 'mismatch_blocked'}
+              unavailable={drift.currencyStatus === 'unknown'}
+            />
+          </div>
+          <div>
+            <div className="text-xs uppercase text-charcoal-500">As-of date</div>
+            <div className="tabular-nums text-pov-charcoal">{drift.asOfDate}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase text-charcoal-500">Allocation version</div>
+            <div className="tabular-nums text-pov-charcoal">v{drift.allocationVersion}</div>
+          </div>
+          <div className="sm:col-span-2">
+            <div className="text-xs uppercase text-charcoal-500">Facts input hash</div>
+            {factsInputHash ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <code className="text-xs text-pov-charcoal">{factsInputHash.slice(0, 12)}</code>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs text-pov-charcoal"
+                  aria-label="Copy facts input hash"
+                  onClick={() => {
+                    if (!navigator.clipboard) {
+                      return;
+                    }
+                    void navigator.clipboard.writeText(factsInputHash).catch(() => undefined);
+                  }}
+                >
+                  Copy full hash
+                </Button>
+              </div>
+            ) : (
+              <EvidenceState label="unavailable" unavailable />
+            )}
+          </div>
+        </div>
+
+        {drift.supersedeLineage.length > 0 ? (
+          <p className="text-xs text-charcoal-500">
+            Supersede lineage: {drift.supersedeLineage.length}{' '}
+            {drift.supersedeLineage.length === 1 ? 'record' : 'records'}
+          </p>
+        ) : null}
+
+        {drift.warnings.length > 0 ? (
+          <div>
+            <div className="text-xs uppercase text-charcoal-500">Warnings</div>
+            <ul className="mt-1 list-disc space-y-1 pl-5 text-xs text-charcoal-500">
+              {drift.warnings.map((warning, index) => (
+                <li key={`${warning.code}-${index}`}>{warning.message}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/portfolio/tabs/AllocationsTab.tsx
+++ b/client/src/components/portfolio/tabs/AllocationsTab.tsx
@@ -2,7 +2,7 @@
  * Allocations Tab Component
  * Displays allocation state for all companies in a fund
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Table,
   TableBody,
@@ -42,12 +42,14 @@ import { AddCompanyDialog } from './AddCompanyDialog';
 import { EditAllocationDialog } from './EditAllocationDialog';
 import { FmvOverrideDialog } from './FmvOverrideDialog';
 import { ReserveIcPacketCard } from './ReserveIcPacketCard';
+import { AllocationActualsDisclosure } from './AllocationActualsDisclosure';
 import { createAllocationsColumns, type ColumnDef } from './allocations-table-columns';
 import { formatCents } from '@/lib/units';
 import { buildReserveIcPacket } from './reserve-ic-packet';
 import { useLatestPlanningFmvOverrides } from './hooks/usePlanningFmvOverrides';
 import type {
   AllocationCompany,
+  AllocationActualsDriftSummary,
   AllocationScenarioCollaborationContext,
   AllocationScenarioCollaborationContextEvent,
   AllocationScenarioChangeSummary,
@@ -336,6 +338,75 @@ function CollaborationContextEventCard({
   );
 }
 
+function ActualsDriftSummarySkeleton() {
+  return (
+    <section
+      aria-label="Actuals drift summary"
+      aria-busy="true"
+      className="border-y border-beige-200 bg-white px-4 py-3"
+    >
+      <p className="text-sm font-medium text-pov-charcoal">Loading actuals drift disclosure</p>
+      <div className="mt-2 grid gap-3 sm:grid-cols-3">
+        {['Drifted', 'Material', 'Degraded'].map((label) => (
+          <div key={label} className="flex items-center gap-2 text-xs text-charcoal-500">
+            <Skeleton className="h-5 w-8 tabular-nums motion-reduce:animate-none" />
+            <span>{label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ActualsDriftSummaryRail({ summary }: { summary: AllocationActualsDriftSummary }) {
+  const metrics = [
+    { label: 'drifted', value: summary.drifted_company_count },
+    { label: 'material', value: summary.material_company_count },
+    { label: 'degraded', value: summary.degraded_company_count },
+  ];
+  const noDriftDisclosed =
+    summary.facts_status === 'available' && metrics.every((metric) => metric.value === 0);
+
+  return (
+    <section
+      aria-label="Actuals drift summary"
+      className="border-y border-beige-200 bg-white px-4 py-3"
+    >
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+        <p className="font-medium text-pov-charcoal">
+          {summary.facts_status === 'failed'
+            ? 'Facts unavailable'
+            : noDriftDisclosed
+              ? 'No drift disclosed'
+              : 'Actuals drift disclosure'}
+        </p>
+        <p className="text-xs tabular-nums text-charcoal-500">As of {summary.as_of_date}</p>
+      </div>
+      {summary.facts_status === 'failed' ? (
+        <p className="mt-1 inline-flex items-center gap-1.5 text-xs text-charcoal-500">
+          <span
+            aria-hidden="true"
+            className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+          />
+          <span>Facts unavailable; company plan values remain visible.</span>
+        </p>
+      ) : null}
+      <div className="mt-2 grid gap-3 sm:grid-cols-3">
+        {metrics.map((metric) => (
+          <div key={metric.label} className="flex items-center gap-1.5 text-sm text-charcoal-500">
+            {metric.value > 0 ? (
+              <span aria-hidden="true" className="h-2 w-2 rounded-full bg-warning" />
+            ) : null}
+            <span className="tabular-nums text-pov-charcoal">
+              {metric.value} {metric.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function AllocationsTab() {
   const { toast } = useToast();
   const { fundId } = useFundContext();
@@ -351,6 +422,9 @@ export function AllocationsTab() {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isFmvDialogOpen, setIsFmvDialogOpen] = useState(false);
   const [isAddCompanyDialogOpen, setIsAddCompanyDialogOpen] = useState(false);
+  const [expandedActualsCompanyIds, setExpandedActualsCompanyIds] = useState<Set<number>>(
+    () => new Set()
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [sectorFilter, setSectorFilter] = useState<string>('all');
   const [statusFilter, setStatusFilter] = useState<string>('all');
@@ -412,6 +486,10 @@ export function AllocationsTab() {
     previewApplyMutation.isPending ||
     syncScenarioMutation.isPending ||
     applyScenarioMutation.isPending;
+
+  useEffect(() => {
+    setExpandedActualsCompanyIds(new Set());
+  }, [fundId]);
 
   useEffect(() => {
     if (liveCompanies.length === 0 || activeScenarioId) {
@@ -529,6 +607,18 @@ export function AllocationsTab() {
     setIsEditDialogOpen(true);
   }, []);
 
+  const handleToggleActualsDisclosure = useCallback((companyId: number) => {
+    setExpandedActualsCompanyIds((current) => {
+      const next = new Set(current);
+      if (next.has(companyId)) {
+        next.delete(companyId);
+      } else {
+        next.add(companyId);
+      }
+      return next;
+    });
+  }, []);
+
   const handleFmvOverride = useCallback((company: AllocationCompany) => {
     setSelectedFmvCompanyId(company.company_id);
     setIsFmvDialogOpen(true);
@@ -551,7 +641,10 @@ export function AllocationsTab() {
   }, []);
 
   const columns = useMemo(() => {
-    const baseColumns = createAllocationsColumns(handleEdit);
+    const baseColumns = createAllocationsColumns(handleEdit, {
+      expandedCompanyIds: expandedActualsCompanyIds,
+      onToggle: handleToggleActualsDisclosure,
+    });
     if (!planningFmvEnabled) {
       return baseColumns;
     }
@@ -590,7 +683,14 @@ export function AllocationsTab() {
     return actionColumn
       ? [...leadingColumns, currentFmvColumn, actionColumn]
       : [...leadingColumns, currentFmvColumn];
-  }, [handleEdit, handleFmvOverride, planningFmvByCompanyId, planningFmvEnabled]);
+  }, [
+    expandedActualsCompanyIds,
+    handleEdit,
+    handleFmvOverride,
+    handleToggleActualsDisclosure,
+    planningFmvByCompanyId,
+    planningFmvEnabled,
+  ]);
 
   const reservePlanCount = useMemo(
     () => displayedCompanies.filter((company) => company.planned_reserves_cents > 0).length,
@@ -1154,6 +1254,7 @@ export function AllocationsTab() {
   if (isLoading) {
     return (
       <div className="space-y-4">
+        <ActualsDriftSummarySkeleton />
         <Skeleton className="h-12 w-full" />
         <Skeleton className="h-64 w-full" />
       </div>
@@ -1163,6 +1264,9 @@ export function AllocationsTab() {
   if (displayedCompanies.length === 0) {
     return (
       <>
+        {data?.metadata.actuals_drift_summary ? (
+          <ActualsDriftSummaryRail summary={data.metadata.actuals_drift_summary} />
+        ) : null}
         <Card>
           <CardHeader>
             <CardTitle>Company Allocations</CardTitle>
@@ -1233,6 +1337,10 @@ export function AllocationsTab() {
             missing reserve values until allocation facts are recorded.
           </AlertDescription>
         </Alert>
+      ) : null}
+
+      {data?.metadata.actuals_drift_summary ? (
+        <ActualsDriftSummaryRail summary={data.metadata.actuals_drift_summary} />
       ) : null}
 
       <Card className="border-presson-info/20 bg-presson-info/10">
@@ -1939,17 +2047,40 @@ export function AllocationsTab() {
                 </TableRow>
               ) : (
                 filteredAndSortedCompanies.map((company) => (
-                  <TableRow key={company.company_id}>
-                    {enrichedColumns.map((column) => (
-                      <TableCell key={`${company.company_id}-${column.id}`}>
-                        {column.cell
-                          ? column.cell({ row: { original: company } })
-                          : column.accessorKey
-                            ? String(company[column.accessorKey])
-                            : null}
+                  <Fragment key={company.company_id}>
+                    <TableRow>
+                      {enrichedColumns.map((column) => (
+                        <TableCell key={`${company.company_id}-${column.id}`}>
+                          {column.cell
+                            ? column.cell({ row: { original: company } })
+                            : column.accessorKey
+                              ? String(company[column.accessorKey])
+                              : null}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                    <TableRow
+                      className={
+                        expandedActualsCompanyIds.has(company.company_id)
+                          ? 'border-0 hover:bg-transparent'
+                          : 'hidden'
+                      }
+                    >
+                      <TableCell colSpan={enrichedColumns.length} className="p-0">
+                        <div
+                          id={`allocation-actuals-disclosure-${company.company_id}`}
+                          aria-hidden={!expandedActualsCompanyIds.has(company.company_id)}
+                        >
+                          {expandedActualsCompanyIds.has(company.company_id) ? (
+                            <AllocationActualsDisclosure
+                              drift={company.actuals_drift}
+                              companyName={company.company_name}
+                            />
+                          ) : null}
+                        </div>
                       </TableCell>
-                    ))}
-                  </TableRow>
+                    </TableRow>
+                  </Fragment>
                 ))
               )}
             </TableBody>

--- a/client/src/components/portfolio/tabs/allocations-table-columns.tsx
+++ b/client/src/components/portfolio/tabs/allocations-table-columns.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { formatCents } from '@/lib/units';
 import { formatDistanceToNow } from 'date-fns';
-import { ArrowUpDown, Pencil } from 'lucide-react';
+import { ArrowUpDown, ChevronRight, Pencil } from 'lucide-react';
 import type { AllocationCompany } from './types';
 
 export interface ColumnDef<T> {
@@ -20,15 +20,126 @@ export interface Column {
   toggleSorting: () => void;
 }
 
+export interface AllocationActualsDisclosureColumnOptions {
+  expandedCompanyIds: ReadonlySet<number>;
+  onToggle: (companyId: number) => void;
+}
+
 function hasMissingAllocationField(company: AllocationCompany, field: string) {
   return Boolean(
     company.allocation_facts_missing && company.missing_allocation_fields?.includes(field)
   );
 }
 
+interface ActualsDriftIndicatorState {
+  kind: 'exact' | 'caveated' | 'material' | 'unavailable';
+  label: string;
+}
+
+function getActualsDriftIndicator(company: AllocationCompany): ActualsDriftIndicatorState {
+  const drift = company.actuals_drift;
+  const hasUnavailableComparison = drift.comparisons.some(
+    (comparison) => comparison.state === 'unavailable'
+  );
+  const hasMaterialDrift = drift.comparisons.some((comparison) => comparison.material);
+  const hasDrift = drift.comparisons.some((comparison) => comparison.state === 'drifted');
+
+  if (
+    drift.trustState === 'FAILED' ||
+    drift.trustState === 'UNAVAILABLE' ||
+    hasUnavailableComparison
+  ) {
+    const label =
+      drift.currencyStatus === 'mismatch_blocked'
+        ? 'currency blocked'
+        : drift.trustState === 'FAILED'
+          ? 'facts unavailable'
+          : 'unavailable';
+
+    return { kind: 'unavailable', label };
+  }
+
+  if (hasMaterialDrift) {
+    return { kind: 'material', label: 'material drift' };
+  }
+
+  if (hasDrift) {
+    return { kind: 'caveated', label: 'drift disclosed' };
+  }
+
+  if (drift.trustState === 'PARTIAL') {
+    return { kind: 'caveated', label: 'degraded' };
+  }
+
+  return { kind: 'exact', label: 'no drift' };
+}
+
+function ActualsDriftIndicator({ indicator }: { indicator: ActualsDriftIndicatorState }) {
+  if (indicator.kind === 'unavailable') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-charcoal-500">
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+        />
+        <span>{indicator.label}</span>
+      </span>
+    );
+  }
+
+  if (indicator.kind === 'material') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs font-medium text-pov-charcoal">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-warning" />
+        <span>{indicator.label}</span>
+      </span>
+    );
+  }
+
+  if (indicator.kind === 'caveated') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-charcoal-500">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-warning" />
+        <span>{indicator.label}</span>
+      </span>
+    );
+  }
+
+  return <span className="text-xs font-medium text-pov-charcoal">{indicator.label}</span>;
+}
+
 export const createAllocationsColumns = (
-  onEdit: (company: AllocationCompany) => void
+  onEdit: (company: AllocationCompany) => void,
+  disclosure: AllocationActualsDisclosureColumnOptions
 ): ColumnDef<AllocationCompany>[] => [
+  {
+    id: 'actuals_drift',
+    header: 'Plan vs actual',
+    cell: ({ row }) => {
+      const company = row.original;
+      const isExpanded = disclosure.expandedCompanyIds.has(company.company_id);
+      const indicator = getActualsDriftIndicator(company);
+
+      return (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto min-w-[132px] justify-start gap-1.5 px-1.5 py-1 text-left hover:bg-pov-gray motion-reduce:transition-none"
+          aria-expanded={isExpanded}
+          aria-controls={`allocation-actuals-disclosure-${company.company_id}`}
+          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} Plan vs actual for ${company.company_name}. Status: ${indicator.label}`}
+          onClick={() => disclosure.onToggle(company.company_id)}
+        >
+          <ChevronRight
+            aria-hidden="true"
+            className={`h-4 w-4 flex-none text-charcoal-500 transition-transform duration-200 motion-reduce:transition-none ${isExpanded ? 'rotate-90' : ''}`}
+          />
+          <ActualsDriftIndicator indicator={indicator} />
+        </Button>
+      );
+    },
+  },
   {
     id: 'company_name',
     accessorKey: 'company_name',

--- a/client/src/components/portfolio/tabs/types.ts
+++ b/client/src/components/portfolio/tabs/types.ts
@@ -3,6 +3,7 @@ import type {
   ReserveIcDecisionRecordV1,
   UpdateReserveIcDecisionV1,
 } from '@shared/contracts/reserve-ic-decision-v1.contract';
+import type { AllocationCompanyActualsDriftV1 } from '@shared/contracts/allocations/allocation-actuals-drift-v1.contract';
 
 /**
  * TypeScript types for Fund Allocation Management
@@ -21,8 +22,18 @@ export interface AllocationCompany {
   allocation_reason: string | null;
   allocation_version: number;
   last_allocation_at: string | null;
+  actuals_drift: AllocationCompanyActualsDriftV1;
   allocation_facts_missing?: boolean;
   missing_allocation_fields?: string[];
+}
+
+export interface AllocationActualsDriftSummary {
+  facts_status: 'available' | 'failed';
+  drifted_company_count: number;
+  material_company_count: number;
+  degraded_company_count: number;
+  facts_input_hash: string | null;
+  as_of_date: string;
 }
 
 export interface AllocationMetadata {
@@ -31,6 +42,7 @@ export interface AllocationMetadata {
   companies_count: number;
   allocation_facts_missing_count?: number;
   last_updated_at: string | null;
+  actuals_drift_summary: AllocationActualsDriftSummary;
 }
 
 export interface AllocationsResponse {

--- a/tests/unit/components/portfolio/allocation-actuals-disclosure.test.tsx
+++ b/tests/unit/components/portfolio/allocation-actuals-disclosure.test.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AllocationActualsDisclosure } from '../../../../client/src/components/portfolio/tabs/AllocationActualsDisclosure';
+import {
+  AllocationCompanyActualsDriftV1Schema,
+  type AllocationCompanyActualsDriftV1,
+} from '@shared/contracts/allocations/allocation-actuals-drift-v1.contract';
+
+const FACTS_HASH = 'a'.repeat(64);
+
+function buildDrift(
+  overrides: Partial<AllocationCompanyActualsDriftV1> = {}
+): AllocationCompanyActualsDriftV1 {
+  return AllocationCompanyActualsDriftV1Schema.parse({
+    contractVersion: 'allocation-actuals-drift-v1',
+    companyId: 11,
+    asOfDate: '2026-07-11',
+    allocationVersion: 4,
+    lastAllocationAt: '2026-07-10T12:00:00.000Z',
+    factsInputHash: FACTS_HASH,
+    trustState: 'LIVE',
+    planningFmvStatus: 'active',
+    currencyStatus: 'base_currency',
+    activeRoundIds: [101],
+    supersedeLineage: [{ roundId: 101, supersedesRoundId: null }],
+    comparisons: [
+      {
+        basis: 'deployed_reserves_vs_observed_follow_on',
+        state: 'exact',
+        planCents: '100000',
+        actualCents: '100000',
+        deltaCents: '0',
+        relativeDelta: '0',
+        material: false,
+        subCentRemainder: null,
+        unavailableReason: null,
+      },
+      {
+        basis: 'legacy_invested_vs_observed_total',
+        state: 'exact',
+        planCents: '500000',
+        actualCents: '500000',
+        deltaCents: '0',
+        relativeDelta: '0',
+        material: false,
+        subCentRemainder: null,
+        unavailableReason: null,
+      },
+    ],
+    warnings: [],
+    ...overrides,
+  });
+}
+
+describe('AllocationActualsDisclosure', () => {
+  it('renders contract-valid exact comparisons and copyable evidence without success styling', async () => {
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: clipboardWrite },
+    });
+    const drift = buildDrift();
+
+    expect(AllocationCompanyActualsDriftV1Schema.parse(drift)).toEqual(drift);
+
+    render(<AllocationActualsDisclosure drift={drift} companyName="Example Co" />);
+
+    expect(screen.getByText('Deployed reserves vs observed follow-on')).toBeInTheDocument();
+    expect(screen.getByText('Legacy invested vs observed total')).toBeInTheDocument();
+    for (const value of screen.getAllByText('$1,000.00')) {
+      expect(value).toHaveClass('tabular-nums');
+    }
+    for (const value of screen.getAllByText('$5,000.00')) {
+      expect(value).toHaveClass('tabular-nums');
+    }
+    expect(screen.getAllByText('exact')).toHaveLength(2);
+    expect(screen.getByText('Live fund company actuals facts')).toBeInTheDocument();
+    expect(screen.getByText('2026-07-11')).toBeInTheDocument();
+    expect(screen.getByText(FACTS_HASH.slice(0, 12))).toBeInTheDocument();
+
+    const copyButton = screen.getByRole('button', { name: 'Copy facts input hash' });
+    fireEvent.click(copyButton);
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith(FACTS_HASH));
+
+    for (const exactLabel of screen.getAllByText('exact')) {
+      expect(exactLabel.className).not.toMatch(/success|positive|confidence/);
+    }
+  });
+
+  it('distinguishes material and non-material drift without a green trust signal', () => {
+    const drift = buildDrift({
+      comparisons: [
+        {
+          basis: 'deployed_reserves_vs_observed_follow_on',
+          state: 'drifted',
+          planCents: '100000',
+          actualCents: '125000',
+          deltaCents: '25000',
+          relativeDelta: '0.25',
+          material: true,
+          subCentRemainder: null,
+          unavailableReason: null,
+        },
+        {
+          basis: 'legacy_invested_vs_observed_total',
+          state: 'drifted',
+          planCents: '500000',
+          actualCents: '501000',
+          deltaCents: '1000',
+          relativeDelta: '0.002',
+          material: false,
+          subCentRemainder: '0.004',
+          unavailableReason: null,
+        },
+      ],
+    });
+
+    render(<AllocationActualsDisclosure drift={drift} companyName="Example Co" />);
+
+    expect(screen.getByText('material drift')).toBeInTheDocument();
+    const disclosed = screen.getByText('drift disclosed');
+    expect(disclosed).toBeInTheDocument();
+    expect(disclosed.className).not.toMatch(/success|positive|confidence/);
+    expect(screen.getByText('25%')).toHaveClass('tabular-nums');
+    expect(screen.getByText('sub-cent remainder: 0.004')).toBeInTheDocument();
+  });
+
+  it('renders partial currency-blocked reasons and stale evidence as text, not color alone', () => {
+    const drift = buildDrift({
+      trustState: 'PARTIAL',
+      planningFmvStatus: 'stale',
+      currencyStatus: 'mismatch_blocked',
+      comparisons: [
+        {
+          basis: 'deployed_reserves_vs_observed_follow_on',
+          state: 'unavailable',
+          planCents: '100000',
+          actualCents: null,
+          deltaCents: null,
+          relativeDelta: null,
+          material: false,
+          subCentRemainder: null,
+          unavailableReason: 'currency_blocked',
+        },
+        {
+          basis: 'legacy_invested_vs_observed_total',
+          state: 'unavailable',
+          planCents: '500000',
+          actualCents: null,
+          deltaCents: null,
+          relativeDelta: null,
+          material: false,
+          subCentRemainder: null,
+          unavailableReason: 'facts_missing',
+        },
+      ],
+      warnings: [
+        {
+          code: 'CURRENCY_MISMATCH_BLOCK',
+          severity: 'blocking',
+          message: 'Observed actuals use a different currency.',
+        },
+        {
+          code: 'DATA_STALE',
+          severity: 'warning',
+          message: 'Planning FMV is stale.',
+        },
+      ],
+    });
+
+    render(<AllocationActualsDisclosure drift={drift} companyName="Example Co" />);
+
+    expect(screen.getAllByText('currency blocked').length).toBeGreaterThan(0);
+    expect(screen.getByText('facts missing')).toBeInTheDocument();
+    expect(screen.getByText('PARTIAL')).toBeInTheDocument();
+    expect(screen.getByText('stale')).toBeInTheDocument();
+    expect(screen.getByText('Observed actuals use a different currency.')).toBeInTheDocument();
+    expect(screen.getByText('$1,000.00')).toHaveClass('tabular-nums');
+  });
+
+  it('keeps plan numbers visible and explains failed facts', () => {
+    const drift = buildDrift({
+      factsInputHash: null,
+      trustState: 'FAILED',
+      planningFmvStatus: 'none',
+      currencyStatus: 'unknown',
+      comparisons: [
+        {
+          basis: 'deployed_reserves_vs_observed_follow_on',
+          state: 'unavailable',
+          planCents: '100000',
+          actualCents: null,
+          deltaCents: null,
+          relativeDelta: null,
+          material: false,
+          subCentRemainder: null,
+          unavailableReason: 'facts_failed',
+        },
+        {
+          basis: 'legacy_invested_vs_observed_total',
+          state: 'unavailable',
+          planCents: '500000',
+          actualCents: null,
+          deltaCents: null,
+          relativeDelta: null,
+          material: false,
+          subCentRemainder: null,
+          unavailableReason: 'facts_failed',
+        },
+      ],
+      warnings: [
+        {
+          code: 'ROUND_ADAPTER_FAILED',
+          severity: 'blocking',
+          message: 'Round facts adapter timed out.',
+        },
+      ],
+    });
+
+    render(<AllocationActualsDisclosure drift={drift} companyName="Example Co" />);
+
+    expect(screen.getByText(/facts unavailable/i)).toHaveTextContent(
+      'Round facts adapter timed out.'
+    );
+    expect(screen.getAllByText('facts failed')).toHaveLength(2);
+    expect(screen.getByText('$1,000.00')).toHaveClass('tabular-nums');
+    expect(screen.getByText('$5,000.00')).toHaveClass('tabular-nums');
+    expect(screen.queryByRole('button', { name: 'Copy facts input hash' })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/portfolio/allocations-workspace.test.tsx
+++ b/tests/unit/components/portfolio/allocations-workspace.test.tsx
@@ -5,6 +5,10 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AllocationsTab } from '../../../../client/src/components/portfolio/tabs/AllocationsTab';
 import { EditAllocationDialog } from '../../../../client/src/components/portfolio/tabs/EditAllocationDialog';
+import {
+  AllocationCompanyActualsDriftV1Schema,
+  type AllocationCompanyActualsDriftV1,
+} from '@shared/contracts/allocations/allocation-actuals-drift-v1.contract';
 import type { ReserveIcDecisionRecordV1 } from '@shared/contracts/reserve-ic-decision-v1.contract';
 import type {
   AllocationCompany,
@@ -117,6 +121,62 @@ vi.mock('../../../../client/src/components/portfolio/tabs/hooks/useUpdateAllocat
   }),
 }));
 
+const FACTS_INPUT_HASH = 'b'.repeat(64);
+
+function buildActualsDrift(
+  companyId: number,
+  overrides: Partial<AllocationCompanyActualsDriftV1> = {}
+): AllocationCompanyActualsDriftV1 {
+  return AllocationCompanyActualsDriftV1Schema.parse({
+    contractVersion: 'allocation-actuals-drift-v1',
+    companyId,
+    asOfDate: '2026-07-11',
+    allocationVersion: 1,
+    lastAllocationAt: '2024-01-01T00:00:00.000Z',
+    factsInputHash: FACTS_INPUT_HASH,
+    trustState: 'LIVE',
+    planningFmvStatus: 'active',
+    currencyStatus: 'base_currency',
+    activeRoundIds: [companyId * 100],
+    supersedeLineage: [],
+    comparisons: [
+      {
+        basis: 'deployed_reserves_vs_observed_follow_on',
+        state: 'exact',
+        planCents: '50000000',
+        actualCents: '50000000',
+        deltaCents: '0',
+        relativeDelta: '0',
+        material: false,
+        subCentRemainder: null,
+        unavailableReason: null,
+      },
+      {
+        basis: 'legacy_invested_vs_observed_total',
+        state: 'exact',
+        planCents: '100000000',
+        actualCents: '100000000',
+        deltaCents: '0',
+        relativeDelta: '0',
+        material: false,
+        subCentRemainder: null,
+        unavailableReason: null,
+      },
+    ],
+    warnings: [],
+    ...overrides,
+  });
+}
+
+const mockActualsDriftSummary = {
+  facts_status: 'available' as const,
+  drifted_company_count: 1,
+  material_company_count: 1,
+  degraded_company_count: 1,
+  facts_input_hash: FACTS_INPUT_HASH,
+  as_of_date: '2026-07-11',
+};
+
 const mockAllocationsData: AllocationsResponse = {
   companies: [
     {
@@ -132,6 +192,7 @@ const mockAllocationsData: AllocationsResponse = {
       allocation_reason: 'Strong growth trajectory',
       allocation_version: 1,
       last_allocation_at: '2024-01-01T00:00:00Z',
+      actuals_drift: buildActualsDrift(1),
     },
     {
       company_id: 2,
@@ -146,6 +207,32 @@ const mockAllocationsData: AllocationsResponse = {
       allocation_reason: null,
       allocation_version: 1,
       last_allocation_at: null,
+      actuals_drift: buildActualsDrift(2, {
+        comparisons: [
+          {
+            basis: 'deployed_reserves_vs_observed_follow_on',
+            state: 'drifted',
+            planCents: '0',
+            actualCents: '25000000',
+            deltaCents: '25000000',
+            relativeDelta: null,
+            material: true,
+            subCentRemainder: null,
+            unavailableReason: null,
+          },
+          {
+            basis: 'legacy_invested_vs_observed_total',
+            state: 'exact',
+            planCents: '50000000',
+            actualCents: '50000000',
+            deltaCents: '0',
+            relativeDelta: '0',
+            material: false,
+            subCentRemainder: null,
+            unavailableReason: null,
+          },
+        ],
+      }),
     },
     {
       company_id: 3,
@@ -160,6 +247,42 @@ const mockAllocationsData: AllocationsResponse = {
       allocation_reason: 'Exited via acquisition',
       allocation_version: 2,
       last_allocation_at: '2024-02-15T00:00:00Z',
+      actuals_drift: buildActualsDrift(3, {
+        allocationVersion: 2,
+        trustState: 'PARTIAL',
+        planningFmvStatus: 'stale',
+        comparisons: [
+          {
+            basis: 'deployed_reserves_vs_observed_follow_on',
+            state: 'unavailable',
+            planCents: '100000000',
+            actualCents: null,
+            deltaCents: null,
+            relativeDelta: null,
+            material: false,
+            subCentRemainder: null,
+            unavailableReason: 'facts_missing',
+          },
+          {
+            basis: 'legacy_invested_vs_observed_total',
+            state: 'exact',
+            planCents: '200000000',
+            actualCents: '200000000',
+            deltaCents: '0',
+            relativeDelta: '0',
+            material: false,
+            subCentRemainder: null,
+            unavailableReason: null,
+          },
+        ],
+        warnings: [
+          {
+            code: 'DATA_STALE',
+            severity: 'warning',
+            message: 'Planning FMV is stale.',
+          },
+        ],
+      }),
     },
   ],
   metadata: {
@@ -167,6 +290,7 @@ const mockAllocationsData: AllocationsResponse = {
     total_deployed_cents: 150000000,
     companies_count: 3,
     last_updated_at: '2024-02-15T00:00:00Z',
+    actuals_drift_summary: mockActualsDriftSummary,
   },
 };
 
@@ -458,6 +582,11 @@ describe('portfolio reserve planning workspace', () => {
   it('renders the live reserve-planning workspace summary and saved scenario controls', () => {
     renderWithQuery(<AllocationsTab />);
 
+    for (const company of mockAllocationsData.companies) {
+      expect(AllocationCompanyActualsDriftV1Schema.parse(company.actuals_drift)).toEqual(
+        company.actuals_drift
+      );
+    }
     expect(screen.getByText('Reserve Planning Workspace')).toBeInTheDocument();
     expect(screen.getByText('Companies with plans')).toBeInTheDocument();
     expect(screen.getByText('Documented notes')).toBeInTheDocument();
@@ -472,6 +601,156 @@ describe('portfolio reserve planning workspace', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders drift summary counts and toggles disclosure by keyboard without mutations', async () => {
+    const user = userEvent.setup();
+    renderWithQuery(<AllocationsTab />);
+
+    expect(screen.getByText('1 drifted')).toBeInTheDocument();
+    expect(screen.getByText('1 material')).toBeInTheDocument();
+    expect(screen.getByText('1 degraded')).toBeInTheDocument();
+
+    const expander = screen.getByRole('button', {
+      name: 'Expand Plan vs actual for TechCorp. Status: no drift',
+    });
+    const disclosure = document.getElementById('allocation-actuals-disclosure-1');
+
+    expect(expander).toHaveAttribute('aria-expanded', 'false');
+    expect(expander).toHaveAccessibleName('Expand Plan vs actual for TechCorp. Status: no drift');
+    expect(disclosure).toHaveAttribute('aria-hidden', 'true');
+
+    expander.focus();
+    await user.keyboard('{Enter}');
+
+    expect(expander).toHaveAttribute('aria-expanded', 'true');
+    expect(disclosure).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByText('Deployed reserves vs observed follow-on')).toBeInTheDocument();
+    expect(screen.getByText('Legacy invested vs observed total')).toBeInTheDocument();
+
+    await user.keyboard(' ');
+
+    expect(expander).toHaveAttribute('aria-expanded', 'false');
+    expect(disclosure).toHaveAttribute('aria-hidden', 'true');
+    expect(liveAllocationMutateMock).not.toHaveBeenCalled();
+    expect(createScenarioMutateAsyncMock).not.toHaveBeenCalled();
+    expect(updateScenarioMutateAsyncMock).not.toHaveBeenCalled();
+    expect(previewScenarioMutateAsyncMock).not.toHaveBeenCalled();
+    expect(syncScenarioMutateAsyncMock).not.toHaveBeenCalled();
+    expect(applyScenarioMutateAsyncMock).not.toHaveBeenCalled();
+    expect(reserveIcDecisionCreateMutateAsyncMock).not.toHaveBeenCalled();
+    expect(reserveIcDecisionUpdateMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the disclosure loading rail with tabular placeholders', () => {
+    latestAllocationsHookMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    renderWithQuery(<AllocationsTab />);
+
+    const rail = screen.getByLabelText('Actuals drift summary');
+    expect(rail).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('Loading actuals drift disclosure')).toBeInTheDocument();
+    expect(rail.querySelectorAll('.tabular-nums').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders the no-drift disclosure state with its as-of date', () => {
+    latestAllocationsHookMock.mockReturnValue({
+      data: {
+        ...mockAllocationsData,
+        metadata: {
+          ...mockAllocationsData.metadata,
+          actuals_drift_summary: {
+            ...mockActualsDriftSummary,
+            drifted_company_count: 0,
+            material_company_count: 0,
+            degraded_company_count: 0,
+          },
+        },
+      },
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    renderWithQuery(<AllocationsTab />);
+
+    expect(screen.getByText('No drift disclosed')).toBeInTheDocument();
+    expect(screen.getByText('As of 2026-07-11')).toBeInTheDocument();
+  });
+
+  it('keeps plan values visible when the facts summary failed', () => {
+    const failedDrift = buildActualsDrift(1, {
+      factsInputHash: null,
+      trustState: 'FAILED',
+      planningFmvStatus: 'none',
+      currencyStatus: 'unknown',
+      comparisons: [
+        {
+          basis: 'deployed_reserves_vs_observed_follow_on',
+          state: 'unavailable',
+          planCents: '50000000',
+          actualCents: null,
+          deltaCents: null,
+          relativeDelta: null,
+          material: false,
+          subCentRemainder: null,
+          unavailableReason: 'facts_failed',
+        },
+        {
+          basis: 'legacy_invested_vs_observed_total',
+          state: 'unavailable',
+          planCents: '100000000',
+          actualCents: null,
+          deltaCents: null,
+          relativeDelta: null,
+          material: false,
+          subCentRemainder: null,
+          unavailableReason: 'facts_failed',
+        },
+      ],
+      warnings: [
+        {
+          code: 'ROUND_ADAPTER_FAILED',
+          severity: 'blocking',
+          message: 'Round facts adapter failed.',
+        },
+      ],
+    });
+    latestAllocationsHookMock.mockReturnValue({
+      data: {
+        companies: [{ ...mockAllocationsData.companies[0]!, actuals_drift: failedDrift }],
+        metadata: {
+          ...mockAllocationsData.metadata,
+          companies_count: 1,
+          actuals_drift_summary: {
+            facts_status: 'failed',
+            drifted_company_count: 0,
+            material_company_count: 0,
+            degraded_company_count: 1,
+            facts_input_hash: null,
+            as_of_date: '2026-07-11',
+          },
+        },
+      },
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    renderWithQuery(<AllocationsTab />);
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Expand Plan vs actual for TechCorp. Status: facts unavailable',
+      })
+    );
+
+    expect(screen.getAllByText(/facts unavailable/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('$500,000.00').length).toBeGreaterThan(0);
+  });
+
   it('renders a true empty state only when the fund has no portfolio companies', () => {
     latestAllocationsHookMock.mockReturnValue({
       data: {
@@ -482,6 +761,12 @@ describe('portfolio reserve planning workspace', () => {
           companies_count: 0,
           allocation_facts_missing_count: 0,
           last_updated_at: null,
+          actuals_drift_summary: {
+            ...mockActualsDriftSummary,
+            drifted_company_count: 0,
+            material_company_count: 0,
+            degraded_company_count: 0,
+          },
         },
       },
       isLoading: false,
@@ -491,6 +776,8 @@ describe('portfolio reserve planning workspace', () => {
 
     renderWithQuery(<AllocationsTab />);
 
+    expect(screen.getByText('No drift disclosed')).toBeInTheDocument();
+    expect(screen.getByText('As of 2026-07-11')).toBeInTheDocument();
     expect(screen.getByText('No portfolio companies found')).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -511,6 +798,36 @@ describe('portfolio reserve planning workspace', () => {
             deployed_reserves_cents: 0,
             allocation_version: 0,
             allocation_facts_missing: true,
+            actuals_drift: buildActualsDrift(1, {
+              factsInputHash: null,
+              trustState: 'UNAVAILABLE',
+              planningFmvStatus: 'none',
+              currencyStatus: 'unknown',
+              comparisons: [
+                {
+                  basis: 'deployed_reserves_vs_observed_follow_on',
+                  state: 'unavailable',
+                  planCents: '0',
+                  actualCents: null,
+                  deltaCents: null,
+                  relativeDelta: null,
+                  material: false,
+                  subCentRemainder: null,
+                  unavailableReason: 'facts_missing',
+                },
+                {
+                  basis: 'legacy_invested_vs_observed_total',
+                  state: 'unavailable',
+                  planCents: '100000000',
+                  actualCents: null,
+                  deltaCents: null,
+                  relativeDelta: null,
+                  material: false,
+                  subCentRemainder: null,
+                  unavailableReason: 'facts_missing',
+                },
+              ],
+            }),
             missing_allocation_fields: [
               'planned_reserves_cents',
               'deployed_reserves_cents',
@@ -524,6 +841,13 @@ describe('portfolio reserve planning workspace', () => {
           companies_count: 1,
           allocation_facts_missing_count: 1,
           last_updated_at: null,
+          actuals_drift_summary: {
+            ...mockActualsDriftSummary,
+            drifted_company_count: 0,
+            material_company_count: 0,
+            degraded_company_count: 1,
+            facts_input_hash: null,
+          },
         },
       },
       isLoading: false,
@@ -580,6 +904,12 @@ describe('portfolio reserve planning workspace', () => {
     expect(screen.getByText('IC Reserve Packet')).toBeInTheDocument();
     expect(screen.getAllByText('follow on').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('proposed').length).toBeGreaterThanOrEqual(1);
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Expand Plan vs actual for TechCorp. Status: no drift',
+      })
+    );
+    expect(screen.getByText('Live fund company actuals facts')).toBeInTheDocument();
 
     const editButtons = screen.getAllByRole('button', { name: /edit/i });
     await user.click(editButtons[0]!);


### PR DESCRIPTION
## Summary

Plan 5 wave 3 (Task 5.5) — the client disclosure for the drift data shipped in #1097. Client-only; completes Plan 5.

- **New** `AllocationActualsDisclosure.tsx`: per-company "Plan vs actual" expansion showing both comparison bases (deployed-reserves-vs-observed-follow-on, legacy-invested-vs-observed-total) with plan/actual/delta money, relative delta, sub-cent remainder disclosure, and an evidence block (trust state, FMV/currency status, as-of, allocation version, short facts hash + accessibly-named copy-full-hash action, warnings).
- **AllocationsTab**: summary rail (drifted / material / degraded counts from `actuals_drift_summary`) + row expansion wiring; `allocations-table-columns` gains a quiet expander/indicator column; `types.ts` gains the two contract fields imported from `@shared/contracts/allocations/allocation-actuals-drift-v1.contract`.

## Design compliance (binding D-A..D-D)

- No pill, no green, no checkmark for any trust/drift state (grep-verified: zero success/green/positive styling in the component). Full-ink text for exact, muted "drift disclosed" for non-material, amber dot for material, hollow-dot + reason for unavailable — every dot state carries a text label.
- Facts-failed rows keep their numbers with a disclosed reason; empty state is "No drift disclosed" + as-of date.
- No "apply actuals" action anywhere; the component has zero mutation code (grep-verified) and expanding is pinned test-wise to trigger no writes. Scenario editing/optimistic locking untouched.
- A11y: aria-expanded/aria-hidden expansion via the CollapsibleCard keyboard pattern (Enter/Space), tabular-nums on money, accessible copy-hash name.

## Verification

- 22/22 client tests green independently (new disclosure suite + extended workspace suite; fixtures validated with the real `AllocationCompanyActualsDriftV1Schema.parse`).
- `npm run check` 0 TS errors; ESLint clean.
- Reuses existing primitives (CollapsibleCard pattern, TrustStateCounts-style rail, EvidenceHeader conventions, existing warning-amber Tailwind classes); no new colors or tokens.

**Plan 5 exit gate status with this PR:** drift contract/service (5.1), read-time disclosure (5.2), eligibility-gated facts reserve inputs (5.3), flag-off-identical shadow + H9 (5.4), and UI disclosure (5.5) all landed. Follow-on plans: 6 (planned-reserve MOIC basis) now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h