### PR TITLE
test(scenarios): pin explicit asOfDate in seeds tests

### DIFF
--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -806,7 +806,9 @@ describe('scenario-analysis actuals-backed seed suggestions', () => {
       new Error('database unavailable')
     );
 
-    const res = await request(makeApp()).get('/api/funds/7/scenario-analysis/seeds');
+    const res = await request(makeApp()).get(
+      '/api/funds/7/scenario-analysis/seeds?asOfDate=2026-07-13'
+    );
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({


### PR DESCRIPTION
## Summary

Unblocks CI for all open PRs. The seeds failure-path test from #1105 asserted `asOfDate: '2026-07-13'` (the date it was written) while sending no `asOfDate` query param, so the route defaulted to real today — the assertion became a time bomb that detonated at UTC midnight and now fails every PR's unit-fast lane (first seen on #1108's checks, reproduced identically on rerun at 00:11 UTC).

Fix is test-only and minimal: the request now passes `?asOfDate=2026-07-13` explicitly, matching the file's fixture date. Swept the file for other implicit-today assertions — none remain. 39/39 suite green re-run past UTC midnight (the previously-failing condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h