### PR TITLE
feat(monte-carlo): extract versioned assumptions profile (Plan 8 wave 7 — final)

### DIFF
--- a/server/services/monte-carlo-simulation.ts
+++ b/server/services/monte-carlo-simulation.ts
@@ -23,6 +23,10 @@ import { PRNG } from '@shared/utils/prng';
 import { isFlagEnabled } from '@shared/flags/getFlag';
 import type { FactsMonteCarloInputV1 } from '@shared/contracts/monte-carlo/facts-input-v1.contract';
 import { logger } from '../lib/logger';
+import {
+  assumptionsProfileHash,
+  defaultMonteCarloAssumptionsProfile,
+} from './monte-carlo/default-assumptions-profile';
 
 const MONTE_CARLO_ACTUALS_CALCULATION_KEY = 'monte_carlo_actuals_inputs';
 
@@ -160,6 +164,8 @@ export interface MonteCarloForecast {
   };
 
   provenance?: {
+    assumptionsHash: string;
+    profileVersion: typeof defaultMonteCarloAssumptionsProfile.profileVersion;
     actualsFacts: MonteCarloActualsFactsProvenance;
   };
 }
@@ -383,7 +389,11 @@ function snapshotMetadata(
     baselineId: forecast.baselineId,
     scenarios: forecast.parameters.scenarios,
     timeHorizon: forecast.parameters.timeHorizonYears,
-    ...(factsMetadata !== undefined && { actualsFacts: factsMetadata }),
+    ...(factsMetadata !== undefined && {
+      assumptionsHash: assumptionsProfileHash,
+      profileVersion: defaultMonteCarloAssumptionsProfile.profileVersion,
+      actualsFacts: factsMetadata,
+    }),
   };
 }
 
@@ -489,7 +499,11 @@ export class MonteCarloSimulationService {
       riskMetrics,
       scenarioAnalysis,
       ...(actualsState !== undefined && {
-        provenance: { actualsFacts: actualsProvenance(actualsState, 'on') },
+        provenance: {
+          assumptionsHash: assumptionsProfileHash,
+          profileVersion: defaultMonteCarloAssumptionsProfile.profileVersion,
+          actualsFacts: actualsProvenance(actualsState, 'on'),
+        },
       }),
     };
 
@@ -506,7 +520,11 @@ export class MonteCarloSimulationService {
       }
       const shadowProvenance = await this.runActualsShadow(forecast, snapshotId);
       if (shadowProvenance !== undefined) {
-        forecast.provenance = { actualsFacts: shadowProvenance };
+        forecast.provenance = {
+          assumptionsHash: assumptionsProfileHash,
+          profileVersion: defaultMonteCarloAssumptionsProfile.profileVersion,
+          actualsFacts: shadowProvenance,
+        };
       }
     }
 
@@ -581,9 +599,9 @@ export class MonteCarloSimulationService {
       // Use default conservative estimates if insufficient data
       return {
         mean: 0,
-        standardDeviation: 0.15, // 15% default volatility
+        standardDeviation: defaultMonteCarloAssumptionsProfile.lowDataVolatility,
         count: 0,
-        confidence: 0.3, // Low confidence due to insufficient data
+        confidence: defaultMonteCarloAssumptionsProfile.lowDataConfidence,
       };
     }
 
@@ -744,23 +762,23 @@ export class MonteCarloSimulationService {
     // Generate power law scenario for realistic VC returns.
     // Use seed profile for aggregate portfolio return distribution calibration.
     const powerLawScenario = this.powerLawDistribution.generateInvestmentScenario(
-      'seed',
+      defaultMonteCarloAssumptionsProfile.aggregateStageProfile,
       timeHorizonYears
     );
 
     // Apply moderate upside compression to reflect 2024-2025 multiple compression.
     // Keep downside behavior intact so failure-rate characteristics are preserved.
-    const upsideCompression = 0.82;
     const adjustedMultiple =
       powerLawScenario.multiple <= 1
         ? powerLawScenario.multiple
-        : 1 + (powerLawScenario.multiple - 1) * upsideCompression;
+        : 1 +
+          (powerLawScenario.multiple - 1) * defaultMonteCarloAssumptionsProfile.upsideCompression;
 
     // Sample from traditional distributions for other metrics
     const totalValueVariance = this.sampleFromDistribution(
       distributions['totalValueVariance'] || {
         mean: 0,
-        standardDeviation: 0.15,
+        standardDeviation: defaultMonteCarloAssumptionsProfile.lowDataVolatility,
         distribution: 'normal',
         historicalCount: 0,
         confidence: 0.5,
@@ -787,9 +805,15 @@ export class MonteCarloSimulationService {
 
     // Calculate baseline values
     const baselineTotalValue = toDecimal(baseline.totalValue.toString());
-    const baselineIrr = toDecimal(baseline.irr?.toString() || '0.12').toNumber();
-    const baselineDpi = toDecimal(baseline.dpi?.toString() || '0.5');
-    const baselineTvpi = toDecimal(baseline.tvpi?.toString() || '1.5');
+    const baselineIrr = toDecimal(
+      baseline.irr?.toString() || defaultMonteCarloAssumptionsProfile.baselineIrrFallback
+    ).toNumber();
+    const baselineDpi = toDecimal(
+      baseline.dpi?.toString() || defaultMonteCarloAssumptionsProfile.baselineDpiFallback
+    );
+    const baselineTvpi = toDecimal(
+      baseline.tvpi?.toString() || defaultMonteCarloAssumptionsProfile.baselineTvpiFallback
+    );
     const totalValueVarianceFactor = toDecimal(totalValueVariance).times(0.1);
     const dpiVarianceFactor = toDecimal(dpiVariance).times(0.5);
     const tvpiVarianceFactor = toDecimal(tvpiVariance).times(0.5);
@@ -838,7 +862,9 @@ export class MonteCarloSimulationService {
         );
       case 'powerlaw': {
         // Use power law distribution for return multiples
-        const powerLawSample = this.powerLawDistribution.sampleReturn('seed');
+        const powerLawSample = this.powerLawDistribution.sampleReturn(
+          defaultMonteCarloAssumptionsProfile.aggregateStageProfile
+        );
         return powerLawSample.multiple - 1; // Convert to variance form
       }
       default:

--- a/server/services/monte-carlo/default-assumptions-profile.ts
+++ b/server/services/monte-carlo/default-assumptions-profile.ts
@@ -1,0 +1,28 @@
+import { MonteCarloAssumptionsProfileV1Schema } from '@shared/contracts/monte-carlo/assumptions-profile-v1.contract';
+import type { MonteCarloAssumptionsProfileV1 } from '@shared/contracts/monte-carlo/assumptions-profile-v1.contract';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+
+const defaultProfileValues = {
+  profileVersion: 'mc-assumptions-v1',
+  lowDataVolatility: 0.15,
+  lowDataConfidence: 0.3,
+  aggregateStageProfile: 'seed',
+  upsideCompression: 0.82,
+  baselineIrrFallback: '0.12',
+  baselineDpiFallback: '0.5',
+  baselineTvpiFallback: '1.5',
+  distributionSelectionRules: {
+    multiples: 'power_law',
+    skewedMetrics: 'lognormal_when_skew_gt_1',
+    smallSamples: 'triangular_when_n_lt_10',
+  },
+} as const satisfies MonteCarloAssumptionsProfileV1;
+
+const parsedDefaultProfile = MonteCarloAssumptionsProfileV1Schema.parse(
+  defaultProfileValues
+) as typeof defaultProfileValues;
+
+Object.freeze(parsedDefaultProfile.distributionSelectionRules);
+export const defaultMonteCarloAssumptionsProfile = Object.freeze(parsedDefaultProfile);
+
+export const assumptionsProfileHash = canonicalSha256(defaultMonteCarloAssumptionsProfile);

--- a/shared/contracts/monte-carlo/assumptions-profile-v1.contract.ts
+++ b/shared/contracts/monte-carlo/assumptions-profile-v1.contract.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+import { DecimalStringSchema } from '../lp-reporting/cash-flow-event.contract';
+
+export const MonteCarloAssumptionsProfileV1Schema = z
+  .object({
+    profileVersion: z.literal('mc-assumptions-v1'),
+    lowDataVolatility: z.number(),
+    lowDataConfidence: z.number().nullable(),
+    aggregateStageProfile: z.string(),
+    upsideCompression: z.number(),
+    baselineIrrFallback: DecimalStringSchema,
+    baselineDpiFallback: DecimalStringSchema,
+    baselineTvpiFallback: DecimalStringSchema,
+    distributionSelectionRules: z
+      .object({
+        multiples: z.string(),
+        skewedMetrics: z.string(),
+        smallSamples: z.string(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type MonteCarloAssumptionsProfileV1 = z.infer<typeof MonteCarloAssumptionsProfileV1Schema>;

--- a/tests/unit/services/monte-carlo-actuals-inputs.test.ts
+++ b/tests/unit/services/monte-carlo-actuals-inputs.test.ts
@@ -3,6 +3,12 @@ import { createHash } from 'node:crypto';
 import path from 'node:path';
 
 import { FLAG_DEFAULTS, FLAG_DEFINITIONS } from '../../../shared/generated/flag-defaults';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import { MonteCarloAssumptionsProfileV1Schema } from '../../../shared/contracts/monte-carlo/assumptions-profile-v1.contract';
+import {
+  assumptionsProfileHash,
+  defaultMonteCarloAssumptionsProfile,
+} from '../../../server/services/monte-carlo/default-assumptions-profile';
 
 const {
   buildFactsMonteCarloInput,
@@ -115,6 +121,8 @@ const LEGACY_COMPANIES = [
 
 const FACTS_INPUT_HASH = 'a'.repeat(64);
 const SOURCE_FACTS_INPUT_HASH = 'b'.repeat(64);
+const EXPECTED_ASSUMPTIONS_PROFILE_HASH =
+  '0ad0b399c6ff13ab0cd398b36ebc70cf48d013823a4cbf0f51507bf4aa2facd9';
 const FACTS_RESPONSE = {
   fundId: 7,
   asOfDate: '2026-07-13',
@@ -160,6 +168,20 @@ function sha256(value: unknown): string {
   return createHash('sha256').update(JSON.stringify(value)).digest('hex');
 }
 
+function withoutAssumptionsProvenance(
+  forecast: Awaited<ReturnType<MonteCarloSimulationService['generateForecast']>>
+): Record<string, unknown> {
+  const normalized = structuredClone(forecast) as Record<string, unknown>;
+  const provenance = normalized['provenance'];
+  if (provenance !== null && typeof provenance === 'object' && !Array.isArray(provenance)) {
+    const existingProvenance = { ...(provenance as Record<string, unknown>) };
+    delete existingProvenance['assumptionsHash'];
+    delete existingProvenance['profileVersion'];
+    normalized['provenance'] = existingProvenance;
+  }
+  return normalized;
+}
+
 async function simulateLegacy(): Promise<
   Awaited<ReturnType<MonteCarloSimulationService['generateForecast']>>
 > {
@@ -173,6 +195,44 @@ async function simulate(input: {
   isFlagEnabled.mockReturnValue(input.flag);
   return new MonteCarloSimulationService().generateForecast(PARAMS);
 }
+
+describe('Monte Carlo assumptions profile v1', () => {
+  it('is strict, schema-valid, and hash-stable', () => {
+    expect(MonteCarloAssumptionsProfileV1Schema.parse(defaultMonteCarloAssumptionsProfile)).toEqual(
+      defaultMonteCarloAssumptionsProfile
+    );
+    expect(
+      MonteCarloAssumptionsProfileV1Schema.safeParse({
+        ...defaultMonteCarloAssumptionsProfile,
+        unexpected: true,
+      }).success
+    ).toBe(false);
+    expect(
+      MonteCarloAssumptionsProfileV1Schema.safeParse({
+        ...defaultMonteCarloAssumptionsProfile,
+        distributionSelectionRules: {
+          ...defaultMonteCarloAssumptionsProfile.distributionSelectionRules,
+          unexpected: true,
+        },
+      }).success
+    ).toBe(false);
+    expect(assumptionsProfileHash).toBe(EXPECTED_ASSUMPTIONS_PROFILE_HASH);
+    expect(assumptionsProfileHash).toBe(canonicalSha256(defaultMonteCarloAssumptionsProfile));
+    expect(Object.isFrozen(defaultMonteCarloAssumptionsProfile)).toBe(true);
+    expect(Object.isFrozen(defaultMonteCarloAssumptionsProfile.distributionSelectionRules)).toBe(
+      true
+    );
+  });
+
+  it('changes the canonical hash when a profile value changes', () => {
+    const modifiedProfile = {
+      ...defaultMonteCarloAssumptionsProfile,
+      lowDataVolatility: defaultMonteCarloAssumptionsProfile.lowDataVolatility + 0.01,
+    };
+
+    expect(canonicalSha256(modifiedProfile)).not.toBe(assumptionsProfileHash);
+  });
+});
 
 describe('MonteCarloSimulationService actuals-backed company inputs', () => {
   beforeEach(() => {
@@ -229,9 +289,27 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
     );
     expect(flagOffForecast).not.toHaveProperty('provenance');
     expect(insertedSnapshots[1]?.metadata).not.toHaveProperty('actualsFacts');
+    expect(insertedSnapshots[1]?.metadata).not.toHaveProperty('assumptionsHash');
+    expect(insertedSnapshots[1]?.metadata).not.toHaveProperty('profileVersion');
     expect(modeFindFirst).not.toHaveBeenCalled();
     expect(buildFundCompanyActualsFacts).not.toHaveBeenCalled();
     expect(buildFactsMonteCarloInput).not.toHaveBeenCalled();
+  });
+
+  it('keeps fixed-seed on and shadow computation identical when assumptions provenance is excluded', async () => {
+    isFlagEnabled.mockReturnValue(true);
+    modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
+    const onForecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
+    const shadowForecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
+
+    expect
+      .soft(sha256(withoutAssumptionsProvenance(onForecast)))
+      .toBe('3ecee4b969b8e5bd423bb322a0cb078e862a4069eb24a2526d63252dc49f70ad');
+    expect
+      .soft(sha256(withoutAssumptionsProvenance(shadowForecast)))
+      .toBe('35736f29571844d463574dcf59c57836e67d9712297c41d90075f108c30f8e1d');
   });
 
   it('registers the server-only actuals-input flag off in every environment', () => {
@@ -325,6 +403,8 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
       'Healthtech',
     ]);
     expect(forecast.provenance).toEqual({
+      assumptionsHash: EXPECTED_ASSUMPTIONS_PROFILE_HASH,
+      profileVersion: 'mc-assumptions-v1',
       actualsFacts: {
         factsInputHash: FACTS_INPUT_HASH,
         sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
@@ -340,6 +420,8 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
       },
     });
     expect(insertedSnapshots[0]?.metadata).toMatchObject({
+      assumptionsHash: EXPECTED_ASSUMPTIONS_PROFILE_HASH,
+      profileVersion: 'mc-assumptions-v1',
       actualsFacts: {
         factsInputHash: FACTS_INPUT_HASH,
         sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
@@ -361,6 +443,8 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
     expect(insertedSnapshots[1]?.metadata).toEqual(insertedSnapshots[0]?.metadata);
     expect(updatedSnapshotMetadata).toHaveLength(1);
     expect(updatedSnapshotMetadata[0]?.metadata).toMatchObject({
+      assumptionsHash: EXPECTED_ASSUMPTIONS_PROFILE_HASH,
+      profileVersion: 'mc-assumptions-v1',
       actualsFacts: {
         factsInputHash: FACTS_INPUT_HASH,
         sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
@@ -368,6 +452,8 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
       },
     });
     expect(shadowForecast.provenance).toEqual({
+      assumptionsHash: EXPECTED_ASSUMPTIONS_PROFILE_HASH,
+      profileVersion: 'mc-assumptions-v1',
       actualsFacts: {
         factsInputHash: FACTS_INPUT_HASH,
         sourceFactsInputHash: SOURCE_FACTS_INPUT_HASH,
@@ -438,22 +524,56 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
     });
   });
 
-  it('pins the legacy distribution rules and calibration constants by value', async () => {
+  it('pins the distribution rules and extracted calibration constants by value', async () => {
     const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
     const source = actualFs.readFileSync(
       path.join(process.cwd(), 'server/services/monte-carlo-simulation.ts'),
       'utf8'
     );
 
-    expect(source).toContain('standardDeviation: 0.15, // 15% default volatility');
+    expect(defaultMonteCarloAssumptionsProfile).toEqual({
+      profileVersion: 'mc-assumptions-v1',
+      lowDataVolatility: 0.15,
+      lowDataConfidence: 0.3,
+      aggregateStageProfile: 'seed',
+      upsideCompression: 0.82,
+      baselineIrrFallback: '0.12',
+      baselineDpiFallback: '0.5',
+      baselineTvpiFallback: '1.5',
+      distributionSelectionRules: {
+        multiples: 'power_law',
+        skewedMetrics: 'lognormal_when_skew_gt_1',
+        smallSamples: 'triangular_when_n_lt_10',
+      },
+    });
     expect(source).toContain("distribution = 'powerlaw'");
     expect(source).toContain("distribution = 'lognormal'");
     expect(source).toContain("distribution = 'triangular'");
-    expect(source).toMatch(/generateInvestmentScenario\(\s*'seed',\s*timeHorizonYears\s*\)/);
-    expect(source).toContain('const upsideCompression = 0.82');
-    expect(source).toContain("baseline.irr?.toString() || '0.12'");
-    expect(source).toContain("baseline.dpi?.toString() || '0.5'");
-    expect(source).toContain("baseline.tvpi?.toString() || '1.5'");
+    const multiplesRuleIndex = source.indexOf(
+      "if (metric === 'multipleVariance' || metric.includes('multiple'))"
+    );
+    const skewedMetricsRuleIndex = source.indexOf(
+      'else if (p.skewness !== undefined && Math.abs(p.skewness) > 1.0)'
+    );
+    const smallSamplesRuleIndex = source.indexOf('else if (p.count < 10)');
+    expect(multiplesRuleIndex).toBeGreaterThanOrEqual(0);
+    expect(multiplesRuleIndex).toBeLessThan(skewedMetricsRuleIndex);
+    expect(skewedMetricsRuleIndex).toBeLessThan(smallSamplesRuleIndex);
+    expect(source).toContain('defaultMonteCarloAssumptionsProfile.lowDataVolatility');
+    expect(source).toContain('defaultMonteCarloAssumptionsProfile.lowDataConfidence');
+    expect(source).toContain('defaultMonteCarloAssumptionsProfile.aggregateStageProfile');
+    expect(source).toContain('defaultMonteCarloAssumptionsProfile.upsideCompression');
+    expect(source).toContain('defaultMonteCarloAssumptionsProfile.baselineIrrFallback');
+    expect(source).toContain('defaultMonteCarloAssumptionsProfile.baselineDpiFallback');
+    expect(source).toContain('defaultMonteCarloAssumptionsProfile.baselineTvpiFallback');
+    expect(source).not.toMatch(/standardDeviation:\s*0\.15/);
+    expect(source).not.toContain('confidence: 0.3, // Low confidence due to insufficient data');
+    expect(source).not.toMatch(/generateInvestmentScenario\(\s*'seed'/);
+    expect(source).not.toContain("sampleReturn('seed')");
+    expect(source).not.toContain('const upsideCompression = 0.82');
+    expect(source).not.toContain("baseline.irr?.toString() || '0.12'");
+    expect(source).not.toContain("baseline.dpi?.toString() || '0.5'");
+    expect(source).not.toContain("baseline.tvpi?.toString() || '1.5'");
     expect(source).toContain('eq(fundSnapshots.id, snapshotId)');
     expect(source).toContain('eq(fundSnapshots.metadata, legacyMetadata)');
     expect(source).toContain('.returning({ id: fundSnapshots.id })');


### PR DESCRIPTION
## Summary

Plan 8 wave 7 (Task 8.8, server side) — the Monte Carlo calibration constants move into a versioned, hashed assumptions profile with zero value changes. Completes Plan 8's server-side scope.

- **New contract** `shared/contracts/monte-carlo/assumptions-profile-v1.contract.ts` + **default profile** `server/services/monte-carlo/default-assumptions-profile.ts` (`mc-assumptions-v1`, schema-parsed at load, canonical SHA-256 `assumptionsProfileHash`): lowDataVolatility 0.15, lowDataConfidence 0.3, aggregateStageProfile 'seed', upsideCompression 0.82, baseline IRR/DPI/TVPI fallbacks '0.12'/'0.5'/'1.5', versioned encoding of the distribution-selection rules.
- **Simulation service** consumes the constants from the profile (same literals, single source — the one remaining `0.15` in the file is an unrelated sector-scenario mean, not a profile field); under shadow/on modes result provenance gains `assumptionsHash` + `profileVersion` beside #1107's `actualsFacts`; under flag-off the new fields are absent and output stays byte-identical.
- Future profile changes are explicit model-version changes via `profileVersion`. UI disclosure of profile version + low-data warnings lands with Plan 9's shared evidence surfaces.

## Process note

Round 1 of this lane ended in a **BLOCKED report instead of code**: the worker correctly identified that the original spec demanded mutually impossible things (flag-on byte identity vs. new provenance fields; unmodified tests vs. exact provenance assertions; untouched literal-grep pins vs. extraction). Three spec amendments were approved (exclusion-based flag-on parity; the two provenance assertions may gain the new fields; pins relocate to the profile with a no-duplicate-literals assertion) and round 2 implemented cleanly.

## Verification

- 53/53 tests independently green: extended actuals-inputs suite (flag-off byte parity unchanged, exclusion-based flag-on parity, profile hash stability/sensitivity, relocated value pins incl. lowDataConfidence 0.3, no duplicate literals) + parity-assertions + orchestrator suites unmodified.
- `npm run calc-gate` PASS (from the lane); `npm run check` 0 TS errors; ESLint clean. 4-file diff; PRNG/other engines/routes/queues untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h