### PR TITLE
feat(ui): shared evidence primitives and badge delegation (Plan 9 wave 9A)

### DIFF
--- a/client/src/components/fund-results/DecisionStateBadge.tsx
+++ b/client/src/components/fund-results/DecisionStateBadge.tsx
@@ -34,11 +34,14 @@ export function DecisionStateBadge({
   const resolvedLabel = label ?? CANONICAL_LABELS[state];
   // D-A quiet badge: actionable = full ink; everything else = muted label.
   const labelClass = state === 'actionable' ? 'text-pov-charcoal' : 'text-presson-textMuted';
-  const hasDetails = details !== undefined && details.length > 0;
+  // An explicitly supplied details array (even empty) keeps the badge
+  // tooltip-bearing and focusable (review P3-4: parity with the
+  // pre-delegation MOIC badge, whose trigger was unconditional).
+  const tooltipBearing = details !== undefined;
 
   const badge = (
     <span
-      {...(hasDetails ? { tabIndex: 0 } : {})}
+      {...(tooltipBearing ? { tabIndex: 0 } : {})}
       {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
       className={`inline-flex items-center gap-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2 ${labelClass}`}
     >
@@ -59,7 +62,7 @@ export function DecisionStateBadge({
     </span>
   );
 
-  if (!hasDetails) {
+  if (!tooltipBearing) {
     return badge;
   }
 

--- a/client/src/components/fund-results/DecisionStateBadge.tsx
+++ b/client/src/components/fund-results/DecisionStateBadge.tsx
@@ -1,0 +1,80 @@
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+/**
+ * The single generic renderer for decision-state badges (design decision D-G).
+ * Knows nothing about MOIC/FMV/facts semantics: domain surfaces map their own
+ * vocabulary (labels, remediation copy) onto these three generic states.
+ */
+export type DecisionState = 'actionable' | 'indicative' | 'not_actionable';
+
+export interface DecisionStateBadgeProps {
+  state: DecisionState;
+  /** Domain label override; defaults to the canonical state label. */
+  label?: string;
+  /** Remediation/reason copy shown in a keyboard-reachable tooltip, in order. */
+  details?: readonly string[];
+  ariaLabel?: string;
+  /** Prefix for data-testid hooks (`<prefix>-dot`). */
+  testIdPrefix?: string;
+}
+
+const CANONICAL_LABELS: Record<DecisionState, string> = {
+  actionable: 'Actionable',
+  indicative: 'Indicative',
+  not_actionable: 'Not actionable',
+};
+
+export function DecisionStateBadge({
+  state,
+  label,
+  details,
+  ariaLabel,
+  testIdPrefix = 'decision-state',
+}: DecisionStateBadgeProps) {
+  const resolvedLabel = label ?? CANONICAL_LABELS[state];
+  // D-A quiet badge: actionable = full ink; everything else = muted label.
+  const labelClass = state === 'actionable' ? 'text-pov-charcoal' : 'text-presson-textMuted';
+  const hasDetails = details !== undefined && details.length > 0;
+
+  const badge = (
+    <span
+      {...(hasDetails ? { tabIndex: 0 } : {})}
+      {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
+      className={`inline-flex items-center gap-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2 ${labelClass}`}
+    >
+      {state === 'indicative' ? (
+        <span
+          aria-hidden="true"
+          data-testid={`${testIdPrefix}-dot`}
+          className="h-2 w-2 rounded-full border border-warning/50 bg-warning/10"
+        />
+      ) : state === 'not_actionable' ? (
+        <span
+          aria-hidden="true"
+          data-testid={`${testIdPrefix}-dot`}
+          className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
+        />
+      ) : null}
+      {resolvedLabel}
+    </span>
+  );
+
+  if (!hasDetails) {
+    return badge;
+  }
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>{badge}</TooltipTrigger>
+        <TooltipContent className="max-w-sm motion-reduce:animate-none motion-reduce:transition-none">
+          <ul className="space-y-1">
+            {details.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/client/src/components/fund-results/FinancialEvidenceDrawer.tsx
+++ b/client/src/components/fund-results/FinancialEvidenceDrawer.tsx
@@ -1,0 +1,239 @@
+import { useState } from 'react';
+import type { ReactNode, RefObject } from 'react';
+import { Button } from '@/components/ui/button';
+import { WorkPanel } from '@/components/work-panel/WorkPanel';
+import { DecisionStateBadge, type DecisionState } from './DecisionStateBadge';
+import type { FinancialEvidence } from './financial-evidence';
+
+export type FinancialEvidenceDrawerStatus = 'ready' | 'loading' | 'empty' | 'failed';
+
+export interface FinancialEvidenceDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entityLabel: string;
+  /** Presentation state (AMENDMENT 6 model). Defaults to 'ready'. */
+  status?: FinancialEvidenceDrawerStatus;
+  /** Reason copy for the failed state; never rendered blank. */
+  statusReason?: string;
+  /** Non-null REQUIRED when status='ready'; may be null otherwise. */
+  evidence: FinancialEvidence | null;
+  decisionState: DecisionState;
+  /** Inline primary reason rendered next to the decision-state badge. */
+  decisionReason?: string;
+  /** Domain noun for the empty state ("No <noun> disclosed"). */
+  factsDomainNoun?: string;
+  /** Exactly one proof region; the consuming surface passes it. The panel NEVER fetches. */
+  proofSlot?: ReactNode;
+  /** AMENDMENT 8: focus is restored to this element when the panel closes. */
+  returnFocusRef?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * D-D content-transition cap: drawer-owned classes cap the sheet slide at
+ * 200ms (tailwind-merge keeps the last same-variant duration class). The
+ * shared overlay fade stays on the Sheet defaults -- an accepted, logged
+ * deviation (AMENDMENT 7) pending global duration normalization.
+ */
+const DRAWER_TRANSITION_CAP = 'data-[state=closed]:duration-200 data-[state=open]:duration-200';
+
+function EvidenceField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs uppercase text-presson-textMuted">{label}</div>
+      <div className="mt-1 text-pov-charcoal">{children}</div>
+    </div>
+  );
+}
+
+function HashField({
+  label,
+  hash,
+  copyLabel,
+}: {
+  label: string;
+  hash: string | null;
+  copyLabel: string;
+}) {
+  return (
+    <EvidenceField label={label}>
+      {hash === null ? (
+        'Not disclosed'
+      ) : (
+        <span className="flex flex-wrap items-center gap-2">
+          <code className="text-xs tabular-nums text-pov-charcoal">{hash.slice(0, 12)}</code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs text-pov-charcoal"
+            aria-label={copyLabel}
+            onClick={() => {
+              if (!navigator.clipboard) {
+                return;
+              }
+              void navigator.clipboard.writeText(hash).catch(() => undefined);
+            }}
+          >
+            Copy full hash
+          </Button>
+        </span>
+      )}
+    </EvidenceField>
+  );
+}
+
+function LoadingBody() {
+  return (
+    <div className="space-y-3 text-sm">
+      <p className="text-xs text-presson-textMuted">resolving evidence…</p>
+      <div className="space-y-2">
+        {[0, 1, 2].map((row) => (
+          <div
+            key={row}
+            data-testid="evidence-skeleton-row"
+            className="animate-pulse rounded bg-beige-200 motion-reduce:animate-none"
+          >
+            <span aria-hidden="true" className="text-xs tabular-nums text-transparent">
+              000000000000
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function FinancialEvidenceDrawer({
+  open,
+  onOpenChange,
+  entityLabel,
+  status = 'ready',
+  statusReason,
+  evidence,
+  decisionState,
+  decisionReason,
+  factsDomainNoun = 'facts',
+  proofSlot,
+  returnFocusRef,
+}: FinancialEvidenceDrawerProps) {
+  const [provenanceOpen, setProvenanceOpen] = useState(false);
+  const failed = status === 'failed';
+  // D-C: facts FAILED presents as not_actionable, never success-colored.
+  const badgeState: DecisionState = failed ? 'not_actionable' : decisionState;
+  const inlineReason = failed ? statusReason : decisionReason;
+
+  const headerSlot = (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1">
+      {evidence?.asOfDate ? (
+        <span className="text-xs text-presson-textMuted">
+          As of <span className="tabular-nums">{evidence.asOfDate}</span>
+        </span>
+      ) : null}
+      <span className="flex items-center gap-1.5">
+        <span className="text-xs uppercase text-presson-textMuted">Decision state</span>
+        <DecisionStateBadge
+          state={badgeState}
+          testIdPrefix="evidence-decision"
+          {...(failed ? { label: 'Facts unavailable' } : {})}
+        />
+      </span>
+      {inlineReason ? <span className="text-xs text-presson-textMuted">{inlineReason}</span> : null}
+    </div>
+  );
+
+  let body: ReactNode = null;
+  if (status === 'loading') {
+    body = <LoadingBody />;
+  } else if (status === 'failed') {
+    body = (
+      <div className="space-y-2 text-sm">
+        <p className="font-medium text-pov-charcoal">Facts unavailable</p>
+        {statusReason ? <p className="text-presson-textMuted">{statusReason}</p> : null}
+      </div>
+    );
+  } else if (status === 'empty') {
+    // The as-of date (when available) is disclosed in the header slot above.
+    body = <p className="text-sm text-presson-textMuted">No {factsDomainNoun} disclosed</p>;
+  } else if (evidence !== null) {
+    body = (
+      <div className="space-y-4 text-sm">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceField label="Source">{evidence.source}</EvidenceField>
+          <EvidenceField label="Contract version">{evidence.contractVersion}</EvidenceField>
+          <EvidenceField label="Source version">
+            {evidence.sourceVersion ?? 'Unavailable'}
+          </EvidenceField>
+          <EvidenceField label="Trust state">{evidence.trustState}</EvidenceField>
+          <EvidenceField label="Currency status">
+            {evidence.currencyStatus ?? 'Unavailable'}
+          </EvidenceField>
+        </div>
+        {proofSlot !== undefined ? (
+          <section
+            aria-label={`${entityLabel} facts basis`}
+            className="border-t border-beige-200 pt-3"
+          >
+            <h3 className="text-xs font-semibold uppercase text-pov-charcoal">Facts basis</h3>
+            <div className="mt-2">{proofSlot}</div>
+          </section>
+        ) : null}
+        <div className="border-t border-beige-200 pt-3">
+          <div className="text-xs uppercase text-presson-textMuted">Warnings</div>
+          {evidence.warnings.length > 0 ? (
+            <ul className="mt-1 list-disc space-y-1 pl-5 text-xs text-presson-textMuted">
+              {evidence.warnings.map((warning, index) => (
+                <li key={`${warning.code}-${index}`}>{warning.message}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-1 text-xs text-presson-textMuted">None</p>
+          )}
+        </div>
+        <div className="border-t border-beige-200 pt-3">
+          <button
+            type="button"
+            aria-expanded={provenanceOpen}
+            className="text-xs font-semibold uppercase text-pov-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2"
+            onClick={() => setProvenanceOpen((current) => !current)}
+          >
+            Provenance
+          </button>
+          {provenanceOpen ? (
+            <div className="mt-2 grid gap-3 sm:grid-cols-2">
+              <HashField
+                label="Facts input hash"
+                hash={evidence.factsInputHash}
+                copyLabel={`Copy full facts input hash for ${entityLabel}`}
+              />
+              <HashField
+                label="Assumptions hash"
+                hash={evidence.assumptionsHash}
+                copyLabel={`Copy full assumptions hash for ${entityLabel}`}
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <WorkPanel
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title={entityLabel}
+      className={DRAWER_TRANSITION_CAP}
+      headerSlot={headerSlot}
+      {...(returnFocusRef
+        ? {
+            onCloseAutoFocus: (event: Event) => {
+              event.preventDefault();
+              returnFocusRef.current?.focus();
+            },
+          }
+        : {})}
+    >
+      {body}
+    </WorkPanel>
+  );
+}

--- a/client/src/components/fund-results/FinancialEvidenceDrawer.tsx
+++ b/client/src/components/fund-results/FinancialEvidenceDrawer.tsx
@@ -7,16 +7,10 @@ import type { FinancialEvidence } from './financial-evidence';
 
 export type FinancialEvidenceDrawerStatus = 'ready' | 'loading' | 'empty' | 'failed';
 
-export interface FinancialEvidenceDrawerProps {
+interface FinancialEvidenceDrawerBaseProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   entityLabel: string;
-  /** Presentation state (AMENDMENT 6 model). Defaults to 'ready'. */
-  status?: FinancialEvidenceDrawerStatus;
-  /** Reason copy for the failed state; never rendered blank. */
-  statusReason?: string;
-  /** Non-null REQUIRED when status='ready'; may be null otherwise. */
-  evidence: FinancialEvidence | null;
   decisionState: DecisionState;
   /** Inline primary reason rendered next to the decision-state badge. */
   decisionReason?: string;
@@ -27,6 +21,21 @@ export interface FinancialEvidenceDrawerProps {
   /** AMENDMENT 8: focus is restored to this element when the panel closes. */
   returnFocusRef?: RefObject<HTMLElement | null>;
 }
+
+/**
+ * Presentation state (AMENDMENT 6 model), discriminated so the compiler
+ * rejects the blank-drawer combinations (review P2-1): 'ready' (the default)
+ * REQUIRES non-null evidence, and 'failed' REQUIRES a statusReason.
+ */
+export type FinancialEvidenceDrawerProps = FinancialEvidenceDrawerBaseProps &
+  (
+    | { status?: 'ready'; evidence: FinancialEvidence; statusReason?: string }
+    | { status: 'loading' | 'empty'; evidence: FinancialEvidence | null; statusReason?: string }
+    | { status: 'failed'; evidence: FinancialEvidence | null; statusReason: string }
+  );
+
+/** Runtime backstop so the failed state never renders a blank reason (D-C). */
+const FALLBACK_FAILED_REASON = 'No failure reason disclosed.';
 
 /**
  * D-D content-transition cap: drawer-owned classes cap the sheet slide at
@@ -65,7 +74,7 @@ function HashField({
             type="button"
             variant="ghost"
             size="sm"
-            className="h-7 px-2 text-xs text-pov-charcoal"
+            className="h-7 px-2 text-xs text-pov-charcoal motion-reduce:transition-none"
             aria-label={copyLabel}
             onClick={() => {
               if (!navigator.clipboard) {
@@ -120,7 +129,11 @@ export function FinancialEvidenceDrawer({
   const failed = status === 'failed';
   // D-C: facts FAILED presents as not_actionable, never success-colored.
   const badgeState: DecisionState = failed ? 'not_actionable' : decisionState;
-  const inlineReason = failed ? statusReason : decisionReason;
+  const failedReason =
+    statusReason !== undefined && statusReason.trim() !== ''
+      ? statusReason
+      : FALLBACK_FAILED_REASON;
+  const inlineReason = failed ? failedReason : decisionReason;
 
   const headerSlot = (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1">
@@ -148,7 +161,7 @@ export function FinancialEvidenceDrawer({
     body = (
       <div className="space-y-2 text-sm">
         <p className="font-medium text-pov-charcoal">Facts unavailable</p>
-        {statusReason ? <p className="text-presson-textMuted">{statusReason}</p> : null}
+        <p className="text-presson-textMuted">{failedReason}</p>
       </div>
     );
   } else if (status === 'empty') {
@@ -159,9 +172,11 @@ export function FinancialEvidenceDrawer({
       <div className="space-y-4 text-sm">
         <div className="grid gap-3 sm:grid-cols-2">
           <EvidenceField label="Source">{evidence.source}</EvidenceField>
-          <EvidenceField label="Contract version">{evidence.contractVersion}</EvidenceField>
+          <EvidenceField label="Contract version">
+            <span className="tabular-nums">{evidence.contractVersion}</span>
+          </EvidenceField>
           <EvidenceField label="Source version">
-            {evidence.sourceVersion ?? 'Unavailable'}
+            <span className="tabular-nums">{evidence.sourceVersion ?? 'Unavailable'}</span>
           </EvidenceField>
           <EvidenceField label="Trust state">{evidence.trustState}</EvidenceField>
           <EvidenceField label="Currency status">
@@ -227,8 +242,13 @@ export function FinancialEvidenceDrawer({
       {...(returnFocusRef
         ? {
             onCloseAutoFocus: (event: Event) => {
-              event.preventDefault();
-              returnFocusRef.current?.focus();
+              // Review P2-2: only take over restoration when there is a
+              // connected target; otherwise leave Radix's default intact.
+              const target = returnFocusRef.current;
+              if (target && target.isConnected) {
+                event.preventDefault();
+                target.focus();
+              }
             },
           }
         : {})}

--- a/client/src/components/fund-results/FundForecastModeSelector.tsx
+++ b/client/src/components/fund-results/FundForecastModeSelector.tsx
@@ -1,0 +1,123 @@
+import { Button } from '@/components/ui/button';
+import type { ForecastBasis, ScenarioOverlay } from './financial-evidence';
+
+const BASIS_LABELS: Record<ForecastBasis, string> = {
+  construction: 'Construction',
+  current: 'Current',
+};
+
+const BASES: readonly ForecastBasis[] = ['construction', 'current'];
+
+export interface ForecastBasisControlProps {
+  value: ForecastBasis;
+  onChange?: (basis: ForecastBasis) => void;
+  /** Per-basis disable reason; a disabled basis always shows its reason (D-C). */
+  disabledBases?: Partial<Record<ForecastBasis, string>>;
+  /** Locked by an applied scenario overlay; shows the lock reason. */
+  locked?: boolean;
+  /** 'indicator' renders the static "Basis: <x>" form for single-basis surfaces. */
+  variant?: 'segmented' | 'indicator';
+}
+
+/**
+ * Ink-only segmented control for the two-axis forecast model (D-E). Selected
+ * state uses the charcoal accent, never a status hue. Controlled and pure --
+ * URL/data wiring happens in Wave 9B1.
+ */
+export function ForecastBasisControl({
+  value,
+  onChange,
+  disabledBases,
+  locked = false,
+  variant = 'segmented',
+}: ForecastBasisControlProps) {
+  if (variant === 'indicator') {
+    return (
+      <p className="text-xs font-medium text-pov-charcoal">{`Basis: ${BASIS_LABELS[value]}`}</p>
+    );
+  }
+
+  const disabledReasons = BASES.flatMap((basis) => {
+    const reason = disabledBases?.[basis];
+    return reason === undefined ? [] : [{ basis, reason }];
+  });
+
+  return (
+    <div>
+      <span className="text-xs uppercase text-presson-textMuted">Forecast basis</span>
+      <div
+        role="radiogroup"
+        aria-label="Forecast basis"
+        className="mt-1 inline-flex items-center gap-0.5 rounded-md border border-beige-200 p-0.5"
+      >
+        {BASES.map((basis) => {
+          const selected = value === basis;
+          const disabled = locked || disabledBases?.[basis] !== undefined;
+          return (
+            <button
+              key={basis}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              disabled={disabled}
+              onClick={() => {
+                if (!selected) {
+                  onChange?.(basis);
+                }
+              }}
+              className={`rounded px-3 py-1 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+                selected
+                  ? 'bg-pov-charcoal text-pov-white'
+                  : 'text-presson-textMuted hover:text-pov-charcoal'
+              }`}
+            >
+              {BASIS_LABELS[basis]}
+            </button>
+          );
+        })}
+      </div>
+      {locked ? (
+        <p className="mt-1 text-xs text-presson-textMuted">Locked by selected scenario</p>
+      ) : null}
+      {disabledReasons.map(({ basis, reason }) => (
+        <p key={basis} className="mt-1 text-xs text-presson-textMuted">
+          {`${BASIS_LABELS[basis]}: ${reason}`}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export interface ScenarioOverlayControlProps {
+  overlay: ScenarioOverlay;
+  onClear: () => void;
+}
+
+/**
+ * Discloses the applied saved-scenario overlay (D-E). NEVER renders a scenario
+ * without its basis label; renders nothing when no overlay is applied.
+ */
+export function ScenarioOverlayControl({ overlay, onClear }: ScenarioOverlayControlProps) {
+  if (overlay.kind !== 'saved') {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <p className="text-xs text-presson-textMuted">
+        {`Scenario: ${overlay.name} — based on ${BASIS_LABELS[overlay.baseBasis]} · as of `}
+        <span className="tabular-nums">{overlay.baseAsOfDate}</span>
+      </p>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 px-2 text-xs text-pov-charcoal"
+        aria-label={`Clear scenario ${overlay.name}`}
+        onClick={onClear}
+      >
+        Clear
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/fund-results/FundForecastModeSelector.tsx
+++ b/client/src/components/fund-results/FundForecastModeSelector.tsx
@@ -112,7 +112,7 @@ export function ScenarioOverlayControl({ overlay, onClear }: ScenarioOverlayCont
         type="button"
         variant="ghost"
         size="sm"
-        className="h-7 px-2 text-xs text-pov-charcoal"
+        className="h-7 px-2 text-xs text-pov-charcoal motion-reduce:transition-none"
         aria-label={`Clear scenario ${overlay.name}`}
         onClick={onClear}
       >

--- a/client/src/components/fund-results/financial-evidence.ts
+++ b/client/src/components/fund-results/financial-evidence.ts
@@ -53,6 +53,25 @@ export interface FundResultsViewState {
   overlay: ScenarioOverlay;
 }
 
+/**
+ * Validating factory for FundResultsViewState. Encodes the D-E invariant
+ * `overlay.kind === 'saved' ? basis === overlay.baseBasis : true` at the one
+ * construction point (review P2-3); throws on a mismatched saved overlay.
+ * The plain interface stays exported for backward-compatible 9B use.
+ */
+export function createFundResultsViewState(
+  basis: ForecastBasis,
+  overlay: ScenarioOverlay
+): FundResultsViewState {
+  if (overlay.kind === 'saved' && overlay.baseBasis !== basis) {
+    throw new Error(
+      `FundResultsViewState invariant violated: basis '${basis}' must equal ` +
+        `overlay.baseBasis '${overlay.baseBasis}' while a saved scenario overlay is applied`
+    );
+  }
+  return { basis, overlay };
+}
+
 const TRUST_STATE_WORST_FIRST = ['FAILED', 'UNAVAILABLE', 'PARTIAL', 'LIVE'] as const;
 
 function worstTrustState(counts: DualForecastTrustCounts): string {
@@ -152,7 +171,8 @@ export function evidenceFromScenarioComparison(
  */
 export interface MoicBasisEvidenceSource {
   rankability: 'actionable' | 'indicative' | 'not_actionable';
-  currencyStatus: string;
+  /** FundCompanyActualsCurrencyStatusSchema vocabulary, restated structurally (review P3-7). */
+  currencyStatus: 'base_currency' | 'mismatch_blocked' | 'unknown';
   factsInputHash: string | null;
   warnings: StructuredWarning[];
 }

--- a/client/src/components/fund-results/financial-evidence.ts
+++ b/client/src/components/fund-results/financial-evidence.ts
@@ -1,0 +1,178 @@
+/**
+ * financial-evidence -- the shared evidence value object rendered by
+ * FinancialEvidenceDrawer, the two-axis forecast view-state model, and the
+ * pure adapters that map source contracts onto FinancialEvidence.
+ *
+ * Adapters follow the Plan 9 Wave 9A Adapter Mapping Policy: every field is
+ * either mapped verbatim from the source contract's own vocabulary or set to
+ * null/[] -- nothing is invented. This module knows NOTHING about the MOIC
+ * domain (see no-moic-imports.test.tsx); the MOIC adapter accepts a local
+ * structural slice instead of the MOIC contract type.
+ *
+ * @module client/components/fund-results/financial-evidence
+ */
+
+import {
+  DUAL_FORECAST_CONTRACT_VERSION,
+  type DualForecastResponse,
+  type DualForecastTrustCounts,
+} from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
+import type {
+  FundScenarioComparisonV1,
+  ScenarioComparisonStalenessV1,
+} from '@shared/contracts/fund-scenario-comparison-v1.contract';
+import type { StructuredWarning } from '@shared/contracts/provenance-envelope.contract';
+import { comparisonEvidenceState } from './scenario-comparison-evidence';
+
+export interface FinancialEvidence {
+  source: string;
+  asOfDate: string | null;
+  contractVersion: string;
+  sourceVersion: string | null;
+  factsInputHash: string | null;
+  assumptionsHash: string | null;
+  trustState: string;
+  currencyStatus: string | null;
+  warnings: StructuredWarning[];
+}
+
+export type ForecastBasis = 'construction' | 'current';
+export type ScenarioOverlay =
+  | { kind: 'none' }
+  | {
+      kind: 'saved';
+      scenarioSetId: string;
+      variantId: string | null;
+      name: string;
+      baseBasis: ForecastBasis;
+      baseInputHash: string;
+      baseAsOfDate: string;
+    };
+export interface FundResultsViewState {
+  basis: ForecastBasis;
+  overlay: ScenarioOverlay;
+}
+
+const TRUST_STATE_WORST_FIRST = ['FAILED', 'UNAVAILABLE', 'PARTIAL', 'LIVE'] as const;
+
+function worstTrustState(counts: DualForecastTrustCounts): string {
+  for (const state of TRUST_STATE_WORST_FIRST) {
+    if (counts[state] > 0) {
+      return state;
+    }
+  }
+  // AMENDMENT 8: an all-zero count map is a valid empty facts universe with
+  // no trusted dataset, pinned to UNAVAILABLE.
+  return 'UNAVAILABLE';
+}
+
+/**
+ * Maps a dual-forecast response onto FinancialEvidence. Without a companyId
+ * the trust state is worst-state-wins over the ADR-030 counts rollup; with a
+ * companyId it is that company's own dataset trust state. The top-level
+ * string[] warnings are deliberately excluded -- only StructuredWarning-typed
+ * warnings at the mapped level are carried.
+ */
+export function evidenceFromDualForecast(
+  response: DualForecastResponse,
+  companyId?: number
+): FinancialEvidence {
+  const facts = response.actualsFacts;
+  const base = {
+    source: response.config.source,
+    asOfDate: response.asOfDate,
+    contractVersion: String(DUAL_FORECAST_CONTRACT_VERSION),
+    sourceVersion: response.config.version === null ? null : String(response.config.version),
+    assumptionsHash: null,
+    currencyStatus: null,
+  };
+
+  if (companyId !== undefined) {
+    const company = facts?.companies.find((entry) => entry.companyId === companyId);
+    if (facts === null || company === undefined) {
+      // AMENDMENT 6 ratified fallback: no matching facts entry for the company.
+      return { ...base, factsInputHash: null, trustState: 'UNAVAILABLE', warnings: [] };
+    }
+    return {
+      ...base,
+      factsInputHash: facts.inputHash,
+      trustState: company.trustState,
+      currencyStatus: company.currencyStatus,
+      warnings: company.warnings,
+    };
+  }
+
+  // AMENDMENT 6 ratified fallback: navAnchoring null is the contract-documented
+  // facts-fetch-failure case and reads FAILED.
+  const trustState =
+    response.navAnchoring === null
+      ? 'FAILED'
+      : worstTrustState(response.navAnchoring.countsByTrustState);
+  return {
+    ...base,
+    factsInputHash: facts === null ? null : facts.inputHash,
+    trustState,
+    warnings: facts === null ? [] : facts.warnings,
+  };
+}
+
+/**
+ * Maps a scenario comparison onto FinancialEvidence. Exposes the evidence
+ * state and source config version only; asOfDate and hashes stay null per the
+ * Adapter Mapping Policy. The explicit staleness argument overrides the
+ * comparison's own staleness when provided (callers normally pass
+ * `comparison.staleness`), reusing the shipped comparisonEvidenceState so the
+ * surfaces never drift.
+ */
+export function evidenceFromScenarioComparison(
+  comparison: FundScenarioComparisonV1,
+  staleness: ScenarioComparisonStalenessV1 | null
+): FinancialEvidence {
+  const trustState = comparisonEvidenceState(
+    staleness === null ? comparison : { ...comparison, staleness }
+  );
+  return {
+    source: 'scenario_comparison',
+    asOfDate: null,
+    contractVersion: 'fund-scenario-comparison-v1',
+    sourceVersion: String(comparison.scenarioSet.sourceConfigVersion),
+    factsInputHash: null,
+    assumptionsHash: null,
+    trustState,
+    currencyStatus: null,
+    warnings: [],
+  };
+}
+
+/**
+ * Structural slice of the MOIC facts basis needed for evidence mapping.
+ * Deliberately NOT imported from the MOIC contract: fund-results primitives
+ * stay decoupled from the MOIC domain (no-moic-imports.test.tsx enforces
+ * this). FundMoicFactsBasisV1 is structurally assignable to this shape.
+ */
+export interface MoicBasisEvidenceSource {
+  rankability: 'actionable' | 'indicative' | 'not_actionable';
+  currencyStatus: string;
+  factsInputHash: string | null;
+  warnings: StructuredWarning[];
+}
+
+/**
+ * Maps a MOIC facts basis onto FinancialEvidence. trustState is the basis
+ * contract's own rankability state, verbatim. The basis carries no top-level
+ * as-of date (the valuation anchor's asOfDate is anchor-specific), so asOfDate
+ * is null per the Adapter Mapping Policy.
+ */
+export function evidenceFromMoicBasis(basis: MoicBasisEvidenceSource): FinancialEvidence {
+  return {
+    source: 'fund_moic_facts',
+    asOfDate: null,
+    contractVersion: 'fund-moic-v1',
+    sourceVersion: null,
+    factsInputHash: basis.factsInputHash,
+    assumptionsHash: null,
+    trustState: basis.rankability,
+    currencyStatus: basis.currencyStatus,
+    warnings: basis.warnings,
+  };
+}

--- a/client/src/components/fund-results/index.ts
+++ b/client/src/components/fund-results/index.ts
@@ -20,6 +20,7 @@ export { DecisionStateBadge } from './DecisionStateBadge';
 export { FinancialEvidenceDrawer } from './FinancialEvidenceDrawer';
 export { ForecastBasisControl, ScenarioOverlayControl } from './FundForecastModeSelector';
 export {
+  createFundResultsViewState,
   evidenceFromDualForecast,
   evidenceFromMoicBasis,
   evidenceFromScenarioComparison,

--- a/client/src/components/fund-results/index.ts
+++ b/client/src/components/fund-results/index.ts
@@ -16,6 +16,14 @@ export {
 } from './CrossSetScenarioComparisonTable';
 export { ScenarioSetsSummary } from './ScenarioSetsSummary';
 export { EngineMetricsGrid } from './EngineMetricsGrid';
+export { DecisionStateBadge } from './DecisionStateBadge';
+export { FinancialEvidenceDrawer } from './FinancialEvidenceDrawer';
+export { ForecastBasisControl, ScenarioOverlayControl } from './FundForecastModeSelector';
+export {
+  evidenceFromDualForecast,
+  evidenceFromMoicBasis,
+  evidenceFromScenarioComparison,
+} from './financial-evidence';
 
 export type { FundModelScorecardProps } from './FundModelScorecard';
 export type { ReserveAllocationBreakdownProps } from './ReserveAllocationBreakdown';
@@ -24,3 +32,19 @@ export type { CrossSetScenarioComparisonTableProps } from './CrossSetScenarioCom
 export type { FundScenarioComparisonV1 } from '@shared/contracts/fund-scenario-comparison-v1.contract';
 export type { ScenarioSetsSummaryProps } from './ScenarioSetsSummary';
 export type { EngineMetricsGridProps } from './EngineMetricsGrid';
+export type { DecisionState, DecisionStateBadgeProps } from './DecisionStateBadge';
+export type {
+  FinancialEvidenceDrawerProps,
+  FinancialEvidenceDrawerStatus,
+} from './FinancialEvidenceDrawer';
+export type {
+  ForecastBasisControlProps,
+  ScenarioOverlayControlProps,
+} from './FundForecastModeSelector';
+export type {
+  FinancialEvidence,
+  ForecastBasis,
+  FundResultsViewState,
+  MoicBasisEvidenceSource,
+  ScenarioOverlay,
+} from './financial-evidence';

--- a/client/src/components/moic/MoicBasisDisclosure.tsx
+++ b/client/src/components/moic/MoicBasisDisclosure.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { DecisionStateBadge } from '@/components/fund-results/DecisionStateBadge';
 import type { FundMoicFactsBasisV1 } from '@shared/contracts/fund-moic-v1.contract';
 
 interface MoicBasisDisclosureProps {
@@ -78,52 +78,29 @@ function reasonCopy(basis: FundMoicFactsBasisV1 | null): string[] {
     : basis.reasons.map((reason) => REASON_COPY[reason]);
 }
 
+/**
+ * Thin domain adapter over the generic DecisionStateBadge (design decision
+ * D-G): `facts_unavailable` is a MOIC domain LABEL mapped onto the
+ * not_actionable presentation, not a fourth generic state. Remediation copy
+ * keeps the deterministic `basis.reasons` order.
+ */
 export function MoicRankabilityBadge({ basis }: MoicRankabilityBadgeProps) {
-  const rankability = basis?.rankability ?? 'facts_unavailable';
-  const copy = reasonCopy(basis);
-  const label =
-    rankability === 'actionable'
-      ? 'Actionable'
-      : rankability === 'indicative'
-        ? 'Indicative'
-        : rankability === 'not_actionable'
-          ? 'Not actionable'
-          : 'Facts unavailable';
-  const labelClass = rankability === 'actionable' ? 'text-pov-charcoal' : 'text-charcoal-500';
-
+  if (basis === null) {
+    return (
+      <DecisionStateBadge
+        state="not_actionable"
+        label="Facts unavailable"
+        details={[FACTS_UNAVAILABLE_COPY]}
+        testIdPrefix="moic-rankability"
+      />
+    );
+  }
   return (
-    <TooltipProvider delayDuration={0}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            tabIndex={0}
-            className={`inline-flex items-center gap-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2 ${labelClass}`}
-          >
-            {rankability === 'indicative' ? (
-              <span
-                aria-hidden="true"
-                data-testid="moic-rankability-dot"
-                className="h-2 w-2 rounded-full border border-warning/50 bg-warning/10 text-warning-dark"
-              />
-            ) : rankability === 'not_actionable' || rankability === 'facts_unavailable' ? (
-              <span
-                aria-hidden="true"
-                data-testid="moic-rankability-dot"
-                className="h-2 w-2 rounded-full border border-charcoal-400 bg-transparent"
-              />
-            ) : null}
-            {label}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent className="max-w-sm motion-reduce:animate-none motion-reduce:transition-none">
-          <ul className="space-y-1">
-            {copy.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <DecisionStateBadge
+      state={basis.rankability}
+      details={reasonCopy(basis)}
+      testIdPrefix="moic-rankability"
+    />
   );
 }
 

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none',
       className
     )}
     {...props}
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 motion-reduce:transition-none motion-reduce:animate-none',
   {
     variants: {
       side: {
@@ -60,7 +60,7 @@ const SheetContent = React.forwardRef<
     <SheetOverlay />
     <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity motion-reduce:transition-none hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/client/src/components/work-panel/WorkPanel.tsx
+++ b/client/src/components/work-panel/WorkPanel.tsx
@@ -15,6 +15,8 @@ export function WorkPanel({
   description,
   children,
   className,
+  headerSlot,
+  onCloseAutoFocus,
 }: {
   open: boolean;
   onClose: () => void;
@@ -22,6 +24,10 @@ export function WorkPanel({
   description?: string;
   children: ReactNode;
   className?: string;
+  /** AMENDMENT 8 (Plan 9 Wave 9A) additive: rendered inside the sheet header after the title row. */
+  headerSlot?: ReactNode;
+  /** AMENDMENT 8 (Plan 9 Wave 9A) additive: forwarded to the sheet content. */
+  onCloseAutoFocus?: (event: Event) => void;
 }) {
   return (
     <Sheet
@@ -34,12 +40,14 @@ export function WorkPanel({
         side="right"
         className={cn('w-full overflow-y-auto p-0 sm:max-w-xl md:max-w-2xl', className)}
         {...(description ? {} : { 'aria-describedby': undefined })}
+        {...(onCloseAutoFocus ? { onCloseAutoFocus } : {})}
       >
         <SheetHeader className="border-b border-beige-200 px-6 py-4 text-left">
           <SheetTitle className="text-charcoal-900">{title}</SheetTitle>
           {description ? (
             <SheetDescription className="text-charcoal-600">{description}</SheetDescription>
           ) : null}
+          {headerSlot ?? null}
         </SheetHeader>
         <div className="px-6 py-4">{children}</div>
       </SheetContent>

--- a/tests/unit/components/fund-results/decision-state-badge.test.tsx
+++ b/tests/unit/components/fund-results/decision-state-badge.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DecisionStateBadge } from '@/components/fund-results/DecisionStateBadge';
+
+describe('DecisionStateBadge', () => {
+  it('renders the actionable state as a full-ink label with no dot', () => {
+    render(<DecisionStateBadge state="actionable" />);
+
+    const label = screen.getByText('Actionable');
+    expect(label).toHaveClass('text-pov-charcoal');
+    expect(screen.queryByTestId('decision-state-dot')).not.toBeInTheDocument();
+  });
+
+  it('renders the indicative state as a muted label with an amber dot', () => {
+    render(<DecisionStateBadge state="indicative" />);
+
+    expect(screen.getByText('Indicative')).toHaveClass('text-presson-textMuted');
+    const dot = screen.getByTestId('decision-state-dot');
+    expect(dot).toHaveClass('border-warning/50', 'bg-warning/10');
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders the not-actionable state as a muted label with a hollow dot', () => {
+    render(<DecisionStateBadge state="not_actionable" />);
+
+    expect(screen.getByText('Not actionable')).toHaveClass('text-presson-textMuted');
+    const dot = screen.getByTestId('decision-state-dot');
+    expect(dot).toHaveClass('border-charcoal-400', 'bg-transparent');
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('never renders forbidden status classes in any state', () => {
+    const forbidden = /success|positive|confidence-|charcoal-500|warning-dark|#10b981|#127E3D/;
+    for (const state of ['actionable', 'indicative', 'not_actionable'] as const) {
+      const { container, unmount } = render(
+        <DecisionStateBadge state={state} details={['Reason copy.']} />
+      );
+      expect(container.innerHTML).not.toMatch(forbidden);
+      unmount();
+    }
+  });
+
+  it('keeps the dot aria-hidden inside the visible text label', () => {
+    render(<DecisionStateBadge state="indicative" />);
+
+    const label = screen.getByText('Indicative');
+    const dot = screen.getByTestId('decision-state-dot');
+    expect(dot.parentElement).toBe(label);
+    expect(label).toBeVisible();
+  });
+
+  it('exposes details in a keyboard-reachable tooltip', async () => {
+    render(<DecisionStateBadge state="indicative" details={['First reason.', 'Second reason.']} />);
+
+    const trigger = screen.getByText('Indicative');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+
+    fireEvent.focus(trigger);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('First reason.');
+    expect(tooltip).toHaveTextContent('Second reason.');
+    expect(tooltip.parentElement).toHaveClass(
+      'motion-reduce:animate-none',
+      'motion-reduce:transition-none'
+    );
+  });
+
+  it('preserves the given order of details', async () => {
+    render(
+      <DecisionStateBadge
+        state="not_actionable"
+        details={['Zulu reason.', 'Alpha reason.', 'Mike reason.']}
+      />
+    );
+
+    fireEvent.focus(screen.getByText('Not actionable'));
+    const tooltip = await screen.findByRole('tooltip');
+    const items = Array.from(tooltip.querySelectorAll('li')).map((item) => item.textContent);
+    expect(items).toEqual(['Zulu reason.', 'Alpha reason.', 'Mike reason.']);
+  });
+
+  it('honors label, ariaLabel, and testIdPrefix overrides', () => {
+    render(
+      <DecisionStateBadge
+        state="not_actionable"
+        label="Facts unavailable"
+        ariaLabel="Facts unavailable for Acme"
+        testIdPrefix="acme-facts"
+      />
+    );
+
+    expect(screen.getByText('Facts unavailable')).toBeInTheDocument();
+    expect(screen.getByLabelText('Facts unavailable for Acme')).toBeInTheDocument();
+    expect(screen.getByTestId('acme-facts-dot')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/fund-results/decision-state-badge.test.tsx
+++ b/tests/unit/components/fund-results/decision-state-badge.test.tsx
@@ -81,6 +81,19 @@ describe('DecisionStateBadge', () => {
     expect(items).toEqual(['Zulu reason.', 'Alpha reason.', 'Mike reason.']);
   });
 
+  it('stays tooltip-bearing when an explicitly supplied details array is empty', async () => {
+    // Review P3-4: presentation parity with the pre-delegation badge, which was
+    // unconditionally focusable even when the reason list was empty.
+    render(<DecisionStateBadge state="actionable" details={[]} />);
+
+    const trigger = screen.getByText('Actionable');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+
+    fireEvent.focus(trigger);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip.querySelectorAll('li')).toHaveLength(0);
+  });
+
   it('honors label, ariaLabel, and testIdPrefix overrides', () => {
     render(
       <DecisionStateBadge

--- a/tests/unit/components/fund-results/financial-evidence-drawer.test.tsx
+++ b/tests/unit/components/fund-results/financial-evidence-drawer.test.tsx
@@ -1,0 +1,242 @@
+import React, { useRef, useState } from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FundMoicFactsBasisV1Schema } from '@shared/contracts/fund-moic-v1.contract';
+import { FinancialEvidenceDrawer } from '@/components/fund-results/FinancialEvidenceDrawer';
+import {
+  evidenceFromMoicBasis,
+  type FinancialEvidence,
+} from '@/components/fund-results/financial-evidence';
+
+const FACTS_HASH = 'c'.repeat(64);
+
+/** Evidence derived from a schema-parsed contract fixture via the real adapter. */
+function evidenceFixture(overrides: Partial<FinancialEvidence> = {}): FinancialEvidence {
+  const basis = FundMoicFactsBasisV1Schema.parse({
+    rankability: 'indicative',
+    reasons: ['planning_fmv_stale'],
+    observedInitialInvestment: '1000000.5',
+    observedFollowOnInvestment: '250000',
+    observedTotalInvestment: '1250000.5',
+    valuationAnchor: { kind: 'planning_fmv', value: '4000000', asOfDate: '2026-07-12' },
+    planningFmvStatus: 'stale',
+    currencyStatus: 'base_currency',
+    factsInputHash: FACTS_HASH,
+    warnings: [
+      {
+        code: 'PLANNING_FMV_STALE',
+        severity: 'warning',
+        message: 'Planning FMV is stale.',
+      },
+    ],
+  });
+  return { ...evidenceFromMoicBasis(basis), asOfDate: '2026-07-10', ...overrides };
+}
+
+function assertPrecedes(first: HTMLElement, second: HTMLElement) {
+  expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+}
+
+function DrawerHarness({ evidence }: { evidence: FinancialEvidence }) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button ref={triggerRef} onClick={() => setOpen(true)}>
+        Open evidence
+      </button>
+      <FinancialEvidenceDrawer
+        open={open}
+        onOpenChange={setOpen}
+        entityLabel="Acme Corp"
+        evidence={evidence}
+        decisionState="indicative"
+        returnFocusRef={triggerRef}
+      />
+    </>
+  );
+}
+
+describe('FinancialEvidenceDrawer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a labeled region with the D-B section order and exactly one proof slot', () => {
+    render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        evidence={evidenceFixture()}
+        decisionState="indicative"
+        decisionReason="Planning FMV is stale."
+        proofSlot={<div data-testid="proof-slot-content">proof rows</div>}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Acme Corp' });
+    const utils = within(dialog);
+
+    // (1) header: entity + as-of + labeled decision state + inline primary reason
+    expect(utils.getByText('Acme Corp')).toBeInTheDocument();
+    expect(utils.getByText('2026-07-10')).toHaveClass('tabular-nums');
+    expect(utils.getByText('Decision state')).toBeInTheDocument();
+    const badge = utils.getByText('Indicative');
+    expect(badge).toHaveClass('text-presson-textMuted');
+    expect(utils.getByText('Planning FMV is stale.', { selector: 'span' })).toBeInTheDocument();
+
+    // (2) compact evidence fields
+    expect(utils.getByText('Source')).toBeInTheDocument();
+    expect(utils.getByText('fund_moic_facts')).toBeInTheDocument();
+    expect(utils.getByText('Contract version')).toBeInTheDocument();
+    expect(utils.getByText('fund-moic-v1')).toBeInTheDocument();
+    expect(utils.getByText('Trust state')).toBeInTheDocument();
+    expect(utils.getByText('Currency status')).toBeInTheDocument();
+
+    // (3) exactly one proof slot, headed "Facts basis"
+    expect(utils.getAllByText('Facts basis')).toHaveLength(1);
+    expect(utils.getByTestId('proof-slot-content')).toBeInTheDocument();
+
+    // (4) warnings, (5) provenance LAST as a collapsed disclosure
+    const provenanceToggle = utils.getByRole('button', { name: 'Provenance' });
+    expect(provenanceToggle).toHaveAttribute('aria-expanded', 'false');
+
+    assertPrecedes(badge, utils.getByText('Source'));
+    assertPrecedes(utils.getByText('Source'), utils.getByText('Facts basis'));
+    assertPrecedes(utils.getByText('Facts basis'), utils.getByText('Warnings'));
+    assertPrecedes(utils.getByText('Warnings'), provenanceToggle);
+    expect(utils.getByText('Planning FMV is stale.', { selector: 'li' })).toBeInTheDocument();
+  });
+
+  it('copies the FULL hash while displaying the 12-char short form', async () => {
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: clipboardWrite },
+    });
+
+    render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        evidence={evidenceFixture()}
+        decisionState="indicative"
+      />
+    );
+
+    const provenanceToggle = screen.getByRole('button', { name: 'Provenance' });
+    fireEvent.click(provenanceToggle);
+    expect(provenanceToggle).toHaveAttribute('aria-expanded', 'true');
+
+    expect(screen.getByText(FACTS_HASH.slice(0, 12))).toBeInTheDocument();
+    expect(screen.queryByText(FACTS_HASH)).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Copy full facts input hash for Acme Corp' })
+    );
+    await waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith(FACTS_HASH));
+
+    // assumptionsHash is null -> "Not disclosed" and no copy button for it
+    expect(screen.getByText('Not disclosed')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Copy full assumptions hash for Acme Corp' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape and restores focus to the trigger via returnFocusRef', async () => {
+    const user = userEvent.setup();
+    render(<DrawerHarness evidence={evidenceFixture()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Open evidence' }));
+    await screen.findByRole('dialog', { name: 'Acme Corp' });
+
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Acme Corp' })).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole('button', { name: 'Open evidence' })).toHaveFocus();
+  });
+
+  it('renders the loading state as skeleton rows with tabular-nums placeholders', () => {
+    render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        status="loading"
+        evidence={null}
+        decisionState="indicative"
+      />
+    );
+
+    expect(screen.getByText('resolving evidence…')).toBeInTheDocument();
+    const rows = screen.getAllByTestId('evidence-skeleton-row');
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row).toHaveClass('animate-pulse', 'motion-reduce:animate-none');
+      expect(row.querySelector('.tabular-nums')).not.toBeNull();
+    }
+  });
+
+  it('renders the failed state as not_actionable with the reason, never success-colored', () => {
+    const { container } = render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        status="failed"
+        statusReason="Facts fetch timed out."
+        evidence={null}
+        decisionState="actionable"
+      />
+    );
+
+    expect(screen.getAllByText('Facts unavailable').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Facts fetch timed out.', { selector: 'span' })).toBeInTheDocument();
+    // badge forced to the not_actionable presentation (hollow dot)
+    const dot = screen.getByTestId('evidence-decision-dot');
+    expect(dot).toHaveClass('border-charcoal-400', 'bg-transparent');
+    expect(container.innerHTML).not.toMatch(
+      /success|positive|confidence-|charcoal-500|warning-dark|#10b981|#127E3D/
+    );
+  });
+
+  it('renders the empty state with the facts domain noun and the as-of date', () => {
+    render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        status="empty"
+        factsDomainNoun="cash flows"
+        evidence={evidenceFixture()}
+        decisionState="not_actionable"
+      />
+    );
+
+    expect(screen.getByText(/No cash flows disclosed/)).toBeInTheDocument();
+    expect(screen.getByText('2026-07-10')).toHaveClass('tabular-nums');
+  });
+
+  it('caps drawer content transitions at 200ms and gates them behind motion-reduce', () => {
+    render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        evidence={evidenceFixture()}
+        decisionState="indicative"
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Acme Corp' });
+    expect(dialog.className).toContain('data-[state=open]:duration-200');
+    expect(dialog.className).toContain('data-[state=closed]:duration-200');
+    expect(dialog.className).toContain('motion-reduce:transition-none');
+    expect(dialog.className).toContain('motion-reduce:animate-none');
+  });
+});

--- a/tests/unit/components/fund-results/financial-evidence-drawer.test.tsx
+++ b/tests/unit/components/fund-results/financial-evidence-drawer.test.tsx
@@ -161,6 +161,66 @@ describe('FinancialEvidenceDrawer', () => {
     expect(screen.getByRole('button', { name: 'Open evidence' })).toHaveFocus();
   });
 
+  it('falls back to default focus restoration when returnFocusRef is never attached', async () => {
+    // Review P2-2: a null-current ref must NOT preventDefault (which would
+    // cancel Radix restoration and focus nothing).
+    function NullRefHarness() {
+      const [open, setOpen] = useState(false);
+      const detachedRef = useRef<HTMLElement>(null);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open evidence</button>
+          <FinancialEvidenceDrawer
+            open={open}
+            onOpenChange={setOpen}
+            entityLabel="Acme Corp"
+            evidence={evidenceFixture()}
+            decisionState="indicative"
+            returnFocusRef={detachedRef}
+          />
+        </>
+      );
+    }
+    const user = userEvent.setup();
+    render(<NullRefHarness />);
+
+    await user.click(screen.getByRole('button', { name: 'Open evidence' }));
+    await screen.findByRole('dialog', { name: 'Acme Corp' });
+
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Acme Corp' })).not.toBeInTheDocument()
+    );
+    // With a null-current ref the drawer must NOT preventDefault, leaving
+    // Radix's own close-autofocus default in charge. For a controlled,
+    // triggerless dialog that default focuses its (absent) Radix trigger and
+    // focus settles on the document body -- the close completes cleanly
+    // instead of throwing or leaving focus on a detached node.
+    await waitFor(() => expect(document.body).toHaveFocus());
+  });
+
+  it('renders version values with tabular-nums and motion-reduce-gated copy buttons', () => {
+    render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        evidence={evidenceFixture({ sourceVersion: '4' })}
+        decisionState="indicative"
+      />
+    );
+
+    // Review P3-6: version values are numeric text.
+    expect(screen.getByText('fund-moic-v1')).toHaveClass('tabular-nums');
+    expect(screen.getByText('4')).toHaveClass('tabular-nums');
+
+    // Review P3-5: the copy button inherits transition-colors and must be gated.
+    fireEvent.click(screen.getByRole('button', { name: 'Provenance' }));
+    expect(
+      screen.getByRole('button', { name: 'Copy full facts input hash for Acme Corp' }).className
+    ).toContain('motion-reduce:transition-none');
+  });
+
   it('renders the loading state as skeleton rows with tabular-nums placeholders', () => {
     render(
       <FinancialEvidenceDrawer
@@ -203,6 +263,23 @@ describe('FinancialEvidenceDrawer', () => {
     expect(container.innerHTML).not.toMatch(
       /success|positive|confidence-|charcoal-500|warning-dark|#10b981|#127E3D/
     );
+  });
+
+  it('never renders a blank failed reason', () => {
+    // Review P2-1: a whitespace-only statusReason falls back to disclosed copy.
+    render(
+      <FinancialEvidenceDrawer
+        open
+        onOpenChange={() => {}}
+        entityLabel="Acme Corp"
+        status="failed"
+        statusReason="   "
+        evidence={null}
+        decisionState="actionable"
+      />
+    );
+
+    expect(screen.getAllByText('No failure reason disclosed.').length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders the empty state with the facts domain noun and the as-of date', () => {

--- a/tests/unit/components/fund-results/financial-evidence.test.tsx
+++ b/tests/unit/components/fund-results/financial-evidence.test.tsx
@@ -1,0 +1,321 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DUAL_FORECAST_CONTRACT_VERSION,
+  DualForecastResponseSchema,
+  type DualForecastResponse,
+} from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
+import {
+  FundScenarioComparisonV1Schema,
+  type FundScenarioComparisonV1,
+} from '@shared/contracts/fund-scenario-comparison-v1.contract';
+import {
+  FundMoicFactsBasisV1Schema,
+  type FundMoicFactsBasisV1,
+} from '@shared/contracts/fund-moic-v1.contract';
+import {
+  evidenceFromDualForecast,
+  evidenceFromMoicBasis,
+  evidenceFromScenarioComparison,
+} from '@/components/fund-results/financial-evidence';
+
+const INPUT_HASH = 'b'.repeat(64);
+const FACTS_HASH = 'a'.repeat(64);
+
+const COMPANY_WARNING = {
+  code: 'PLANNING_FMV_STALE',
+  severity: 'warning',
+  message: 'Planning FMV is stale.',
+} as const;
+
+const FACTS_WARNING = {
+  code: 'DATA_STALE',
+  severity: 'info',
+  message: 'Facts are one day old.',
+} as const;
+
+function dualForecastResponse(overrides: Partial<DualForecastResponse> = {}): DualForecastResponse {
+  return DualForecastResponseSchema.parse({
+    fundId: 1,
+    fundName: 'Fund I',
+    asOfDate: '2026-07-10',
+    series: [],
+    sources: {
+      construction: 'construction_forecast_jcurve',
+      current: 'projected_metrics_calculator',
+      actual: 'actual_metrics_calculator',
+    },
+    config: {
+      source: 'published',
+      version: 3,
+      publishedAt: '2026-07-01T00:00:00.000Z',
+      fallbackReason: null,
+    },
+    actualsFacts: {
+      asOfDate: '2026-07-10',
+      generatedAt: '2026-07-10T12:00:00.000Z',
+      inputHash: INPUT_HASH,
+      companies: [
+        {
+          companyId: 11,
+          companyName: 'Acme Corp',
+          trustState: 'PARTIAL',
+          planningFmvStatus: 'stale',
+          currency: 'USD',
+          currencyStatus: 'base_currency',
+          activeRoundIds: [1],
+          supersedeLineage: [],
+          latestRoundDate: '2026-06-30',
+          latestRoundValuation: '4000000',
+          latestPlanningFmvDate: '2026-06-30',
+          latestPlanningFmvValue: '5000000',
+          warnings: [COMPANY_WARNING],
+        },
+      ],
+      warnings: [FACTS_WARNING],
+    },
+    navAnchoring: {
+      blendedNav: '1000000.00',
+      countsByTrustState: { LIVE: 2, PARTIAL: 1, UNAVAILABLE: 0, FAILED: 0 },
+      companies: [],
+    },
+    currentProjection: { status: 'projected', fallbackReason: null },
+    warnings: ['legacy string warning, excluded from FinancialEvidence'],
+    ...overrides,
+  });
+}
+
+function trustCountsResponse(
+  counts: Record<'LIVE' | 'PARTIAL' | 'UNAVAILABLE' | 'FAILED', number>
+): DualForecastResponse {
+  return dualForecastResponse({
+    navAnchoring: {
+      blendedNav: '1000000.00',
+      countsByTrustState: counts,
+      companies: [],
+    },
+  });
+}
+
+function metricMap() {
+  return {
+    lpNetIrr: 0.15,
+    gpNetIrr: 0.1,
+    totalManagementFees: 2_000_000,
+    totalGpCarryDistributed: 500_000,
+    totalGpFeeIncome: 2_000_000,
+    finalDpi: 0.6,
+    finalTvpi: 2.1,
+    finalClawbackDue: 0,
+  };
+}
+
+function comparison(overrides: Partial<FundScenarioComparisonV1> = {}): FundScenarioComparisonV1 {
+  return FundScenarioComparisonV1Schema.parse({
+    fundId: 1,
+    comparisonStatus: 'comparable',
+    unavailableReason: null,
+    scenarioSet: {
+      scenarioSetId: '00000000-0000-0000-0000-000000000111',
+      name: 'Fee sensitivity',
+      sourceConfigId: 12,
+      sourceConfigVersion: 4,
+    },
+    baseline: { label: 'Authoritative baseline', metrics: metricMap() },
+    variants: [],
+    staleness: 'CURRENT',
+    calculatedAt: '2026-05-26T12:30:00.000Z',
+    ...overrides,
+  });
+}
+
+function moicBasis(overrides: Partial<FundMoicFactsBasisV1> = {}): FundMoicFactsBasisV1 {
+  return FundMoicFactsBasisV1Schema.parse({
+    rankability: 'indicative',
+    reasons: ['planning_fmv_stale'],
+    observedInitialInvestment: '1000000.5',
+    observedFollowOnInvestment: '250000',
+    observedTotalInvestment: '1250000.5',
+    valuationAnchor: {
+      kind: 'planning_fmv',
+      value: '4000000',
+      asOfDate: '2026-07-12',
+    },
+    planningFmvStatus: 'stale',
+    currencyStatus: 'base_currency',
+    factsInputHash: FACTS_HASH,
+    warnings: [COMPANY_WARNING],
+    ...overrides,
+  });
+}
+
+describe('evidenceFromDualForecast', () => {
+  it('maps the aggregate response per the Adapter Mapping Policy', () => {
+    // trustState: worst-state-wins over countsByTrustState (PARTIAL beats LIVE).
+    // warnings: only the StructuredWarning-typed facts-level warnings; the
+    // top-level string[] warnings are excluded from FinancialEvidence.
+    expect(evidenceFromDualForecast(dualForecastResponse())).toEqual({
+      source: 'published',
+      asOfDate: '2026-07-10',
+      contractVersion: String(DUAL_FORECAST_CONTRACT_VERSION),
+      sourceVersion: '3',
+      factsInputHash: INPUT_HASH,
+      assumptionsHash: null,
+      trustState: 'PARTIAL',
+      currencyStatus: null,
+      warnings: [FACTS_WARNING],
+    });
+  });
+
+  it('applies worst-state-wins precedence FAILED > UNAVAILABLE > PARTIAL > LIVE', () => {
+    expect(
+      evidenceFromDualForecast(
+        trustCountsResponse({ LIVE: 1, PARTIAL: 1, UNAVAILABLE: 1, FAILED: 1 })
+      ).trustState
+    ).toBe('FAILED');
+    expect(
+      evidenceFromDualForecast(
+        trustCountsResponse({ LIVE: 1, PARTIAL: 1, UNAVAILABLE: 1, FAILED: 0 })
+      ).trustState
+    ).toBe('UNAVAILABLE');
+    expect(
+      evidenceFromDualForecast(
+        trustCountsResponse({ LIVE: 3, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 })
+      ).trustState
+    ).toBe('LIVE');
+  });
+
+  it('pins the all-zero counts case (valid empty universe) to UNAVAILABLE', () => {
+    // AMENDMENT 8 ruling: an empty facts universe has no trusted dataset.
+    expect(
+      evidenceFromDualForecast(
+        trustCountsResponse({ LIVE: 0, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 })
+      ).trustState
+    ).toBe('UNAVAILABLE');
+  });
+
+  it('stringifies a numeric config version and nulls an absent one', () => {
+    expect(evidenceFromDualForecast(dualForecastResponse()).sourceVersion).toBe('3');
+    const legacy = dualForecastResponse({
+      config: {
+        source: 'legacy_default_no_published_config',
+        version: null,
+        publishedAt: null,
+        fallbackReason: 'no published config',
+      },
+    });
+    const evidence = evidenceFromDualForecast(legacy);
+    expect(evidence.sourceVersion).toBeNull();
+    expect(evidence.source).toBe('legacy_default_no_published_config');
+  });
+
+  it('maps navAnchoring null (facts fetch failure) to trustState FAILED', () => {
+    // AMENDMENT 6 ratified fallback: contract-documented facts-fetch-failure case.
+    const failed = dualForecastResponse({ actualsFacts: null, navAnchoring: null });
+    const evidence = evidenceFromDualForecast(failed);
+    expect(evidence.trustState).toBe('FAILED');
+    expect(evidence.factsInputHash).toBeNull();
+    expect(evidence.warnings).toEqual([]);
+  });
+
+  it('keeps worst-state-wins when actualsFacts is null but navAnchoring is present', () => {
+    // AMENDMENT 6 ratified fallback: hash fields null, trust state as normal.
+    const partialFacts = dualForecastResponse({ actualsFacts: null });
+    const evidence = evidenceFromDualForecast(partialFacts);
+    expect(evidence.trustState).toBe('PARTIAL');
+    expect(evidence.factsInputHash).toBeNull();
+    expect(evidence.warnings).toEqual([]);
+  });
+
+  it('maps the company overload from that company facts entry', () => {
+    expect(evidenceFromDualForecast(dualForecastResponse(), 11)).toEqual({
+      source: 'published',
+      asOfDate: '2026-07-10',
+      contractVersion: String(DUAL_FORECAST_CONTRACT_VERSION),
+      sourceVersion: '3',
+      factsInputHash: INPUT_HASH,
+      assumptionsHash: null,
+      trustState: 'PARTIAL',
+      currencyStatus: 'base_currency',
+      warnings: [COMPANY_WARNING],
+    });
+  });
+
+  it('maps a companyId with no matching company to UNAVAILABLE with null fields', () => {
+    // AMENDMENT 6 ratified fallback.
+    const evidence = evidenceFromDualForecast(dualForecastResponse(), 99);
+    expect(evidence.trustState).toBe('UNAVAILABLE');
+    expect(evidence.currencyStatus).toBeNull();
+    expect(evidence.factsInputHash).toBeNull();
+    expect(evidence.warnings).toEqual([]);
+  });
+});
+
+describe('evidenceFromScenarioComparison', () => {
+  it('maps a comparable comparison per the Adapter Mapping Policy', () => {
+    const comparable = comparison();
+    expect(evidenceFromScenarioComparison(comparable, comparable.staleness)).toEqual({
+      source: 'scenario_comparison',
+      asOfDate: null,
+      contractVersion: 'fund-scenario-comparison-v1',
+      sourceVersion: '4',
+      factsInputHash: null,
+      assumptionsHash: null,
+      trustState: 'CURRENT',
+      currencyStatus: null,
+      warnings: [],
+    });
+  });
+
+  it('resolves the object staleness form to its state', () => {
+    const stale = comparison({
+      staleness: {
+        state: 'STALE_PUBLISH',
+        sourceConfigVersion: 4,
+        currentPublishedConfigVersion: 6,
+      },
+    });
+    expect(evidenceFromScenarioComparison(stale, stale.staleness).trustState).toBe('STALE_PUBLISH');
+  });
+
+  it('reads UNAVAILABLE for a non-comparable comparison', () => {
+    const unavailable = comparison({
+      comparisonStatus: 'baseline_unavailable',
+      baseline: null,
+      staleness: null,
+      calculatedAt: null,
+    });
+    expect(evidenceFromScenarioComparison(unavailable, null).trustState).toBe('UNAVAILABLE');
+  });
+});
+
+describe('evidenceFromMoicBasis', () => {
+  it('maps the facts basis per the Adapter Mapping Policy', () => {
+    // trustState: the basis contract's own rankability state field.
+    const basis = moicBasis();
+    expect(evidenceFromMoicBasis(basis)).toEqual({
+      source: 'fund_moic_facts',
+      asOfDate: null,
+      contractVersion: 'fund-moic-v1',
+      sourceVersion: null,
+      factsInputHash: FACTS_HASH,
+      assumptionsHash: null,
+      trustState: 'indicative',
+      currencyStatus: 'base_currency',
+      warnings: [COMPANY_WARNING],
+    });
+  });
+
+  it('carries a null facts input hash and each rankability verbatim', () => {
+    const basis = moicBasis({
+      rankability: 'not_actionable',
+      reasons: ['valuation_unavailable'],
+      factsInputHash: null,
+      warnings: [],
+    });
+    const evidence = evidenceFromMoicBasis(basis);
+    expect(evidence.trustState).toBe('not_actionable');
+    expect(evidence.factsInputHash).toBeNull();
+    expect(evidence.warnings).toEqual([]);
+  });
+});

--- a/tests/unit/components/fund-results/financial-evidence.test.tsx
+++ b/tests/unit/components/fund-results/financial-evidence.test.tsx
@@ -14,9 +14,11 @@ import {
   type FundMoicFactsBasisV1,
 } from '@shared/contracts/fund-moic-v1.contract';
 import {
+  createFundResultsViewState,
   evidenceFromDualForecast,
   evidenceFromMoicBasis,
   evidenceFromScenarioComparison,
+  type ScenarioOverlay,
 } from '@/components/fund-results/financial-evidence';
 
 const INPUT_HASH = 'b'.repeat(64);
@@ -317,5 +319,37 @@ describe('evidenceFromMoicBasis', () => {
     expect(evidence.trustState).toBe('not_actionable');
     expect(evidence.factsInputHash).toBeNull();
     expect(evidence.warnings).toEqual([]);
+  });
+});
+
+describe('createFundResultsViewState', () => {
+  // Review P2-3: the D-E invariant
+  // (overlay.kind === 'saved' ? basis === overlay.baseBasis : true).
+  const savedOverlay: ScenarioOverlay = {
+    kind: 'saved',
+    scenarioSetId: '00000000-0000-0000-0000-000000000111',
+    variantId: null,
+    name: 'Fee sensitivity',
+    baseBasis: 'construction',
+    baseInputHash: 'd'.repeat(64),
+    baseAsOfDate: '2026-07-01',
+  };
+
+  it('accepts a none overlay with either basis', () => {
+    expect(createFundResultsViewState('current', { kind: 'none' })).toEqual({
+      basis: 'current',
+      overlay: { kind: 'none' },
+    });
+  });
+
+  it('accepts a saved overlay whose baseBasis matches the basis', () => {
+    expect(createFundResultsViewState('construction', savedOverlay)).toEqual({
+      basis: 'construction',
+      overlay: savedOverlay,
+    });
+  });
+
+  it('throws when a saved overlay disagrees with the basis', () => {
+    expect(() => createFundResultsViewState('current', savedOverlay)).toThrow(/baseBasis/);
   });
 });

--- a/tests/unit/components/fund-results/fund-forecast-mode-selector.test.tsx
+++ b/tests/unit/components/fund-results/fund-forecast-mode-selector.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ForecastBasisControl,
+  ScenarioOverlayControl,
+} from '@/components/fund-results/FundForecastModeSelector';
+import type { ScenarioOverlay } from '@/components/fund-results/financial-evidence';
+
+const SAVED_OVERLAY: ScenarioOverlay = {
+  kind: 'saved',
+  scenarioSetId: '00000000-0000-0000-0000-000000000111',
+  variantId: null,
+  name: 'Fee sensitivity',
+  baseBasis: 'construction',
+  baseInputHash: 'd'.repeat(64),
+  baseAsOfDate: '2026-07-01',
+};
+
+describe('ForecastBasisControl', () => {
+  it('renders an ink-only segmented control labeled "Forecast basis"', () => {
+    render(<ForecastBasisControl value="construction" onChange={() => {}} />);
+
+    const group = screen.getByRole('radiogroup', { name: 'Forecast basis' });
+    const construction = screen.getByRole('radio', { name: 'Construction' });
+    const current = screen.getByRole('radio', { name: 'Current' });
+    expect(construction).toHaveAttribute('aria-checked', 'true');
+    expect(current).toHaveAttribute('aria-checked', 'false');
+    // ink-only: no status hue anywhere in the control
+    expect(group.innerHTML).not.toMatch(/success|positive|warning|info|blue|green|red/);
+  });
+
+  it('fires onChange for the unselected basis only', () => {
+    const onChange = vi.fn();
+    render(<ForecastBasisControl value="construction" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Current' }));
+    expect(onChange).toHaveBeenCalledWith('current');
+    fireEvent.click(screen.getByRole('radio', { name: 'Construction' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables a basis WITH its visible reason', () => {
+    render(
+      <ForecastBasisControl
+        value="construction"
+        onChange={() => {}}
+        disabledBases={{ current: 'Current basis requires published actuals.' }}
+      />
+    );
+
+    expect(screen.getByRole('radio', { name: 'Current' })).toBeDisabled();
+    expect(screen.getByText(/Current basis requires published actuals\./)).toBeInTheDocument();
+  });
+
+  it('renders the locked variant with its reason and disabled segments', () => {
+    render(<ForecastBasisControl value="current" onChange={() => {}} locked />);
+
+    expect(screen.getByText('Locked by selected scenario')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Construction' })).toBeDisabled();
+    expect(screen.getByRole('radio', { name: 'Current' })).toBeDisabled();
+  });
+
+  it('renders the static indicator variant as "Basis: <x>"', () => {
+    render(<ForecastBasisControl value="current" variant="indicator" />);
+
+    expect(screen.getByText('Basis: Current')).toBeInTheDocument();
+    expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument();
+  });
+});
+
+describe('ScenarioOverlayControl', () => {
+  it('renders the scenario with its basis label and as-of date', () => {
+    render(<ScenarioOverlayControl overlay={SAVED_OVERLAY} onClear={() => {}} />);
+
+    expect(
+      screen.getByText(/Scenario: Fee sensitivity — based on Construction · as of/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('2026-07-01')).toHaveClass('tabular-nums');
+  });
+
+  it('fires the clear action', () => {
+    const onClear = vi.fn();
+    render(<ScenarioOverlayControl overlay={SAVED_OVERLAY} onClear={onClear} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear scenario Fee sensitivity' }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when no scenario overlay is applied', () => {
+    const { container } = render(
+      <ScenarioOverlayControl overlay={{ kind: 'none' }} onClear={() => {}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/unit/components/fund-results/fund-forecast-mode-selector.test.tsx
+++ b/tests/unit/components/fund-results/fund-forecast-mode-selector.test.tsx
@@ -80,11 +80,14 @@ describe('ScenarioOverlayControl', () => {
     expect(screen.getByText('2026-07-01')).toHaveClass('tabular-nums');
   });
 
-  it('fires the clear action', () => {
+  it('fires the clear action from a motion-reduce-gated button', () => {
     const onClear = vi.fn();
     render(<ScenarioOverlayControl overlay={SAVED_OVERLAY} onClear={onClear} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Clear scenario Fee sensitivity' }));
+    const clear = screen.getByRole('button', { name: 'Clear scenario Fee sensitivity' });
+    // Review P3-5: the Button base carries transition-colors; gate it.
+    expect(clear.className).toContain('motion-reduce:transition-none');
+    fireEvent.click(clear);
     expect(onClear).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/components/fund-results/no-moic-imports.test.tsx
+++ b/tests/unit/components/fund-results/no-moic-imports.test.tsx
@@ -1,0 +1,27 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const COMPONENT_DIR = path.resolve(process.cwd(), 'client/src/components/fund-results');
+const FORBIDDEN_IMPORT = /FundMoicFactsBasisV1|REASON_COPY|components\/moic|fund-moic-v1/;
+
+describe('fund-results sources stay decoupled from the MOIC domain', () => {
+  it('has no MOIC imports in any fund-results component source', () => {
+    const files = readdirSync(COMPONENT_DIR).filter(
+      (file) => file.endsWith('.ts') || file.endsWith('.tsx')
+    );
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(path.join(COMPONENT_DIR, file), 'utf8');
+      const importStatements = source.match(/(?:import|export)[^;]*?from\s*['"][^'"]+['"]/g) ?? [];
+      for (const statement of importStatements) {
+        if (FORBIDDEN_IMPORT.test(statement)) {
+          violations.push(`${file}: ${statement.replace(/\s+/g, ' ')}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/components/moic/moic-basis-disclosure.test.tsx
+++ b/tests/unit/components/moic/moic-basis-disclosure.test.tsx
@@ -85,11 +85,10 @@ describe('MoicBasisDisclosure', () => {
     render(<MoicBasisDisclosure basis={basis} investmentName="Beta Labs" />);
 
     const indicative = screen.getByText('Indicative');
-    expect(indicative).toHaveClass('text-charcoal-500');
+    expect(indicative).toHaveClass('text-presson-textMuted');
     expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
       'border-warning/50',
-      'bg-warning/10',
-      'text-warning-dark'
+      'bg-warning/10'
     );
     expect(
       screen.getByText('Refresh the stale Planning FMV before relying on this ranking.')
@@ -135,7 +134,7 @@ describe('MoicBasisDisclosure', () => {
     });
     const { unmount } = render(<MoicBasisDisclosure basis={basis} investmentName="Gamma Bio" />);
 
-    expect(screen.getByText('Not actionable')).toHaveClass('text-charcoal-500');
+    expect(screen.getByText('Not actionable')).toHaveClass('text-presson-textMuted');
     expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
       'border-charcoal-400',
       'bg-transparent'

--- a/tests/unit/components/moic/moic-rankability-badge.test.tsx
+++ b/tests/unit/components/moic/moic-rankability-badge.test.tsx
@@ -102,6 +102,19 @@ describe('MoicRankabilityBadge (DecisionStateBadge domain adapter)', () => {
     expect(tooltip).toHaveTextContent(/supporting facts basis could not be loaded/);
   });
 
+  it('keeps the badge focusable and tooltip-bearing when reasons is empty', async () => {
+    // Review P3-4: reasons: [] is schema-valid; the delegated badge must keep
+    // the previously unconditional focusable tooltip trigger.
+    render(<MoicRankabilityBadge basis={buildBasis({ reasons: [] })} />);
+
+    const label = screen.getByText('Actionable');
+    expect(label).toHaveAttribute('tabindex', '0');
+
+    fireEvent.focus(label);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip.querySelectorAll('li')).toHaveLength(0);
+  });
+
   it('preserves the deterministic basis.reasons order in the remediation tooltip', async () => {
     render(
       <MoicRankabilityBadge

--- a/tests/unit/components/moic/moic-rankability-badge.test.tsx
+++ b/tests/unit/components/moic/moic-rankability-badge.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MoicRankabilityBadge } from '../../../../client/src/components/moic/MoicBasisDisclosure';
+import {
+  FundMoicFactsBasisV1Schema,
+  type FundMoicFactsBasisV1,
+} from '@shared/contracts/fund-moic-v1.contract';
+
+const FACTS_HASH = 'a'.repeat(64);
+
+function buildBasis(overrides: Partial<FundMoicFactsBasisV1> = {}): FundMoicFactsBasisV1 {
+  return FundMoicFactsBasisV1Schema.parse({
+    rankability: 'actionable',
+    reasons: ['planning_fmv_active'],
+    observedInitialInvestment: '1000000.5',
+    observedFollowOnInvestment: '250000',
+    observedTotalInvestment: '1250000.5',
+    valuationAnchor: {
+      kind: 'planning_fmv',
+      value: '4000000',
+      asOfDate: '2026-07-12',
+    },
+    planningFmvStatus: 'active',
+    currencyStatus: 'base_currency',
+    factsInputHash: FACTS_HASH,
+    warnings: [],
+    ...overrides,
+  });
+}
+
+describe('MoicRankabilityBadge (DecisionStateBadge domain adapter)', () => {
+  it('maps actionable onto the full-ink presentation with no dot and its remediation copy', async () => {
+    render(<MoicRankabilityBadge basis={buildBasis()} />);
+
+    const label = screen.getByText('Actionable');
+    expect(label).toHaveClass('text-pov-charcoal');
+    expect(screen.queryByTestId('moic-rankability-dot')).not.toBeInTheDocument();
+
+    fireEvent.focus(label);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('An active Planning FMV supports this ranking.');
+  });
+
+  it('maps indicative onto the muted amber-dot presentation with its remediation copy', async () => {
+    render(
+      <MoicRankabilityBadge
+        basis={buildBasis({
+          rankability: 'indicative',
+          reasons: ['planning_fmv_stale'],
+          planningFmvStatus: 'stale',
+        })}
+      />
+    );
+
+    const label = screen.getByText('Indicative');
+    expect(label).toHaveClass('text-presson-textMuted');
+    expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
+      'border-warning/50',
+      'bg-warning/10'
+    );
+
+    fireEvent.focus(label);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(
+      'Refresh the stale Planning FMV before relying on this ranking.'
+    );
+  });
+
+  it('maps not_actionable onto the muted hollow-dot presentation', () => {
+    render(
+      <MoicRankabilityBadge
+        basis={buildBasis({
+          rankability: 'not_actionable',
+          reasons: ['valuation_unavailable'],
+          valuationAnchor: { kind: 'none', value: null, asOfDate: null },
+          planningFmvStatus: 'none',
+        })}
+      />
+    );
+
+    expect(screen.getByText('Not actionable')).toHaveClass('text-presson-textMuted');
+    expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
+      'border-charcoal-400',
+      'bg-transparent'
+    );
+  });
+
+  it('maps a null basis onto the Facts unavailable (not_actionable) presentation', async () => {
+    render(<MoicRankabilityBadge basis={null} />);
+
+    const label = screen.getByText('Facts unavailable');
+    expect(label).toHaveClass('text-presson-textMuted');
+    expect(screen.getByTestId('moic-rankability-dot')).toHaveClass(
+      'border-charcoal-400',
+      'bg-transparent'
+    );
+
+    fireEvent.focus(label);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(/supporting facts basis could not be loaded/);
+  });
+
+  it('preserves the deterministic basis.reasons order in the remediation tooltip', async () => {
+    render(
+      <MoicRankabilityBadge
+        basis={buildBasis({
+          rankability: 'not_actionable',
+          reasons: ['valuation_unavailable', 'currency_blocked', 'planned_reserves_zero'],
+          valuationAnchor: { kind: 'none', value: null, asOfDate: null },
+          planningFmvStatus: 'none',
+          currencyStatus: 'mismatch_blocked',
+          factsInputHash: null,
+        })}
+      />
+    );
+
+    fireEvent.focus(screen.getByText('Not actionable'));
+    const tooltip = await screen.findByRole('tooltip');
+    const items = Array.from(tooltip.querySelectorAll('li')).map((item) => item.textContent);
+    expect(items).toEqual([
+      'Add a current Planning FMV before relying on this ranking.',
+      'Resolve the currency mismatch before relying on this ranking.',
+      'Add planned reserves before relying on this ranking.',
+    ]);
+  });
+});

--- a/tests/unit/components/ui/sheet.test.tsx
+++ b/tests/unit/components/ui/sheet.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet';
+
+describe('Sheet reduced-motion gating (DESIGN.md mandatory rule)', () => {
+  it('gates content, overlay, and close-control animations behind motion-reduce', () => {
+    render(
+      <Sheet open onOpenChange={() => {}}>
+        <SheetContent side="right">
+          <SheetTitle>Panel</SheetTitle>
+          <SheetDescription>Details</SheetDescription>
+        </SheetContent>
+      </Sheet>
+    );
+
+    const content = screen.getByRole('dialog');
+    expect(content.className).toContain('motion-reduce:transition-none');
+    expect(content.className).toContain('motion-reduce:animate-none');
+
+    const overlay = document.querySelector('div[class*="bg-black/80"]');
+    expect(overlay).not.toBeNull();
+    expect(overlay?.className).toContain('motion-reduce:animate-none');
+
+    const close = screen.getByRole('button', { name: /close/i });
+    expect(close.className).toContain('motion-reduce:transition-none');
+  });
+});

--- a/tests/unit/components/work-panel/WorkPanel.test.tsx
+++ b/tests/unit/components/work-panel/WorkPanel.test.tsx
@@ -1,5 +1,6 @@
+import React, { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WorkPanel } from '@/components/work-panel/WorkPanel';
 
@@ -34,5 +35,64 @@ describe('WorkPanel', () => {
     );
     await user.click(screen.getByRole('button', { name: /close/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // AMENDMENT 8 pin: the headerSlot/onCloseAutoFocus extension is additive only.
+  it('renders an unchanged header when the new optional props are absent', () => {
+    render(
+      <WorkPanel open onClose={() => {}} title="Scenario proof">
+        <p>Panel body</p>
+      </WorkPanel>
+    );
+    const header = screen.getByText('Scenario proof').parentElement;
+    expect(header).not.toBeNull();
+    expect(header?.children).toHaveLength(1);
+
+    render(
+      <WorkPanel open onClose={() => {}} title="Second proof" description="Read-only details">
+        <p>Panel body</p>
+      </WorkPanel>
+    );
+    const describedHeader = screen.getByText('Second proof').parentElement;
+    expect(describedHeader?.children).toHaveLength(2);
+  });
+
+  it('renders headerSlot inside the sheet header after the title row', () => {
+    render(
+      <WorkPanel
+        open
+        onClose={() => {}}
+        title="Scenario proof"
+        description="Read-only details"
+        headerSlot={<div data-testid="header-slot">Slot content</div>}
+      >
+        <p>Panel body</p>
+      </WorkPanel>
+    );
+    const title = screen.getByText('Scenario proof');
+    const slot = screen.getByTestId('header-slot');
+    expect(slot.parentElement).toBe(title.parentElement);
+    expect(title.compareDocumentPosition(slot) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('forwards onCloseAutoFocus to the sheet content', async () => {
+    const user = userEvent.setup();
+    const onCloseAutoFocus = vi.fn((event: Event) => event.preventDefault());
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <WorkPanel
+          open={open}
+          onClose={() => setOpen(false)}
+          title="Scenario proof"
+          onCloseAutoFocus={onCloseAutoFocus}
+        >
+          <p>Panel body</p>
+        </WorkPanel>
+      );
+    }
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    await waitFor(() => expect(onCloseAutoFocus).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
## Summary

Plan 9 (Integrated GP Workspace) wave 9A: the shared trust-evidence primitives that all fund-workspace surfaces consume in later waves.

- **DecisionStateBadge** — single generic quiet-badge renderer (D-A grammar: full-ink actionable, muted+amber-dot indicative, muted+hollow-dot not_actionable; `text-presson-textMuted` #5A5A5A fixes the WCAG AA failure of the previous `charcoal-500` muted color).
- **MoicRankabilityBadge delegation** — the shipped PR #1111 badge becomes a thin domain adapter over the generic renderer (call sites untouched; `facts_unavailable` stays a domain label; only the three authorized test-assertion updates).
- **FinancialEvidenceDrawer** — context-preserving work panel composing the existing `WorkPanel` (additive `headerSlot`/`onCloseAutoFocus` props); fixed internal order with provenance last+collapsed; hash short-form + copy-full actions; status-discriminated prop union (ready/loading/empty/failed).
- **ForecastBasisControl / ScenarioOverlayControl** — two-axis forecast model (D-E): basis segmented control + scenario overlay bound to `baseBasis`/`baseInputHash`/`baseAsOfDate`, with validating factory enforcing the invariant.
- **Adapters** (`financial-evidence.ts`) — dual-forecast / scenario-comparison / moic-basis mappings per the binding Adapter Mapping Policy (worst-state-wins aggregation, authorized fallbacks, structured-warnings-only).
- **sheet.tsx** — adds `motion-reduce:` gating only (fixes a mandatory-reduced-motion violation for all five existing Sheet consumers; no duration changes).

## Review provenance

Plan passed `/plan-design-review` (7 passes + Codex + blind-subagent outside voices; six owner-ratified decisions). Implementation spec survived 8 rounds of adversarial escape-hatch verification. Post-implementation adversarial Codex review: 0 P1 / 3 P2 / 4 P3 — all seven fixed in the third commit.

## Test evidence

46+ new tests; targeted 14 files / 104 tests green; full client project 712 files / 8318 tests green; lint + typecheck clean; compliance greps (forbidden tokens) empty on all new files. Deviations + follow-ups logged in the wave summary (notable follow-ups: legacy tokens in 6 pre-existing fund-results components; global Sheet duration normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h