### PR TITLE
feat(lp-reporting): report qualification characterization and gap-fills (Plan 9 wave 9D)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -52,6 +52,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-036: Named Identities, Explicit Fund Grants, and jti Revocation (Plan 2)](#adr-036-named-identities-explicit-fund-grants-and-jti-revocation-plan-2)
 - [ADR-037: Browser HttpOnly JWT Cookie and Signed CSRF Contract (D4)](#adr-037-browser-httponly-jwt-cookie-and-signed-csrf-contract-d4)
 - [ADR-039: Planned-reserve MOIC candidate basis moves to Round/FMV facts (moic-round-fmv-facts-v2)](#adr-039-planned-reserve-moic-candidate-basis-moves-to-roundfmv-facts-moic-round-fmv-facts-v2)
+- [ADR-040: Report Qualification Semantics (Plan 9)](#adr-040-report-qualification-semantics-plan-9)
 
 ---
 
@@ -6082,3 +6083,130 @@ fingerprint before an on-mode candidate can become actionable.
 
 **Implementation:** Plan 6 wave 2, Task 6.4 / PR 6B plus the facts-fingerprint
 unification fix.
+
+---
+
+## ADR-040: Report Qualification Semantics (Plan 9)
+
+**Date:** 2026-07-13 **Status:** [IMPLEMENTED] Implemented **Decision:** Treat
+partner and admin as the authoritative LP report render/export roles, keep H9
+fail-closed at persistence, reuse, and artifact-serving boundaries, and use
+qualification-state disclosure rather than unqualified numeric previews.
+
+### Context
+
+Plan 9 Wave 9D characterized the existing LP-reporting authorization and H9
+boundaries before closing two narrow enforcement gaps. The characterization
+showed that the eight export-perimeter routes already require the partner or
+admin role, fund access, and the export-fund grant posture from ADR-025. It also
+showed that workflow state and H9 qualification reject unqualified values before
+the render model is constructed. CSV creation and idempotent replay were the
+exception: they checked workflow state but did not revalidate H9 until artifact
+retrieval. Wave 9D brought CSV persistence and reuse into the same fail-closed
+posture as stored JSON.
+
+The original Plan 9 language also called for read-only indicative previews. The
+live UI does not render stored, unqualified package values as that preview. It
+consumes metric-run, narrative, package, and error state from read/lifecycle
+surfaces, and renders numeric metric sections only when the fail-closed render
+model succeeds. This makes qualification state, rather than unqualified numeric
+values, the current indicative disclosure.
+
+### Decision
+
+#### Authorization posture
+
+| Surface                                                                          | Current authorization                                                                                | Qualification posture                                                                                                                                           |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Render model, live JSON, and stored JSON/CSV create, status, and artifact routes | Partner with an explicit export fund grant, or admin under the ADR-025 admin scope exemption         | Export perimeter; creation/artifact serving is authoritative, while status GETs are metadata-only                                                               |
+| Viewer, analyst, and operator access to those eight routes                       | Denied with 403, including when the caller otherwise has fund access                                 | No export grant is implied by these roles                                                                                                                       |
+| Read and lifecycle routes                                                        | Authentication plus the existing fund-access middleware; no partner/admin or export-grant middleware | Read access remains available to fund-granted viewer/analyst callers; the current middleware also does not establish a separate operator lifecycle-write policy |
+
+Partner/admin authority in this decision means authority to produce or retrieve
+qualified report outputs. It does not retroactively add role checks to draft,
+approval, lock, narrative, evidence, or package-assembly lifecycle routes.
+
+#### Workflow and H9 gates
+
+- Workflow qualification precedes value construction: only `locked` or
+  `exported` metric runs can reach H9 validation and the render/export value
+  builders.
+- H9 is fail-closed for report persistence, idempotent reuse, live export, and
+  stored artifact serving. Missing metadata, non-actionable stored state, a
+  stale fingerprint, or unavailable revalidation blocks with the existing
+  structured H9 error.
+- Stored JSON and CSV status GETs remain role-and-export-grant-gated readiness
+  metadata. They re-check workflow state but intentionally defer H9 to creation
+  and authoritative artifact serving.
+- Read/lifecycle surfaces remain H9-independent under ADR-028's
+  disclose-not-block rule. Qualification-state disclosure does not display
+  unqualified numeric values in the current client: the package record is used
+  for assembly, narrative-reference, and lifecycle state, while numeric sections
+  come only from the H9-gated render model.
+
+#### Exclusions and server flagging
+
+- Marginal MOIC is excluded from every LP-reporting render and export payload.
+  It remains shadow-only and non-actionable until a separate activation and
+  export ADR authorizes its inclusion.
+- `POST /funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed`
+  is gated on the server by `ENABLE_SCENARIO_SEED_PICKER`, default off. When
+  disabled, the route returns 404 before body validation, idempotency,
+  provenance lookup, or persistence.
+
+### Evidence
+
+- `server/routes/lp-reporting/metric-runs.ts` defines the eight
+  partner/admin-and-export-grant routes and leaves read/lifecycle routes on the
+  existing authenticated fund-scope chain.
+- `server/services/lp-reporting/h9-export-gate.ts`,
+  `report-package-render-model-service.ts`, and the stored JSON/CSV export
+  services enforce the workflow/H9 ordering and stored-artifact boundaries.
+- `tests/unit/lp-reporting/report-qualification-characterization.test.ts` pins
+  the role matrix, H9 failure codes, status-GET exception, marginal-MOIC
+  exclusion, and production gate wiring.
+- `tests/unit/services/lp-reporting/report-package-render-model-service.test.ts`
+  pins that workflow and H9 failures occur before metric values are built.
+- `client/src/pages/lp-reporting/metrics.tsx` renders numeric sections from the
+  render model and uses the report-package record for lifecycle and reference
+  state rather than rendering its stored payload.
+- `server/config/features.ts`, `server/routes/scenario-analysis.ts`, and
+  `tests/unit/routes/scenario-analysis.contract.test.ts` pin the default-off,
+  server-side from-seed gate and its unchanged enabled behavior.
+
+### Alternatives Considered
+
+- **Serve numeric indicative previews before workflow/H9 qualification:**
+  rejected because it would create a second, less trustworthy output path and
+  contradict the existing fail-closed render-model boundary.
+- **Revalidate H9 on stored-export status GETs:** rejected because those routes
+  report readiness metadata; artifact creation and serving are the authoritative
+  qualification boundaries.
+- **Treat fund access as an export grant for viewer, analyst, or operator:**
+  rejected because ADR-025 and the live middleware require partner/admin plus
+  the explicit export-fund posture.
+- **Include marginal MOIC because its shadow endpoint exists:** rejected because
+  shadow computation is not activation or export authorization.
+- **Rely on the client to hide from-seed creation:** rejected because direct API
+  callers would bypass a client-only flag.
+
+### Consequences
+
+- JSON and CSV stored-export creation, replay, and artifact retrieval now share
+  the same H9 fail-closed contract; status GETs remain the documented metadata
+  exception.
+- A future numeric indicative-preview surface requires its own contract and ADR;
+  it must not weaken the authoritative render/export gates by implication.
+- A future lifecycle role redesign must be explicit. This decision records the
+  current fund-scope-only lifecycle middleware and does not infer export rights
+  for viewer, analyst, or operator.
+
+### Follow-ups
+
+- Consolidate dual-forecast-dashboard/overview trust components into the shared
+  evidence panel.
+- Retitle the `/reports` page `Variance Reports`.
+- Clean stale LP-reporting `placeholder` comments in Wave 9F.
+
+**Implementation:** Plan 9 Wave 9D report-qualification characterization and
+named server-side gap fills.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6137,7 +6137,9 @@ approval, lock, narrative, evidence, or package-assembly lifecycle routes.
   structured H9 error.
 - Stored JSON and CSV status GETs remain role-and-export-grant-gated readiness
   metadata. They re-check workflow state but intentionally defer H9 to creation
-  and authoritative artifact serving.
+  and authoritative artifact serving. The route-policy registry declares them as
+  `not_exportable` readiness metadata without a stale-blocks-export assertion,
+  matching that runtime posture.
 - Read/lifecycle surfaces remain H9-independent under ADR-028's
   disclose-not-block rule. Qualification-state disclosure does not display
   unqualified numeric values in the current client: the package record is used
@@ -6152,7 +6154,10 @@ approval, lock, narrative, evidence, or package-assembly lifecycle routes.
 - `POST /funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed`
   is gated on the server by `ENABLE_SCENARIO_SEED_PICKER`, default off. When
   disabled, the route returns 404 before body validation, idempotency,
-  provenance lookup, or persistence.
+  provenance lookup, or persistence. The 404 is auth-first: it is only reached
+  after authentication and fund-access middleware succeed, matching the
+  marginal-rankings precedent, so anonymous callers still receive 401 while the
+  flag is off and no idempotency or provenance row is ever written.
 
 ### Evidence
 
@@ -6163,8 +6168,9 @@ approval, lock, narrative, evidence, or package-assembly lifecycle routes.
   `report-package-render-model-service.ts`, and the stored JSON/CSV export
   services enforce the workflow/H9 ordering and stored-artifact boundaries.
 - `tests/unit/lp-reporting/report-qualification-characterization.test.ts` pins
-  the role matrix, H9 failure codes, status-GET exception, marginal-MOIC
-  exclusion, and production gate wiring.
+  the role matrix, H9 failure codes, status-GET exception, and marginal-MOIC
+  exclusion by executing the real H9 gates and services through `makeApp`
+  routes, mocking only the database rows and the actionability resolver.
 - `tests/unit/services/lp-reporting/report-package-render-model-service.test.ts`
   pins that workflow and H9 failures occur before metric values are built.
 - `client/src/pages/lp-reporting/metrics.tsx` renders numeric sections from the
@@ -6200,6 +6206,23 @@ approval, lock, narrative, evidence, or package-assembly lifecycle routes.
 - A future lifecycle role redesign must be explicit. This decision records the
   current fund-scope-only lifecycle middleware and does not infer export rights
   for viewer, analyst, or operator.
+- Per-metric provenance bumped the render-model version to 2. Stored-export
+  replay compares content hashes only within the same render-model version: a
+  stored row whose artifact carries an older render-model version replays
+  against its own bytes/hash instead of conflicting with the current renderer
+  output, while same-version drift still fails with
+  `EXPORT_CONTENT_HASH_CONFLICT`.
+
+### Accepted residuals
+
+- The H9 revalidation check and the stored CSV insert/replay run as separate
+  autocommit operations, so H9 can go stale in the window between the check and
+  the write (TOCTOU). This is accepted at the current ~5-user internal scale
+  because the artifact GET re-validates H9 at delivery and fails closed,
+  bounding the worst case to an inert stored metadata row that can never serve
+  artifact bytes. Serializing H9 writers is not warranted for this deployment.
+  The backstop is pinned by the stored-CSV service test that makes H9 stale
+  after CSV creation and asserts the artifact GET still blocks.
 
 ### Follow-ups
 
@@ -6207,6 +6230,10 @@ approval, lock, narrative, evidence, or package-assembly lifecycle routes.
   evidence panel.
 - Retitle the `/reports` page `Variance Reports`.
 - Clean stale LP-reporting `placeholder` comments in Wave 9F.
+- Add request-hash comparison to evidence-record idempotency replay: today it is
+  key-only deduplication, so a different body with a reused Idempotency-Key is
+  silently accepted and returns the stored record; a mismatched request hash
+  should return 409.
 
 **Implementation:** Plan 9 Wave 9D report-qualification characterization and
 named server-side gap fills.

--- a/server/config/features.ts
+++ b/server/config/features.ts
@@ -19,6 +19,7 @@ export const FEATURES = {
   portfolioIntelligence: flag(process.env['ENABLE_PORTFOLIO_INTELLIGENCE'], false),
   // Server-only shadow route; production remains fail-closed unless explicitly enabled.
   marginalReserveMoic: flag(process.env['ENABLE_MARGINAL_RESERVE_MOIC'], false),
+  scenarioSeedPicker: flag(process.env['ENABLE_SCENARIO_SEED_PICKER'], false),
 };
 
 export type FeatureBag = typeof FEATURES;

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -466,14 +466,17 @@ const PROTOTYPE_ROUTE_NOTE = 'Prototype route must return 501 with non_actionabl
 const LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT = 'metric_run_locked_or_exported';
 const LP_REPORT_PACKAGE_EXPORT_NOTE =
   'PRD #996 AC-1, AC-2, AC-3, D1, D2, and D3: Surface-A report-package export requires partner/admin role, denies empty-fundIds non-admin exports, requires metric-run workflow state locked or exported, and scopes visual watermarking out by ADR-027 because h9Stamp plus contentHash provide JSON/CSV hash attestation.';
+const LP_REPORT_PACKAGE_EXPORT_STATUS_NOTE =
+  'Readiness-metadata status GET (in-code Finding 8, ADR-040): partner/admin role, export-grant, and workflow-state gated, but intentionally H9-independent and non-exportable. It serves stored-export metadata only; the authoritative artifact GET re-validates H9 before any artifact bytes are served.';
 
 type LpReportingRoutePolicyGroup = Pick<
   RoutePolicyEntry,
   'workflowRequirement' | 'exportPolicy' | 'provenanceRequired'
-> & {
-  governanceRef: '/lp-reporting/metrics' | '/lp-reporting/imports';
-  routes: ReadonlyArray<readonly [method: string, path: string]>;
-};
+> &
+  Partial<Pick<RoutePolicyEntry, 'notes'>> & {
+    governanceRef: '/lp-reporting/metrics' | '/lp-reporting/imports';
+    routes: ReadonlyArray<readonly [method: string, path: string]>;
+  };
 
 const LP_REPORTING_ADDITIONAL_ROUTE_POLICY_GROUPS = [
   {
@@ -528,9 +531,11 @@ const LP_REPORTING_ADDITIONAL_ROUTE_POLICY_GROUPS = [
   {
     governanceRef: '/lp-reporting/metrics',
     routes: [['POST', '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records']],
-    workflowRequirement: 'draft_metric_run_and_idempotency_verified',
+    workflowRequirement: 'draft_metric_run_and_idempotency_key_dedup',
     exportPolicy: 'not_exportable',
     provenanceRequired: true,
+    notes:
+      'Idempotency on this route is key-only deduplication: a replayed Idempotency-Key returns the stored evidence record without comparing the request body, so a different body with the same key is silently accepted (metric-run-evidence-service). Request-hash comparison returning 409 is an ADR-040 follow-up.',
   },
   {
     governanceRef: '/lp-reporting/metrics',
@@ -1030,12 +1035,12 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
     workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
-    exportPolicy: 'qualified_exportable',
+    exportPolicy: 'not_exportable',
     provenanceRequired: true,
-    staleBlocksExport: true,
+    staleBlocksExport: false,
     humanReviewRequired: true,
     performanceBudgetMs: null,
-    notes: LP_REPORT_PACKAGE_EXPORT_NOTE,
+    notes: LP_REPORT_PACKAGE_EXPORT_STATUS_NOTE,
   },
   {
     id: 'api:get:/api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/json/artifact',
@@ -1099,12 +1104,12 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
     workflowRequirement: LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT,
-    exportPolicy: 'qualified_exportable',
+    exportPolicy: 'not_exportable',
     provenanceRequired: true,
-    staleBlocksExport: true,
+    staleBlocksExport: false,
     humanReviewRequired: true,
     performanceBudgetMs: null,
-    notes: LP_REPORT_PACKAGE_EXPORT_NOTE,
+    notes: LP_REPORT_PACKAGE_EXPORT_STATUS_NOTE,
   },
   {
     id: 'api:get:/api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/csv/artifact',

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -467,6 +467,154 @@ const LP_REPORT_PACKAGE_EXPORT_WORKFLOW_REQUIREMENT = 'metric_run_locked_or_expo
 const LP_REPORT_PACKAGE_EXPORT_NOTE =
   'PRD #996 AC-1, AC-2, AC-3, D1, D2, and D3: Surface-A report-package export requires partner/admin role, denies empty-fundIds non-admin exports, requires metric-run workflow state locked or exported, and scopes visual watermarking out by ADR-027 because h9Stamp plus contentHash provide JSON/CSV hash attestation.';
 
+type LpReportingRoutePolicyGroup = Pick<
+  RoutePolicyEntry,
+  'workflowRequirement' | 'exportPolicy' | 'provenanceRequired'
+> & {
+  governanceRef: '/lp-reporting/metrics' | '/lp-reporting/imports';
+  routes: ReadonlyArray<readonly [method: string, path: string]>;
+};
+
+const LP_REPORTING_ADDITIONAL_ROUTE_POLICY_GROUPS = [
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [['POST', '/api/funds/:fundId/metric-runs/dry-run']],
+    workflowRequirement: 'source_rows_and_preview_hash_generated',
+    exportPolicy: 'preview_only',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [['POST', '/api/funds/:fundId/metric-runs/commit']],
+    workflowRequirement: 'preview_hash_source_rows_and_idempotency_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [
+      ['GET', '/api/funds/:fundId/metric-runs/latest'],
+      ['GET', '/api/funds/:fundId/metric-runs/:metricRunId'],
+      ['GET', '/api/funds/:fundId/metric-runs/:metricRunId/report-package'],
+      ['GET', '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records'],
+      ['GET', '/api/funds/:fundId/metric-runs/:metricRunId/narrative-runs'],
+      ['GET', '/api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId'],
+    ],
+    workflowRequirement: 'fund_scope_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [['POST', '/api/funds/:fundId/metric-runs/:metricRunId/approve']],
+    workflowRequirement: 'draft_metric_run_evidence_and_expected_version_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [['POST', '/api/funds/:fundId/metric-runs/:metricRunId/lock']],
+    workflowRequirement: 'approved_metric_run_and_expected_version_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [['POST', '/api/funds/:fundId/metric-runs/:metricRunId/report-package']],
+    workflowRequirement: 'locked_metric_run_and_approved_narrative_versions_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [['POST', '/api/funds/:fundId/metric-runs/:metricRunId/evidence-records']],
+    workflowRequirement: 'draft_metric_run_and_idempotency_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [['POST', '/api/funds/:fundId/metric-runs/:metricRunId/narrative-runs']],
+    workflowRequirement: 'locked_metric_run_source_contract_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [
+      ['PATCH', '/api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId'],
+    ],
+    workflowRequirement: 'locked_metric_run_draft_and_expected_version_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [
+      ['POST', '/api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId/review'],
+    ],
+    workflowRequirement: 'locked_metric_run_edited_draft_and_expected_version_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/metrics',
+    routes: [
+      [
+        'POST',
+        '/api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId/approve',
+      ],
+    ],
+    workflowRequirement: 'locked_metric_run_edited_review_and_expected_version_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/imports',
+    routes: [
+      ['POST', '/api/funds/:fundId/imports/ledger/dry-run'],
+      ['POST', '/api/funds/:fundId/imports/valuation-marks/dry-run'],
+    ],
+    workflowRequirement: 'reconciliation_preview_hash_generated',
+    exportPolicy: 'preview_only',
+    provenanceRequired: true,
+  },
+  {
+    governanceRef: '/lp-reporting/imports',
+    routes: [
+      ['POST', '/api/funds/:fundId/imports/ledger/commit'],
+      ['POST', '/api/funds/:fundId/imports/valuation-marks/commit'],
+    ],
+    workflowRequirement: 'clean_preview_hash_fund_references_and_source_hashes_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
+] satisfies ReadonlyArray<LpReportingRoutePolicyGroup>;
+
+const LP_REPORTING_ADDITIONAL_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] =
+  LP_REPORTING_ADDITIONAL_ROUTE_POLICY_GROUPS.flatMap(({ routes, governanceRef, ...decision }) =>
+    routes.map(([method, path]) => ({
+      id: `api:${method.toLowerCase()}:${path}`,
+      method,
+      path,
+      lifecycle: 'durable_crud',
+      governanceRef,
+      surface:
+        governanceRef === '/lp-reporting/imports'
+          ? 'lp-reporting-imports-api'
+          : 'lp-reporting-metric-runs-api',
+      owner: ownerForFinancialSurface('lp_reporting'),
+      telemetryKey: telemetryKeyForRoute('api.route', path),
+      financialSurface: 'lp_reporting',
+      apiAuthBoundary: 'require_auth_and_fund_access',
+      fundScopeMode: 'route_param_fund_id',
+      ...decision,
+      staleBlocksExport: false,
+      humanReviewRequired: true,
+      performanceBudgetMs: null,
+    }))
+  );
+
 const PORTFOLIO_INTELLIGENCE_ROUTE_POLICY_DECISIONS: Readonly<PortfolioIntelligenceRouteDecisionMap> =
   {
     'POST /api/portfolio/strategies': {
@@ -796,6 +944,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     notes:
       'Idempotent case creation preserves the selected actuals snapshot and requires optimistic locking on the parent scenario.',
   },
+  ...LP_REPORTING_ADDITIONAL_ROUTE_POLICY_ENTRIES,
   {
     id: 'api:get:/api/funds/:fundId/metric-runs/:metricRunId/report-package/render-model',
     method: 'GET',

--- a/server/routes/scenario-analysis.ts
+++ b/server/routes/scenario-analysis.ts
@@ -33,6 +33,7 @@ import {
 } from '@shared/utils/scenario-math';
 import type { ScenarioCase } from '@shared/types/scenario';
 import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
+import { FEATURES } from '../config/features.js';
 import { firstString } from '../lib/request-values';
 import { createRouteLogger } from '../lib/route-logger.js';
 import { enforceCompanyFundScope, resolveCompanyFundId } from '../lib/auth/company-fund-scope';
@@ -372,6 +373,10 @@ router['post'](
   async (req: Request, res: Response) => {
     const { fundId } = FundIdParamSchema.parse(req.params);
     const scenarioId = z.string().uuid().parse(req.params['scenarioId']);
+    if (!FEATURES.scenarioSeedPicker) {
+      return res.status(404).json({ error: 'not_found' });
+    }
+
     const parsedBody = CreateScenarioCaseFromSeedRequestSchema.safeParse(req.body);
     if (!parsedBody.success) {
       return res.status(400).json({

--- a/server/services/lp-reporting/report-package-csv-stored-export-service.ts
+++ b/server/services/lp-reporting/report-package-csv-stored-export-service.ts
@@ -421,6 +421,12 @@ export async function createMetricRunReportPackageStoredCsvExport(
     metricRunId: input.metricRunId,
     database,
   });
+  await assertH9PackageExportable({
+    surface: 'stored_csv_export',
+    fundId: input.fundId,
+    metricRunId: input.metricRunId,
+    database,
+  });
 
   const sourceJson = await loadStoredExport(database, input, 'json');
   if (sourceJson === null) {

--- a/server/services/lp-reporting/report-package-json-stored-export-service.ts
+++ b/server/services/lp-reporting/report-package-json-stored-export-service.ts
@@ -12,6 +12,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { db } from '../../db';
 import {
+  CURRENT_REPORT_PACKAGE_RENDER_MODEL_VERSION,
   ReportPackageExportContentHashConflictResponseSchema,
   ReportPackageExportNotFoundResponseSchema,
   ReportPackageExportRecordSchema,
@@ -208,6 +209,26 @@ function assertHashMatch(row: LpReportPackageExport, currentContentHash: string)
   }
 }
 
+/**
+ * Version-aware replay comparison. Content hashes are only comparable within
+ * the same render-model version: bumping the render-model shape (for example
+ * adding per-metric provenance in version 2) changes canonical bytes, so a
+ * stored row from an older version replays against its own stored bytes/hash
+ * instead of conflicting with the current renderer output. Rows whose stored
+ * artifact does not parse (legacy pre-stamp rows) keep the existing
+ * hash-conflict path.
+ */
+function assertReplayMatchesStored(row: LpReportPackageExport, currentContentHash: string): void {
+  const parsed = ReportPackageJsonExportArtifactSchema.safeParse(row.artifactPayload);
+  if (
+    parsed.success &&
+    parsed.data.renderModel.renderModelVersion !== CURRENT_REPORT_PACKAGE_RENDER_MODEL_VERSION
+  ) {
+    return;
+  }
+  assertHashMatch(row, currentContentHash);
+}
+
 async function markMetricRunStoredJsonExported(
   database: StoredExportDatabase,
   input: ReportPackageStoredJsonExportInput
@@ -278,7 +299,7 @@ export async function createMetricRunReportPackageStoredJsonExport(
       'Stored report package JSON export could not be created or reloaded.'
     );
   }
-  assertHashMatch(existing, contentHash);
+  assertReplayMatchesStored(existing, contentHash);
   await markMetricRunStoredJsonExported(database, input);
   return ReportPackageJsonStoredExportResponseSchema.parse({
     record: toExportRecord(existing),

--- a/server/services/lp-reporting/report-package-render-model-service.ts
+++ b/server/services/lp-reporting/report-package-render-model-service.ts
@@ -232,12 +232,22 @@ function metricRow(
   return { metricId, label, value, valueKind, currency };
 }
 
-function buildMetricSections(payload: ReportPackagePayload): ReportPackageRenderMetricSection[] {
+function buildMetricSections(
+  payload: ReportPackagePayload,
+  metricRun: LpMetricRun
+): ReportPackageRenderMetricSection[] {
   const { results } = payload;
+  const provenance = {
+    inputsHash: metricRun.inputsHash,
+    inputsHashShort: metricRun.inputsHash.slice(0, 12),
+    methodologyVersion: metricRun.methodologyVersion,
+    calculationVersion: metricRun.calculationVersion,
+  };
   return [
     {
       sectionId: 'performance',
       title: 'Performance',
+      ...provenance,
       rows: [
         metricRow('dpi', 'DPI', results.dpi, 'multiple'),
         metricRow('rvpi', 'RVPI', results.rvpi, 'multiple'),
@@ -250,6 +260,7 @@ function buildMetricSections(payload: ReportPackagePayload): ReportPackageRender
     {
       sectionId: 'capital',
       title: 'Capital',
+      ...provenance,
       rows: [
         metricRow(
           'contributionsTotal',
@@ -271,6 +282,7 @@ function buildMetricSections(payload: ReportPackagePayload): ReportPackageRender
     {
       sectionId: 'mark_confidence',
       title: 'Mark confidence',
+      ...provenance,
       rows: [
         metricRow(
           'markConfidenceHigh',
@@ -399,7 +411,7 @@ export async function getMetricRunReportPackageRenderModel(
         },
       },
       fundDisplay,
-      metricSections: buildMetricSections(payload),
+      metricSections: buildMetricSections(payload, metricRun),
       narrativeSections: buildNarrativeSections(payload),
       diagnostics: {
         engineVersion: payload.diagnostics.engineVersion,

--- a/server/services/lp-reporting/report-package-render-model-service.ts
+++ b/server/services/lp-reporting/report-package-render-model-service.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 
 import { db } from '../../db';
 import {
+  CURRENT_REPORT_PACKAGE_RENDER_MODEL_VERSION,
   ReportPackagePayloadSchema,
   ReportPackageRecordSchema,
   ReportPackageRenderModelResponseSchema,
@@ -390,7 +391,7 @@ export async function getMetricRunReportPackageRenderModel(
 
   return ReportPackageRenderModelResponseSchema.parse({
     renderModel: {
-      renderModelVersion: 1,
+      renderModelVersion: CURRENT_REPORT_PACKAGE_RENDER_MODEL_VERSION,
       source: {
         reportPackageId: reportPackage.reportPackageId,
         fundId: reportPackage.fundId,

--- a/shared/contracts/lp-reporting/lp-report-package-render-model.contract.ts
+++ b/shared/contracts/lp-reporting/lp-report-package-render-model.contract.ts
@@ -100,6 +100,10 @@ export const ReportPackageRenderMetricSectionSchema = z
   .object({
     sectionId: ReportPackageRenderMetricSectionIdSchema,
     title: z.string().min(1),
+    inputsHash: z.string().min(1).max(128).optional(),
+    inputsHashShort: z.string().length(12).optional(),
+    methodologyVersion: z.string().min(1).max(64).optional(),
+    calculationVersion: z.string().min(1).max(64).optional(),
     rows: z.array(ReportPackageRenderMetricRowSchema),
   })
   .strict();

--- a/shared/contracts/lp-reporting/lp-report-package-render-model.contract.ts
+++ b/shared/contracts/lp-reporting/lp-report-package-render-model.contract.ts
@@ -25,6 +25,16 @@ const PositiveIntegerSchema = z.number().int().positive();
 const NonnegativeIntegerSchema = z.number().int().nonnegative();
 const HexSha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 
+/**
+ * Render-model shape versions. Version 2 added the optional per-metric
+ * provenance fields (inputsHash, inputsHashShort, methodologyVersion,
+ * calculationVersion) to metric sections. Stored export replays compare
+ * content hashes only within the same render-model version; older stored
+ * artifacts replay against their own bytes/hash.
+ */
+export const CURRENT_REPORT_PACKAGE_RENDER_MODEL_VERSION = 2;
+export const ReportPackageRenderModelVersionSchema = z.union([z.literal(1), z.literal(2)]);
+
 export const ReportPackageRenderMetricSectionIdSchema = z.enum([
   'performance',
   'capital',
@@ -155,7 +165,7 @@ export const ReportPackageRenderReferencesSchema = z
 
 export const ReportPackageRenderModelSchema = z
   .object({
-    renderModelVersion: z.literal(1),
+    renderModelVersion: ReportPackageRenderModelVersionSchema,
     source: ReportPackageRenderSourceSchema,
     fundDisplay: ReportPackageRenderFundDisplaySchema,
     metricSections: z.array(ReportPackageRenderMetricSectionSchema),

--- a/tests/unit/lp-reporting/report-qualification-characterization.test.ts
+++ b/tests/unit/lp-reporting/report-qualification-characterization.test.ts
@@ -11,19 +11,6 @@ const actionabilityState = vi.hoisted(() => ({
   resolveForFund: vi.fn(),
 }));
 
-const reportServiceState = vi.hoisted(() => ({
-  getReportPackage: vi.fn(),
-  assembleReportPackage: vi.fn(),
-  getRenderModel: vi.fn(),
-  getJsonExport: vi.fn(),
-  createStoredJsonExport: vi.fn(),
-  getStoredJsonExport: vi.fn(),
-  getStoredJsonArtifact: vi.fn(),
-  createStoredCsvExport: vi.fn(),
-  getStoredCsvExport: vi.fn(),
-  getStoredCsvArtifact: vi.fn(),
-}));
-
 vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => ({
   ...(await importOriginal<
     typeof import('../../../server/services/fund-calculation-mode-service')
@@ -33,43 +20,92 @@ vi.mock('../../../server/services/fund-calculation-mode-service', async (importO
   }),
 }));
 
-vi.mock('../../../server/services/lp-reporting/report-package-service', () => ({
-  getMetricRunReportPackage: reportServiceState.getReportPackage,
-  assembleMetricRunReportPackage: reportServiceState.assembleReportPackage,
+/**
+ * Data-layer fake (repo pattern). The production LP-reporting routes, services,
+ * workflow gate, and H9 export gates all execute for real through makeApp;
+ * only the database rows they read and write are supplied by this table-keyed
+ * stub. The MOIC actionability resolver above is the only other mocked seam
+ * because it is a DB-heavy resolver input.
+ */
+const dbState = vi.hoisted(() => ({
+  tables: {} as Record<string, Array<Record<string, unknown>>>,
+  exportInsertAttempts: 0,
+  insertedExportRows: [] as Array<Record<string, unknown>>,
+  metricRunStatusUpdates: [] as Array<Record<string, unknown>>,
+  nextId: 9000,
 }));
 
-vi.mock('../../../server/services/lp-reporting/report-package-render-model-service', () => ({
-  getMetricRunReportPackageRenderModel: reportServiceState.getRenderModel,
-}));
+vi.mock('../../../server/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/db')>();
+  const { getTableName } = await import('drizzle-orm');
 
-vi.mock('../../../server/services/lp-reporting/report-package-json-export-service', () => ({
-  getMetricRunReportPackageJsonExport: reportServiceState.getJsonExport,
-  ReportPackageJsonExportBlockedError: class ReportPackageJsonExportBlockedError extends Error {},
-}));
+  function rowsFor(table: unknown): Array<Record<string, unknown>> {
+    return dbState.tables[getTableName(table as never)] ?? [];
+  }
 
-vi.mock('../../../server/services/lp-reporting/report-package-json-stored-export-service', () => ({
-  createMetricRunReportPackageStoredJsonExport: reportServiceState.createStoredJsonExport,
-  getMetricRunReportPackageStoredJsonExport: reportServiceState.getStoredJsonExport,
-  getMetricRunReportPackageStoredJsonArtifact: reportServiceState.getStoredJsonArtifact,
-  reportPackageExportContentHashConflictBody: vi.fn(),
-  reportPackageExportNotFoundBody: vi.fn(),
-  ReportPackageExportContentHashConflictError: class ReportPackageExportContentHashConflictError extends Error {},
-  ReportPackageExportNotFoundError: class ReportPackageExportNotFoundError extends Error {},
-}));
+  function queryResult(rows: Array<Record<string, unknown>>) {
+    const promise = Promise.resolve(rows) as Promise<Array<Record<string, unknown>>> & {
+      limit: (count: number) => Promise<Array<Record<string, unknown>>>;
+    };
+    promise.limit = () => Promise.resolve(rows);
+    return promise;
+  }
 
-vi.mock('../../../server/services/lp-reporting/report-package-csv-stored-export-service', () => ({
-  createMetricRunReportPackageStoredCsvExport: reportServiceState.createStoredCsvExport,
-  getMetricRunReportPackageStoredCsvExport: reportServiceState.getStoredCsvExport,
-  getMetricRunReportPackageStoredCsvArtifact: reportServiceState.getStoredCsvArtifact,
-  reportPackageCsvExportContentHashConflictBody: vi.fn(),
-  reportPackageCsvExportNotFoundBody: vi.fn(),
-  reportPackageCsvSourceJsonExportRequiredBody: vi.fn(),
-  ReportPackageCsvExportContentHashConflictError: class ReportPackageCsvExportContentHashConflictError extends Error {},
-  ReportPackageCsvExportNotFoundError: class ReportPackageCsvExportNotFoundError extends Error {},
-  ReportPackageCsvSourceJsonExportRequiredError: class ReportPackageCsvSourceJsonExportRequiredError extends Error {},
-}));
+  const fakeDb = {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => queryResult(rowsFor(table)),
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (row: Record<string, unknown>) => ({
+        onConflictDoNothing: () => ({
+          returning: async () => {
+            const name = getTableName(table as never);
+            if (name !== 'lp_report_package_exports') return [];
+            dbState.exportInsertAttempts += 1;
+            const rows = rowsFor(table);
+            const duplicate = rows.find(
+              (candidate) =>
+                candidate['reportPackageId'] === row['reportPackageId'] &&
+                candidate['format'] === row['format'] &&
+                candidate['exportVersion'] === row['exportVersion']
+            );
+            if (duplicate) return [];
+            const stored = { id: dbState.nextId++, ...row };
+            rows.push(stored);
+            dbState.insertedExportRows.push(stored);
+            return [stored];
+          },
+        }),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            const name = getTableName(table as never);
+            if (name !== 'lp_metric_runs') return [];
+            const current = rowsFor(table).find((candidate) => candidate['status'] === 'locked');
+            if (!current) return [];
+            Object.assign(current, values);
+            dbState.metricRunStatusUpdates.push(values);
+            return [current];
+          },
+        }),
+      }),
+    }),
+    execute: async () => [],
+  };
 
-import { assertH9ExportActionable } from '../../../server/services/lp-reporting/h9-export-gate';
+  return { ...actual, db: fakeDb as never };
+});
+
+import { createHash } from 'node:crypto';
+
+import { buildReportPackageCsv } from '../../../server/services/lp-reporting/report-package-csv-stored-export-service';
+import { sha256CanonicalJson } from '../../../server/services/lp-reporting/report-package-json-export-service';
+import { ReportPackageJsonExportArtifactSchema } from '@shared/contracts/lp-reporting';
 
 const EXPORT_ROUTES = [
   ['GET', '/api/funds/1/metric-runs/11/report-package/render-model'],
@@ -130,7 +166,7 @@ const READ_AND_LIFECYCLE_PROBES = [
   {
     route: ['GET', '/api/funds/1/metric-runs/11/report-package'],
     expectedStatus: 200,
-    expectedBody: { record: null },
+    expectedBody: { record: { reportPackageId: 501, metricRunId: 11, status: 'assembled' } },
   },
 ] as const;
 
@@ -242,41 +278,240 @@ const renderModel = {
   },
 } as const;
 
-const jsonExport = {
+/**
+ * A stored export row created BEFORE per-metric provenance existed:
+ * render-model version 1 metric sections without provenance fields. Its
+ * content hash is the real hash of its own bytes, so replays must succeed
+ * against the stored row even though the current renderer output differs.
+ */
+const legacyJsonArtifact = ReportPackageJsonExportArtifactSchema.parse({
   exportVersion: 1,
   format: 'json',
   source,
   renderModel,
-  contentHashAlgorithm: 'sha256',
-  contentHash: 'a'.repeat(64),
+});
+const STORED_JSON_CONTENT_HASH = sha256CanonicalJson(legacyJsonArtifact);
+const STORED_CSV_STRING = buildReportPackageCsv(legacyJsonArtifact);
+const STORED_CSV_CONTENT_HASH = createHash('sha256')
+  .update(STORED_CSV_STRING, 'utf8')
+  .digest('hex');
+const METRIC_RUN_INPUTS_HASH = '0123456789abcdef'.repeat(4);
+
+const validXirrDiagnostic = {
+  convergence: 'converged',
+  iterations: 5,
+  method: 'newton',
+  boundHit: null,
+  failureReason: null,
 } as const;
 
-const exportRecord = {
-  reportPackageExportId: 601,
-  fundId: 1,
-  metricRunId: 11,
-  reportPackageId: 501,
-  format: 'json',
-  exportVersion: 1,
-  status: 'ready',
-  contentHashAlgorithm: 'sha256',
-  contentHash: 'a'.repeat(64),
-  artifactSizeBytes: 512,
-  createdBy: 7,
-  readyAt: '2026-05-10T04:00:00.000Z',
-  createdAt: '2026-05-10T04:00:00.000Z',
-  updatedAt: '2026-05-10T04:00:00.000Z',
-} as const;
+function reportPackagePayload() {
+  const narratives = [
+    ['no_dpi', 100, 'Approved no DPI copy.'],
+    ['methodology', 101, 'Approved methodology copy.'],
+    ['portfolio_update', 102, 'Approved portfolio update copy.'],
+    ['risk_disclosure', 103, 'Approved risk disclosure copy.'],
+  ] as const;
 
-const csvExport = {
-  exportVersion: 1,
-  format: 'csv',
-  sourceJsonExportId: 601,
-  sourceJsonContentHash: jsonExport.contentHash,
-  contentType: 'text/csv; charset=utf-8',
-  filename: 'lp-report-package-1-11-csv-v1.csv',
-  csv: 'section,field,value\nperformance,moic,1.500000\n',
-} as const;
+  return {
+    payloadVersion: 1,
+    results: {
+      asOfDate: '2026-03-31',
+      currency: 'USD',
+      dpi: '0.450000',
+      rvpi: '1.250000',
+      tvpi: '1.700000',
+      moic: '1.700000',
+      netIrr: '0.150000',
+      grossIrr: '0.180000',
+      xirrDiagnostic: {
+        net: validXirrDiagnostic,
+        gross: validXirrDiagnostic,
+      },
+      contributionsTotal: '50000000.000000',
+      distributionsTotal: '22500000.000000',
+      currentNav: '62500000.000000',
+      markConfidenceMix: { high: 8, medium: 3, low: 1 },
+    },
+    diagnostics: {
+      engineVersion: 'lp-reporting-engine@1.2.0',
+      decimalPrecision: 6,
+      excludedFutureMarks: [],
+      warnings: [],
+    },
+    sourceEventIds: [101, 102],
+    sourceMarkIds: [201],
+    evidenceRecordIds: [300, 301],
+    narratives: narratives.map(([narrativeType, narrativeRunId, effectiveText]) => ({
+      narrativeType,
+      narrativeRunId,
+      narrativeVersion: 3,
+      approvedBy: 7,
+      approvedAt: '2026-05-10T02:30:00.000Z',
+      textHash: 'a'.repeat(64),
+      effectiveText,
+    })),
+  };
+}
+
+function metricRunRow(): Record<string, unknown> {
+  return {
+    id: 11,
+    fundId: 1,
+    vehicleId: null,
+    asOfDate: '2026-03-31',
+    runType: 'quarterly_report',
+    perspective: 'lp_net',
+    status: 'locked',
+    inputsHash: METRIC_RUN_INPUTS_HASH,
+    sourceEventIds: [101, 102],
+    sourceMarkIds: [201],
+    sourceEvidenceIds: [300, 301],
+    resultsJson: {},
+    diagnosticsJson: {},
+    methodologyVersion: 'lp-reporting-methodology-v1',
+    calculationVersion: 'lp-reporting-metrics-engine-1.0.0',
+    generatedBy: 7,
+    approvedBy: 7,
+    approvedAt: new Date('2026-05-10T01:00:00Z'),
+    lockedBy: 7,
+    lockedAt: new Date('2026-05-10T02:00:00Z'),
+    exportedAt: null,
+    version: 4,
+    createdAt: new Date('2026-05-10T00:00:00Z'),
+    updatedAt: new Date('2026-05-10T02:00:00Z'),
+  };
+}
+
+function fundRow(): Record<string, unknown> {
+  return {
+    id: 1,
+    name: 'Qualification Test Fund',
+    size: '100000000.000000',
+    deployedCapital: '0',
+    managementFee: '0.0200',
+    carryPercentage: '0.2000',
+    vintageYear: 2024,
+    establishmentDate: null,
+    status: 'active',
+    isActive: true,
+    engineResults: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+function reportPackageRow(): Record<string, unknown> {
+  const payload = reportPackagePayload();
+  return {
+    id: 501,
+    fundId: 1,
+    metricRunId: 11,
+    status: 'assembled',
+    asOfDate: '2026-03-31',
+    metricRunVersion: 4,
+    metricRunLockedBy: 7,
+    metricRunLockedAt: new Date('2026-05-10T02:00:00Z'),
+    narrativeRefs: payload.narratives.map((narrative) => ({
+      narrativeType: narrative.narrativeType,
+      narrativeRunId: narrative.narrativeRunId,
+      narrativeVersion: narrative.narrativeVersion,
+      approvedBy: narrative.approvedBy,
+      approvedAt: narrative.approvedAt,
+      textHash: narrative.textHash,
+    })),
+    payload,
+    h9MoicSourceInputHash: 'a'.repeat(64),
+    h9RoundEvidenceInputHash: 'b'.repeat(64),
+    h9RoundEvidenceAssumptionsHash: 'c'.repeat(64),
+    h9FingerprintHash: H9_FINGERPRINT,
+    h9PolicyVersion: H9_POLICY_VERSION,
+    h9ActionabilityStatus: 'actionable',
+    assembledBy: 7,
+    assembledAt: new Date('2026-05-10T03:00:00Z'),
+    version: 1,
+    createdAt: new Date('2026-05-10T03:00:00Z'),
+    updatedAt: new Date('2026-05-10T03:00:00Z'),
+  };
+}
+
+function evidenceRow(id: number): Record<string, unknown> {
+  return {
+    id,
+    fundId: 1,
+    metricRunId: 11,
+    confidentiality: 'internal',
+    redactionRequired: false,
+  };
+}
+
+function storedJsonExportRow(): Record<string, unknown> {
+  return {
+    id: 601,
+    fundId: 1,
+    metricRunId: 11,
+    reportPackageId: 501,
+    format: 'json',
+    exportVersion: 1,
+    status: 'ready',
+    contentHashAlgorithm: 'sha256',
+    contentHash: STORED_JSON_CONTENT_HASH,
+    artifactPayload: legacyJsonArtifact,
+    artifactSizeBytes: 1000,
+    createdBy: 7,
+    readyAt: new Date('2026-05-10T04:00:00Z'),
+    createdAt: new Date('2026-05-10T04:00:00Z'),
+    updatedAt: new Date('2026-05-10T04:00:00Z'),
+  };
+}
+
+function storedCsvExportRow(): Record<string, unknown> {
+  return {
+    id: 602,
+    fundId: 1,
+    metricRunId: 11,
+    reportPackageId: 501,
+    format: 'csv',
+    exportVersion: 1,
+    status: 'ready',
+    contentHashAlgorithm: 'sha256',
+    contentHash: STORED_CSV_CONTENT_HASH,
+    artifactPayload: {
+      exportVersion: 1,
+      format: 'csv',
+      sourceJsonExportId: 601,
+      sourceJsonContentHash: STORED_JSON_CONTENT_HASH,
+      contentType: 'text/csv; charset=utf-8',
+      filename: 'lp-report-package-1-11-csv-v1.csv',
+      csv: STORED_CSV_STRING,
+    },
+    artifactSizeBytes: Buffer.byteLength(STORED_CSV_STRING, 'utf8'),
+    createdBy: 7,
+    readyAt: new Date('2026-05-10T05:00:00Z'),
+    createdAt: new Date('2026-05-10T05:00:00Z'),
+    updatedAt: new Date('2026-05-10T05:00:00Z'),
+  };
+}
+
+function seedDatabaseFixtures(): void {
+  dbState.tables = {
+    funds: [fundRow()],
+    users: [{ id: 1 }, { id: 7 }],
+    lp_metric_runs: [metricRunRow()],
+    lp_report_packages: [reportPackageRow()],
+    lp_report_package_exports: [storedJsonExportRow(), storedCsvExportRow()],
+    evidence_records: [evidenceRow(300), evidenceRow(301)],
+  };
+  dbState.exportInsertAttempts = 0;
+  dbState.insertedExportRows = [];
+  dbState.metricRunStatusUpdates = [];
+  dbState.nextId = 9000;
+}
+
+function setStoredPackageH9(overrides: Record<string, unknown>): void {
+  const [pkg] = dbState.tables['lp_report_packages'] ?? [];
+  if (!pkg) throw new Error('lp_report_packages fixture row is missing');
+  Object.assign(pkg, overrides);
+}
 
 function configureTestEnv(): void {
   for (const key of ENV_KEYS) originalEnv.set(key, process.env[key]);
@@ -318,65 +553,6 @@ function restoreTestEnv(): void {
   originalEnv.clear();
 }
 
-function configureReportServiceFixtures(): void {
-  reportServiceState.getReportPackage.mockResolvedValue({ record: null });
-  reportServiceState.getRenderModel.mockImplementation(async () => {
-    await assertFixtureH9('render_model');
-    return { renderModel };
-  });
-  reportServiceState.getJsonExport.mockImplementation(async () => {
-    await assertFixtureH9('live_json_export');
-    return { export: jsonExport };
-  });
-  reportServiceState.createStoredJsonExport.mockImplementation(async () => {
-    await assertFixtureH9('live_json_export');
-    return {
-      record: exportRecord,
-      inserted: false,
-    };
-  });
-  reportServiceState.getStoredJsonExport.mockResolvedValue({ record: exportRecord });
-  reportServiceState.getStoredJsonArtifact.mockImplementation(async () => {
-    await assertFixtureH9('stored_json_export');
-    return {
-      record: exportRecord,
-      export: jsonExport,
-    };
-  });
-
-  const csvRecord = {
-    ...exportRecord,
-    reportPackageExportId: 602,
-    format: 'csv',
-    contentHash: 'b'.repeat(64),
-  } as const;
-  const csvMetadata = {
-    sourceJsonExportId: csvExport.sourceJsonExportId,
-    sourceJsonContentHash: csvExport.sourceJsonContentHash,
-    contentType: csvExport.contentType,
-    filename: csvExport.filename,
-  } as const;
-  reportServiceState.createStoredCsvExport.mockImplementation(async () => {
-    await assertFixtureH9('stored_csv_export');
-    return {
-      record: csvRecord,
-      inserted: false,
-      ...csvMetadata,
-    };
-  });
-  reportServiceState.getStoredCsvExport.mockResolvedValue({
-    record: csvRecord,
-    ...csvMetadata,
-  });
-  reportServiceState.getStoredCsvArtifact.mockImplementation(async () => {
-    await assertFixtureH9('stored_csv_export');
-    return {
-      record: csvRecord,
-      csv: csvExport,
-    };
-  });
-}
-
 let nextAuthorizationUserId = 100;
 
 async function authorizationHeader(role: string, fundIds: number[]): Promise<string> {
@@ -396,31 +572,6 @@ function sendRoute(
 ): Test {
   const [method, routePath] = route;
   return method === 'POST' ? request(app).post(routePath).send({}) : request(app).get(routePath);
-}
-
-function storedH9(overrides: Record<string, unknown> = {}) {
-  return {
-    h9MoicSourceInputHash: 'a'.repeat(64),
-    h9RoundEvidenceInputHash: 'b'.repeat(64),
-    h9RoundEvidenceAssumptionsHash: 'c'.repeat(64),
-    h9FingerprintHash: H9_FINGERPRINT,
-    h9PolicyVersion: H9_POLICY_VERSION,
-    h9ActionabilityStatus: 'actionable',
-    ...overrides,
-  };
-}
-
-let storedH9Fixture = storedH9();
-
-async function assertFixtureH9(
-  surface: Parameters<typeof assertH9ExportActionable>[0]['surface']
-): Promise<void> {
-  await assertH9ExportActionable({
-    surface,
-    fundId: 1,
-    stored: storedH9Fixture as never,
-    database: {} as never,
-  });
 }
 
 function productionSourceFile(relativePath: string): ts.SourceFile {
@@ -561,7 +712,6 @@ let app: Awaited<ReturnType<(typeof import('../../../server/app'))['makeApp']>>;
 
 beforeAll(async () => {
   configureTestEnv();
-  configureReportServiceFixtures();
   const appModule = await import('../../../server/app');
   app = appModule.makeApp();
 }, 60_000);
@@ -571,7 +721,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  storedH9Fixture = storedH9();
+  seedDatabaseFixtures();
   actionabilityState.resolveForFund.mockReset();
   actionabilityState.resolveForFund.mockResolvedValue({
     actionability: 'actionable',
@@ -635,13 +785,16 @@ describe('LP report export authorization', () => {
           issues: expect.any(Array),
         });
       } else {
-        expect(response.body, probe.route.join(' ')).toEqual(probe.expectedBody);
+        expect(response.body, probe.route.join(' ')).toMatchObject(probe.expectedBody);
       }
     }
   });
 });
 
 describe('H9 export qualification', () => {
+  // These tests execute the REAL production gates (assertH9ExportActionable /
+  // assertH9PackageExportable) through real makeApp routes and real services;
+  // only the database rows and the MOIC actionability resolver are stubbed.
   async function expectH9BlockAcrossCurrentExportRoutes(code: string): Promise<void> {
     const authorization = await authorizationHeader('partner', [1]);
     for (const route of CURRENT_H9_GATED_EXPORT_ROUTES) {
@@ -649,15 +802,19 @@ describe('H9 export qualification', () => {
       expect(response.status, route.join(' ')).toBe(409);
       expect(response.body, route.join(' ')).toMatchObject({ error: code });
     }
+    // While the real gate blocks, neither export-creation POST may attempt a
+    // persistence write (gate-before-insert ordering, proven behaviorally).
+    expect(dbState.exportInsertAttempts).toBe(0);
+    expect(dbState.insertedExportRows).toHaveLength(0);
   }
 
   it('blocks missing stored H9 metadata across every currently H9-gated export route', async () => {
-    storedH9Fixture = storedH9({ h9ActionabilityStatus: null, h9FingerprintHash: null });
+    setStoredPackageH9({ h9ActionabilityStatus: null, h9FingerprintHash: null });
     await expectH9BlockAcrossCurrentExportRoutes('H9_METADATA_MISSING');
   });
 
   it('blocks stored H9 that is not actionable across every currently H9-gated export route', async () => {
-    storedH9Fixture = storedH9({ h9ActionabilityStatus: 'non_actionable' });
+    setStoredPackageH9({ h9ActionabilityStatus: 'non_actionable' });
     await expectH9BlockAcrossCurrentExportRoutes('H9_NOT_ACTIONABLE');
   });
 
@@ -678,7 +835,7 @@ describe('H9 export qualification', () => {
   });
 
   it('keeps stored-export status GETs role-and-grant gated without invoking H9', async () => {
-    storedH9Fixture = storedH9({ h9ActionabilityStatus: null, h9FingerprintHash: null });
+    setStoredPackageH9({ h9ActionabilityStatus: null, h9FingerprintHash: null });
     actionabilityState.resolveForFund.mockRejectedValue(new Error('resolver unavailable'));
     const authorization = await authorizationHeader('partner', [1]);
 
@@ -689,77 +846,46 @@ describe('H9 export qualification', () => {
     expect(actionabilityState.resolveForFund).not.toHaveBeenCalled();
   });
 
-  it('pins the production service call chain for all six H9-gated routes', () => {
-    const renderModelBody = productionFunctionBody(
-      'server/services/lp-reporting/report-package-render-model-service.ts',
-      'getMetricRunReportPackageRenderModel'
-    );
-    expect(renderModelBody).toContain('await assertH9ExportActionable({');
-    expect(renderModelBody).toContain("surface: options.h9Surface ?? 'render_model'");
+  it('serves per-metric provenance and render-model version 2 on live export surfaces', async () => {
+    const authorization = await authorizationHeader('partner', [1]);
 
-    const liveJsonBody = productionFunctionBody(
-      'server/services/lp-reporting/report-package-json-export-service.ts',
-      'getMetricRunReportPackageJsonExport'
+    const renderModelResponse = await sendRoute(app, EXPORT_ROUTES[0]).set(
+      'Authorization',
+      authorization
     );
-    expect(liveJsonBody).toContain(
-      'options.renderModelService ?? getMetricRunReportPackageRenderModel'
-    );
-    expect(liveJsonBody).toContain("h9Surface: 'live_json_export'");
+    expect(renderModelResponse.status).toBe(200);
+    const { renderModel: liveRenderModel } = renderModelResponse.body;
+    expect(liveRenderModel.renderModelVersion).toBe(2);
+    expect(liveRenderModel.metricSections.length).toBeGreaterThan(0);
+    for (const section of liveRenderModel.metricSections) {
+      expect(section.inputsHash).toBe(METRIC_RUN_INPUTS_HASH);
+      expect(section.inputsHashShort).toBe(METRIC_RUN_INPUTS_HASH.slice(0, 12));
+      expect(section.inputsHashShort).toHaveLength(12);
+      expect(section.methodologyVersion).toBe('lp-reporting-methodology-v1');
+      expect(section.calculationVersion).toBe('lp-reporting-metrics-engine-1.0.0');
+    }
 
-    const storedJsonCreateBody = productionFunctionBody(
-      'server/services/lp-reporting/report-package-json-stored-export-service.ts',
-      'createMetricRunReportPackageStoredJsonExport'
+    const liveExportResponse = await sendRoute(app, EXPORT_ROUTES[1]).set(
+      'Authorization',
+      authorization
     );
-    expect(storedJsonCreateBody).toContain(
-      'options.jsonExportService ?? getMetricRunReportPackageJsonExport'
-    );
-    const liveGateCall = storedJsonCreateBody.indexOf('const live = await jsonExportService(');
-    const firstPersistence = storedJsonCreateBody.indexOf('.insert(lpReportPackageExports)');
-    expect(liveGateCall).toBeGreaterThanOrEqual(0);
-    expect(firstPersistence).toBeGreaterThan(liveGateCall);
-
-    const storedJsonArtifactBody = productionFunctionBody(
-      'server/services/lp-reporting/report-package-json-stored-export-service.ts',
-      'getMetricRunReportPackageStoredJsonArtifact'
-    );
-    expect(storedJsonArtifactBody).toContain('await assertH9PackageExportable({');
-    expect(storedJsonArtifactBody).toContain("surface: 'stored_json_export'");
-
-    const storedCsvCreateBody = productionFunctionBody(
-      'server/services/lp-reporting/report-package-csv-stored-export-service.ts',
-      'createMetricRunReportPackageStoredCsvExport'
-    );
-    const storedCsvCreateGate = storedCsvCreateBody.indexOf('await assertH9PackageExportable({');
-    const storedCsvFirstPersistence = storedCsvCreateBody.indexOf(
-      '.insert(lpReportPackageExports)'
-    );
-    expect(storedCsvCreateGate).toBeGreaterThanOrEqual(0);
-    expect(storedCsvFirstPersistence).toBeGreaterThan(storedCsvCreateGate);
-
-    const storedCsvArtifactBody = productionFunctionBody(
-      'server/services/lp-reporting/report-package-csv-stored-export-service.ts',
-      'getMetricRunReportPackageStoredCsvArtifact'
-    );
-    expect(storedCsvArtifactBody).toContain('await assertH9PackageExportable({');
-    expect(storedCsvArtifactBody).toContain("surface: 'stored_csv_export'");
+    expect(liveExportResponse.status).toBe(200);
+    expect(liveExportResponse.body.export.renderModel.renderModelVersion).toBe(2);
+    for (const section of liveExportResponse.body.export.renderModel.metricSections) {
+      expect(section.inputsHashShort).toHaveLength(12);
+    }
   });
 
-  it('pins both production stored-export status functions as workflow-gated but H9-independent', () => {
-    const statusFunctions = [
-      productionFunctionBody(
-        'server/services/lp-reporting/report-package-json-stored-export-service.ts',
-        'getMetricRunReportPackageStoredJsonExport'
-      ),
-      productionFunctionBody(
-        'server/services/lp-reporting/report-package-csv-stored-export-service.ts',
-        'getMetricRunReportPackageStoredCsvExport'
-      ),
-    ];
+  it('replays a pre-provenance stored JSON export without a content-hash conflict', async () => {
+    const authorization = await authorizationHeader('partner', [1]);
 
-    for (const functionBody of statusFunctions) {
-      expect(functionBody).toContain('await assertMetricRunExportWorkflowState({');
-      expect(functionBody).not.toMatch(/assertH9(?:ExportActionable|PackageExportable)/);
-    }
+    const response = await sendRoute(app, EXPORT_ROUTES[2]).set('Authorization', authorization);
+
+    expect(response.status).toBe(200);
+    expect(response.body.inserted).toBe(false);
+    expect(response.body.record.reportPackageExportId).toBe(601);
+    expect(response.body.record.contentHash).toBe(STORED_JSON_CONTENT_HASH);
+    expect(dbState.insertedExportRows).toHaveLength(0);
   });
 });
 

--- a/tests/unit/lp-reporting/report-qualification-characterization.test.ts
+++ b/tests/unit/lp-reporting/report-qualification-characterization.test.ts
@@ -1,0 +1,935 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import request, { type Test } from 'supertest';
+import * as ts from 'typescript';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Route = readonly ['GET' | 'POST', string];
+
+const actionabilityState = vi.hoisted(() => ({
+  resolveForFund: vi.fn(),
+}));
+
+const reportServiceState = vi.hoisted(() => ({
+  getReportPackage: vi.fn(),
+  assembleReportPackage: vi.fn(),
+  getRenderModel: vi.fn(),
+  getJsonExport: vi.fn(),
+  createStoredJsonExport: vi.fn(),
+  getStoredJsonExport: vi.fn(),
+  getStoredJsonArtifact: vi.fn(),
+  createStoredCsvExport: vi.fn(),
+  getStoredCsvExport: vi.fn(),
+  getStoredCsvArtifact: vi.fn(),
+}));
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('../../../server/services/fund-calculation-mode-service')
+  >()),
+  createMoicActionabilityResolver: () => ({
+    resolveForFund: actionabilityState.resolveForFund,
+  }),
+}));
+
+vi.mock('../../../server/services/lp-reporting/report-package-service', () => ({
+  getMetricRunReportPackage: reportServiceState.getReportPackage,
+  assembleMetricRunReportPackage: reportServiceState.assembleReportPackage,
+}));
+
+vi.mock('../../../server/services/lp-reporting/report-package-render-model-service', () => ({
+  getMetricRunReportPackageRenderModel: reportServiceState.getRenderModel,
+}));
+
+vi.mock('../../../server/services/lp-reporting/report-package-json-export-service', () => ({
+  getMetricRunReportPackageJsonExport: reportServiceState.getJsonExport,
+  ReportPackageJsonExportBlockedError: class ReportPackageJsonExportBlockedError extends Error {},
+}));
+
+vi.mock('../../../server/services/lp-reporting/report-package-json-stored-export-service', () => ({
+  createMetricRunReportPackageStoredJsonExport: reportServiceState.createStoredJsonExport,
+  getMetricRunReportPackageStoredJsonExport: reportServiceState.getStoredJsonExport,
+  getMetricRunReportPackageStoredJsonArtifact: reportServiceState.getStoredJsonArtifact,
+  reportPackageExportContentHashConflictBody: vi.fn(),
+  reportPackageExportNotFoundBody: vi.fn(),
+  ReportPackageExportContentHashConflictError: class ReportPackageExportContentHashConflictError extends Error {},
+  ReportPackageExportNotFoundError: class ReportPackageExportNotFoundError extends Error {},
+}));
+
+vi.mock('../../../server/services/lp-reporting/report-package-csv-stored-export-service', () => ({
+  createMetricRunReportPackageStoredCsvExport: reportServiceState.createStoredCsvExport,
+  getMetricRunReportPackageStoredCsvExport: reportServiceState.getStoredCsvExport,
+  getMetricRunReportPackageStoredCsvArtifact: reportServiceState.getStoredCsvArtifact,
+  reportPackageCsvExportContentHashConflictBody: vi.fn(),
+  reportPackageCsvExportNotFoundBody: vi.fn(),
+  reportPackageCsvSourceJsonExportRequiredBody: vi.fn(),
+  ReportPackageCsvExportContentHashConflictError: class ReportPackageCsvExportContentHashConflictError extends Error {},
+  ReportPackageCsvExportNotFoundError: class ReportPackageCsvExportNotFoundError extends Error {},
+  ReportPackageCsvSourceJsonExportRequiredError: class ReportPackageCsvSourceJsonExportRequiredError extends Error {},
+}));
+
+import { assertH9ExportActionable } from '../../../server/services/lp-reporting/h9-export-gate';
+
+const EXPORT_ROUTES = [
+  ['GET', '/api/funds/1/metric-runs/11/report-package/render-model'],
+  ['GET', '/api/funds/1/metric-runs/11/report-package/export/json'],
+  ['POST', '/api/funds/1/metric-runs/11/report-package/exports/json'],
+  ['GET', '/api/funds/1/metric-runs/11/report-package/exports/json'],
+  ['GET', '/api/funds/1/metric-runs/11/report-package/exports/json/artifact'],
+  ['POST', '/api/funds/1/metric-runs/11/report-package/exports/csv'],
+  ['GET', '/api/funds/1/metric-runs/11/report-package/exports/csv'],
+  ['GET', '/api/funds/1/metric-runs/11/report-package/exports/csv/artifact'],
+] as const;
+
+const CURRENT_H9_GATED_EXPORT_ROUTES = [
+  EXPORT_ROUTES[0],
+  EXPORT_ROUTES[1],
+  EXPORT_ROUTES[2],
+  EXPORT_ROUTES[4],
+  EXPORT_ROUTES[7],
+] as const;
+
+const H9_INDEPENDENT_STATUS_ROUTES = [EXPORT_ROUTES[3], EXPORT_ROUTES[6]] as const;
+
+const READ_AND_LIFECYCLE_PROBES = [
+  {
+    route: ['POST', '/api/funds/1/metric-runs/dry-run'],
+    expectedStatus: 400,
+    expectedBody: { error: 'INVALID_REQUEST_BODY', issues: true },
+  },
+  {
+    route: ['POST', '/api/funds/1/metric-runs/commit'],
+    expectedStatus: 400,
+    expectedBody: { error: 'INVALID_REQUEST_BODY', issues: true },
+  },
+  {
+    route: ['GET', '/api/funds/1/metric-runs/latest'],
+    expectedStatus: 400,
+    expectedBody: { error: 'INVALID_REQUEST_QUERY', issues: true },
+  },
+  {
+    route: ['GET', '/api/funds/1/metric-runs/not-a-number'],
+    expectedStatus: 400,
+    expectedBody: {
+      error: 'INVALID_METRIC_RUN_ID',
+      message: 'metricRunId must be a positive integer.',
+    },
+  },
+  {
+    route: ['POST', '/api/funds/1/metric-runs/11/approve'],
+    expectedStatus: 400,
+    expectedBody: { error: 'INVALID_REQUEST_BODY', issues: true },
+  },
+  {
+    route: ['POST', '/api/funds/1/metric-runs/11/lock'],
+    expectedStatus: 400,
+    expectedBody: { error: 'INVALID_REQUEST_BODY', issues: true },
+  },
+  {
+    route: ['GET', '/api/funds/1/metric-runs/11/report-package'],
+    expectedStatus: 200,
+    expectedBody: { record: null },
+  },
+] as const;
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'RATE_LIMIT_MAX',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+const H9_FINGERPRINT = 'd'.repeat(64);
+const H9_POLICY_VERSION = 'h9-policy-v1';
+
+const source = {
+  reportPackageId: 501,
+  fundId: 1,
+  metricRunId: 11,
+  reportPackageStatus: 'assembled',
+  asOfDate: '2026-03-31',
+  metricRunVersion: 4,
+  metricRunLockedBy: 7,
+  metricRunLockedAt: '2026-05-10T02:00:00.000Z',
+  assembledBy: 7,
+  assembledAt: '2026-05-10T03:00:00.000Z',
+  packageVersion: 1,
+  payloadVersion: 1,
+  h9Stamp: {
+    fingerprintHash: H9_FINGERPRINT,
+    policyVersion: H9_POLICY_VERSION,
+    actionabilityStatus: 'actionable',
+  },
+} as const;
+
+const renderModel = {
+  renderModelVersion: 1,
+  source,
+  fundDisplay: {
+    fundId: 1,
+    name: 'Qualification Test Fund',
+    vintageYear: 2024,
+    size: '100000000.000000',
+  },
+  metricSections: [
+    {
+      sectionId: 'performance',
+      title: 'Performance',
+      rows: [
+        {
+          metricId: 'moic',
+          label: 'MOIC',
+          value: '1.500000',
+          valueKind: 'multiple',
+          currency: null,
+        },
+      ],
+    },
+  ],
+  narrativeSections: [],
+  diagnostics: {
+    engineVersion: 'lp-reporting-engine@1.2.0',
+    decimalPrecision: 6,
+    excludedFutureMarks: [],
+    warnings: [],
+    xirr: {
+      net: {
+        convergence: 'converged',
+        iterations: 5,
+        method: 'newton',
+        boundHit: null,
+        failureReason: null,
+      },
+      gross: {
+        convergence: 'converged',
+        iterations: 4,
+        method: 'newton',
+        boundHit: null,
+        failureReason: null,
+      },
+    },
+  },
+  references: {
+    sourceEventIds: [],
+    sourceMarkIds: [],
+    evidenceRecordIds: [],
+    narrativeRunIds: [],
+  },
+} as const;
+
+const jsonExport = {
+  exportVersion: 1,
+  format: 'json',
+  source,
+  renderModel,
+  contentHashAlgorithm: 'sha256',
+  contentHash: 'a'.repeat(64),
+} as const;
+
+const exportRecord = {
+  reportPackageExportId: 601,
+  fundId: 1,
+  metricRunId: 11,
+  reportPackageId: 501,
+  format: 'json',
+  exportVersion: 1,
+  status: 'ready',
+  contentHashAlgorithm: 'sha256',
+  contentHash: 'a'.repeat(64),
+  artifactSizeBytes: 512,
+  createdBy: 7,
+  readyAt: '2026-05-10T04:00:00.000Z',
+  createdAt: '2026-05-10T04:00:00.000Z',
+  updatedAt: '2026-05-10T04:00:00.000Z',
+} as const;
+
+const csvExport = {
+  exportVersion: 1,
+  format: 'csv',
+  sourceJsonExportId: 601,
+  sourceJsonContentHash: jsonExport.contentHash,
+  contentType: 'text/csv; charset=utf-8',
+  filename: 'lp-report-package-1-11-csv-v1.csv',
+  csv: 'section,field,value\nperformance,moic,1.500000\n',
+} as const;
+
+function configureTestEnv(): void {
+  for (const key of ENV_KEYS) originalEnv.set(key, process.env[key]);
+
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.RATE_LIMIT_MAX = '1000';
+  process.env.REQUIRE_AUTH = '1';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'report-qualification-test-secret-32-chars';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'report-qualification-session-secret-32-chars';
+}
+
+function restoreTestEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  originalEnv.clear();
+}
+
+function configureReportServiceFixtures(): void {
+  reportServiceState.getReportPackage.mockResolvedValue({ record: null });
+  reportServiceState.getRenderModel.mockImplementation(async () => {
+    await assertFixtureH9('render_model');
+    return { renderModel };
+  });
+  reportServiceState.getJsonExport.mockImplementation(async () => {
+    await assertFixtureH9('live_json_export');
+    return { export: jsonExport };
+  });
+  reportServiceState.createStoredJsonExport.mockImplementation(async () => {
+    await assertFixtureH9('live_json_export');
+    return {
+      record: exportRecord,
+      inserted: false,
+    };
+  });
+  reportServiceState.getStoredJsonExport.mockResolvedValue({ record: exportRecord });
+  reportServiceState.getStoredJsonArtifact.mockImplementation(async () => {
+    await assertFixtureH9('stored_json_export');
+    return {
+      record: exportRecord,
+      export: jsonExport,
+    };
+  });
+
+  const csvRecord = {
+    ...exportRecord,
+    reportPackageExportId: 602,
+    format: 'csv',
+    contentHash: 'b'.repeat(64),
+  } as const;
+  const csvMetadata = {
+    sourceJsonExportId: csvExport.sourceJsonExportId,
+    sourceJsonContentHash: csvExport.sourceJsonContentHash,
+    contentType: csvExport.contentType,
+    filename: csvExport.filename,
+  } as const;
+  reportServiceState.createStoredCsvExport.mockResolvedValue({
+    record: csvRecord,
+    inserted: false,
+    ...csvMetadata,
+  });
+  reportServiceState.getStoredCsvExport.mockResolvedValue({
+    record: csvRecord,
+    ...csvMetadata,
+  });
+  reportServiceState.getStoredCsvArtifact.mockImplementation(async () => {
+    await assertFixtureH9('stored_csv_export');
+    return {
+      record: csvRecord,
+      csv: csvExport,
+    };
+  });
+}
+
+let nextAuthorizationUserId = 100;
+
+async function authorizationHeader(role: string, fundIds: number[]): Promise<string> {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  const userId = nextAuthorizationUserId++;
+  return `Bearer ${signToken({
+    sub: String(userId),
+    email: `qualification-${role}-${userId}@example.com`,
+    role,
+    fundIds,
+  })}`;
+}
+
+function sendRoute(
+  app: Awaited<ReturnType<(typeof import('../../../server/app'))['makeApp']>>,
+  route: Route
+): Test {
+  const [method, routePath] = route;
+  return method === 'POST' ? request(app).post(routePath).send({}) : request(app).get(routePath);
+}
+
+function storedH9(overrides: Record<string, unknown> = {}) {
+  return {
+    h9MoicSourceInputHash: 'a'.repeat(64),
+    h9RoundEvidenceInputHash: 'b'.repeat(64),
+    h9RoundEvidenceAssumptionsHash: 'c'.repeat(64),
+    h9FingerprintHash: H9_FINGERPRINT,
+    h9PolicyVersion: H9_POLICY_VERSION,
+    h9ActionabilityStatus: 'actionable',
+    ...overrides,
+  };
+}
+
+let storedH9Fixture = storedH9();
+
+async function assertFixtureH9(
+  surface: Parameters<typeof assertH9ExportActionable>[0]['surface']
+): Promise<void> {
+  await assertH9ExportActionable({
+    surface,
+    fundId: 1,
+    stored: storedH9Fixture as never,
+    database: {} as never,
+  });
+}
+
+function productionSourceFile(relativePath: string): ts.SourceFile {
+  const source = fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+  return ts.createSourceFile(relativePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function productionFunctionBody(relativePath: string, functionName: string): string {
+  const sourceFile = productionSourceFile(relativePath);
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) &&
+      statement.name?.text === functionName &&
+      ts
+        .getModifiers(statement)
+        ?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) === true
+  );
+
+  if (declaration?.body === undefined) {
+    throw new Error(`Exported function ${functionName} not found in ${relativePath}`);
+  }
+  return declaration.body.getText(sourceFile);
+}
+
+function sourceFunctionBody(relativePath: string, functionName: string): string {
+  const sourceFile = productionSourceFile(relativePath);
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === functionName
+  );
+
+  if (declaration?.body === undefined) {
+    throw new Error(`Function ${functionName} not found in ${relativePath}`);
+  }
+  return declaration.body.getText(sourceFile);
+}
+
+function productionImportSpecifiers(relativePath: string): string[] {
+  const sourceFile = productionSourceFile(relativePath);
+  return [
+    ...new Set(
+      sourceFile.statements
+        .filter(ts.isImportDeclaration)
+        .map((declaration) => declaration.moduleSpecifier)
+        .filter(ts.isStringLiteral)
+        .map((moduleSpecifier) => moduleSpecifier.text)
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
+function productionImportBindings(relativePath: string, moduleSpecifier: string): string[] {
+  const sourceFile = productionSourceFile(relativePath);
+  const bindings: string[] = [];
+
+  for (const declaration of sourceFile.statements.filter(ts.isImportDeclaration)) {
+    if (!ts.isStringLiteral(declaration.moduleSpecifier)) continue;
+    if (declaration.moduleSpecifier.text !== moduleSpecifier) continue;
+
+    const importClause = declaration.importClause;
+    if (importClause === undefined) continue;
+    if (importClause.name !== undefined) {
+      bindings.push(`default ${importClause.name.text}`);
+    }
+
+    const namedBindings = importClause.namedBindings;
+    if (namedBindings === undefined) continue;
+    if (ts.isNamespaceImport(namedBindings)) {
+      bindings.push(`* as ${namedBindings.name.text}`);
+      continue;
+    }
+
+    for (const element of namedBindings.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      const localName = element.name.text;
+      const bindingName =
+        importedName === localName ? importedName : `${importedName} as ${localName}`;
+      const typePrefix = importClause.isTypeOnly || element.isTypeOnly ? 'type ' : '';
+      bindings.push(`${typePrefix}${bindingName}`);
+    }
+  }
+
+  return bindings.sort((left, right) => left.localeCompare(right));
+}
+
+function productionZodObjectFields(relativePath: string, schemaName: string): string[] {
+  const sourceFile = productionSourceFile(relativePath);
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    const declaration = statement.declarationList.declarations.find(
+      (candidate) => ts.isIdentifier(candidate.name) && candidate.name.text === schemaName
+    );
+    if (declaration?.initializer === undefined || !ts.isCallExpression(declaration.initializer)) {
+      continue;
+    }
+
+    const objectArgument = declaration.initializer.arguments[0];
+    if (objectArgument === undefined || !ts.isObjectLiteralExpression(objectArgument)) continue;
+
+    return objectArgument.properties.map((property) => {
+      if (!ts.isPropertyAssignment(property)) {
+        throw new Error(`Unsupported field in ${schemaName} from ${relativePath}`);
+      }
+      if (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) {
+        return property.name.text;
+      }
+      throw new Error(`Unsupported field name in ${schemaName} from ${relativePath}`);
+    });
+  }
+
+  throw new Error(`Zod object ${schemaName} not found in ${relativePath}`);
+}
+
+function readTypeScriptSourcesRecursively(
+  rootDirectory: string
+): Array<{ relativePath: string; source: string }> {
+  const sources: Array<{ relativePath: string; source: string }> = [];
+
+  function visit(directory: string): void {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+      } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        sources.push({
+          relativePath: path.relative(rootDirectory, absolutePath).replaceAll('\\', '/'),
+          source: fs.readFileSync(absolutePath, 'utf8'),
+        });
+      }
+    }
+  }
+
+  visit(rootDirectory);
+  return sources.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+let app: Awaited<ReturnType<(typeof import('../../../server/app'))['makeApp']>>;
+
+beforeAll(async () => {
+  configureTestEnv();
+  configureReportServiceFixtures();
+  const appModule = await import('../../../server/app');
+  app = appModule.makeApp();
+}, 60_000);
+
+afterAll(() => {
+  restoreTestEnv();
+});
+
+beforeEach(() => {
+  storedH9Fixture = storedH9();
+  actionabilityState.resolveForFund.mockReset();
+  actionabilityState.resolveForFund.mockResolvedValue({
+    actionability: 'actionable',
+    sourceFingerprint: {
+      fingerprintHash: H9_FINGERPRINT,
+      policyVersion: H9_POLICY_VERSION,
+    },
+  });
+});
+
+describe('LP report export authorization', () => {
+  it('returns 401 for anonymous requests across all eight export routes', async () => {
+    for (const route of EXPORT_ROUTES) {
+      const response = await sendRoute(app, route);
+      expect(response.status, route.join(' ')).toBe(401);
+    }
+  });
+
+  it.each(['viewer', 'analyst', 'operator'])(
+    'returns 403 for the %s role across all eight export routes',
+    async (role) => {
+      const authorization = await authorizationHeader(role, [1]);
+      for (const route of EXPORT_ROUTES) {
+        const response = await sendRoute(app, route).set('Authorization', authorization);
+        expect(response.status, `${role} ${route.join(' ')}`).toBe(403);
+      }
+    }
+  );
+
+  it('returns 403 for a partner without an explicit export fund grant', async () => {
+    const authorization = await authorizationHeader('partner', []);
+    for (const route of EXPORT_ROUTES) {
+      const response = await sendRoute(app, route).set('Authorization', authorization);
+      expect(response.status, route.join(' ')).toBe(403);
+    }
+  });
+
+  it.each([
+    ['partner', [1]],
+    ['admin', []],
+  ] as const)(
+    'returns 200 for an authorized %s across all eight export routes',
+    async (role, grants) => {
+      const authorization = await authorizationHeader(role, [...grants]);
+      for (const route of EXPORT_ROUTES) {
+        const response = await sendRoute(app, route).set('Authorization', authorization);
+        expect(response.status, route.join(' ')).toBe(200);
+        expect(JSON.stringify(response.body)).not.toMatch(/marginal|non_actionable_shadow/i);
+      }
+    }
+  );
+
+  it('keeps read and lifecycle routes reachable with exact non-partner response contracts', async () => {
+    const authorization = await authorizationHeader('analyst', [1]);
+    for (const probe of READ_AND_LIFECYCLE_PROBES) {
+      const response = await sendRoute(app, probe.route).set('Authorization', authorization);
+      expect(response.status, probe.route.join(' ')).toBe(probe.expectedStatus);
+      if ('issues' in probe.expectedBody) {
+        expect(response.body, probe.route.join(' ')).toEqual({
+          error: probe.expectedBody.error,
+          issues: expect.any(Array),
+        });
+      } else {
+        expect(response.body, probe.route.join(' ')).toEqual(probe.expectedBody);
+      }
+    }
+  });
+});
+
+describe('H9 export qualification', () => {
+  async function expectH9BlockAcrossCurrentExportRoutes(code: string): Promise<void> {
+    const authorization = await authorizationHeader('partner', [1]);
+    for (const route of CURRENT_H9_GATED_EXPORT_ROUTES) {
+      const response = await sendRoute(app, route).set('Authorization', authorization);
+      expect(response.status, route.join(' ')).toBe(409);
+      expect(response.body, route.join(' ')).toMatchObject({ error: code });
+    }
+  }
+
+  it('blocks missing stored H9 metadata across every currently H9-gated export route', async () => {
+    storedH9Fixture = storedH9({ h9ActionabilityStatus: null, h9FingerprintHash: null });
+    await expectH9BlockAcrossCurrentExportRoutes('H9_METADATA_MISSING');
+  });
+
+  it('blocks stored H9 that is not actionable across every currently H9-gated export route', async () => {
+    storedH9Fixture = storedH9({ h9ActionabilityStatus: 'non_actionable' });
+    await expectH9BlockAcrossCurrentExportRoutes('H9_NOT_ACTIONABLE');
+  });
+
+  it('blocks a stale H9 fingerprint across every currently H9-gated export route', async () => {
+    actionabilityState.resolveForFund.mockResolvedValue({
+      actionability: 'actionable',
+      sourceFingerprint: {
+        fingerprintHash: 'e'.repeat(64),
+        policyVersion: H9_POLICY_VERSION,
+      },
+    });
+    await expectH9BlockAcrossCurrentExportRoutes('H9_FINGERPRINT_STALE');
+  });
+
+  it('fails closed across every currently H9-gated export route when revalidation is unavailable', async () => {
+    actionabilityState.resolveForFund.mockRejectedValue(new Error('resolver unavailable'));
+    await expectH9BlockAcrossCurrentExportRoutes('H9_REVALIDATION_UNAVAILABLE');
+  });
+
+  it('keeps stored-export status GETs role-and-grant gated without invoking H9', async () => {
+    storedH9Fixture = storedH9({ h9ActionabilityStatus: null, h9FingerprintHash: null });
+    actionabilityState.resolveForFund.mockRejectedValue(new Error('resolver unavailable'));
+    const authorization = await authorizationHeader('partner', [1]);
+
+    for (const route of H9_INDEPENDENT_STATUS_ROUTES) {
+      const response = await sendRoute(app, route).set('Authorization', authorization);
+      expect(response.status, route.join(' ')).toBe(200);
+    }
+    expect(actionabilityState.resolveForFund).not.toHaveBeenCalled();
+  });
+
+  it('pins the production service call chain for all five currently H9-gated routes', () => {
+    const renderModelBody = productionFunctionBody(
+      'server/services/lp-reporting/report-package-render-model-service.ts',
+      'getMetricRunReportPackageRenderModel'
+    );
+    expect(renderModelBody).toContain('await assertH9ExportActionable({');
+    expect(renderModelBody).toContain("surface: options.h9Surface ?? 'render_model'");
+
+    const liveJsonBody = productionFunctionBody(
+      'server/services/lp-reporting/report-package-json-export-service.ts',
+      'getMetricRunReportPackageJsonExport'
+    );
+    expect(liveJsonBody).toContain(
+      'options.renderModelService ?? getMetricRunReportPackageRenderModel'
+    );
+    expect(liveJsonBody).toContain("h9Surface: 'live_json_export'");
+
+    const storedJsonCreateBody = productionFunctionBody(
+      'server/services/lp-reporting/report-package-json-stored-export-service.ts',
+      'createMetricRunReportPackageStoredJsonExport'
+    );
+    expect(storedJsonCreateBody).toContain(
+      'options.jsonExportService ?? getMetricRunReportPackageJsonExport'
+    );
+    const liveGateCall = storedJsonCreateBody.indexOf('const live = await jsonExportService(');
+    const firstPersistence = storedJsonCreateBody.indexOf('.insert(lpReportPackageExports)');
+    expect(liveGateCall).toBeGreaterThanOrEqual(0);
+    expect(firstPersistence).toBeGreaterThan(liveGateCall);
+
+    const storedJsonArtifactBody = productionFunctionBody(
+      'server/services/lp-reporting/report-package-json-stored-export-service.ts',
+      'getMetricRunReportPackageStoredJsonArtifact'
+    );
+    expect(storedJsonArtifactBody).toContain('await assertH9PackageExportable({');
+    expect(storedJsonArtifactBody).toContain("surface: 'stored_json_export'");
+
+    const storedCsvArtifactBody = productionFunctionBody(
+      'server/services/lp-reporting/report-package-csv-stored-export-service.ts',
+      'getMetricRunReportPackageStoredCsvArtifact'
+    );
+    expect(storedCsvArtifactBody).toContain('await assertH9PackageExportable({');
+    expect(storedCsvArtifactBody).toContain("surface: 'stored_csv_export'");
+  });
+
+  it('pins both production stored-export status functions as workflow-gated but H9-independent', () => {
+    const statusFunctions = [
+      productionFunctionBody(
+        'server/services/lp-reporting/report-package-json-stored-export-service.ts',
+        'getMetricRunReportPackageStoredJsonExport'
+      ),
+      productionFunctionBody(
+        'server/services/lp-reporting/report-package-csv-stored-export-service.ts',
+        'getMetricRunReportPackageStoredCsvExport'
+      ),
+    ];
+
+    for (const functionBody of statusFunctions) {
+      expect(functionBody).toContain('await assertMetricRunExportWorkflowState({');
+      expect(functionBody).not.toMatch(/assertH9(?:ExportActionable|PackageExportable)/);
+    }
+  });
+});
+
+describe('marginal MOIC and report-sharing boundaries', () => {
+  it('keeps marginal MOIC contracts out of every LP reporting service', () => {
+    const serviceDirectory = path.join(process.cwd(), 'server', 'services', 'lp-reporting');
+    const serviceSource = fs
+      .readdirSync(serviceDirectory)
+      .filter((file) => file.endsWith('.ts'))
+      .map((file) => fs.readFileSync(path.join(serviceDirectory, file), 'utf8'))
+      .join('\n');
+
+    expect(serviceSource).not.toMatch(/marginal-reserve-moic|non_actionable_shadow/i);
+  });
+
+  it('pins public share delivery to immutable snapshots without LP-reporting dependencies', () => {
+    expect(productionImportSpecifiers('server/routes/shares.ts')).toEqual([
+      '../db',
+      '../lib/http-preconditions',
+      '../lib/logger.js',
+      '../lib/request-values',
+      '../lib/stable-json.js',
+      '../services/share-snapshot-service',
+      '@shared/schema/shares',
+      '@shared/sharing-schema',
+      'drizzle-orm',
+      'express',
+      'express-rate-limit',
+      'node:crypto',
+      'uuid',
+      'zod',
+    ]);
+    expect(productionImportSpecifiers('server/services/share-snapshot-service.ts')).toEqual([
+      '../db',
+      '../lib/stable-json.js',
+      '../storage',
+      './dashboard-summary-read-service',
+      '@shared/contracts/public-share-snapshot.contract',
+      '@shared/schema/shares',
+      'drizzle-orm',
+      'node:crypto',
+      'uuid',
+    ]);
+    expect(
+      productionImportSpecifiers('shared/contracts/public-share-snapshot.contract.ts')
+    ).toEqual(['zod']);
+    expect(
+      productionImportBindings('server/routes/shares.ts', '../services/share-snapshot-service')
+    ).toEqual(['createShareSnapshot', 'getLatestShareSnapshot', 'markShareSnapshotsRevoked']);
+    expect(
+      productionImportBindings(
+        'server/services/share-snapshot-service.ts',
+        './dashboard-summary-read-service'
+      )
+    ).toEqual(['getDashboardSummaryReadModel']);
+    expect(
+      productionImportBindings(
+        'server/services/share-snapshot-service.ts',
+        '@shared/contracts/public-share-snapshot.contract'
+      )
+    ).toEqual([
+      'type PublicMetricValue',
+      'type PublicPortfolioCompany',
+      'type PublicShareSnapshotPayload',
+    ]);
+    expect(
+      productionImportBindings('server/services/share-snapshot-service.ts', '@shared/schema/shares')
+    ).toEqual(['shareSnapshots', 'type Share', 'type ShareSnapshotRecord']);
+    expect(
+      productionImportBindings('shared/contracts/public-share-snapshot.contract.ts', 'zod')
+    ).toEqual(['z']);
+    expect(
+      productionImportBindings(
+        'shared/schema/shares.ts',
+        '../contracts/public-share-snapshot.contract'
+      )
+    ).toEqual(['type PublicShareSnapshotPayload']);
+
+    expect(
+      productionZodObjectFields(
+        'shared/contracts/public-share-snapshot.contract.ts',
+        'PublicShareSnapshotPayloadSchema'
+      )
+    ).toEqual([
+      'payloadVersion',
+      'snapshotId',
+      'shareId',
+      'title',
+      'message',
+      'asOfDate',
+      'generatedAt',
+      'metrics',
+      'portfolioCompanies',
+      'hiddenMetricPolicy',
+      'sourceCalculationRunIds',
+    ]);
+
+    const publicDelivery = sourceFunctionBody('server/routes/shares.ts', 'sendPublicSharePayload');
+    expect(publicDelivery).toContain('await getLatestShareSnapshot(share.id)');
+    expect(publicDelivery).toContain('snapshot: snapshot.payload');
+    expect(publicDelivery).not.toMatch(
+      /getDashboardSummaryReadModel|buildPublicShareSnapshotPayload/
+    );
+
+    const payloadBuilder = productionFunctionBody(
+      'server/services/share-snapshot-service.ts',
+      'buildPublicShareSnapshotPayload'
+    );
+    expect(payloadBuilder).toContain('await getDashboardSummaryReadModel(storage, fundId)');
+    expect(payloadBuilder).toContain('const payload: PublicShareSnapshotPayload');
+    expect(payloadBuilder).toContain('return { payload, payloadHash: hashPayload(payload) };');
+
+    const snapshotCreation = productionFunctionBody(
+      'server/services/share-snapshot-service.ts',
+      'createShareSnapshot'
+    );
+    expect(snapshotCreation).toContain('await buildPublicShareSnapshotPayload');
+    expect(snapshotCreation).toContain('.insert(shareSnapshots)');
+    expect(snapshotCreation).toContain('payloadHash,');
+    expect(snapshotCreation).toContain('payload,');
+
+    const snapshotRead = productionFunctionBody(
+      'server/services/share-snapshot-service.ts',
+      'getLatestShareSnapshot'
+    );
+    expect(snapshotRead).toContain('.from(shareSnapshots)');
+    expect(snapshotRead).toContain('.orderBy(desc(shareSnapshots.generatedAt))');
+
+    const boundaryFiles = [
+      'server/routes/shares.ts',
+      'server/services/share-snapshot-service.ts',
+      'shared/contracts/public-share-snapshot.contract.ts',
+      'shared/schema/shares.ts',
+    ];
+    const forbiddenReportingDependency =
+      /lp(?:[-_/]?reporting)|report(?:[-_/]?package)s?|metric(?:[-_/]?run)s?/i;
+
+    for (const forbiddenSpelling of [
+      'lpReporting',
+      'LPReporting',
+      'reportPackage',
+      'ReportPackage',
+      'metricRun',
+      'MetricRun',
+    ]) {
+      expect(forbiddenSpelling).toMatch(forbiddenReportingDependency);
+    }
+
+    for (const relativePath of boundaryFiles) {
+      const source = fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+      expect(source, relativePath).not.toMatch(forbiddenReportingDependency);
+    }
+
+    const snapshotSchema = fs.readFileSync(
+      path.join(process.cwd(), 'shared/schema/shares.ts'),
+      'utf8'
+    );
+    expect(snapshotSchema).toContain("payload: jsonb('payload')");
+    expect(snapshotSchema).toContain('$type<PublicShareSnapshotPayload>().notNull()');
+  });
+
+  it('confines every server report-package route to the fund and workflow scoped router', () => {
+    const routeDirectory = path.join(process.cwd(), 'server', 'routes');
+    const routeSources = readTypeScriptSourcesRecursively(routeDirectory);
+    const filesMentioningReportPackages = routeSources
+      .filter(({ source }) => source.includes('report-package'))
+      .map(({ relativePath }) => relativePath);
+
+    expect(filesMentioningReportPackages).toEqual(['lp-reporting/metric-runs.ts']);
+
+    const routePattern =
+      /\brouter\.(?:get|post|put|patch|delete)\(\s*['"`]([^'"`]*report-package[^'"`]*)['"`]/g;
+    const reportPackageRoutes = routeSources.flatMap(({ relativePath, source }) =>
+      [...source.matchAll(routePattern)].map((match) => ({
+        relativePath,
+        routePath: match[1] ?? '',
+      }))
+    );
+
+    expect(reportPackageRoutes.length).toBeGreaterThan(0);
+    for (const occurrence of reportPackageRoutes) {
+      expect(occurrence.relativePath).toBe('lp-reporting/metric-runs.ts');
+      expect(occurrence.routePath).toMatch(
+        /^\/api\/funds\/:fundId\/metric-runs\/:metricRunId\/report-package(?:\/|$)/
+      );
+    }
+  });
+});

--- a/tests/unit/lp-reporting/report-qualification-characterization.test.ts
+++ b/tests/unit/lp-reporting/report-qualification-characterization.test.ts
@@ -87,6 +87,7 @@ const CURRENT_H9_GATED_EXPORT_ROUTES = [
   EXPORT_ROUTES[1],
   EXPORT_ROUTES[2],
   EXPORT_ROUTES[4],
+  EXPORT_ROUTES[5],
   EXPORT_ROUTES[7],
 ] as const;
 
@@ -355,10 +356,13 @@ function configureReportServiceFixtures(): void {
     contentType: csvExport.contentType,
     filename: csvExport.filename,
   } as const;
-  reportServiceState.createStoredCsvExport.mockResolvedValue({
-    record: csvRecord,
-    inserted: false,
-    ...csvMetadata,
+  reportServiceState.createStoredCsvExport.mockImplementation(async () => {
+    await assertFixtureH9('stored_csv_export');
+    return {
+      record: csvRecord,
+      inserted: false,
+      ...csvMetadata,
+    };
   });
   reportServiceState.getStoredCsvExport.mockResolvedValue({
     record: csvRecord,
@@ -685,7 +689,7 @@ describe('H9 export qualification', () => {
     expect(actionabilityState.resolveForFund).not.toHaveBeenCalled();
   });
 
-  it('pins the production service call chain for all five currently H9-gated routes', () => {
+  it('pins the production service call chain for all six H9-gated routes', () => {
     const renderModelBody = productionFunctionBody(
       'server/services/lp-reporting/report-package-render-model-service.ts',
       'getMetricRunReportPackageRenderModel'
@@ -720,6 +724,17 @@ describe('H9 export qualification', () => {
     );
     expect(storedJsonArtifactBody).toContain('await assertH9PackageExportable({');
     expect(storedJsonArtifactBody).toContain("surface: 'stored_json_export'");
+
+    const storedCsvCreateBody = productionFunctionBody(
+      'server/services/lp-reporting/report-package-csv-stored-export-service.ts',
+      'createMetricRunReportPackageStoredCsvExport'
+    );
+    const storedCsvCreateGate = storedCsvCreateBody.indexOf('await assertH9PackageExportable({');
+    const storedCsvFirstPersistence = storedCsvCreateBody.indexOf(
+      '.insert(lpReportPackageExports)'
+    );
+    expect(storedCsvCreateGate).toBeGreaterThanOrEqual(0);
+    expect(storedCsvFirstPersistence).toBeGreaterThan(storedCsvCreateGate);
 
     const storedCsvArtifactBody = productionFunctionBody(
       'server/services/lp-reporting/report-package-csv-stored-export-service.ts',

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { FinancialProvenanceSchema } from '../../../shared/contracts/financial-provenance.contract';
@@ -35,6 +38,14 @@ function routeKey(route: { method: string; path: string }): string {
   return `${route.method.toUpperCase()} ${route.path}`;
 }
 
+function declaredRoutePolicyKeys(relativePath: string): string[] {
+  const source = fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+
+  return [...source.matchAll(/router\.(get|post|put|patch|delete)\(\s*['"]([^'"]+)['"]/g)].map(
+    ([, method, routePath]) => `${method?.toUpperCase()} ${routePath}`
+  );
+}
+
 const policyByKey = new Map(
   API_ROUTE_POLICY_REGISTRY.map((entry) => [routePolicyKey(entry), entry])
 );
@@ -49,6 +60,162 @@ const LP_REPORT_PACKAGE_EXPORT_POLICY_KEYS = [
   'GET /api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/csv',
   'GET /api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/csv/artifact',
 ] as const;
+
+const LP_REPORTING_ROUTE_POLICY_KEYS = [
+  'POST /api/funds/:fundId/metric-runs/dry-run',
+  'POST /api/funds/:fundId/metric-runs/commit',
+  'GET /api/funds/:fundId/metric-runs/latest',
+  'GET /api/funds/:fundId/metric-runs/:metricRunId',
+  'POST /api/funds/:fundId/metric-runs/:metricRunId/approve',
+  'POST /api/funds/:fundId/metric-runs/:metricRunId/lock',
+  'GET /api/funds/:fundId/metric-runs/:metricRunId/report-package',
+  ...LP_REPORT_PACKAGE_EXPORT_POLICY_KEYS,
+  'POST /api/funds/:fundId/metric-runs/:metricRunId/report-package',
+  'GET /api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
+  'POST /api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
+  'GET /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs',
+  'POST /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs',
+  'PATCH /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId',
+  'POST /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId/review',
+  'POST /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId/approve',
+  'GET /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId',
+  'POST /api/funds/:fundId/imports/ledger/dry-run',
+  'POST /api/funds/:fundId/imports/valuation-marks/dry-run',
+  'POST /api/funds/:fundId/imports/ledger/commit',
+  'POST /api/funds/:fundId/imports/valuation-marks/commit',
+] as const;
+
+type LpReportingPolicyExpectation = Pick<
+  RoutePolicyEntry,
+  'workflowRequirement' | 'exportPolicy' | 'provenanceRequired'
+>;
+
+const LP_REPORTING_ADDITIONAL_POLICY_GROUPS: ReadonlyArray<{
+  keys: readonly string[];
+  expected: LpReportingPolicyExpectation;
+}> = [
+  {
+    keys: ['POST /api/funds/:fundId/metric-runs/dry-run'],
+    expected: {
+      workflowRequirement: 'source_rows_and_preview_hash_generated',
+      exportPolicy: 'preview_only',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: [
+      'POST /api/funds/:fundId/imports/ledger/dry-run',
+      'POST /api/funds/:fundId/imports/valuation-marks/dry-run',
+    ],
+    expected: {
+      workflowRequirement: 'reconciliation_preview_hash_generated',
+      exportPolicy: 'preview_only',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: [
+      'GET /api/funds/:fundId/metric-runs/latest',
+      'GET /api/funds/:fundId/metric-runs/:metricRunId',
+      'GET /api/funds/:fundId/metric-runs/:metricRunId/report-package',
+      'GET /api/funds/:fundId/metric-runs/:metricRunId/evidence-records',
+      'GET /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs',
+      'GET /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId',
+    ],
+    expected: {
+      workflowRequirement: 'fund_scope_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: ['POST /api/funds/:fundId/metric-runs/commit'],
+    expected: {
+      workflowRequirement: 'preview_hash_source_rows_and_idempotency_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: ['POST /api/funds/:fundId/metric-runs/:metricRunId/approve'],
+    expected: {
+      workflowRequirement: 'draft_metric_run_evidence_and_expected_version_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: ['POST /api/funds/:fundId/metric-runs/:metricRunId/lock'],
+    expected: {
+      workflowRequirement: 'approved_metric_run_and_expected_version_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: ['POST /api/funds/:fundId/metric-runs/:metricRunId/report-package'],
+    expected: {
+      workflowRequirement: 'locked_metric_run_and_approved_narrative_versions_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: ['POST /api/funds/:fundId/metric-runs/:metricRunId/evidence-records'],
+    expected: {
+      workflowRequirement: 'draft_metric_run_and_idempotency_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: ['POST /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs'],
+    expected: {
+      workflowRequirement: 'locked_metric_run_source_contract_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: ['PATCH /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId'],
+    expected: {
+      workflowRequirement: 'locked_metric_run_draft_and_expected_version_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: [
+      'POST /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId/review',
+    ],
+    expected: {
+      workflowRequirement: 'locked_metric_run_edited_draft_and_expected_version_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: [
+      'POST /api/funds/:fundId/metric-runs/:metricRunId/narrative-runs/:narrativeRunId/approve',
+    ],
+    expected: {
+      workflowRequirement: 'locked_metric_run_edited_review_and_expected_version_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: [
+      'POST /api/funds/:fundId/imports/ledger/commit',
+      'POST /api/funds/:fundId/imports/valuation-marks/commit',
+    ],
+    expected: {
+      workflowRequirement: 'clean_preview_hash_fund_references_and_source_hashes_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+];
 
 function expectPolicy(key: string): RoutePolicyEntry {
   const entry = policyByKey.get(key);
@@ -185,6 +352,43 @@ describe('route policy coverage', () => {
       expect(policyEntry.provenanceRequired, key).toBe(true);
       expect(policyEntry.staleBlocksExport, key).toBe(true);
       expect(policyEntry.workflowRequirement, key).toBe('metric_run_locked_or_exported');
+    }
+  });
+
+  it('covers every LP-reporting metric-run and import route', () => {
+    expect(LP_REPORTING_ROUTE_POLICY_KEYS).toHaveLength(28);
+
+    const declaredRoutes = [
+      ...declaredRoutePolicyKeys('server/routes/lp-reporting/metric-runs.ts'),
+      ...declaredRoutePolicyKeys('server/routes/lp-reporting/imports.ts'),
+    ];
+    expect(declaredRoutes).toEqual(LP_REPORTING_ROUTE_POLICY_KEYS);
+
+    for (const key of declaredRoutes) {
+      expectPolicy(key);
+    }
+  });
+
+  it('pins existing LP-reporting preview, provenance, and lifecycle policy gates', () => {
+    const exportKeys = new Set<string>(LP_REPORT_PACKAGE_EXPORT_POLICY_KEYS);
+    const expectedAdditionalKeys = LP_REPORTING_ROUTE_POLICY_KEYS.filter(
+      (key) => !exportKeys.has(key)
+    ).sort();
+    const groupedKeys = LP_REPORTING_ADDITIONAL_POLICY_GROUPS.flatMap((group) => group.keys).sort();
+    expect(groupedKeys).toEqual(expectedAdditionalKeys);
+
+    for (const group of LP_REPORTING_ADDITIONAL_POLICY_GROUPS) {
+      for (const key of group.keys) {
+        const policy = expectPolicy(key);
+
+        expect(policy.financialSurface, key).toBe('lp_reporting');
+        expect(policy.apiAuthBoundary, key).toBe('require_auth_and_fund_access');
+        expect(policy.fundScopeMode, key).toBe('route_param_fund_id');
+        expect(policy.workflowRequirement, key).toBe(group.expected.workflowRequirement);
+        expect(policy.exportPolicy, key).toBe(group.expected.exportPolicy);
+        expect(policy.provenanceRequired, key).toBe(group.expected.provenanceRequired);
+        expect(policy.staleBlocksExport, key).toBe(false);
+      }
     }
   });
 

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -355,6 +355,35 @@ describe('route policy coverage', () => {
     }
   });
 
+  it('keeps stored CSV creation policy exactly aligned with stored JSON creation posture', () => {
+    const jsonPolicy = expectPolicy(
+      'POST /api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/json'
+    );
+    const csvPolicy = expectPolicy(
+      'POST /api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/csv'
+    );
+    const postureFields = [
+      'lifecycle',
+      'governanceRef',
+      'surface',
+      'owner',
+      'financialSurface',
+      'apiAuthBoundary',
+      'fundScopeMode',
+      'workflowRequirement',
+      'exportPolicy',
+      'provenanceRequired',
+      'staleBlocksExport',
+      'humanReviewRequired',
+      'performanceBudgetMs',
+      'notes',
+    ] as const satisfies readonly (keyof RoutePolicyEntry)[];
+
+    for (const field of postureFields) {
+      expect(csvPolicy[field], field).toEqual(jsonPolicy[field]);
+    }
+  });
+
   it('covers every LP-reporting metric-run and import route', () => {
     expect(LP_REPORTING_ROUTE_POLICY_KEYS).toHaveLength(28);
 

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -61,6 +61,19 @@ const LP_REPORT_PACKAGE_EXPORT_POLICY_KEYS = [
   'GET /api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/csv/artifact',
 ] as const;
 
+// The two stored-export status GETs are readiness metadata: role/grant/workflow
+// gated but intentionally H9-independent and non-exportable (in-code Finding 8,
+// ADR-040). They share the export perimeter's auth posture, not its export policy.
+const LP_REPORT_PACKAGE_STATUS_GET_POLICY_KEYS = [
+  'GET /api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/json',
+  'GET /api/funds/:fundId/metric-runs/:metricRunId/report-package/exports/csv',
+] as const;
+
+const LP_REPORT_PACKAGE_AUTHORITATIVE_EXPORT_POLICY_KEYS =
+  LP_REPORT_PACKAGE_EXPORT_POLICY_KEYS.filter(
+    (key) => !(LP_REPORT_PACKAGE_STATUS_GET_POLICY_KEYS as readonly string[]).includes(key)
+  );
+
 const LP_REPORTING_ROUTE_POLICY_KEYS = [
   'POST /api/funds/:fundId/metric-runs/dry-run',
   'POST /api/funds/:fundId/metric-runs/commit',
@@ -163,7 +176,10 @@ const LP_REPORTING_ADDITIONAL_POLICY_GROUPS: ReadonlyArray<{
   {
     keys: ['POST /api/funds/:fundId/metric-runs/:metricRunId/evidence-records'],
     expected: {
-      workflowRequirement: 'draft_metric_run_and_idempotency_verified',
+      // Key-only deduplication: a replayed Idempotency-Key returns the stored
+      // record without comparing the request body (request-hash comparison is
+      // an ADR-040 follow-up).
+      workflowRequirement: 'draft_metric_run_and_idempotency_key_dedup',
       exportPolicy: 'not_exportable',
       provenanceRequired: true,
     },
@@ -342,7 +358,9 @@ describe('route policy coverage', () => {
   });
 
   it('covers PRD #996 Surface-A report-package exports with role-gated fund access', () => {
-    for (const key of LP_REPORT_PACKAGE_EXPORT_POLICY_KEYS) {
+    expect(LP_REPORT_PACKAGE_AUTHORITATIVE_EXPORT_POLICY_KEYS).toHaveLength(6);
+
+    for (const key of LP_REPORT_PACKAGE_AUTHORITATIVE_EXPORT_POLICY_KEYS) {
       const policyEntry = expectPolicy(key);
 
       expect(policyEntry.apiAuthBoundary, key).toBe('require_auth_fund_access_and_role');
@@ -352,6 +370,21 @@ describe('route policy coverage', () => {
       expect(policyEntry.provenanceRequired, key).toBe(true);
       expect(policyEntry.staleBlocksExport, key).toBe(true);
       expect(policyEntry.workflowRequirement, key).toBe('metric_run_locked_or_exported');
+    }
+  });
+
+  it('classifies stored-export status GETs as non-exportable readiness metadata', () => {
+    for (const key of LP_REPORT_PACKAGE_STATUS_GET_POLICY_KEYS) {
+      const policyEntry = expectPolicy(key);
+
+      expect(policyEntry.apiAuthBoundary, key).toBe('require_auth_fund_access_and_role');
+      expect(policyEntry.financialSurface, key).toBe('lp_reporting');
+      expect(policyEntry.fundScopeMode, key).toBe('route_param_fund_id');
+      expect(policyEntry.exportPolicy, key).toBe('not_exportable');
+      expect(policyEntry.provenanceRequired, key).toBe(true);
+      expect(policyEntry.staleBlocksExport, key).toBe(false);
+      expect(policyEntry.workflowRequirement, key).toBe('metric_run_locked_or_exported');
+      expect(policyEntry.notes, key).toMatch(/H9-independent/);
     }
   });
 

--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -21,6 +21,8 @@ const fundAccessState = vi.hoisted(() => ({
   requireFundAccess: vi.fn((_req: Request, _res: Response, next: NextFunction) => next()),
 }));
 
+const featureState = vi.hoisted(() => ({ scenarioSeedPicker: false }));
+
 const factsState = vi.hoisted(() => {
   class FundActualsFactsServiceError extends Error {
     readonly status: number;
@@ -104,6 +106,16 @@ vi.mock('../../../server/lib/auth/jwt', () => ({
   requireFundAccess: fundAccessState.requireFundAccess,
 }));
 
+vi.mock('../../../server/config/features', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/config/features')>();
+  const features = { ...actual.FEATURES };
+  Object.defineProperty(features, 'scenarioSeedPicker', {
+    enumerable: true,
+    get: () => featureState.scenarioSeedPicker,
+  });
+  return { ...actual, FEATURES: features };
+});
+
 vi.mock('../../../server/services/fund-actuals/fund-company-actuals-facts-service', () => ({
   buildFundCompanyActualsFacts: factsState.buildFundCompanyActualsFacts,
   FundActualsFactsServiceError: factsState.FundActualsFactsServiceError,
@@ -149,6 +161,7 @@ function denyOnce() {
 }
 
 function resetState() {
+  featureState.scenarioSeedPicker = false;
   fundScopeState.enforceCompanyFundScope.mockReset();
   fundScopeState.enforceCompanyFundScope.mockResolvedValue(true);
   fundScopeState.resolveCompanyFundId.mockReset();
@@ -826,7 +839,26 @@ describe('scenario-analysis actuals-backed seed suggestions', () => {
 describe('scenario-analysis from-seed case creation', () => {
   beforeEach(() => {
     resetState();
+    featureState.scenarioSeedPicker = true;
     factsState.buildFundCompanyActualsFacts.mockResolvedValue(factsResponse());
+  });
+
+  it('returns 404 without downstream work when the seed picker is disabled', async () => {
+    featureState.scenarioSeedPicker = false;
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-disabled')
+      .send(validFromSeedBody());
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'not_found' });
+    expect(fundScopeState.resolveCompanyFundId).not.toHaveBeenCalled();
+    expect(dbState.select).not.toHaveBeenCalled();
+    expect(dbState.findFirst).not.toHaveBeenCalled();
+    expect(factsState.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+    expectNoScenarioWrites();
   });
 
   it('rejects an invalid fund before fund access and persistence', async () => {

--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -21,6 +21,13 @@ const fundAccessState = vi.hoisted(() => ({
   requireFundAccess: vi.fn((_req: Request, _res: Response, next: NextFunction) => next()),
 }));
 
+// Default authenticated; individual tests flip this to prove the production
+// route chain runs requireAuth() before any handler-level flag or param logic.
+const authState = vi.hoisted(() => ({
+  authenticated: true,
+  requireAuthCalls: 0,
+}));
+
 const featureState = vi.hoisted(() => ({ scenarioSeedPicker: false }));
 
 const factsState = vi.hoisted(() => {
@@ -102,7 +109,14 @@ vi.mock('../../../server/lib/auth/company-fund-scope', () => ({
 }));
 
 vi.mock('../../../server/lib/auth/jwt', () => ({
-  requireAuth: () => (_req: Request, _res: Response, next: () => void) => next(),
+  requireAuth: () => (_req: Request, res: Response, next: () => void) => {
+    authState.requireAuthCalls += 1;
+    if (!authState.authenticated) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    next();
+  },
   requireFundAccess: fundAccessState.requireFundAccess,
 }));
 
@@ -180,6 +194,8 @@ function resetState() {
   fundAccessState.requireFundAccess.mockImplementation(
     (_req: Request, _res: Response, next: NextFunction) => next()
   );
+  authState.authenticated = true;
+  authState.requireAuthCalls = 0;
   factsState.buildFundCompanyActualsFacts.mockReset();
   persistenceState.createScenarioCaseFromSeed.mockReset();
 }
@@ -853,6 +869,33 @@ describe('scenario-analysis from-seed case creation', () => {
 
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ error: 'not_found' });
+    // Auth-first ordering (ADR-040, marginal-rankings precedent): the flag-off
+    // 404 is only reached AFTER requireAuth and requireFundAccess have run.
+    expect(authState.requireAuthCalls).toBe(1);
+    expect(fundAccessState.requireFundAccess).toHaveBeenCalledTimes(1);
+    // No idempotency, provenance, facts, or persistence side effects: no row
+    // is written and no lookup runs while the flag is off.
+    expect(fundScopeState.resolveCompanyFundId).not.toHaveBeenCalled();
+    expect(dbState.select).not.toHaveBeenCalled();
+    expect(dbState.findFirst).not.toHaveBeenCalled();
+    expect(factsState.buildFundCompanyActualsFacts).not.toHaveBeenCalled();
+    expect(persistenceState.createScenarioCaseFromSeed).not.toHaveBeenCalled();
+    expectNoScenarioWrites();
+  });
+
+  it('returns 401 for anonymous callers even while the seed picker is disabled', async () => {
+    featureState.scenarioSeedPicker = false;
+    authState.authenticated = false;
+
+    const res = await request(makeApp())
+      .post(`/api/funds/7/scenario-analysis/scenarios/${SCENARIO_ID}/cases/from-seed`)
+      .set('Idempotency-Key', 'seed-create-anon')
+      .send(validFromSeedBody());
+
+    expect(res.status).toBe(401);
+    expect(authState.requireAuthCalls).toBe(1);
+    // Auth rejected before fund access, the flag-off 404, and any side effect.
+    expect(fundAccessState.requireFundAccess).not.toHaveBeenCalled();
     expect(fundScopeState.resolveCompanyFundId).not.toHaveBeenCalled();
     expect(dbState.select).not.toHaveBeenCalled();
     expect(dbState.findFirst).not.toHaveBeenCalled();

--- a/tests/unit/services/lp-reporting/report-package-csv-stored-export-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-csv-stored-export-service.test.ts
@@ -12,6 +12,10 @@ import {
   getMetricRunReportPackageStoredCsvArtifact,
   getMetricRunReportPackageStoredCsvExport,
 } from '../../../../server/services/lp-reporting/report-package-csv-stored-export-service';
+import type {
+  H9ExportBlockerCode,
+  StoredH9,
+} from '../../../../server/services/lp-reporting/h9-export-gate';
 import {
   ReportPackageJsonExportArtifactSchema,
   type ReportPackageJsonExportArtifact,
@@ -40,7 +44,7 @@ const CURRENT_OK = {
   actionability: 'actionable' as const,
   sourceFingerprint: { fingerprintHash: H9_FP, policyVersion: 'h9-policy-v1' },
 };
-const storedPackageRow = {
+const storedPackageRow: StoredH9 = {
   h9MoicSourceInputHash: 'a'.repeat(64),
   h9RoundEvidenceInputHash: 'b'.repeat(64),
   h9RoundEvidenceAssumptionsHash: 'c'.repeat(64),
@@ -59,6 +63,7 @@ interface State {
   metricRuns: MetricRunStatusRow[];
   insertedRows: unknown[];
   statusUpdates: unknown[];
+  insertAttempts: number;
   users: number[];
   nextId: number;
   dropNextInsert: boolean;
@@ -75,6 +80,7 @@ const state: State = {
   metricRuns: [],
   insertedRows: [],
   statusUpdates: [],
+  insertAttempts: 0,
   users: [7],
   nextId: 4101,
   dropNextInsert: false,
@@ -223,7 +229,7 @@ function rowsFor(table: unknown): unknown[] {
   if (table === users) return state.users.map((id) => ({ id }));
   if (table === lpMetricRuns) return [...state.metricRuns];
   if (table === lpReportPackageExports) return [...state.exportRows];
-  if (table === lpReportPackages) return [storedPackageRow];
+  if (table === lpReportPackages) return [storedH9Fixture];
   return [];
 }
 
@@ -244,6 +250,7 @@ function makeDatabase(): typeof db {
       values: (row: Record<string, unknown>) => ({
         onConflictDoNothing: () => ({
           returning: async () => {
+            state.insertAttempts += 1;
             if (table !== lpReportPackageExports || state.dropNextInsert) {
               state.dropNextInsert = false;
               return [];
@@ -313,15 +320,43 @@ function seedStoredJson(overrides: Partial<LpReportPackageExport> = {}): LpRepor
   return row;
 }
 
+const H9_FAILURE_CODES = [
+  'H9_METADATA_MISSING',
+  'H9_NOT_ACTIONABLE',
+  'H9_FINGERPRINT_STALE',
+  'H9_REVALIDATION_UNAVAILABLE',
+] as const satisfies readonly H9ExportBlockerCode[];
+
+let storedH9Fixture: StoredH9 = { ...storedPackageRow };
+
+function configureH9Failure(code: H9ExportBlockerCode): void {
+  storedH9Fixture = { ...storedPackageRow };
+  if (code === 'H9_METADATA_MISSING') {
+    storedH9Fixture.h9ActionabilityStatus = null;
+    storedH9Fixture.h9FingerprintHash = null;
+  } else if (code === 'H9_NOT_ACTIONABLE') {
+    storedH9Fixture.h9ActionabilityStatus = 'non_actionable';
+  } else if (code === 'H9_FINGERPRINT_STALE') {
+    resolveForFund.mockResolvedValue({
+      actionability: 'actionable',
+      sourceFingerprint: { fingerprintHash: 'e'.repeat(64), policyVersion: 'h9-policy-v1' },
+    });
+  } else {
+    resolveForFund.mockRejectedValue(new Error('resolver unavailable'));
+  }
+}
+
 beforeEach(() => {
   ReportPackageJsonExportArtifactSchema.parse(artifact);
   state.exportRows = [];
   state.metricRuns = [{ id: 500, fundId: 1, status: 'locked' }];
   state.insertedRows = [];
   state.statusUpdates = [];
+  state.insertAttempts = 0;
   state.users = [7];
   state.nextId = 4101;
   state.dropNextInsert = false;
+  storedH9Fixture = { ...storedPackageRow };
   resolveForFund.mockResolvedValue(CURRENT_OK);
 });
 
@@ -422,6 +457,60 @@ describe('stored report package CSV exports', () => {
     expect(state.insertedRows).toHaveLength(1);
   });
 
+  it.each(H9_FAILURE_CODES)(
+    'blocks fresh CSV creation for %s before writing an export row',
+    async (code) => {
+      seedStoredJson();
+      configureH9Failure(code);
+
+      await expect(
+        createMetricRunReportPackageStoredCsvExport(
+          { fundId: 1, metricRunId: 500, userId: 7 },
+          { database: makeDatabase() }
+        )
+      ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+        status: 409,
+        code,
+        surface: 'stored_csv_export',
+      });
+
+      expect(state.insertAttempts).toBe(0);
+      expect(state.insertedRows).toHaveLength(0);
+      expect(state.exportRows).toHaveLength(1);
+      expect(state.exportRows[0]?.format).toBe('json');
+    }
+  );
+
+  it.each(H9_FAILURE_CODES)(
+    'blocks CSV replay for %s before an insert attempt or stored-row reuse',
+    async (code) => {
+      seedStoredJson();
+      const database = makeDatabase();
+      await createMetricRunReportPackageStoredCsvExport(
+        { fundId: 1, metricRunId: 500, userId: 7 },
+        { database }
+      );
+      const storedCsvBeforeFailure = state.exportRows.find((row) => row.format === 'csv');
+      expect(storedCsvBeforeFailure).toBeDefined();
+
+      configureH9Failure(code);
+      await expect(
+        createMetricRunReportPackageStoredCsvExport(
+          { fundId: 1, metricRunId: 500, userId: 7 },
+          { database }
+        )
+      ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+        status: 409,
+        code,
+        surface: 'stored_csv_export',
+      });
+
+      expect(state.insertAttempts).toBe(1);
+      expect(state.insertedRows).toHaveLength(1);
+      expect(state.exportRows.find((row) => row.format === 'csv')).toBe(storedCsvBeforeFailure);
+    }
+  );
+
   it('rejects hash drift on the same package CSV natural key', async () => {
     seedStoredJson();
     const csv = buildReportPackageCsv(artifact);
@@ -498,6 +587,25 @@ describe('stored report package CSV exports', () => {
     expect(artifactResponse.record.reportPackageExportId).toBe(4101);
     expect(artifactResponse.csv.csv).toBe(buildReportPackageCsv(artifact));
     expect(state.statusUpdates).toHaveLength(0);
+  });
+
+  it('keeps stored CSV status metadata H9-independent', async () => {
+    seedStoredJson();
+    const database = makeDatabase();
+    await createMetricRunReportPackageStoredCsvExport(
+      { fundId: 1, metricRunId: 500, userId: 7 },
+      { database }
+    );
+
+    resolveForFund.mockClear();
+    configureH9Failure('H9_REVALIDATION_UNAVAILABLE');
+    const metadata = await getMetricRunReportPackageStoredCsvExport(
+      { fundId: 1, metricRunId: 500 },
+      { database }
+    );
+
+    expect(metadata.record?.format).toBe('csv');
+    expect(resolveForFund).not.toHaveBeenCalled();
   });
 
   it('re-gates CSV create, metadata, and artifact paths without workflow writes', async () => {

--- a/tests/unit/services/lp-reporting/report-package-json-stored-export-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-json-stored-export-service.test.ts
@@ -5,13 +5,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { db } from '../../../../server/db';
 import type { MetricRunCommitError } from '../../../../server/services/lp-reporting/metric-run-commit-service';
-import { ReportPackageJsonExportBlockedError } from '../../../../server/services/lp-reporting/report-package-json-export-service';
+import {
+  ReportPackageJsonExportBlockedError,
+  sha256CanonicalJson,
+} from '../../../../server/services/lp-reporting/report-package-json-export-service';
 import {
   createMetricRunReportPackageStoredJsonExport,
   getMetricRunReportPackageStoredJsonArtifact,
   getMetricRunReportPackageStoredJsonExport,
 } from '../../../../server/services/lp-reporting/report-package-json-stored-export-service';
 import {
+  CURRENT_REPORT_PACKAGE_RENDER_MODEL_VERSION,
   ReportPackageJsonExportArtifactSchema,
   type ReportPackageJsonExportArtifact,
   type ReportPackageJsonExportResponse,
@@ -103,7 +107,7 @@ const artifact: ReportPackageJsonExportArtifact = {
     h9Stamp: H9_STAMP,
   },
   renderModel: {
-    renderModelVersion: 1,
+    renderModelVersion: CURRENT_REPORT_PACKAGE_RENDER_MODEL_VERSION,
     source: {
       reportPackageId: 3000,
       fundId: 1,
@@ -470,6 +474,99 @@ describe('stored report package JSON exports', () => {
       code: 'EXPORT_CONTENT_HASH_CONFLICT',
       storedContentHash: 'b'.repeat(64),
       currentContentHash: 'c'.repeat(64),
+    });
+    expect(state.insertedRows).toHaveLength(0);
+  });
+
+  it('replays a pre-provenance render-model v1 stored export without a hash conflict', async () => {
+    const preProvenanceArtifact: ReportPackageJsonExportArtifact = {
+      ...artifact,
+      renderModel: {
+        ...artifact.renderModel,
+        renderModelVersion: 1,
+        metricSections: [
+          {
+            sectionId: 'performance',
+            title: 'Performance',
+            rows: [
+              {
+                metricId: 'moic',
+                label: 'MOIC',
+                value: '1.700000',
+                valueKind: 'multiple',
+                currency: null,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const storedHash = sha256CanonicalJson(preProvenanceArtifact);
+    state.exportRows.push({
+      id: 4100,
+      fundId: 1,
+      metricRunId: 500,
+      reportPackageId: 3000,
+      format: 'json',
+      exportVersion: 1,
+      status: 'ready',
+      contentHashAlgorithm: 'sha256',
+      contentHash: storedHash,
+      artifactPayload: preProvenanceArtifact,
+      artifactSizeBytes: 1000,
+      createdBy: 7,
+      readyAt: new Date('2026-05-10T04:00:00Z'),
+      createdAt: new Date('2026-05-10T04:00:00Z'),
+      updatedAt: new Date('2026-05-10T04:00:00Z'),
+    });
+
+    const response = await createMetricRunReportPackageStoredJsonExport(
+      { fundId: 1, metricRunId: 500, userId: 7 },
+      {
+        database: makeDatabase(),
+        // Current renderer output embeds provenance, so its hash differs.
+        jsonExportService: vi.fn(async () => makeResponse('9'.repeat(64))),
+      }
+    );
+
+    expect(response.inserted).toBe(false);
+    expect(response.record.reportPackageExportId).toBe(4100);
+    expect(response.record.contentHash).toBe(storedHash);
+    expect(state.insertedRows).toHaveLength(0);
+  });
+
+  it('still rejects hash drift when the stored artifact is the current render-model version', async () => {
+    state.exportRows.push({
+      id: 4100,
+      fundId: 1,
+      metricRunId: 500,
+      reportPackageId: 3000,
+      format: 'json',
+      exportVersion: 1,
+      status: 'ready',
+      contentHashAlgorithm: 'sha256',
+      contentHash: 'c'.repeat(64),
+      artifactPayload: artifact,
+      artifactSizeBytes: 1000,
+      createdBy: 7,
+      readyAt: new Date('2026-05-10T04:00:00Z'),
+      createdAt: new Date('2026-05-10T04:00:00Z'),
+      updatedAt: new Date('2026-05-10T04:00:00Z'),
+    });
+
+    await expect(
+      createMetricRunReportPackageStoredJsonExport(
+        { fundId: 1, metricRunId: 500, userId: 7 },
+        {
+          database: makeDatabase(),
+          jsonExportService: vi.fn(async () => makeResponse('d'.repeat(64))),
+        }
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'EXPORT_CONTENT_HASH_CONFLICT',
+      storedContentHash: 'c'.repeat(64),
+      currentContentHash: 'd'.repeat(64),
     });
     expect(state.insertedRows).toHaveLength(0);
   });

--- a/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
@@ -253,6 +253,7 @@ describe('getMetricRunReportPackageRenderModel', () => {
       { database: makeDatabase() }
     );
 
+    expect(response.renderModel.renderModelVersion).toBe(2);
     expect(response.renderModel.source.reportPackageId).toBe(501);
     expect(response.renderModel.fundDisplay).toEqual({
       fundId: 1,

--- a/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
@@ -49,6 +49,7 @@ interface State {
   funds: Fund[];
   metricRuns: LpMetricRun[];
   reportPackages: LpReportPackage[];
+  readCalls: string[];
   writeCalls: string[];
 }
 
@@ -56,6 +57,7 @@ const state: State = {
   funds: [],
   metricRuns: [],
   reportPackages: [],
+  readCalls: [],
   writeCalls: [],
 };
 
@@ -187,9 +189,19 @@ function reportPackageRow(overrides: Partial<LpReportPackage> = {}): LpReportPac
 }
 
 function rowsFor(table: unknown): unknown[] {
-  if (table === funds) return state.funds;
-  if (table === lpMetricRuns) return state.metricRuns;
-  if (table === lpReportPackages) return state.reportPackages;
+  if (table === funds) {
+    state.readCalls.push('funds');
+    return state.funds;
+  }
+  if (table === lpMetricRuns) {
+    state.readCalls.push('metricRuns');
+    return state.metricRuns;
+  }
+  if (table === lpReportPackages) {
+    state.readCalls.push('reportPackages');
+    return state.reportPackages;
+  }
+  state.readCalls.push('unknown');
   return [];
 }
 
@@ -227,6 +239,7 @@ beforeEach(() => {
   state.funds = [fundRow()];
   state.metricRuns = [metricRunRow()];
   state.reportPackages = [reportPackageRow()];
+  state.readCalls = [];
   state.writeCalls = [];
   assertH9ExportActionable.mockReset();
   assertH9ExportActionable.mockResolvedValue(undefined);
@@ -288,6 +301,40 @@ describe('getMetricRunReportPackageRenderModel', () => {
     ).rejects.toMatchObject({ code: 'H9_FINGERPRINT_STALE' });
   });
 
+  it('blocks locked non-actionable H9 before constructing metric values', async () => {
+    const rawPackage = reportPackageRow({ h9ActionabilityStatus: 'non_actionable' });
+    const payloadRead = vi.fn(() => reportPackagePayload());
+    Object.defineProperty(rawPackage, 'payload', {
+      configurable: true,
+      get: payloadRead,
+    });
+    state.reportPackages = [rawPackage];
+    assertH9ExportActionable.mockRejectedValueOnce(
+      Object.assign(new Error('Report package is not actionable.'), {
+        status: 409,
+        code: 'H9_NOT_ACTIONABLE',
+        details: { surface: 'render_model' },
+      })
+    );
+    const database = makeDatabase();
+
+    await expect(
+      getMetricRunReportPackageRenderModel({ fundId: 1, metricRunId: 11 }, { database })
+    ).rejects.toMatchObject<Partial<MetricRunCommitError>>({
+      status: 409,
+      code: 'H9_NOT_ACTIONABLE',
+      details: { surface: 'render_model' },
+    });
+
+    expect(assertH9ExportActionable).toHaveBeenCalledTimes(1);
+    const [gateInput] = assertH9ExportActionable.mock.calls[0] ?? [];
+    expect(gateInput).toMatchObject({ surface: 'render_model', fundId: 1, database });
+    expect(gateInput?.stored).toBe(rawPackage);
+    expect(payloadRead).not.toHaveBeenCalled();
+    expect(state.readCalls).toEqual(['metricRuns', 'reportPackages']);
+    expect(state.writeCalls).toEqual([]);
+  });
+
   it.each(['draft', 'approved', 'superseded'])(
     'blocks %s metric runs before H9 validation and without writes',
     async (status) => {
@@ -308,6 +355,7 @@ describe('getMetricRunReportPackageRenderModel', () => {
         },
       });
       expect(assertH9ExportActionable).not.toHaveBeenCalled();
+      expect(state.readCalls).toEqual(['metricRuns']);
       expect(state.writeCalls).toEqual([]);
     }
   );

--- a/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
+++ b/tests/unit/services/lp-reporting/report-package-render-model-service.test.ts
@@ -36,6 +36,7 @@ const H9_STAMP = {
   policyVersion: H9_COLUMNS.h9PolicyVersion,
   actionabilityStatus: H9_COLUMNS.h9ActionabilityStatus,
 };
+const METRIC_RUN_INPUTS_HASH = '0123456789abcdef'.repeat(4);
 
 const validXirrDiagnostic = {
   convergence: 'converged',
@@ -70,7 +71,7 @@ function metricRunRow(overrides: Partial<LpMetricRun> = {}): LpMetricRun {
     runType: 'quarterly_report',
     perspective: 'lp_net',
     status: 'locked',
-    inputsHash: 'a'.repeat(64),
+    inputsHash: METRIC_RUN_INPUTS_HASH,
     sourceEventIds: [101, 102],
     sourceMarkIds: [201],
     sourceEvidenceIds: [301],
@@ -264,6 +265,24 @@ describe('getMetricRunReportPackageRenderModel', () => {
       'capital',
       'mark_confidence',
     ]);
+    expect(
+      response.renderModel.metricSections.map((section) => ({
+        inputsHash: section.inputsHash,
+        inputsHashShort: section.inputsHashShort,
+        methodologyVersion: section.methodologyVersion,
+        calculationVersion: section.calculationVersion,
+      }))
+    ).toEqual(
+      Array.from({ length: 3 }, () => ({
+        inputsHash: METRIC_RUN_INPUTS_HASH,
+        inputsHashShort: METRIC_RUN_INPUTS_HASH.slice(0, 12),
+        methodologyVersion: 'lp-reporting-methodology-v1',
+        calculationVersion: 'lp-reporting-metrics-engine-1.0.0',
+      }))
+    );
+    for (const section of response.renderModel.metricSections) {
+      expect(section.inputsHashShort).toHaveLength(12);
+    }
     expect(response.renderModel.narrativeSections.map((section) => section.sectionId)).toEqual([
       'no_dpi',
       'methodology',


### PR DESCRIPTION
## Summary

Plan 9 wave 9D: pins the (largely already-enforced) report-qualification posture with characterization tests and closes five named gaps. Production-code delta is deliberately small (~30 lines across four server files); the weight is in tests and declarations.

- **Characterization** (950-line suite through real `makeApp` + real H9 gate functions with data-layer fakes): partner/admin + export-fund-grant on all 8 export routes; every H9 failure mode blocks; status GETs are role-gated readiness metadata (intentionally H9-independent per in-code Finding 8); read/lifecycle routes unchanged; marginal MOIC excluded from every export payload (import-boundary test).
- **Gap-fills:**
  - H9 revalidation on stored **CSV creation/replay** (was: only artifact GET fail-closed; JSON path already revalidated before persistence) — found by the lane's own escape-hatch verification.
  - Per-metric provenance (`inputsHash`, `methodologyVersion`, `calculationVersion`) in render-model metric sections; render-model version bumped to 2 with **version-keyed replay** so pre-existing stored v1 exports replay cleanly (regression-tested).
  - Server-side `enable_scenario_seed_picker` gate on the from-seed route (auth-first then 404, matching the marginal-rankings idiom; no-side-effect ordering pinned by test).
  - LP-reporting route-policy declarations hand-declared truthfully (incl. relabeling a pre-existing key-only idempotency dedup that an earlier draft overstated).
- **ADR-040** in DECISIONS.md: role matrix, actionability gates, marginal exclusion pending its own activation+export ADR, accepted residuals (H9-check/CSV-insert TOCTOU bounded by delivery-time revalidation at ~5-user scale), and follow-ups.

## Review provenance

Spec survived 4 adversarial escape-hatch rounds (which surfaced the CSV H9 gap and the fail-closed-preview reality). Post-implementation adversarial Codex review: 5 P2 / 1 P3 — all dispositioned (3 fixed, 1 relabeled, 2 documented as accepted semantics/residuals) in the final commit.

## Test evidence

Full server project: 706 files / 8300 tests green. Targeted: characterization 18/18, route-policy 30/30, scenario contract 41/41, lp-reporting services 235. Lint + typecheck clean. Client render-model consumer spot-check 96/96 (renderModelVersion "v2" display is cosmetic; no client files changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h