### PR TITLE
feat(monte-carlo): actuals facts input contract and pure adapter (Plan 8 wave 5)

### DIFF
--- a/server/services/monte-carlo/facts-monte-carlo-input-adapter.ts
+++ b/server/services/monte-carlo/facts-monte-carlo-input-adapter.ts
@@ -1,0 +1,82 @@
+import type { FundCompanyActualsFactsResponse } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import {
+  FactsMonteCarloInputV1Schema,
+  type FactsMonteCarloCompanyV1,
+  type FactsMonteCarloInputV1,
+} from '../../../shared/contracts/monte-carlo/facts-input-v1.contract';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+
+const CONTRACT_VERSION = 'monte-carlo-facts-input-v1' as const;
+
+function normalizeMetadata(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function buildCompany(
+  fact: FundCompanyActualsFactsResponse['facts'][number],
+  metadata: { stage: string | null; sector: string | null } | undefined
+): FactsMonteCarloCompanyV1 {
+  const trustState = fact.provenance.trustState;
+  const moneyUnavailable =
+    fact.currencyStatus === 'mismatch_blocked' ||
+    trustState === 'FAILED' ||
+    trustState === 'UNAVAILABLE';
+
+  return {
+    companyId: fact.companyId,
+    observedInitialInvestment: moneyUnavailable ? null : fact.initialInvestmentAmount,
+    observedFollowOnInvestment: moneyUnavailable ? null : fact.followOnInvestmentAmount,
+    planningFmv:
+      !moneyUnavailable &&
+      fact.planningFmvStatus === 'active' &&
+      fact.currencyStatus === 'base_currency'
+        ? fact.latestPlanningFmvValue
+        : null,
+    planningFmvStatus: fact.planningFmvStatus,
+    stage: normalizeMetadata(metadata?.stage),
+    sector: normalizeMetadata(metadata?.sector),
+    trustState,
+    currencyStatus: fact.currencyStatus,
+    warnings: fact.warnings,
+  };
+}
+
+export function buildFactsMonteCarloInput(input: {
+  fundId: number;
+  asOfDate: string;
+  facts: FundCompanyActualsFactsResponse;
+  companyMetadata: ReadonlyMap<number, { stage: string | null; sector: string | null }>;
+}): FactsMonteCarloInputV1 {
+  if (input.facts.fundId !== input.fundId) {
+    throw new Error(
+      `Facts fundId ${input.facts.fundId} does not match requested fundId ${input.fundId}`
+    );
+  }
+  if (input.facts.asOfDate !== input.asOfDate) {
+    throw new Error(
+      `Facts asOfDate ${input.facts.asOfDate} does not match requested asOfDate ${input.asOfDate}`
+    );
+  }
+  const mismatchedCompany = input.facts.facts.find((fact) => fact.fundId !== input.fundId);
+  if (mismatchedCompany) {
+    throw new Error(
+      `Company ${mismatchedCompany.companyId} facts fundId ${mismatchedCompany.fundId} does not match requested fundId ${input.fundId}`
+    );
+  }
+
+  const normalized = {
+    contractVersion: CONTRACT_VERSION,
+    fundId: input.fundId,
+    asOfDate: input.asOfDate,
+    sourceFactsInputHash: input.facts.inputHash,
+    companies: [...input.facts.facts]
+      .sort((left, right) => left.companyId - right.companyId)
+      .map((fact) => buildCompany(fact, input.companyMetadata.get(fact.companyId))),
+  } satisfies Omit<FactsMonteCarloInputV1, 'factsInputHash'>;
+
+  return FactsMonteCarloInputV1Schema.parse({
+    ...normalized,
+    factsInputHash: canonicalSha256(normalized),
+  });
+}

--- a/shared/contracts/monte-carlo/facts-input-v1.contract.ts
+++ b/shared/contracts/monte-carlo/facts-input-v1.contract.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+import {
+  FundCompanyActualsCurrencyStatusSchema,
+  FundCompanyActualsPlanningFmvStatusSchema,
+  Sha256Schema,
+} from '../fund-actuals/fund-company-actuals-fact.contract';
+import { DecimalStringSchema } from '../lp-reporting/cash-flow-event.contract';
+import { StructuredWarningSchema } from '../provenance-envelope.contract';
+
+export const FactsMonteCarloCompanyV1Schema = z
+  .object({
+    companyId: z.number().int().positive(),
+    observedInitialInvestment: DecimalStringSchema.nullable(),
+    observedFollowOnInvestment: DecimalStringSchema.nullable(),
+    planningFmv: DecimalStringSchema.nullable(),
+    planningFmvStatus: FundCompanyActualsPlanningFmvStatusSchema,
+    stage: z.string().min(1).nullable(),
+    sector: z.string().min(1).nullable(),
+    trustState: z.enum(['LIVE', 'PARTIAL', 'UNAVAILABLE', 'FAILED']),
+    currencyStatus: FundCompanyActualsCurrencyStatusSchema,
+    warnings: z.array(StructuredWarningSchema),
+  })
+  .strict();
+
+export const FactsMonteCarloInputV1Schema = z
+  .object({
+    contractVersion: z.literal('monte-carlo-facts-input-v1'),
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+    factsInputHash: Sha256Schema,
+    sourceFactsInputHash: Sha256Schema,
+    companies: z.array(FactsMonteCarloCompanyV1Schema),
+  })
+  .strict();
+
+export type FactsMonteCarloCompanyV1 = z.infer<typeof FactsMonteCarloCompanyV1Schema>;
+export type FactsMonteCarloInputV1 = z.infer<typeof FactsMonteCarloInputV1Schema>;

--- a/tests/unit/contracts/facts-monte-carlo-input-v1.contract.test.ts
+++ b/tests/unit/contracts/facts-monte-carlo-input-v1.contract.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FactsMonteCarloCompanyV1Schema,
+  FactsMonteCarloInputV1Schema,
+} from '../../../shared/contracts/monte-carlo/facts-input-v1.contract';
+
+const FACTS_INPUT_HASH = 'a'.repeat(64);
+const SOURCE_FACTS_INPUT_HASH = 'b'.repeat(64);
+
+const validCompany = {
+  companyId: 11,
+  observedInitialInvestment: '100.250000',
+  observedFollowOnInvestment: '20.750000',
+  planningFmv: '500.000000',
+  planningFmvStatus: 'active' as const,
+  stage: 'Series A',
+  sector: 'SaaS',
+  trustState: 'LIVE' as const,
+  currencyStatus: 'base_currency' as const,
+  warnings: [],
+};
+
+const validInput = {
+  contractVersion: 'monte-carlo-facts-input-v1' as const,
+  fundId: 7,
+  asOfDate: '2026-07-13',
+  factsInputHash: FACTS_INPUT_HASH,
+  sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+  companies: [validCompany],
+};
+
+describe('FactsMonteCarloCompanyV1Schema', () => {
+  it('accepts normalized company facts and nullable unavailable values', () => {
+    expect(FactsMonteCarloCompanyV1Schema.parse(validCompany)).toEqual(validCompany);
+
+    expect(
+      FactsMonteCarloCompanyV1Schema.parse({
+        ...validCompany,
+        observedInitialInvestment: null,
+        observedFollowOnInvestment: null,
+        planningFmv: null,
+        stage: null,
+        sector: null,
+        trustState: 'UNAVAILABLE',
+        currencyStatus: 'mismatch_blocked',
+      })
+    ).toMatchObject({
+      observedInitialInvestment: null,
+      observedFollowOnInvestment: null,
+      planningFmv: null,
+      stage: null,
+      sector: null,
+    });
+  });
+
+  it('rejects unknown keys', () => {
+    expect(
+      FactsMonteCarloCompanyV1Schema.safeParse({ ...validCompany, distribution: 'power_law' })
+        .success
+    ).toBe(false);
+  });
+
+  it.each([
+    ['trustState', 'STALE'],
+    ['planningFmvStatus', 'pending'],
+    ['currencyStatus', 'converted'],
+  ])('rejects unsupported %s enum values', (field, value) => {
+    expect(
+      FactsMonteCarloCompanyV1Schema.safeParse({ ...validCompany, [field]: value }).success
+    ).toBe(false);
+  });
+});
+
+describe('FactsMonteCarloInputV1Schema', () => {
+  it('accepts the versioned strict input contract', () => {
+    expect(FactsMonteCarloInputV1Schema.parse(validInput)).toEqual(validInput);
+  });
+
+  it('rejects unknown top-level keys and invalid contract identity fields', () => {
+    expect(FactsMonteCarloInputV1Schema.safeParse({ ...validInput, assumptions: {} }).success).toBe(
+      false
+    );
+    expect(
+      FactsMonteCarloInputV1Schema.safeParse({
+        ...validInput,
+        contractVersion: 'monte-carlo-facts-input-v2',
+      }).success
+    ).toBe(false);
+    expect(
+      FactsMonteCarloInputV1Schema.safeParse({
+        ...validInput,
+        sourceFactsInputHash: 'not-a-sha256',
+      }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/services/monte-carlo/facts-monte-carlo-input-adapter.test.ts
+++ b/tests/unit/services/monte-carlo/facts-monte-carlo-input-adapter.test.ts
@@ -1,0 +1,437 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import type { FundCompanyActualsFactsResponse } from '../../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { canonicalSha256 } from '../../../../shared/lib/canonical-hash';
+import { buildFactsMonteCarloInput } from '../../../../server/services/monte-carlo/facts-monte-carlo-input-adapter';
+
+type CompanyFact = FundCompanyActualsFactsResponse['facts'][number];
+type TrustState = CompanyFact['provenance']['trustState'];
+
+const SOURCE_FACTS_INPUT_HASH = 'a'.repeat(64);
+const COMPANY_FACTS_INPUT_HASH = 'b'.repeat(64);
+const ASSUMPTIONS_HASH = 'c'.repeat(64);
+const AS_OF_DATE = '2026-07-13';
+
+const partialWarning = {
+  code: 'PLANNING_FMV_STALE' as const,
+  severity: 'warning' as const,
+  message: 'Planning FMV is stale.',
+  source: 'company:11',
+};
+
+const currencyWarning = {
+  code: 'CURRENCY_MISMATCH_BLOCK' as const,
+  severity: 'blocking' as const,
+  message: 'Company currency does not match the fund base currency.',
+  source: 'company:11',
+};
+
+const failedWarning = {
+  code: 'ROUND_ADAPTER_FAILED' as const,
+  severity: 'blocking' as const,
+  message: 'Round evidence could not be assembled.',
+  source: 'company:11',
+};
+
+const infoWarning = {
+  code: 'PLANNING_FMV_MISSING' as const,
+  severity: 'info' as const,
+  message: 'No planning FMV is available.',
+  source: 'company:11',
+};
+
+function provenance(trustState: TrustState): CompanyFact['provenance'] {
+  if (trustState === 'FAILED') {
+    return {
+      trustState,
+      core: {
+        sourceKind: 'prototype_blocked',
+        actionability: 'non_actionable',
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        quarantineReason: 'round_adapter_failed',
+        warnings: [],
+      },
+      structuredWarnings: [failedWarning],
+    };
+  }
+
+  if (trustState === 'UNAVAILABLE') {
+    return {
+      trustState,
+      core: {
+        sourceKind: 'computed',
+        actionability: 'quarantined',
+        sourceEngine: 'fund-company-actuals-facts',
+        engineVersion: 'fund-company-actuals-facts-v1',
+        inputHash: COMPANY_FACTS_INPUT_HASH,
+        assumptionsHash: ASSUMPTIONS_HASH,
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        quarantineReason: 'currency_mismatch',
+        warnings: [],
+      },
+      structuredWarnings: [currencyWarning],
+    };
+  }
+
+  if (trustState === 'PARTIAL') {
+    return {
+      trustState,
+      core: {
+        sourceKind: 'computed',
+        actionability: 'input_only',
+        sourceEngine: 'fund-company-actuals-facts',
+        engineVersion: 'fund-company-actuals-facts-v1',
+        inputHash: COMPANY_FACTS_INPUT_HASH,
+        assumptionsHash: ASSUMPTIONS_HASH,
+        generatedAt: '2026-07-13T00:00:00.000Z',
+        isFinanciallyActionable: false,
+        warnings: [],
+      },
+      structuredWarnings: [partialWarning],
+    };
+  }
+
+  return {
+    trustState,
+    core: {
+      sourceKind: 'computed',
+      actionability: 'actionable',
+      sourceEngine: 'fund-company-actuals-facts',
+      engineVersion: 'fund-company-actuals-facts-v1',
+      inputHash: COMPANY_FACTS_INPUT_HASH,
+      assumptionsHash: ASSUMPTIONS_HASH,
+      generatedAt: '2026-07-13T00:00:00.000Z',
+      isFinanciallyActionable: true,
+      warnings: [],
+    },
+    structuredWarnings: [],
+  };
+}
+
+function companyFact(companyId: number, overrides: Partial<CompanyFact> = {}): CompanyFact {
+  return {
+    fundId: 7,
+    companyId,
+    companyName: `Company ${companyId}`,
+    investmentIds: [100 + companyId],
+    activeRoundIds: [200 + companyId],
+    approvedPlanningFmvMarkId: 300 + companyId,
+    planningFmvStatus: 'active',
+    initialInvestmentAmount: '100.250000',
+    followOnInvestmentAmount: '20.750000',
+    amountOnlyNonEquityAmount: '0.000000',
+    latestRoundDate: '2026-07-01',
+    latestRoundValuation: '1000.000000',
+    latestPlanningFmvDate: '2026-07-10',
+    latestPlanningFmvValue: '500.000000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [{ roundId: 200 + companyId, supersedesRoundId: null }],
+    warnings: [],
+    provenance: provenance('LIVE'),
+    inputHash: canonicalSha256({ companyId }),
+    ...overrides,
+  };
+}
+
+function factsResponse(facts: CompanyFact[]): FundCompanyActualsFactsResponse {
+  return {
+    fundId: 7,
+    asOfDate: AS_OF_DATE,
+    facts,
+    inputHash: SOURCE_FACTS_INPUT_HASH,
+    generatedAt: '2026-07-13T00:00:00.000Z',
+  };
+}
+
+function buildInput(params?: {
+  facts?: FundCompanyActualsFactsResponse;
+  companyMetadata?: ReadonlyMap<number, { stage: string | null; sector: string | null }>;
+  asOfDate?: string;
+}) {
+  return buildFactsMonteCarloInput({
+    fundId: 7,
+    asOfDate: params?.asOfDate ?? AS_OF_DATE,
+    facts: params?.facts ?? factsResponse([companyFact(11)]),
+    companyMetadata:
+      params?.companyMetadata ?? new Map([[11, { stage: 'Series A', sector: 'SaaS' }]]),
+  });
+}
+
+describe('buildFactsMonteCarloInput', () => {
+  it('builds and hashes an empty portfolio without fabricating companies', () => {
+    const result = buildInput({ facts: factsResponse([]), companyMetadata: new Map() });
+    const normalized = {
+      contractVersion: 'monte-carlo-facts-input-v1',
+      fundId: 7,
+      asOfDate: AS_OF_DATE,
+      sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+      companies: [],
+    };
+
+    expect(result).toEqual({
+      ...normalized,
+      factsInputHash: canonicalSha256(normalized),
+    });
+  });
+
+  it('maps a full LIVE company from facts and explicit metadata', () => {
+    const result = buildInput();
+    const normalized = {
+      contractVersion: 'monte-carlo-facts-input-v1' as const,
+      fundId: 7,
+      asOfDate: AS_OF_DATE,
+      sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+      companies: [
+        {
+          companyId: 11,
+          observedInitialInvestment: '100.250000',
+          observedFollowOnInvestment: '20.750000',
+          planningFmv: '500.000000',
+          planningFmvStatus: 'active' as const,
+          stage: 'Series A',
+          sector: 'SaaS',
+          trustState: 'LIVE' as const,
+          currencyStatus: 'base_currency' as const,
+          warnings: [],
+        },
+      ],
+    };
+
+    expect(result).toEqual({
+      ...normalized,
+      factsInputHash: canonicalSha256(normalized),
+    });
+  });
+
+  it('preserves available PARTIAL fields while withholding an inactive planning FMV', () => {
+    const partialFact = companyFact(11, {
+      planningFmvStatus: 'stale',
+      warnings: [partialWarning],
+      provenance: provenance('PARTIAL'),
+    });
+
+    expect(buildInput({ facts: factsResponse([partialFact]) }).companies[0]).toEqual({
+      companyId: 11,
+      observedInitialInvestment: '100.250000',
+      observedFollowOnInvestment: '20.750000',
+      planningFmv: null,
+      planningFmvStatus: 'stale',
+      stage: 'Series A',
+      sector: 'SaaS',
+      trustState: 'PARTIAL',
+      currencyStatus: 'base_currency',
+      warnings: [partialWarning],
+    });
+  });
+
+  it('nulls every monetary field when currency is blocked', () => {
+    const blockedFact = companyFact(11, {
+      currency: 'EUR',
+      currencyStatus: 'mismatch_blocked',
+      planningFmvStatus: 'blocked',
+      warnings: [currencyWarning],
+      provenance: provenance('UNAVAILABLE'),
+    });
+
+    expect(buildInput({ facts: factsResponse([blockedFact]) }).companies[0]).toMatchObject({
+      observedInitialInvestment: null,
+      observedFollowOnInvestment: null,
+      planningFmv: null,
+      planningFmvStatus: 'blocked',
+      trustState: 'UNAVAILABLE',
+      currencyStatus: 'mismatch_blocked',
+    });
+  });
+
+  it('nulls every monetary field for FAILED facts even in the base currency', () => {
+    const failedFact = companyFact(11, {
+      warnings: [failedWarning],
+      provenance: provenance('FAILED'),
+    });
+
+    expect(buildInput({ facts: factsResponse([failedFact]) }).companies[0]).toMatchObject({
+      observedInitialInvestment: null,
+      observedFollowOnInvestment: null,
+      planningFmv: null,
+      trustState: 'FAILED',
+      currencyStatus: 'base_currency',
+      warnings: [failedWarning],
+    });
+  });
+
+  it('sorts mixed trust states, preserves unavailable companies, and never defaults metadata', () => {
+    const failed = companyFact(13, {
+      warnings: [failedWarning],
+      provenance: provenance('FAILED'),
+    });
+    const live = companyFact(11);
+    const unavailable = companyFact(12, {
+      currency: 'EUR',
+      currencyStatus: 'mismatch_blocked',
+      planningFmvStatus: 'blocked',
+      warnings: [currencyWarning],
+      provenance: provenance('UNAVAILABLE'),
+    });
+    const metadata = new Map([
+      [11, { stage: 'Series A', sector: 'SaaS' }],
+      [12, { stage: '', sector: '   ' }],
+    ]);
+
+    const result = buildInput({
+      facts: factsResponse([failed, live, unavailable]),
+      companyMetadata: metadata,
+    });
+
+    expect(result.companies).toHaveLength(3);
+    expect(result.companies.map((company) => company.companyId)).toEqual([11, 12, 13]);
+    expect(result.companies[1]).toMatchObject({ stage: null, sector: null });
+    expect(result.companies[2]).toMatchObject({ stage: null, sector: null });
+    expect(JSON.stringify(result)).not.toMatch(/unknown|seed/i);
+  });
+
+  it('rejects source response and nested company scope mismatches', () => {
+    expect(() =>
+      buildInput({
+        facts: { ...factsResponse([companyFact(11)]), fundId: 8 },
+      })
+    ).toThrow(/facts fundId 8 does not match requested fundId 7/i);
+
+    expect(() =>
+      buildInput({
+        facts: { ...factsResponse([companyFact(11)]), asOfDate: '2026-07-12' },
+      })
+    ).toThrow(/facts asOfDate 2026-07-12 does not match requested asOfDate 2026-07-13/i);
+
+    expect(() =>
+      buildInput({
+        facts: factsResponse([companyFact(11, { fundId: 8 })]),
+      })
+    ).toThrow(/company 11 facts fundId 8 does not match requested fundId 7/i);
+  });
+
+  it('produces a stable hash and changes it for every normalized field category', () => {
+    const first = buildInput();
+    const second = buildInput();
+    expect(second.factsInputHash).toBe(first.factsInputHash);
+
+    const changedFundFacts = factsResponse([companyFact(11, { fundId: 8 })]);
+    const changedDateFacts = {
+      ...factsResponse([companyFact(11)]),
+      asOfDate: '2026-07-14',
+    };
+    const changedFund = buildFactsMonteCarloInput({
+      fundId: 8,
+      asOfDate: AS_OF_DATE,
+      facts: { ...changedFundFacts, fundId: 8 },
+      companyMetadata: new Map([[11, { stage: 'Series A', sector: 'SaaS' }]]),
+    });
+    const changedDate = buildInput({ facts: changedDateFacts, asOfDate: '2026-07-14' });
+    const changedSourceHash = buildInput({
+      facts: { ...factsResponse([companyFact(11)]), inputHash: 'd'.repeat(64) },
+    });
+    const changedCompanyId = buildInput({
+      facts: factsResponse([companyFact(12)]),
+      companyMetadata: new Map([[12, { stage: 'Series A', sector: 'SaaS' }]]),
+    });
+    const changedInitialInvestment = buildInput({
+      facts: factsResponse([companyFact(11, { initialInvestmentAmount: '101.250000' })]),
+    });
+    const changedFollowOnInvestment = buildInput({
+      facts: factsResponse([companyFact(11, { followOnInvestmentAmount: '21.750000' })]),
+    });
+    const changedPlanningFmv = buildInput({
+      facts: factsResponse([companyFact(11, { latestPlanningFmvValue: '501.000000' })]),
+    });
+    const changedPlanningFmvStatus = buildInput({
+      facts: factsResponse([
+        companyFact(11, { planningFmvStatus: 'none', latestPlanningFmvValue: null }),
+      ]),
+    });
+    const changedStage = buildInput({
+      companyMetadata: new Map([[11, { stage: 'Series B', sector: 'SaaS' }]]),
+    });
+    const changedSector = buildInput({
+      companyMetadata: new Map([[11, { stage: 'Series A', sector: 'Fintech' }]]),
+    });
+    const changedTrustState = buildInput({
+      facts: factsResponse([companyFact(11, { provenance: provenance('PARTIAL') })]),
+    });
+    const changedCurrencyStatus = buildInput({
+      facts: factsResponse([companyFact(11, { currencyStatus: 'unknown' })]),
+    });
+    const changedWarnings = buildInput({
+      facts: factsResponse([
+        companyFact(11, {
+          warnings: [infoWarning],
+          provenance: {
+            ...provenance('LIVE'),
+            structuredWarnings: [infoWarning],
+          },
+        }),
+      ]),
+    });
+
+    const changedHashes = [
+      changedFund,
+      changedDate,
+      changedSourceHash,
+      changedCompanyId,
+      changedInitialInvestment,
+      changedFollowOnInvestment,
+      changedPlanningFmv,
+      changedPlanningFmvStatus,
+      changedStage,
+      changedSector,
+      changedTrustState,
+      changedCurrencyStatus,
+      changedWarnings,
+    ].map((result) => result.factsInputHash);
+
+    expect(new Set([first.factsInputHash, ...changedHashes]).size).toBe(changedHashes.length + 1);
+  });
+
+  it('produces the same ordering and hash for equivalent source fact permutations', () => {
+    const metadata = new Map([
+      [11, { stage: 'Series A', sector: 'SaaS' }],
+      [12, { stage: 'Series B', sector: 'Fintech' }],
+    ]);
+    const ascending = buildInput({
+      facts: factsResponse([companyFact(11), companyFact(12)]),
+      companyMetadata: metadata,
+    });
+    const descending = buildInput({
+      facts: factsResponse([companyFact(12), companyFact(11)]),
+      companyMetadata: metadata,
+    });
+
+    expect(descending.companies).toEqual(ascending.companies);
+    expect(descending.factsInputHash).toBe(ascending.factsInputHash);
+  });
+
+  it('imports no database, schema, HTTP, PRNG, distribution, or simulation modules', async () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+    const source = await readFile(
+      path.join(repoRoot, 'server/services/monte-carlo/facts-monte-carlo-input-adapter.ts'),
+      'utf8'
+    );
+    const fromImports = [...source.matchAll(/from\s+['"]([^'"]+)['"]/g)].map(
+      (match) => match[1] ?? ''
+    );
+    const sideEffectImports = [...source.matchAll(/import\s+['"]([^'"]+)['"]/g)].map(
+      (match) => match[1] ?? ''
+    );
+    const forbiddenImport =
+      /server\/db|(?:^|\/)db$|shared\/(?:schema|schemas)(?:\/|$)|drizzle|express|prng|distribution|simulation/i;
+
+    expect(
+      [...fromImports, ...sideEffectImports].filter((specifier) => forbiddenImport.test(specifier))
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Plan 8 wave 5 (Task 8.6) — the Monte Carlo facts-input seam, as a pure function with zero behavior change to any simulation.

- **New contract** `shared/contracts/monte-carlo/facts-input-v1.contract.ts`: strict per-company state (observed initial/follow-on investment, planning FMV + status, stage/sector, trust state, currency status, warnings) with two hashes — `factsInputHash` (canonical SHA-256 of the normalized adapter output) and `sourceFactsInputHash` (the facts response's own hash).
- **New pure adapter** `server/services/monte-carlo/facts-monte-carlo-input-adapter.ts`: `buildFactsMonteCarloInput` is fully synchronous — the caller supplies the facts response and explicit stage/sector metadata. Blocked-currency and FAILED/UNAVAILABLE trust null all money (never zero); company count preserved with unavailable entries retained; stage/sector are explicit-or-null (no 'unknown'/'seed' fabrication); deterministic companyId ordering; output schema-parsed before return. No distribution choices, no volatility, no PRNG — company state only.
- Two documented additive clarifications vs the plan's literal interface: nullable money fields (required by "blocked money is unavailable, not zero") and the separate `sourceFactsInputHash` (separates adapter-output identity from facts identity).

## Verification

- 17/17 tests independently green (contract strictness/enums; empty/LIVE/PARTIAL/blocked/FAILED/mixed portfolios; count preservation; metadata-absence nulls; hash stability + sensitivity; source-level import guard: no db/schema/express/PRNG/simulation imports in the adapter).
- Zero existing Monte Carlo engine/service/route/queue files touched (grep-verified); purely additive 4-file diff. `npm run check` 0 TS errors; ESLint clean.

Next Plan 8 wave (8.7): flag `enable_monte_carlo_actuals_inputs` + fixed-seed byte-identical flag-off parity, gating exactly at the `portfolioCompanies` read sites in the simulation service. 8.8 (assumptions profile) after 8.7 is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h