### PR TITLE
feat(scenarios): seed staleness disclosure on scenario reads (Plan 8 wave 4)

### DIFF
--- a/server/routes/scenario-analysis.ts
+++ b/server/routes/scenario-analysis.ts
@@ -10,7 +10,11 @@ import type { NextFunction, Request, Response } from 'express';
 import { isDeepStrictEqual } from 'node:util';
 import { z } from 'zod';
 import { db } from '../db';
-import { Sha256Schema } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import {
+  FundCompanyActualsCurrencyStatusSchema,
+  Sha256Schema,
+} from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { DatasetTrustStateSchema } from '@shared/contracts/provenance-envelope.contract';
 import { ScenarioCaseSeedV1Schema } from '@shared/contracts/scenarios/scenario-case-seed-v1.contract';
 import { DecimalStringSchema } from '@shared/contracts/lp-reporting/cash-flow-event.contract';
 import {
@@ -20,14 +24,14 @@ import {
   scenarioCaseSeedProvenance,
 } from '@shared/schema';
 import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import {
   calculateWeightedSummary,
   validateProbabilities,
   normalizeProbabilities,
   addMOICToCases,
 } from '@shared/utils/scenario-math';
-import type { ScenarioAnalysisResponse, ScenarioCase } from '@shared/types/scenario';
+import type { ScenarioCase } from '@shared/types/scenario';
 import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
 import { firstString } from '../lib/request-values';
 import { createRouteLogger } from '../lib/route-logger.js';
@@ -156,6 +160,67 @@ const CreateScenarioCaseFromSeedResponseSchema = z
     scenarioVersion: z.number().int(),
     seededAt: z.string().datetime(),
     replay: z.boolean(),
+  })
+  .strict();
+
+const ScenarioCaseSeedProvenanceReadSchema = z
+  .object({
+    facts_input_hash: Sha256Schema,
+    facts_as_of_date: z.string().date(),
+    seeded_at: z.string().datetime(),
+    trust_state: DatasetTrustStateSchema,
+    currency_status: FundCompanyActualsCurrencyStatusSchema,
+    staleness: z.enum(['current', 'stale', 'unknown']),
+  })
+  .strict();
+
+const ScenarioCaseReadSchema = z
+  .object({
+    id: z.string().optional(),
+    case_name: z.string(),
+    description: z.string().optional(),
+    probability: z.number(),
+    investment: z.number(),
+    follow_ons: z.number(),
+    exit_proceeds: z.number(),
+    exit_valuation: z.number(),
+    moic: z.number().optional(),
+    months_to_exit: z.number().optional(),
+    ownership_at_exit: z.number().optional(),
+    seed_provenance: ScenarioCaseSeedProvenanceReadSchema.optional(),
+  })
+  .strict();
+
+const ScenarioAnalysisReadResponseSchema = z
+  .object({
+    company_name: z.string(),
+    company_id: z.string(),
+    scenario: z
+      .object({
+        id: z.string(),
+        company_id: z.string(),
+        name: z.string(),
+        description: z.string().optional(),
+        version: z.number().int(),
+        is_default: z.boolean(),
+        locked_at: z.date().optional(),
+        created_by: z.string().optional(),
+        created_at: z.date(),
+        updated_at: z.date(),
+      })
+      .strict(),
+    cases: z.array(ScenarioCaseReadSchema),
+    weighted_summary: z
+      .object({
+        moic: z.number().nullable(),
+        investment: z.number(),
+        follow_ons: z.number(),
+        exit_proceeds: z.number(),
+        exit_valuation: z.number(),
+        months_to_exit: z.number().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 
@@ -500,6 +565,81 @@ router['get'](
           ? calculateWeightedSummary(casesWithMOIC)
           : undefined;
 
+      const seedProvenanceByCaseId = new Map<
+        string,
+        z.infer<typeof ScenarioCaseSeedProvenanceReadSchema>
+      >();
+      const caseIds = casesWithMOIC.flatMap((scenarioCase) =>
+        scenarioCase.id === undefined ? [] : [scenarioCase.id]
+      );
+      if (caseIds.length > 0) {
+        const provenanceRows = await db
+          .select({
+            scenarioCaseId: scenarioCaseSeedProvenance.scenarioCaseId,
+            fundId: scenarioCaseSeedProvenance.fundId,
+            companyId: scenarioCaseSeedProvenance.companyId,
+            factsInputHash: scenarioCaseSeedProvenance.factsInputHash,
+            factsAsOfDate: scenarioCaseSeedProvenance.factsAsOfDate,
+            seededAt: scenarioCaseSeedProvenance.seededAt,
+            trustState: scenarioCaseSeedProvenance.trustState,
+            currencyStatus: scenarioCaseSeedProvenance.currencyStatus,
+          })
+          .from(scenarioCaseSeedProvenance)
+          .where(inArray(scenarioCaseSeedProvenance.scenarioCaseId, caseIds));
+
+        if (provenanceRows.length > 0) {
+          const asOfDate = new Date().toISOString().slice(0, 10);
+          const fundId = provenanceRows[0]!.fundId;
+          let currentHashByCompanyId: Map<number, string> | null = null;
+          try {
+            const facts = await buildFundCompanyActualsFacts({ fundId, asOfDate });
+            if (facts.fundId === fundId && facts.asOfDate === asOfDate) {
+              currentHashByCompanyId = new Map(
+                facts.facts.map((fact) => [fact.companyId, fact.inputHash])
+              );
+            } else {
+              routeLog.error(
+                'Scenario seed staleness facts scope mismatch:',
+                new Error(
+                  `Requested fund ${fundId} as of ${asOfDate}, received fund ${facts.fundId} as of ${facts.asOfDate}`
+                )
+              );
+            }
+          } catch (error: unknown) {
+            routeLog.error('Scenario seed staleness facts load failed:', error);
+          }
+
+          for (const provenance of provenanceRows) {
+            const currentHash = currentHashByCompanyId?.get(provenance.companyId);
+            seedProvenanceByCaseId.set(
+              provenance.scenarioCaseId,
+              ScenarioCaseSeedProvenanceReadSchema.parse({
+                facts_input_hash: provenance.factsInputHash,
+                facts_as_of_date: provenance.factsAsOfDate,
+                seeded_at: provenance.seededAt.toISOString(),
+                trust_state: provenance.trustState,
+                currency_status: provenance.currencyStatus,
+                staleness:
+                  currentHash === undefined
+                    ? 'unknown'
+                    : currentHash === provenance.factsInputHash
+                      ? 'current'
+                      : 'stale',
+              })
+            );
+          }
+        }
+      }
+
+      const responseCases = casesWithMOIC.map((scenarioCase) => {
+        const seedProvenance =
+          scenarioCase.id === undefined ? undefined : seedProvenanceByCaseId.get(scenarioCase.id);
+        return {
+          ...scenarioCase,
+          ...(seedProvenance === undefined ? {} : { seed_provenance: seedProvenance }),
+        };
+      });
+
       // Get investment rounds if requested (commented out - investmentRounds not in schema)
       // let rounds = [];
       // if (include.includes('rounds')) {
@@ -509,7 +649,7 @@ router['get'](
       //   });
       // }
 
-      const response: ScenarioAnalysisResponse = {
+      const response = ScenarioAnalysisReadResponseSchema.parse({
         company_name: '', // TODO: fetch company name separately if needed
         company_id: companyId,
         scenario: {
@@ -524,10 +664,10 @@ router['get'](
           created_at: scenarioData.createdAt,
           updated_at: scenarioData.updatedAt,
         },
-        cases: casesWithMOIC,
+        cases: responseCases,
         ...(weighted_summary && { weighted_summary }),
         // rounds: undefined, // include.includes('rounds') ? rounds : undefined,
-      };
+      });
 
       res.json(response);
     } catch (error: unknown) {

--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -69,6 +69,8 @@ const dbState = vi.hoisted(() => {
   selectChain['from'] = vi.fn(() => selectChain);
   selectChain['innerJoin'] = vi.fn(() => selectChain);
   selectChain['where'] = vi.fn(() => selectChain);
+  const selectThen = vi.fn((resolve: (value: unknown[]) => void) => resolve([]));
+  selectChain['then'] = selectThen;
   const selectLimit = vi.fn(async () => [] as unknown[]);
   selectChain['limit'] = selectLimit;
 
@@ -89,7 +91,7 @@ const dbState = vi.hoisted(() => {
   const remove = vi.fn(() => deleteChain);
   const transaction = vi.fn(async () => undefined);
   const findFirst = vi.fn(async () => undefined);
-  return { select, selectLimit, insert, update, remove, transaction, findFirst };
+  return { select, selectThen, selectLimit, insert, update, remove, transaction, findFirst };
 });
 
 vi.mock('../../../server/lib/auth/company-fund-scope', () => ({
@@ -127,6 +129,7 @@ import scenarioAnalysisRouter from '../../../server/routes/scenario-analysis';
 
 const SCENARIO_ID = '00000000-0000-4000-8000-000000000101';
 const SCENARIO_CASE_ID = '00000000-0000-4000-8000-000000000201';
+const UNSEEDED_CASE_ID = '00000000-0000-4000-8000-000000000202';
 
 function makeApp() {
   const app = express();
@@ -151,6 +154,8 @@ function resetState() {
   fundScopeState.resolveCompanyFundId.mockReset();
   fundScopeState.resolveCompanyFundId.mockResolvedValue(7);
   dbState.select.mockClear();
+  dbState.selectThen.mockReset();
+  dbState.selectThen.mockImplementation((resolve: (value: unknown[]) => void) => resolve([]));
   dbState.selectLimit.mockReset();
   dbState.selectLimit.mockResolvedValue([]);
   dbState.insert.mockClear();
@@ -319,6 +324,133 @@ function expectNoScenarioWrites() {
   expect(dbState.transaction).not.toHaveBeenCalled();
 }
 
+interface ScenarioCaseRowFixture {
+  id: string;
+  caseName: string;
+  description: string | null;
+  probability: string;
+  investment: string;
+  followOns: string;
+  exitProceeds: string;
+  exitValuation: string;
+  monthsToExit: number | null;
+  ownershipAtExit: string | null;
+}
+
+interface SeedProvenanceRowFixture {
+  scenarioCaseId: string;
+  fundId: number;
+  companyId: number;
+  factsInputHash: string;
+  factsAsOfDate: string;
+  seededAt: Date;
+  trustState: 'LIVE' | 'PARTIAL' | 'UNAVAILABLE' | 'FAILED';
+  currencyStatus: 'base_currency' | 'mismatch_blocked' | 'unknown';
+}
+
+function makeScenarioRow() {
+  return {
+    id: SCENARIO_ID,
+    companyId: 101,
+    name: 'Actuals-backed scenario',
+    description: null,
+    version: 4,
+    isDefault: false,
+    lockedAt: null,
+    createdBy: null,
+    createdAt: new Date('2026-07-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-07-12T15:30:00.000Z'),
+  };
+}
+
+function makeScenarioCaseRow(
+  overrides: Partial<ScenarioCaseRowFixture> = {}
+): ScenarioCaseRowFixture {
+  return {
+    id: SCENARIO_CASE_ID,
+    caseName: 'Base case',
+    description: null,
+    probability: '0.40',
+    investment: '500000.000000',
+    followOns: '250000.000000',
+    exitProceeds: '1000000.000000',
+    exitValuation: '20000000.000000',
+    monthsToExit: 36,
+    ownershipAtExit: '0.20',
+    ...overrides,
+  };
+}
+
+function makeSeedProvenanceRow(
+  overrides: Partial<SeedProvenanceRowFixture> = {}
+): SeedProvenanceRowFixture {
+  return {
+    scenarioCaseId: SCENARIO_CASE_ID,
+    fundId: 7,
+    companyId: 101,
+    factsInputHash: 'c'.repeat(64),
+    factsAsOfDate: '2026-07-01',
+    seededAt: new Date('2026-07-01T11:00:00.000Z'),
+    trustState: 'LIVE',
+    currencyStatus: 'base_currency',
+    ...overrides,
+  };
+}
+
+function mockScenarioRead(
+  options: {
+    cases?: ScenarioCaseRowFixture[];
+    provenance?: unknown[];
+  } = {}
+) {
+  dbState.selectLimit.mockResolvedValueOnce([makeScenarioRow()]);
+  dbState.selectThen
+    .mockImplementationOnce((resolve: (value: unknown[]) => void) =>
+      resolve(options.cases ?? [makeScenarioCaseRow()])
+    )
+    .mockImplementationOnce((resolve: (value: unknown[]) => void) =>
+      resolve(options.provenance ?? [])
+    );
+}
+
+function currentScenarioReadResponse() {
+  return {
+    company_name: '',
+    company_id: '101',
+    scenario: {
+      id: SCENARIO_ID,
+      company_id: '101',
+      name: 'Actuals-backed scenario',
+      version: 4,
+      is_default: false,
+      created_at: '2026-07-01T10:00:00.000Z',
+      updated_at: '2026-07-12T15:30:00.000Z',
+    },
+    cases: [
+      {
+        id: SCENARIO_CASE_ID,
+        case_name: 'Base case',
+        probability: 0.4,
+        investment: 500000,
+        follow_ons: 250000,
+        exit_proceeds: 1000000,
+        exit_valuation: 20000000,
+        months_to_exit: 36,
+        ownership_at_exit: 0.2,
+        moic: 2,
+      },
+    ],
+    weighted_summary: {
+      moic: 2,
+      investment: 200000,
+      follow_ons: 100000,
+      exit_proceeds: 400000,
+      exit_valuation: 8000000,
+      months_to_exit: 14.4,
+    },
+  };
+}
+
 afterEach(() => vi.useRealTimers());
 
 describe('scenario-analysis route fund-scope contracts', () => {
@@ -406,6 +538,145 @@ describe('scenario-analysis route fund-scope contracts', () => {
     expect(res.body).toMatchObject({ error: 'Invalid company ID' });
     expect(fundScopeState.enforceCompanyFundScope).not.toHaveBeenCalled();
     expect(dbState.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('scenario-analysis read seed provenance disclosure', () => {
+  beforeEach(() => resetState());
+
+  it('keeps the existing response unchanged when no cases were seeded', async () => {
+    mockScenarioRead();
+
+    const res = await request(makeApp()).get(`/api/companies/101/scenarios/${SCENARIO_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(currentScenarioReadResponse());
+    expect(factsState.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expectNoScenarioWrites();
+  });
+
+  it('marks a seeded case current using the per-company facts hash', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-13T23:59:59.000-07:00'));
+    mockScenarioRead({ provenance: [makeSeedProvenanceRow()] });
+    factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce(factsResponse('2026-07-14'));
+
+    const res = await request(makeApp()).get(`/api/companies/101/scenarios/${SCENARIO_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cases[0].seed_provenance).toEqual({
+      facts_input_hash: 'c'.repeat(64),
+      facts_as_of_date: '2026-07-01',
+      seeded_at: '2026-07-01T11:00:00.000Z',
+      trust_state: 'LIVE',
+      currency_status: 'base_currency',
+      staleness: 'current',
+    });
+    expect(res.body.weighted_summary).toEqual(currentScenarioReadResponse().weighted_summary);
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: '2026-07-14',
+    });
+    expectNoScenarioWrites();
+  });
+
+  it('marks a seeded case stale when its stored hash differs from current company facts', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-14T00:00:00.000Z'));
+    mockScenarioRead({
+      provenance: [makeSeedProvenanceRow({ factsInputHash: 'a'.repeat(64) })],
+    });
+    factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce(factsResponse('2026-07-14'));
+
+    const res = await request(makeApp()).get(`/api/companies/101/scenarios/${SCENARIO_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cases[0].seed_provenance).toMatchObject({
+      facts_input_hash: 'a'.repeat(64),
+      staleness: 'stale',
+    });
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expectNoScenarioWrites();
+  });
+
+  it('returns 200 and marks staleness unknown when current facts cannot be loaded', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-14T00:00:00.000Z'));
+    mockScenarioRead({ provenance: [makeSeedProvenanceRow()] });
+    factsState.buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts unavailable'));
+
+    const res = await request(makeApp()).get(`/api/companies/101/scenarios/${SCENARIO_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cases[0].seed_provenance).toEqual({
+      facts_input_hash: 'c'.repeat(64),
+      facts_as_of_date: '2026-07-01',
+      seeded_at: '2026-07-01T11:00:00.000Z',
+      trust_state: 'LIVE',
+      currency_status: 'base_currency',
+      staleness: 'unknown',
+    });
+    expect(res.body.weighted_summary).toEqual(currentScenarioReadResponse().weighted_summary);
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expectNoScenarioWrites();
+  });
+
+  it('marks staleness unknown when current facts omit the seeded company', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-14T00:00:00.000Z'));
+    mockScenarioRead({ provenance: [makeSeedProvenanceRow()] });
+    factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce({
+      ...factsResponse('2026-07-14'),
+      facts: [makeBlockedFact()],
+    });
+
+    const res = await request(makeApp()).get(`/api/companies/101/scenarios/${SCENARIO_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cases[0].seed_provenance.staleness).toBe('unknown');
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expectNoScenarioWrites();
+  });
+
+  it('discloses provenance only on seeded cases and loads current facts exactly once', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-14T00:00:00.000Z'));
+    mockScenarioRead({
+      cases: [
+        makeScenarioCaseRow(),
+        makeScenarioCaseRow({
+          id: UNSEEDED_CASE_ID,
+          caseName: 'Downside case',
+          probability: '0.60',
+          investment: '250000.000000',
+          followOns: '50000.000000',
+          exitProceeds: '750000.000000',
+          exitValuation: '10000000.000000',
+          monthsToExit: 24,
+          ownershipAtExit: '0.15',
+        }),
+      ],
+      provenance: [makeSeedProvenanceRow()],
+    });
+    factsState.buildFundCompanyActualsFacts.mockResolvedValueOnce(factsResponse('2026-07-14'));
+
+    const res = await request(makeApp()).get(`/api/companies/101/scenarios/${SCENARIO_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cases[0].seed_provenance.staleness).toBe('current');
+    expect(res.body.cases[1]).not.toHaveProperty('seed_provenance');
+    expect(res.body.weighted_summary).toEqual({
+      moic: 2.4285714285714284,
+      investment: 350000,
+      follow_ons: 130000,
+      exit_proceeds: 850000,
+      exit_valuation: 14000000,
+      months_to_exit: 28.8,
+    });
+    expect(dbState.select).toHaveBeenCalledTimes(3);
+    expect(factsState.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expectNoScenarioWrites();
   });
 });
 


### PR DESCRIPTION
## Summary

Plan 8 wave 4 — Task 8.5's user-facing intent, re-sliced to the verified architecture: seeded scenario cases now disclose whether their seed's facts snapshot is still current, display-only.

- On `GET /api/companies/:companyId/scenarios/:scenarioId`, cases with a `scenario_case_seed_provenance` row gain an additive `seed_provenance` block: stored facts hash, facts as-of date, seeded-at, trust state, currency status, and `staleness: current | stale | unknown` — comparing the immutably stored per-case facts hash against the live facts hash for that company. One provenance query + at most one facts call per request (only when seeded cases exist); facts failure degrades to `unknown` with the response otherwise unchanged (200). Zero writes on this path.

## Why the re-slice (verified, documented)

The plan's Task 8.5 wanted seed hashes folded into scenario *calculation identity* with a `SCENARIO_INPUT_HASH_VERSION` bump. Verification against current main showed: fund-scenario calculations consume `fund_scenario_variants` only and never touch `scenario_cases`, while the company-level calculations that do consume seeded cases are computed on read with no persisted identity. A version bump would churn every fund-scenario snapshot hash for zero semantic change — violating the plan's own "unseeded scenario hashes stay stable" rule. What remains faithful to the plan's binding decisions and is delivered here/already landed:
- "Persist the exact facts hash used" — persisted immutably at seeding by #1100 (`scenario_case_seed_provenance.facts_input_hash`).
- "Current-facts comparison only as a staleness disclosure; never rewrite a case" — this PR.
- `SCENARIO_INPUT_HASH_VERSION` remains `'scenario-input-hash-v1'`, untouched (scope-checked: no envelope/calculation-service/Monte Carlo/migration files in the diff).

## Verification

- 39/39 route contract tests independently green, including: byte-identical freeze for scenarios with no seeded cases, seeded-current, seeded-stale, facts-failure → `unknown` + 200, mixed seeded/unseeded, exactly-one-facts-call, and hash-granularity pinned to what the persistence service stored.
- Zero added `insert/update/delete` calls on the read path (grep-verified). `npm run check` 0 TS errors; ESLint clean.

Remaining Plan 8 waves: 8.6–8.8 (Monte Carlo facts adapter, fixed-seed flag-off parity, assumptions-profile extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h