### PR TITLE
feat(scenarios): from-seed case creation route and flag-gated seed picker (Plan 8 wave 3)

### DIFF
--- a/client/src/components/scenarios/ScenarioFactsSeedPicker.tsx
+++ b/client/src/components/scenarios/ScenarioFactsSeedPicker.tsx
@@ -1,0 +1,671 @@
+import React, { useRef, useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm, type UseFormRegisterReturn } from 'react-hook-form';
+import { z } from 'zod';
+
+import { TRUST_CHIP_CLASSES } from '@/components/dashboard/TrustStateCounts';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useFeatureFlag } from '@/core/flags/flagAdapter';
+import { useFundScenarioSeeds } from '@/hooks/useFundScenarioSeeds';
+import { scenarioApiPath } from '@/lib/fund-scenario-workspace-api';
+import {
+  fundScenarioSeedsQueryKey,
+  workspaceQueryKey,
+} from '@/lib/fund-scenario-workspace-query-keys';
+import { ApiError, apiRequest } from '@/lib/queryClient';
+import { cn } from '@/lib/utils';
+import type { ScenarioCaseSeedV1 } from '@shared/contracts/scenarios/scenario-case-seed-v1.contract';
+
+const DecimalInputSchema = z
+  .string()
+  .trim()
+  .min(1, 'Required')
+  .regex(/^\d+(\.\d{1,6})?$/, 'Enter a non-negative number with up to 6 decimals');
+
+const FractionInputSchema = DecimalInputSchema.refine(
+  (value) => Number(value) <= 1,
+  'Enter a value from 0 to 1'
+);
+
+const PositiveIntegerInputSchema = z
+  .string()
+  .trim()
+  .min(1, 'Required')
+  .regex(/^\d+$/, 'Enter a whole number')
+  .refine((value) => Number(value) > 0, 'Enter a value greater than 0');
+
+const ScenarioFactsSeedPickerFormSchema = z
+  .object({
+    selectedCompanyId: z.string().min(1, 'Select a company'),
+    caseName: z.string().trim().min(1, 'Required').max(255),
+    probability: FractionInputSchema,
+    exitValuation: DecimalInputSchema,
+    ownershipAtExit: FractionInputSchema,
+    monthsToExit: PositiveIntegerInputSchema,
+    useSeedInvestment: z.boolean(),
+    useSeedFollowOns: z.boolean(),
+    useSeedFmv: z.boolean(),
+    investmentOverride: z.string(),
+    followOnsOverride: z.string(),
+    fmvOverride: z.string(),
+  })
+  .superRefine((values, context) => {
+    const requiredOverrides = [
+      ['useSeedInvestment', 'investmentOverride'],
+      ['useSeedFollowOns', 'followOnsOverride'],
+      ['useSeedFmv', 'fmvOverride'],
+    ] as const;
+
+    for (const [seedToggle, overrideField] of requiredOverrides) {
+      if (values[seedToggle]) continue;
+      const parsed = DecimalInputSchema.safeParse(values[overrideField]);
+      if (!parsed.success) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [overrideField],
+          message: parsed.error.issues[0]?.message ?? 'Required',
+        });
+      }
+    }
+  });
+
+type ScenarioFactsSeedPickerFormValues = z.infer<typeof ScenarioFactsSeedPickerFormSchema>;
+
+const CreateScenarioCaseFromSeedResponseSchema = z
+  .object({
+    scenarioCaseId: z.string().uuid(),
+    scenarioId: z.string().uuid(),
+    scenarioVersion: z.number().int(),
+    seededAt: z.string().datetime(),
+    replay: z.boolean(),
+  })
+  .strict();
+
+type SeedMoneyField =
+  ScenarioCaseSeedV1['fields']['investment'] | ScenarioCaseSeedV1['fields']['fmv'];
+
+export interface ScenarioFactsSeedPickerScenario {
+  id: string;
+  version: number;
+  locked_at?: string | Date | null;
+}
+
+export interface ScenarioFactsSeedPickerProps {
+  fundId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scenario?: ScenarioFactsSeedPickerScenario;
+  createdFromFactsHash?: string;
+}
+
+function unavailableCopy(field: SeedMoneyField): string {
+  if (field.status === 'seeded') return field.value;
+  return field.reason === 'currency_blocked' ? 'currency blocked' : 'facts unavailable';
+}
+
+function SeedValue({ field }: { field: SeedMoneyField }) {
+  if (field.status === 'seeded') {
+    return <span className="tabular-nums text-charcoal">{field.value}</span>;
+  }
+  return <span className="text-charcoal-500">{unavailableCopy(field)}</span>;
+}
+
+function trustLabel(seed: ScenarioCaseSeedV1): string {
+  switch (seed.trustState) {
+    case 'LIVE':
+      return 'Live';
+    case 'PARTIAL':
+      return 'Partial';
+    case 'UNAVAILABLE':
+      return 'Unavailable';
+    case 'FAILED':
+      return 'Failed';
+  }
+}
+
+function currencyLabel(seed: ScenarioCaseSeedV1): string {
+  switch (seed.currencyStatus) {
+    case 'base_currency':
+      return 'Base currency';
+    case 'mismatch_blocked':
+      return 'Currency blocked';
+    case 'unknown':
+      return 'Currency unknown';
+  }
+}
+
+function SeedDisclosureCard({
+  seed,
+  selected,
+  onSelect,
+}: {
+  seed: ScenarioCaseSeedV1;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const radioId = `scenario-seed-company-${seed.companyId}`;
+  const liveMutedOverride =
+    seed.trustState === 'LIVE' ? 'border-beige-200 bg-beige-100 text-charcoal-600' : undefined;
+
+  return (
+    <article
+      className={cn(
+        'space-y-3 rounded-md border p-4',
+        selected ? 'border-charcoal bg-beige-50' : 'border-beige-200 bg-white'
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <input
+            id={radioId}
+            type="radio"
+            name="scenario-seed-company"
+            checked={selected}
+            onChange={onSelect}
+            className="h-4 w-4 accent-charcoal"
+          />
+          <Label htmlFor={radioId} className="font-inter text-sm font-semibold text-charcoal">
+            Company {seed.companyId}
+          </Label>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <span
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs',
+              TRUST_CHIP_CLASSES[seed.trustState],
+              liveMutedOverride
+            )}
+          >
+            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-charcoal-400" />
+            {trustLabel(seed)}
+          </span>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-beige-200 bg-beige-50 px-2 py-0.5 text-xs text-charcoal-600">
+            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-charcoal-400" />
+            {currencyLabel(seed)}
+          </span>
+        </div>
+      </div>
+
+      <dl className="grid gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <dt className="text-charcoal-500">Observed investment</dt>
+          <dd>
+            <SeedValue field={seed.fields.investment} />
+          </dd>
+        </div>
+        <div>
+          <dt className="text-charcoal-500">Follow-ons</dt>
+          <dd>
+            <SeedValue field={seed.fields.followOns} />
+          </dd>
+        </div>
+        <div>
+          <dt className="text-charcoal-500">Active FMV</dt>
+          <dd>
+            <SeedValue field={seed.fields.fmv} />
+          </dd>
+        </div>
+        <div>
+          <dt className="text-charcoal-500">Latest-round market reference — not seeded</dt>
+          <dd>
+            {seed.fields.exitValuation.marketReference === null ? (
+              <span className="text-charcoal-500">facts unavailable</span>
+            ) : (
+              <span className="tabular-nums text-charcoal">
+                {seed.fields.exitValuation.marketReference}
+              </span>
+            )}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-charcoal-500">
+        <span>As of {seed.asOfDate}</span>
+        <span>Facts hash {seed.factsInputHash.slice(0, 8)}…</span>
+      </div>
+      <p className="text-xs text-charcoal-500">
+        This seed is a snapshot of recorded actuals as of {seed.asOfDate}. It will not update
+        automatically.
+      </p>
+    </article>
+  );
+}
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-xs text-error-dark">{message}</p> : null;
+}
+
+function SeedFieldControl({
+  field,
+  label,
+  checkboxLabel,
+  checkboxId,
+  checked,
+  onCheckedChange,
+  overrideId,
+  overrideLabel,
+  overrideRegistration,
+  error,
+}: {
+  field: SeedMoneyField;
+  label: string;
+  checkboxLabel: string;
+  checkboxId: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  overrideId: string;
+  overrideLabel: string;
+  overrideRegistration: UseFormRegisterReturn;
+  error: string | undefined;
+}) {
+  const seedAvailable = field.status === 'seeded';
+
+  return (
+    <div className="space-y-2 rounded-md border border-beige-200 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm text-charcoal-600">{label}</span>
+        <SeedValue field={field} />
+      </div>
+      {seedAvailable && (
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={checkboxId}
+            checked={checked}
+            onCheckedChange={(value) => onCheckedChange(value === true)}
+            className="data-[state=checked]:border-charcoal data-[state=checked]:bg-charcoal"
+          />
+          <Label htmlFor={checkboxId} className="text-sm font-normal text-charcoal-600">
+            {checkboxLabel}
+          </Label>
+        </div>
+      )}
+      {!checked && (
+        <div className="space-y-1">
+          <Label htmlFor={overrideId} className="text-sm text-charcoal">
+            {overrideLabel}
+          </Label>
+          <Input
+            id={overrideId}
+            type="number"
+            min="0"
+            step="0.000001"
+            inputMode="decimal"
+            className="tabular-nums"
+            {...overrideRegistration}
+          />
+          <FieldError message={error} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ScenarioFactsSeedPicker({
+  fundId,
+  open,
+  onOpenChange,
+  scenario,
+  createdFromFactsHash,
+}: ScenarioFactsSeedPickerProps) {
+  const enabledByFlag = useFeatureFlag('enable_scenario_seed_picker');
+  const { seeds, response, isLoading, error } = useFundScenarioSeeds(fundId);
+  const queryClient = useQueryClient();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const idempotencyRef = useRef<{ signature: string; key: string } | null>(null);
+
+  const form = useForm<ScenarioFactsSeedPickerFormValues>({
+    resolver: zodResolver(ScenarioFactsSeedPickerFormSchema),
+    defaultValues: {
+      selectedCompanyId: '',
+      caseName: '',
+      probability: '',
+      exitValuation: '',
+      ownershipAtExit: '',
+      monthsToExit: '',
+      useSeedInvestment: false,
+      useSeedFollowOns: false,
+      useSeedFmv: false,
+      investmentOverride: '',
+      followOnsOverride: '',
+      fmvOverride: '',
+    },
+  });
+
+  const selectedCompanyId = form.watch('selectedCompanyId');
+  const useSeedInvestment = form.watch('useSeedInvestment');
+  const useSeedFollowOns = form.watch('useSeedFollowOns');
+  const useSeedFmv = form.watch('useSeedFmv');
+  const selectedSeed = seeds.find((seed) => String(seed.companyId) === selectedCompanyId);
+  const isLocked = scenario?.locked_at != null;
+  const seedChanged =
+    createdFromFactsHash !== undefined &&
+    response?.factsInputHash !== null &&
+    response?.factsInputHash !== undefined &&
+    response.factsInputHash !== createdFromFactsHash;
+
+  const createMutation = useMutation({
+    retry: false,
+    mutationFn: async ({
+      payload,
+      idempotencyKey,
+    }: {
+      payload: {
+        seed: ScenarioCaseSeedV1;
+        overrides: {
+          caseName: string;
+          probability: string;
+          exitValuation: string;
+          ownershipAtExit: string;
+          monthsToExit: number;
+          investment?: string;
+          followOns?: string;
+          fmv?: string;
+        };
+        expectedScenarioVersion: number;
+      };
+      idempotencyKey: string;
+    }) => {
+      if (!scenario) throw new Error('A scenario is required to create a case.');
+      const raw = await apiRequest(
+        'POST',
+        scenarioApiPath(
+          fundId,
+          `/scenario-analysis/scenarios/${encodeURIComponent(scenario.id)}/cases/from-seed`
+        ),
+        payload,
+        { headers: { 'Idempotency-Key': idempotencyKey } }
+      );
+      return CreateScenarioCaseFromSeedResponseSchema.parse(raw);
+    },
+    onMutate: () => setServerError(null),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: workspaceQueryKey(fundId) }),
+        queryClient.invalidateQueries({ queryKey: fundScenarioSeedsQueryKey(fundId) }),
+      ]);
+      form.reset();
+      idempotencyRef.current = null;
+      setServerError(null);
+      onOpenChange(false);
+    },
+    onError: (mutationError: unknown) => {
+      if (
+        mutationError instanceof ApiError &&
+        mutationError.status === 409 &&
+        mutationError.errorCode === 'version_conflict'
+      ) {
+        setServerError('Scenario changed. Refresh and try again.');
+        return;
+      }
+      if (
+        mutationError instanceof ApiError &&
+        mutationError.status === 409 &&
+        mutationError.errorCode === 'seed_conflict'
+      ) {
+        void queryClient.invalidateQueries({ queryKey: fundScenarioSeedsQueryKey(fundId) });
+        setServerError('Portfolio actuals changed. Refresh and try again.');
+        return;
+      }
+      setServerError('Case creation failed. Review the inputs and try again.');
+    },
+  });
+
+  if (!enabledByFlag) return null;
+
+  function handleSeedSelect(seed: ScenarioCaseSeedV1) {
+    form.reset({
+      selectedCompanyId: String(seed.companyId),
+      caseName: '',
+      probability: '',
+      exitValuation: '',
+      ownershipAtExit: '',
+      monthsToExit: '',
+      useSeedInvestment: seed.fields.investment.status === 'seeded',
+      useSeedFollowOns: seed.fields.followOns.status === 'seeded',
+      useSeedFmv: seed.fields.fmv.status === 'seeded',
+      investmentOverride: '',
+      followOnsOverride: '',
+      fmvOverride: '',
+    });
+    idempotencyRef.current = null;
+    setServerError(null);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && createMutation.isPending) return;
+    if (!nextOpen) {
+      form.reset();
+      idempotencyRef.current = null;
+      setServerError(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  function handleSubmit(values: ScenarioFactsSeedPickerFormValues) {
+    if (!scenario || isLocked || !selectedSeed) return;
+    const overrides = {
+      caseName: values.caseName.trim(),
+      probability: values.probability,
+      exitValuation: values.exitValuation,
+      ownershipAtExit: values.ownershipAtExit,
+      monthsToExit: Number(values.monthsToExit),
+      ...(!values.useSeedInvestment ? { investment: values.investmentOverride } : {}),
+      ...(!values.useSeedFollowOns ? { followOns: values.followOnsOverride } : {}),
+      ...(!values.useSeedFmv ? { fmv: values.fmvOverride } : {}),
+    };
+    const payload = {
+      seed: selectedSeed,
+      overrides,
+      expectedScenarioVersion: scenario.version,
+    };
+    const signature = JSON.stringify(payload);
+    if (idempotencyRef.current?.signature !== signature) {
+      idempotencyRef.current = { signature, key: globalThis.crypto.randomUUID() };
+    }
+    createMutation.mutate({ payload, idempotencyKey: idempotencyRef.current.key });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle className="font-inter text-charcoal">
+            Start case from portfolio actuals
+          </DialogTitle>
+          <DialogDescription>
+            Choose a disclosed company snapshot, then confirm every assumption that is not seeded.
+          </DialogDescription>
+        </DialogHeader>
+
+        {seedChanged && (
+          <Alert className="border-beige-200 bg-beige-50">
+            <AlertDescription className="text-charcoal-600">
+              seed has changed since creation
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {isLoading && <p className="text-sm text-charcoal-500">Loading portfolio actuals…</p>}
+        {error && (
+          <Alert className="border-error/20 bg-error/5">
+            <AlertDescription className="text-error-dark">
+              Seed facts could not be loaded.
+            </AlertDescription>
+          </Alert>
+        )}
+        {response?.factsStatus === 'failed' && (
+          <Alert className="border-beige-200 bg-beige-50">
+            <AlertDescription className="text-charcoal-600">
+              Seed facts are unavailable for this fund.
+            </AlertDescription>
+          </Alert>
+        )}
+        {isLocked ? (
+          <p className="text-sm font-medium text-charcoal-600">Scenario is locked</p>
+        ) : !scenario ? (
+          <p className="text-sm text-charcoal-600">Select a company scenario to create a case.</p>
+        ) : null}
+
+        {seeds.length > 0 && (
+          <div className="space-y-3" role="radiogroup" aria-label="Portfolio actuals seeds">
+            {seeds.map((seed) => (
+              <SeedDisclosureCard
+                key={seed.companyId}
+                seed={seed}
+                selected={selectedCompanyId === String(seed.companyId)}
+                onSelect={() => handleSeedSelect(seed)}
+              />
+            ))}
+          </div>
+        )}
+
+        {selectedSeed && (
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-3">
+              <SeedFieldControl
+                field={selectedSeed.fields.investment}
+                label="Observed investment"
+                checkboxLabel="Use observed investment"
+                checkboxId="use-seed-investment"
+                checked={useSeedInvestment}
+                onCheckedChange={(checked) =>
+                  form.setValue('useSeedInvestment', checked, { shouldValidate: true })
+                }
+                overrideId="investmentOverride"
+                overrideLabel="Observed investment override"
+                overrideRegistration={form.register('investmentOverride')}
+                error={form.formState.errors.investmentOverride?.message}
+              />
+              <SeedFieldControl
+                field={selectedSeed.fields.followOns}
+                label="Follow-ons"
+                checkboxLabel="Use recorded follow-ons"
+                checkboxId="use-seed-follow-ons"
+                checked={useSeedFollowOns}
+                onCheckedChange={(checked) =>
+                  form.setValue('useSeedFollowOns', checked, { shouldValidate: true })
+                }
+                overrideId="followOnsOverride"
+                overrideLabel="Follow-ons override"
+                overrideRegistration={form.register('followOnsOverride')}
+                error={form.formState.errors.followOnsOverride?.message}
+              />
+              <SeedFieldControl
+                field={selectedSeed.fields.fmv}
+                label="Active FMV"
+                checkboxLabel="Use active FMV"
+                checkboxId="use-seed-fmv"
+                checked={useSeedFmv}
+                onCheckedChange={(checked) =>
+                  form.setValue('useSeedFmv', checked, { shouldValidate: true })
+                }
+                overrideId="fmvOverride"
+                overrideLabel="Active FMV override"
+                overrideRegistration={form.register('fmvOverride')}
+                error={form.formState.errors.fmvOverride?.message}
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1">
+                <Label htmlFor="caseName">Case name</Label>
+                <Input id="caseName" {...form.register('caseName')} />
+                <FieldError message={form.formState.errors.caseName?.message} />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="probability">Probability (0 to 1)</Label>
+                <Input
+                  id="probability"
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.000001"
+                  inputMode="decimal"
+                  {...form.register('probability')}
+                />
+                <FieldError message={form.formState.errors.probability?.message} />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="exitValuation">Exit valuation</Label>
+                <Input
+                  id="exitValuation"
+                  type="number"
+                  min="0"
+                  step="0.000001"
+                  inputMode="decimal"
+                  className="tabular-nums"
+                  {...form.register('exitValuation')}
+                />
+                <FieldError message={form.formState.errors.exitValuation?.message} />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="ownershipAtExit">Ownership at exit (0 to 1)</Label>
+                <Input
+                  id="ownershipAtExit"
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.000001"
+                  inputMode="decimal"
+                  {...form.register('ownershipAtExit')}
+                />
+                <FieldError message={form.formState.errors.ownershipAtExit?.message} />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="monthsToExit">Months to exit</Label>
+                <Input
+                  id="monthsToExit"
+                  type="number"
+                  min="1"
+                  step="1"
+                  inputMode="numeric"
+                  {...form.register('monthsToExit')}
+                />
+                <FieldError message={form.formState.errors.monthsToExit?.message} />
+              </div>
+            </div>
+
+            {serverError && (
+              <Alert className="border-error/20 bg-error/5">
+                <AlertDescription className="text-error-dark">{serverError}</AlertDescription>
+              </Alert>
+            )}
+
+            {!isLocked && scenario && (
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={createMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={createMutation.isPending}
+                  className="bg-charcoal text-white hover:bg-charcoal/90"
+                >
+                  {createMutation.isPending ? 'Creating...' : 'Create case'}
+                </Button>
+              </DialogFooter>
+            )}
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/flags/unifiedClientFlags.ts
+++ b/client/src/core/flags/unifiedClientFlags.ts
@@ -69,6 +69,7 @@ const CANONICAL_TO_LEGACY_ALIASES: Record<ClientFlagKey, string[]> = {
   enable_wizard_step_recycling: [],
   enable_wizard_step_waterfall: [],
   enable_wizard_step_results: [],
+  enable_scenario_seed_picker: [],
 };
 
 const overrideCache = new Map<ClientFlagKey, boolean>();

--- a/client/src/hooks/useFundScenarioSeeds.ts
+++ b/client/src/hooks/useFundScenarioSeeds.ts
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { useFeatureFlag } from '@/core/flags/flagAdapter';
+import { fundScenarioSeedsQueryKey } from '@/lib/fund-scenario-workspace-query-keys';
+import { apiRequest } from '@/lib/queryClient';
+import { Sha256Schema } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { ScenarioCaseSeedV1Schema } from '@shared/contracts/scenarios/scenario-case-seed-v1.contract';
+
+export const FundScenarioSeedsResponseSchema = z.discriminatedUnion('factsStatus', [
+  z
+    .object({
+      fundId: z.number().int().positive(),
+      asOfDate: z.string().date(),
+      factsStatus: z.literal('available'),
+      factsInputHash: Sha256Schema,
+      seeds: z.array(ScenarioCaseSeedV1Schema),
+    })
+    .strict(),
+  z
+    .object({
+      fundId: z.number().int().positive(),
+      asOfDate: z.string().date(),
+      factsStatus: z.literal('failed'),
+      factsInputHash: z.null(),
+      seeds: z.array(ScenarioCaseSeedV1Schema).max(0),
+    })
+    .strict(),
+]);
+
+export type FundScenarioSeedsResponse = z.infer<typeof FundScenarioSeedsResponseSchema>;
+
+export function useFundScenarioSeeds(fundId: string | null | undefined) {
+  const enabledByFlag = useFeatureFlag('enable_scenario_seed_picker');
+  const query = useQuery({
+    queryKey: fundScenarioSeedsQueryKey(fundId ?? 'unavailable'),
+    enabled: Boolean(fundId) && enabledByFlag,
+    queryFn: async () => {
+      const raw = await apiRequest(
+        'GET',
+        `/api/funds/${encodeURIComponent(fundId ?? '')}/scenario-analysis/seeds`
+      );
+      return FundScenarioSeedsResponseSchema.parse(raw);
+    },
+  });
+
+  return {
+    seeds: query.data?.seeds ?? [],
+    response: query.data,
+    isLoading: query.isLoading,
+    error: query.error as Error | null,
+  };
+}

--- a/client/src/lib/fund-scenario-workspace-query-keys.ts
+++ b/client/src/lib/fund-scenario-workspace-query-keys.ts
@@ -2,6 +2,10 @@ export function workspaceQueryKey(fundId: string) {
   return ['fund-scenario-workspace', fundId] as const;
 }
 
+export function fundScenarioSeedsQueryKey(fundId: string) {
+  return ['fund-scenario-analysis', fundId, 'seeds'] as const;
+}
+
 export function scenarioSetListQueryKey(fundId: string) {
   return [...workspaceQueryKey(fundId), 'scenario-sets'] as const;
 }

--- a/client/src/pages/fund-scenario-workspace.tsx
+++ b/client/src/pages/fund-scenario-workspace.tsx
@@ -14,6 +14,8 @@ import { Link, useRoute } from 'wouter';
 import { ArrowLeft, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CreateMethodologyScenarioModal } from '@/components/scenarios/CreateMethodologyScenarioModal';
+import { ScenarioFactsSeedPicker } from '@/components/scenarios/ScenarioFactsSeedPicker';
+import { useFeatureFlag } from '@/core/flags/flagAdapter';
 import {
   type Query,
   useMutation,
@@ -493,7 +495,9 @@ function FundScenarioWorkspacePage() {
   const queryClient = useQueryClient();
   const [pendingScenarioSetId, setPendingScenarioSetId] = useState<string | null>(null);
   const [isCreateMethodologyOpen, setIsCreateMethodologyOpen] = useState(false);
+  const [isSeedPickerOpen, setIsSeedPickerOpen] = useState(false);
   const [highlightedScenarioSetId, setHighlightedScenarioSetId] = useState<string | null>(null);
+  const seedPickerEnabled = useFeatureFlag('enable_scenario_seed_picker');
 
   const scenarioSetsQuery = useQuery({
     queryKey: fundId ? scenarioSetListQueryKey(fundId) : ['fund-scenario-workspace', 'invalid'],
@@ -622,6 +626,11 @@ function FundScenarioWorkspacePage() {
             </Link>
           </Button>
           <div className="flex flex-wrap items-center gap-2">
+            {seedPickerEnabled && (
+              <Button variant="outline" size="sm" onClick={() => setIsSeedPickerOpen(true)}>
+                Start case from portfolio actuals
+              </Button>
+            )}
             <Button variant="outline" size="sm" onClick={() => setIsCreateMethodologyOpen(true)}>
               New methodology scenario
             </Button>
@@ -703,6 +712,13 @@ function FundScenarioWorkspacePage() {
         onOpenChange={setIsCreateMethodologyOpen}
         onSuccess={(created) => setHighlightedScenarioSetId(created.id)}
       />
+      {seedPickerEnabled && (
+        <ScenarioFactsSeedPicker
+          fundId={fundId}
+          open={isSeedPickerOpen}
+          onOpenChange={setIsSeedPickerOpen}
+        />
+      )}
     </div>
   );
 }

--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -684,6 +684,20 @@ flags:
     expiresAt: null
     aliases: ['ENABLE_WIZARD_STEP_RESULTS']
 
+  enable_scenario_seed_picker:
+    default: false
+    description: 'Create scenario cases from disclosed portfolio actuals seeds'
+    owner: 'product'
+    risk: medium
+    exposeToClient: true
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: null
+    aliases: ['ENABLE_SCENARIO_SEED_PICKER']
+
 # ============================================
 # DEPRECATED FLAGS (to be removed)
 # ============================================

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -773,6 +773,30 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
       'Read-only Round/FMV-derived model-input facts; no export or UI actionability claim is introduced in this slice.',
   },
   {
+    id: 'api:post:/api/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed',
+    method: 'POST',
+    path: '/api/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed',
+    lifecycle: 'durable_crud',
+    governanceRef: '/fund-model-results/:fundId/scenarios',
+    surface: 'scenario-case-seed-creation-api',
+    owner: ownerForFinancialSurface('fund_modeling'),
+    telemetryKey: telemetryKeyForRoute(
+      'api.route',
+      '/api/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed'
+    ),
+    financialSurface: 'fund_modeling',
+    apiAuthBoundary: 'require_auth_and_fund_access',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'fund_scope_and_optimistic_lock_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+    staleBlocksExport: false,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+    notes:
+      'Idempotent case creation preserves the selected actuals snapshot and requires optimistic locking on the parent scenario.',
+  },
+  {
     id: 'api:get:/api/funds/:fundId/metric-runs/:metricRunId/report-package/render-model',
     method: 'GET',
     path: '/api/funds/:fundId/metric-runs/:metricRunId/report-package/render-model',

--- a/server/routes/scenario-analysis.ts
+++ b/server/routes/scenario-analysis.ts
@@ -7,11 +7,18 @@
 
 import { Router } from 'express';
 import type { NextFunction, Request, Response } from 'express';
+import { isDeepStrictEqual } from 'node:util';
 import { z } from 'zod';
 import { db } from '../db';
 import { Sha256Schema } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 import { ScenarioCaseSeedV1Schema } from '@shared/contracts/scenarios/scenario-case-seed-v1.contract';
-import { scenarios, scenarioCases, scenarioAuditLogs } from '@shared/schema';
+import { DecimalStringSchema } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
+import {
+  scenarios,
+  scenarioCases,
+  scenarioAuditLogs,
+  scenarioCaseSeedProvenance,
+} from '@shared/schema';
 import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
 import { eq, and } from 'drizzle-orm';
 import {
@@ -24,12 +31,16 @@ import type { ScenarioAnalysisResponse, ScenarioCase } from '@shared/types/scena
 import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
 import { firstString } from '../lib/request-values';
 import { createRouteLogger } from '../lib/route-logger.js';
-import { enforceCompanyFundScope } from '../lib/auth/company-fund-scope';
+import { enforceCompanyFundScope, resolveCompanyFundId } from '../lib/auth/company-fund-scope';
 import {
   buildFundCompanyActualsFacts,
   FundActualsFactsServiceError,
 } from '../services/fund-actuals/fund-company-actuals-facts-service';
 import { buildScenarioCaseSeed } from '../services/scenarios/scenario-case-seed-service';
+import {
+  createScenarioCaseFromSeed,
+  ScenarioCaseSeedPersistenceError,
+} from '../services/scenarios/scenario-case-seed-persistence-service';
 
 const routeLog = createRouteLogger('scenario-analysis');
 
@@ -107,6 +118,47 @@ const ScenarioSeedResponseSchema = z.discriminatedUnion('factsStatus', [
     .strict(),
 ]);
 
+const NonnegativeDecimalStringSchema = DecimalStringSchema.refine(
+  (value) => Number(value) >= 0,
+  'Must be a non-negative decimal string'
+);
+
+const FractionDecimalStringSchema = NonnegativeDecimalStringSchema.refine(
+  (value) => Number(value) <= 1,
+  'Must be between 0 and 1'
+);
+
+const ScenarioCaseSeedOverridesSchema = z
+  .object({
+    caseName: z.string().trim().min(1).max(255),
+    probability: FractionDecimalStringSchema,
+    exitValuation: NonnegativeDecimalStringSchema,
+    monthsToExit: z.number().int().positive(),
+    ownershipAtExit: FractionDecimalStringSchema,
+    investment: NonnegativeDecimalStringSchema.optional(),
+    followOns: NonnegativeDecimalStringSchema.optional(),
+    fmv: NonnegativeDecimalStringSchema.optional(),
+  })
+  .strict();
+
+const CreateScenarioCaseFromSeedRequestSchema = z
+  .object({
+    seed: ScenarioCaseSeedV1Schema,
+    overrides: ScenarioCaseSeedOverridesSchema,
+    expectedScenarioVersion: z.number().int(),
+  })
+  .strict();
+
+const CreateScenarioCaseFromSeedResponseSchema = z
+  .object({
+    scenarioCaseId: z.string().uuid(),
+    scenarioId: z.string().uuid(),
+    scenarioVersion: z.number().int(),
+    seededAt: z.string().datetime(),
+    replay: z.boolean(),
+  })
+  .strict();
+
 function failedScenarioSeedResponse(fundId: number, asOfDate: string) {
   return ScenarioSeedResponseSchema.parse({
     fundId,
@@ -126,6 +178,32 @@ function validateScenarioSeedFundId(req: Request, res: Response, next: NextFunct
     });
   }
   next();
+}
+
+function validateScenarioIdParam(req: Request, res: Response, next: NextFunction) {
+  const parsed = z.string().uuid().safeParse(req.params['scenarioId']);
+  if (!parsed.success) {
+    return res.status(400).json({
+      error: 'invalid_scenario_id',
+      message: 'Scenario ID must be a UUID',
+    });
+  }
+  next();
+}
+
+function statusForScenarioCaseSeedError(code: ScenarioCaseSeedPersistenceError['code']): number {
+  switch (code) {
+    case 'scenario_not_found':
+      return 404;
+    case 'scenario_locked':
+      return 423;
+    case 'version_conflict':
+    case 'idempotency_conflict':
+      return 409;
+    case 'missing_required_override':
+    case 'company_mismatch':
+      return 400;
+  }
 }
 
 // ============================================================================
@@ -217,6 +295,134 @@ router['get'](
         seeds: facts.facts.map((fact) => buildScenarioCaseSeed({ fundId, fact, asOfDate })),
       })
     );
+  }
+);
+
+router['post'](
+  '/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed',
+  requireAuth(),
+  validateScenarioSeedFundId,
+  requireFundAccess,
+  validateScenarioIdParam,
+  async (req: Request, res: Response) => {
+    const { fundId } = FundIdParamSchema.parse(req.params);
+    const scenarioId = z.string().uuid().parse(req.params['scenarioId']);
+    const parsedBody = CreateScenarioCaseFromSeedRequestSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'invalid_request',
+        message: 'Request body does not match the from-seed case creation contract',
+      });
+    }
+
+    const idempotencyKey = req.get('Idempotency-Key')?.trim();
+    if (!idempotencyKey) {
+      return res.status(400).json({
+        error: 'missing_idempotency_key',
+        message: 'Idempotency-Key header is required',
+      });
+    }
+
+    const { seed, overrides, expectedScenarioVersion } = parsedBody.data;
+    if (seed.fundId !== fundId) {
+      return res.status(400).json({
+        error: 'seed_fund_mismatch',
+        message: 'Seed fund ID must match the route fund ID',
+      });
+    }
+
+    try {
+      const companyFundId = await resolveCompanyFundId(seed.companyId);
+      if (companyFundId !== fundId) {
+        return res.status(400).json({
+          error: 'company_mismatch',
+          message: 'Seed company must belong to the route fund',
+        });
+      }
+
+      const existingReplayRows = await db
+        .select({ scenarioId: scenarioCases.scenarioId })
+        .from(scenarioCaseSeedProvenance)
+        .innerJoin(scenarioCases, eq(scenarioCases.id, scenarioCaseSeedProvenance.scenarioCaseId))
+        .where(
+          and(
+            eq(scenarioCaseSeedProvenance.fundId, fundId),
+            eq(scenarioCaseSeedProvenance.idempotencyKey, idempotencyKey)
+          )
+        )
+        .limit(1);
+      const existingReplay = existingReplayRows[0];
+      if (existingReplay && existingReplay.scenarioId !== scenarioId) {
+        return res.status(409).json({
+          error: 'idempotency_conflict',
+          message: 'Idempotency-Key is already associated with another scenario',
+        });
+      }
+      if (!existingReplay) {
+        const facts = await buildFundCompanyActualsFacts({ fundId, asOfDate: seed.asOfDate });
+        const fact = facts.facts.find((candidate) => candidate.companyId === seed.companyId);
+        const canonicalSeed =
+          facts.fundId === fundId && facts.asOfDate === seed.asOfDate && fact
+            ? buildScenarioCaseSeed({ fundId, fact, asOfDate: seed.asOfDate })
+            : null;
+        if (!canonicalSeed || !isDeepStrictEqual(seed, canonicalSeed)) {
+          return res.status(409).json({
+            error: 'seed_conflict',
+            message: 'Seed no longer matches disclosed portfolio actuals. Refresh and try again.',
+          });
+        }
+      }
+
+      const actorUserId = (req as { user?: { id?: string } }).user?.id ?? null;
+      const persistenceOverrides = {
+        caseName: overrides.caseName,
+        probability: overrides.probability,
+        exitValuation: overrides.exitValuation,
+        monthsToExit: overrides.monthsToExit,
+        ownershipAtExit: overrides.ownershipAtExit,
+        ...(overrides.investment !== undefined ? { investment: overrides.investment } : {}),
+        ...(overrides.followOns !== undefined ? { followOns: overrides.followOns } : {}),
+        ...(overrides.fmv !== undefined ? { fmv: overrides.fmv } : {}),
+      };
+      const created = await createScenarioCaseFromSeed({
+        scenarioId,
+        expectedScenarioVersion,
+        seed,
+        overrides: persistenceOverrides,
+        actor: { userId: actorUserId },
+        idempotencyKey,
+      });
+      const currentScenario = await db.query.scenarios.findFirst({
+        where: eq(scenarios.id, scenarioId),
+        columns: { version: true },
+      });
+      if (!currentScenario) {
+        throw new Error('Scenario version unavailable after case creation');
+      }
+
+      return res.status(201).json(
+        CreateScenarioCaseFromSeedResponseSchema.parse({
+          scenarioCaseId: created.case.id,
+          scenarioId: created.case.scenarioId,
+          scenarioVersion: currentScenario.version,
+          seededAt: created.provenance.seededAt.toISOString(),
+          replay: created.replayed,
+        })
+      );
+    } catch (error: unknown) {
+      if (error instanceof ScenarioCaseSeedPersistenceError) {
+        return res.status(statusForScenarioCaseSeedError(error.code)).json({
+          error: error.code,
+          message: error.message,
+          ...(error.details !== undefined ? { details: error.details } : {}),
+        });
+      }
+      routeLog.error('Create scenario case from seed failed:', error);
+      return res.status(500).json({
+        error: 'internal_error',
+        message: 'Scenario case creation failed',
+      });
+    }
   }
 );
 

--- a/shared/generated/flag-defaults.ts
+++ b/shared/generated/flag-defaults.ts
@@ -760,6 +760,22 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     expiresAt: null,
     aliases: ['ENABLE_WIZARD_STEP_RESULTS'],
   },
+  enable_scenario_seed_picker: {
+    default: false,
+    description: 'Create scenario cases from disclosed portfolio actuals seeds',
+    owner: 'product',
+    risk: 'medium',
+    exposeToClient: true,
+
+    environments: {
+      development: false,
+      staging: false,
+      production: false,
+    },
+    dependencies: [],
+    expiresAt: null,
+    aliases: ['ENABLE_SCENARIO_SEED_PICKER'],
+  },
 };
 
 /**
@@ -814,6 +830,7 @@ export const FLAG_DEFAULTS: FlagRecord = {
   enable_wizard_step_recycling: false,
   enable_wizard_step_waterfall: false,
   enable_wizard_step_results: false,
+  enable_scenario_seed_picker: false,
 };
 
 /**
@@ -902,6 +919,7 @@ export const FLAG_ALIASES: Record<string, FlagKey> = {
   ENABLE_WIZARD_STEP_WATERFALL: 'enable_wizard_step_waterfall',
   ENABLE_WIZARD_STEP_RECYCLING: 'enable_wizard_step_waterfall',
   ENABLE_WIZARD_STEP_RESULTS: 'enable_wizard_step_results',
+  ENABLE_SCENARIO_SEED_PICKER: 'enable_scenario_seed_picker',
 };
 
 /**

--- a/shared/generated/flag-types.ts
+++ b/shared/generated/flag-types.ts
@@ -57,7 +57,8 @@ export type FlagKey =
   | 'enable_wizard_step_fees'
   | 'enable_wizard_step_recycling'
   | 'enable_wizard_step_waterfall'
-  | 'enable_wizard_step_results';
+  | 'enable_wizard_step_results'
+  | 'enable_scenario_seed_picker';
 
 /**
  * Flags safe to expose to client
@@ -104,7 +105,8 @@ export type ClientFlagKey =
   | 'enable_wizard_step_fees'
   | 'enable_wizard_step_recycling'
   | 'enable_wizard_step_waterfall'
-  | 'enable_wizard_step_results';
+  | 'enable_wizard_step_results'
+  | 'enable_scenario_seed_picker';
 
 /**
  * Server-only flags (not exposed to client)
@@ -210,6 +212,7 @@ export const ALL_FLAG_KEYS: readonly FlagKey[] = [
   'enable_wizard_step_recycling',
   'enable_wizard_step_waterfall',
   'enable_wizard_step_results',
+  'enable_scenario_seed_picker',
 ] as const;
 
 /**
@@ -258,6 +261,7 @@ export const CLIENT_FLAG_KEYS: readonly ClientFlagKey[] = [
   'enable_wizard_step_recycling',
   'enable_wizard_step_waterfall',
   'enable_wizard_step_results',
+  'enable_scenario_seed_picker',
 ] as const;
 
 /**

--- a/tests/unit/components/scenarios/scenario-facts-seed-picker.test.tsx
+++ b/tests/unit/components/scenarios/scenario-facts-seed-picker.test.tsx
@@ -1,0 +1,407 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ScenarioCaseSeedV1Schema } from '../../../../shared/contracts/scenarios/scenario-case-seed-v1.contract';
+import { ScenarioFactsSeedPicker } from '../../../../client/src/components/scenarios/ScenarioFactsSeedPicker';
+
+const pickerState = vi.hoisted(() => ({
+  flagEnabled: true,
+  hookResult: {
+    seeds: [] as unknown[],
+    response: undefined as unknown,
+    isLoading: false,
+    error: null as Error | null,
+  },
+}));
+
+vi.mock('@/core/flags/flagAdapter', () => ({
+  useFeatureFlag: () => pickerState.flagEnabled,
+}));
+
+vi.mock('@/hooks/useFundScenarioSeeds', () => ({
+  useFundScenarioSeeds: () => pickerState.hookResult,
+}));
+
+const SCENARIO_ID = '00000000-0000-4000-8000-000000000101';
+const SCENARIO_CASE_ID = '00000000-0000-4000-8000-000000000201';
+
+function makeLiveSeed() {
+  return ScenarioCaseSeedV1Schema.parse({
+    contractVersion: 'scenario-case-seed-v1',
+    fundId: 7,
+    companyId: 101,
+    asOfDate: '2026-07-13',
+    factsInputHash: 'c'.repeat(64),
+    trustState: 'LIVE',
+    currencyStatus: 'base_currency',
+    fields: {
+      investment: {
+        status: 'seeded',
+        value: '500000.000000',
+        source: 'investment_rounds',
+      },
+      followOns: {
+        status: 'seeded',
+        value: '250000.000000',
+        source: 'investment_rounds',
+      },
+      fmv: {
+        status: 'seeded',
+        value: '14000000.000000',
+        source: 'approved_planning_fmv',
+      },
+      exitValuation: {
+        status: 'user_required',
+        value: null,
+        marketReference: '12000000.000000',
+      },
+      probability: { status: 'user_required', value: null },
+      ownershipAtExit: { status: 'user_required', value: null },
+    },
+    warnings: [],
+  });
+}
+
+function makePartialSeed() {
+  return ScenarioCaseSeedV1Schema.parse({
+    ...makeLiveSeed(),
+    companyId: 102,
+    factsInputHash: 'd'.repeat(64),
+    trustState: 'PARTIAL',
+    fields: {
+      ...makeLiveSeed().fields,
+      followOns: { status: 'unavailable', value: null, reason: 'facts_unavailable' },
+      fmv: { status: 'unavailable', value: null, reason: 'no_active_fmv' },
+    },
+  });
+}
+
+function makeCurrencyBlockedSeed() {
+  return ScenarioCaseSeedV1Schema.parse({
+    ...makeLiveSeed(),
+    companyId: 103,
+    factsInputHash: 'e'.repeat(64),
+    trustState: 'UNAVAILABLE',
+    currencyStatus: 'mismatch_blocked',
+    fields: {
+      ...makeLiveSeed().fields,
+      investment: { status: 'unavailable', value: null, reason: 'currency_blocked' },
+      followOns: { status: 'unavailable', value: null, reason: 'currency_blocked' },
+      fmv: { status: 'unavailable', value: null, reason: 'currency_blocked' },
+    },
+  });
+}
+
+function availableResponse(seeds = [makeLiveSeed()]) {
+  return {
+    fundId: 7,
+    asOfDate: '2026-07-13',
+    factsStatus: 'available' as const,
+    factsInputHash: '9'.repeat(64),
+    seeds,
+  };
+}
+
+function failedResponse() {
+  return {
+    fundId: 7,
+    asOfDate: '2026-07-13',
+    factsStatus: 'failed' as const,
+    factsInputHash: null,
+    seeds: [],
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+interface RenderPickerOptions {
+  scenario?: { id: string; version: number; locked_at?: string | null } | null;
+  createdFromFactsHash?: string;
+}
+
+function renderPicker(options: RenderPickerOptions = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const onOpenChange = vi.fn();
+  const scenario =
+    options.scenario === undefined
+      ? { id: SCENARIO_ID, version: 4, locked_at: null }
+      : options.scenario;
+
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <ScenarioFactsSeedPicker
+        fundId="7"
+        open
+        onOpenChange={onOpenChange}
+        scenario={scenario ?? undefined}
+        createdFromFactsHash={options.createdFromFactsHash}
+      />
+    </QueryClientProvider>
+  );
+
+  return { ...result, queryClient, invalidateSpy, onOpenChange };
+}
+
+async function selectLiveSeedAndFillRequiredInputs(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('radio', { name: /company 101/i }));
+  await user.type(screen.getByLabelText(/case name/i), 'Base case');
+  await user.type(screen.getByLabelText(/probability/i), '0.4');
+  await user.type(screen.getByLabelText(/^exit valuation/i), '20000000');
+  await user.type(screen.getByLabelText(/ownership at exit/i), '0.2');
+  await user.type(screen.getByLabelText(/months to exit/i), '36');
+}
+
+describe('ScenarioFactsSeedPicker', () => {
+  beforeEach(() => {
+    pickerState.flagEnabled = true;
+    const response = availableResponse();
+    pickerState.hookResult = {
+      seeds: response.seeds,
+      response,
+      isLoading: false,
+      error: null,
+    };
+    globalThis.fetch = vi.fn();
+  });
+
+  it('validates LIVE, PARTIAL, and currency-blocked fixtures with the shared contract', () => {
+    expect(ScenarioCaseSeedV1Schema.parse(makeLiveSeed()).trustState).toBe('LIVE');
+    expect(ScenarioCaseSeedV1Schema.parse(makePartialSeed()).trustState).toBe('PARTIAL');
+    expect(ScenarioCaseSeedV1Schema.parse(makeCurrencyBlockedSeed()).currencyStatus).toBe(
+      'mismatch_blocked'
+    );
+  });
+
+  it('renders disclosed LIVE facts, market-reference copy, and snapshot provenance', () => {
+    renderPicker();
+
+    expect(
+      screen.getByRole('dialog', { name: /start case from portfolio actuals/i })
+    ).toBeVisible();
+    expect(screen.getByText('Company 101')).toBeInTheDocument();
+    expect(screen.getByText('Live')).toHaveClass('bg-beige-100', 'text-charcoal-600');
+    expect(screen.getByText('Live')).not.toHaveClass('bg-success/10', 'text-success-dark');
+    expect(screen.getByText('500000.000000')).toHaveClass('tabular-nums');
+    expect(screen.getByText('250000.000000')).toHaveClass('tabular-nums');
+    expect(screen.getByText('14000000.000000')).toHaveClass('tabular-nums');
+    expect(screen.getByText(/market reference — not seeded/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This seed is a snapshot of recorded actuals as of 2026-07-13. It will not update automatically.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/cccccccc/)).toBeInTheDocument();
+  });
+
+  it('renders PARTIAL unavailable values as facts unavailable and requires their inputs', async () => {
+    const response = availableResponse([makePartialSeed()]);
+    pickerState.hookResult = {
+      seeds: response.seeds,
+      response,
+      isLoading: false,
+      error: null,
+    };
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(screen.getByRole('radio', { name: /company 102/i }));
+
+    expect(screen.getAllByText('facts unavailable').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByLabelText(/follow-ons override/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/active fmv override/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^0$/)).not.toBeInTheDocument();
+  });
+
+  it('renders currency-blocked values as muted text and never as zero', async () => {
+    const response = availableResponse([makeCurrencyBlockedSeed()]);
+    pickerState.hookResult = {
+      seeds: response.seeds,
+      response,
+      isLoading: false,
+      error: null,
+    };
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(screen.getByRole('radio', { name: /company 103/i }));
+
+    expect(screen.getAllByText('currency blocked').length).toBeGreaterThanOrEqual(3);
+    expect(screen.queryByText(/^0$/)).not.toBeInTheDocument();
+  });
+
+  it('renders a failed facts envelope without a selectable seed', () => {
+    pickerState.hookResult = {
+      seeds: [],
+      response: failedResponse(),
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker();
+
+    expect(screen.getByText(/seed facts are unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+
+  it('reveals an explicit input when a seeded field is deselected', async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(screen.getByRole('radio', { name: /company 101/i }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /use observed investment/i });
+    expect(checkbox).toBeChecked();
+    await user.click(checkbox);
+
+    expect(screen.getByLabelText(/observed investment override/i)).toBeInTheDocument();
+  });
+
+  it('blocks submit until every explicit input is supplied', async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(screen.getByRole('radio', { name: /company 101/i }));
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(await screen.findAllByText('Required')).toHaveLength(5);
+  });
+
+  it('hides mutation for locked scenarios', () => {
+    renderPicker({
+      scenario: {
+        id: SCENARIO_ID,
+        version: 4,
+        locked_at: '2026-07-13T18:00:00.000Z',
+      },
+    });
+
+    expect(screen.getByText('Scenario is locked')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /create case/i })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the feature flag is off', () => {
+    pickerState.flagEnabled = false;
+
+    const { container } = renderPicker();
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('posts the selected seed with one Idempotency-Key and invalidates workspace data', async () => {
+    const user = userEvent.setup();
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          scenarioCaseId: SCENARIO_CASE_ID,
+          scenarioId: SCENARIO_ID,
+          scenarioVersion: 5,
+          seededAt: '2026-07-13T19:53:05.111Z',
+          replay: false,
+        },
+        201
+      )
+    );
+    globalThis.fetch = fetchSpy;
+    const { invalidateSpy } = renderPicker();
+
+    await selectLiveSeedAndFillRequiredInputs(user);
+    await user.click(screen.getByRole('checkbox', { name: /use observed investment/i }));
+    await user.type(screen.getByLabelText(/observed investment override/i), '600000');
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Idempotency-Key']).toEqual(expect.any(String));
+    expect(JSON.parse(String(init.body))).toEqual({
+      seed: makeLiveSeed(),
+      overrides: {
+        caseName: 'Base case',
+        probability: '0.4',
+        exitValuation: '20000000',
+        ownershipAtExit: '0.2',
+        monthsToExit: 36,
+        investment: '600000',
+      },
+      expectedScenarioVersion: 4,
+    });
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['fund-scenario-workspace', '7'],
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['fund-scenario-analysis', '7', 'seeds'],
+      });
+    });
+  });
+
+  it('shows a retryable message on version conflict and does not auto-retry', async () => {
+    const user = userEvent.setup();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ error: 'version_conflict', message: 'stale' }, 409));
+    globalThis.fetch = fetchSpy;
+    renderPicker();
+
+    await selectLiveSeedAndFillRequiredInputs(user);
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+
+    expect(await screen.findByText(/scenario changed.*try again/i)).toBeInTheDocument();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes disclosed seeds when the server rejects a stale seed', async () => {
+    const user = userEvent.setup();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ error: 'seed_conflict', message: 'stale seed' }, 409));
+    globalThis.fetch = fetchSpy;
+    const { invalidateSpy } = renderPicker();
+
+    await selectLiveSeedAndFillRequiredInputs(user);
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+
+    expect(await screen.findByText(/portfolio actuals changed.*refresh/i)).toBeInTheDocument();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['fund-scenario-analysis', '7', 'seeds'],
+    });
+  });
+
+  it('shows staleness without mutating anything', () => {
+    renderPicker({ createdFromFactsHash: 'a'.repeat(64) });
+
+    expect(screen.getByText('seed has changed since creation')).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('opens in discovery-only mode without issuing a mutation when no scenario is supplied', () => {
+    renderPicker({ scenario: null });
+
+    expect(screen.getByText(/select a company scenario to create a case/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /create case/i })).not.toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape through the dialog focus trap', async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderPicker();
+
+    await user.keyboard('{Escape}');
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/hooks/useFundScenarioSeeds.test.tsx
+++ b/tests/unit/hooks/useFundScenarioSeeds.test.tsx
@@ -1,0 +1,73 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  FundScenarioSeedsResponseSchema,
+  useFundScenarioSeeds,
+} from '@/hooks/useFundScenarioSeeds';
+import { fundScenarioSeedsQueryKey } from '@/lib/fund-scenario-workspace-query-keys';
+import { apiRequest } from '@/lib/queryClient';
+
+const flagState = vi.hoisted(() => ({ enabled: true }));
+
+vi.mock('@/core/flags/flagAdapter', () => ({
+  useFeatureFlag: () => flagState.enabled,
+}));
+
+vi.mock('@/lib/queryClient', async (orig) => {
+  const actual = await orig<typeof import('@/lib/queryClient')>();
+  return { ...actual, apiRequest: vi.fn() };
+});
+
+const mockApiRequest = vi.mocked(apiRequest);
+
+const responseFixture = FundScenarioSeedsResponseSchema.parse({
+  fundId: 7,
+  asOfDate: '2026-07-13',
+  factsStatus: 'available',
+  factsInputHash: 'a'.repeat(64),
+  seeds: [],
+});
+
+function wrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useFundScenarioSeeds', () => {
+  beforeEach(() => {
+    flagState.enabled = true;
+    mockApiRequest.mockReset();
+  });
+
+  it('fetches and parses the fund seed envelope with the canonical query key', async () => {
+    mockApiRequest.mockResolvedValue(responseFixture);
+
+    const { result } = renderHook(() => useFundScenarioSeeds('7'), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockApiRequest).toHaveBeenCalledWith('GET', '/api/funds/7/scenario-analysis/seeds');
+    expect(result.current.response).toEqual(responseFixture);
+    expect(fundScenarioSeedsQueryKey('7')).toEqual(['fund-scenario-analysis', '7', 'seeds']);
+  });
+
+  it('does not fetch without a fund id', () => {
+    const { result } = renderHook(() => useFundScenarioSeeds(null), { wrapper: wrapper() });
+
+    expect(mockApiRequest).not.toHaveBeenCalled();
+    expect(result.current.seeds).toEqual([]);
+  });
+
+  it('does not fetch while the client flag is off', () => {
+    flagState.enabled = false;
+
+    const { result } = renderHook(() => useFundScenarioSeeds('7'), { wrapper: wrapper() });
+
+    expect(mockApiRequest).not.toHaveBeenCalled();
+    expect(result.current.seeds).toEqual([]);
+  });
+});

--- a/tests/unit/pages/fund-scenario-workspace.test.tsx
+++ b/tests/unit/pages/fund-scenario-workspace.test.tsx
@@ -34,6 +34,7 @@ describe('FundScenarioWorkspacePage', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
@@ -122,6 +123,18 @@ describe('FundScenarioWorkspacePage', () => {
 
       if (method === 'GET' && url === '/api/funds/123/results') {
         return Promise.resolve(jsonResponse(fundResultsResponse()));
+      }
+
+      if (method === 'GET' && url === '/api/funds/123/scenario-analysis/seeds') {
+        return Promise.resolve(
+          jsonResponse({
+            fundId: 123,
+            asOfDate: '2026-07-13',
+            factsStatus: 'failed',
+            factsInputHash: null,
+            seeds: [],
+          })
+        );
       }
 
       if (method === 'GET' && url.endsWith('/comparison')) {
@@ -562,6 +575,37 @@ describe('FundScenarioWorkspacePage', () => {
         !url.includes('/calculate')
     );
     expect(createPosts).toHaveLength(0);
+  });
+
+  it('renders no seed-picker entry while the flag is off', async () => {
+    vi.stubEnv('VITE_ENABLE_SCENARIO_SEED_PICKER', 'false');
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    expect(await screen.findByText('Scenario Workspace')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /start case from portfolio actuals/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the flag-gated picker without issuing a case mutation', async () => {
+    vi.stubEnv('VITE_ENABLE_SCENARIO_SEED_PICKER', 'true');
+    mockWorkspaceFetches();
+    renderWorkspace();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /start case from portfolio actuals/i })
+    );
+
+    expect(
+      await screen.findByRole('dialog', { name: /start case from portfolio actuals/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/select a company scenario to create a case/i)).toBeInTheDocument();
+    const caseMutations = fetchSpy.mock.calls.filter(([input, init]) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      return url.endsWith('/cases/from-seed') && (init?.method ?? 'GET') === 'POST';
+    });
+    expect(caseMutations).toHaveLength(0);
   });
 });
 
@@ -1013,10 +1057,7 @@ function syncCalculationPayload({
   name,
 }: {
   calculationMode:
-    | 'sync_fee_profile'
-    | 'sync_allocation'
-    | 'sync_sector_profile'
-    | 'sync_methodology';
+    'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile' | 'sync_methodology';
   scenarioSetId: string;
   variantId: string;
   overrideType: 'fee_profile' | 'allocation' | 'sector_profile' | 'methodology';

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -161,6 +161,19 @@ describe('route policy coverage', () => {
     expect(policy.provenanceRequired).toBe(true);
   });
 
+  it('classifies from-seed case creation as a fund-scoped provenance mutation', () => {
+    const policy = expectPolicy(
+      'POST /api/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed'
+    );
+
+    expect(policy.governanceRef).toBe('/fund-model-results/:fundId/scenarios');
+    expect(policy.financialSurface).toBe('fund_modeling');
+    expect(policy.apiAuthBoundary).toBe('require_auth_and_fund_access');
+    expect(policy.fundScopeMode).toBe('route_param_fund_id');
+    expect(policy.exportPolicy).toBe('not_exportable');
+    expect(policy.provenanceRequired).toBe(true);
+  });
+
   it('covers PRD #996 Surface-A report-package exports with role-gated fund access', () => {
     for (const key of LP_REPORT_PACKAGE_EXPORT_POLICY_KEYS) {
       const policyEntry = expectPolicy(key);

--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -7,9 +7,14 @@ import {
   FundCompanyActualsFactSchema,
   type FundCompanyActualsFact,
 } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import {
+  ScenarioCaseSeedV1Schema,
+  type ScenarioCaseSeedV1,
+} from '../../../shared/contracts/scenarios/scenario-case-seed-v1.contract';
 
 const fundScopeState = vi.hoisted(() => ({
   enforceCompanyFundScope: vi.fn(async (_req: Request, _res: Response, _companyId: number) => true),
+  resolveCompanyFundId: vi.fn(async (_companyId: number) => 7 as number | null | undefined),
 }));
 
 const fundAccessState = vi.hoisted(() => ({
@@ -35,14 +40,37 @@ const factsState = vi.hoisted(() => {
   };
 });
 
+const persistenceState = vi.hoisted(() => {
+  class ScenarioCaseSeedPersistenceError extends Error {
+    readonly status: number;
+    readonly code: string;
+    readonly details?: unknown;
+
+    constructor(status: number, code: string, message: string, details?: unknown) {
+      super(message);
+      this.name = 'ScenarioCaseSeedPersistenceError';
+      this.status = status;
+      this.code = code;
+      this.details = details;
+    }
+  }
+
+  return {
+    createScenarioCaseFromSeed: vi.fn(),
+    ScenarioCaseSeedPersistenceError,
+  };
+});
+
 // Chain-safe db stub: every builder method is a spy; terminal awaits resolve to
 // empty/benign values so a neutered guard (negative control) falls through to a
 // harmless 404 instead of throwing mid-chain before the assertion runs.
 const dbState = vi.hoisted(() => {
   const selectChain: Record<string, unknown> = {};
   selectChain['from'] = vi.fn(() => selectChain);
+  selectChain['innerJoin'] = vi.fn(() => selectChain);
   selectChain['where'] = vi.fn(() => selectChain);
-  selectChain['limit'] = vi.fn(async () => [] as unknown[]);
+  const selectLimit = vi.fn(async () => [] as unknown[]);
+  selectChain['limit'] = selectLimit;
 
   const insertChain: Record<string, unknown> = {};
   insertChain['values'] = vi.fn(() => insertChain);
@@ -61,11 +89,12 @@ const dbState = vi.hoisted(() => {
   const remove = vi.fn(() => deleteChain);
   const transaction = vi.fn(async () => undefined);
   const findFirst = vi.fn(async () => undefined);
-  return { select, insert, update, remove, transaction, findFirst };
+  return { select, selectLimit, insert, update, remove, transaction, findFirst };
 });
 
 vi.mock('../../../server/lib/auth/company-fund-scope', () => ({
   enforceCompanyFundScope: fundScopeState.enforceCompanyFundScope,
+  resolveCompanyFundId: fundScopeState.resolveCompanyFundId,
 }));
 
 vi.mock('../../../server/lib/auth/jwt', () => ({
@@ -76,6 +105,11 @@ vi.mock('../../../server/lib/auth/jwt', () => ({
 vi.mock('../../../server/services/fund-actuals/fund-company-actuals-facts-service', () => ({
   buildFundCompanyActualsFacts: factsState.buildFundCompanyActualsFacts,
   FundActualsFactsServiceError: factsState.FundActualsFactsServiceError,
+}));
+
+vi.mock('../../../server/services/scenarios/scenario-case-seed-persistence-service', () => ({
+  createScenarioCaseFromSeed: persistenceState.createScenarioCaseFromSeed,
+  ScenarioCaseSeedPersistenceError: persistenceState.ScenarioCaseSeedPersistenceError,
 }));
 
 vi.mock('../../../server/db', () => ({
@@ -91,7 +125,8 @@ vi.mock('../../../server/db', () => ({
 
 import scenarioAnalysisRouter from '../../../server/routes/scenario-analysis';
 
-const SCENARIO_ID = '00000000-0000-0000-0000-000000000101';
+const SCENARIO_ID = '00000000-0000-4000-8000-000000000101';
+const SCENARIO_CASE_ID = '00000000-0000-4000-8000-000000000201';
 
 function makeApp() {
   const app = express();
@@ -113,7 +148,11 @@ function denyOnce() {
 function resetState() {
   fundScopeState.enforceCompanyFundScope.mockReset();
   fundScopeState.enforceCompanyFundScope.mockResolvedValue(true);
+  fundScopeState.resolveCompanyFundId.mockReset();
+  fundScopeState.resolveCompanyFundId.mockResolvedValue(7);
   dbState.select.mockClear();
+  dbState.selectLimit.mockReset();
+  dbState.selectLimit.mockResolvedValue([]);
   dbState.insert.mockClear();
   dbState.update.mockClear();
   dbState.remove.mockClear();
@@ -124,6 +163,7 @@ function resetState() {
     (_req: Request, _res: Response, next: NextFunction) => next()
   );
   factsState.buildFundCompanyActualsFacts.mockReset();
+  persistenceState.createScenarioCaseFromSeed.mockReset();
 }
 
 function denyFundAccessOnce() {
@@ -216,6 +256,59 @@ function factsResponse(asOfDate = '2026-07-13') {
     facts: [makeFact(), makeBlockedFact()],
     inputHash: '9'.repeat(64),
     generatedAt: '2026-07-13T00:00:00.000Z',
+  };
+}
+
+function makeSeed(overrides: Partial<ScenarioCaseSeedV1> = {}): ScenarioCaseSeedV1 {
+  return ScenarioCaseSeedV1Schema.parse({
+    contractVersion: 'scenario-case-seed-v1',
+    fundId: 7,
+    companyId: 101,
+    asOfDate: '2026-07-13',
+    factsInputHash: 'c'.repeat(64),
+    trustState: 'LIVE',
+    currencyStatus: 'base_currency',
+    fields: {
+      investment: {
+        status: 'seeded',
+        value: '500000.000000',
+        source: 'facts.initialInvestmentAmount',
+      },
+      followOns: {
+        status: 'seeded',
+        value: '250000.000000',
+        source: 'facts.followOnInvestmentAmount',
+      },
+      fmv: {
+        status: 'seeded',
+        value: '14000000.000000',
+        source: 'facts.latestPlanningFmvValue',
+      },
+      exitValuation: {
+        status: 'user_required',
+        value: null,
+        marketReference: '12000000.000000',
+      },
+      probability: { status: 'user_required', value: null },
+      ownershipAtExit: { status: 'user_required', value: null },
+    },
+    warnings: [],
+    ...overrides,
+  });
+}
+
+function validFromSeedBody(overrides: Record<string, unknown> = {}) {
+  return {
+    seed: makeSeed(),
+    overrides: {
+      caseName: 'Base case',
+      probability: '0.40',
+      exitValuation: '20000000.000000',
+      monthsToExit: 36,
+      ownershipAtExit: '0.20',
+    },
+    expectedScenarioVersion: 4,
+    ...overrides,
   };
 }
 
@@ -454,5 +547,245 @@ describe('scenario-analysis actuals-backed seed suggestions', () => {
     });
     expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
     expectNoScenarioWrites();
+  });
+});
+
+describe('scenario-analysis from-seed case creation', () => {
+  beforeEach(() => {
+    resetState();
+    factsState.buildFundCompanyActualsFacts.mockResolvedValue(factsResponse());
+  });
+
+  it('rejects an invalid fund before fund access and persistence', async () => {
+    const res = await request(makeApp())
+      .post(`/api/funds/07/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-1')
+      .send(validFromSeedBody());
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_fund_id');
+    expect(fundAccessState.requireFundAccess).not.toHaveBeenCalled();
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('enforces fund access before scenario and body validation', async () => {
+    denyFundAccessOnce();
+
+    const res = await request(makeApp())
+      .post('/api/funds/7/scenario-analysis/scenarios/not-a-uuid/cases/from-seed')
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid scenario id before body validation', async () => {
+    const res = await request(makeApp())
+      .post('/api/funds/7/scenario-analysis/scenarios/not-a-uuid/cases/from-seed')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_scenario_id');
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('validates the strict body before requiring an idempotency key', async () => {
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .send({ ...validFromSeedBody(), unexpected: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('requires the Idempotency-Key header', async () => {
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .send(validFromSeedBody());
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('missing_idempotency_key');
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('rejects a seed from another fund before calling persistence', async () => {
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-2')
+      .send(validFromSeedBody({ seed: makeSeed({ fundId: 8 }) }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('seed_fund_mismatch');
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('rejects a seed whose company belongs to another fund before calling persistence', async () => {
+    fundScopeState.resolveCompanyFundId.mockResolvedValueOnce(8);
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-company-scope')
+      .send(validFromSeedBody());
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('company_mismatch');
+    expect(fundScopeState.resolveCompanyFundId).toHaveBeenCalledWith(101);
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('rejects a structurally valid seed that differs from server-generated actuals', async () => {
+    const seed = makeSeed();
+    const tamperedSeed = ScenarioCaseSeedV1Schema.parse({
+      ...seed,
+      fields: {
+        ...seed.fields,
+        investment: {
+          ...seed.fields.investment,
+          value: '999999.000000',
+        },
+      },
+    });
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-tampered')
+      .send(validFromSeedBody({ seed: tamperedSeed }));
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('seed_conflict');
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: '2026-07-13',
+    });
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it('creates a case and returns the strict route response', async () => {
+    const seededAt = new Date('2026-07-13T19:53:05.111Z');
+    const body = validFromSeedBody();
+    persistenceState.createScenarioCaseFromSeed.mockResolvedValueOnce({
+      case: { id: SCENARIO_CASE_ID, scenarioId: SCENARIO_ID },
+      provenance: { seededAt },
+      replayed: false,
+    });
+    dbState.findFirst.mockResolvedValueOnce({ version: 5 });
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-3')
+      .send(body);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      scenarioCaseId: SCENARIO_CASE_ID,
+      scenarioId: SCENARIO_ID,
+      scenarioVersion: 5,
+      seededAt: seededAt.toISOString(),
+      replay: false,
+    });
+    expect(persistenceState.createScenarioCaseFromSeed).toHaveBeenCalledWith({
+      scenarioId: SCENARIO_ID,
+      expectedScenarioVersion: 4,
+      seed: body.seed,
+      overrides: body.overrides,
+      actor: { userId: null },
+      idempotencyKey: 'seed-create-3',
+    });
+  });
+
+  it('returns the original replay after facts drift following a successful create', async () => {
+    const seededAt = new Date('2026-07-13T19:53:05.111Z');
+    const body = validFromSeedBody();
+    dbState.selectLimit
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ scenarioId: SCENARIO_ID }]);
+    persistenceState.createScenarioCaseFromSeed
+      .mockResolvedValueOnce({
+        case: { id: SCENARIO_CASE_ID, scenarioId: SCENARIO_ID },
+        provenance: { seededAt },
+        replayed: false,
+      })
+      .mockResolvedValueOnce({
+        case: { id: SCENARIO_CASE_ID, scenarioId: SCENARIO_ID },
+        provenance: { seededAt },
+        replayed: true,
+      });
+    dbState.findFirst.mockResolvedValueOnce({ version: 5 }).mockResolvedValueOnce({ version: 17 });
+
+    const first = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-replay')
+      .send(body);
+
+    expect(first.status).toBe(201);
+    expect(first.body.replay).toBe(false);
+
+    factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce({
+      ...factsResponse(),
+      facts: [
+        makeFact({
+          initialInvestmentAmount: '600000.000000',
+          inputHash: 'd'.repeat(64),
+        }),
+      ],
+      inputHash: '8'.repeat(64),
+    });
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-replay')
+      .send(body);
+
+    expect(res.status).toBe(201);
+    expect(res.body.replay).toBe(true);
+    expect(res.body.scenarioVersion).toBe(17);
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an idempotency key already associated with another scenario', async () => {
+    dbState.selectLimit.mockResolvedValueOnce([
+      { scenarioId: '00000000-0000-4000-8000-000000000102' },
+    ]);
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-other-scenario')
+      .send(validFromSeedBody());
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('idempotency_conflict');
+    expect(factsState.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['scenario_not_found', 404, 404],
+    ['scenario_locked', 409, 423],
+    ['version_conflict', 409, 409],
+    ['missing_required_override', 422, 400],
+    ['company_mismatch', 422, 400],
+    ['idempotency_conflict', 409, 409],
+  ])('maps %s to HTTP %i', async (code, serviceStatus, expectedStatus) => {
+    persistenceState.createScenarioCaseFromSeed.mockRejectedValueOnce(
+      new persistenceState.ScenarioCaseSeedPersistenceError(
+        serviceStatus,
+        code,
+        `Persistence rejected ${code}`,
+        { code }
+      )
+    );
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', `seed-create-${code}`)
+      .send(validFromSeedBody());
+
+    expect(res.status).toBe(expectedStatus);
+    expect(res.body).toEqual({
+      error: code,
+      message: `Persistence rejected ${code}`,
+      details: { code },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Plan 8 wave 3 (Task 8.4 + route exposure) — wires #1100's persistence service to a route and ships the seed-picker UI behind a default-false flag.

- **Route** `POST /api/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed` on the existing router/mount: `requireAuth` -> strict fundId (400) -> `requireFundAccess` (403) -> strict body/uuid validation -> required `Idempotency-Key` header (400 `missing_idempotency_key`) -> seed.fundId/param match check -> `createScenarioCaseFromSeed`. Typed-error mapping: not-found 404, **locked 423**, version/idempotency conflicts 409, missing-override/company-mismatch 400; 201 with a strict response incl. `replay` flag. Route-policy registry entry added; policy coverage suite green.
- **Flag** `enable_scenario_seed_picker` (default false, all envs false, `exposeToClient: true`) + regenerated flag files + client flag map registration.
- **Client**: `useFundScenarioSeeds` hook (flag-gated, fund-scoped query) and `ScenarioFactsSeedPicker` — self-contained shadcn Dialog showing observed investment/follow-ons/active FMV/trust/currency/as-of/short hash per company, latest-round valuation labeled "market reference — not seeded", per-field deselection, explicit probability/exit valuation/ownership/timing/case-name inputs with no defaults, snapshot copy ("will not update automatically"), locked scenarios hidden (423-safe), unavailable money rendered as reasons ("currency blocked"/"facts unavailable") never zero or green. Idempotency-Key from a useRef'd `crypto.randomUUID()`; no auto-retry on writes.

## Scope decision (verified drift, documented)

No scenario-case CRUD UI exists anywhere today — the workspace page owns scenario *sets* and the company-scenarios API is UI-orphaned. The picker therefore ships as a self-contained modal with a **flag-gated** workspace entry ("Start case from portfolio actuals", renders nothing while the flag is off — the default everywhere). Plan 9 Task 9.2 re-homes the entry point from company rows; flipping the flag stays a deliberate activation step.

## Verification

- 59/59 server tests (route contract incl. guard order 400/403/404/423/409/replay + route-policy coverage) and 33/33 client tests (picker states incl. per-field unavailability, deselect flow, required-input enforcement, locked hidden, flag-off renders nothing, Idempotency-Key posting; fixtures validated with `ScenarioCaseSeedV1Schema.parse`) — run independently post-implementation.
- `npm run check` 0 TS errors; ESLint clean.
- Reminder residual: migration 0032 must be applied to prod via the protected reconcile workflow (M8 manifest ready) before this flag is ever enabled in production.

Spec: Plan 8 (line 3118) + amendments; Hermes/Codex lane, Claude-verified. Remaining Plan 8 waves: 8.5 scenario hash, 8.6-8.8 Monte Carlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h