### PR TITLE
feat(moic): facts basis, hash-frozen disclosure, shadow telemetry (Plan 6 wave 1 / PR 6A)

### DIFF
--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -49,6 +49,7 @@ import {
   type MarginalReserveRankingItemV1,
 } from '../../shared/contracts/marginal-reserve-moic-v1.contract.js';
 import { buildMarginalReserveMoicInputs } from '../services/moic/marginal-reserve-moic-input-service.js';
+import { emitFundMoicFactsShadowTelemetry } from '../services/moic/fund-moic-facts-shadow-telemetry.js';
 
 const router = Router();
 
@@ -228,6 +229,8 @@ router.get(
       });
     }
 
+    const factsShadowStartedAt = performance.now();
+
     // TODO(perf): this loads the full company-actuals facts corpus (~6 queries + hash in
     // fund-company-actuals-facts-service) for provenance and disclosure. Per-company facts
     // are not used in ranking values. MOIC analysis is a low-frequency GP page today, so ship
@@ -329,7 +332,16 @@ router.get(
       generatedAt: new Date().toISOString(),
     };
 
-    return res.json(FundMoicRankingsResponseV2Schema.parse(response));
+    const parsedResponse = FundMoicRankingsResponseV2Schema.parse(response);
+    if (modePreview.effectiveMode === 'shadow' || modePreview.effectiveMode === 'on') {
+      emitFundMoicFactsShadowTelemetry({
+        fundId,
+        factsInputHash: actualsProvenanceSummary.factsInputHash,
+        sources,
+        durationMs: performance.now() - factsShadowStartedAt,
+      });
+    }
+    return res.json(parsedResponse);
   })
 );
 

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -228,32 +228,18 @@ router.get(
       });
     }
 
-    const [sources, latestReconciliation, evidence] = await Promise.all([
-      getFundMoicRankingSources(fundId),
-      getLatestCompletedMoicReconciliation(fundId),
-      buildRoundsToModelEvidence({ fundId }),
-    ]);
     // TODO(perf): this loads the full company-actuals facts corpus (~6 queries + hash in
-    // fund-company-actuals-facts-service) only to tally trustState counts; per-company facts
+    // fund-company-actuals-facts-service) for provenance and disclosure. Per-company facts
     // are not used in ranking values. MOIC analysis is a low-frequency GP page today, so ship
     // as-is, but memoize per (fundId, asOfDate) or expose a count-only facts helper if this page
     // becomes polled or the corpus grows. Tracked as a separate low-priority GitHub perf issue.
     const actualsAsOfDate = new Date().toISOString().slice(0, 10);
-    const sourceCompanyCount = sources.legacy.provenance.sourceRecordCount;
-    let actualsProvenanceSummary: ReturnType<typeof summarizeMoicActualsProvenance>;
+    let actualsFacts: Awaited<ReturnType<typeof buildFundCompanyActualsFacts>> | null = null;
 
     try {
-      const actualsFacts = await buildFundCompanyActualsFacts({
+      actualsFacts = await buildFundCompanyActualsFacts({
         fundId,
         asOfDate: actualsAsOfDate,
-      });
-      actualsProvenanceSummary = summarizeMoicActualsProvenance({
-        factsStatus: 'available',
-        factsInputHash: actualsFacts.inputHash,
-        trustStates: actualsFacts.facts.map((fact) => fact.provenance.trustState),
-        defaultedEconomicInputCount:
-          sources.moicInputSummary.defaultedExitProbabilityCount +
-          sources.moicInputSummary.defaultedReserveExitMultipleCount,
       });
     } catch (error) {
       // Disclosed to the client via warnings, but not silent server-side: operators need the reason.
@@ -265,6 +251,29 @@ router.get(
         },
         'fund-moic v2 actuals facts load failed; returning UNAVAILABLE provenance summary'
       );
+    }
+
+    const factsByCompanyId = actualsFacts
+      ? new Map(actualsFacts.facts.map((fact) => [fact.companyId, fact] as const))
+      : undefined;
+    const [sources, latestReconciliation, evidence] = await Promise.all([
+      getFundMoicRankingSources(fundId, undefined, factsByCompanyId),
+      getLatestCompletedMoicReconciliation(fundId),
+      buildRoundsToModelEvidence({ fundId }),
+    ]);
+    const sourceCompanyCount = sources.legacy.provenance.sourceRecordCount;
+    let actualsProvenanceSummary: ReturnType<typeof summarizeMoicActualsProvenance>;
+
+    if (actualsFacts) {
+      actualsProvenanceSummary = summarizeMoicActualsProvenance({
+        factsStatus: 'available',
+        factsInputHash: actualsFacts.inputHash,
+        trustStates: actualsFacts.facts.map((fact) => fact.provenance.trustState),
+        defaultedEconomicInputCount:
+          sources.moicInputSummary.defaultedExitProbabilityCount +
+          sources.moicInputSummary.defaultedReserveExitMultipleCount,
+      });
+    } else {
       actualsProvenanceSummary = summarizeMoicActualsProvenance({
         factsStatus: 'failed',
         factsInputHash: null,
@@ -291,7 +300,7 @@ router.get(
     const response: FundMoicRankingsResponseV2 = {
       contractVersion: '2.1.0',
       fundId,
-      rankings: discloseFundMoicRankings(rankings).rankings,
+      rankings: discloseFundMoicRankings(rankings, sources.factsBasisByInvestmentId).rankings,
       provenance: {
         mode: usingCandidateRankings ? 'candidate' : 'legacy',
         warnings: modePreview.blockers,

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -14,6 +14,7 @@ import {
   MOIC_MATERIALITY_EPSILON,
 } from '../services/fund-moic-materiality.js';
 import {
+  discloseFundMoicRankings,
   getFundMoicRankingSources,
   summarizeMoicActualsProvenance,
 } from '../services/fund-moic-ranking-service.js';
@@ -217,7 +218,7 @@ router.get(
         modePreview.effectiveMode === 'on' && actionability.actionability === 'actionable'
           ? sources.candidate
           : sources.legacy;
-      return res.json(rankings);
+      return res.json(discloseFundMoicRankings(rankings));
     }
 
     if (contract !== 'v2') {
@@ -290,7 +291,7 @@ router.get(
     const response: FundMoicRankingsResponseV2 = {
       contractVersion: '2.1.0',
       fundId,
-      rankings: rankings.rankings,
+      rankings: discloseFundMoicRankings(rankings).rankings,
       provenance: {
         mode: usingCandidateRankings ? 'candidate' : 'legacy',
         warnings: modePreview.blockers,

--- a/server/services/fund-moic-materiality.ts
+++ b/server/services/fund-moic-materiality.ts
@@ -1,6 +1,8 @@
 /** No-op/materiality detector for MOIC reconciliation using epsilon-based rank-or-value sensitivity. */
 import type { FundMoicRankingItemV1 } from '../../shared/contracts/fund-moic-v1.contract';
 
+type MaterialityRankingItem = Pick<FundMoicRankingItemV1, 'investmentId' | 'rank' | 'reservesMoic'>;
+
 export const MOIC_MATERIALITY_EPSILON = 1e-8;
 
 export interface MoicMaterialityResult {
@@ -12,8 +14,8 @@ export interface MoicMaterialityResult {
 }
 
 export function assessMoicMateriality(
-  legacy: readonly FundMoicRankingItemV1[],
-  candidate: readonly FundMoicRankingItemV1[],
+  legacy: readonly MaterialityRankingItem[],
+  candidate: readonly MaterialityRankingItem[],
   epsilon: number = MOIC_MATERIALITY_EPSILON
 ): MoicMaterialityResult {
   const candidateById = new Map(candidate.map((item) => [item.investmentId, item]));

--- a/server/services/fund-moic-ranking-service.ts
+++ b/server/services/fund-moic-ranking-service.ts
@@ -2,7 +2,11 @@ import { db } from '../db';
 import { MOICCalculator } from '../../shared/core/moic/MOICCalculator.js';
 import type { Investment as MOICInvestment } from '../../shared/core/moic/MOICCalculator.js';
 import { dbToMOICInvestment } from '../lib/moic-mapper.js';
-import type { FundMoicRankingsResponseV1 } from '../../shared/contracts/fund-moic-v1.contract.js';
+import type {
+  FundMoicFactsBasisV1,
+  FundMoicRankingItemV1,
+  FundMoicRankingsResponseV1,
+} from '../../shared/contracts/fund-moic-v1.contract.js';
 import { canonicalSha256 } from '../../shared/lib/canonical-hash';
 
 export const MOIC_CANDIDATE_SOURCE_VERSION = 'moic-exit-probability-v1';
@@ -19,10 +23,19 @@ export interface FundMoicInputSummary {
 }
 
 export interface FundMoicRankingSources {
-  legacy: FundMoicRankingsResponseV1;
-  candidate: FundMoicRankingsResponseV1;
+  legacy: FundMoicRankingSourceResponse;
+  candidate: FundMoicRankingSourceResponse;
   moicInputSummary: FundMoicInputSummary;
   moicSourceInputHash: string;
+}
+
+export type FundMoicRankingSourceItem = Omit<FundMoicRankingItemV1, 'factsBasis'>;
+
+export interface FundMoicRankingSourceResponse extends Omit<
+  FundMoicRankingsResponseV1,
+  'rankings'
+> {
+  rankings: FundMoicRankingSourceItem[];
 }
 
 export function summarizeMoicActualsProvenance(input: {
@@ -47,7 +60,7 @@ export function summarizeMoicActualsProvenance(input: {
   };
 }
 
-type PortfolioCompanyMoicSourceRow = {
+export type PortfolioCompanyMoicSourceRow = {
   id: number;
   fundId?: number | null;
   name: string;
@@ -161,10 +174,10 @@ function buildCandidateMoicInvestment(row: PortfolioCompanyMoicSourceRow): Candi
   };
 }
 
-export function buildMoicRankingsFromInvestments(
+function buildMoicRankingSourceFromInvestments(
   fundId: number,
   investments: MOICInvestment[]
-): FundMoicRankingsResponseV1 {
+): FundMoicRankingSourceResponse {
   const ranked = MOICCalculator.rankByReservesMOIC(investments);
 
   return {
@@ -187,6 +200,26 @@ export function buildMoicRankingsFromInvestments(
       },
     })),
   };
+}
+
+export function discloseFundMoicRankings(
+  source: FundMoicRankingSourceResponse,
+  factsBasisByInvestmentId?: ReadonlyMap<string, FundMoicFactsBasisV1>
+): FundMoicRankingsResponseV1 {
+  return {
+    ...source,
+    rankings: source.rankings.map((ranking) => ({
+      ...ranking,
+      factsBasis: factsBasisByInvestmentId?.get(ranking.investmentId) ?? null,
+    })),
+  };
+}
+
+export function buildMoicRankingsFromInvestments(
+  fundId: number,
+  investments: MOICInvestment[]
+): FundMoicRankingsResponseV1 {
+  return discloseFundMoicRankings(buildMoicRankingSourceFromInvestments(fundId, investments));
 }
 
 export function buildMoicRankingSourcesFromCompanies(
@@ -226,8 +259,8 @@ export function buildMoicRankingSourcesFromCompanies(
   });
 
   return {
-    legacy: buildMoicRankingsFromInvestments(fundId, legacyInvestments),
-    candidate: buildMoicRankingsFromInvestments(fundId, candidateInvestments),
+    legacy: buildMoicRankingSourceFromInvestments(fundId, legacyInvestments),
+    candidate: buildMoicRankingSourceFromInvestments(fundId, candidateInvestments),
     moicInputSummary,
     moicSourceInputHash,
   };
@@ -250,5 +283,5 @@ export async function getFundMoicRankings(
   database: FundMoicRankingDatabase = db
 ): Promise<FundMoicRankingsResponseV1> {
   const sources = await getFundMoicRankingSources(fundId, database);
-  return sources.legacy;
+  return discloseFundMoicRankings(sources.legacy);
 }

--- a/server/services/fund-moic-ranking-service.ts
+++ b/server/services/fund-moic-ranking-service.ts
@@ -8,6 +8,8 @@ import type {
   FundMoicRankingsResponseV1,
 } from '../../shared/contracts/fund-moic-v1.contract.js';
 import { canonicalSha256 } from '../../shared/lib/canonical-hash';
+import type { FundCompanyActualsFact } from '../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { buildFundMoicFactsBasis } from './moic/fund-moic-facts-basis';
 
 export const MOIC_CANDIDATE_SOURCE_VERSION = 'moic-exit-probability-v1';
 export const FUND_MOIC_CALCULATION_KEY = 'fund_moic_rankings_exit_probability';
@@ -27,6 +29,7 @@ export interface FundMoicRankingSources {
   candidate: FundMoicRankingSourceResponse;
   moicInputSummary: FundMoicInputSummary;
   moicSourceInputHash: string;
+  factsBasisByInvestmentId?: ReadonlyMap<string, FundMoicFactsBasisV1>;
 }
 
 export type FundMoicRankingSourceItem = Omit<FundMoicRankingItemV1, 'factsBasis'>;
@@ -224,7 +227,8 @@ export function buildMoicRankingsFromInvestments(
 
 export function buildMoicRankingSourcesFromCompanies(
   fundId: number,
-  companies: PortfolioCompanyMoicSourceRow[]
+  companies: PortfolioCompanyMoicSourceRow[],
+  factsByCompanyId?: ReadonlyMap<number, FundCompanyActualsFact>
 ): FundMoicRankingSources {
   const sortedCompanies = [...companies].sort((a, b) => a.id - b.id);
   const legacyInvestments = sortedCompanies.map(buildLegacyMoicInvestment);
@@ -257,25 +261,38 @@ export function buildMoicRankingSourcesFromCompanies(
     rows: candidateInputs.map((input) => input.hashRow),
     sourceVersion: MOIC_CANDIDATE_SOURCE_VERSION,
   });
+  const factsBasisByInvestmentId = factsByCompanyId
+    ? new Map(
+        sortedCompanies.map((company) => [
+          String(company.id),
+          buildFundMoicFactsBasis({
+            company,
+            fact: factsByCompanyId.get(company.id) ?? null,
+          }),
+        ])
+      )
+    : undefined;
 
   return {
     legacy: buildMoicRankingSourceFromInvestments(fundId, legacyInvestments),
     candidate: buildMoicRankingSourceFromInvestments(fundId, candidateInvestments),
     moicInputSummary,
     moicSourceInputHash,
+    ...(factsBasisByInvestmentId !== undefined && { factsBasisByInvestmentId }),
   };
 }
 
 export async function getFundMoicRankingSources(
   fundId: number,
-  database: FundMoicRankingDatabase = db
+  database: FundMoicRankingDatabase = db,
+  factsByCompanyId?: ReadonlyMap<number, FundCompanyActualsFact>
 ): Promise<FundMoicRankingSources> {
   const companies = await database.query.portfolioCompanies.findMany({
     where: (pc, { eq }) => eq(pc.fundId, fundId),
     orderBy: (pc, { asc }) => [asc(pc.id)],
   });
 
-  return buildMoicRankingSourcesFromCompanies(fundId, companies);
+  return buildMoicRankingSourcesFromCompanies(fundId, companies, factsByCompanyId);
 }
 
 export async function getFundMoicRankings(

--- a/server/services/moic/fund-moic-facts-basis.ts
+++ b/server/services/moic/fund-moic-facts-basis.ts
@@ -1,0 +1,174 @@
+import Decimal from '../../../shared/lib/decimal-config';
+import {
+  FundMoicFactsBasisV1Schema,
+  type FundMoicFactsBasisV1,
+} from '../../../shared/contracts/fund-moic-v1.contract';
+import type { FundCompanyActualsFact } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import type { PortfolioCompanyMoicSourceRow } from '../fund-moic-ranking-service';
+
+function legacyValuation(company: PortfolioCompanyMoicSourceRow): string | null {
+  return company.currentValuation === null || company.currentValuation === undefined
+    ? null
+    : new Decimal(company.currentValuation).toDecimalPlaces(6).toString();
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasExplicitExitProbability(company: PortfolioCompanyMoicSourceRow): boolean {
+  const value = finiteNumber(company.exitProbability);
+  return value !== null && value >= 0 && value <= 1;
+}
+
+function hasExplicitReserveExitMultiple(company: PortfolioCompanyMoicSourceRow): boolean {
+  const value = finiteNumber(company.exitMoicBps);
+  return value !== null && value > 0;
+}
+
+function plannedReservesAreZero(company: PortfolioCompanyMoicSourceRow): boolean {
+  const value = finiteNumber(company.plannedReservesCents);
+  return value === null || value <= 0;
+}
+
+function appendEconomicInputReasons(
+  reasons: FundMoicFactsBasisV1['reasons'],
+  company: PortfolioCompanyMoicSourceRow
+): boolean {
+  let missing = false;
+  if (!hasExplicitExitProbability(company)) {
+    reasons.push('exit_probability_missing');
+    missing = true;
+  }
+  if (!hasExplicitReserveExitMultiple(company)) {
+    reasons.push('reserve_exit_multiple_missing');
+    missing = true;
+  }
+  return missing;
+}
+
+export function buildFundMoicFactsBasis(input: {
+  company: PortfolioCompanyMoicSourceRow;
+  fact: FundCompanyActualsFact | null;
+}): FundMoicFactsBasisV1 {
+  if (input.fact === null) {
+    const currentValuation = legacyValuation(input.company);
+    const reasons: FundMoicFactsBasisV1['reasons'] = [
+      currentValuation === null ? 'valuation_unavailable' : 'legacy_current_valuation_fallback',
+    ];
+    let rankability: FundMoicFactsBasisV1['rankability'] =
+      currentValuation === null ? 'not_actionable' : 'indicative';
+    if (plannedReservesAreZero(input.company)) {
+      reasons.push('planned_reserves_zero');
+      rankability = 'not_actionable';
+    }
+    appendEconomicInputReasons(reasons, input.company);
+
+    return FundMoicFactsBasisV1Schema.parse({
+      rankability,
+      reasons,
+      observedInitialInvestment: '0',
+      observedFollowOnInvestment: '0',
+      observedTotalInvestment: '0',
+      valuationAnchor:
+        currentValuation === null
+          ? { kind: 'none', value: null, asOfDate: null }
+          : {
+              kind: 'legacy_current_valuation',
+              value: currentValuation,
+              asOfDate: null,
+            },
+      planningFmvStatus: 'none',
+      currencyStatus: 'unknown',
+      factsInputHash: null,
+      warnings: [
+        {
+          code: 'FACTS_MISSING',
+          severity: 'warning',
+          message: 'Company actuals facts are unavailable; observed investment amounts are zero',
+          source: 'fund-company-actuals-facts',
+        },
+      ],
+    });
+  }
+
+  const hasPlanningFmv =
+    (input.fact.planningFmvStatus === 'active' || input.fact.planningFmvStatus === 'stale') &&
+    input.fact.currencyStatus === 'base_currency' &&
+    input.fact.latestPlanningFmvValue !== null;
+  const currencyBlocked = input.fact.currencyStatus === 'mismatch_blocked';
+  const legacyCurrentValuation = legacyValuation(input.company);
+  const plannedReservesZero = plannedReservesAreZero(input.company);
+
+  let rankability: FundMoicFactsBasisV1['rankability'] = currencyBlocked
+    ? 'not_actionable'
+    : hasPlanningFmv
+      ? input.fact.planningFmvStatus === 'active'
+        ? 'actionable'
+        : 'indicative'
+      : legacyCurrentValuation !== null
+        ? 'indicative'
+        : 'not_actionable';
+  const reasons: FundMoicFactsBasisV1['reasons'] = [];
+  if (currencyBlocked) {
+    reasons.push('currency_blocked');
+  } else if (hasPlanningFmv) {
+    reasons.push(
+      input.fact.planningFmvStatus === 'active' ? 'planning_fmv_active' : 'planning_fmv_stale'
+    );
+  } else if (legacyCurrentValuation !== null) {
+    reasons.push('legacy_current_valuation_fallback');
+  } else {
+    reasons.push('valuation_unavailable');
+  }
+  if (plannedReservesZero) {
+    reasons.push('planned_reserves_zero');
+    rankability = 'not_actionable';
+  }
+  if (appendEconomicInputReasons(reasons, input.company) && rankability === 'actionable') {
+    rankability = 'indicative';
+  }
+  const valuationAnchor = currencyBlocked
+    ? {
+        kind: 'none' as const,
+        value: null,
+        asOfDate: null,
+      }
+    : hasPlanningFmv
+      ? {
+          kind: 'planning_fmv' as const,
+          value: input.fact.latestPlanningFmvValue,
+          asOfDate: input.fact.latestPlanningFmvDate,
+        }
+      : legacyCurrentValuation !== null
+        ? {
+            kind: 'legacy_current_valuation' as const,
+            value: legacyCurrentValuation,
+            asOfDate: null,
+          }
+        : {
+            kind: 'none' as const,
+            value: null,
+            asOfDate: null,
+          };
+
+  return FundMoicFactsBasisV1Schema.parse({
+    rankability,
+    reasons,
+    observedInitialInvestment: input.fact.initialInvestmentAmount,
+    observedFollowOnInvestment: input.fact.followOnInvestmentAmount,
+    observedTotalInvestment: new Decimal(input.fact.initialInvestmentAmount)
+      .plus(input.fact.followOnInvestmentAmount)
+      .toString(),
+    valuationAnchor,
+    planningFmvStatus: input.fact.planningFmvStatus,
+    currencyStatus: input.fact.currencyStatus,
+    factsInputHash: input.fact.inputHash,
+    warnings: input.fact.warnings,
+  });
+}

--- a/server/services/moic/fund-moic-facts-shadow-telemetry.ts
+++ b/server/services/moic/fund-moic-facts-shadow-telemetry.ts
@@ -1,0 +1,85 @@
+import type { FundMoicRankingSources } from '../fund-moic-ranking-service';
+import { logger } from '../../lib/logger';
+
+export interface FundMoicFactsShadowTelemetryEvent {
+  fundId: number;
+  factsInputHash: string | null;
+  companyCount: number;
+  actionableCount: number;
+  indicativeCount: number;
+  notActionableCount: number;
+  legacyTopCompanyId: number | null;
+  factsEligibleTopCompanyId: number | null;
+  topNOverlap: number;
+  defaultedExitProbabilityCount: number;
+  defaultedReserveExitMultipleCount: number;
+  currencyBlockedCount: number;
+  durationMs: number;
+}
+
+export interface FundMoicFactsShadowLogger {
+  info(bindings: FundMoicFactsShadowTelemetryEvent, message: string): void;
+}
+
+function positiveCompanyId(value: string): number | null {
+  if (!/^[1-9]\d*$/.test(value)) return null;
+  const companyId = Number.parseInt(value, 10);
+  return Number.isSafeInteger(companyId) ? companyId : null;
+}
+
+export function buildFundMoicFactsShadowTelemetryEvent(input: {
+  fundId: number;
+  factsInputHash: string | null;
+  sources: FundMoicRankingSources;
+  durationMs: number;
+}): FundMoicFactsShadowTelemetryEvent {
+  const basisByInvestmentId = input.sources.factsBasisByInvestmentId;
+  const rankingBasis = input.sources.legacy.rankings.map((ranking) => ({
+    companyId: positiveCompanyId(ranking.investmentId),
+    basis: basisByInvestmentId?.get(ranking.investmentId) ?? null,
+  }));
+  const actionable = rankingBasis.filter((item) => item.basis?.rankability === 'actionable');
+  const legacyTopCompanyIds = rankingBasis
+    .slice(0, 5)
+    .map((item) => item.companyId)
+    .filter((companyId): companyId is number => companyId !== null);
+  const factsEligibleTopCompanyIds = actionable
+    .map((item) => item.companyId)
+    .filter((companyId): companyId is number => companyId !== null)
+    .slice(0, 5);
+  const eligibleTopSet = new Set(factsEligibleTopCompanyIds);
+
+  return {
+    fundId: input.fundId,
+    factsInputHash: input.factsInputHash?.slice(0, 12) ?? null,
+    companyCount: input.sources.legacy.provenance.sourceRecordCount,
+    actionableCount: actionable.length,
+    indicativeCount: rankingBasis.filter((item) => item.basis?.rankability === 'indicative').length,
+    notActionableCount: rankingBasis.filter((item) => item.basis?.rankability === 'not_actionable')
+      .length,
+    legacyTopCompanyId: rankingBasis[0]?.companyId ?? null,
+    factsEligibleTopCompanyId: factsEligibleTopCompanyIds[0] ?? null,
+    topNOverlap: legacyTopCompanyIds.filter((companyId) => eligibleTopSet.has(companyId)).length,
+    defaultedExitProbabilityCount: input.sources.moicInputSummary.defaultedExitProbabilityCount,
+    defaultedReserveExitMultipleCount:
+      input.sources.moicInputSummary.defaultedReserveExitMultipleCount,
+    currencyBlockedCount: rankingBasis.filter((item) =>
+      item.basis?.reasons.includes('currency_blocked')
+    ).length,
+    durationMs: input.durationMs,
+  };
+}
+
+export function emitFundMoicFactsShadowTelemetry(
+  input: Parameters<typeof buildFundMoicFactsShadowTelemetryEvent>[0],
+  log: FundMoicFactsShadowLogger = logger
+): void {
+  try {
+    log.info(
+      buildFundMoicFactsShadowTelemetryEvent(input),
+      'fund-moic facts-basis shadow comparison generated'
+    );
+  } catch {
+    return;
+  }
+}

--- a/server/services/moic/marginal-reserve-moic-shadow-service.ts
+++ b/server/services/moic/marginal-reserve-moic-shadow-service.ts
@@ -6,6 +6,8 @@ import type {
 import Decimal from '../../../shared/lib/decimal-config';
 import { logger } from '../../lib/logger';
 
+type PlannedRankingItem = Pick<FundMoicRankingItemV1, 'investmentId' | 'rank' | 'reservesMoic'>;
+
 export interface MarginalReserveShadowMetrics {
   top_3_overlap: number;
   top_5_overlap: number;
@@ -45,7 +47,7 @@ export interface MarginalReserveMoicShadowArtifact {
 
 export interface MarginalReserveMoicShadowInput {
   fundId: number;
-  plannedRankings: readonly FundMoicRankingItemV1[];
+  plannedRankings: readonly PlannedRankingItem[];
   marginalRankings: readonly MarginalReserveRankingItemV1[];
   unavailable: readonly MarginalReserveInputFailure[];
   annotationsByInversionId?: Readonly<Record<string, MarginalReserveShadowAnnotationInput>>;
@@ -73,9 +75,7 @@ function positiveCompanyId(value: string): number | null {
   return Number.isSafeInteger(companyId) ? companyId : null;
 }
 
-function plannedActionableRankings(
-  rankings: readonly FundMoicRankingItemV1[]
-): ActionableRanking[] {
+function plannedActionableRankings(rankings: readonly PlannedRankingItem[]): ActionableRanking[] {
   const seen = new Set<number>();
   const ordered = [...rankings].sort((left, right) => {
     const rankOrder = left.rank - right.rank;

--- a/shared/contracts/fund-moic-v1.contract.ts
+++ b/shared/contracts/fund-moic-v1.contract.ts
@@ -1,5 +1,47 @@
 import { z } from 'zod';
 
+import {
+  FundCompanyActualsCurrencyStatusSchema,
+  FundCompanyActualsPlanningFmvStatusSchema,
+  Sha256Schema,
+} from './fund-actuals/fund-company-actuals-fact.contract';
+import { DecimalStringSchema } from './lp-reporting/cash-flow-event.contract';
+import { StructuredWarningSchema } from './provenance-envelope.contract';
+
+export const FundMoicRankabilitySchema = z.enum(['actionable', 'indicative', 'not_actionable']);
+
+export const FundMoicFactsBasisReasonSchema = z.enum([
+  'planning_fmv_active',
+  'planning_fmv_stale',
+  'legacy_current_valuation_fallback',
+  'valuation_unavailable',
+  'currency_blocked',
+  'planned_reserves_zero',
+  'exit_probability_missing',
+  'reserve_exit_multiple_missing',
+]);
+
+export const FundMoicFactsBasisV1Schema = z
+  .object({
+    rankability: FundMoicRankabilitySchema,
+    reasons: z.array(FundMoicFactsBasisReasonSchema),
+    observedInitialInvestment: DecimalStringSchema,
+    observedFollowOnInvestment: DecimalStringSchema,
+    observedTotalInvestment: DecimalStringSchema,
+    valuationAnchor: z
+      .object({
+        kind: z.enum(['planning_fmv', 'legacy_current_valuation', 'none']),
+        value: DecimalStringSchema.nullable(),
+        asOfDate: z.string().date().nullable(),
+      })
+      .strict(),
+    planningFmvStatus: FundCompanyActualsPlanningFmvStatusSchema,
+    currencyStatus: FundCompanyActualsCurrencyStatusSchema,
+    factsInputHash: Sha256Schema.nullable(),
+    warnings: z.array(StructuredWarningSchema),
+  })
+  .strict();
+
 export const FundMoicRankingsProvenanceV1Schema = z
   .object({
     source: z.literal('portfolio_companies'),
@@ -23,13 +65,13 @@ export const FundMoicRankingItemV1Schema = z
     investmentId: z.string(),
     investmentName: z.string(),
     reservesMoic: FundMoicReservesMoicV1Schema,
+    factsBasis: FundMoicFactsBasisV1Schema.nullable(),
   })
   .strict();
 
-export type FundMoicRankingsProvenanceV1 = z.infer<
-  typeof FundMoicRankingsProvenanceV1Schema
->;
+export type FundMoicRankingsProvenanceV1 = z.infer<typeof FundMoicRankingsProvenanceV1Schema>;
 export type FundMoicReservesMoicV1 = z.infer<typeof FundMoicReservesMoicV1Schema>;
+export type FundMoicFactsBasisV1 = z.infer<typeof FundMoicFactsBasisV1Schema>;
 export type FundMoicRankingItemV1 = z.infer<typeof FundMoicRankingItemV1Schema>;
 
 export const FundMoicRankingsResponseV1Schema = z

--- a/shared/contracts/provenance-envelope.contract.ts
+++ b/shared/contracts/provenance-envelope.contract.ts
@@ -16,6 +16,7 @@ export const WarningCodeSchema = z.enum([
   'INVALID_ROUND_AMOUNT',
   'NON_EQUITY_AMOUNT_ONLY',
   'EMPTY_FUND',
+  'FACTS_MISSING',
 ]);
 
 export const StructuredWarningSchema = z

--- a/tests/unit/contract/fund-moic-v1.contract.test.ts
+++ b/tests/unit/contract/fund-moic-v1.contract.test.ts
@@ -18,6 +18,7 @@ function makeValidResponse() {
         rank: 1,
         investmentId: '101',
         investmentName: 'Acme Corp',
+        factsBasis: null,
         reservesMoic: {
           value: 3.5,
           description: 'Expected return on planned reserves',
@@ -91,6 +92,20 @@ describe('FundMoicRankingsResponseV1 contract', () => {
     };
 
     expect(FundMoicRankingsResponseV1Schema.safeParse(withExtraRanking).success).toBe(false);
+  });
+
+  it('requires factsBasis while accepting an explicit null disclosure', () => {
+    const response = makeValidResponse();
+    const [ranking] = response.rankings;
+    const { factsBasis: _factsBasis, ...withoutFactsBasis } = ranking;
+
+    expect(FundMoicRankingsResponseV1Schema.safeParse(response).success).toBe(true);
+    expect(
+      FundMoicRankingsResponseV1Schema.safeParse({
+        ...response,
+        rankings: [withoutFactsBasis],
+      }).success
+    ).toBe(false);
   });
 
   it('rejects unknown reservesMoic keys', () => {

--- a/tests/unit/contract/fund-moic-v2.contract.test.ts
+++ b/tests/unit/contract/fund-moic-v2.contract.test.ts
@@ -8,8 +8,8 @@ import {
 /**
  * Structural allowlist tests for the V2 read contract.
  *
- * PR-E's whole point is that the V2 surface leaks NO ranking values, monetary
- * amounts, raw diffs, or per-investment shadow comparisons. A test that only
+ * The V2 surface permits only the declared ranking values and decimal-string
+ * facts basis; it still rejects raw diffs and shadow comparisons. A test that only
  * checks "a valid payload parses" is vacuous against that goal. So every object
  * here is pinned to an EXACT allowed key set, and `.strict()` is proven to
  * reject an injected forbidden field on each nested object.
@@ -24,6 +24,7 @@ const makeValidV2 = (): FundMoicRankingsResponseV2 => ({
       investmentId: 'inv-a',
       investmentName: 'Acme',
       reservesMoic: { value: 1.5, description: 'desc', formula: 'formula' },
+      factsBasis: null,
     },
   ],
   provenance: { mode: 'legacy', warnings: [] },

--- a/tests/unit/hooks/use-moic-v2.test.tsx
+++ b/tests/unit/hooks/use-moic-v2.test.tsx
@@ -14,6 +14,7 @@ function makeV2Response(fundId: number): FundMoicRankingsResponseV2 {
         rank: 1,
         investmentId: '101',
         investmentName: 'Acme Corp',
+        factsBasis: null,
         reservesMoic: {
           value: 0,
           description: 'Expected return on planned reserves',

--- a/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
+++ b/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
@@ -29,6 +29,7 @@ const canonicalFixture = {
       rank: 1,
       investmentId: '101',
       investmentName: 'Acme Corp',
+      factsBasis: null,
       reservesMoic: {
         value: 2.8,
         description: 'Expected return on planned reserves',
@@ -170,9 +171,7 @@ describe('FundModelResultsMoicAnalysisPage', () => {
     expect(screen.getByText('Facts input hash')).toBeInTheDocument();
     expect(screen.getByText('facts-hash')).toBeInTheDocument();
     expect(screen.getByText('Facts trust')).toBeInTheDocument();
-    expect(
-      screen.getByText('LIVE 2, PARTIAL 1, UNAVAILABLE 1, FAILED 0')
-    ).toBeInTheDocument();
+    expect(screen.getByText('LIVE 2, PARTIAL 1, UNAVAILABLE 1, FAILED 0')).toBeInTheDocument();
     expect(screen.getByText('Defaulted economic inputs')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.queryByText(/marginal next-dollar/i)).not.toBeInTheDocument();

--- a/tests/unit/routes/fund-moic-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-rankings.behavior.test.ts
@@ -294,7 +294,10 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     const res = await getRankings('/api/funds/1/moic/rankings');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(sources.legacy);
+    expect(res.body).toEqual({
+      ...sources.legacy,
+      rankings: sources.legacy.rankings.map((ranking) => ({ ...ranking, factsBasis: null })),
+    });
     expect(res.body).not.toHaveProperty('modePreview');
     expect(res.body).not.toHaveProperty('materiality');
     expect(res.body).not.toHaveProperty('latestReconciliation');

--- a/tests/unit/routes/fund-moic-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-rankings.behavior.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FundMoicRankingsResponseV2Schema } from '../../../shared/contracts/fund-moic-v2.contract';
+import type { FundMoicFactsBasisV1 } from '../../../shared/contracts/fund-moic-v1.contract';
 import type { FundMoicRankingSources } from '../../../server/services/fund-moic-ranking-service';
 import type {
   FundCalculationModePreview,
@@ -11,6 +12,11 @@ import type {
 
 const authState = vi.hoisted(() => ({
   user: null as null | { id: number | string; sub?: string; role: string; fundIds: number[] },
+}));
+
+const log = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
 }));
 
 const svc = vi.hoisted(() => ({
@@ -83,13 +89,24 @@ vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
   };
 });
 
+vi.mock('../../../server/lib/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/logger')>();
+  const mockedLogger = Object.create(actual.logger) as typeof actual.logger;
+  mockedLogger.info = log.info;
+  mockedLogger.warn = log.warn;
+  return {
+    ...actual,
+    logger: mockedLogger,
+  };
+});
+
 import fundMoicRouter from '../../../server/routes/fund-moic';
 
 const generatedAt = '2026-06-24T00:00:00.000Z';
 const USER = { id: 101, role: 'admin', fundIds: [1] };
 const FACTS_INPUT_HASH = 'f'.repeat(64);
 
-function factsBasis() {
+function factsBasis(overrides: Partial<FundMoicFactsBasisV1> = {}): FundMoicFactsBasisV1 {
   return {
     rankability: 'actionable' as const,
     reasons: ['planning_fmv_active' as const],
@@ -105,6 +122,7 @@ function factsBasis() {
     currencyStatus: 'base_currency' as const,
     factsInputHash: FACTS_INPUT_HASH,
     warnings: [],
+    ...overrides,
   };
 }
 
@@ -123,9 +141,9 @@ function actualsFactsResponse() {
   };
 }
 
-function rankingItem(investmentId: string, value: number) {
+function rankingItem(investmentId: string, value: number, rank = 1) {
   return {
-    rank: 1,
+    rank,
     investmentId,
     investmentName: investmentId,
     reservesMoic: { value, description: 'desc', formula: 'formula' },
@@ -339,6 +357,158 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     });
     expect(parsed.rankings.every((ranking) => ranking.factsBasis === null)).toBe(true);
     expect(svc.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['shadow', 'on'] as const)(
+    'emits one privacy-bounded facts-basis comparison when effective mode is %s',
+    async (mode) => {
+      const base = sourceBundle();
+      const legacyRankings = [1, 2, 3, 4, 5, 6].map((companyId) =>
+        rankingItem(String(companyId), companyId, companyId)
+      );
+      const candidateRankings = legacyRankings.map((ranking) => ({
+        ...ranking,
+        reservesMoic: { ...ranking.reservesMoic, value: (ranking.reservesMoic.value ?? 0) + 10 },
+      }));
+      svc.getFundMoicRankingSources.mockResolvedValue(
+        sourceBundle({
+          legacy: {
+            ...base.legacy,
+            provenance: { ...base.legacy.provenance, sourceRecordCount: 6 },
+            rankings: legacyRankings,
+          },
+          candidate: {
+            ...base.candidate,
+            provenance: { ...base.candidate.provenance, sourceRecordCount: 6 },
+            rankings: candidateRankings,
+          },
+          moicInputSummary: {
+            ...base.moicInputSummary,
+            defaultedExitProbabilityCount: 2,
+            defaultedReserveExitMultipleCount: 1,
+          },
+          factsBasisByInvestmentId: new Map([
+            ['1', factsBasis({ rankability: 'indicative', reasons: ['planning_fmv_stale'] })],
+            ['2', factsBasis()],
+            [
+              '3',
+              factsBasis({
+                rankability: 'not_actionable',
+                reasons: ['currency_blocked'],
+                currencyStatus: 'mismatch_blocked',
+                valuationAnchor: { kind: 'none', value: null, asOfDate: null },
+              }),
+            ],
+            ['4', factsBasis()],
+            ['5', factsBasis({ rankability: 'indicative', reasons: ['planning_fmv_stale'] })],
+            ['6', factsBasis()],
+          ]),
+        })
+      );
+      svc.resolveFundCalculationMode.mockResolvedValue(
+        modePreview({ configuredMode: mode, effectiveMode: mode })
+      );
+      svc.resolveMoicActionability.mockResolvedValue(
+        actionability({
+          actionability: mode === 'on' ? 'actionable' : 'non_actionable',
+          actionabilityStatus: mode === 'on' ? 'actionable' : 'non_actionable',
+          sourceFingerprintMatches: mode === 'on',
+        })
+      );
+
+      const res = await getRankings();
+
+      expect(res.status).toBe(200);
+      expect(log.info).toHaveBeenCalledTimes(1);
+      const [bindings, message] = log.info.mock.calls[0] ?? [];
+      expect(Object.keys(bindings ?? {}).sort()).toEqual(
+        [
+          'actionableCount',
+          'companyCount',
+          'currencyBlockedCount',
+          'defaultedExitProbabilityCount',
+          'defaultedReserveExitMultipleCount',
+          'durationMs',
+          'factsEligibleTopCompanyId',
+          'factsInputHash',
+          'fundId',
+          'indicativeCount',
+          'legacyTopCompanyId',
+          'notActionableCount',
+          'topNOverlap',
+        ].sort()
+      );
+      expect(bindings).toMatchObject({
+        fundId: 1,
+        factsInputHash: 'ffffffffffff',
+        companyCount: 6,
+        actionableCount: 3,
+        indicativeCount: 2,
+        notActionableCount: 1,
+        legacyTopCompanyId: 1,
+        factsEligibleTopCompanyId: 2,
+        topNOverlap: 2,
+        defaultedExitProbabilityCount: 2,
+        defaultedReserveExitMultipleCount: 1,
+        currencyBlockedCount: 1,
+        durationMs: expect.any(Number),
+      });
+      expect(bindings?.durationMs).toBeGreaterThanOrEqual(0);
+      expect(message).toBe('fund-moic facts-basis shadow comparison generated');
+      expect(JSON.stringify(bindings)).not.toMatch(
+        /legacy-output|candidate-output|Acme|observed|valuationAnchor|reservesMoic/
+      );
+    }
+  );
+
+  it('emits no facts-basis comparison when effective mode is off', async () => {
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('emits an unavailable comparison without leaking values when shadow facts fail', async () => {
+    svc.buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts backend down'));
+    svc.resolveFundCalculationMode.mockResolvedValue(
+      modePreview({ configuredMode: 'shadow', effectiveMode: 'shadow' })
+    );
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    expect(log.info).toHaveBeenCalledWith(
+      {
+        fundId: 1,
+        factsInputHash: null,
+        companyCount: 1,
+        actionableCount: 0,
+        indicativeCount: 0,
+        notActionableCount: 0,
+        legacyTopCompanyId: null,
+        factsEligibleTopCompanyId: null,
+        topNOverlap: 0,
+        defaultedExitProbabilityCount: 0,
+        defaultedReserveExitMultipleCount: 0,
+        currencyBlockedCount: 0,
+        durationMs: expect.any(Number),
+      },
+      'fund-moic facts-basis shadow comparison generated'
+    );
+  });
+
+  it('keeps the response successful when facts-basis telemetry logging throws', async () => {
+    svc.resolveFundCalculationMode.mockResolvedValue(
+      modePreview({ configuredMode: 'shadow', effectiveMode: 'shadow' })
+    );
+    log.info.mockImplementationOnce(() => {
+      throw new Error('logger unavailable');
+    });
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    expect(log.info).toHaveBeenCalledTimes(1);
   });
 
   it('returns candidate rankings when mode is on and actionability is actionable', async () => {

--- a/tests/unit/routes/fund-moic-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-rankings.behavior.test.ts
@@ -19,6 +19,7 @@ const svc = vi.hoisted(() => ({
   resolveFundCalculationMode: vi.fn(),
   resolveMoicActionability: vi.fn(),
   buildRoundsToModelEvidence: vi.fn(),
+  buildFundCompanyActualsFacts: vi.fn(),
 }));
 
 vi.mock('../../../server/services/fund-moic-ranking-service', async (importOriginal) => {
@@ -56,6 +57,20 @@ vi.mock('../../../server/services/rounds-to-model-evidence-service', async (impo
   return { ...actual, buildRoundsToModelEvidence: svc.buildRoundsToModelEvidence };
 });
 
+vi.mock(
+  '../../../server/services/fund-actuals/fund-company-actuals-facts-service',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('../../../server/services/fund-actuals/fund-company-actuals-facts-service')
+      >();
+    return {
+      ...actual,
+      buildFundCompanyActualsFacts: svc.buildFundCompanyActualsFacts,
+    };
+  }
+);
+
 vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
   return {
@@ -72,6 +87,41 @@ import fundMoicRouter from '../../../server/routes/fund-moic';
 
 const generatedAt = '2026-06-24T00:00:00.000Z';
 const USER = { id: 101, role: 'admin', fundIds: [1] };
+const FACTS_INPUT_HASH = 'f'.repeat(64);
+
+function factsBasis() {
+  return {
+    rankability: 'actionable' as const,
+    reasons: ['planning_fmv_active' as const],
+    observedInitialInvestment: '500000',
+    observedFollowOnInvestment: '125000',
+    observedTotalInvestment: '625000',
+    valuationAnchor: {
+      kind: 'planning_fmv' as const,
+      value: '1500000',
+      asOfDate: '2026-07-01',
+    },
+    planningFmvStatus: 'active' as const,
+    currencyStatus: 'base_currency' as const,
+    factsInputHash: FACTS_INPUT_HASH,
+    warnings: [],
+  };
+}
+
+function actualsFactsResponse() {
+  return {
+    fundId: 1,
+    asOfDate: '2026-07-13',
+    inputHash: FACTS_INPUT_HASH,
+    generatedAt: '2026-07-13T00:00:00.000Z',
+    facts: [
+      {
+        companyId: 1,
+        provenance: { trustState: 'LIVE' as const },
+      },
+    ],
+  };
+}
 
 function rankingItem(investmentId: string, value: number) {
   return {
@@ -190,6 +240,7 @@ beforeEach(() => {
   svc.resolveFundCalculationMode.mockResolvedValue(modePreview());
   svc.resolveMoicActionability.mockResolvedValue(actionability());
   svc.buildRoundsToModelEvidence.mockResolvedValue(roundsEvidence());
+  svc.buildFundCompanyActualsFacts.mockResolvedValue(actualsFactsResponse());
 });
 
 describe('fund MOIC rankings route - behavioral state machine', () => {
@@ -200,6 +251,94 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
     expect(parsed.provenance.mode).toBe('legacy');
     expect(parsed.rankings[0]?.investmentId).toBe('legacy-output-a');
+  });
+
+  it('attaches available facts basis without changing ranking values or order', async () => {
+    const before = sourceBundle();
+    const after = sourceBundle({
+      factsBasisByInvestmentId: new Map([
+        ['legacy-output-a', factsBasis()],
+        ['candidate-output-a', factsBasis()],
+      ]),
+    });
+    svc.getFundMoicRankingSources.mockResolvedValue(after);
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.rankings.map(({ factsBasis: _factsBasis, ...ranking }) => ranking)).toEqual(
+      before.legacy.rankings
+    );
+    expect(parsed.rankings.some((ranking) => ranking.factsBasis !== null)).toBe(true);
+    expect(svc.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1, undefined, expect.any(Map));
+  });
+
+  it.each([
+    {
+      mode: 'off' as const,
+      actionability: 'non_actionable' as const,
+      expectedSource: 'legacy' as const,
+    },
+    {
+      mode: 'shadow' as const,
+      actionability: 'non_actionable' as const,
+      expectedSource: 'legacy' as const,
+    },
+    {
+      mode: 'on' as const,
+      actionability: 'actionable' as const,
+      expectedSource: 'candidate' as const,
+    },
+  ])(
+    'keeps $mode mode ranking values identical while adding disclosure',
+    async ({ mode, actionability: actionabilityStatus, expectedSource }) => {
+      const before = sourceBundle();
+      svc.getFundMoicRankingSources.mockResolvedValue(
+        sourceBundle({
+          factsBasisByInvestmentId: new Map([
+            ['legacy-output-a', factsBasis()],
+            ['candidate-output-a', factsBasis()],
+          ]),
+        })
+      );
+      svc.resolveFundCalculationMode.mockResolvedValue(
+        modePreview({ configuredMode: mode, effectiveMode: mode })
+      );
+      svc.resolveMoicActionability.mockResolvedValue(
+        actionability({
+          actionability: actionabilityStatus,
+          actionabilityStatus,
+          sourceFingerprintMatches: actionabilityStatus === 'actionable',
+        })
+      );
+
+      const res = await getRankings();
+
+      expect(res.status).toBe(200);
+      const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+      expect(parsed.rankings.map(({ factsBasis: _factsBasis, ...ranking }) => ranking)).toEqual(
+        before[expectedSource].rankings
+      );
+      expect(parsed.rankings.some((ranking) => ranking.factsBasis !== null)).toBe(true);
+    }
+  );
+
+  it('keeps HTTP behavior unchanged and returns null bases when the facts load fails', async () => {
+    svc.buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts backend down'));
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.actualsProvenanceSummary).toMatchObject({
+      factsStatus: 'failed',
+      factsInputHash: null,
+      warnings: ['actuals_facts_failed'],
+    });
+    expect(parsed.rankings.every((ranking) => ranking.factsBasis === null)).toBe(true);
+    expect(svc.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
   });
 
   it('returns candidate rankings when mode is on and actionability is actionable', async () => {
@@ -302,5 +441,7 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     expect(res.body).not.toHaveProperty('materiality');
     expect(res.body).not.toHaveProperty('latestReconciliation');
     expect(res.body).not.toHaveProperty('roundEvidenceSummary');
+    expect(res.body.rankings[0]?.factsBasis).toBeNull();
+    expect(svc.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/routes/fund-moic-route-contract.test.ts
+++ b/tests/unit/routes/fund-moic-route-contract.test.ts
@@ -41,6 +41,9 @@ describe('fund-moic route contract', () => {
     const source = await readRepoFile('server/routes/fund-moic.ts');
     expect(source).toContain('buildFundCompanyActualsFacts({');
     expect(source).toContain('asOfDate: actualsAsOfDate');
+    expect(source).toContain('factsByCompanyId');
+    expect(source).toContain('sources.factsBasisByInvestmentId');
+    expect(source).toContain('discloseFundMoicRankings');
     expect(source).toContain("factsStatus: 'available'");
     expect(source).toContain(
       'trustStates: actualsFacts.facts.map((fact) => fact.provenance.trustState)'

--- a/tests/unit/routes/fund-moic-route-contract.test.ts
+++ b/tests/unit/routes/fund-moic-route-contract.test.ts
@@ -58,6 +58,13 @@ describe('fund-moic route contract', () => {
     expect(source).toContain("warnings: ['actuals_facts_failed']");
   });
 
+  it('gates facts-basis comparison telemetry on effective shadow or on mode', async () => {
+    const source = await readRepoFile('server/routes/fund-moic.ts');
+    expect(source).toContain("modePreview.effectiveMode === 'shadow'");
+    expect(source).toContain("modePreview.effectiveMode === 'on'");
+    expect(source).toContain('emitFundMoicFactsShadowTelemetry({');
+  });
+
   it('exposes the admin reconciliation POST with role + idempotency guards', async () => {
     const source = await readRepoFile('server/routes/fund-moic.ts');
     expect(source).toContain('/admin/funds/:fundId/moic/reconciliations');

--- a/tests/unit/services/fund-moic-ranking-service.test.ts
+++ b/tests/unit/services/fund-moic-ranking-service.test.ts
@@ -29,10 +29,13 @@ vi.mock('../../../server/lib/moic-mapper', async (importOriginal) => {
 import {
   buildMoicRankingSourcesFromCompanies,
   buildMoicRankingsFromInvestments,
+  discloseFundMoicRankings,
   summarizeMoicActualsProvenance,
 } from '../../../server/services/fund-moic-ranking-service';
 import { FundMoicRankingsResponseV1Schema } from '../../../shared/contracts/fund-moic-v1.contract';
+import type { FundCompanyActualsFact } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 import type { Investment } from '../../../shared/core/moic/MOICCalculator';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
 
 const makeInvestment = (overrides: Partial<Investment> = {}): Investment => ({
   id: '1',
@@ -47,6 +50,48 @@ const makeInvestment = (overrides: Partial<Investment> = {}): Investment => ({
   investmentDate: new Date('2022-01-01'),
   ...overrides,
 });
+
+const FACTS_HASH = 'a'.repeat(64);
+
+function actualsFact(overrides: Partial<FundCompanyActualsFact> = {}): FundCompanyActualsFact {
+  return {
+    fundId: 10,
+    companyId: 1,
+    companyName: 'Acme',
+    investmentIds: [101],
+    activeRoundIds: [201],
+    approvedPlanningFmvMarkId: 301,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '500000',
+    followOnInvestmentAmount: '125000',
+    amountOnlyNonEquityAmount: '0',
+    latestRoundDate: '2026-06-30',
+    latestRoundValuation: '9000000',
+    latestPlanningFmvDate: '2026-07-01',
+    latestPlanningFmvValue: '1500000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [{ roundId: 201, supersedesRoundId: null }],
+    warnings: [],
+    provenance: {
+      trustState: 'LIVE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'actionable',
+        sourceEngine: 'rounds-to-model',
+        engineVersion: 'rounds-to-model-v1',
+        inputHash: FACTS_HASH,
+        assumptionsHash: 'b'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: true,
+        warnings: [],
+      },
+      structuredWarnings: [],
+    },
+    inputHash: FACTS_HASH,
+    ...overrides,
+  };
+}
 
 describe('fund MOIC ranking service', () => {
   beforeEach(() => {
@@ -312,6 +357,65 @@ describe('fund MOIC ranking service', () => {
 
     expect(forward.moicSourceInputHash).toBe(reverse.moicSourceInputHash);
     expect(edited.moicSourceInputHash).not.toBe(forward.moicSourceInputHash);
+  });
+
+  it('attaches facts basis without changing internal rankings or the source hash', () => {
+    const companies = [
+      {
+        id: 1,
+        fundId: 10,
+        name: 'Acme',
+        investmentAmount: 500_000,
+        currentValuation: 1_500_000,
+        plannedReservesCents: 300_000_00,
+        exitMoicBps: 35000,
+        exitProbability: 0.8,
+        investmentDate: new Date('2022-01-01T00:00:00.000Z'),
+      },
+    ];
+    const before = buildMoicRankingSourcesFromCompanies(10, companies);
+    const after = buildMoicRankingSourcesFromCompanies(
+      10,
+      companies,
+      new Map([[1, actualsFact()]])
+    );
+    const disclosed = discloseFundMoicRankings(after.legacy, after.factsBasisByInvestmentId);
+
+    expect(after.legacy.rankings).toEqual(before.legacy.rankings);
+    expect(after.candidate.rankings).toEqual(before.candidate.rankings);
+    expect(after.moicSourceInputHash).toBe(before.moicSourceInputHash);
+    expect(canonicalSha256(after.legacy.rankings)).toBe(canonicalSha256(before.legacy.rankings));
+    expect(canonicalSha256(after.candidate.rankings)).toBe(
+      canonicalSha256(before.candidate.rankings)
+    );
+    expect(disclosed.rankings.map(({ factsBasis: _factsBasis, ...ranking }) => ranking)).toEqual(
+      before.legacy.rankings
+    );
+    expect(disclosed.rankings.some((ranking) => ranking.factsBasis !== null)).toBe(true);
+  });
+
+  it('discloses FACTS_MISSING when a successful facts response omits a company', () => {
+    const sources = buildMoicRankingSourcesFromCompanies(
+      10,
+      [
+        {
+          id: 1,
+          fundId: 10,
+          name: 'Acme',
+          currentValuation: '1500000',
+          plannedReservesCents: 300_000_00,
+          exitMoicBps: 35000,
+          exitProbability: 0.8,
+        },
+      ],
+      new Map()
+    );
+
+    expect(sources.factsBasisByInvestmentId?.get('1')).toMatchObject({
+      rankability: 'indicative',
+      factsInputHash: null,
+      warnings: [{ code: 'FACTS_MISSING' }],
+    });
   });
 
   it('characterizes follow-on/initial-only changes as no-ops for reserves MOIC value and rank', () => {

--- a/tests/unit/services/moic/fund-moic-facts-basis.test.ts
+++ b/tests/unit/services/moic/fund-moic-facts-basis.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FundMoicFactsBasisV1Schema,
+  FundMoicRankabilitySchema,
+} from '../../../../shared/contracts/fund-moic-v1.contract';
+import type { FundCompanyActualsFact } from '../../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { buildFundMoicFactsBasis } from '../../../../server/services/moic/fund-moic-facts-basis';
+
+const FACTS_HASH = 'a'.repeat(64);
+const ASSUMPTIONS_HASH = 'b'.repeat(64);
+
+function company(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    fundId: 1,
+    name: 'Alpha AI',
+    investmentAmount: '1000',
+    currentValuation: '3000',
+    plannedReservesCents: 100_000,
+    exitMoicBps: 250,
+    exitProbability: '0.4',
+    investmentDate: '2025-01-01',
+    ...overrides,
+  };
+}
+
+function fact(overrides: Partial<FundCompanyActualsFact> = {}): FundCompanyActualsFact {
+  return {
+    fundId: 1,
+    companyId: 11,
+    companyName: 'Alpha AI',
+    investmentIds: [21],
+    activeRoundIds: [31],
+    approvedPlanningFmvMarkId: 41,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '100.125',
+    followOnInvestmentAmount: '25.875',
+    amountOnlyNonEquityAmount: '0',
+    latestRoundDate: '2026-06-30',
+    latestRoundValuation: '9000',
+    latestPlanningFmvDate: '2026-07-01',
+    latestPlanningFmvValue: '5000.25',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [{ roundId: 31, supersedesRoundId: null }],
+    warnings: [],
+    provenance: {
+      trustState: 'LIVE',
+      core: {
+        sourceKind: 'computed',
+        actionability: 'actionable',
+        sourceEngine: 'rounds-to-model',
+        engineVersion: 'rounds-to-model-v1',
+        inputHash: FACTS_HASH,
+        assumptionsHash: ASSUMPTIONS_HASH,
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: true,
+        warnings: [],
+      },
+      structuredWarnings: [],
+    },
+    inputHash: FACTS_HASH,
+    ...overrides,
+  };
+}
+
+describe('FundMoicFactsBasisV1 contract', () => {
+  it('pins rankability and every reason while rejecting unknown fields', () => {
+    expect(FundMoicRankabilitySchema.options).toEqual([
+      'actionable',
+      'indicative',
+      'not_actionable',
+    ]);
+
+    const valid = {
+      rankability: 'actionable',
+      reasons: [
+        'planning_fmv_active',
+        'planning_fmv_stale',
+        'legacy_current_valuation_fallback',
+        'valuation_unavailable',
+        'currency_blocked',
+        'planned_reserves_zero',
+        'exit_probability_missing',
+        'reserve_exit_multiple_missing',
+      ],
+      observedInitialInvestment: '100.25',
+      observedFollowOnInvestment: '25.75',
+      observedTotalInvestment: '126',
+      valuationAnchor: {
+        kind: 'planning_fmv',
+        value: '500',
+        asOfDate: '2026-07-13',
+      },
+      planningFmvStatus: 'active',
+      currencyStatus: 'base_currency',
+      factsInputHash: 'a'.repeat(64),
+      warnings: [],
+    } as const;
+
+    expect(FundMoicFactsBasisV1Schema.parse(valid)).toEqual(valid);
+    expect(FundMoicFactsBasisV1Schema.safeParse({ ...valid, extra: true }).success).toBe(false);
+    expect(
+      FundMoicFactsBasisV1Schema.safeParse({
+        ...valid,
+        valuationAnchor: { ...valid.valuationAnchor, extra: true },
+      }).success
+    ).toBe(false);
+    expect(
+      FundMoicFactsBasisV1Schema.safeParse({ ...valid, observedInitialInvestment: 100.25 }).success
+    ).toBe(false);
+    expect(
+      FundMoicFactsBasisV1Schema.safeParse({
+        ...valid,
+        valuationAnchor: { ...valid.valuationAnchor, value: 500 },
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('buildFundMoicFactsBasis', () => {
+  it('uses an active base-currency Planning FMV as the actionable anchor', () => {
+    expect(buildFundMoicFactsBasis({ company: company(), fact: fact() })).toEqual({
+      rankability: 'actionable',
+      reasons: ['planning_fmv_active'],
+      observedInitialInvestment: '100.125',
+      observedFollowOnInvestment: '25.875',
+      observedTotalInvestment: '126',
+      valuationAnchor: {
+        kind: 'planning_fmv',
+        value: '5000.25',
+        asOfDate: '2026-07-01',
+      },
+      planningFmvStatus: 'active',
+      currencyStatus: 'base_currency',
+      factsInputHash: FACTS_HASH,
+      warnings: [],
+    });
+  });
+
+  it('keeps a stale Planning FMV visible but only indicative', () => {
+    expect(
+      buildFundMoicFactsBasis({
+        company: company(),
+        fact: fact({ planningFmvStatus: 'stale' }),
+      })
+    ).toMatchObject({
+      rankability: 'indicative',
+      reasons: ['planning_fmv_stale'],
+      valuationAnchor: {
+        kind: 'planning_fmv',
+        value: '5000.25',
+        asOfDate: '2026-07-01',
+      },
+    });
+  });
+
+  it.each(['none', 'superseded', 'blocked'] as const)(
+    'falls back from %s Planning FMV status to legacy current valuation',
+    (planningFmvStatus) => {
+      expect(
+        buildFundMoicFactsBasis({ company: company(), fact: fact({ planningFmvStatus }) })
+      ).toMatchObject({
+        rankability: 'indicative',
+        reasons: ['legacy_current_valuation_fallback'],
+        valuationAnchor: {
+          kind: 'legacy_current_valuation',
+          value: '3000',
+          asOfDate: null,
+        },
+      });
+    }
+  );
+
+  it('is not actionable when neither Planning FMV nor legacy valuation is available', () => {
+    expect(
+      buildFundMoicFactsBasis({
+        company: company({ currentValuation: null }),
+        fact: fact({
+          planningFmvStatus: 'none',
+          latestPlanningFmvValue: null,
+          latestPlanningFmvDate: null,
+        }),
+      })
+    ).toMatchObject({
+      rankability: 'not_actionable',
+      reasons: ['valuation_unavailable'],
+      valuationAnchor: { kind: 'none', value: null, asOfDate: null },
+    });
+  });
+
+  it('blocks currency mismatches without exposing a valuation anchor', () => {
+    expect(
+      buildFundMoicFactsBasis({
+        company: company(),
+        fact: fact({ currency: 'EUR', currencyStatus: 'mismatch_blocked' }),
+      })
+    ).toMatchObject({
+      rankability: 'not_actionable',
+      reasons: ['currency_blocked'],
+      valuationAnchor: { kind: 'none', value: null, asOfDate: null },
+      currencyStatus: 'mismatch_blocked',
+    });
+  });
+
+  it.each([null, 0] as const)(
+    'keeps %s planned reserves visible but not actionable',
+    (plannedReservesCents) => {
+      expect(
+        buildFundMoicFactsBasis({ company: company({ plannedReservesCents }), fact: fact() })
+      ).toMatchObject({
+        rankability: 'not_actionable',
+        reasons: ['planning_fmv_active', 'planned_reserves_zero'],
+      });
+    }
+  );
+
+  it.each([
+    ['exitProbability', 'exit_probability_missing'],
+    ['exitMoicBps', 'reserve_exit_multiple_missing'],
+  ] as const)('downgrades an active anchor when %s is missing', (field, reason) => {
+    expect(
+      buildFundMoicFactsBasis({ company: company({ [field]: null }), fact: fact() })
+    ).toMatchObject({
+      rankability: 'indicative',
+      reasons: ['planning_fmv_active', reason],
+    });
+  });
+
+  it('uses zero observed amounts plus FACTS_MISSING disclosure when the fact is absent', () => {
+    expect(buildFundMoicFactsBasis({ company: company(), fact: null })).toEqual({
+      rankability: 'indicative',
+      reasons: ['legacy_current_valuation_fallback'],
+      observedInitialInvestment: '0',
+      observedFollowOnInvestment: '0',
+      observedTotalInvestment: '0',
+      valuationAnchor: {
+        kind: 'legacy_current_valuation',
+        value: '3000',
+        asOfDate: null,
+      },
+      planningFmvStatus: 'none',
+      currencyStatus: 'unknown',
+      factsInputHash: null,
+      warnings: [
+        {
+          code: 'FACTS_MISSING',
+          severity: 'warning',
+          message: 'Company actuals facts are unavailable; observed investment amounts are zero',
+          source: 'fund-company-actuals-facts',
+        },
+      ],
+    });
+  });
+
+  it('emits all applicable reasons in declaration order', () => {
+    const result = buildFundMoicFactsBasis({
+      company: company({
+        plannedReservesCents: 0,
+        exitProbability: null,
+        exitMoicBps: null,
+      }),
+      fact: fact(),
+    });
+
+    expect(result.reasons).toEqual([
+      'planning_fmv_active',
+      'planned_reserves_zero',
+      'exit_probability_missing',
+      'reserve_exit_multiple_missing',
+    ]);
+    expect(result.rankability).toBe('not_actionable');
+  });
+
+  it('treats invalid explicit inputs as missing just like candidate defaulting', () => {
+    expect(
+      buildFundMoicFactsBasis({
+        company: company({ exitProbability: '1.1', exitMoicBps: 0 }),
+        fact: fact(),
+      }).reasons
+    ).toEqual(['planning_fmv_active', 'exit_probability_missing', 'reserve_exit_multiple_missing']);
+  });
+});


### PR DESCRIPTION
## Summary

Plan 6 wave 1 (Tasks 6.1 + 6.2 + 6.3) — disclosure-only. The planned-reserve MOIC ranking now carries an actuals facts basis per item without changing a single ranking value or hash.

- **New pure builder** `server/services/moic/fund-moic-facts-basis.ts`: rankability (`actionable`/`indicative`/`not_actionable`) from the binding valuation ladder — active base-currency Planning FMV -> actionable anchor; stale FMV -> indicative; legacy current valuation -> indicative fallback; none/currency-block -> not_actionable. Latest round valuation never anchors. Observed invested split from facts (Decimal strings). Missing explicit exit probability / reserve exit multiple and zero planned reserves are disclosed as blocking reasons (deterministic enum ordering). Fact-missing emits observed '0' + a new additive `FACTS_MISSING` structured warning code.
- **Contract**: `factsBasis: FundMoicFactsBasisV1 | null` added as a required-nullable field on the ranking item (the V2 response is `.strict()` — required-nullable keeps both v1/v2 responses parse-safe). Client/server fixtures updated minimally.
- **Attachment (PR 6A discipline)**: bases are built from the facts response the v2 route already loads — still exactly one facts call per request; facts failure -> `factsBasis: null` everywhere with HTTP behavior unchanged.
- **Shadow telemetry**: one structured event per v2 request when the calculation mode is shadow/on (never off) — counts by rankability, top-company/top-5 overlap vs legacy ordering, defaulted probability/multiple counts, currency-blocked count, short facts hash, duration. No company names, no raw money, no polling/caching.

## Freeze proof

- `MOIC_CANDIDATE_SOURCE_VERSION` still `'moic-exit-probability-v1'`; hashRow construction has zero diff lines; reconciliation service and MOICCalculator untouched.
- Behavior suite pins "ranking values identical while adding disclosure" across off/shadow/on, `moicSourceInputHash` byte-equal, unchanged plain-v1 payload, and facts-failure null-basis paths.
- Two compile-level accommodations outside the core list, both zero-behavior: marginal shadow service and materiality detector now accept a `Pick<>` of the ranking item so the additive field doesn't burden their callers.

## Verification

- 104/104 server tests (15 basis-ladder, 11+31 contract, 12 route-contract, 17 behavior incl. freeze, ranking-service suite) + 13/13 client fixture tests — run independently post-implementation.
- `npm run check` 0 TS errors; ESLint clean.

Spec: Plan 6 (line 2279) + amendments; Hermes/Codex lane, Claude-verified. Next waves: 6D basis + `MOIC_CANDIDATE_SOURCE_VERSION` switch in one commit (with ADR-039), 6.5 UI, 6.6 activation-after-reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h