### PR TITLE
feat(moic): facts basis and rankability disclosure UI (Plan 6 wave 3)

### DIFF
--- a/client/src/components/moic/MoicBasisDisclosure.tsx
+++ b/client/src/components/moic/MoicBasisDisclosure.tsx
@@ -1,0 +1,262 @@
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import type { FundMoicFactsBasisV1 } from '@shared/contracts/fund-moic-v1.contract';
+
+interface MoicBasisDisclosureProps {
+  basis: FundMoicFactsBasisV1 | null;
+  investmentName: string;
+}
+
+interface MoicRankabilityBadgeProps {
+  basis: FundMoicFactsBasisV1 | null;
+}
+
+type FactsBasisReason = FundMoicFactsBasisV1['reasons'][number];
+
+const REASON_COPY: Record<FactsBasisReason, string> = {
+  planning_fmv_active: 'An active Planning FMV supports this ranking.',
+  planning_fmv_stale: 'Refresh the stale Planning FMV before relying on this ranking.',
+  legacy_current_valuation_fallback:
+    'Add a current Planning FMV before relying on the legacy valuation fallback.',
+  valuation_unavailable: 'Add a current Planning FMV before relying on this ranking.',
+  currency_blocked: 'Resolve the currency mismatch before relying on this ranking.',
+  planned_reserves_zero: 'Add planned reserves before relying on this ranking.',
+  exit_probability_missing: 'Add an exit probability before relying on this ranking.',
+  reserve_exit_multiple_missing: 'Add a reserve exit multiple before relying on this ranking.',
+};
+
+const PLANNING_FMV_STATUS_COPY: Record<FundMoicFactsBasisV1['planningFmvStatus'], string> = {
+  none: 'No Planning FMV',
+  active: 'Active Planning FMV',
+  superseded: 'Superseded Planning FMV',
+  stale: 'Stale Planning FMV',
+  blocked: 'Planning FMV blocked',
+};
+
+const CURRENCY_STATUS_COPY: Record<FundMoicFactsBasisV1['currencyStatus'], string> = {
+  base_currency: 'Base currency',
+  mismatch_blocked: 'Currency mismatch blocked',
+  unknown: 'Currency unknown',
+};
+
+const VALUATION_ANCHOR_COPY: Record<FundMoicFactsBasisV1['valuationAnchor']['kind'], string> = {
+  planning_fmv: 'Planning FMV',
+  legacy_current_valuation: 'Legacy current valuation',
+  none: 'No valuation anchor',
+};
+
+const FACTS_UNAVAILABLE_COPY =
+  'Facts unavailable. The ranking value is retained, but its supporting facts basis could not be loaded.';
+
+function formatBaseCurrencyAmount(value: string | null): string {
+  if (value === null) {
+    return 'Unavailable';
+  }
+
+  const match = /^(?<sign>-?)(?<integer>\d+)(?:\.(?<fraction>\d{1,6}))?$/.exec(value);
+  if (!match?.groups) {
+    return 'Unavailable';
+  }
+
+  const fraction = (match.groups['fraction'] ?? '').padEnd(3, '0');
+  let magnitudeInCents = BigInt(match.groups['integer']) * 100n + BigInt(fraction.slice(0, 2));
+  if (fraction[2] >= '5') {
+    magnitudeInCents += 1n;
+  }
+
+  const wholeUnits = magnitudeInCents / 100n;
+  const cents = (magnitudeInCents % 100n).toString().padStart(2, '0');
+  const sign = match.groups['sign'] === '-' && magnitudeInCents !== 0n ? '-' : '';
+  const groupedWholeUnits = wholeUnits.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  return `${sign}${groupedWholeUnits}.${cents}`;
+}
+
+function reasonCopy(basis: FundMoicFactsBasisV1 | null): string[] {
+  return basis === null
+    ? [FACTS_UNAVAILABLE_COPY]
+    : basis.reasons.map((reason) => REASON_COPY[reason]);
+}
+
+export function MoicRankabilityBadge({ basis }: MoicRankabilityBadgeProps) {
+  const rankability = basis?.rankability ?? 'facts_unavailable';
+  const copy = reasonCopy(basis);
+  const label =
+    rankability === 'actionable'
+      ? 'Actionable'
+      : rankability === 'indicative'
+        ? 'Indicative'
+        : rankability === 'not_actionable'
+          ? 'Not actionable'
+          : 'Facts unavailable';
+  const labelClass = rankability === 'actionable' ? 'text-pov-charcoal' : 'text-charcoal-500';
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            className={`inline-flex items-center gap-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2 ${labelClass}`}
+          >
+            {rankability === 'indicative' ? (
+              <span
+                aria-hidden="true"
+                data-testid="moic-rankability-dot"
+                className="h-2 w-2 rounded-full border border-warning/50 bg-warning/10 text-warning-dark"
+              />
+            ) : rankability === 'not_actionable' || rankability === 'facts_unavailable' ? (
+              <span
+                aria-hidden="true"
+                data-testid="moic-rankability-dot"
+                className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+              />
+            ) : null}
+            {label}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-sm motion-reduce:animate-none motion-reduce:transition-none">
+          <ul className="space-y-1">
+            {copy.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function EvidenceField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs uppercase text-charcoal-500">{label}</div>
+      <div className="mt-1 text-pov-charcoal">{children}</div>
+    </div>
+  );
+}
+
+export function MoicBasisDisclosure({ basis, investmentName }: MoicBasisDisclosureProps) {
+  if (basis === null) {
+    return (
+      <section
+        aria-label={`${investmentName} MOIC facts basis`}
+        className="space-y-3 border-y border-beige-200 bg-pov-gray/40 px-4 py-4 text-sm text-charcoal-500"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h3 className="font-semibold text-pov-charcoal">Facts basis</h3>
+            <p className="text-xs text-charcoal-500">{investmentName}</p>
+          </div>
+          <MoicRankabilityBadge basis={null} />
+        </div>
+        <p>{FACTS_UNAVAILABLE_COPY}</p>
+      </section>
+    );
+  }
+
+  const reasons = reasonCopy(basis);
+  const anchor = basis.valuationAnchor;
+  const factsInputHash = basis.factsInputHash;
+
+  return (
+    <section
+      aria-label={`${investmentName} MOIC facts basis`}
+      className="space-y-4 border-y border-beige-200 bg-pov-gray/40 px-4 py-4 text-sm text-charcoal-500"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="font-semibold text-pov-charcoal">Facts basis</h3>
+          <p className="text-xs text-charcoal-500">{investmentName}</p>
+        </div>
+        <MoicRankabilityBadge basis={basis} />
+      </div>
+
+      <div>
+        <div className="text-xs uppercase text-charcoal-500">Why this state</div>
+        <ul className="mt-1 list-disc space-y-1 pl-5 text-charcoal-500">
+          {reasons.map((reason) => (
+            <li key={reason}>{reason}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="grid gap-3 border-t border-beige-200 pt-3 sm:grid-cols-3">
+        <EvidenceField label="Observed initial investment (base currency)">
+          <span className="tabular-nums">
+            {formatBaseCurrencyAmount(basis.observedInitialInvestment)}
+          </span>
+        </EvidenceField>
+        <EvidenceField label="Observed follow-on investment (base currency)">
+          <span className="tabular-nums">
+            {formatBaseCurrencyAmount(basis.observedFollowOnInvestment)}
+          </span>
+        </EvidenceField>
+        <EvidenceField label="Observed total investment (base currency)">
+          <span className="tabular-nums">
+            {formatBaseCurrencyAmount(basis.observedTotalInvestment)}
+          </span>
+        </EvidenceField>
+      </div>
+
+      <div className="grid gap-3 border-t border-beige-200 pt-3 sm:grid-cols-2 lg:grid-cols-4">
+        <EvidenceField label="Valuation anchor">{VALUATION_ANCHOR_COPY[anchor.kind]}</EvidenceField>
+        <EvidenceField label="Anchor value (base currency)">
+          <span className="tabular-nums">{formatBaseCurrencyAmount(anchor.value)}</span>
+        </EvidenceField>
+        <EvidenceField label="Anchor as-of date">
+          <span className="tabular-nums">{anchor.asOfDate ?? 'Unavailable'}</span>
+        </EvidenceField>
+        <EvidenceField label="Planning FMV status">
+          {PLANNING_FMV_STATUS_COPY[basis.planningFmvStatus]}
+        </EvidenceField>
+        <EvidenceField label="Currency status">
+          {CURRENCY_STATUS_COPY[basis.currencyStatus]}
+        </EvidenceField>
+        <EvidenceField label="Facts input hash">
+          {factsInputHash ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <code className="text-xs text-pov-charcoal">{factsInputHash.slice(0, 12)}</code>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs text-pov-charcoal"
+                aria-label={`Copy facts input hash for ${investmentName}`}
+                onClick={() => {
+                  if (!navigator.clipboard) {
+                    return;
+                  }
+                  void navigator.clipboard.writeText(factsInputHash).catch(() => undefined);
+                }}
+              >
+                Copy full hash
+              </Button>
+            </div>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 text-charcoal-500">
+              <span
+                aria-hidden="true"
+                className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+              />
+              Unavailable
+            </span>
+          )}
+        </EvidenceField>
+      </div>
+
+      <div className="border-t border-beige-200 pt-3">
+        <div className="text-xs uppercase text-charcoal-500">Warnings</div>
+        {basis.warnings.length > 0 ? (
+          <ul className="mt-1 list-disc space-y-1 pl-5 text-xs text-charcoal-500">
+            {basis.warnings.map((warning, index) => (
+              <li key={`${warning.code}-${index}`}>{warning.message}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-1 text-xs text-charcoal-500">None</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/pages/fund-model-results-moic-analysis.tsx
+++ b/client/src/pages/fund-model-results-moic-analysis.tsx
@@ -1,5 +1,7 @@
-import { AlertTriangle, Info, Loader2 } from 'lucide-react';
+import { Fragment, useState } from 'react';
+import { AlertTriangle, ChevronRight, Info } from 'lucide-react';
 import { useRoute } from 'wouter';
+import { MoicBasisDisclosure, MoicRankabilityBadge } from '@/components/moic/MoicBasisDisclosure';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -10,6 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { usePortfolioCompanies } from '@/hooks/use-fund-data';
 import { useFundMoicRankingsV2 } from '@/hooks/use-moic';
 import type { FundMoicRankingsResponseV2 } from '@shared/contracts/fund-moic-v2.contract';
 
@@ -21,6 +24,20 @@ type FundIdParseResult =
 type FundMoicRankingV2 = FundMoicRankingsResponseV2['rankings'][number];
 type LatestReconciliationV2 = FundMoicRankingsResponseV2['latestReconciliation'];
 type ActualsProvenanceSummaryV2 = FundMoicRankingsResponseV2['actualsProvenanceSummary'];
+
+interface PortfolioCompanyReserves {
+  id: number;
+  plannedReservesCents: number;
+  deployedReservesCents: number;
+}
+
+const MOIC_METRIC_LABEL = 'Expected MOIC on planned reserves — assumption-based';
+
+const RANKABILITY_GROUPS = [
+  { key: 'actionable', label: 'Actionable' },
+  { key: 'indicative', label: 'Indicative' },
+  { key: 'not_actionable', label: 'Not actionable' },
+] as const;
 
 const ACTIVATION_BLOCKER_LABELS: Record<string, string> = {
   accepted_reconciliation_required: 'Accepted reconciliation required',
@@ -58,6 +75,21 @@ function parseFundIdParam(rawValue: string | undefined): FundIdParseResult {
 
 function formatMoicValue(value: number | null): string {
   return value === null ? 'Unavailable' : `${value.toFixed(2)}x`;
+}
+
+function formatBaseCurrencyCents(value: number | undefined): string {
+  if (value === undefined || !Number.isSafeInteger(value)) {
+    return 'Unavailable';
+  }
+
+  const signedCents = BigInt(value);
+  const magnitudeInCents = signedCents < 0n ? -signedCents : signedCents;
+  const wholeUnits = magnitudeInCents / 100n;
+  const cents = (magnitudeInCents % 100n).toString().padStart(2, '0');
+  const sign = signedCents < 0n ? '-' : '';
+  const groupedWholeUnits = wholeUnits.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  return `${sign}${groupedWholeUnits}.${cents}`;
 }
 
 export function formatRankingsSource(
@@ -111,19 +143,47 @@ function StateCard({
 }: {
   title: string;
   description: string;
-  icon?: 'loading' | 'info' | 'warning';
+  icon?: 'info' | 'warning';
 }) {
-  const Icon = icon === 'loading' ? Loader2 : icon === 'info' ? Info : AlertTriangle;
+  const Icon = icon === 'info' ? Info : AlertTriangle;
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-pov-charcoal">
-          <Icon className={`h-5 w-5 ${icon === 'loading' ? 'animate-spin' : ''}`} />
+          <Icon className="h-5 w-5" />
           <span>{title}</span>
         </CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
+    </Card>
+  );
+}
+
+function RankingsLoadingSkeleton() {
+  return (
+    <Card aria-label="Loading MOIC rankings">
+      <CardHeader>
+        <CardTitle className="text-pov-charcoal">Loading MOIC rankings</CardTitle>
+        <CardDescription>Fetching the fund-scoped MOIC rankings response.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3" aria-hidden="true">
+        {[0, 1, 2].map((index) => (
+          <div
+            key={index}
+            className="grid grid-cols-[3rem_1fr_auto] items-center gap-4 border-b border-beige-200 py-3 last:border-b-0"
+          >
+            <span className="h-4 animate-pulse bg-pov-gray motion-reduce:animate-none" />
+            <span className="h-4 animate-pulse bg-pov-gray motion-reduce:animate-none" />
+            <span
+              data-testid="moic-loading-number"
+              className="animate-pulse tabular-nums text-transparent motion-reduce:animate-none"
+            >
+              00.00x
+            </span>
+          </div>
+        ))}
+      </CardContent>
     </Card>
   );
 }
@@ -305,35 +365,121 @@ function ProvenanceStrip({ data }: { data: FundMoicRankingsResponseV2 }) {
   );
 }
 
-function RankingsTable({ rankings }: { rankings: FundMoicRankingV2[] }) {
+function rankingGroup(item: FundMoicRankingV2): (typeof RANKABILITY_GROUPS)[number]['key'] {
+  return item.factsBasis?.rankability ?? 'not_actionable';
+}
+
+function RankingsTable({
+  rankings,
+  portfolioCompanies,
+}: {
+  rankings: FundMoicRankingV2[];
+  portfolioCompanies: PortfolioCompanyReserves[];
+}) {
+  const [expandedInvestmentId, setExpandedInvestmentId] = useState<string | null>(null);
+  const reservesByInvestmentId = new Map(
+    portfolioCompanies.map((company) => [String(company.id), company])
+  );
+  const groupedRankings = RANKABILITY_GROUPS.map((group) => ({
+    ...group,
+    rankings: rankings
+      .filter((item) => rankingGroup(item) === group.key)
+      .sort((left, right) => left.rank - right.rank),
+  })).filter((group) => group.rankings.length > 0);
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>MOIC Rankings</CardTitle>
-        <CardDescription>Fund-scoped V2 rankings payload.</CardDescription>
+        <h2 className="text-lg font-inter font-bold leading-none tracking-tight text-charcoal">
+          {MOIC_METRIC_LABEL}
+        </h2>
+        <CardDescription>
+          Companies are grouped by decision use; overall MOIC rank is retained while display order
+          is trust-first. Reserve columns show current portfolio values.
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Rank</TableHead>
+              <TableHead>Overall MOIC rank</TableHead>
               <TableHead>Investment</TableHead>
-              <TableHead className="text-right">Reserves MOIC</TableHead>
+              <TableHead>Rankability</TableHead>
+              <TableHead className="text-right">Current planned reserves (base currency)</TableHead>
+              <TableHead className="text-right">
+                Current deployed reserves (base currency)
+              </TableHead>
+              <TableHead className="text-right">Expected MOIC</TableHead>
             </TableRow>
           </TableHeader>
-          <TableBody>
-            {rankings.map((item) => (
-              <TableRow key={item.investmentId}>
-                <TableCell className="font-semibold text-charcoal-600">#{item.rank}</TableCell>
-                <TableCell className="font-medium text-pov-charcoal">
-                  {item.investmentName}
-                </TableCell>
-                <TableCell className="text-right font-bold tabular-nums text-pov-charcoal">
-                  {formatMoicValue(item.reservesMoic.value)}
-                </TableCell>
+          {groupedRankings.map((group) => (
+            <TableBody key={group.key}>
+              <TableRow className="bg-pov-gray/60 hover:bg-pov-gray/60">
+                <TableHead
+                  scope="rowgroup"
+                  colSpan={6}
+                  className="h-auto py-2 text-xs font-semibold uppercase text-charcoal-500"
+                >
+                  {group.label}
+                </TableHead>
               </TableRow>
-            ))}
-          </TableBody>
+              {group.rankings.map((item) => {
+                const isExpanded = expandedInvestmentId === item.investmentId;
+                const disclosureId = `moic-basis-${item.investmentId}`;
+                const reserveData = reservesByInvestmentId.get(item.investmentId);
+
+                return (
+                  <Fragment key={item.investmentId}>
+                    <TableRow>
+                      <TableCell className="font-semibold text-charcoal-600">
+                        #{item.rank}
+                      </TableCell>
+                      <TableCell className="font-medium text-pov-charcoal">
+                        <button
+                          type="button"
+                          aria-expanded={isExpanded}
+                          aria-controls={disclosureId}
+                          aria-label={`${isExpanded ? 'Hide' : 'Show'} facts basis for ${item.investmentName}`}
+                          onClick={() =>
+                            setExpandedInvestmentId(isExpanded ? null : item.investmentId)
+                          }
+                          className="inline-flex min-h-10 items-center gap-2 text-left text-pov-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2"
+                        >
+                          <ChevronRight
+                            aria-hidden="true"
+                            className={`h-4 w-4 shrink-0 transition-transform motion-reduce:transition-none ${isExpanded ? 'rotate-90' : ''}`}
+                          />
+                          {item.investmentName}
+                        </button>
+                      </TableCell>
+                      <TableCell>
+                        <MoicRankabilityBadge basis={item.factsBasis} />
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-pov-charcoal">
+                        {formatBaseCurrencyCents(reserveData?.plannedReservesCents)}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-pov-charcoal">
+                        {formatBaseCurrencyCents(reserveData?.deployedReservesCents)}
+                      </TableCell>
+                      <TableCell className="text-right font-bold tabular-nums text-pov-charcoal">
+                        {formatMoicValue(item.reservesMoic.value)}
+                      </TableCell>
+                    </TableRow>
+                    {isExpanded ? (
+                      <TableRow id={disclosureId}>
+                        <TableCell colSpan={6} className="p-0">
+                          <MoicBasisDisclosure
+                            basis={item.factsBasis}
+                            investmentName={item.investmentName}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ) : null}
+                  </Fragment>
+                );
+              })}
+            </TableBody>
+          ))}
         </Table>
       </CardContent>
     </Card>
@@ -344,6 +490,7 @@ export default function FundModelResultsMoicAnalysisPage() {
   const [, params] = useRoute('/fund-model-results/:fundId/moic-analysis');
   const fundIdResult = parseFundIdParam(params?.fundId);
   const { data, error, isLoading } = useFundMoicRankingsV2(fundIdResult.fundId);
+  const { portfolioCompanies } = usePortfolioCompanies(fundIdResult.fundId ?? undefined);
   const hasParsedResponse = fundIdResult.status === 'valid' && !error && data;
 
   return (
@@ -370,13 +517,7 @@ export default function FundModelResultsMoicAnalysisPage() {
         />
       ) : null}
 
-      {fundIdResult.status === 'valid' && isLoading ? (
-        <StateCard
-          title="Loading MOIC rankings"
-          description="Fetching the fund-scoped MOIC rankings response."
-          icon="loading"
-        />
-      ) : null}
+      {fundIdResult.status === 'valid' && isLoading ? <RankingsLoadingSkeleton /> : null}
 
       {fundIdResult.status === 'valid' && error ? (
         <StateCard
@@ -397,8 +538,8 @@ export default function FundModelResultsMoicAnalysisPage() {
         <>
           <ProvenanceStrip data={data} />
           <StateCard
-            title="No rankings available"
-            description="The V2 response returned zero reserves MOIC ranking rows for this fund."
+            title="No rankings disclosed"
+            description={`As of ${data.generatedAt.slice(0, 10)}. The V2 response returned zero reserves MOIC ranking rows for this fund.`}
             icon="info"
           />
         </>
@@ -407,7 +548,7 @@ export default function FundModelResultsMoicAnalysisPage() {
       {hasParsedResponse && data.rankings.length > 0 ? (
         <>
           <ProvenanceStrip data={data} />
-          <RankingsTable rankings={data.rankings} />
+          <RankingsTable rankings={data.rankings} portfolioCompanies={portfolioCompanies} />
         </>
       ) : null}
     </div>

--- a/tests/unit/components/moic/moic-basis-disclosure.test.tsx
+++ b/tests/unit/components/moic/moic-basis-disclosure.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MoicBasisDisclosure } from '../../../../client/src/components/moic/MoicBasisDisclosure';
+import {
+  FundMoicFactsBasisV1Schema,
+  type FundMoicFactsBasisV1,
+} from '@shared/contracts/fund-moic-v1.contract';
+
+const FACTS_HASH = 'a'.repeat(64);
+
+function buildBasis(overrides: Partial<FundMoicFactsBasisV1> = {}): FundMoicFactsBasisV1 {
+  return FundMoicFactsBasisV1Schema.parse({
+    rankability: 'actionable',
+    reasons: ['planning_fmv_active'],
+    observedInitialInvestment: '1000000.5',
+    observedFollowOnInvestment: '250000',
+    observedTotalInvestment: '1250000.5',
+    valuationAnchor: {
+      kind: 'planning_fmv',
+      value: '4000000',
+      asOfDate: '2026-07-12',
+    },
+    planningFmvStatus: 'active',
+    currencyStatus: 'base_currency',
+    factsInputHash: FACTS_HASH,
+    warnings: [],
+    ...overrides,
+  });
+}
+
+describe('MoicBasisDisclosure', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders schema-valid actionable evidence, money, warnings, and a copy-full-hash action', async () => {
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: clipboardWrite },
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const basis = buildBasis({
+      warnings: [
+        {
+          code: 'ROUND_MODEL_OVERRIDE_APPLIED',
+          severity: 'info',
+          message: 'A reviewed round model override was applied.',
+        },
+      ],
+    });
+
+    expect(FundMoicFactsBasisV1Schema.parse(basis)).toEqual(basis);
+
+    render(<MoicBasisDisclosure basis={basis} investmentName="Acme Corp" />);
+
+    const actionable = screen.getByText('Actionable');
+    expect(actionable).toHaveClass('text-pov-charcoal');
+    expect(actionable.className).not.toMatch(/success|positive|confidence|rounded|border|bg-/);
+    expect(screen.getByText('1,000,000.50')).toHaveClass('tabular-nums');
+    expect(screen.getByText('250,000.00')).toHaveClass('tabular-nums');
+    expect(screen.getByText('1,250,000.50')).toHaveClass('tabular-nums');
+    expect(screen.getByText('Planning FMV')).toBeInTheDocument();
+    expect(screen.getByText('4,000,000.00')).toHaveClass('tabular-nums');
+    expect(screen.getByText('2026-07-12')).toHaveClass('tabular-nums');
+    expect(screen.getByText('Active Planning FMV')).toBeInTheDocument();
+    expect(screen.getByText('Base currency')).toBeInTheDocument();
+    expect(screen.getByText(FACTS_HASH.slice(0, 12))).toBeInTheDocument();
+    expect(screen.getByText('A reviewed round model override was applied.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy facts input hash for Acme Corp' }));
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith(FACTS_HASH));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders indicative remediation copy and exposes the reason on badge focus', async () => {
+    const basis = buildBasis({
+      rankability: 'indicative',
+      reasons: ['planning_fmv_stale', 'exit_probability_missing', 'reserve_exit_multiple_missing'],
+      planningFmvStatus: 'stale',
+    });
+
+    render(<MoicBasisDisclosure basis={basis} investmentName="Beta Labs" />);
+
+    const indicative = screen.getByText('Indicative');
+    expect(indicative).toHaveClass('text-charcoal-500');
+    expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
+      'border-warning/50',
+      'bg-warning/10',
+      'text-warning-dark'
+    );
+    expect(
+      screen.getByText('Refresh the stale Planning FMV before relying on this ranking.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Add an exit probability before relying on this ranking.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Add a reserve exit multiple before relying on this ranking.')
+    ).toBeInTheDocument();
+
+    fireEvent.focus(indicative);
+    await waitFor(() => {
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip.parentElement).toHaveClass(
+        'motion-reduce:animate-none',
+        'motion-reduce:transition-none'
+      );
+      expect(tooltip).toHaveTextContent(
+        'Refresh the stale Planning FMV before relying on this ranking.'
+      );
+    });
+  });
+
+  it('preserves decimal-string precision beyond Number.MAX_SAFE_INTEGER', () => {
+    const basis = buildBasis({
+      observedInitialInvestment: '9007199254740993',
+    });
+
+    render(<MoicBasisDisclosure basis={basis} investmentName="Precision Co" />);
+
+    expect(screen.getByText('9,007,199,254,740,993.00')).toHaveClass('tabular-nums');
+  });
+
+  it('renders not-actionable and null-basis states with text labels and hollow dots', () => {
+    const basis = buildBasis({
+      rankability: 'not_actionable',
+      reasons: ['valuation_unavailable', 'currency_blocked', 'planned_reserves_zero'],
+      valuationAnchor: { kind: 'none', value: null, asOfDate: null },
+      planningFmvStatus: 'none',
+      currencyStatus: 'mismatch_blocked',
+      factsInputHash: null,
+    });
+    const { unmount } = render(<MoicBasisDisclosure basis={basis} investmentName="Gamma Bio" />);
+
+    expect(screen.getByText('Not actionable')).toHaveClass('text-charcoal-500');
+    expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
+      'border-charcoal-400',
+      'bg-transparent'
+    );
+    expect(
+      screen.getByText('Add a current Planning FMV before relying on this ranking.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Resolve the currency mismatch before relying on this ranking.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Add planned reserves before relying on this ranking.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('No valuation anchor')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /copy facts input hash/i })
+    ).not.toBeInTheDocument();
+
+    unmount();
+    render(<MoicBasisDisclosure basis={null} investmentName="Delta Co" />);
+
+    expect(screen.getAllByText('Facts unavailable').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/supporting facts basis could not be loaded/i)).toBeInTheDocument();
+    expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
+      'border-charcoal-400',
+      'bg-transparent'
+    );
+  });
+});

--- a/tests/unit/hooks/use-moic-v2.test.tsx
+++ b/tests/unit/hooks/use-moic-v2.test.tsx
@@ -4,6 +4,26 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useFundMoicRankingsV2 } from '../../../client/src/hooks/use-moic';
 import type { FundMoicRankingsResponseV2 } from '../../../shared/contracts/fund-moic-v2.contract';
+import { FundMoicFactsBasisV1Schema } from '../../../shared/contracts/fund-moic-v1.contract';
+
+const FACTS_HASH = 'b'.repeat(64);
+
+const populatedFactsBasis = FundMoicFactsBasisV1Schema.parse({
+  rankability: 'actionable',
+  reasons: ['planning_fmv_active'],
+  observedInitialInvestment: '1000000',
+  observedFollowOnInvestment: '250000',
+  observedTotalInvestment: '1250000',
+  valuationAnchor: {
+    kind: 'planning_fmv',
+    value: '4000000',
+    asOfDate: '2026-07-12',
+  },
+  planningFmvStatus: 'active',
+  currencyStatus: 'base_currency',
+  factsInputHash: FACTS_HASH,
+  warnings: [],
+});
 
 function makeV2Response(fundId: number): FundMoicRankingsResponseV2 {
   return {
@@ -14,7 +34,7 @@ function makeV2Response(fundId: number): FundMoicRankingsResponseV2 {
         rank: 1,
         investmentId: '101',
         investmentName: 'Acme Corp',
-        factsBasis: null,
+        factsBasis: populatedFactsBasis,
         reservesMoic: {
           value: 0,
           description: 'Expected return on planned reserves',
@@ -103,6 +123,7 @@ describe('useFundMoicRankingsV2', () => {
       trustStateCounts: { LIVE: 1, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 },
       defaultedEconomicInputCount: 0,
     });
+    expect(result.current.data?.rankings[0]?.factsBasis).toEqual(populatedFactsBasis);
     expect(JSON.stringify(result.current.data)).not.toMatch(/marginal next-dollar/i);
     expect(fetchSpy).toHaveBeenCalledWith('/api/funds/5/moic/rankings?contract=v2', {
       credentials: 'include',

--- a/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
+++ b/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createWouterWrapper } from '../../utils/withWouter';
@@ -7,6 +8,10 @@ import {
   FundMoicRankingsResponseV2Schema,
   type FundMoicRankingsResponseV2,
 } from '../../../shared/contracts/fund-moic-v2.contract';
+import {
+  FundMoicFactsBasisV1Schema,
+  type FundMoicFactsBasisV1,
+} from '../../../shared/contracts/fund-moic-v1.contract';
 
 type HookError = { code: string };
 type HookResult = {
@@ -16,9 +21,44 @@ type HookResult = {
 };
 
 const useFundMoicRankingsV2 = vi.fn<(fundId: number | null) => HookResult>();
+const usePortfolioCompanies = vi.fn<
+  (fundId: number | undefined) => {
+    portfolioCompanies: Array<{
+      id: number;
+      plannedReservesCents: number;
+      deployedReservesCents: number;
+    }>;
+  }
+>();
+
+const FACTS_HASH = 'a'.repeat(64);
+
+function makeFactsBasis(overrides: Partial<FundMoicFactsBasisV1> = {}): FundMoicFactsBasisV1 {
+  return FundMoicFactsBasisV1Schema.parse({
+    rankability: 'actionable',
+    reasons: ['planning_fmv_active'],
+    observedInitialInvestment: '1000000',
+    observedFollowOnInvestment: '250000',
+    observedTotalInvestment: '1250000',
+    valuationAnchor: {
+      kind: 'planning_fmv',
+      value: '4000000',
+      asOfDate: '2026-07-12',
+    },
+    planningFmvStatus: 'active',
+    currencyStatus: 'base_currency',
+    factsInputHash: FACTS_HASH,
+    warnings: [],
+    ...overrides,
+  });
+}
 
 vi.mock('../../../client/src/hooks/use-moic', () => ({
   useFundMoicRankingsV2: (fundId: number | null) => useFundMoicRankingsV2(fundId),
+}));
+
+vi.mock('../../../client/src/hooks/use-fund-data', () => ({
+  usePortfolioCompanies: (fundId: number | undefined) => usePortfolioCompanies(fundId),
 }));
 
 const canonicalFixture = {
@@ -29,7 +69,7 @@ const canonicalFixture = {
       rank: 1,
       investmentId: '101',
       investmentName: 'Acme Corp',
-      factsBasis: null,
+      factsBasis: makeFactsBasis(),
       reservesMoic: {
         value: 2.8,
         description: 'Expected return on planned reserves',
@@ -123,6 +163,15 @@ function mockHook(result: HookResult) {
 describe('FundModelResultsMoicAnalysisPage', () => {
   beforeEach(() => {
     useFundMoicRankingsV2.mockReset();
+    usePortfolioCompanies.mockReset();
+    usePortfolioCompanies.mockReturnValue({
+      portfolioCompanies: [
+        { id: 101, plannedReservesCents: 140_000_000, deployedReservesCents: 100_000_000 },
+        { id: 102, plannedReservesCents: 130_000_000, deployedReservesCents: 90_000_000 },
+        { id: 103, plannedReservesCents: 120_000_000, deployedReservesCents: 80_000_000 },
+        { id: 104, plannedReservesCents: 110_000_000, deployedReservesCents: 70_000_000 },
+      ],
+    });
   });
 
   it('renders legacy source, warning banners, mapped codes, blocking counts, and reconciliation indicators', () => {
@@ -176,6 +225,8 @@ describe('FundModelResultsMoicAnalysisPage', () => {
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.queryByText(/marginal next-dollar/i)).not.toBeInTheDocument();
     expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('1,400,000.00')).toHaveClass('tabular-nums');
+    expect(screen.getByText('1,000,000.00')).toHaveClass('tabular-nums');
   });
 
   it('renders candidate source copy when candidate rankings are active', () => {
@@ -208,6 +259,105 @@ describe('FundModelResultsMoicAnalysisPage', () => {
     expect(screen.getByText('Inputs match')).toBeInTheDocument();
     expect(screen.getByText('Fingerprint match')).toBeInTheDocument();
     expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('groups every company by rankability and expands disclosure from the keyboard', async () => {
+    const user = userEvent.setup();
+    const fixture = makeV2();
+    const rankingTemplate = fixture.rankings[0];
+
+    fixture.rankings = [
+      {
+        ...rankingTemplate,
+        rank: 2,
+        investmentId: '104',
+        investmentName: 'Unavailable Co',
+        factsBasis: null,
+        reservesMoic: { ...rankingTemplate.reservesMoic, value: 1.1 },
+      },
+      {
+        ...rankingTemplate,
+        rank: 1,
+        investmentId: '103',
+        investmentName: 'Blocked Co',
+        factsBasis: makeFactsBasis({
+          rankability: 'not_actionable',
+          reasons: ['currency_blocked'],
+          valuationAnchor: { kind: 'none', value: null, asOfDate: null },
+          currencyStatus: 'mismatch_blocked',
+        }),
+        reservesMoic: { ...rankingTemplate.reservesMoic, value: 1.2 },
+      },
+      {
+        ...rankingTemplate,
+        rank: 3,
+        investmentId: '102',
+        investmentName: 'Indicative Co',
+        factsBasis: makeFactsBasis({
+          rankability: 'indicative',
+          reasons: ['planning_fmv_stale'],
+          planningFmvStatus: 'stale',
+        }),
+        reservesMoic: { ...rankingTemplate.reservesMoic, value: 1.3 },
+      },
+      {
+        ...rankingTemplate,
+        rank: 4,
+        investmentId: '101',
+        investmentName: 'Action Co',
+        factsBasis: makeFactsBasis(),
+        reservesMoic: { ...rankingTemplate.reservesMoic, value: 1.4 },
+      },
+    ];
+
+    mockHook({
+      data: FundMoicRankingsResponseV2Schema.parse(fixture),
+      error: null,
+      isLoading: false,
+    });
+
+    const { container } = renderPage();
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Expected MOIC on planned reserves — assumption-based',
+      })
+    ).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/marginal|opportunity cost/i);
+    expect(screen.getByText('Overall MOIC rank')).toBeInTheDocument();
+    const rankingGroups = screen.getByRole('table').querySelectorAll('tbody');
+    expect(rankingGroups).toHaveLength(3);
+    expect(
+      Array.from(rankingGroups, (group) =>
+        group.querySelector('th[scope="rowgroup"]')?.textContent?.trim()
+      )
+    ).toEqual(['Actionable', 'Indicative', 'Not actionable']);
+    expect(
+      screen
+        .getAllByRole('button', { name: /show facts basis for/i })
+        .map((button) => button.textContent?.trim())
+    ).toEqual(['Action Co', 'Indicative Co', 'Blocked Co', 'Unavailable Co']);
+
+    const actionButton = screen.getByRole('button', { name: 'Show facts basis for Action Co' });
+    expect(actionButton).toHaveAttribute('aria-expanded', 'false');
+    actionButton.focus();
+    await user.keyboard('{Enter}');
+    expect(actionButton).toHaveAttribute('aria-expanded', 'true');
+    expect(actionButton).toHaveAccessibleName('Hide facts basis for Action Co');
+    expect(screen.getByRole('region', { name: 'Action Co MOIC facts basis' })).toBeInTheDocument();
+    await user.keyboard(' ');
+    expect(actionButton).toHaveAttribute('aria-expanded', 'false');
+    expect(actionButton).toHaveAccessibleName('Show facts basis for Action Co');
+
+    expect(screen.getByText('#2')).toBeInTheDocument();
+    expect(screen.getByText('1.10x')).toHaveClass('tabular-nums');
+    expect(screen.getByText('1,100,000.00')).toHaveClass('tabular-nums');
+    expect(screen.getByText('700,000.00')).toHaveClass('tabular-nums');
+    expect(screen.getByText('Facts unavailable')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Show facts basis for Unavailable Co' }));
+    expect(screen.getByText(/supporting facts basis could not be loaded/i)).toBeInTheDocument();
+    expect(useFundMoicRankingsV2).toHaveBeenCalledTimes(1);
+    expect(usePortfolioCompanies).toHaveBeenCalledWith(7);
   });
 
   it('renders zero blocking counts, empty warning groups, and no reconciliation copy', () => {
@@ -291,9 +441,11 @@ describe('FundModelResultsMoicAnalysisPage', () => {
 
     renderPage();
 
-    expect(screen.getByText('No rankings available')).toBeInTheDocument();
+    expect(screen.getByText('No rankings disclosed')).toBeInTheDocument();
     expect(
-      screen.getByText('The V2 response returned zero reserves MOIC ranking rows for this fund.')
+      screen.getByText(
+        'As of 2026-06-24. The V2 response returned zero reserves MOIC ranking rows for this fund.'
+      )
     ).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
@@ -307,6 +459,10 @@ describe('FundModelResultsMoicAnalysisPage', () => {
     expect(
       screen.getByText('Fetching the fund-scoped MOIC rankings response.')
     ).toBeInTheDocument();
+    expect(screen.getAllByTestId('moic-loading-number')).toHaveLength(3);
+    for (const skeleton of screen.getAllByTestId('moic-loading-number')) {
+      expect(skeleton).toHaveClass('tabular-nums', 'motion-reduce:animate-none');
+    }
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Plan 6 wave 3 (Task 6.5) — the client disclosure for the facts basis shipped in #1104/#1108. Client-only.

- **New** `MoicBasisDisclosure.tsx`: quiet rankability badge (D-A: full-ink actionable, muted+amber-dot indicative, muted+hollow-dot not-actionable — every state text-labeled, zero green/pill/checkmark), reasons mapped to plain-language remediation copy (missing exit probability / reserve exit multiple, stale or absent Planning FMV, currency blocked, zero planned reserves), observed invested split with tabular-nums, valuation anchor kind + as-of, facts hash short form with accessible copy action, warnings. Pure display, zero mutations.
- **MOIC analysis page**: rows grouped and ordered actionable → indicative → not-actionable (null-basis rows keep their numbers with a disclosed "facts unavailable" reason — never hidden, never blank); metric labeled exactly "Expected MOIC on planned reserves — assumption-based"; planned/deployed reserves stay visible.
- Naming discipline is test-enforced: an assertion pins that "marginal" and "opportunity cost" never appear in rendered output (grep-verified zero occurrences in source too).

## Verification

- Client suites independently green (new disclosure suite + extended page/hook suites; fixtures parse with the real `FundMoicFactsBasisV1Schema`).
- Zero server/shared/migration files touched; `npm run check` 0 TS errors; ESLint clean; a11y (aria-expanded keyboard expansion, labeled copy action, reduced-motion) per D-D.

Remaining Plan 6 wave: 6.6 activation-after-reconciliation (operational gates + human flag decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h