### PR TITLE
feat(moic): activate round and FMV facts basis (Plan 6 wave 2 / PR 6B)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6035,21 +6035,21 @@ fingerprint before an on-mode candidate can become actionable.
 - Candidate ordering is actionable, then indicative, then effectively
   non-actionable. Numeric rows sort by candidate MOIC within their tier, and
   retained non-actionable rows sort last with deterministic company-ID ties.
-- The candidate source hash includes the facts input hash, observed initial and
-  follow-on amounts, selected anchor kind/value/date, Planning FMV status,
-  currency status, and disclosed rankability. Monetary values in the hash row
-  are canonical decimal strings.
+- The candidate source hash includes the investment name, facts input hash,
+  observed initial and follow-on amounts, selected anchor kind/value/date,
+  Planning FMV status, currency status, and disclosed rankability. Monetary
+  values in the hash row are canonical decimal strings.
 - `moic-round-fmv-facts-v2` appears in both the response summary and every
   candidate hash row. The version change and basis switch are atomic.
-- Reconciliation history semantics remain unchanged. A new idempotency key can
-  record a new row in the v2 source regime; an old row is never updated or
-  backfilled, and replay/conflict semantics remain scoped to the original
-  `(fundId, idempotencyKey)` request. Task 6.6 must make reconciliation and mode
-  acceptance compute the same facts-backed fingerprint as the v2 read path
-  before mode-on activation.
-- V1 reads use the explicit absent-facts state and retain the legacy candidate
-  construction path. Off and shadow modes continue to serve legacy rankings;
-  this decision does not activate on mode.
+- Reconciliation, actionability, mode validation, and both V1 and V2 reads load
+  the same facts-backed source fingerprint. A new idempotency key can record a
+  new row in the v2 source regime; an old row is never updated or backfilled,
+  and replay/conflict semantics remain scoped to the original
+  `(fundId, idempotencyKey)` request. Facts-unavailable reconciliation is
+  rejected before a completed row can be recorded.
+- V1 reads use the same facts-backed sources as V2. If facts are unavailable, V1
+  serves legacy output and remains non-actionable. Off and shadow modes continue
+  to serve legacy rankings; this decision does not itself activate on mode.
 
 ### Alternatives Considered
 
@@ -6067,10 +6067,11 @@ fingerprint before an on-mode candidate can become actionable.
 ### Consequences
 
 - Every otherwise identical portfolio receives a new candidate source hash under
-  the v2 regime. Mode-on eligibility therefore requires a fresh accepted
-  reconciliation before Plan 6 task 6.6 can activate serving.
-- Existing v1 reconciliation rows remain byte-identical and replayable by their
-  original hashes, but they cannot satisfy the new v2 source fingerprint.
+  the v2 regime. Mode-on eligibility and candidate serving therefore require a
+  fresh accepted reconciliation under that source regime.
+- Existing v1 reconciliation rows remain byte-identical and auditable, but
+  reusing an old idempotency key under v2 conflicts because the current request
+  hash differs. A fresh key is required for the v2 source fingerprint.
 - Mode off is the rollback: legacy rankings remain served without changing or
   deleting reconciliation history. Shadow continues to compute the facts
   candidate and emit comparison telemetry while serving legacy output.
@@ -6079,4 +6080,5 @@ fingerprint before an on-mode candidate can become actionable.
   indicative. Activation-block counts continue to prevent that source from
   becoming actionable.
 
-**Implementation:** Plan 6 wave 2, Task 6.4 / PR 6B.
+**Implementation:** Plan 6 wave 2, Task 6.4 / PR 6B plus the facts-fingerprint
+unification fix.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-07-12
+last_updated: 2026-07-13
 owner: Core Team
 review_cadence: P90D
 ---
@@ -51,6 +51,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-035: Ordered Manifests as the Executable Production Schema Contract](#adr-035-ordered-manifests-as-the-executable-production-schema-contract)
 - [ADR-036: Named Identities, Explicit Fund Grants, and jti Revocation (Plan 2)](#adr-036-named-identities-explicit-fund-grants-and-jti-revocation-plan-2)
 - [ADR-037: Browser HttpOnly JWT Cookie and Signed CSRF Contract (D4)](#adr-037-browser-httponly-jwt-cookie-and-signed-csrf-contract-d4)
+- [ADR-039: Planned-reserve MOIC candidate basis moves to Round/FMV facts (moic-round-fmv-facts-v2)](#adr-039-planned-reserve-moic-candidate-basis-moves-to-roundfmv-facts-moic-round-fmv-facts-v2)
 
 ---
 
@@ -5998,3 +5999,84 @@ synchronous behind its authentication and CSRF boundary.
   runtime or probe contract.
 
 **Implementation:** Plan 4 wave 2 common-mount convergence, Tasks 4.3-4.6.
+
+---
+
+## ADR-039: Planned-reserve MOIC candidate basis moves to Round/FMV facts (moic-round-fmv-facts-v2)
+
+**Date:** 2026-07-13 **Status:** [IMPLEMENTED] Implemented **Decision:** Move
+the mode-gated planned-reserve MOIC candidate from legacy portfolio-company
+amounts and defaulted economics to the canonical Round/FMV facts basis, and
+identify the new source regime as `moic-round-fmv-facts-v2`.
+
+### Context
+
+Plan 6 wave 1 disclosed the Round/FMV facts basis beside each ranking while
+intentionally freezing candidate values, ordering, source hashes, and
+reconciliation behavior. The candidate still used the legacy investment amount
+and current valuation and substituted `1` when exit probability or reserve exit
+multiple was missing. That was safe for disclosure, but it was too permissive
+for serving a facts-derived reserve recommendation.
+
+The existing mode machinery already keeps the candidate default-off and serves
+legacy output in off and shadow modes. It also requires an accepted source
+fingerprint before an on-mode candidate can become actionable.
+
+### Decision
+
+- A facts-backed candidate uses observed initial and follow-on investment from
+  the company facts response and the valuation anchor selected by the existing
+  facts-basis ladder. Latest financing-round valuation remains evidence and is
+  never substituted for position FMV.
+- Planned reserves come only from explicit `plannedReservesCents`; exit
+  probability and reserve exit multiple are explicit-only. Missing economics, a
+  currency block, no valuation anchor, or zero planned reserves retains the
+  company but produces no numeric candidate MOIC.
+- Candidate ordering is actionable, then indicative, then effectively
+  non-actionable. Numeric rows sort by candidate MOIC within their tier, and
+  retained non-actionable rows sort last with deterministic company-ID ties.
+- The candidate source hash includes the facts input hash, observed initial and
+  follow-on amounts, selected anchor kind/value/date, Planning FMV status,
+  currency status, and disclosed rankability. Monetary values in the hash row
+  are canonical decimal strings.
+- `moic-round-fmv-facts-v2` appears in both the response summary and every
+  candidate hash row. The version change and basis switch are atomic.
+- Reconciliation history semantics remain unchanged. A new idempotency key can
+  record a new row in the v2 source regime; an old row is never updated or
+  backfilled, and replay/conflict semantics remain scoped to the original
+  `(fundId, idempotencyKey)` request. Task 6.6 must make reconciliation and mode
+  acceptance compute the same facts-backed fingerprint as the v2 read path
+  before mode-on activation.
+- V1 reads use the explicit absent-facts state and retain the legacy candidate
+  construction path. Off and shadow modes continue to serve legacy rankings;
+  this decision does not activate on mode.
+
+### Alternatives Considered
+
+- **Keep the Wave 1 disclosure-only candidate:** rejected because the served
+  candidate would continue to ignore observed Round/FMV inputs and fabricate
+  missing economics with `1`.
+- **Re-derive the valuation ladder in the ranking service:** rejected because it
+  would create a second source of truth for Planning FMV staleness, fallback,
+  and currency blocking.
+- **Rewrite reconciliation history in place:** rejected because accepted rows
+  are immutable audit evidence and the new source regime must be explicit.
+- **Hide non-actionable companies:** rejected because missing or blocked inputs
+  are decision-relevant disclosure, not a reason to remove portfolio rows.
+
+### Consequences
+
+- Every otherwise identical portfolio receives a new candidate source hash under
+  the v2 regime. Mode-on eligibility therefore requires a fresh accepted
+  reconciliation before Plan 6 task 6.6 can activate serving.
+- Existing v1 reconciliation rows remain byte-identical and replayable by their
+  original hashes, but they cannot satisfy the new v2 source fingerprint.
+- Mode off is the rollback: legacy rankings remain served without changing or
+  deleting reconciliation history. Shadow continues to compute the facts
+  candidate and emit comparison telemetry while serving legacy output.
+- Missing explicit economics can no longer create a numeric candidate ranking,
+  even though the Wave 1 disclosure may still classify an anchored row as
+  indicative. Activation-block counts continue to prevent that source from
+  becoming actionable.
+
+**Implementation:** Plan 6 wave 2, Task 6.4 / PR 6B.

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -15,6 +15,7 @@ import {
 } from '../services/fund-moic-materiality.js';
 import {
   discloseFundMoicRankings,
+  FUND_MOIC_FACTS_ABSENT,
   getFundMoicRankingSources,
   summarizeMoicActualsProvenance,
 } from '../services/fund-moic-ranking-service.js';
@@ -212,7 +213,7 @@ router.get(
 
     const contract = req.query['contract'];
     if (contract === undefined || contract === 'v1') {
-      const sources = await getFundMoicRankingSources(fundId);
+      const sources = await getFundMoicRankingSources(fundId, undefined, FUND_MOIC_FACTS_ABSENT);
       const modePreview = await resolveFundCalculationMode({ fundId, sources });
       const actionability = await resolveMoicActionability({ fundId, sources });
       const rankings =
@@ -232,10 +233,9 @@ router.get(
     const factsShadowStartedAt = performance.now();
 
     // TODO(perf): this loads the full company-actuals facts corpus (~6 queries + hash in
-    // fund-company-actuals-facts-service) for provenance and disclosure. Per-company facts
-    // are not used in ranking values. MOIC analysis is a low-frequency GP page today, so ship
-    // as-is, but memoize per (fundId, asOfDate) or expose a count-only facts helper if this page
-    // becomes polled or the corpus grows. Tracked as a separate low-priority GitHub perf issue.
+    // fund-company-actuals-facts-service) for candidate rankings, provenance, and disclosure.
+    // MOIC analysis is a low-frequency GP page today, so ship as-is, but memoize per
+    // (fundId, asOfDate) if this page becomes polled or the corpus grows.
     const actualsAsOfDate = new Date().toISOString().slice(0, 10);
     let actualsFacts: Awaited<ReturnType<typeof buildFundCompanyActualsFacts>> | null = null;
 
@@ -256,11 +256,11 @@ router.get(
       );
     }
 
-    const factsByCompanyId = actualsFacts
-      ? new Map(actualsFacts.facts.map((fact) => [fact.companyId, fact] as const))
-      : undefined;
+    const factsSource = actualsFacts
+      ? ({ status: 'available', response: actualsFacts } as const)
+      : FUND_MOIC_FACTS_ABSENT;
     const [sources, latestReconciliation, evidence] = await Promise.all([
-      getFundMoicRankingSources(fundId, undefined, factsByCompanyId),
+      getFundMoicRankingSources(fundId, undefined, factsSource),
       getLatestCompletedMoicReconciliation(fundId),
       buildRoundsToModelEvidence({ fundId }),
     ]);
@@ -291,7 +291,9 @@ router.get(
     const modePreview = await resolveFundCalculationMode({ fundId, sources });
     const actionability = await resolveMoicActionability({ fundId, sources, evidence });
     const usingCandidateRankings =
-      modePreview.effectiveMode === 'on' && actionability.actionability === 'actionable';
+      actualsFacts !== null &&
+      modePreview.effectiveMode === 'on' &&
+      actionability.actionability === 'actionable';
     const rankings = usingCandidateRankings ? sources.candidate : sources.legacy;
     const materiality = assessMoicMateriality(sources.legacy.rankings, sources.candidate.rankings);
     const latestCurrentMatches =
@@ -303,7 +305,12 @@ router.get(
     const response: FundMoicRankingsResponseV2 = {
       contractVersion: '2.1.0',
       fundId,
-      rankings: discloseFundMoicRankings(rankings, sources.factsBasisByInvestmentId).rankings,
+      rankings: discloseFundMoicRankings(
+        rankings,
+        usingCandidateRankings
+          ? sources.candidateFactsBasisByInvestmentId
+          : sources.factsBasisByInvestmentId
+      ).rankings,
       provenance: {
         mode: usingCandidateRankings ? 'candidate' : 'legacy',
         warnings: modePreview.blockers,

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -7,7 +7,6 @@ import {
   FundMoicRankingsResponseV2Schema,
   type FundMoicRankingsResponseV2,
 } from '../../shared/contracts/fund-moic-v2.contract.js';
-import { logger } from '../lib/logger.js';
 import { FundIdParamSchema } from '../../shared/schemas/portfolio-route.js';
 import {
   assessMoicMateriality,
@@ -15,14 +14,13 @@ import {
 } from '../services/fund-moic-materiality.js';
 import {
   discloseFundMoicRankings,
-  FUND_MOIC_FACTS_ABSENT,
   getFundMoicRankingSources,
   summarizeMoicActualsProvenance,
 } from '../services/fund-moic-ranking-service.js';
-import { buildFundCompanyActualsFacts } from '../services/fund-actuals/fund-company-actuals-facts-service.js';
 import {
   getLatestCompletedMoicReconciliation,
   MoicReconciliationConflictError,
+  MoicReconciliationFactsUnavailableError,
   recordMoicReconciliation,
 } from '../services/fund-moic-reconciliation-service.js';
 import {
@@ -213,11 +211,13 @@ router.get(
 
     const contract = req.query['contract'];
     if (contract === undefined || contract === 'v1') {
-      const sources = await getFundMoicRankingSources(fundId, undefined, FUND_MOIC_FACTS_ABSENT);
+      const sources = await getFundMoicRankingSources(fundId);
       const modePreview = await resolveFundCalculationMode({ fundId, sources });
       const actionability = await resolveMoicActionability({ fundId, sources });
       const rankings =
-        modePreview.effectiveMode === 'on' && actionability.actionability === 'actionable'
+        sources.factsSource.status === 'available' &&
+        modePreview.effectiveMode === 'on' &&
+        actionability.actionability === 'actionable'
           ? sources.candidate
           : sources.legacy;
       return res.json(discloseFundMoicRankings(rankings));
@@ -232,38 +232,13 @@ router.get(
 
     const factsShadowStartedAt = performance.now();
 
-    // TODO(perf): this loads the full company-actuals facts corpus (~6 queries + hash in
-    // fund-company-actuals-facts-service) for candidate rankings, provenance, and disclosure.
-    // MOIC analysis is a low-frequency GP page today, so ship as-is, but memoize per
-    // (fundId, asOfDate) if this page becomes polled or the corpus grows.
-    const actualsAsOfDate = new Date().toISOString().slice(0, 10);
-    let actualsFacts: Awaited<ReturnType<typeof buildFundCompanyActualsFacts>> | null = null;
-
-    try {
-      actualsFacts = await buildFundCompanyActualsFacts({
-        fundId,
-        asOfDate: actualsAsOfDate,
-      });
-    } catch (error) {
-      // Disclosed to the client via warnings, but not silent server-side: operators need the reason.
-      logger.warn(
-        {
-          fundId,
-          asOfDate: actualsAsOfDate,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        'fund-moic v2 actuals facts load failed; returning UNAVAILABLE provenance summary'
-      );
-    }
-
-    const factsSource = actualsFacts
-      ? ({ status: 'available', response: actualsFacts } as const)
-      : FUND_MOIC_FACTS_ABSENT;
     const [sources, latestReconciliation, evidence] = await Promise.all([
-      getFundMoicRankingSources(fundId, undefined, factsSource),
+      getFundMoicRankingSources(fundId),
       getLatestCompletedMoicReconciliation(fundId),
       buildRoundsToModelEvidence({ fundId }),
     ]);
+    const actualsFacts =
+      sources.factsSource.status === 'available' ? sources.factsSource.response : null;
     const sourceCompanyCount = sources.legacy.provenance.sourceRecordCount;
     let actualsProvenanceSummary: ReturnType<typeof summarizeMoicActualsProvenance>;
 
@@ -291,7 +266,7 @@ router.get(
     const modePreview = await resolveFundCalculationMode({ fundId, sources });
     const actionability = await resolveMoicActionability({ fundId, sources, evidence });
     const usingCandidateRankings =
-      actualsFacts !== null &&
+      sources.factsSource.status === 'available' &&
       modePreview.effectiveMode === 'on' &&
       actionability.actionability === 'actionable';
     const rankings = usingCandidateRankings ? sources.candidate : sources.legacy;
@@ -384,6 +359,12 @@ router.post(
         replayed,
       });
     } catch (error) {
+      if (error instanceof MoicReconciliationFactsUnavailableError) {
+        return res.status(409).json({
+          error: error.code,
+          message: error.message,
+        });
+      }
       if (error instanceof MoicReconciliationConflictError) {
         return res.status(409).json({
           error: 'idempotency_conflict',

--- a/server/services/fund-calculation-mode-service.ts
+++ b/server/services/fund-calculation-mode-service.ts
@@ -11,6 +11,7 @@ import { canonicalSha256 } from '../../shared/lib/canonical-hash';
 import {
   FUND_MOIC_CALCULATION_KEY,
   getFundMoicRankingSources,
+  type FundMoicFactsSource,
   type FundMoicRankingSources,
 } from './fund-moic-ranking-service';
 import { invalidateH9Artifacts } from './h9-artifact-invalidation-service';
@@ -28,6 +29,7 @@ export type FundCalculationModeBlocker =
   | 'accepted_reconciliation_not_found'
   | 'current_source_changed'
   | 'exit_probability_source_incomplete'
+  | 'facts_unavailable'
   | 'kill_switch_active'
   | 'reserve_exit_multiple_source_incomplete'
   | 'shadow_residency_pending';
@@ -289,18 +291,42 @@ function buildH9SourceFingerprint(params: {
   });
 }
 
-export function createMoicActionabilityResolver(params: { database?: unknown; now?: Date }) {
+export function createMoicActionabilityResolver(params: {
+  database?: unknown;
+  now?: Date;
+  reuseFactsSource?: boolean;
+}) {
   if (!params.database) {
     throw new Error('createMoicActionabilityResolver requires database');
   }
 
   const database = params.database;
+  const factsSourceByFund = new Map<number, FundMoicFactsSource>();
 
   async function resolve(input: MoicActionabilityResolveInput): Promise<MoicActionabilityResult> {
     const now = params.now ?? new Date();
-    const sources =
-      input.sources ??
-      (await getFundMoicRankingSources(input.fundId, database as FundCalculationModeDatabase));
+    let sources = input.sources;
+    if (!sources) {
+      const reusedFactsSource = params.reuseFactsSource
+        ? factsSourceByFund.get(input.fundId)
+        : undefined;
+      sources = reusedFactsSource
+        ? await getFundMoicRankingSources(
+            input.fundId,
+            database as FundCalculationModeDatabase,
+            reusedFactsSource,
+            now
+          )
+        : await getFundMoicRankingSources(
+            input.fundId,
+            database as FundCalculationModeDatabase,
+            undefined,
+            now
+          );
+      if (params.reuseFactsSource) {
+        factsSourceByFund.set(input.fundId, sources.factsSource);
+      }
+    }
     const evidence =
       input.evidence ??
       (await buildRoundsToModelEvidence({
@@ -314,11 +340,13 @@ export function createMoicActionabilityResolver(params: { database?: unknown; no
       roundEvidenceAssumptionsHash: buildRoundEvidenceAssumptionsHash(),
     });
     const accepted = await loadAcceptedMoicReconciliation({ database, fundId: input.fundId });
-    const sourceFingerprintMatches = Boolean(
-      accepted &&
-      acceptedCandidateInputHash(accepted) === sourceFingerprint.moicSourceInputHash &&
-      acceptedEvidenceInputHash(accepted) === sourceFingerprint.roundEvidenceInputHash
-    );
+    const sourceFingerprintMatches =
+      sources.factsSource.status === 'available' &&
+      Boolean(
+        accepted &&
+        acceptedCandidateInputHash(accepted) === sourceFingerprint.moicSourceInputHash &&
+        acceptedEvidenceInputHash(accepted) === sourceFingerprint.roundEvidenceInputHash
+      );
     const actionability: H9ActionabilityStatus = sourceFingerprintMatches
       ? 'actionable'
       : 'non_actionable';
@@ -455,6 +483,9 @@ function addDays(date: Date, days: number): Date {
 
 function sourceBlockers(sources: FundMoicRankingSources): FundCalculationModeBlocker[] {
   const blockers: FundCalculationModeBlocker[] = [];
+  if (sources.factsSource.status !== 'available') {
+    blockers.push('facts_unavailable');
+  }
   if (sources.moicInputSummary.activationBlockingDefaultedExitProbabilityCount > 0) {
     blockers.push('exit_probability_source_incomplete');
   }

--- a/server/services/fund-moic-ranking-service.ts
+++ b/server/services/fund-moic-ranking-service.ts
@@ -8,11 +8,17 @@ import type {
   FundMoicRankingsResponseV1,
 } from '../../shared/contracts/fund-moic-v1.contract.js';
 import { canonicalSha256 } from '../../shared/lib/canonical-hash';
-import type { FundCompanyActualsFact } from '../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import type { FundCompanyActualsFactsResponse } from '../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import Decimal from '../../shared/lib/decimal-config';
 import { buildFundMoicFactsBasis } from './moic/fund-moic-facts-basis';
 
-export const MOIC_CANDIDATE_SOURCE_VERSION = 'moic-exit-probability-v1';
+export const MOIC_CANDIDATE_SOURCE_VERSION = 'moic-round-fmv-facts-v2';
 export const FUND_MOIC_CALCULATION_KEY = 'fund_moic_rankings_exit_probability';
+export const FUND_MOIC_FACTS_ABSENT = { status: 'absent' } as const;
+
+export type FundMoicFactsSource =
+  | typeof FUND_MOIC_FACTS_ABSENT
+  | { status: 'available'; response: FundCompanyActualsFactsResponse };
 
 export interface FundMoicInputSummary {
   sourceVersion: typeof MOIC_CANDIDATE_SOURCE_VERSION;
@@ -30,6 +36,7 @@ export interface FundMoicRankingSources {
   moicInputSummary: FundMoicInputSummary;
   moicSourceInputHash: string;
   factsBasisByInvestmentId?: ReadonlyMap<string, FundMoicFactsBasisV1>;
+  candidateFactsBasisByInvestmentId?: ReadonlyMap<string, FundMoicFactsBasisV1>;
 }
 
 export type FundMoicRankingSourceItem = Omit<FundMoicRankingItemV1, 'factsBasis'>;
@@ -78,15 +85,27 @@ export type PortfolioCompanyMoicSourceRow = {
 type FundMoicRankingDatabase = typeof db;
 
 type CandidateInput = {
-  investment: MOICInvestment;
+  companyName: string;
+  investment: MOICInvestment | null;
+  factsBasis: FundMoicFactsBasisV1;
+  candidateRankability: FundMoicFactsBasisV1['rankability'];
   hashRow: {
     companyId: number;
     fundId: number | null;
-    plannedReservesCents: number;
+    plannedReservesCents: string;
     exitProbability: number | null;
     exitProbabilitySource: 'explicit' | 'defaulted';
     exitMoicBps: number | null;
     reserveExitMultipleSource: 'explicit' | 'defaulted';
+    factsInputHash: string | null;
+    observedInitialInvestment: string;
+    observedFollowOnInvestment: string;
+    valuationAnchorKind: FundMoicFactsBasisV1['valuationAnchor']['kind'];
+    valuationAnchorValue: string | null;
+    valuationAnchorAsOfDate: string | null;
+    planningFmvStatus: FundMoicFactsBasisV1['planningFmvStatus'];
+    currencyStatus: FundMoicFactsBasisV1['currencyStatus'];
+    rankability: FundMoicFactsBasisV1['rankability'];
     sourceVersion: typeof MOIC_CANDIDATE_SOURCE_VERSION;
   };
   hasExplicitExitProbability: boolean;
@@ -106,6 +125,21 @@ function parseFiniteNumber(value: unknown): number | null {
     return Number.isFinite(parsed) ? parsed : null;
   }
   return null;
+}
+
+function parseDecimalString(value: unknown): string | null {
+  try {
+    if (typeof value === 'bigint') return value.toString();
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? new Decimal(value).toString() : null;
+    }
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return new Decimal(value.trim()).toString();
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 function parseExitProbability(value: unknown): number | null {
@@ -133,7 +167,11 @@ function buildLegacyMoicInvestment(row: PortfolioCompanyMoicSourceRow): MOICInve
   });
 }
 
-function buildCandidateMoicInvestment(row: PortfolioCompanyMoicSourceRow): CandidateInput {
+function buildCandidateMoicInvestment(
+  row: PortfolioCompanyMoicSourceRow,
+  factsBasis: FundMoicFactsBasisV1,
+  useFactsCandidate: boolean
+): CandidateInput {
   const plannedReservesCents = parseFiniteNumber(row.plannedReservesCents) ?? 0;
   const explicitExitProbability = parseExitProbability(row.exitProbability);
   const explicitExitMoicBps = parsePositiveExitMoicBps(row.exitMoicBps);
@@ -146,9 +184,34 @@ function buildCandidateMoicInvestment(row: PortfolioCompanyMoicSourceRow): Candi
     plannedReservesCanAffectMoic && !hasExplicitReserveExitMultiple;
   const activationBlocksExitProbability =
     plannedReservesCanAffectMoic && !hasExplicitExitProbability && hasExplicitReserveExitMultiple;
+  const candidateRankability: FundMoicFactsBasisV1['rankability'] =
+    useFactsCandidate && (!hasExplicitExitProbability || !hasExplicitReserveExitMultiple)
+      ? 'not_actionable'
+      : factsBasis.rankability;
+  let investment: MOICInvestment | null;
 
-  return {
-    investment: {
+  if (useFactsCandidate) {
+    const valuationAnchor = parseFiniteNumber(factsBasis.valuationAnchor.value);
+    investment =
+      candidateRankability === 'not_actionable' ||
+      explicitExitProbability === null ||
+      explicitExitMoicBps === null ||
+      valuationAnchor === null
+        ? null
+        : {
+            id: String(row.id),
+            name: row.name,
+            initialInvestment: parseFiniteNumber(factsBasis.observedInitialInvestment) ?? 0,
+            followOnInvestment: parseFiniteNumber(factsBasis.observedFollowOnInvestment) ?? 0,
+            currentValuation: valuationAnchor,
+            projectedExitValue: 0,
+            exitProbability: explicitExitProbability,
+            plannedReserves: plannedReservesCents / 100,
+            reserveExitMultiple: explicitExitMoicBps / 100,
+            investmentDate: row.investmentDate ? new Date(row.investmentDate) : new Date(),
+          };
+  } else {
+    investment = {
       id: String(row.id),
       name: row.name,
       initialInvestment: parseFiniteNumber(row.investmentAmount) ?? 0,
@@ -159,15 +222,31 @@ function buildCandidateMoicInvestment(row: PortfolioCompanyMoicSourceRow): Candi
       plannedReserves: plannedReservesCents / 100,
       reserveExitMultiple,
       investmentDate: row.investmentDate ? new Date(row.investmentDate) : new Date(),
-    },
+    };
+  }
+
+  return {
+    companyName: row.name,
+    investment,
+    factsBasis,
+    candidateRankability,
     hashRow: {
       companyId: row.id,
       fundId: row.fundId ?? null,
-      plannedReservesCents,
+      plannedReservesCents: parseDecimalString(row.plannedReservesCents) ?? '0',
       exitProbability: explicitExitProbability,
       exitProbabilitySource: hasExplicitExitProbability ? 'explicit' : 'defaulted',
       exitMoicBps: explicitExitMoicBps,
       reserveExitMultipleSource: hasExplicitReserveExitMultiple ? 'explicit' : 'defaulted',
+      factsInputHash: factsBasis.factsInputHash,
+      observedInitialInvestment: factsBasis.observedInitialInvestment,
+      observedFollowOnInvestment: factsBasis.observedFollowOnInvestment,
+      valuationAnchorKind: factsBasis.valuationAnchor.kind,
+      valuationAnchorValue: factsBasis.valuationAnchor.value,
+      valuationAnchorAsOfDate: factsBasis.valuationAnchor.asOfDate,
+      planningFmvStatus: factsBasis.planningFmvStatus,
+      currencyStatus: factsBasis.currencyStatus,
+      rankability: candidateRankability,
       sourceVersion: MOIC_CANDIDATE_SOURCE_VERSION,
     },
     hasExplicitExitProbability,
@@ -205,6 +284,61 @@ function buildMoicRankingSourceFromInvestments(
   };
 }
 
+function buildFactsCandidateRankingSource(
+  fundId: number,
+  candidateInputs: CandidateInput[]
+): FundMoicRankingSourceResponse {
+  const rankabilityOrder: Record<FundMoicFactsBasisV1['rankability'], number> = {
+    actionable: 0,
+    indicative: 1,
+    not_actionable: 2,
+  };
+  const ranked = candidateInputs
+    .map((input) => ({
+      input,
+      reservesMoic:
+        input.investment === null
+          ? {
+              value: null,
+              description: 'Not actionable from the current Round/FMV facts basis',
+              formula: 'N/A (non-actionable inputs)',
+            }
+          : MOICCalculator.calculateReservesMOIC(input.investment, true),
+    }))
+    .sort((left, right) => {
+      const rankabilityDifference =
+        rankabilityOrder[left.input.candidateRankability] -
+        rankabilityOrder[right.input.candidateRankability];
+      if (rankabilityDifference !== 0) return rankabilityDifference;
+
+      const leftValue = left.reservesMoic.value ?? Number.NEGATIVE_INFINITY;
+      const rightValue = right.reservesMoic.value ?? Number.NEGATIVE_INFINITY;
+      if (leftValue !== rightValue) return rightValue - leftValue;
+      return left.input.hashRow.companyId - right.input.hashRow.companyId;
+    });
+
+  return {
+    fundId,
+    provenance: {
+      source: 'portfolio_companies',
+      calculation: 'reserves_moic_rankings',
+      metricBasis: 'planned_reserves',
+      sourceRecordCount: candidateInputs.length,
+    },
+    generatedAt: new Date().toISOString(),
+    rankings: ranked.map(({ input, reservesMoic }, index) => ({
+      rank: index + 1,
+      investmentId: String(input.hashRow.companyId),
+      investmentName: input.companyName,
+      reservesMoic: {
+        value: reservesMoic.value,
+        description: reservesMoic.description,
+        formula: reservesMoic.formula,
+      },
+    })),
+  };
+}
+
 export function discloseFundMoicRankings(
   source: FundMoicRankingSourceResponse,
   factsBasisByInvestmentId?: ReadonlyMap<string, FundMoicFactsBasisV1>
@@ -228,12 +362,35 @@ export function buildMoicRankingsFromInvestments(
 export function buildMoicRankingSourcesFromCompanies(
   fundId: number,
   companies: PortfolioCompanyMoicSourceRow[],
-  factsByCompanyId?: ReadonlyMap<number, FundCompanyActualsFact>
+  factsSource: FundMoicFactsSource = FUND_MOIC_FACTS_ABSENT
 ): FundMoicRankingSources {
   const sortedCompanies = [...companies].sort((a, b) => a.id - b.id);
+  const actualsFacts = factsSource.status === 'available' ? factsSource.response : undefined;
+  const factsByCompanyId = actualsFacts
+    ? new Map(actualsFacts.facts.map((fact) => [fact.companyId, fact] as const))
+    : undefined;
   const legacyInvestments = sortedCompanies.map(buildLegacyMoicInvestment);
-  const candidateInputs = sortedCompanies.map(buildCandidateMoicInvestment);
-  const candidateInvestments = candidateInputs.map((input) => input.investment);
+  const candidateInputs = sortedCompanies.map((company) => {
+    const factsBasis = buildFundMoicFactsBasis({
+      company,
+      fact: factsByCompanyId?.get(company.id) ?? null,
+    });
+    return buildCandidateMoicInvestment(company, factsBasis, actualsFacts !== undefined);
+  });
+  const factsBasisByInvestmentId = new Map(
+    candidateInputs.map((input) => [String(input.hashRow.companyId), input.factsBasis])
+  );
+  const candidateFactsBasisByInvestmentId = new Map(
+    candidateInputs.map((input) => [
+      String(input.hashRow.companyId),
+      input.candidateRankability === input.factsBasis.rankability
+        ? input.factsBasis
+        : { ...input.factsBasis, rankability: input.candidateRankability },
+    ])
+  );
+  const candidateInvestments = candidateInputs.flatMap((input) =>
+    input.investment === null ? [] : [input.investment]
+  );
   const moicInputSummary: FundMoicInputSummary = {
     sourceVersion: MOIC_CANDIDATE_SOURCE_VERSION,
     explicitExitProbabilityCount: candidateInputs.filter(
@@ -261,38 +418,38 @@ export function buildMoicRankingSourcesFromCompanies(
     rows: candidateInputs.map((input) => input.hashRow),
     sourceVersion: MOIC_CANDIDATE_SOURCE_VERSION,
   });
-  const factsBasisByInvestmentId = factsByCompanyId
-    ? new Map(
-        sortedCompanies.map((company) => [
-          String(company.id),
-          buildFundMoicFactsBasis({
-            company,
-            fact: factsByCompanyId.get(company.id) ?? null,
-          }),
-        ])
-      )
+  const disclosedFactsBasisByInvestmentId = actualsFacts ? factsBasisByInvestmentId : undefined;
+  const disclosedCandidateFactsBasisByInvestmentId = actualsFacts
+    ? candidateFactsBasisByInvestmentId
     : undefined;
 
   return {
     legacy: buildMoicRankingSourceFromInvestments(fundId, legacyInvestments),
-    candidate: buildMoicRankingSourceFromInvestments(fundId, candidateInvestments),
+    candidate: actualsFacts
+      ? buildFactsCandidateRankingSource(fundId, candidateInputs)
+      : buildMoicRankingSourceFromInvestments(fundId, candidateInvestments),
     moicInputSummary,
     moicSourceInputHash,
-    ...(factsBasisByInvestmentId !== undefined && { factsBasisByInvestmentId }),
+    ...(disclosedFactsBasisByInvestmentId !== undefined && {
+      factsBasisByInvestmentId: disclosedFactsBasisByInvestmentId,
+    }),
+    ...(disclosedCandidateFactsBasisByInvestmentId !== undefined && {
+      candidateFactsBasisByInvestmentId: disclosedCandidateFactsBasisByInvestmentId,
+    }),
   };
 }
 
 export async function getFundMoicRankingSources(
   fundId: number,
   database: FundMoicRankingDatabase = db,
-  factsByCompanyId?: ReadonlyMap<number, FundCompanyActualsFact>
+  factsSource: FundMoicFactsSource = FUND_MOIC_FACTS_ABSENT
 ): Promise<FundMoicRankingSources> {
   const companies = await database.query.portfolioCompanies.findMany({
     where: (pc, { eq }) => eq(pc.fundId, fundId),
     orderBy: (pc, { asc }) => [asc(pc.id)],
   });
 
-  return buildMoicRankingSourcesFromCompanies(fundId, companies, factsByCompanyId);
+  return buildMoicRankingSourcesFromCompanies(fundId, companies, factsSource);
 }
 
 export async function getFundMoicRankings(

--- a/server/services/fund-moic-ranking-service.ts
+++ b/server/services/fund-moic-ranking-service.ts
@@ -10,6 +10,8 @@ import type {
 import { canonicalSha256 } from '../../shared/lib/canonical-hash';
 import type { FundCompanyActualsFactsResponse } from '../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 import Decimal from '../../shared/lib/decimal-config';
+import { logger } from '../lib/logger.js';
+import { buildFundCompanyActualsFacts } from './fund-actuals/fund-company-actuals-facts-service.js';
 import { buildFundMoicFactsBasis } from './moic/fund-moic-facts-basis';
 
 export const MOIC_CANDIDATE_SOURCE_VERSION = 'moic-round-fmv-facts-v2';
@@ -35,6 +37,7 @@ export interface FundMoicRankingSources {
   candidate: FundMoicRankingSourceResponse;
   moicInputSummary: FundMoicInputSummary;
   moicSourceInputHash: string;
+  factsSource: FundMoicFactsSource;
   factsBasisByInvestmentId?: ReadonlyMap<string, FundMoicFactsBasisV1>;
   candidateFactsBasisByInvestmentId?: ReadonlyMap<string, FundMoicFactsBasisV1>;
 }
@@ -92,6 +95,7 @@ type CandidateInput = {
   hashRow: {
     companyId: number;
     fundId: number | null;
+    investmentName: string;
     plannedReservesCents: string;
     exitProbability: number | null;
     exitProbabilitySource: 'explicit' | 'defaulted';
@@ -233,6 +237,7 @@ function buildCandidateMoicInvestment(
     hashRow: {
       companyId: row.id,
       fundId: row.fundId ?? null,
+      investmentName: row.name,
       plannedReservesCents: parseDecimalString(row.plannedReservesCents) ?? '0',
       exitProbability: explicitExitProbability,
       exitProbabilitySource: hasExplicitExitProbability ? 'explicit' : 'defaulted',
@@ -430,6 +435,7 @@ export function buildMoicRankingSourcesFromCompanies(
       : buildMoicRankingSourceFromInvestments(fundId, candidateInvestments),
     moicInputSummary,
     moicSourceInputHash,
+    factsSource,
     ...(disclosedFactsBasisByInvestmentId !== undefined && {
       factsBasisByInvestmentId: disclosedFactsBasisByInvestmentId,
     }),
@@ -442,14 +448,33 @@ export function buildMoicRankingSourcesFromCompanies(
 export async function getFundMoicRankingSources(
   fundId: number,
   database: FundMoicRankingDatabase = db,
-  factsSource: FundMoicFactsSource = FUND_MOIC_FACTS_ABSENT
+  factsSource?: FundMoicFactsSource,
+  now: Date = new Date()
 ): Promise<FundMoicRankingSources> {
-  const companies = await database.query.portfolioCompanies.findMany({
-    where: (pc, { eq }) => eq(pc.fundId, fundId),
-    orderBy: (pc, { asc }) => [asc(pc.id)],
-  });
+  const asOfDate = now.toISOString().slice(0, 10);
+  const [companies, resolvedFactsSource] = await Promise.all([
+    database.query.portfolioCompanies.findMany({
+      where: (pc, { eq }) => eq(pc.fundId, fundId),
+      orderBy: (pc, { asc }) => [asc(pc.id)],
+    }),
+    factsSource
+      ? Promise.resolve(factsSource)
+      : buildFundCompanyActualsFacts({ fundId, asOfDate, database, now })
+          .then((response) => ({ status: 'available' as const, response }))
+          .catch((error: unknown) => {
+            logger.warn(
+              {
+                fundId,
+                asOfDate,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              'fund-moic actuals facts load failed; using unavailable facts source'
+            );
+            return FUND_MOIC_FACTS_ABSENT;
+          }),
+  ]);
 
-  return buildMoicRankingSourcesFromCompanies(fundId, companies, factsSource);
+  return buildMoicRankingSourcesFromCompanies(fundId, companies, resolvedFactsSource);
 }
 
 export async function getFundMoicRankings(

--- a/server/services/fund-moic-reconciliation-service.ts
+++ b/server/services/fund-moic-reconciliation-service.ts
@@ -30,6 +30,15 @@ export class MoicReconciliationConflictError extends Error {
   }
 }
 
+export class MoicReconciliationFactsUnavailableError extends Error {
+  readonly code = 'facts_unavailable';
+
+  constructor() {
+    super('Round/FMV facts are unavailable for MOIC reconciliation');
+    this.name = 'MoicReconciliationFactsUnavailableError';
+  }
+}
+
 export interface MoicReconciliationRunRef {
   runId: string;
   createdAt: string;
@@ -125,6 +134,9 @@ export async function recordMoicReconciliation(params: {
 }): Promise<{ run: MoicReconciliationRunRef; replayed: boolean }> {
   const database = params.database ?? db;
   const sources = await getFundMoicRankingSources(params.fundId, database);
+  if (sources.factsSource.status !== 'available') {
+    throw new MoicReconciliationFactsUnavailableError();
+  }
   const requestHash = requestHashFor({
     fundId: params.fundId,
     moicSourceInputHash: sources.moicSourceInputHash,

--- a/server/services/lp-reporting/report-package-service.ts
+++ b/server/services/lp-reporting/report-package-service.ts
@@ -620,7 +620,7 @@ export async function assembleMetricRunReportPackage(
 
     const { createMoicActionabilityResolver, toH9SnapshotColumns } =
       await import('../fund-calculation-mode-service');
-    const h9Resolver = createMoicActionabilityResolver({ database: tx });
+    const h9Resolver = createMoicActionabilityResolver({ database: tx, reuseFactsSource: true });
     const h9 = await h9Resolver.resolveForFund(input.fundId);
     const h9Columns = toH9SnapshotColumns(h9);
 

--- a/server/services/lp-reporting/report-package-service.ts
+++ b/server/services/lp-reporting/report-package-service.ts
@@ -620,7 +620,7 @@ export async function assembleMetricRunReportPackage(
 
     const { createMoicActionabilityResolver, toH9SnapshotColumns } =
       await import('../fund-calculation-mode-service');
-    const h9Resolver = createMoicActionabilityResolver({ database: tx, reuseFactsSource: true });
+    const h9Resolver = createMoicActionabilityResolver({ database: tx, reuseFactsSource: false });
     const h9 = await h9Resolver.resolveForFund(input.fundId);
     const h9Columns = toH9SnapshotColumns(h9);
 

--- a/server/services/reserve-calculation-service.ts
+++ b/server/services/reserve-calculation-service.ts
@@ -7,6 +7,11 @@ import type { ReserveCompanyInput, ReserveSummary } from '@shared/types';
 import Decimal from '@shared/lib/decimal-config';
 import { logger } from '../lib/logger';
 import { resolveMoicActionability, toH9SnapshotColumns } from './fund-calculation-mode-service';
+import {
+  getFundMoicRankingSources,
+  type FundMoicFactsSource,
+  type FundMoicRankingSources,
+} from './fund-moic-ranking-service';
 import { markCalcRunCompletedIfReady } from './calc-run-tracking';
 import { buildReservePortfolioInputWithProvenance } from './reserve-input-builder';
 import {
@@ -97,6 +102,7 @@ function logReserveFactsShadowEvent(event: Record<string, unknown>): void {
 async function emitReserveFactsShadowComparison(input: {
   fundId: number;
   asOfDate: string;
+  factsSource: FundMoicFactsSource;
   legacyCompanyCount: number;
   legacySummary: ReserveSummary;
 }): Promise<void> {
@@ -105,6 +111,7 @@ async function emitReserveFactsShadowComparison(input: {
     const facts = await buildFactsReserveCandidates({
       fundId: input.fundId,
       asOfDate: input.asOfDate,
+      factsSource: input.factsSource,
     });
     const factsPortfolio = eligibleInputs(facts.candidates);
     const factsSummary = generateReserveSummary(input.fundId, factsPortfolio);
@@ -192,11 +199,17 @@ export async function runReserveCalculation({
   let reserveInputTrustSummary: ReserveInputTrustSummary;
   let factsBasis: FactsBasisMetadata | undefined;
   let factsInputsTrustedForActivation = true;
+  let moicSources: FundMoicRankingSources | undefined;
+  let factsAsOfDate: string | undefined;
 
   if (reserveFactsMode === 'on') {
+    const factsNow = new Date();
+    factsAsOfDate = factsNow.toISOString().slice(0, 10);
+    moicSources = await getFundMoicRankingSources(fundId, db, undefined, factsNow);
     const facts = await buildFactsReserveCandidates({
       fundId,
-      asOfDate: new Date().toISOString().slice(0, 10),
+      asOfDate: factsAsOfDate,
+      factsSource: moicSources.factsSource,
     });
     portfolio = eligibleInputs(facts.candidates);
     reserveInputTrustSummary = facts.trustSummary;
@@ -216,9 +229,17 @@ export async function runReserveCalculation({
   }
 
   const reserves = generateReserveSummary(fundId, portfolio);
+  if (reserveFactsMode === 'shadow') {
+    const factsNow = new Date();
+    factsAsOfDate = factsNow.toISOString().slice(0, 10);
+    moicSources = await getFundMoicRankingSources(fundId, db, undefined, factsNow);
+  }
   // H9: stamp the actionability fingerprint onto the authoritative snapshot so
   // downstream reuse/cache/export can gate on it. Display reads are unaffected.
-  const actionability = await resolveMoicActionability({ fundId });
+  const actionability = await resolveMoicActionability({
+    fundId,
+    ...(moicSources !== undefined && { sources: moicSources }),
+  });
   const h9Columns = toH9SnapshotColumns(actionability);
   if (reserveFactsMode === 'on' && !factsInputsTrustedForActivation) {
     h9Columns.h9ActionabilityStatus = 'non_actionable';
@@ -256,10 +277,11 @@ export async function runReserveCalculation({
     await markCalcRunCompletedIfReady(runId);
   }
 
-  if (reserveFactsMode === 'shadow') {
+  if (reserveFactsMode === 'shadow' && moicSources !== undefined && factsAsOfDate !== undefined) {
     await emitReserveFactsShadowComparison({
       fundId,
-      asOfDate: new Date().toISOString().slice(0, 10),
+      asOfDate: factsAsOfDate,
+      factsSource: moicSources.factsSource,
       legacyCompanyCount: portfolio.length,
       legacySummary: reserves,
     });

--- a/server/services/reserves/facts-reserve-input-adapter.ts
+++ b/server/services/reserves/facts-reserve-input-adapter.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../shared/contracts/reserve-input-provenance.contract';
 import Decimal from '../../../shared/lib/decimal-config';
 import { buildFundCompanyActualsFacts } from '../fund-actuals/fund-company-actuals-facts-service';
+import type { FundMoicFactsSource } from '../fund-moic-ranking-service';
 import { buildReservePortfolioInputWithProvenance } from '../reserve-input-builder';
 
 export type { FactsReserveCandidate } from '../../../shared/contracts/reserve-input-provenance.contract';
@@ -40,13 +41,19 @@ function eligibleInputIsTrusted(input: ReserveCompanyInputWithProvenance): boole
 export async function buildFactsReserveCandidates(input: {
   fundId: number;
   asOfDate: string;
+  factsSource?: FundMoicFactsSource;
 }): Promise<{
   candidates: FactsReserveCandidate[];
   factsInputHash: string | null;
   trustSummary: ReserveInputTrustSummary;
 }> {
   const legacy = await buildReservePortfolioInputWithProvenance(input.fundId);
-  const facts = await buildFundCompanyActualsFacts(input).catch(() => null);
+  const factsSource =
+    input.factsSource ??
+    (await buildFundCompanyActualsFacts({ fundId: input.fundId, asOfDate: input.asOfDate })
+      .then((response) => ({ status: 'available' as const, response }))
+      .catch(() => ({ status: 'absent' as const })));
+  const facts = factsSource.status === 'available' ? factsSource.response : null;
   const factsByCompany = new Map(
     (facts?.facts ?? []).map((fact) => [fact.companyId, fact] as const)
   );

--- a/shared/contracts/fund-moic-v2.contract.ts
+++ b/shared/contracts/fund-moic-v2.contract.ts
@@ -19,6 +19,7 @@ const ModePreviewSchema = z
         'accepted_reconciliation_not_found',
         'current_source_changed',
         'exit_probability_source_incomplete',
+        'facts_unavailable',
         'kill_switch_active',
         'reserve_exit_multiple_source_incomplete',
         'shadow_residency_pending',

--- a/shared/contracts/fund-moic-v2.contract.ts
+++ b/shared/contracts/fund-moic-v2.contract.ts
@@ -30,7 +30,7 @@ const ModePreviewSchema = z
 
 const MoicInputSummarySchema = z
   .object({
-    sourceVersion: z.literal('moic-exit-probability-v1'),
+    sourceVersion: z.literal('moic-round-fmv-facts-v2'),
     explicitExitProbabilityCount: z.number().int().nonnegative(),
     defaultedExitProbabilityCount: z.number().int().nonnegative(),
     activationBlockingDefaultedExitProbabilityCount: z.number().int().nonnegative(),

--- a/tests/unit/contract/fund-moic-v2.contract.test.ts
+++ b/tests/unit/contract/fund-moic-v2.contract.test.ts
@@ -45,7 +45,7 @@ const makeValidV2 = (): FundMoicRankingsResponseV2 => ({
     version: 0,
   },
   moicInputSummary: {
-    sourceVersion: 'moic-exit-probability-v1',
+    sourceVersion: 'moic-round-fmv-facts-v2',
     explicitExitProbabilityCount: 1,
     defaultedExitProbabilityCount: 0,
     activationBlockingDefaultedExitProbabilityCount: 0,

--- a/tests/unit/hooks/use-moic-v2.test.tsx
+++ b/tests/unit/hooks/use-moic-v2.test.tsx
@@ -40,7 +40,7 @@ function makeV2Response(fundId: number): FundMoicRankingsResponseV2 {
       version: 0,
     },
     moicInputSummary: {
-      sourceVersion: 'moic-exit-probability-v1',
+      sourceVersion: 'moic-round-fmv-facts-v2',
       explicitExitProbabilityCount: 1,
       defaultedExitProbabilityCount: 0,
       activationBlockingDefaultedExitProbabilityCount: 0,

--- a/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
+++ b/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
@@ -71,7 +71,7 @@ const canonicalFixture = {
     version: 2,
   },
   moicInputSummary: {
-    sourceVersion: 'moic-exit-probability-v1',
+    sourceVersion: 'moic-round-fmv-facts-v2',
     explicitExitProbabilityCount: 1,
     defaultedExitProbabilityCount: 2,
     activationBlockingDefaultedExitProbabilityCount: 2,

--- a/tests/unit/routes/fund-moic-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-rankings.behavior.test.ts
@@ -184,6 +184,7 @@ function sourceBundle(overrides: Partial<FundMoicRankingSources> = {}): FundMoic
       activationBlockingDefaultedReserveExitMultipleCount: 0,
     },
     moicSourceInputHash: 'moic-source-input-a',
+    factsSource: { status: 'available' as const, response: actualsFactsResponse() },
     ...overrides,
   };
 }
@@ -289,11 +290,8 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
       before.legacy.rankings
     );
     expect(parsed.rankings.some((ranking) => ranking.factsBasis !== null)).toBe(true);
-    expect(svc.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
-    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1, undefined, {
-      status: 'available',
-      response: expect.objectContaining({ inputHash: FACTS_INPUT_HASH }),
-    });
+    expect(svc.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1);
   });
 
   it.each([
@@ -352,6 +350,9 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
   );
 
   it('keeps HTTP behavior unchanged and returns null bases when the facts load fails', async () => {
+    svc.getFundMoicRankingSources.mockResolvedValue(
+      Object.assign(sourceBundle(), { factsSource: { status: 'absent' as const } })
+    );
     svc.buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts backend down'));
 
     const res = await getRankings();
@@ -364,10 +365,13 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
       warnings: ['actuals_facts_failed'],
     });
     expect(parsed.rankings.every((ranking) => ranking.factsBasis === null)).toBe(true);
-    expect(svc.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+    expect(svc.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
   });
 
   it('never serves the candidate when the facts load fails, even if mode state is otherwise on', async () => {
+    svc.getFundMoicRankingSources.mockResolvedValue(
+      Object.assign(sourceBundle(), { factsSource: { status: 'absent' as const } })
+    );
     svc.buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts backend down'));
     svc.resolveFundCalculationMode.mockResolvedValue(
       modePreview({ configuredMode: 'on', effectiveMode: 'on' })
@@ -386,9 +390,7 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
     expect(parsed.provenance.mode).toBe('legacy');
     expect(parsed.rankings[0]?.investmentId).toBe('legacy-output-a');
-    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1, undefined, {
-      status: 'absent',
-    });
+    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1);
   });
 
   it.each(['shadow', 'on'] as const)(
@@ -501,6 +503,9 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
   });
 
   it('emits an unavailable comparison without leaking values when shadow facts fail', async () => {
+    svc.getFundMoicRankingSources.mockResolvedValue(
+      Object.assign(sourceBundle(), { factsSource: { status: 'absent' as const } })
+    );
     svc.buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts backend down'));
     svc.resolveFundCalculationMode.mockResolvedValue(
       modePreview({ configuredMode: 'shadow', effectiveMode: 'shadow' })
@@ -628,9 +633,17 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     expect(res.body).toMatchObject({ error: 'invalid_contract' });
   });
 
-  it('returns the unchanged V1 payload when no contract query is provided', async () => {
-    const sources = sourceBundle();
+  it('serves unchanged legacy V1 output when mode is on but facts are unavailable', async () => {
+    const sources = Object.assign(sourceBundle(), {
+      factsSource: { status: 'absent' as const },
+    });
     svc.getFundMoicRankingSources.mockResolvedValue(sources);
+    svc.resolveFundCalculationMode.mockResolvedValue(
+      modePreview({ configuredMode: 'on', effectiveMode: 'on' })
+    );
+    svc.resolveMoicActionability.mockResolvedValue(
+      actionability({ actionability: 'non_actionable', actionabilityStatus: 'non_actionable' })
+    );
 
     const res = await getRankings('/api/funds/1/moic/rankings');
 
@@ -644,6 +657,8 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     expect(res.body).not.toHaveProperty('latestReconciliation');
     expect(res.body).not.toHaveProperty('roundEvidenceSummary');
     expect(res.body.rankings[0]?.factsBasis).toBeNull();
+    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1);
+    expect(svc.resolveMoicActionability).toHaveBeenCalledWith({ fundId: 1, sources });
     expect(svc.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/routes/fund-moic-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-rankings.behavior.test.ts
@@ -175,7 +175,7 @@ function sourceBundle(overrides: Partial<FundMoicRankingSources> = {}): FundMoic
       rankings: [rankingItem('candidate-output-a', 2.4)],
     },
     moicInputSummary: {
-      sourceVersion: 'moic-exit-probability-v1',
+      sourceVersion: 'moic-round-fmv-facts-v2',
       explicitExitProbabilityCount: 1,
       defaultedExitProbabilityCount: 0,
       activationBlockingDefaultedExitProbabilityCount: 0,
@@ -290,7 +290,10 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     );
     expect(parsed.rankings.some((ranking) => ranking.factsBasis !== null)).toBe(true);
     expect(svc.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
-    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1, undefined, expect.any(Map));
+    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1, undefined, {
+      status: 'available',
+      response: expect.objectContaining({ inputHash: FACTS_INPUT_HASH }),
+    });
   });
 
   it.each([
@@ -317,8 +320,12 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
         sourceBundle({
           factsBasisByInvestmentId: new Map([
             ['legacy-output-a', factsBasis()],
-            ['candidate-output-a', factsBasis()],
+            [
+              'candidate-output-a',
+              factsBasis({ rankability: 'indicative', reasons: ['planning_fmv_stale'] }),
+            ],
           ]),
+          candidateFactsBasisByInvestmentId: new Map([['candidate-output-a', factsBasis()]]),
         })
       );
       svc.resolveFundCalculationMode.mockResolvedValue(
@@ -340,6 +347,7 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
         before[expectedSource].rankings
       );
       expect(parsed.rankings.some((ranking) => ranking.factsBasis !== null)).toBe(true);
+      expect(parsed.rankings[0]?.factsBasis?.rankability).toBe('actionable');
     }
   );
 
@@ -357,6 +365,30 @@ describe('fund MOIC rankings route - behavioral state machine', () => {
     });
     expect(parsed.rankings.every((ranking) => ranking.factsBasis === null)).toBe(true);
     expect(svc.buildFundCompanyActualsFacts).toHaveBeenCalledTimes(1);
+  });
+
+  it('never serves the candidate when the facts load fails, even if mode state is otherwise on', async () => {
+    svc.buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts backend down'));
+    svc.resolveFundCalculationMode.mockResolvedValue(
+      modePreview({ configuredMode: 'on', effectiveMode: 'on' })
+    );
+    svc.resolveMoicActionability.mockResolvedValue(
+      actionability({
+        sourceFingerprintMatches: true,
+        actionability: 'actionable',
+        actionabilityStatus: 'actionable',
+      })
+    );
+
+    const res = await getRankings();
+
+    expect(res.status).toBe(200);
+    const parsed = FundMoicRankingsResponseV2Schema.parse(res.body);
+    expect(parsed.provenance.mode).toBe('legacy');
+    expect(parsed.rankings[0]?.investmentId).toBe('legacy-output-a');
+    expect(svc.getFundMoicRankingSources).toHaveBeenCalledWith(1, undefined, {
+      status: 'absent',
+    });
   });
 
   it.each(['shadow', 'on'] as const)(

--- a/tests/unit/routes/fund-moic-reconciliations.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-reconciliations.behavior.test.ts
@@ -13,6 +13,7 @@ const authState = vi.hoisted(() => ({
 
 const ranking = vi.hoisted(() => ({ getFundMoicRankingSources: vi.fn() }));
 const evidence = vi.hoisted(() => ({ buildRoundsToModelEvidence: vi.fn() }));
+const actuals = vi.hoisted(() => ({ buildFundCompanyActualsFacts: vi.fn() }));
 
 const dbHolder = vi.hoisted(() => {
   const state = {
@@ -62,6 +63,10 @@ vi.mock('../../../server/db', () => ({ db: dbHolder.db }));
 
 vi.mock('../../../server/services/rounds-to-model-evidence-service', () => ({
   buildRoundsToModelEvidence: evidence.buildRoundsToModelEvidence,
+}));
+
+vi.mock('../../../server/services/fund-actuals/fund-company-actuals-facts-service', () => ({
+  buildFundCompanyActualsFacts: actuals.buildFundCompanyActualsFacts,
 }));
 
 vi.mock('../../../server/services/fund-moic-ranking-service', async (importOriginal) => {
@@ -117,7 +122,7 @@ const sourceBundle = (overrides: Partial<FundMoicRankingSources> = {}): FundMoic
     rankings: [rankingItem('1', 2.8)],
   },
   moicInputSummary: {
-    sourceVersion: 'moic-exit-probability-v1',
+    sourceVersion: 'moic-round-fmv-facts-v2',
     explicitExitProbabilityCount: 1,
     defaultedExitProbabilityCount: 0,
     activationBlockingDefaultedExitProbabilityCount: 0,
@@ -169,12 +174,20 @@ beforeEach(() => {
     inserted: [],
   });
   ranking.getFundMoicRankingSources.mockResolvedValue(sourceBundle());
+  actuals.buildFundCompanyActualsFacts.mockResolvedValue({
+    fundId: 1,
+    asOfDate: '2026-07-13',
+    facts: [],
+    inputHash: 'f'.repeat(64),
+    generatedAt: '2026-07-13T00:00:00.000Z',
+  });
   evidence.buildRoundsToModelEvidence.mockResolvedValue({
     coverage: { activeRoundCount: 0, activeOverrideCount: 0, warningsByCode: {} },
   });
 });
 
 const expectZeroDownstream = () => {
+  expect(actuals.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
   expect(ranking.getFundMoicRankingSources).not.toHaveBeenCalled();
   expect(evidence.buildRoundsToModelEvidence).not.toHaveBeenCalled();
   expect(dbHolder.state.selectCalls).toBe(0);

--- a/tests/unit/routes/fund-moic-reconciliations.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-reconciliations.behavior.test.ts
@@ -98,41 +98,53 @@ const rankingItem = (investmentId: string, value: number) => ({
   reservesMoic: { value, description: 'desc', formula: 'formula' },
 });
 
-const sourceBundle = (overrides: Partial<FundMoicRankingSources> = {}): FundMoicRankingSources => ({
-  legacy: {
-    fundId: 1,
-    provenance: {
-      source: 'portfolio_companies',
-      calculation: 'reserves_moic_rankings',
-      metricBasis: 'planned_reserves',
-      sourceRecordCount: 1,
+const sourceBundle = (overrides: Partial<FundMoicRankingSources> = {}): FundMoicRankingSources => {
+  return {
+    legacy: {
+      fundId: 1,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt: '2026-06-24T00:00:00.000Z',
+      rankings: [rankingItem('1', 0)],
     },
-    generatedAt: '2026-06-24T00:00:00.000Z',
-    rankings: [rankingItem('1', 0)],
-  },
-  candidate: {
-    fundId: 1,
-    provenance: {
-      source: 'portfolio_companies',
-      calculation: 'reserves_moic_rankings',
-      metricBasis: 'planned_reserves',
-      sourceRecordCount: 1,
+    candidate: {
+      fundId: 1,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt: '2026-06-24T00:00:00.000Z',
+      rankings: [rankingItem('1', 2.8)],
     },
-    generatedAt: '2026-06-24T00:00:00.000Z',
-    rankings: [rankingItem('1', 2.8)],
-  },
-  moicInputSummary: {
-    sourceVersion: 'moic-round-fmv-facts-v2',
-    explicitExitProbabilityCount: 1,
-    defaultedExitProbabilityCount: 0,
-    activationBlockingDefaultedExitProbabilityCount: 0,
-    explicitReserveExitMultipleCount: 1,
-    defaultedReserveExitMultipleCount: 0,
-    activationBlockingDefaultedReserveExitMultipleCount: 0,
-  },
-  moicSourceInputHash: 'source-hash-a',
-  ...overrides,
-});
+    moicInputSummary: {
+      sourceVersion: 'moic-round-fmv-facts-v2',
+      explicitExitProbabilityCount: 1,
+      defaultedExitProbabilityCount: 0,
+      activationBlockingDefaultedExitProbabilityCount: 0,
+      explicitReserveExitMultipleCount: 1,
+      defaultedReserveExitMultipleCount: 0,
+      activationBlockingDefaultedReserveExitMultipleCount: 0,
+    },
+    moicSourceInputHash: 'source-hash-a',
+    factsSource: {
+      status: 'available' as const,
+      response: {
+        fundId: 1,
+        asOfDate: '2026-07-13',
+        facts: [],
+        inputHash: 'f'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+      },
+    },
+    ...overrides,
+  };
+};
 
 const requestHashFor = (fundId: number, moicSourceInputHash: string): string =>
   canonicalSha256({
@@ -245,6 +257,24 @@ describe('fund MOIC reconciliation route - behavioral state machine', () => {
     expect(res.status).toBe(403);
     expect(res.body).toEqual({ error: 'Forbidden', message: 'You do not have access to fund 1' });
     expectZeroDownstream();
+  });
+
+  it('409 with no acceptable run when the v2 facts source is unavailable', async () => {
+    authState.user = ADMIN;
+    ranking.getFundMoicRankingSources.mockResolvedValue(
+      Object.assign(sourceBundle(), { factsSource: { status: 'absent' as const } })
+    );
+
+    const res = await post(1, 'facts-unavailable');
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: 'facts_unavailable',
+      message: 'Round/FMV facts are unavailable for MOIC reconciliation',
+    });
+    expect(evidence.buildRoundsToModelEvidence).not.toHaveBeenCalled();
+    expect(dbHolder.state.insertAttempts).toBe(0);
+    expect(dbHolder.state.inserted).toHaveLength(0);
   });
 
   it('201 first run: persists requestedBy=101, one ranking, one evidence, one insert', async () => {

--- a/tests/unit/routes/fund-moic-route-contract.test.ts
+++ b/tests/unit/routes/fund-moic-route-contract.test.ts
@@ -39,10 +39,12 @@ describe('fund-moic route contract', () => {
 
   it('reports companyCount from facts on success and from source record count on failure', async () => {
     const source = await readRepoFile('server/routes/fund-moic.ts');
-    expect(source).toContain('buildFundCompanyActualsFacts({');
-    expect(source).toContain('asOfDate: actualsAsOfDate');
-    expect(source).toContain("{ status: 'available', response: actualsFacts }");
-    expect(source).toContain('FUND_MOIC_FACTS_ABSENT');
+    const rankingSource = await readRepoFile('server/services/fund-moic-ranking-service.ts');
+    expect(rankingSource).toContain('buildFundCompanyActualsFacts({');
+    expect(rankingSource).toContain('asOfDate');
+    expect(source).not.toContain('buildFundCompanyActualsFacts');
+    expect(source).not.toContain('FUND_MOIC_FACTS_ABSENT');
+    expect(source).toContain('sources.factsSource');
     expect(source).not.toContain('factsByCompanyId');
     expect(source).toContain('sources.factsBasisByInvestmentId');
     expect(source).toContain('discloseFundMoicRankings');

--- a/tests/unit/routes/fund-moic-route-contract.test.ts
+++ b/tests/unit/routes/fund-moic-route-contract.test.ts
@@ -41,7 +41,9 @@ describe('fund-moic route contract', () => {
     const source = await readRepoFile('server/routes/fund-moic.ts');
     expect(source).toContain('buildFundCompanyActualsFacts({');
     expect(source).toContain('asOfDate: actualsAsOfDate');
-    expect(source).toContain('factsByCompanyId');
+    expect(source).toContain("{ status: 'available', response: actualsFacts }");
+    expect(source).toContain('FUND_MOIC_FACTS_ABSENT');
+    expect(source).not.toContain('factsByCompanyId');
     expect(source).toContain('sources.factsBasisByInvestmentId');
     expect(source).toContain('discloseFundMoicRankings');
     expect(source).toContain("factsStatus: 'available'");

--- a/tests/unit/services/fund-calculation-mode-service.test.ts
+++ b/tests/unit/services/fund-calculation-mode-service.test.ts
@@ -56,6 +56,16 @@ function sourceBundle(overrides: Partial<FundMoicRankingSources> = {}): FundMoic
       activationBlockingDefaultedReserveExitMultipleCount: 0,
     },
     moicSourceInputHash: 'source-hash-a',
+    factsSource: {
+      status: 'available' as const,
+      response: {
+        fundId: 7,
+        asOfDate: '2026-07-13',
+        facts: [],
+        inputHash: 'f'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+      },
+    },
     ...overrides,
   };
 }
@@ -219,6 +229,27 @@ describe('fund calculation mode service', () => {
       })
     ).rejects.toMatchObject({
       blockers: ['exit_probability_source_incomplete'],
+    });
+  });
+
+  it('blocks an on transition when the facts source is unavailable', async () => {
+    const { database } = makeDatabase([
+      [{ id: 100 }],
+      [modeRow()],
+      [modeRow({ configured_mode: 'on', version: 2 })],
+      [],
+    ]);
+
+    await expect(
+      updateFundMoicCalculationMode({
+        ...baseUpdate,
+        database: database as never,
+        sources: Object.assign(sourceBundle(), {
+          factsSource: { status: 'absent' as const },
+        }),
+      })
+    ).rejects.toMatchObject({
+      blockers: ['facts_unavailable'],
     });
   });
 

--- a/tests/unit/services/fund-calculation-mode-service.test.ts
+++ b/tests/unit/services/fund-calculation-mode-service.test.ts
@@ -47,7 +47,7 @@ function sourceBundle(overrides: Partial<FundMoicRankingSources> = {}): FundMoic
       rankings: [],
     },
     moicInputSummary: {
-      sourceVersion: 'moic-exit-probability-v1',
+      sourceVersion: 'moic-round-fmv-facts-v2',
       explicitExitProbabilityCount: 1,
       defaultedExitProbabilityCount: 0,
       activationBlockingDefaultedExitProbabilityCount: 0,

--- a/tests/unit/services/fund-moic-actionability-service.test.ts
+++ b/tests/unit/services/fund-moic-actionability-service.test.ts
@@ -69,7 +69,7 @@ const assumptionsHash = canonicalSha256({
 const sourceBundle = {
   moicSourceInputHash,
   moicInputSummary: {
-    sourceVersion: 'moic-exit-probability-v1',
+    sourceVersion: 'moic-round-fmv-facts-v2',
     explicitExitProbabilityCount: 1,
     defaultedExitProbabilityCount: 0,
     activationBlockingDefaultedExitProbabilityCount: 0,
@@ -217,9 +217,7 @@ describe('fund MOIC actionability resolver', () => {
     expect(early.sourceFingerprint?.roundEvidenceAssumptionsHash).toBe(
       late.sourceFingerprint?.roundEvidenceAssumptionsHash
     );
-    expect(early.sourceFingerprint?.fingerprintHash).toBe(
-      late.sourceFingerprint?.fingerprintHash
-    );
+    expect(early.sourceFingerprint?.fingerprintHash).toBe(late.sourceFingerprint?.fingerprintHash);
   });
 
   it('keeps defaulted exit probability and reserve multiple blockers visible', async () => {

--- a/tests/unit/services/fund-moic-actionability-service.test.ts
+++ b/tests/unit/services/fund-moic-actionability-service.test.ts
@@ -68,6 +68,16 @@ const assumptionsHash = canonicalSha256({
 
 const sourceBundle = {
   moicSourceInputHash,
+  factsSource: {
+    status: 'available' as const,
+    response: {
+      fundId: 7,
+      asOfDate: '2026-07-13',
+      facts: [],
+      inputHash: 'f'.repeat(64),
+      generatedAt: '2026-07-13T00:00:00.000Z',
+    },
+  },
   moicInputSummary: {
     sourceVersion: 'moic-round-fmv-facts-v2',
     explicitExitProbabilityCount: 1,
@@ -173,13 +183,48 @@ describe('fund MOIC actionability resolver', () => {
     expect(() => createMoicActionabilityResolver({ now })).toThrow();
   });
 
-  it('reports fresh when accepted candidate and evidence hashes match the current fingerprint', async () => {
+  it('reaches actionable when a facts-backed v2 reconciliation round-trips the current hash', async () => {
     const database = makeDatabase([reconciliationRow()]);
     const resolver = createMoicActionabilityResolver({ database, now });
 
     const result = await resolveForFund(resolver, 7);
 
     expect(result.sourceFingerprintMatches).toBe(true);
+    expect(actionabilityStatus(result)).toBe('actionable');
+    expect(getFundMoicRankingSources).toHaveBeenCalledWith(7, database, undefined, now);
+  });
+
+  it('keeps an absent-facts fingerprint non-actionable even when an accepted row matches it', async () => {
+    const unavailableSources = {
+      ...sourceBundle,
+      factsSource: { status: 'absent' as const },
+    };
+    getFundMoicRankingSources.mockResolvedValue(unavailableSources);
+    const database = makeDatabase([reconciliationRow()]);
+    const resolver = createMoicActionabilityResolver({ database, now });
+
+    const result = await resolveForFund(resolver, 7);
+
+    expect(result.sourceFingerprintMatches).toBe(false);
+    expect(actionabilityStatus(result)).toBe('non_actionable');
+  });
+
+  it('reuses one facts snapshot when a resolver intentionally rechecks source drift', async () => {
+    const database = makeDatabase([reconciliationRow()]);
+    const resolverOptions = { database, now, reuseFactsSource: true };
+    const resolver = createMoicActionabilityResolver(resolverOptions);
+
+    await resolveForFund(resolver, 7);
+    await resolveForFund(resolver, 7);
+
+    expect(getFundMoicRankingSources).toHaveBeenNthCalledWith(1, 7, database, undefined, now);
+    expect(getFundMoicRankingSources).toHaveBeenNthCalledWith(
+      2,
+      7,
+      database,
+      sourceBundle.factsSource,
+      now
+    );
   });
 
   it('reports stale when candidate hash matches but evidence hash differs', async () => {

--- a/tests/unit/services/fund-moic-ranking-service.test.ts
+++ b/tests/unit/services/fund-moic-ranking-service.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { dbToMOICInvestment, findMany, investmentRoundsFindMany } = vi.hoisted(() => ({
+const {
+  buildFundCompanyActualsFacts,
+  buildRoundsToModelEvidence,
+  dbToMOICInvestment,
+  findMany,
+  investmentRoundsFindMany,
+} = vi.hoisted(() => ({
+  buildFundCompanyActualsFacts: vi.fn(),
+  buildRoundsToModelEvidence: vi.fn(),
   dbToMOICInvestment: vi.fn(),
   findMany: vi.fn(),
   investmentRoundsFindMany: vi.fn(),
@@ -26,12 +34,23 @@ vi.mock('../../../server/lib/moic-mapper', async (importOriginal) => {
   };
 });
 
+vi.mock('../../../server/services/fund-actuals/fund-company-actuals-facts-service', () => ({
+  buildFundCompanyActualsFacts,
+}));
+
+vi.mock('../../../server/services/rounds-to-model-evidence-service', () => ({
+  buildRoundsToModelEvidence,
+}));
+
 import {
   buildMoicRankingSourcesFromCompanies,
   buildMoicRankingsFromInvestments,
   discloseFundMoicRankings,
+  getFundMoicRankingSources,
   summarizeMoicActualsProvenance,
 } from '../../../server/services/fund-moic-ranking-service';
+import { recordMoicReconciliation } from '../../../server/services/fund-moic-reconciliation-service';
+import { createMoicActionabilityResolver } from '../../../server/services/fund-calculation-mode-service';
 import { FundMoicRankingsResponseV1Schema } from '../../../shared/contracts/fund-moic-v1.contract';
 import type {
   FundCompanyActualsFact,
@@ -115,6 +134,14 @@ function availableFacts(facts: FundCompanyActualsFact[] = [actualsFact()]) {
 describe('fund MOIC ranking service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    buildFundCompanyActualsFacts.mockResolvedValue(actualsFactsResponse());
+    buildRoundsToModelEvidence.mockResolvedValue({
+      coverage: {
+        activeRoundCount: 1,
+        activeOverrideCount: 0,
+        warningsByCode: {},
+      },
+    });
   });
 
   it('ranks investments by reserves MOIC descending', () => {
@@ -210,6 +237,130 @@ describe('fund MOIC ranking service', () => {
     expect(result.provenance.source).toBe('portfolio_companies');
     expect(result.provenance.metricBasis).toBe('planned_reserves');
     expect(result.rankings).toHaveLength(1);
+  });
+
+  it('persists a facts-backed reconciliation hash that a later v2 read makes actionable', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        fundId: 10,
+        name: 'Acme',
+        plannedReservesCents: 300_000_00,
+        exitMoicBps: 35000,
+        exitProbability: 0.8,
+      },
+    ]);
+    const now = new Date('2026-07-13T12:00:00.000Z');
+    let acceptedRow: Record<string, unknown> | null = null;
+    const findAccepted = vi.fn(async () => acceptedRow);
+    const database = {
+      query: {
+        portfolioCompanies: { findMany },
+        reconciliationRuns: { findFirst: findAccepted },
+      },
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => []),
+          })),
+        })),
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn((values: unknown) => ({
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(async () => {
+              acceptedRow = {
+                ...(values as Record<string, unknown>),
+                id: 123,
+                requestedAt: now,
+              };
+              return [acceptedRow];
+            }),
+          })),
+        })),
+      })),
+    };
+
+    const firstV2Sources = await getFundMoicRankingSources(10, database as never, undefined, now);
+    await recordMoicReconciliation({
+      fundId: 10,
+      idempotencyKey: 'facts-round-trip',
+      requestedBy: 42,
+      database: database as never,
+    });
+    const laterV2Sources = await getFundMoicRankingSources(10, database as never, undefined, now);
+    const actionability = await createMoicActionabilityResolver({ database, now }).resolve({
+      fundId: 10,
+      sources: laterV2Sources,
+    });
+
+    expect(acceptedRow).toMatchObject({
+      candidateInputHash: firstV2Sources.moicSourceInputHash,
+      evidenceInputHash: canonicalSha256({
+        activeRoundCount: 1,
+        activeOverrideCount: 0,
+        warningsByCode: {},
+      }),
+      status: 'completed',
+    });
+    expect(laterV2Sources.moicSourceInputHash).toBe(firstV2Sources.moicSourceInputHash);
+    expect(laterV2Sources.factsSource.status).toBe('available');
+    expect(actionability).toMatchObject({
+      sourceFingerprintMatches: true,
+      actionability: 'actionable',
+    });
+    expect(buildFundCompanyActualsFacts).toHaveBeenCalledTimes(3);
+    expect(database.insert).toHaveBeenCalledOnce();
+    expect(findAccepted).toHaveBeenCalledOnce();
+  });
+
+  it('fails a rejected shared facts load closed for candidate actionability', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        fundId: 10,
+        name: 'Acme',
+        plannedReservesCents: 300_000_00,
+        exitMoicBps: 35000,
+        exitProbability: 0.8,
+      },
+    ]);
+    buildFundCompanyActualsFacts.mockRejectedValueOnce(new Error('facts backend unavailable'));
+    const now = new Date('2026-07-13T12:00:00.000Z');
+    const evidenceInputHash = canonicalSha256({
+      activeRoundCount: 1,
+      activeOverrideCount: 0,
+      warningsByCode: {},
+    });
+    const database = {
+      query: {
+        portfolioCompanies: { findMany },
+        reconciliationRuns: {
+          findFirst: vi.fn(async () => ({
+            id: 456,
+            candidateInputHash: '',
+            evidenceInputHash,
+          })),
+        },
+      },
+    };
+
+    const sources = await getFundMoicRankingSources(10, database as never, undefined, now);
+    database.query.reconciliationRuns.findFirst.mockResolvedValue({
+      id: 456,
+      candidateInputHash: sources.moicSourceInputHash,
+      evidenceInputHash,
+    });
+    const actionability = await createMoicActionabilityResolver({ database, now }).resolve({
+      fundId: 10,
+      sources,
+    });
+
+    expect(sources.factsSource).toEqual({ status: 'absent' });
+    expect(actionability).toMatchObject({
+      sourceFingerprintMatches: false,
+      actionability: 'non_actionable',
+    });
   });
 
   it('keeps legacy/off rankings on the existing null-coerced probability path', async () => {
@@ -467,6 +618,26 @@ describe('fund MOIC ranking service', () => {
     expect(after.moicSourceInputHash).not.toBe(before.moicSourceInputHash);
   });
 
+  it('changes the source hash when only the investment name changes', () => {
+    const company = {
+      id: 1,
+      fundId: 10,
+      name: 'Acme',
+      plannedReservesCents: 300_000_00,
+      exitMoicBps: 35000,
+      exitProbability: 0.8,
+    };
+
+    const before = buildMoicRankingSourcesFromCompanies(10, [company], availableFacts());
+    const after = buildMoicRankingSourcesFromCompanies(
+      10,
+      [{ ...company, name: 'Acme Renamed' }],
+      availableFacts()
+    );
+
+    expect(after.moicSourceInputHash).not.toBe(before.moicSourceInputHash);
+  });
+
   it('changes the source hash when only the per-company facts input hash changes', () => {
     const companies = [
       {
@@ -551,6 +722,7 @@ describe('fund MOIC ranking service', () => {
           {
             companyId: 1,
             fundId: 10,
+            investmentName: 'Acme',
             plannedReservesCents: '30000000',
             exitProbability: 0.8,
             exitProbabilitySource: 'explicit',
@@ -701,6 +873,7 @@ describe('fund MOIC ranking service', () => {
           {
             companyId: 1,
             fundId: 10,
+            investmentName: 'Missing probability',
             plannedReservesCents: '100000',
             exitProbability: null,
             exitProbabilitySource: 'defaulted',

--- a/tests/unit/services/fund-moic-ranking-service.test.ts
+++ b/tests/unit/services/fund-moic-ranking-service.test.ts
@@ -33,8 +33,11 @@ import {
   summarizeMoicActualsProvenance,
 } from '../../../server/services/fund-moic-ranking-service';
 import { FundMoicRankingsResponseV1Schema } from '../../../shared/contracts/fund-moic-v1.contract';
-import type { FundCompanyActualsFact } from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
-import type { Investment } from '../../../shared/core/moic/MOICCalculator';
+import type {
+  FundCompanyActualsFact,
+  FundCompanyActualsFactsResponse,
+} from '../../../shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { MOICCalculator, type Investment } from '../../../shared/core/moic/MOICCalculator';
 import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
 
 const makeInvestment = (overrides: Partial<Investment> = {}): Investment => ({
@@ -91,6 +94,22 @@ function actualsFact(overrides: Partial<FundCompanyActualsFact> = {}): FundCompa
     inputHash: FACTS_HASH,
     ...overrides,
   };
+}
+
+function actualsFactsResponse(
+  facts: FundCompanyActualsFact[] = [actualsFact()]
+): FundCompanyActualsFactsResponse {
+  return {
+    fundId: 10,
+    asOfDate: '2026-07-13',
+    facts,
+    inputHash: 'c'.repeat(64),
+    generatedAt: '2026-07-13T00:00:00.000Z',
+  };
+}
+
+function availableFacts(facts: FundCompanyActualsFact[] = [actualsFact()]) {
+  return { status: 'available' as const, response: actualsFactsResponse(facts) };
 }
 
 describe('fund MOIC ranking service', () => {
@@ -262,6 +281,27 @@ describe('fund MOIC ranking service', () => {
     expect(result.moicInputSummary.activationBlockingDefaultedReserveExitMultipleCount).toBe(0);
   });
 
+  it('keeps the legacy candidate default only for an explicit absent-facts state', () => {
+    const result = buildMoicRankingSourcesFromCompanies(
+      10,
+      [
+        {
+          id: 1,
+          fundId: 10,
+          name: 'Acme',
+          currentValuation: 1_500_000,
+          plannedReservesCents: 300_000_00,
+          exitMoicBps: 25000,
+          exitProbability: null,
+        },
+      ],
+      { status: 'absent' }
+    );
+
+    expect(result.candidate.rankings[0]?.reservesMoic.value).toBe(250);
+    expect(result.factsBasisByInvestmentId).toBeUndefined();
+  });
+
   it('keeps candidate rankings on facts/provenance integration and does not claim marginal next-dollar MOIC', () => {
     const result = buildMoicRankingSourcesFromCompanies(10, [
       {
@@ -359,7 +399,7 @@ describe('fund MOIC ranking service', () => {
     expect(edited.moicSourceInputHash).not.toBe(forward.moicSourceInputHash);
   });
 
-  it('attaches facts basis without changing internal rankings or the source hash', () => {
+  it('starts a new facts-backed source-hash regime without changing legacy rankings', () => {
     const companies = [
       {
         id: 1,
@@ -374,24 +414,313 @@ describe('fund MOIC ranking service', () => {
       },
     ];
     const before = buildMoicRankingSourcesFromCompanies(10, companies);
-    const after = buildMoicRankingSourcesFromCompanies(
-      10,
-      companies,
-      new Map([[1, actualsFact()]])
-    );
+    const legacyRegimeHash = canonicalSha256({
+      kind: 'fund_moic_candidate_source',
+      fundId: 10,
+      rows: [
+        {
+          companyId: 1,
+          fundId: 10,
+          plannedReservesCents: 300_000_00,
+          exitProbability: 0.8,
+          exitProbabilitySource: 'explicit',
+          exitMoicBps: 35000,
+          reserveExitMultipleSource: 'explicit',
+          sourceVersion: 'moic-exit-probability-v1',
+        },
+      ],
+      sourceVersion: 'moic-exit-probability-v1',
+    });
+    const after = buildMoicRankingSourcesFromCompanies(10, companies, availableFacts());
     const disclosed = discloseFundMoicRankings(after.legacy, after.factsBasisByInvestmentId);
 
     expect(after.legacy.rankings).toEqual(before.legacy.rankings);
-    expect(after.candidate.rankings).toEqual(before.candidate.rankings);
-    expect(after.moicSourceInputHash).toBe(before.moicSourceInputHash);
+    expect(after.moicInputSummary.sourceVersion).toBe('moic-round-fmv-facts-v2');
+    expect(after.moicSourceInputHash).not.toBe(legacyRegimeHash);
     expect(canonicalSha256(after.legacy.rankings)).toBe(canonicalSha256(before.legacy.rankings));
-    expect(canonicalSha256(after.candidate.rankings)).toBe(
-      canonicalSha256(before.candidate.rankings)
-    );
     expect(disclosed.rankings.map(({ factsBasis: _factsBasis, ...ranking }) => ranking)).toEqual(
       before.legacy.rankings
     );
     expect(disclosed.rankings.some((ranking) => ranking.factsBasis !== null)).toBe(true);
+  });
+
+  it('changes the source hash when the selected valuation anchor changes', () => {
+    const companies = [
+      {
+        id: 1,
+        fundId: 10,
+        name: 'Acme',
+        currentValuation: 1_500_000,
+        plannedReservesCents: 300_000_00,
+        exitMoicBps: 35000,
+        exitProbability: 0.8,
+      },
+    ];
+
+    const before = buildMoicRankingSourcesFromCompanies(10, companies, availableFacts());
+    const after = buildMoicRankingSourcesFromCompanies(
+      10,
+      companies,
+      availableFacts([actualsFact({ latestPlanningFmvValue: '1750000' })])
+    );
+
+    expect(after.moicSourceInputHash).not.toBe(before.moicSourceInputHash);
+  });
+
+  it('changes the source hash when only the per-company facts input hash changes', () => {
+    const companies = [
+      {
+        id: 1,
+        fundId: 10,
+        name: 'Acme',
+        currentValuation: 1_500_000,
+        plannedReservesCents: 300_000_00,
+        exitMoicBps: 35000,
+        exitProbability: 0.8,
+      },
+    ];
+
+    const before = buildMoicRankingSourcesFromCompanies(10, companies, availableFacts());
+    const after = buildMoicRankingSourcesFromCompanies(
+      10,
+      companies,
+      availableFacts([actualsFact({ inputHash: 'd'.repeat(64) })])
+    );
+
+    expect(after.moicSourceInputHash).not.toBe(before.moicSourceInputHash);
+  });
+
+  it('feeds observed investments and the selected valuation anchor to MOICCalculator', () => {
+    const calculateReservesMoic = vi.spyOn(MOICCalculator, 'calculateReservesMOIC');
+
+    try {
+      buildMoicRankingSourcesFromCompanies(
+        10,
+        [
+          {
+            id: 1,
+            fundId: 10,
+            name: 'Acme',
+            investmentAmount: 999,
+            currentValuation: 888,
+            plannedReservesCents: 300_000_00,
+            exitMoicBps: 35000,
+            exitProbability: 0.8,
+          },
+        ],
+        availableFacts()
+      );
+
+      expect(calculateReservesMoic).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialInvestment: 500_000,
+          followOnInvestment: 125_000,
+          currentValuation: 1_500_000,
+          plannedReserves: 300_000,
+          exitProbability: 0.8,
+          reserveExitMultiple: 350,
+        }),
+        true
+      );
+    } finally {
+      calculateReservesMoic.mockRestore();
+    }
+  });
+
+  it('hashes the complete facts row with decimal-string money and the v2 source version', () => {
+    const result = buildMoicRankingSourcesFromCompanies(
+      10,
+      [
+        {
+          id: 1,
+          fundId: 10,
+          name: 'Acme',
+          plannedReservesCents: 300_000_00,
+          exitMoicBps: 35000,
+          exitProbability: 0.8,
+        },
+      ],
+      availableFacts()
+    );
+
+    expect(result.moicSourceInputHash).toBe(
+      canonicalSha256({
+        kind: 'fund_moic_candidate_source',
+        fundId: 10,
+        rows: [
+          {
+            companyId: 1,
+            fundId: 10,
+            plannedReservesCents: '30000000',
+            exitProbability: 0.8,
+            exitProbabilitySource: 'explicit',
+            exitMoicBps: 35000,
+            reserveExitMultipleSource: 'explicit',
+            factsInputHash: FACTS_HASH,
+            observedInitialInvestment: '500000',
+            observedFollowOnInvestment: '125000',
+            valuationAnchorKind: 'planning_fmv',
+            valuationAnchorValue: '1500000',
+            valuationAnchorAsOfDate: '2026-07-01',
+            planningFmvStatus: 'active',
+            currencyStatus: 'base_currency',
+            rankability: 'actionable',
+            sourceVersion: 'moic-round-fmv-facts-v2',
+          },
+        ],
+        sourceVersion: 'moic-round-fmv-facts-v2',
+      })
+    );
+  });
+
+  it('orders facts candidates by rankability and retains non-actionable rows without a number', () => {
+    const companies = [
+      {
+        id: 6,
+        fundId: 10,
+        name: 'No anchor',
+        currentValuation: null,
+        plannedReservesCents: 100_000,
+        exitMoicBps: 1000,
+        exitProbability: 1,
+      },
+      {
+        id: 5,
+        fundId: 10,
+        name: 'Missing multiple',
+        plannedReservesCents: 100_000,
+        exitMoicBps: null,
+        exitProbability: 1,
+      },
+      {
+        id: 4,
+        fundId: 10,
+        name: 'Currency blocked',
+        plannedReservesCents: 100_000,
+        exitMoicBps: 1000,
+        exitProbability: 1,
+      },
+      {
+        id: 3,
+        fundId: 10,
+        name: 'Missing probability',
+        plannedReservesCents: 100_000,
+        exitMoicBps: 1000,
+        exitProbability: null,
+      },
+      {
+        id: 2,
+        fundId: 10,
+        name: 'Indicative',
+        plannedReservesCents: 100_000,
+        exitMoicBps: 400,
+        exitProbability: 0.5,
+      },
+      {
+        id: 1,
+        fundId: 10,
+        name: 'Actionable',
+        plannedReservesCents: 100_000,
+        exitMoicBps: 200,
+        exitProbability: 0.5,
+      },
+    ];
+    const facts = availableFacts([
+      actualsFact({ companyId: 1, companyName: 'Actionable' }),
+      actualsFact({
+        companyId: 2,
+        companyName: 'Indicative',
+        planningFmvStatus: 'stale',
+      }),
+      actualsFact({ companyId: 3, companyName: 'Missing probability' }),
+      actualsFact({
+        companyId: 4,
+        companyName: 'Currency blocked',
+        currency: 'EUR',
+        currencyStatus: 'mismatch_blocked',
+      }),
+      actualsFact({ companyId: 5, companyName: 'Missing multiple' }),
+      actualsFact({
+        companyId: 6,
+        companyName: 'No anchor',
+        planningFmvStatus: 'none',
+        latestPlanningFmvDate: null,
+        latestPlanningFmvValue: null,
+      }),
+    ]);
+
+    const result = buildMoicRankingSourcesFromCompanies(10, companies, facts);
+
+    expect(result.candidate.rankings.map((ranking) => ranking.investmentId)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+    ]);
+    expect(result.candidate.rankings.map((ranking) => ranking.reservesMoic.value)).toEqual([
+      1,
+      2,
+      null,
+      null,
+      null,
+      null,
+    ]);
+    expect(result.factsBasisByInvestmentId?.get('3')?.rankability).toBe('indicative');
+    expect(result.candidateFactsBasisByInvestmentId?.get('3')?.rankability).toBe('not_actionable');
+    expect(result.factsBasisByInvestmentId?.get('4')?.rankability).toBe('not_actionable');
+    expect(result.factsBasisByInvestmentId?.get('5')?.rankability).toBe('indicative');
+    expect(result.candidateFactsBasisByInvestmentId?.get('5')?.rankability).toBe('not_actionable');
+    expect(result.factsBasisByInvestmentId?.get('6')?.rankability).toBe('not_actionable');
+    expect(result.moicInputSummary.activationBlockingDefaultedExitProbabilityCount).toBe(1);
+    expect(result.moicInputSummary.activationBlockingDefaultedReserveExitMultipleCount).toBe(1);
+  });
+
+  it('hashes missing explicit economics as non-actionable in the facts candidate regime', () => {
+    const result = buildMoicRankingSourcesFromCompanies(
+      10,
+      [
+        {
+          id: 1,
+          fundId: 10,
+          name: 'Missing probability',
+          plannedReservesCents: 100_000,
+          exitMoicBps: 1000,
+          exitProbability: null,
+        },
+      ],
+      availableFacts()
+    );
+
+    expect(result.moicSourceInputHash).toBe(
+      canonicalSha256({
+        kind: 'fund_moic_candidate_source',
+        fundId: 10,
+        rows: [
+          {
+            companyId: 1,
+            fundId: 10,
+            plannedReservesCents: '100000',
+            exitProbability: null,
+            exitProbabilitySource: 'defaulted',
+            exitMoicBps: 1000,
+            reserveExitMultipleSource: 'explicit',
+            factsInputHash: FACTS_HASH,
+            observedInitialInvestment: '500000',
+            observedFollowOnInvestment: '125000',
+            valuationAnchorKind: 'planning_fmv',
+            valuationAnchorValue: '1500000',
+            valuationAnchorAsOfDate: '2026-07-01',
+            planningFmvStatus: 'active',
+            currencyStatus: 'base_currency',
+            rankability: 'not_actionable',
+            sourceVersion: 'moic-round-fmv-facts-v2',
+          },
+        ],
+        sourceVersion: 'moic-round-fmv-facts-v2',
+      })
+    );
   });
 
   it('discloses FACTS_MISSING when a successful facts response omits a company', () => {
@@ -408,7 +737,7 @@ describe('fund MOIC ranking service', () => {
           exitProbability: 0.8,
         },
       ],
-      new Map()
+      availableFacts([])
     );
 
     expect(sources.factsBasisByInvestmentId?.get('1')).toMatchObject({

--- a/tests/unit/services/fund-moic-reconciliation-service.test.ts
+++ b/tests/unit/services/fund-moic-reconciliation-service.test.ts
@@ -59,7 +59,7 @@ const sourceBundle = (overrides: Partial<FundMoicRankingSources> = {}): FundMoic
     rankings: [rankingItem('1', 2.8)],
   },
   moicInputSummary: {
-    sourceVersion: 'moic-exit-probability-v1',
+    sourceVersion: 'moic-round-fmv-facts-v2',
     explicitExitProbabilityCount: 1,
     defaultedExitProbabilityCount: 0,
     activationBlockingDefaultedExitProbabilityCount: 0,
@@ -169,29 +169,69 @@ describe('fund MOIC reconciliation service', () => {
     expect(capture.onConflictArg).toEqual({
       target: [reconciliationRuns.fundId, reconciliationRuns.idempotencyKey],
     });
+    expect(getFundMoicRankingSources).toHaveBeenCalledWith(7, database);
   });
 
-  it('replays an existing fund-scoped idempotency key with the same request hash', async () => {
-    getFundMoicRankingSources.mockResolvedValue(sourceBundle());
-    const existing = {
+  it('keeps a v1 row byte-identical while a fresh key inserts a separate v2 row', async () => {
+    const v1SourceHash = 'v1-source-hash';
+    const v2SourceHash = 'v2-source-hash';
+    getFundMoicRankingSources.mockResolvedValue(
+      sourceBundle({ moicSourceInputHash: v2SourceHash })
+    );
+    const existingV1 = {
       id: 321,
       requestedAt: new Date('2026-06-24T01:00:00.000Z'),
-      requestHash: requestHashFor(7, 'source-hash-a'),
+      requestHash: requestHashFor(7, v1SourceHash),
+      candidateInputHash: v1SourceHash,
     };
-    const database = makeDatabase({ selectResults: [[existing]] });
+    const existingBefore = structuredClone(existingV1);
+    const reusedKeyDatabase = makeDatabase({ selectResults: [[existingV1]] });
 
+    await expect(
+      recordMoicReconciliation({
+        fundId: 7,
+        idempotencyKey: 'v1-key',
+        requestedBy: 42,
+        database: reusedKeyDatabase as never,
+      })
+    ).rejects.toBeInstanceOf(MoicReconciliationConflictError);
+
+    expect(existingV1).toEqual(existingBefore);
+    expect(reusedKeyDatabase.insert).not.toHaveBeenCalled();
+
+    const capture: { insertValues?: unknown } = {};
+    const freshKeyDatabase = makeDatabase({
+      selectResults: [[]],
+      insertResult: [{ id: 654, requestedAt: new Date('2026-07-13T00:00:00.000Z') }],
+      capture,
+    });
     const result = await recordMoicReconciliation({
       fundId: 7,
-      idempotencyKey: 'idem-1',
+      idempotencyKey: 'v2-key',
       requestedBy: 42,
-      database: database as never,
+      database: freshKeyDatabase as never,
     });
 
     expect(result).toEqual({
-      run: { runId: '321', createdAt: '2026-06-24T01:00:00.000Z' },
-      replayed: true,
+      run: { runId: '654', createdAt: '2026-07-13T00:00:00.000Z' },
+      replayed: false,
     });
-    expect(database.insert).not.toHaveBeenCalled();
+    expect(capture.insertValues).toMatchObject({
+      idempotencyKey: 'v2-key',
+      candidateInputHash: v2SourceHash,
+    });
+
+    const simulatedPersistedRows = [existingV1, capture.insertValues];
+    expect(
+      simulatedPersistedRows.find(
+        (row) =>
+          typeof row === 'object' &&
+          row !== null &&
+          'candidateInputHash' in row &&
+          row.candidateInputHash === v1SourceHash
+      )
+    ).toEqual(existingBefore);
+    expect(simulatedPersistedRows).toHaveLength(2);
   });
 
   it('conflicts when an idempotency key is reused after MOIC source input changes', async () => {

--- a/tests/unit/services/fund-moic-reconciliation-service.test.ts
+++ b/tests/unit/services/fund-moic-reconciliation-service.test.ts
@@ -35,41 +35,53 @@ const rankingItem = (investmentId: string, value: number) => ({
   reservesMoic: { value, description: 'desc', formula: 'formula' },
 });
 
-const sourceBundle = (overrides: Partial<FundMoicRankingSources> = {}): FundMoicRankingSources => ({
-  legacy: {
-    fundId: 7,
-    provenance: {
-      source: 'portfolio_companies',
-      calculation: 'reserves_moic_rankings',
-      metricBasis: 'planned_reserves',
-      sourceRecordCount: 1,
+const sourceBundle = (overrides: Partial<FundMoicRankingSources> = {}): FundMoicRankingSources => {
+  return {
+    legacy: {
+      fundId: 7,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt: '2026-06-24T00:00:00.000Z',
+      rankings: [rankingItem('1', 0)],
     },
-    generatedAt: '2026-06-24T00:00:00.000Z',
-    rankings: [rankingItem('1', 0)],
-  },
-  candidate: {
-    fundId: 7,
-    provenance: {
-      source: 'portfolio_companies',
-      calculation: 'reserves_moic_rankings',
-      metricBasis: 'planned_reserves',
-      sourceRecordCount: 1,
+    candidate: {
+      fundId: 7,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt: '2026-06-24T00:00:00.000Z',
+      rankings: [rankingItem('1', 2.8)],
     },
-    generatedAt: '2026-06-24T00:00:00.000Z',
-    rankings: [rankingItem('1', 2.8)],
-  },
-  moicInputSummary: {
-    sourceVersion: 'moic-round-fmv-facts-v2',
-    explicitExitProbabilityCount: 1,
-    defaultedExitProbabilityCount: 0,
-    activationBlockingDefaultedExitProbabilityCount: 0,
-    explicitReserveExitMultipleCount: 1,
-    defaultedReserveExitMultipleCount: 0,
-    activationBlockingDefaultedReserveExitMultipleCount: 0,
-  },
-  moicSourceInputHash: 'source-hash-a',
-  ...overrides,
-});
+    moicInputSummary: {
+      sourceVersion: 'moic-round-fmv-facts-v2',
+      explicitExitProbabilityCount: 1,
+      defaultedExitProbabilityCount: 0,
+      activationBlockingDefaultedExitProbabilityCount: 0,
+      explicitReserveExitMultipleCount: 1,
+      defaultedReserveExitMultipleCount: 0,
+      activationBlockingDefaultedReserveExitMultipleCount: 0,
+    },
+    moicSourceInputHash: 'source-hash-a',
+    factsSource: {
+      status: 'available' as const,
+      response: {
+        fundId: 7,
+        asOfDate: '2026-07-13',
+        facts: [],
+        inputHash: 'f'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+      },
+    },
+    ...overrides,
+  };
+};
 
 function requestHashFor(fundId: number, moicSourceInputHash: string): string {
   return canonicalSha256({

--- a/tests/unit/services/lp-reporting/report-package-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-service.test.ts
@@ -25,7 +25,21 @@ import { users } from '@shared/schema/user';
 const { createMoicActionabilityResolver, resolveForFund } = vi.hoisted(() => {
   const resolveForFund = vi.fn();
   return {
-    createMoicActionabilityResolver: vi.fn(() => ({ resolveForFund })),
+    createMoicActionabilityResolver: vi.fn((params: { reuseFactsSource?: boolean }) => {
+      let cachedResult: unknown;
+      return {
+        resolveForFund: vi.fn((fundId: number) => {
+          if (params.reuseFactsSource && cachedResult !== undefined) {
+            return cachedResult;
+          }
+          const result: unknown = resolveForFund(fundId);
+          if (params.reuseFactsSource) {
+            cachedResult = result;
+          }
+          return result;
+        }),
+      };
+    }),
     resolveForFund,
   };
 });
@@ -372,12 +386,12 @@ describe('assembleMetricRunReportPackage', () => {
     });
     expect(createMoicActionabilityResolver).toHaveBeenCalledWith({
       database: expect.anything(),
-      reuseFactsSource: true,
+      reuseFactsSource: false,
     });
     expect(resolveForFund).toHaveBeenCalledWith(1);
   });
 
-  it('aborts assembly with H9_SOURCE_CHANGED_DURING_ASSEMBLY when the fingerprint drifts mid-assembly', async () => {
+  it('bypasses the facts cache and aborts assembly when the H9 fingerprint drifts mid-assembly', async () => {
     resolveForFund.mockResolvedValueOnce(H9_RESULT).mockResolvedValueOnce({
       ...H9_RESULT,
       sourceFingerprint: { ...H9_RESULT.sourceFingerprint, fingerprintHash: 'f'.repeat(64) },

--- a/tests/unit/services/lp-reporting/report-package-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-service.test.ts
@@ -22,14 +22,20 @@ import {
 } from '@shared/schema/lp-reporting-evidence';
 import { users } from '@shared/schema/user';
 
-const { resolveForFund } = vi.hoisted(() => ({ resolveForFund: vi.fn() }));
+const { createMoicActionabilityResolver, resolveForFund } = vi.hoisted(() => {
+  const resolveForFund = vi.fn();
+  return {
+    createMoicActionabilityResolver: vi.fn(() => ({ resolveForFund })),
+    resolveForFund,
+  };
+});
 
 vi.mock('../../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
   const actual =
     await importOriginal<
       typeof import('../../../../server/services/fund-calculation-mode-service')
     >();
-  return { ...actual, createMoicActionabilityResolver: () => ({ resolveForFund }) };
+  return { ...actual, createMoicActionabilityResolver };
 });
 
 const H9_RESULT = {
@@ -289,6 +295,7 @@ function makeDatabase(): typeof db {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   state.metricRuns = [metricRunRow()];
   state.narratives = [
     narrativeRow('no_dpi', 100),
@@ -362,6 +369,10 @@ describe('assembleMetricRunReportPackage', () => {
       policyVersion: 'h9-policy-v1',
       actionabilityStatus: 'actionable',
       moicSourceInputHash: 'a'.repeat(64),
+    });
+    expect(createMoicActionabilityResolver).toHaveBeenCalledWith({
+      database: expect.anything(),
+      reuseFactsSource: true,
     });
     expect(resolveForFund).toHaveBeenCalledWith(1);
   });

--- a/tests/unit/services/reserve-calculation-facts-inputs.test.ts
+++ b/tests/unit/services/reserve-calculation-facts-inputs.test.ts
@@ -10,6 +10,7 @@ const {
   buildReservePortfolioInputWithProvenance,
   eventOrder,
   generateReserveSummary,
+  getFundMoicRankingSources,
   isFlagEnabled,
   loggerInfo,
   modeFindFirst,
@@ -20,6 +21,7 @@ const {
   buildReservePortfolioInputWithProvenance: vi.fn(),
   eventOrder: [] as string[],
   generateReserveSummary: vi.fn(),
+  getFundMoicRankingSources: vi.fn(),
   isFlagEnabled: vi.fn(),
   loggerInfo: vi.fn(),
   modeFindFirst: vi.fn(),
@@ -56,6 +58,12 @@ vi.mock('../../../server/services/fund-calculation-mode-service', async (importO
   const actual =
     await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
   return { ...actual, resolveMoicActionability };
+});
+
+vi.mock('../../../server/services/fund-moic-ranking-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-moic-ranking-service')>();
+  return { ...actual, getFundMoicRankingSources };
 });
 
 vi.mock('../../../server/services/reserve-input-builder', () => ({
@@ -125,6 +133,17 @@ const LEGACY_RESERVES: ReserveSummary = {
 };
 
 const FACTS_INPUT_HASH = 'd'.repeat(64);
+const FACTS_SOURCE = {
+  status: 'available' as const,
+  response: {
+    fundId: 7,
+    asOfDate: '2026-07-13',
+    facts: [],
+    inputHash: FACTS_INPUT_HASH,
+    generatedAt: '2026-07-13T00:00:00.000Z',
+  },
+};
+const MOIC_SOURCES = { factsSource: FACTS_SOURCE };
 const FACTS_COMPANY: ReserveCompanyInputWithProvenance = {
   id: 11,
   invested: 125,
@@ -196,6 +215,7 @@ describe('runReserveCalculation facts-sourced inputs', () => {
       reserveInputTrustSummary: LEGACY_TRUST_SUMMARY,
     });
     generateReserveSummary.mockReturnValue(LEGACY_RESERVES);
+    getFundMoicRankingSources.mockResolvedValue(MOIC_SOURCES);
     resolveMoicActionability.mockResolvedValue(actionabilityResult());
     buildFactsReserveCandidates.mockResolvedValue({
       candidates: [
@@ -259,7 +279,9 @@ describe('runReserveCalculation facts-sourced inputs', () => {
       },
     });
     expect(modeFindFirst).not.toHaveBeenCalled();
+    expect(getFundMoicRankingSources).not.toHaveBeenCalled();
     expect(buildFactsReserveCandidates).not.toHaveBeenCalled();
+    expect(resolveMoicActionability).toHaveBeenCalledWith({ fundId: 7 });
     expect(loggerInfo).not.toHaveBeenCalled();
   });
 
@@ -275,7 +297,32 @@ describe('runReserveCalculation facts-sourced inputs', () => {
     expect(generateReserveSummary).toHaveBeenCalledWith(7, LEGACY_PORTFOLIO);
   });
 
-  it('emits aggregate shadow telemetry without changing served values, persistence, or H9', async () => {
+  it('threads one facts snapshot through on-mode reserve inputs and H9', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
+    generateReserveSummary.mockReturnValue(FACTS_RESERVES);
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-on-snapshot' });
+
+    expect(getFundMoicRankingSources).toHaveBeenCalledOnce();
+    expect(buildFactsReserveCandidates).toHaveBeenCalledOnce();
+    expect(buildFactsReserveCandidates).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: expect.any(String),
+      factsSource: FACTS_SOURCE,
+    });
+    expect(resolveMoicActionability).toHaveBeenCalledWith({
+      fundId: 7,
+      sources: MOIC_SOURCES,
+    });
+    expect(persistedSnapshots[0]).toMatchObject({
+      metadata: {
+        factsBasis: { factsInputHash: FACTS_SOURCE.response.inputHash },
+      },
+    });
+  });
+
+  it('threads one facts snapshot through shadow H9 and post-persist telemetry', async () => {
     isFlagEnabled.mockReturnValue(true);
     modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
     buildFactsReserveCandidates.mockImplementation(async () => {
@@ -307,6 +354,17 @@ describe('runReserveCalculation facts-sourced inputs', () => {
 
     expect(result.reserves).toEqual(LEGACY_RESERVES);
     expect(eventOrder).toEqual(['persist', 'shadow']);
+    expect(getFundMoicRankingSources).toHaveBeenCalledOnce();
+    expect(buildFactsReserveCandidates).toHaveBeenCalledOnce();
+    expect(buildFactsReserveCandidates).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: expect.any(String),
+      factsSource: FACTS_SOURCE,
+    });
+    expect(resolveMoicActionability).toHaveBeenCalledWith({
+      fundId: 7,
+      sources: MOIC_SOURCES,
+    });
     expect(generateReserveSummary).toHaveBeenNthCalledWith(1, 7, LEGACY_PORTFOLIO);
     expect(generateReserveSummary).toHaveBeenNthCalledWith(2, 7, [FACTS_COMPANY]);
     expect(persistedSnapshots[0]).toMatchObject({

--- a/tests/unit/services/reserve-calculation-h9-stamp.test.ts
+++ b/tests/unit/services/reserve-calculation-h9-stamp.test.ts
@@ -3,13 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MoicActionabilityResult } from '../../../server/services/fund-calculation-mode-service';
 
 // Mock only resolveMoicActionability; keep the real toH9SnapshotColumns (pure mapper under test).
-const { buildFactsReserveCandidates, isFlagEnabled, modeFindFirst, resolveMoicActionability } =
-  vi.hoisted(() => ({
-    buildFactsReserveCandidates: vi.fn(),
-    isFlagEnabled: vi.fn(),
-    modeFindFirst: vi.fn(),
-    resolveMoicActionability: vi.fn(),
-  }));
+const {
+  buildFactsReserveCandidates,
+  getFundMoicRankingSources,
+  isFlagEnabled,
+  modeFindFirst,
+  resolveMoicActionability,
+} = vi.hoisted(() => ({
+  buildFactsReserveCandidates: vi.fn(),
+  getFundMoicRankingSources: vi.fn(),
+  isFlagEnabled: vi.fn(),
+  modeFindFirst: vi.fn(),
+  resolveMoicActionability: vi.fn(),
+}));
 
 vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
   const actual =
@@ -18,6 +24,12 @@ vi.mock('../../../server/services/fund-calculation-mode-service', async (importO
     ...actual,
     resolveMoicActionability,
   };
+});
+
+vi.mock('../../../server/services/fund-moic-ranking-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-moic-ranking-service')>();
+  return { ...actual, getFundMoicRankingSources };
 });
 
 // Capture the values handed to db.insert(...).values(...).
@@ -88,6 +100,24 @@ function actionabilityResult(status: 'actionable' | 'non_actionable'): MoicActio
     },
     acceptedReconciliationRunId: status === 'actionable' ? 42 : null,
   } as MoicActionabilityResult;
+}
+
+function moicSources(factsInputHash: string | null) {
+  return {
+    factsSource:
+      factsInputHash === null
+        ? ({ status: 'absent' } as const)
+        : {
+            status: 'available' as const,
+            response: {
+              fundId: 7,
+              asOfDate: '2026-07-13',
+              facts: [],
+              inputHash: factsInputHash,
+              generatedAt: '2026-07-13T00:00:00.000Z',
+            },
+          },
+  };
 }
 
 describe('toH9SnapshotColumns', () => {
@@ -188,10 +218,14 @@ describe('runReserveCalculation H9 stamp', () => {
         unavailableFields: [],
       },
     });
+    const sources = moicSources('a'.repeat(64));
+    getFundMoicRankingSources.mockResolvedValue(sources);
     resolveMoicActionability.mockResolvedValue(actionabilityResult('actionable'));
 
     await runReserveCalculation({ fundId: 7, correlationId: 'corr-facts-on' });
 
+    expect(getFundMoicRankingSources).toHaveBeenCalledOnce();
+    expect(resolveMoicActionability).toHaveBeenCalledWith({ fundId: 7, sources });
     expect(captured.values).toMatchObject({
       h9MoicSourceInputHash: 'moic-src-hash',
       h9RoundEvidenceInputHash: 'round-evidence-hash',
@@ -235,10 +269,13 @@ describe('runReserveCalculation H9 stamp', () => {
         unavailableFields: ['invested'],
       },
     });
+    const sources = moicSources(null);
+    getFundMoicRankingSources.mockResolvedValue(sources);
     resolveMoicActionability.mockResolvedValue(actionabilityResult('actionable'));
 
     await runReserveCalculation({ fundId: 7, correlationId: 'corr-facts-unavailable' });
 
+    expect(resolveMoicActionability).toHaveBeenCalledWith({ fundId: 7, sources });
     expect(captured.values).toMatchObject({
       h9FingerprintHash: 'fingerprint-hash',
       h9ActionabilityStatus: 'non_actionable',

--- a/tests/unit/services/reserves/facts-reserve-input-adapter.test.ts
+++ b/tests/unit/services/reserves/facts-reserve-input-adapter.test.ts
@@ -165,7 +165,12 @@ describe('buildFactsReserveCandidates', () => {
   });
 
   it('builds an eligible engine input from facts money and trusted builder fields', async () => {
-    const result = await buildFactsReserveCandidates({ fundId: 7, asOfDate: '2026-07-13' });
+    const preloadedFacts = facts(11);
+    const result = await buildFactsReserveCandidates({
+      fundId: 7,
+      asOfDate: '2026-07-13',
+      factsSource: { status: 'available', response: preloadedFacts },
+    });
 
     expect(result).toMatchObject({
       factsInputHash: FUND_FACTS_HASH,
@@ -201,10 +206,7 @@ describe('buildFactsReserveCandidates', () => {
         unavailableFields: [],
       },
     });
-    expect(buildFundCompanyActualsFacts).toHaveBeenCalledWith({
-      fundId: 7,
-      asOfDate: '2026-07-13',
-    });
+    expect(buildFundCompanyActualsFacts).not.toHaveBeenCalled();
   });
 
   it('excludes missing ownership instead of substituting the legacy 15 percent default', async () => {


### PR DESCRIPTION
## Summary

Plan 6 wave 2 (Task 6.4) — the planned-reserve MOIC candidate basis moves to Round/FMV facts, with `MOIC_CANDIDATE_SOURCE_VERSION -> 'moic-round-fmv-facts-v2'` bumped in the same commit. Serving stays governed by the existing off/shadow/on machinery and remains **default-off everywhere**; activation is a later deliberate step behind 6.6's reconciliation-acceptance + residency gates. ADR-039 documents the decision, hash-regime consequences, and rollback.

Three commits, two adversarial review rounds:

1. `ea01497b` — facts candidate mapping (observed initial/follow-on, wave-1 valuation-anchor ladder, explicit-only plannedReserves/exitProbability/reserveExitMultiple), extended hash rows, one-commit version bump, non-actionable rows retained without fabricated rankings and sorted last, reconciliation continuity by test.
2. `2bb20b67` — fixes from independent Codex review round 1: **[P1]** v1/reconciliation/actionability/mode flows used an absent-facts sentinel while only v2 threaded facts (split fingerprint universes: activation deadlock + v1-on-mode could serve the suppressed fallback candidate) — all flows now share the facts-backed source loader; facts failure collapses to non-actionable + legacy serving; absent-facts fingerprints cannot satisfy v2 acceptance. **[P2]** `investmentName` added to the hash row (rename now moves the source hash with the output hash).
3. `47060f3b` — fixes from review round 2: the lp-reporting H9 drift recheck now bypasses the facts cache (independence restored, pinned by a differing-loads test), and facts-on/shadow reserve runs perform exactly one facts load shared across reserve inputs, H9 metadata, and telemetry.

## Review evidence

- Codex round 1: found the P1/P2 above (my 124-test + phoenix-282 gate had passed without catching the cross-flow fingerprint split — the adversarial second model earned its place on hash-regime changes).
- Codex round 2 (on the fix): both fixes hold; found the two P2 regressions addressed in commit 3.
- Codex round 3 (final): both round-2 repairs hold, no new findings. One disclosed residual, noted by the reviewer as predating the fix: under flag-off, `resolveMoicActionability` itself loads facts to compute the unified fingerprint — this is the intended consequence of the P1 fix (one fingerprint universe) and does not touch the flag-off reserve engine path; one extra read per run is immaterial at this deployment's scale.
- Tests: 139/139 (round 1) and 92/92 (round 2) across every affected suite, run independently; `npm run calc-gate` PASS and `npm run phoenix:truth` 282/282 from the lane; TS baseline 0 errors; lint clean.

## Continuity proof (pinned in tests)

Old reconciliation rows byte-identical and retrievable; new source hash creates new rows; valuation-anchor or facts-hash changes move the source hash; missing explicit probability/multiple can never activate; mode off serves byte-identical legacy; shadow computes both and serves legacy; on serves the facts candidate only when actionable.

Remaining Plan 6 waves: 6.5 client disclosure UI, 6.6 activation-after-reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h