### PR TITLE
feat(monte-carlo): shadow actuals-backed company inputs behind fixed-seed-identical gate (Plan 8 wave 6)

### DIFF
--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -530,6 +530,20 @@ flags:
     expiresAt: null
     aliases: ['ENABLE_FACTS_SOURCED_RESERVE_INPUTS']
 
+  enable_monte_carlo_actuals_inputs:
+    default: false
+    description: 'Gates facts-backed company-state inputs for Monte Carlo forecasts'
+    owner: 'analytics'
+    risk: high
+    exposeToClient: false
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: null
+    aliases: ['ENABLE_MONTE_CARLO_ACTUALS_INPUTS']
+
   enable_faults:
     default: false
     description: 'Enable fault injection for testing'

--- a/server/services/monte-carlo-simulation.ts
+++ b/server/services/monte-carlo-simulation.ts
@@ -20,6 +20,30 @@ import type { PowerLawDistribution } from './power-law-distribution';
 import { createVCPowerLawDistribution, type InvestmentStage } from './power-law-distribution';
 import { Decimal, toDecimal } from '@shared/lib/decimal-utils';
 import { PRNG } from '@shared/utils/prng';
+import { isFlagEnabled } from '@shared/flags/getFlag';
+import type { FactsMonteCarloInputV1 } from '@shared/contracts/monte-carlo/facts-input-v1.contract';
+import { logger } from '../lib/logger';
+
+const MONTE_CARLO_ACTUALS_CALCULATION_KEY = 'monte_carlo_actuals_inputs';
+
+type MonteCarloActualsCalculationMode = 'off' | 'shadow' | 'on';
+type ActiveMonteCarloActualsMode = Exclude<MonteCarloActualsCalculationMode, 'off'>;
+
+interface MonteCarloActualsFactsMetadata {
+  factsInputHash: string;
+  sourceFactsInputHash: string;
+  mode: ActiveMonteCarloActualsMode;
+}
+
+interface MonteCarloActualsWarning {
+  code: 'ACTUALS_MONEY_BLOCKED';
+  blockedCompanyCount: number;
+  message: string;
+}
+
+interface MonteCarloActualsFactsProvenance extends MonteCarloActualsFactsMetadata {
+  warnings?: MonteCarloActualsWarning[];
+}
 
 /**
  * Core Monte Carlo simulation parameters
@@ -134,6 +158,10 @@ export interface MonteCarloForecast {
     worstCase: Record<string, number>; // 10th percentile outcomes
     stressTest: Record<string, number>; // 5th percentile outcomes
   };
+
+  provenance?: {
+    actualsFacts: MonteCarloActualsFactsProvenance;
+  };
 }
 
 /**
@@ -202,9 +230,170 @@ interface ReserveScenario {
 /**
  * Portfolio company with optional investments relation
  */
-type PortfolioCompanyWithInvestments = PortfolioCompany & {
-  investments?: unknown[];
+type PortfolioCompanyWithInvestments = Pick<PortfolioCompany, 'id'> & {
+  stage: string | null;
+  sector: string | null;
+  investmentAmount?: string | null;
+  investments?: ReadonlyArray<{ amount: string }>;
 };
+
+interface ActualsMonteCarloCompanyState {
+  companies: PortfolioCompanyWithInvestments[];
+  usableMoneyCount: number;
+  blockedCount: number;
+}
+
+interface LoadedActualsMonteCarloCompanyState extends ActualsMonteCarloCompanyState {
+  factsInputHash: string;
+  sourceFactsInputHash: string;
+  legacyCompanyCount: number;
+}
+
+async function resolveMonteCarloActualsCalculationMode(
+  fundId: number
+): Promise<MonteCarloActualsCalculationMode> {
+  const mode = await db.query.fundCalculationModes.findFirst({
+    columns: { configuredMode: true, killSwitchActive: true },
+    where: (row, { and: andWhere, eq: eqWhere }) =>
+      andWhere(
+        eqWhere(row.fundId, fundId),
+        eqWhere(row.calculationKey, MONTE_CARLO_ACTUALS_CALCULATION_KEY)
+      ),
+  });
+  if (mode?.killSwitchActive) return 'off';
+  return mode?.configuredMode === 'shadow' || mode?.configuredMode === 'on'
+    ? mode.configuredMode
+    : 'off';
+}
+
+export function buildActualsMonteCarloCompanyState(
+  factsInput: FactsMonteCarloInputV1
+): ActualsMonteCarloCompanyState {
+  let usableMoneyCount = 0;
+  let blockedCount = 0;
+  const companies = factsInput.companies.map((company) => {
+    const initialInvestment = company.observedInitialInvestment;
+    const followOnInvestment = company.observedFollowOnInvestment;
+
+    if (initialInvestment === null || followOnInvestment === null) {
+      blockedCount += 1;
+      // Keep the company for count/stage/sector analysis, but provide no money
+      // rows so monetary consumers cannot accidentally aggregate blocked facts.
+      return {
+        id: company.companyId,
+        stage: company.stage,
+        sector: company.sector,
+        investmentAmount: null,
+        investments: [],
+      };
+    }
+
+    usableMoneyCount += 1;
+    return {
+      id: company.companyId,
+      stage: company.stage,
+      sector: company.sector,
+      investmentAmount: toDecimal(initialInvestment).plus(followOnInvestment).toString(),
+      investments: [{ amount: initialInvestment }, { amount: followOnInvestment }],
+    };
+  });
+
+  return { companies, usableMoneyCount, blockedCount };
+}
+
+async function loadPortfolioCompanyMetadata(
+  fundId: number
+): Promise<PortfolioCompanyWithInvestments[]> {
+  return db.query.portfolioCompanies.findMany({
+    where: eq(portfolioCompanies.fundId, fundId),
+    with: { investments: true },
+  });
+}
+
+async function buildActualsCompanyStateFromMetadata(input: {
+  fundId: number;
+  asOfDate: string;
+  portfolioRows: PortfolioCompanyWithInvestments[];
+}): Promise<LoadedActualsMonteCarloCompanyState> {
+  const { buildFundCompanyActualsFacts } =
+    await import('./fund-actuals/fund-company-actuals-facts-service');
+  const facts = await buildFundCompanyActualsFacts({
+    fundId: input.fundId,
+    asOfDate: input.asOfDate,
+  });
+  const { buildFactsMonteCarloInput } =
+    await import('./monte-carlo/facts-monte-carlo-input-adapter');
+  const companyMetadata = new Map(
+    input.portfolioRows.map((company) => [
+      company.id,
+      { stage: company.stage, sector: company.sector },
+    ])
+  );
+  const factsInput = buildFactsMonteCarloInput({
+    fundId: input.fundId,
+    asOfDate: input.asOfDate,
+    facts,
+    companyMetadata,
+  });
+
+  return {
+    ...buildActualsMonteCarloCompanyState(factsInput),
+    factsInputHash: factsInput.factsInputHash,
+    sourceFactsInputHash: factsInput.sourceFactsInputHash,
+    legacyCompanyCount: input.portfolioRows.length,
+  };
+}
+
+function actualsMetadata(
+  input: LoadedActualsMonteCarloCompanyState,
+  mode: ActiveMonteCarloActualsMode
+): MonteCarloActualsFactsMetadata {
+  return {
+    factsInputHash: input.factsInputHash,
+    sourceFactsInputHash: input.sourceFactsInputHash,
+    mode,
+  };
+}
+
+function actualsProvenance(
+  input: LoadedActualsMonteCarloCompanyState,
+  mode: ActiveMonteCarloActualsMode
+): MonteCarloActualsFactsProvenance {
+  const metadata = actualsMetadata(input, mode);
+  if (mode !== 'on' || input.blockedCount === 0) return metadata;
+
+  const noun = input.blockedCount === 1 ? 'company' : 'companies';
+  return {
+    ...metadata,
+    warnings: [
+      {
+        code: 'ACTUALS_MONEY_BLOCKED',
+        blockedCompanyCount: input.blockedCount,
+        message: `${input.blockedCount} ${noun} retained for count-based analysis and excluded from monetary aggregates`,
+      },
+    ],
+  };
+}
+
+function snapshotMetadata(
+  forecast: MonteCarloForecast,
+  factsMetadata?: MonteCarloActualsFactsMetadata
+): Record<string, unknown> {
+  return {
+    baselineId: forecast.baselineId,
+    scenarios: forecast.parameters.scenarios,
+    timeHorizon: forecast.parameters.timeHorizonYears,
+    ...(factsMetadata !== undefined && { actualsFacts: factsMetadata }),
+  };
+}
+
+function logMonteCarloActualsShadowEvent(event: Record<string, unknown>): void {
+  try {
+    logger.info(event, 'monte carlo actuals-input shadow comparison generated');
+  } catch {
+    return;
+  }
+}
 
 /**
  * Main Monte Carlo Simulation Service
@@ -225,6 +414,19 @@ export class MonteCarloSimulationService {
   async generateForecast(params: SimulationParameters): Promise<MonteCarloForecast> {
     const _startTime = Date.now();
     const simulationId = uuidv4();
+    const actualsMode = isFlagEnabled('enable_monte_carlo_actuals_inputs')
+      ? await resolveMonteCarloActualsCalculationMode(params.fundId)
+      : 'off';
+    let actualsState: LoadedActualsMonteCarloCompanyState | undefined;
+
+    if (actualsMode === 'on') {
+      const portfolioRows = await loadPortfolioCompanyMetadata(params.fundId);
+      actualsState = await buildActualsCompanyStateFromMetadata({
+        fundId: params.fundId,
+        asOfDate: new Date().toISOString().slice(0, 10),
+        portfolioRows,
+      });
+    }
 
     // Get baseline data
     const baseline = await this.getBaselineData(params.fundId, params.baselineId);
@@ -236,13 +438,19 @@ export class MonteCarloSimulationService {
     const distributions = await this.generateDistributions(variancePatterns);
 
     // Run Monte Carlo simulations
-    const simulationResults = await this.runSimulations(params, baseline, distributions);
+    const simulationResults = await this.runSimulations(
+      params,
+      baseline,
+      distributions,
+      actualsState?.companies
+    );
 
     // Analyze portfolio metrics
     const portfolioMetrics = await this.analyzePortfolioScenarios(
       params,
       baseline,
-      simulationResults
+      simulationResults,
+      actualsState?.companies
     );
 
     // Optimize reserve allocation
@@ -280,10 +488,27 @@ export class MonteCarloSimulationService {
       reserveOptimization,
       riskMetrics,
       scenarioAnalysis,
+      ...(actualsState !== undefined && {
+        provenance: { actualsFacts: actualsProvenance(actualsState, 'on') },
+      }),
     };
 
     // Store forecast results
-    await this.storeForecast(forecast);
+    const snapshotId = await this.storeForecast(
+      forecast,
+      actualsState === undefined ? undefined : actualsMetadata(actualsState, 'on'),
+      actualsMode === 'shadow'
+    );
+
+    if (actualsMode === 'shadow') {
+      if (snapshotId === undefined) {
+        throw new Error('Missing persisted Monte Carlo snapshot id for shadow provenance');
+      }
+      const shadowProvenance = await this.runActualsShadow(forecast, snapshotId);
+      if (shadowProvenance !== undefined) {
+        forecast.provenance = { actualsFacts: shadowProvenance };
+      }
+    }
 
     return forecast;
   }
@@ -433,7 +658,8 @@ export class MonteCarloSimulationService {
   private async runSimulations(
     params: SimulationParameters,
     baseline: FundBaseline,
-    distributions: Record<string, DistributionParams>
+    distributions: Record<string, DistributionParams>,
+    portfolioCompanyState?: PortfolioCompanyWithInvestments[]
   ) {
     const scenarios = params.scenarios || 10000;
     interface SimulationResultArrays {
@@ -458,7 +684,10 @@ export class MonteCarloSimulationService {
     }
 
     // Get portfolio stage distribution
-    const stageDistribution = await this.getPortfolioStageDistribution(params.fundId);
+    const stageDistribution = await this.getPortfolioStageDistribution(
+      params.fundId,
+      portfolioCompanyState
+    );
 
     // Run simulation scenarios
     for (let i = 0; i < scenarios; i++) {
@@ -623,13 +852,16 @@ export class MonteCarloSimulationService {
   private async analyzePortfolioScenarios(
     params: SimulationParameters,
     _baseline: FundBaseline,
-    _simulationResults: Record<string, SimulationResult>
+    _simulationResults: Record<string, SimulationResult>,
+    portfolioCompanyState?: PortfolioCompanyWithInvestments[]
   ) {
     // Get portfolio composition
-    const portfolioCompaniesData = await db.query.portfolioCompanies.findMany({
-      where: eq(portfolioCompanies.fundId, params.fundId),
-      with: { investments: true },
-    });
+    const portfolioCompaniesData =
+      portfolioCompanyState ??
+      (await db.query.portfolioCompanies.findMany({
+        where: eq(portfolioCompanies.fundId, params.fundId),
+        with: { investments: true },
+      }));
 
     // Generate portfolio-specific scenarios
     const expectedExits = this.generateExitScenarios(
@@ -643,7 +875,13 @@ export class MonteCarloSimulationService {
 
     // Analyze sector performance
     const sectorPerformance: Record<string, SimulationResult> = {};
-    const sectors = [...new Set(portfolioCompaniesData.map((c) => c.sector).filter(Boolean))];
+    const sectors = [
+      ...new Set(
+        portfolioCompaniesData
+          .map((company) => company.sector)
+          .filter((sector): sector is string => Boolean(sector))
+      ),
+    ];
 
     for (const sector of sectors) {
       const sectorScenarios = this.generateSectorScenarios(
@@ -659,7 +897,13 @@ export class MonteCarloSimulationService {
 
     // Analyze stage performance
     const stagePerformance: Record<string, SimulationResult> = {};
-    const stages = [...new Set(portfolioCompaniesData.map((c) => c.stage).filter(Boolean))];
+    const stages = [
+      ...new Set(
+        portfolioCompaniesData
+          .map((company) => company.stage)
+          .filter((stage): stage is string => Boolean(stage))
+      ),
+    ];
 
     for (const stage of stages) {
       const stageScenarios = this.generateStageScenarios(
@@ -948,22 +1192,99 @@ export class MonteCarloSimulationService {
   /**
    * Store forecast results for future reference
    */
-  private async storeForecast(forecast: MonteCarloForecast): Promise<void> {
+  private async storeForecast(
+    forecast: MonteCarloForecast,
+    factsMetadata?: MonteCarloActualsFactsMetadata,
+    returnSnapshotId: boolean = false
+  ): Promise<number | undefined> {
     // Store in fund snapshots for integration with existing infrastructure
     // ADR-022: authoritative-only writer. scenario_set_id intentionally omitted (defaults to NULL).
-    await db.insert(fundSnapshots).values({
+    const insertQuery = db.insert(fundSnapshots).values({
       fundId: forecast.fundId,
       type: 'MONTE_CARLO',
       payload: forecast,
       calcVersion: 'mc-v1.0',
       correlationId: forecast.simulationId,
       snapshotTime: forecast.createdAt,
-      metadata: {
-        baselineId: forecast.baselineId,
-        scenarios: forecast.parameters.scenarios,
-        timeHorizon: forecast.parameters.timeHorizonYears,
-      },
+      metadata: snapshotMetadata(forecast, factsMetadata),
     });
+    if (!returnSnapshotId) {
+      await insertQuery;
+      return undefined;
+    }
+
+    const insertedSnapshots = await insertQuery.returning({ id: fundSnapshots.id });
+    if (insertedSnapshots.length !== 1) {
+      throw new Error(
+        `Expected one persisted Monte Carlo snapshot, received ${insertedSnapshots.length}`
+      );
+    }
+    return insertedSnapshots[0]?.id;
+  }
+
+  private async runActualsShadow(
+    forecast: MonteCarloForecast,
+    snapshotId: number
+  ): Promise<MonteCarloActualsFactsProvenance | undefined> {
+    const startedAt = performance.now();
+    let legacyCompanyCount = 0;
+
+    try {
+      const portfolioRows = await loadPortfolioCompanyMetadata(forecast.fundId);
+      legacyCompanyCount = portfolioRows.length;
+      const actualsState = await buildActualsCompanyStateFromMetadata({
+        fundId: forecast.fundId,
+        asOfDate: new Date().toISOString().slice(0, 10),
+        portfolioRows,
+      });
+      const metadata = actualsMetadata(actualsState, 'shadow');
+
+      // The authoritative legacy payload is already inserted. Compare against
+      // its expected metadata so this idempotent provenance stamp cannot clobber
+      // a concurrent writer even though fund_snapshots has no version column.
+      const legacyMetadata = snapshotMetadata(forecast);
+      const updatedSnapshots = await db
+        .update(fundSnapshots)
+        .set({ metadata: snapshotMetadata(forecast, metadata) })
+        .where(
+          and(
+            eq(fundSnapshots.id, snapshotId),
+            eq(fundSnapshots.fundId, forecast.fundId),
+            eq(fundSnapshots.metadata, legacyMetadata)
+          )
+        )
+        .returning({ id: fundSnapshots.id });
+      if (updatedSnapshots.length !== 1) {
+        throw new Error(
+          `Expected one Monte Carlo snapshot provenance update, received ${updatedSnapshots.length}`
+        );
+      }
+
+      logMonteCarloActualsShadowEvent({
+        eventName: 'monte_carlo_actuals_shadow',
+        fundId: forecast.fundId,
+        factsInputHash: actualsState.factsInputHash.slice(0, 12),
+        companyCount: actualsState.companies.length,
+        usableMoneyCount: actualsState.usableMoneyCount,
+        blockedCount: actualsState.blockedCount,
+        legacyCompanyCount: actualsState.legacyCompanyCount,
+        durationMs: performance.now() - startedAt,
+      });
+      return actualsProvenance(actualsState, 'shadow');
+    } catch {
+      logMonteCarloActualsShadowEvent({
+        eventName: 'monte_carlo_actuals_shadow',
+        fundId: forecast.fundId,
+        factsInputHash: null,
+        companyCount: 0,
+        usableMoneyCount: 0,
+        blockedCount: 0,
+        legacyCompanyCount,
+        durationMs: performance.now() - startedAt,
+        warningCode: 'SHADOW_BUILD_FAILED',
+      });
+      return undefined;
+    }
   }
 
   // Statistical utility functions
@@ -1175,10 +1496,15 @@ export class MonteCarloSimulationService {
   /**
    * Get portfolio stage distribution for power law sampling
    */
-  private async getPortfolioStageDistribution(fundId: number): Promise<Record<string, number>> {
-    const portfolioCompaniesData = await db.query.portfolioCompanies.findMany({
-      where: eq(portfolioCompanies.fundId, fundId),
-    });
+  private async getPortfolioStageDistribution(
+    fundId: number,
+    portfolioCompanyState?: PortfolioCompanyWithInvestments[]
+  ): Promise<Record<string, number>> {
+    const portfolioCompaniesData =
+      portfolioCompanyState ??
+      (await db.query.portfolioCompanies.findMany({
+        where: eq(portfolioCompanies.fundId, fundId),
+      }));
 
     if (portfolioCompaniesData.length === 0) {
       // Default to seed stage if no portfolio data

--- a/shared/generated/flag-defaults.ts
+++ b/shared/generated/flag-defaults.ts
@@ -588,6 +588,22 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     expiresAt: null,
     aliases: ['ENABLE_FACTS_SOURCED_RESERVE_INPUTS'],
   },
+  enable_monte_carlo_actuals_inputs: {
+    default: false,
+    description: 'Gates facts-backed company-state inputs for Monte Carlo forecasts',
+    owner: 'analytics',
+    risk: 'high',
+    exposeToClient: false,
+
+    environments: {
+      development: false,
+      staging: false,
+      production: false,
+    },
+    dependencies: [],
+    expiresAt: null,
+    aliases: ['ENABLE_MONTE_CARLO_ACTUALS_INPUTS'],
+  },
   enable_faults: {
     default: false,
     description: 'Enable fault injection for testing',
@@ -819,6 +835,7 @@ export const FLAG_DEFAULTS: FlagRecord = {
   enable_portfolio_intelligence: false,
   enable_marginal_reserve_moic: false,
   enable_facts_sourced_reserve_inputs: false,
+  enable_monte_carlo_actuals_inputs: false,
   enable_faults: false,
   enable_wizard_step_general: false,
   enable_wizard_step_sectors: false,
@@ -909,6 +926,7 @@ export const FLAG_ALIASES: Record<string, FlagKey> = {
   ENABLE_PORTFOLIO_INTELLIGENCE: 'enable_portfolio_intelligence',
   ENABLE_MARGINAL_RESERVE_MOIC: 'enable_marginal_reserve_moic',
   ENABLE_FACTS_SOURCED_RESERVE_INPUTS: 'enable_facts_sourced_reserve_inputs',
+  ENABLE_MONTE_CARLO_ACTUALS_INPUTS: 'enable_monte_carlo_actuals_inputs',
   ENABLE_WIZARD_STEP_GENERAL: 'enable_wizard_step_general',
   ENABLE_WIZARD_STEP_SIZING: 'enable_wizard_step_sizing',
   ENABLE_WIZARD_STEP_SECTORS: 'enable_wizard_step_sizing',

--- a/shared/generated/flag-types.ts
+++ b/shared/generated/flag-types.ts
@@ -47,6 +47,7 @@ export type FlagKey =
   | 'enable_portfolio_intelligence'
   | 'enable_marginal_reserve_moic'
   | 'enable_facts_sourced_reserve_inputs'
+  | 'enable_monte_carlo_actuals_inputs'
   | 'enable_faults'
   | 'enable_wizard_step_general'
   | 'enable_wizard_step_sectors'
@@ -117,6 +118,7 @@ export type ServerOnlyFlagKey =
   | 'enable_portfolio_intelligence'
   | 'enable_marginal_reserve_moic'
   | 'enable_facts_sourced_reserve_inputs'
+  | 'enable_monte_carlo_actuals_inputs'
   | 'enable_faults';
 
 /**
@@ -201,6 +203,7 @@ export const ALL_FLAG_KEYS: readonly FlagKey[] = [
   'enable_portfolio_intelligence',
   'enable_marginal_reserve_moic',
   'enable_facts_sourced_reserve_inputs',
+  'enable_monte_carlo_actuals_inputs',
   'enable_faults',
   'enable_wizard_step_general',
   'enable_wizard_step_sectors',

--- a/tests/unit/services/monte-carlo-actuals-inputs.test.ts
+++ b/tests/unit/services/monte-carlo-actuals-inputs.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+import { FLAG_DEFAULTS, FLAG_DEFINITIONS } from '../../../shared/generated/flag-defaults';
+
+const {
+  buildFactsMonteCarloInput,
+  buildFundCompanyActualsFacts,
+  eventOrder,
+  insertedSnapshots,
+  isFlagEnabled,
+  loggerInfo,
+  modeFindFirst,
+  portfolioCompaniesFindMany,
+  updateReturning,
+  updatedSnapshotMetadata,
+} = vi.hoisted(() => ({
+  buildFactsMonteCarloInput: vi.fn(),
+  buildFundCompanyActualsFacts: vi.fn(),
+  eventOrder: [] as string[],
+  insertedSnapshots: [] as Record<string, unknown>[],
+  isFlagEnabled: vi.fn(),
+  loggerInfo: vi.fn(),
+  modeFindFirst: vi.fn(),
+  portfolioCompaniesFindMany: vi.fn(),
+  updateReturning: vi.fn(),
+  updatedSnapshotMetadata: [] as Record<string, unknown>[],
+}));
+
+vi.mock('../../../server/db', () => ({
+  db: {
+    query: {
+      fundBaselines: { findFirst: vi.fn() },
+      varianceReports: { findMany: vi.fn() },
+      portfolioCompanies: { findMany: portfolioCompaniesFindMany },
+      funds: { findFirst: vi.fn() },
+      fundCalculationModes: { findFirst: modeFindFirst },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        insertedSnapshots.push(structuredClone(values));
+        eventOrder.push('persist');
+        return { returning: vi.fn(async () => [{ id: 901 }]) };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => {
+            updatedSnapshotMetadata.push(values);
+            eventOrder.push('metadata');
+            return updateReturning();
+          }),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock('@shared/flags/getFlag', () => ({ isFlagEnabled }));
+
+vi.mock('../../../server/services/fund-actuals/fund-company-actuals-facts-service', () => ({
+  buildFundCompanyActualsFacts,
+}));
+
+vi.mock('../../../server/services/monte-carlo/facts-monte-carlo-input-adapter', () => ({
+  buildFactsMonteCarloInput,
+}));
+
+vi.mock('../../../server/lib/logger', () => ({
+  logger: {
+    info: loggerInfo,
+    child: vi.fn(() => ({ info: loggerInfo, warn: vi.fn(), error: vi.fn() })),
+  },
+}));
+
+vi.mock('uuid', () => ({ v4: () => 'fixed-monte-carlo-simulation-id' }));
+
+import { db } from '../../../server/db';
+import {
+  buildActualsMonteCarloCompanyState,
+  MonteCarloSimulationService,
+  type SimulationParameters,
+} from '../../../server/services/monte-carlo-simulation';
+
+const PARAMS: SimulationParameters = {
+  fundId: 7,
+  scenarios: 8,
+  timeHorizonYears: 5,
+  confidenceIntervals: [10, 25, 50, 75, 90],
+  randomSeed: 42,
+};
+
+const LEGACY_COMPANIES = [
+  {
+    id: 11,
+    fundId: 7,
+    name: 'Alpha',
+    stage: 'Seed',
+    sector: 'Fintech',
+    investmentAmount: '100.00',
+    investments: [{ amount: '100.00' }],
+  },
+  {
+    id: 12,
+    fundId: 7,
+    name: 'Beta',
+    stage: 'Series A',
+    sector: 'Healthtech',
+    investmentAmount: '50.00',
+    investments: [{ amount: '50.00' }],
+  },
+];
+
+const FACTS_INPUT_HASH = 'a'.repeat(64);
+const SOURCE_FACTS_INPUT_HASH = 'b'.repeat(64);
+const FACTS_RESPONSE = {
+  fundId: 7,
+  asOfDate: '2026-07-13',
+  facts: [],
+  inputHash: SOURCE_FACTS_INPUT_HASH,
+  generatedAt: '2026-07-13T12:00:00.000Z',
+};
+const FACTS_INPUT = {
+  contractVersion: 'monte-carlo-facts-input-v1' as const,
+  fundId: 7,
+  asOfDate: '2026-07-13',
+  factsInputHash: FACTS_INPUT_HASH,
+  sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+  companies: [
+    {
+      companyId: 11,
+      observedInitialInvestment: '100.000000',
+      observedFollowOnInvestment: '25.000000',
+      planningFmv: null,
+      planningFmvStatus: 'none' as const,
+      stage: 'Seed',
+      sector: 'Fintech',
+      trustState: 'LIVE' as const,
+      currencyStatus: 'base_currency' as const,
+      warnings: [],
+    },
+    {
+      companyId: 12,
+      observedInitialInvestment: null,
+      observedFollowOnInvestment: null,
+      planningFmv: null,
+      planningFmvStatus: 'blocked' as const,
+      stage: 'Series A',
+      sector: 'Healthtech',
+      trustState: 'UNAVAILABLE' as const,
+      currencyStatus: 'mismatch_blocked' as const,
+      warnings: [],
+    },
+  ],
+};
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+async function simulateLegacy(): Promise<
+  Awaited<ReturnType<MonteCarloSimulationService['generateForecast']>>
+> {
+  isFlagEnabled.mockReturnValue(false);
+  return new MonteCarloSimulationService().generateForecast(PARAMS);
+}
+
+async function simulate(input: {
+  flag: boolean;
+}): Promise<Awaited<ReturnType<MonteCarloSimulationService['generateForecast']>>> {
+  isFlagEnabled.mockReturnValue(input.flag);
+  return new MonteCarloSimulationService().generateForecast(PARAMS);
+}
+
+describe('MonteCarloSimulationService actuals-backed company inputs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-13T12:00:00.000Z'));
+    vi.clearAllMocks();
+    insertedSnapshots.length = 0;
+    updatedSnapshotMetadata.length = 0;
+    eventOrder.length = 0;
+    isFlagEnabled.mockReturnValue(false);
+    modeFindFirst.mockResolvedValue(undefined);
+    portfolioCompaniesFindMany.mockResolvedValue(LEGACY_COMPANIES);
+    updateReturning.mockReturnValue([{ id: 1 }]);
+    buildFundCompanyActualsFacts.mockImplementation(async () => {
+      eventOrder.push('facts');
+      return FACTS_RESPONSE;
+    });
+    buildFactsMonteCarloInput.mockReturnValue(FACTS_INPUT);
+    loggerInfo.mockImplementation(() => {
+      eventOrder.push('log');
+    });
+    vi.mocked(db.query.fundBaselines.findFirst).mockResolvedValue({
+      id: 'baseline-7',
+      fundId: 7,
+      totalValue: '1000000',
+      deployedCapital: '500000',
+      irr: '0.12',
+      multiple: '1.5',
+      dpi: '0.5',
+      tvpi: '1.5',
+      isDefault: true,
+      isActive: true,
+    } as never);
+    vi.mocked(db.query.varianceReports.findMany).mockResolvedValue([]);
+    vi.mocked(db.query.funds.findFirst).mockResolvedValue({ id: 7, size: '2000000' } as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps the fixed-seed flag-off return and persisted snapshot byte-identical to legacy', async () => {
+    const legacyForecast = await simulateLegacy();
+    const flagOffForecast = await simulate({ flag: false });
+
+    expect(flagOffForecast).toEqual(legacyForecast);
+    expect(insertedSnapshots).toHaveLength(2);
+    expect(insertedSnapshots[1]).toEqual(insertedSnapshots[0]);
+    expect(sha256(legacyForecast)).toBe(
+      '69a0799ff35b8790f91d22989c9079ab78eee22159f3976f0bc4a5ee765c2c49'
+    );
+    expect(sha256(insertedSnapshots[0])).toBe(
+      '44481fab6a0726bbabc2bdedb4d98bc499792a5725cbdab31b301d226df6b643'
+    );
+    expect(flagOffForecast).not.toHaveProperty('provenance');
+    expect(insertedSnapshots[1]?.metadata).not.toHaveProperty('actualsFacts');
+    expect(modeFindFirst).not.toHaveBeenCalled();
+    expect(buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expect(buildFactsMonteCarloInput).not.toHaveBeenCalled();
+  });
+
+  it('registers the server-only actuals-input flag off in every environment', () => {
+    expect(FLAG_DEFAULTS.enable_monte_carlo_actuals_inputs).toBe(false);
+    expect(FLAG_DEFINITIONS.enable_monte_carlo_actuals_inputs).toMatchObject({
+      default: false,
+      owner: 'analytics',
+      risk: 'high',
+      exposeToClient: false,
+      environments: { development: false, staging: false, production: false },
+    });
+  });
+
+  it('keeps the legacy path when the enabled flag has no mode row', async () => {
+    const legacyForecast = await simulateLegacy();
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue(undefined);
+
+    const modeOffForecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    expect(modeOffForecast).toEqual(legacyForecast);
+    expect(insertedSnapshots[1]).toEqual(insertedSnapshots[0]);
+    expect(modeFindFirst).toHaveBeenCalledOnce();
+    expect(buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expect(buildFactsMonteCarloInput).not.toHaveBeenCalled();
+  });
+
+  it('restores byte-identical legacy behavior when the kill switch is active', async () => {
+    const legacyForecast = await simulateLegacy();
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: true });
+
+    const killedForecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    expect(killedForecast).toEqual(legacyForecast);
+    expect(insertedSnapshots[1]).toEqual(insertedSnapshots[0]);
+    expect(buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expect(buildFactsMonteCarloInput).not.toHaveBeenCalled();
+  });
+
+  it('maps observed money into aggregates while retaining blocked companies only for counts', () => {
+    expect(buildActualsMonteCarloCompanyState(FACTS_INPUT)).toEqual({
+      companies: [
+        {
+          id: 11,
+          stage: 'Seed',
+          sector: 'Fintech',
+          investmentAmount: '125',
+          investments: [{ amount: '100.000000' }, { amount: '25.000000' }],
+        },
+        {
+          id: 12,
+          stage: 'Series A',
+          sector: 'Healthtech',
+          investmentAmount: null,
+          investments: [],
+        },
+      ],
+      usableMoneyCount: 1,
+      blockedCount: 1,
+    });
+  });
+
+  it('uses adapter-derived company state in on mode and discloses blocked money', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
+
+    const forecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    expect(buildFundCompanyActualsFacts).toHaveBeenCalledOnce();
+    expect(buildFundCompanyActualsFacts).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: '2026-07-13',
+    });
+    expect(buildFactsMonteCarloInput).toHaveBeenCalledOnce();
+    const adapterInput = buildFactsMonteCarloInput.mock.calls[0]?.[0] as
+      | { companyMetadata: ReadonlyMap<number, { stage: string | null; sector: string | null }> }
+      | undefined;
+    expect(adapterInput?.companyMetadata.get(11)).toEqual({ stage: 'Seed', sector: 'Fintech' });
+    expect(adapterInput?.companyMetadata.get(12)).toEqual({
+      stage: 'Series A',
+      sector: 'Healthtech',
+    });
+    expect(portfolioCompaniesFindMany).toHaveBeenCalledOnce();
+    expect(Object.keys(forecast.portfolioMetrics.stagePerformance).sort()).toEqual([
+      'Seed',
+      'Series A',
+    ]);
+    expect(Object.keys(forecast.portfolioMetrics.sectorPerformance).sort()).toEqual([
+      'Fintech',
+      'Healthtech',
+    ]);
+    expect(forecast.provenance).toEqual({
+      actualsFacts: {
+        factsInputHash: FACTS_INPUT_HASH,
+        sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+        mode: 'on',
+        warnings: [
+          {
+            code: 'ACTUALS_MONEY_BLOCKED',
+            blockedCompanyCount: 1,
+            message:
+              '1 company retained for count-based analysis and excluded from monetary aggregates',
+          },
+        ],
+      },
+    });
+    expect(insertedSnapshots[0]?.metadata).toMatchObject({
+      actualsFacts: {
+        factsInputHash: FACTS_INPUT_HASH,
+        sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+        mode: 'on',
+      },
+    });
+  });
+
+  it('persists legacy shadow output first, then adds provenance and emits one aggregate event', async () => {
+    const legacyForecast = await simulateLegacy();
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
+    eventOrder.length = 0;
+
+    const shadowForecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    expect(eventOrder).toEqual(['persist', 'facts', 'metadata', 'log']);
+    expect(insertedSnapshots[1]?.payload).toEqual(legacyForecast);
+    expect(insertedSnapshots[1]?.metadata).toEqual(insertedSnapshots[0]?.metadata);
+    expect(updatedSnapshotMetadata).toHaveLength(1);
+    expect(updatedSnapshotMetadata[0]?.metadata).toMatchObject({
+      actualsFacts: {
+        factsInputHash: FACTS_INPUT_HASH,
+        sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+        mode: 'shadow',
+      },
+    });
+    expect(shadowForecast.provenance).toEqual({
+      actualsFacts: {
+        factsInputHash: FACTS_INPUT_HASH,
+        sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
+        mode: 'shadow',
+      },
+    });
+    expect(buildFundCompanyActualsFacts).toHaveBeenCalledOnce();
+    expect(buildFactsMonteCarloInput).toHaveBeenCalledOnce();
+    expect(loggerInfo).toHaveBeenCalledOnce();
+    expect(loggerInfo.mock.calls[0]?.[0]).toEqual({
+      eventName: 'monte_carlo_actuals_shadow',
+      fundId: 7,
+      factsInputHash: FACTS_INPUT_HASH.slice(0, 12),
+      companyCount: 2,
+      usableMoneyCount: 1,
+      blockedCount: 1,
+      legacyCompanyCount: 2,
+      durationMs: expect.any(Number),
+    });
+    const serializedEvent = JSON.stringify(loggerInfo.mock.calls[0]?.[0]);
+    expect(serializedEvent).not.toContain('Alpha');
+    expect(serializedEvent).not.toContain('Beta');
+    expect(serializedEvent).not.toContain('100.000000');
+  });
+
+  it('swallows shadow facts failures after persistence and emits one warning event', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
+    buildFundCompanyActualsFacts.mockImplementation(async () => {
+      eventOrder.push('facts');
+      throw new Error('facts unavailable');
+    });
+
+    const forecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    expect(forecast).not.toHaveProperty('provenance');
+    expect(insertedSnapshots).toHaveLength(1);
+    expect(updatedSnapshotMetadata).toHaveLength(0);
+    expect(loggerInfo).toHaveBeenCalledOnce();
+    expect(loggerInfo.mock.calls[0]?.[0]).toEqual({
+      eventName: 'monte_carlo_actuals_shadow',
+      fundId: 7,
+      factsInputHash: null,
+      companyCount: 0,
+      usableMoneyCount: 0,
+      blockedCount: 0,
+      legacyCompanyCount: 2,
+      durationMs: expect.any(Number),
+      warningCode: 'SHADOW_BUILD_FAILED',
+    });
+  });
+
+  it('keeps serving legacy output when the shadow metadata compare-and-swap misses', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
+    updateReturning.mockReturnValue([]);
+
+    const forecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    expect(forecast).not.toHaveProperty('provenance');
+    expect(insertedSnapshots).toHaveLength(1);
+    expect(updateReturning).toHaveBeenCalledOnce();
+    expect(loggerInfo).toHaveBeenCalledOnce();
+    expect(loggerInfo.mock.calls[0]?.[0]).toMatchObject({
+      eventName: 'monte_carlo_actuals_shadow',
+      fundId: 7,
+      warningCode: 'SHADOW_BUILD_FAILED',
+    });
+  });
+
+  it('pins the legacy distribution rules and calibration constants by value', async () => {
+    const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const source = actualFs.readFileSync(
+      path.join(process.cwd(), 'server/services/monte-carlo-simulation.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain('standardDeviation: 0.15, // 15% default volatility');
+    expect(source).toContain("distribution = 'powerlaw'");
+    expect(source).toContain("distribution = 'lognormal'");
+    expect(source).toContain("distribution = 'triangular'");
+    expect(source).toMatch(/generateInvestmentScenario\(\s*'seed',\s*timeHorizonYears\s*\)/);
+    expect(source).toContain('const upsideCompression = 0.82');
+    expect(source).toContain("baseline.irr?.toString() || '0.12'");
+    expect(source).toContain("baseline.dpi?.toString() || '0.5'");
+    expect(source).toContain("baseline.tvpi?.toString() || '1.5'");
+    expect(source).toContain('eq(fundSnapshots.id, snapshotId)');
+    expect(source).toContain('eq(fundSnapshots.metadata, legacyMetadata)');
+    expect(source).toContain('.returning({ id: fundSnapshots.id })');
+  });
+});


### PR DESCRIPTION
## Summary

Plan 8 wave 6 (Task 8.7) — Monte Carlo can consume the actuals facts state, shadow-first, with flag-off proven byte-identical for a fixed seed.

- **Flag** `enable_monte_carlo_actuals_inputs` (default false, all environments false, exposeToClient false) + regenerated flag files; mode machinery via `fund_calculation_modes` (`monte_carlo_actuals_inputs`), kill switch honored — flag false / mode off / kill switch all collapse to the exact legacy path with no facts load.
- **Shadow**: legacy forecast computed and persisted exactly as today, first; afterwards one facts load + adapter build + a single aggregate telemetry event (short hash, counts, duration — no names, no raw money); shadow failures are swallowed into a warning event after persistence and can never affect serving.
- **Mode on**: only the company-state inputs at the two `portfolioCompanies` read sites are replaced with adapter-derived rows; blocked/unavailable money excluded from aggregates but companies retained for counts, with explicit assumption-driven disclosure in the forecast provenance. Distribution selection, 15% low-data volatility, seed-stage power law, 0.82 compression, baseline IRR/DPI/TVPI fallbacks, and the PRNG are untouched — pinned by value in tests and zero diff lines on any constant.
- **Provenance**: snapshot metadata gains `actualsFacts { factsInputHash, sourceFactsInputHash, mode }` under shadow/on; the field is absent (not undefined) under flag-off to preserve byte identity.

## Verification

- 127/127 tests independently green: the new 10-test suite (fixed-seed flag-off byte parity of both return value and persisted snapshot; kill-switch restore; shadow persist-first + single event; shadow-failure safety; on-mode mapping; constants pinned by value) plus all five pre-existing MC suites (orchestrator, parity assertions, power-law, statistical, engine) unmodified and green.
- Scope: 5 files (flag + generated + simulation service + tests); zero changes to PRNG, other MC engines, routes, queues, migrations, client (grep-verified). `npm run check` 0 TS errors; ESLint clean.

Final Plan 8 wave (8.8, after this is accepted): versioned assumptions-profile extraction with fixed-seed output parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h