### PR TITLE
feat(results): cross-surface readiness rollup on fund summary (Plan 9 wave 9B2)

### DIFF
--- a/client/src/hooks/use-scenario-set-list.ts
+++ b/client/src/hooks/use-scenario-set-list.ts
@@ -1,0 +1,27 @@
+/**
+ * Scenario-set list query hook (Plan 9 Wave 9B2 fix round F1).
+ *
+ * Reuses the scenario workspace's fetcher and query key VERBATIM so the
+ * Summary readiness rollup shares the react-query cache with the Scenarios
+ * destination page. The list is the completeness authority for the rollup's
+ * Scenarios row: the results section only carries sets with calculated
+ * snapshots, so active sets missing from it must degrade the row.
+ *
+ * @module client/hooks/use-scenario-set-list
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { fetchScenarioSetList } from '@/lib/fund-scenario-workspace-api';
+import { scenarioSetListQueryKey } from '@/lib/fund-scenario-workspace-query-keys';
+import type { FundScenarioSetSummaryV1 } from '@shared/contracts/fund-scenario-sets-v1.contract';
+
+export function useScenarioSetList(
+  fundId: string | null
+): UseQueryResult<FundScenarioSetSummaryV1[], Error> {
+  return useQuery<FundScenarioSetSummaryV1[], Error>({
+    queryKey:
+      fundId !== null ? scenarioSetListQueryKey(fundId) : ['fund-scenario-workspace', 'invalid'],
+    queryFn: () => fetchScenarioSetList(fundId ?? ''),
+    enabled: fundId !== null,
+  });
+}

--- a/client/src/lib/fund-scenario-workspace-api.ts
+++ b/client/src/lib/fund-scenario-workspace-api.ts
@@ -1,3 +1,6 @@
+import { apiRequest } from '@/lib/queryClient';
+import { FundScenarioSetListResponseV1Schema } from '@shared/contracts/fund-scenario-sets-v1.contract';
+
 const FUND_ID_PATTERN = /^\d+$/;
 const SCENARIO_SET_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -21,4 +24,14 @@ export function scenarioApiPath(fundId: string, suffix: string): string {
 export function scenarioSetApiPath(fundId: string, scenarioSetId: string, suffix = ''): string {
   assertScenarioSetId(scenarioSetId);
   return scenarioApiPath(fundId, `/scenario-sets/${encodeURIComponent(scenarioSetId)}${suffix}`);
+}
+
+/**
+ * Fetches the fund's scenario-set list (extracted verbatim from
+ * fund-scenario-workspace.tsx for reuse by the Summary readiness rollup;
+ * Plan 9 Wave 9B2 fix round F1).
+ */
+export async function fetchScenarioSetList(fundId: string) {
+  const raw = await apiRequest('GET', scenarioApiPath(fundId, '/scenario-sets'));
+  return FundScenarioSetListResponseV1Schema.parse(raw).scenarioSets;
 }

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -55,6 +55,9 @@ import {
 import { SectionRenderer } from './fund-model-results/SectionRenderer';
 import { WorkspaceBasisIndicator, WorkspaceNav } from './fund-model-results/workspace-nav';
 import { ErrorState, LatestErrorState, LoadingState } from './fund-model-results/states';
+import { FundReadinessRollup } from './fund-model-results/FundReadinessRollup';
+import type { ReadinessSourceInput, ScenariosSection } from './fund-model-results/readiness-rollup';
+import { useReadinessRollup } from './fund-model-results/use-readiness-rollup';
 import type { LifecycleStatus } from './fund-model-results/types';
 
 // ============================================================================
@@ -83,6 +86,17 @@ function FundModelResultsPage() {
   // section header and focus returns to it on close).
   const [scenarioEvidenceOpen, setScenarioEvidenceOpen] = useState(false);
   const scenarioEvidenceTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+  // D-H readiness rollup (9B2): the Scenarios row derives from the scenarios
+  // section this page already fetches; the other rows consume their existing
+  // hooks inside useReadinessRollup. Mounted in ALL page states below.
+  const scenariosInput: ReadinessSourceInput<ScenariosSection> =
+    fetchState.kind === 'data'
+      ? { kind: 'data', data: fetchState.results.sections.scenarios }
+      : fetchState.kind === 'error'
+        ? { kind: 'error', message: fetchState.message }
+        : { kind: 'loading' };
+  const readinessModel = useReadinessRollup(fundId, scenariosInput);
 
   useEffect(() => {
     if (fetchState.kind !== 'data') return;
@@ -116,11 +130,14 @@ function FundModelResultsPage() {
     />
   );
 
-  // Handle /latest or missing fundId
+  // Handle /latest or missing fundId. The readiness rollup stays mounted
+  // through every state the workspace row survives (P3-7 precedent): rows
+  // render their D-C fallback states, never a blank dominant object.
   if (fundId === 'latest' || !fundId) {
     return (
       <div className="max-w-6xl mx-auto px-6 py-8 space-y-8">
         {partialStateNav}
+        <FundReadinessRollup model={readinessModel} />
         <LatestErrorState />
       </div>
     );
@@ -130,6 +147,7 @@ function FundModelResultsPage() {
     return (
       <div className="max-w-6xl mx-auto px-6 py-8 space-y-8">
         {partialStateNav}
+        <FundReadinessRollup model={readinessModel} />
         <LoadingState />
       </div>
     );
@@ -139,6 +157,7 @@ function FundModelResultsPage() {
     return (
       <div className="max-w-6xl mx-auto px-6 py-8 space-y-8">
         {partialStateNav}
+        <FundReadinessRollup model={readinessModel} />
         <ErrorState message={fetchState.message} />
       </div>
     );
@@ -170,6 +189,10 @@ function FundModelResultsPage() {
         active="summary"
         indicator={<WorkspaceBasisIndicator mode="construction" />}
       />
+
+      {/* Dominant object (D-H): cross-surface readiness rollup, first section
+          under the workspace row; existing sections render below unchanged. */}
+      <FundReadinessRollup model={readinessModel} />
 
       <ConfigDiffBanner lifecycle={results.lifecycle} />
 

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -90,9 +90,16 @@ function FundModelResultsPage() {
   // D-H readiness rollup (9B2): the Scenarios row derives from the scenarios
   // section this page already fetches; the other rows consume their existing
   // hooks inside useReadinessRollup. Mounted in ALL page states below.
+  // Fix round F2: an in-place route change renders one frame with the
+  // PREVIOUS fund's results before the fetch-state reset effect runs — gate
+  // the scenarios facts on the payload's own fundId so a stale fund's facts
+  // never render beside the new fund's links.
+  const routeFundNumber = fundId !== null && /^[1-9]\d*$/.test(fundId) ? Number(fundId) : null;
   const scenariosInput: ReadinessSourceInput<ScenariosSection> =
     fetchState.kind === 'data'
-      ? { kind: 'data', data: fetchState.results.sections.scenarios }
+      ? fetchState.results.fundId === routeFundNumber
+        ? { kind: 'data', data: fetchState.results.sections.scenarios }
+        : { kind: 'loading' }
       : fetchState.kind === 'error'
         ? { kind: 'error', message: fetchState.message }
         : { kind: 'loading' };

--- a/client/src/pages/fund-model-results/FundReadinessRollup.tsx
+++ b/client/src/pages/fund-model-results/FundReadinessRollup.tsx
@@ -1,0 +1,210 @@
+/**
+ * Summary cross-surface readiness rollup (Plan 9 Wave 9B2, D-H).
+ *
+ * Presentational dense-table renderer for ReadinessRollupModel: five surface
+ * rows, each with an underlined workspace link, a dedicated "Decision state"
+ * column (D-A placement), the primary blocker inline in muted text, a
+ * tabular-nums as-of date, and full warnings behind a row-level disclosure
+ * (Enter/Space + aria-expanded, D-D). A neutral blocked-count line renders
+ * above the rows when any surface is not actionable. Loading rows render as
+ * skeleton placeholders (tabular-nums, motion-reduce gated) — the rollup
+ * itself never blanks.
+ *
+ * @module client/pages/fund-model-results/FundReadinessRollup
+ */
+
+import { Fragment, useState } from 'react';
+import { Link } from 'wouter';
+import { DecisionStateBadge } from '@/components/fund-results';
+import type { ReadinessRollupModel, ReadinessRollupRow, ReadinessRowKey } from './readiness-rollup';
+
+function SkeletonValue({ widthClass }: { widthClass: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-block h-3 ${widthClass} animate-pulse rounded bg-beige-200 tabular-nums motion-reduce:animate-none`}
+    />
+  );
+}
+
+interface RollupRowProps {
+  row: ReadinessRollupRow;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function RollupRow({ row, expanded, onToggle }: RollupRowProps) {
+  const detailsId = `readiness-row-${row.key}-details`;
+
+  return (
+    <Fragment>
+      <tr data-testid={`readiness-row-${row.key}`} className="border-b border-beige-100 align-top">
+        <td className="py-2 pr-4">
+          {row.href !== null ? (
+            <Link
+              href={row.href}
+              data-testid={`readiness-link-${row.key}`}
+              className="font-medium text-pov-charcoal underline decoration-1 underline-offset-4 hover:text-pov-charcoal"
+            >
+              {row.label}
+            </Link>
+          ) : (
+            <span
+              aria-disabled="true"
+              data-testid={`readiness-link-${row.key}-disabled`}
+              className="text-presson-textMuted"
+            >
+              {row.label}
+              {row.hrefDisabledReason !== null ? (
+                <span className="ml-1 text-xs">({row.hrefDisabledReason})</span>
+              ) : null}
+            </span>
+          )}
+        </td>
+        {row.loading ? (
+          <>
+            <td className="py-2 pr-4">
+              <span className="sr-only">Resolving readiness</span>
+              <SkeletonValue widthClass="w-20" />
+            </td>
+            <td className="py-2 pr-4">
+              <SkeletonValue widthClass="w-32" />
+            </td>
+            <td className="py-2 pr-4">
+              <SkeletonValue widthClass="w-16" />
+            </td>
+            <td className="py-2" />
+          </>
+        ) : (
+          <>
+            <td className="py-2 pr-4">
+              <DecisionStateBadge
+                state={row.state}
+                {...(row.stateLabel !== null ? { label: row.stateLabel } : {})}
+                testIdPrefix={`readiness-${row.key}`}
+              />
+            </td>
+            <td className="py-2 pr-4">
+              {row.primaryReason !== null ? (
+                <p
+                  className="text-xs text-presson-textMuted"
+                  data-testid={`readiness-row-${row.key}-reason`}
+                >
+                  {row.primaryReason}
+                </p>
+              ) : (
+                <p aria-hidden="true" className="text-xs text-presson-textMuted">
+                  —
+                </p>
+              )}
+              {row.blockedSummary !== null ? (
+                <p
+                  className="mt-0.5 text-xs tabular-nums text-presson-textMuted"
+                  data-testid={`readiness-row-${row.key}-blocked-summary`}
+                >
+                  {row.blockedSummary}
+                </p>
+              ) : null}
+            </td>
+            <td className="py-2 pr-4 text-xs tabular-nums text-presson-textMuted">
+              {row.asOfDate ?? '—'}
+            </td>
+            <td className="py-2 text-right">
+              {row.details.length > 0 ? (
+                <button
+                  type="button"
+                  aria-expanded={expanded}
+                  {...(expanded ? { 'aria-controls': detailsId } : {})}
+                  data-testid={`readiness-row-${row.key}-disclosure`}
+                  onClick={onToggle}
+                  className="text-xs font-medium text-pov-charcoal underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2"
+                >
+                  Warnings (<span className="tabular-nums">{row.details.length}</span>)
+                </button>
+              ) : null}
+            </td>
+          </>
+        )}
+      </tr>
+      {expanded && row.details.length > 0 ? (
+        <tr id={detailsId} data-testid={detailsId}>
+          <td colSpan={5} className="bg-beige-50 px-2 py-2">
+            <ul className="list-disc space-y-1 pl-5 text-xs text-presson-textMuted">
+              {row.details.map((detail, index) => (
+                <li key={`${index}-${detail}`}>{detail}</li>
+              ))}
+            </ul>
+          </td>
+        </tr>
+      ) : null}
+    </Fragment>
+  );
+}
+
+export function FundReadinessRollup({ model }: { model: ReadinessRollupModel }) {
+  const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<ReadinessRowKey>>(new Set());
+
+  const toggleRow = (key: ReadinessRowKey) => {
+    setExpandedKeys((previous) => {
+      const next = new Set(previous);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <section
+      aria-labelledby="fund-readiness-rollup-heading"
+      data-testid="fund-readiness-rollup"
+      className="bg-white rounded-lg border border-beige-200 p-6"
+    >
+      <h2 id="fund-readiness-rollup-heading" className="text-lg font-medium text-charcoal">
+        Readiness — what is blocked and where
+      </h2>
+      {model.blockedCount > 0 ? (
+        <p
+          className="mt-1 text-xs text-presson-textMuted"
+          data-testid="fund-readiness-rollup-blocked-count"
+        >
+          <span className="tabular-nums">{model.blockedCount}</span> of{' '}
+          <span className="tabular-nums">{model.surfaceCount}</span> surfaces not actionable
+        </p>
+      ) : null}
+      <table className="mt-4 w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-beige-200 text-xs uppercase text-presson-textMuted">
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Surface
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Decision state
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Primary blocker
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              As of
+            </th>
+            <th scope="col" className="py-2 font-medium">
+              <span className="sr-only">Warnings</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {model.rows.map((row) => (
+            <RollupRow
+              key={row.key}
+              row={row}
+              expanded={expandedKeys.has(row.key)}
+              onToggle={() => toggleRow(row.key)}
+            />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/client/src/pages/fund-model-results/FundReadinessRollup.tsx
+++ b/client/src/pages/fund-model-results/FundReadinessRollup.tsx
@@ -39,7 +39,8 @@ function RollupRow({ row, expanded, onToggle }: RollupRowProps) {
   return (
     <Fragment>
       <tr data-testid={`readiness-row-${row.key}`} className="border-b border-beige-100 align-top">
-        <td className="py-2 pr-4">
+        {/* Fix round F6: the surface name is the row header. */}
+        <th scope="row" className="py-2 pr-4 text-left font-normal">
           {row.href !== null ? (
             <Link
               href={row.href}
@@ -60,7 +61,7 @@ function RollupRow({ row, expanded, onToggle }: RollupRowProps) {
               ) : null}
             </span>
           )}
-        </td>
+        </th>
         {row.loading ? (
           <>
             <td className="py-2 pr-4">
@@ -114,6 +115,9 @@ function RollupRow({ row, expanded, onToggle }: RollupRowProps) {
                 <button
                   type="button"
                   aria-expanded={expanded}
+                  // Fix round F6: per-surface accessible name so the five
+                  // disclosures are distinguishable to assistive tech.
+                  aria-label={`Warnings for ${row.label} (${row.details.length})`}
                   {...(expanded ? { 'aria-controls': detailsId } : {})}
                   data-testid={`readiness-row-${row.key}-disclosure`}
                   onClick={onToggle}

--- a/client/src/pages/fund-model-results/readiness-rollup.ts
+++ b/client/src/pages/fund-model-results/readiness-rollup.ts
@@ -1,0 +1,361 @@
+/**
+ * Cross-surface readiness rollup derivation (Plan 9 Wave 9B2, D-H).
+ *
+ * Pure derivation from EXISTING read contracts onto the Summary page's
+ * dominant object: five rows (Forecast, Portfolio Actuals, Reserves,
+ * Scenarios, Reports), each carrying a generic DecisionState, its primary
+ * blocker, an as-of date, and the workspace link. Fail-closed: a row never
+ * renders a healthier state than its input proves; any fetch failure reads
+ * not_actionable with the D-C "Facts unavailable" domain label; loading rows
+ * stay not_actionable (excluded from blockedCount) and render as skeletons.
+ *
+ * The Reports row is an honest STATIC state (9B1 deviation 1, owner-accepted
+ * pre-decision): no unfiltered latest-metric-run read exists, so the Summary
+ * never presents export-readiness — qualification is verified on the Reports
+ * surface itself.
+ *
+ * @module client/pages/fund-model-results/readiness-rollup
+ */
+
+import type { DecisionState } from '@/components/fund-results';
+import type { AllocationsResponse } from '@/components/portfolio/tabs/types';
+import type { DualForecastResponse } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
+import type { FundMoicRankingsResponseV2 } from '@shared/contracts/fund-moic-v2.contract';
+import type { FundResultsReadV1 } from '@shared/contracts/fund-results-v1.contract';
+import { workspaceNavItems, type WorkspaceNavKey } from './workspace-nav';
+
+/** The scenarios section envelope the results page already fetches. */
+export type ScenariosSection = FundResultsReadV1['sections']['scenarios'];
+
+export type ReadinessSourceInput<T> =
+  { kind: 'loading' } | { kind: 'error'; message: string | null } | { kind: 'data'; data: T };
+
+export type ReadinessRowKey = Exclude<WorkspaceNavKey, 'summary'>;
+
+export interface ReadinessRollupRow {
+  key: ReadinessRowKey;
+  label: string;
+  /** Skeleton row while the backing read is in flight (D-C loading state). */
+  loading: boolean;
+  /**
+   * Loading rows also carry not_actionable so no consumer can ever read an
+   * unproven row as healthy; they are excluded from blockedCount.
+   */
+  state: DecisionState;
+  /** Domain label override for the badge (null = canonical D-A label). */
+  stateLabel: string | null;
+  primaryReason: string | null;
+  asOfDate: string | null;
+  href: string | null;
+  hrefDisabledReason: string | null;
+  /** Neutral counts summary (e.g. drift counts) rendered under the reason. */
+  blockedSummary: string | null;
+  /** Full warning copy behind the row-level disclosure (D-D). */
+  details: readonly string[];
+}
+
+export interface ReadinessRollupInputs {
+  /** Canonical positive-integer route fund id string, or null when unresolved. */
+  fundId: string | null;
+  forecast: ReadinessSourceInput<DualForecastResponse>;
+  portfolioActuals: ReadinessSourceInput<AllocationsResponse>;
+  reserves: ReadinessSourceInput<FundMoicRankingsResponseV2>;
+  scenarios: ReadinessSourceInput<ScenariosSection>;
+}
+
+export interface ReadinessRollupModel {
+  rows: readonly ReadinessRollupRow[];
+  surfaceCount: number;
+  /** Non-loading rows in not_actionable — the D-A blocked-count line. */
+  blockedCount: number;
+}
+
+/** D-A domain label for fetch/facts failures (never a fourth generic state). */
+const FACTS_UNAVAILABLE = 'Facts unavailable';
+
+interface RowSeed {
+  loading?: boolean;
+  state: DecisionState;
+  stateLabel?: string | null;
+  primaryReason?: string | null;
+  asOfDate?: string | null;
+  blockedSummary?: string | null;
+  details?: readonly string[];
+}
+
+const LOADING_SEED: RowSeed = { loading: true, state: 'not_actionable' };
+
+function factsUnavailableSeed(cause: string | null): RowSeed {
+  return { state: 'not_actionable', stateLabel: FACTS_UNAVAILABLE, primaryReason: cause };
+}
+
+/** Normalizes ISO datetimes to their date part for tabular as-of display. */
+function isoDateOnly(value: string): string {
+  return /^\d{4}-\d{2}-\d{2}/.test(value) ? value.slice(0, 10) : value;
+}
+
+function maxIsoDate(values: ReadonlyArray<string | null>): string | null {
+  let max: string | null = null;
+  for (const value of values) {
+    if (value === null) continue;
+    const date = isoDateOnly(value);
+    if (max === null || date > max) {
+      max = date;
+    }
+  }
+  return max;
+}
+
+function deriveForecastSeed(input: ReadinessSourceInput<DualForecastResponse>): RowSeed {
+  if (input.kind === 'loading') return LOADING_SEED;
+  if (input.kind === 'error') {
+    return factsUnavailableSeed(input.message ?? 'The forecast read failed');
+  }
+
+  const forecast = input.data;
+  const asOfDate = isoDateOnly(forecast.asOfDate);
+  const details = forecast.warnings;
+  const firstWarning = forecast.warnings[0] ?? null;
+
+  // Contract-documented facts-fetch failure: null facts/anchoring reads FAILED
+  // (matches evidenceFromDualForecast, AMENDMENT 6).
+  if (forecast.actualsFacts === null || forecast.navAnchoring === null) {
+    return {
+      state: 'not_actionable',
+      stateLabel: FACTS_UNAVAILABLE,
+      primaryReason: firstWarning ?? 'Company facts could not be resolved for this forecast',
+      asOfDate,
+      details,
+    };
+  }
+
+  const counts = forecast.navAnchoring.countsByTrustState;
+  const total = counts.LIVE + counts.PARTIAL + counts.UNAVAILABLE + counts.FAILED;
+
+  if (counts.FAILED > 0) {
+    return {
+      state: 'not_actionable',
+      stateLabel: FACTS_UNAVAILABLE,
+      primaryReason: `${counts.FAILED} of ${total} companies have failed facts`,
+      asOfDate,
+      details,
+    };
+  }
+
+  // Fail-closed: defaulted Current quarters are not decision-grade (D-C).
+  if (forecast.currentProjection.status === 'fallback_default') {
+    const fallbackReason = forecast.currentProjection.fallbackReason;
+    return {
+      state: 'not_actionable',
+      primaryReason: 'Current projection unavailable — a default projection is substituted',
+      asOfDate,
+      details: fallbackReason === null ? details : [...details, fallbackReason],
+    };
+  }
+
+  // AMENDMENT 8 pins the all-zero count map as an untrusted empty universe.
+  if (total === 0) {
+    return { state: 'indicative', primaryReason: 'No company facts disclosed', asOfDate, details };
+  }
+
+  const belowLive = counts.PARTIAL + counts.UNAVAILABLE;
+  if (belowLive > 0) {
+    return {
+      state: 'indicative',
+      primaryReason: `${belowLive} of ${total} companies below live facts`,
+      asOfDate,
+      details,
+    };
+  }
+
+  if (forecast.warnings.length > 0) {
+    return { state: 'indicative', primaryReason: firstWarning, asOfDate, details };
+  }
+
+  return { state: 'actionable', asOfDate, details };
+}
+
+function derivePortfolioActualsSeed(input: ReadinessSourceInput<AllocationsResponse>): RowSeed {
+  if (input.kind === 'loading') return LOADING_SEED;
+  if (input.kind === 'error') {
+    return factsUnavailableSeed(input.message ?? 'The allocations read failed');
+  }
+
+  const summary = input.data.metadata.actuals_drift_summary;
+  const asOfDate = isoDateOnly(summary.as_of_date);
+  const parts: string[] = [];
+  if (summary.drifted_company_count > 0) parts.push(`${summary.drifted_company_count} drifted`);
+  if (summary.material_company_count > 0) parts.push(`${summary.material_company_count} material`);
+  const blockedSummary = parts.length > 0 ? parts.join(', ') : null;
+
+  if (summary.facts_status === 'failed') {
+    return {
+      state: 'not_actionable',
+      stateLabel: FACTS_UNAVAILABLE,
+      primaryReason: 'Company facts failed to resolve for allocations',
+      asOfDate,
+      blockedSummary,
+    };
+  }
+
+  if (summary.degraded_company_count > 0) {
+    const count = summary.degraded_company_count;
+    return {
+      state: 'indicative',
+      primaryReason: `${count} ${count === 1 ? 'company' : 'companies'} degraded`,
+      asOfDate,
+      blockedSummary,
+    };
+  }
+
+  return { state: 'actionable', asOfDate, blockedSummary };
+}
+
+function deriveReservesSeed(input: ReadinessSourceInput<FundMoicRankingsResponseV2>): RowSeed {
+  if (input.kind === 'loading') return LOADING_SEED;
+  if (input.kind === 'error') {
+    return factsUnavailableSeed(input.message ?? 'The reserve rankings read failed');
+  }
+
+  const rankings = input.data.rankings;
+  const total = rankings.length;
+  const asOfDate = maxIsoDate(
+    rankings.map((ranking) => ranking.factsBasis?.valuationAnchor.asOfDate ?? null)
+  );
+
+  if (total === 0) {
+    return { state: 'not_actionable', primaryReason: 'No reserve rankings disclosed', asOfDate };
+  }
+
+  // The rankability enum IS the DecisionState enum here — mapped 1:1; a null
+  // facts basis reads not_actionable (the MOIC adapter's Facts unavailable).
+  const states = rankings.map<DecisionState>(
+    (ranking) => ranking.factsBasis?.rankability ?? 'not_actionable'
+  );
+  const notActionable = states.filter((state) => state === 'not_actionable').length;
+  const indicative = states.filter((state) => state === 'indicative').length;
+
+  if (notActionable === total) {
+    return {
+      state: 'not_actionable',
+      primaryReason: `All ${total} rankings are not actionable`,
+      asOfDate,
+    };
+  }
+  if (notActionable > 0) {
+    return {
+      state: 'indicative',
+      primaryReason: `${notActionable} of ${total} rankings not actionable`,
+      asOfDate,
+    };
+  }
+  if (indicative > 0) {
+    return {
+      state: 'indicative',
+      primaryReason: `${indicative} of ${total} rankings indicative`,
+      asOfDate,
+    };
+  }
+  return { state: 'actionable', asOfDate };
+}
+
+function deriveScenariosSeed(input: ReadinessSourceInput<ScenariosSection>): RowSeed {
+  if (input.kind === 'loading') return LOADING_SEED;
+  if (input.kind === 'error') {
+    return factsUnavailableSeed(input.message ?? 'The results read failed');
+  }
+
+  const section = input.data;
+  if (section.status !== 'available') {
+    if (section.reasonCode === 'SCENARIOS_NONE_EXIST') {
+      return { state: 'not_actionable', primaryReason: 'No scenario sets disclosed' };
+    }
+    if (section.reasonCode === 'SCENARIOS_NONE_CALCULATED') {
+      return {
+        state: 'not_actionable',
+        primaryReason: 'Scenario sets exist but none have calculated results',
+      };
+    }
+    return factsUnavailableSeed(section.reason);
+  }
+
+  const sets = section.payload.sets;
+  const total = sets.length;
+  const asOfDate = maxIsoDate(sets.map((set) => set.calculatedAt));
+  const failed = sets.filter(
+    (set) => set.staleness === 'FAILED' || set.staleness === 'UNAVAILABLE'
+  ).length;
+  const calculating = sets.filter((set) => set.staleness === 'CALCULATING').length;
+  const stale = sets.filter(
+    (set) => set.staleness === 'STALE_PUBLISH' || set.staleness === 'STALE_CONFIG'
+  ).length;
+
+  if (failed === total) {
+    return {
+      state: 'not_actionable',
+      primaryReason: `All ${total} scenario sets failed`,
+      asOfDate,
+    };
+  }
+  if (failed > 0) {
+    return {
+      state: 'indicative',
+      primaryReason: `${failed} of ${total} scenario sets failed`,
+      asOfDate,
+    };
+  }
+  if (calculating > 0) {
+    return { state: 'indicative', primaryReason: 'Scenario calculation in progress', asOfDate };
+  }
+  if (stale > 0) {
+    return {
+      state: 'indicative',
+      primaryReason: `${stale} of ${total} scenario sets stale against the published config`,
+      asOfDate,
+    };
+  }
+  return { state: 'actionable', asOfDate };
+}
+
+/**
+ * Honest static Reports state (pre-decided): the Summary NEVER presents
+ * export-readiness; the D-C gated affordance points at the Reports surface.
+ */
+const REPORTS_SEED: RowSeed = {
+  state: 'not_actionable',
+  stateLabel: 'Not verified',
+  primaryReason: 'Qualification is verified on the Reports surface',
+};
+
+export function deriveReadinessRollup(inputs: ReadinessRollupInputs): ReadinessRollupModel {
+  const navByKey = new Map(workspaceNavItems(inputs.fundId).map((item) => [item.key, item]));
+  const seeds: ReadonlyArray<[ReadinessRowKey, RowSeed]> = [
+    ['forecast', deriveForecastSeed(inputs.forecast)],
+    ['portfolio-actuals', derivePortfolioActualsSeed(inputs.portfolioActuals)],
+    ['reserves', deriveReservesSeed(inputs.reserves)],
+    ['scenarios', deriveScenariosSeed(inputs.scenarios)],
+    ['reports', REPORTS_SEED],
+  ];
+
+  const rows: ReadinessRollupRow[] = seeds.map(([key, seed]) => {
+    const navItem = navByKey.get(key);
+    const href = navItem?.href ?? null;
+    return {
+      key,
+      label: navItem?.label ?? key,
+      loading: seed.loading ?? false,
+      state: seed.state,
+      stateLabel: seed.stateLabel ?? null,
+      primaryReason: seed.primaryReason ?? null,
+      asOfDate: seed.asOfDate ?? null,
+      href,
+      hrefDisabledReason: href === null ? (navItem?.disabledReason ?? null) : null,
+      blockedSummary: seed.blockedSummary ?? null,
+      details: seed.details ?? [],
+    };
+  });
+
+  const blockedCount = rows.filter((row) => !row.loading && row.state === 'not_actionable').length;
+
+  return { rows, surfaceCount: rows.length, blockedCount };
+}

--- a/client/src/pages/fund-model-results/readiness-rollup.ts
+++ b/client/src/pages/fund-model-results/readiness-rollup.ts
@@ -22,6 +22,7 @@ import type { AllocationsResponse } from '@/components/portfolio/tabs/types';
 import type { DualForecastResponse } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
 import type { FundMoicRankingsResponseV2 } from '@shared/contracts/fund-moic-v2.contract';
 import type { FundResultsReadV1 } from '@shared/contracts/fund-results-v1.contract';
+import type { FundScenarioSetSummaryV1 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 import { workspaceNavItems, type WorkspaceNavKey } from './workspace-nav';
 
 /** The scenarios section envelope the results page already fetches. */
@@ -61,6 +62,13 @@ export interface ReadinessRollupInputs {
   portfolioActuals: ReadinessSourceInput<AllocationsResponse>;
   reserves: ReadinessSourceInput<FundMoicRankingsResponseV2>;
   scenarios: ReadinessSourceInput<ScenariosSection>;
+  /**
+   * The scenario-set LIST (fix round F1): the results section only carries
+   * sets with calculated snapshots, so the list is the completeness
+   * authority — the Scenarios row may read actionable ONLY when every active
+   * listed set is present and CURRENT in the results section.
+   */
+  scenarioSetList: ReadinessSourceInput<readonly FundScenarioSetSummaryV1[]>;
 }
 
 export interface ReadinessRollupModel {
@@ -153,12 +161,23 @@ function deriveForecastSeed(input: ReadinessSourceInput<DualForecastResponse>): 
     };
   }
 
-  // AMENDMENT 8 pins the all-zero count map as an untrusted empty universe.
-  if (total === 0) {
-    return { state: 'indicative', primaryReason: 'No company facts disclosed', asOfDate, details };
+  const belowLive = counts.PARTIAL + counts.UNAVAILABLE;
+
+  // Fix round F3: zero LIVE companies — including AMENDMENT 8's all-zero
+  // empty universe, pinned UNAVAILABLE — cannot anchor a decision-grade
+  // forecast and fails closed. Mixed trust with some LIVE stays indicative.
+  if (counts.LIVE === 0) {
+    return {
+      state: 'not_actionable',
+      primaryReason:
+        total === 0
+          ? 'No company facts disclosed'
+          : `${belowLive} of ${total} companies below live facts`,
+      asOfDate,
+      details,
+    };
   }
 
-  const belowLive = counts.PARTIAL + counts.UNAVAILABLE;
   if (belowLive > 0) {
     return {
       state: 'indicative',
@@ -196,6 +215,12 @@ function derivePortfolioActualsSeed(input: ReadinessSourceInput<AllocationsRespo
       asOfDate,
       blockedSummary,
     };
+  }
+
+  // Fix round F4: the endpoint pins 200 + companies_count 0 as a true-empty
+  // state — the D-C empty idiom, consistent with reserves/scenarios.
+  if (input.data.metadata.companies_count === 0) {
+    return { state: 'not_actionable', primaryReason: 'No portfolio actuals disclosed', asOfDate };
   }
 
   if (summary.degraded_company_count > 0) {
@@ -259,7 +284,10 @@ function deriveReservesSeed(input: ReadinessSourceInput<FundMoicRankingsResponse
   return { state: 'actionable', asOfDate };
 }
 
-function deriveScenariosSeed(input: ReadinessSourceInput<ScenariosSection>): RowSeed {
+function deriveScenariosSeed(
+  input: ReadinessSourceInput<ScenariosSection>,
+  listInput: ReadinessSourceInput<readonly FundScenarioSetSummaryV1[]>
+): RowSeed {
   if (input.kind === 'loading') return LOADING_SEED;
   if (input.kind === 'error') {
     return factsUnavailableSeed(input.message ?? 'The results read failed');
@@ -314,6 +342,31 @@ function deriveScenariosSeed(input: ReadinessSourceInput<ScenariosSection>): Row
       asOfDate,
     };
   }
+
+  // Fix round F1: every results-section set is CURRENT, but the section only
+  // carries sets with calculated snapshots. The actionable claim additionally
+  // requires the scenario-set LIST to prove completeness; unprovable
+  // completeness NEVER reads actionable.
+  if (listInput.kind === 'loading') {
+    return LOADING_SEED;
+  }
+  if (listInput.kind === 'error') {
+    return {
+      state: 'indicative',
+      primaryReason: 'Scenario set inventory unavailable',
+      asOfDate,
+    };
+  }
+  const activeSets = listInput.data.filter((set) => set.archivedAt === null);
+  const calculatedIds = new Set(sets.map((set) => set.scenarioSetId));
+  const missing = activeSets.filter((set) => !calculatedIds.has(set.id)).length;
+  if (missing > 0) {
+    return {
+      state: 'indicative',
+      primaryReason: `${missing} of ${activeSets.length} sets have no calculated results`,
+      asOfDate,
+    };
+  }
   return { state: 'actionable', asOfDate };
 }
 
@@ -333,7 +386,7 @@ export function deriveReadinessRollup(inputs: ReadinessRollupInputs): ReadinessR
     ['forecast', deriveForecastSeed(inputs.forecast)],
     ['portfolio-actuals', derivePortfolioActualsSeed(inputs.portfolioActuals)],
     ['reserves', deriveReservesSeed(inputs.reserves)],
-    ['scenarios', deriveScenariosSeed(inputs.scenarios)],
+    ['scenarios', deriveScenariosSeed(inputs.scenarios, inputs.scenarioSetList)],
     ['reports', REPORTS_SEED],
   ];
 

--- a/client/src/pages/fund-model-results/use-readiness-rollup.ts
+++ b/client/src/pages/fund-model-results/use-readiness-rollup.ts
@@ -14,6 +14,7 @@
 import { useFundContext } from '@/contexts/FundContext';
 import { useDualForecast } from '@/hooks/useDualForecast';
 import { useFundMoicRankingsV2 } from '@/hooks/use-moic';
+import { useScenarioSetList } from '@/hooks/use-scenario-set-list';
 import { useLatestAllocations } from '@/components/portfolio/tabs/hooks/useLatestAllocations';
 import type { AllocationsResponse } from '@/components/portfolio/tabs/types';
 import {
@@ -55,6 +56,9 @@ export function useReadinessRollup(
   // while the route fund is unresolved.
   const forecastQuery = useDualForecast(numericFundId);
   const reservesQuery = useFundMoicRankingsV2(numericFundId);
+  // Fix round F1: the scenario-set list (workspace fetcher + query key,
+  // shared cache) is the completeness authority for the Scenarios row.
+  const scenarioSetListQuery = useScenarioSetList(validFundId);
   const allocationsQuery = useLatestAllocations();
   const { fundId: contextFundId, isLoading: fundContextLoading } = useFundContext();
 
@@ -66,6 +70,7 @@ export function useReadinessRollup(
       portfolioActuals: noFund,
       reserves: noFund,
       scenarios: noFund,
+      scenarioSetList: noFund,
     });
   }
 
@@ -82,5 +87,6 @@ export function useReadinessRollup(
     portfolioActuals,
     reserves: queryInput(reservesQuery),
     scenarios,
+    scenarioSetList: queryInput(scenarioSetListQuery),
   });
 }

--- a/client/src/pages/fund-model-results/use-readiness-rollup.ts
+++ b/client/src/pages/fund-model-results/use-readiness-rollup.ts
@@ -1,0 +1,86 @@
+/**
+ * Container hook for the Summary readiness rollup (Plan 9 Wave 9B2).
+ *
+ * Consumes ONLY existing hooks/endpoints (dual forecast, latest allocations,
+ * MOIC rankings v2) plus the scenarios section the page already fetched, and
+ * maps their query states onto the pure derivation's inputs. Fail-closed fund
+ * scoping: the allocations hook reads the FundContext fund, so its data is
+ * rendered ONLY when that fund is the validated route fund — a mismatched or
+ * unresolved context reads "Facts unavailable", never another fund's facts.
+ *
+ * @module client/pages/fund-model-results/use-readiness-rollup
+ */
+
+import { useFundContext } from '@/contexts/FundContext';
+import { useDualForecast } from '@/hooks/useDualForecast';
+import { useFundMoicRankingsV2 } from '@/hooks/use-moic';
+import { useLatestAllocations } from '@/components/portfolio/tabs/hooks/useLatestAllocations';
+import type { AllocationsResponse } from '@/components/portfolio/tabs/types';
+import {
+  deriveReadinessRollup,
+  type ReadinessRollupModel,
+  type ReadinessSourceInput,
+  type ScenariosSection,
+} from './readiness-rollup';
+
+const NO_FUND_MESSAGE = 'No fund is resolved on this route';
+
+interface QueryLike<T> {
+  isSuccess: boolean;
+  isError: boolean;
+  data: T | undefined;
+  error: unknown;
+}
+
+function queryInput<T>(query: QueryLike<T>): ReadinessSourceInput<T> {
+  if (query.isSuccess && query.data !== undefined) {
+    return { kind: 'data', data: query.data };
+  }
+  if (query.isError) {
+    const message =
+      query.error instanceof Error && query.error.message.length > 0 ? query.error.message : null;
+    return { kind: 'error', message };
+  }
+  return { kind: 'loading' };
+}
+
+export function useReadinessRollup(
+  routeFundId: string | null,
+  scenarios: ReadinessSourceInput<ScenariosSection>
+): ReadinessRollupModel {
+  const validFundId = routeFundId !== null && /^[1-9]\d*$/.test(routeFundId) ? routeFundId : null;
+  const numericFundId = validFundId === null ? null : Number(validFundId);
+
+  // Hooks run unconditionally (rules of hooks); their queries are disabled
+  // while the route fund is unresolved.
+  const forecastQuery = useDualForecast(numericFundId);
+  const reservesQuery = useFundMoicRankingsV2(numericFundId);
+  const allocationsQuery = useLatestAllocations();
+  const { fundId: contextFundId, isLoading: fundContextLoading } = useFundContext();
+
+  if (numericFundId === null) {
+    const noFund: ReadinessSourceInput<never> = { kind: 'error', message: NO_FUND_MESSAGE };
+    return deriveReadinessRollup({
+      fundId: null,
+      forecast: noFund,
+      portfolioActuals: noFund,
+      reserves: noFund,
+      scenarios: noFund,
+    });
+  }
+
+  const portfolioActuals: ReadinessSourceInput<AllocationsResponse> =
+    contextFundId === numericFundId
+      ? queryInput(allocationsQuery)
+      : fundContextLoading
+        ? { kind: 'loading' }
+        : { kind: 'error', message: 'Allocation facts are not resolved for this fund' };
+
+  return deriveReadinessRollup({
+    fundId: validFundId,
+    forecast: queryInput(forecastQuery),
+    portfolioActuals,
+    reserves: queryInput(reservesQuery),
+    scenarios,
+  });
+}

--- a/client/src/pages/fund-scenario-workspace.tsx
+++ b/client/src/pages/fund-scenario-workspace.tsx
@@ -38,7 +38,6 @@ import {
   FundScenarioCalculationStatusV1Schema,
   FundScenarioReserveCalculationQueuedV1Schema,
   FundScenarioSetDetailV1Schema,
-  FundScenarioSetListResponseV1Schema,
   type FundScenarioCalculationModeV1,
   type FundScenarioCalculationStatusV1,
   type FundScenarioOverrideTypeV1,
@@ -58,7 +57,11 @@ import {
   scenarioSetStatusQueryKey,
   workspaceQueryKey,
 } from '@/lib/fund-scenario-workspace-query-keys';
-import { scenarioApiPath, scenarioSetApiPath } from '@/lib/fund-scenario-workspace-api';
+import {
+  fetchScenarioSetList,
+  scenarioApiPath,
+  scenarioSetApiPath,
+} from '@/lib/fund-scenario-workspace-api';
 
 const FUND_SCENARIO_WORKSPACE_ROUTE = '/fund-model-results/:fundId/scenarios';
 const OVERRIDE_TYPE_LABELS: Record<FundScenarioOverrideTypeV1, string> = {
@@ -78,11 +81,6 @@ export function reserveStatusPollIntervalMs(
   status: FundScenarioCalculationStatusV1['status'] | undefined
 ): number | false {
   return status === 'queued' || status === 'calculating' ? RESERVE_STATUS_POLL_INTERVAL_MS : false;
-}
-
-async function fetchScenarioSetList(fundId: string) {
-  const raw = await apiRequest('GET', scenarioApiPath(fundId, '/scenario-sets'));
-  return FundScenarioSetListResponseV1Schema.parse(raw).scenarioSets;
 }
 
 async function fetchScenarioSetDetail(fundId: string, scenarioSetId: string) {

--- a/tests/integration/wizard-to-results-e2e.test.ts
+++ b/tests/integration/wizard-to-results-e2e.test.ts
@@ -102,6 +102,14 @@ vi.mock('@/components/portfolio/tabs/hooks/useLatestAllocations', () => ({
     error: new Error('allocations unavailable'),
   }),
 }));
+vi.mock('@/hooks/use-scenario-set-list', () => ({
+  useScenarioSetList: () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error('scenario set list unavailable'),
+  }),
+}));
 
 vi.mock('@/stores/useFundSelector', () => ({
   useFundSelector: (selector: (s: typeof mockFundState) => unknown) => selector(mockFundState),

--- a/tests/integration/wizard-to-results-e2e.test.ts
+++ b/tests/integration/wizard-to-results-e2e.test.ts
@@ -73,6 +73,36 @@ vi.mock('@/contexts/FundContext', () => ({
   }),
 }));
 
+// Plan 9 Wave 9B2: the readiness rollup's data-source hooks are react-query
+// hooks; this harness has no QueryClientProvider and its strict fetch mock
+// deliberately rejects unexpected URLs. Mock them at the module boundary
+// (same pattern as the release-owned page suite) so the rollup renders its
+// fail-closed rows while the wizard flow under test stays fetch-strict.
+vi.mock('@/hooks/useDualForecast', () => ({
+  useDualForecast: () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error('dual forecast unavailable'),
+  }),
+}));
+vi.mock('@/hooks/use-moic', () => ({
+  useFundMoicRankingsV2: () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error('rankings unavailable'),
+  }),
+}));
+vi.mock('@/components/portfolio/tabs/hooks/useLatestAllocations', () => ({
+  useLatestAllocations: () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error('allocations unavailable'),
+  }),
+}));
+
 vi.mock('@/stores/useFundSelector', () => ({
   useFundSelector: (selector: (s: typeof mockFundState) => unknown) => selector(mockFundState),
   useFundTuple: (selector: (s: typeof mockFundState) => readonly unknown[]) =>
@@ -205,7 +235,9 @@ describe('wizard to results flow', () => {
       expect(screen.queryByText(/No published configuration yet/i)).toBeNull();
       expect(screen.getAllByText('v1').length).toBeGreaterThan(0);
       expect(screen.getAllByText(/Run 10/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText('No authoritative source')).toHaveLength(3);
+      // 9B2: 3 unavailable sections + the readiness rollup's Scenarios row,
+      // which honestly repeats the scenarios section's unavailability reason.
+      expect(screen.getAllByText('No authoritative source')).toHaveLength(4);
 
       firstRender.unmount();
 

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -18,6 +18,38 @@ import { createWouterWrapper } from '../../utils/withWouter';
 import FundModelResultsPage from '../../../client/src/pages/fund-model-results';
 import type { FundScenarioComparisonV1 } from '../../../shared/contracts/fund-scenario-comparison-v1.contract';
 
+// Plan 9 Wave 9B2: the readiness rollup's data-source hooks are mocked at the
+// module boundary (this file's fetch mock only covers the page's own reads).
+// Errored queries exercise the fail-closed "Facts unavailable" rows; the
+// Scenarios row still derives from the REAL /results fetch mock below.
+vi.mock('@/hooks/useDualForecast', () => ({
+  useDualForecast: () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error('dual forecast unavailable'),
+  }),
+}));
+vi.mock('@/hooks/use-moic', () => ({
+  useFundMoicRankingsV2: () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error('rankings unavailable'),
+  }),
+}));
+vi.mock('@/components/portfolio/tabs/hooks/useLatestAllocations', () => ({
+  useLatestAllocations: () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error('allocations unavailable'),
+  }),
+}));
+vi.mock('@/contexts/FundContext', () => ({
+  useFundContext: () => ({ fundId: 123, isLoading: false }),
+}));
+
 describe('FundModelResultsPage (server-backed)', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let sessionGetSpy: ReturnType<typeof vi.spyOn>;
@@ -584,7 +616,10 @@ describe('FundModelResultsPage (server-backed)', () => {
       await Promise.resolve();
     });
 
-    expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+    // 9B2 narrow re-scope: the readiness rollup honestly repeats the failure
+    // cause in its Scenarios row, so the error-state assertion pins the alert
+    // region semantically instead of a page-global text match.
+    expect(await screen.findByRole('alert')).toHaveTextContent(/not found/i);
   });
 
   it('shows error state on network failure', async () => {
@@ -597,7 +632,8 @@ describe('FundModelResultsPage (server-backed)', () => {
       await Promise.resolve();
     });
 
-    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+    // 9B2 narrow re-scope: see the 404 test above.
+    expect(await screen.findByRole('alert')).toHaveTextContent(/network error/i);
   });
 
   // -- Pending/calculating --
@@ -1398,7 +1434,9 @@ describe('FundModelResultsPage (server-backed)', () => {
       await Promise.resolve();
     });
 
-    expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+    // 9B2 narrow re-scope: the rollup repeats the failure cause, so pin the
+    // alert region semantically (see the 404 error-state test).
+    expect(await screen.findByRole('alert')).toHaveTextContent(/not found/i);
     nav = screen.getByRole('navigation', { name: 'Fund workspace' });
     expect(within(nav).getByRole('link', { name: 'Reserves' })).toHaveAttribute(
       'href',
@@ -1436,6 +1474,97 @@ describe('FundModelResultsPage (server-backed)', () => {
       '/fund-model-results/123/reports'
     );
     expect(within(nav).getByText('Basis: Construction')).toBeInTheDocument();
+  });
+
+  // -- Plan 9 Wave 9B2: cross-surface readiness rollup (D-H) --
+
+  it('mounts the readiness rollup as the dominant object directly under the workspace row', async () => {
+    mockFundPageFetches();
+    await renderPage('/fund-model-results/123');
+
+    await screen.findByRole('heading', { level: 1, name: 'Test Fund' });
+    const nav = screen.getByTestId('workspace-nav');
+    const rollup = screen.getByTestId('fund-readiness-rollup');
+    expect(nav.nextElementSibling).toBe(rollup);
+
+    const scoped = within(rollup);
+    expect(
+      scoped.getByRole('heading', { level: 2, name: 'Readiness — what is blocked and where' })
+    ).toBeInTheDocument();
+    for (const key of ['forecast', 'portfolio-actuals', 'reserves', 'scenarios', 'reports']) {
+      expect(scoped.getByTestId(`readiness-row-${key}`)).toBeInTheDocument();
+    }
+  });
+
+  it('fails rollup rows closed on data-source errors and keeps the static Reports row honest', async () => {
+    mockFundPageFetches();
+    await renderPage('/fund-model-results/123');
+
+    // Wait for the loaded surface (the Scenarios row is a skeleton until the
+    // page's own /results read resolves).
+    await screen.findByRole('heading', { level: 1, name: 'Test Fund' });
+    const rollup = within(screen.getByTestId('fund-readiness-rollup'));
+    // The mocked hook failures read Facts unavailable with the short cause.
+    expect(rollup.getByTestId('readiness-row-forecast-reason')).toHaveTextContent(
+      'dual forecast unavailable'
+    );
+    expect(
+      within(rollup.getByTestId('readiness-row-forecast')).getByText('Facts unavailable')
+    ).toBeInTheDocument();
+    // The Scenarios row derives from the page's own /results payload
+    // (SCENARIOS_NONE_EXIST in the default fixture -> D-C empty copy).
+    expect(rollup.getByTestId('readiness-row-scenarios-reason')).toHaveTextContent(
+      'No scenario sets disclosed'
+    );
+    // Reports never claims export readiness from the Summary (pre-decision).
+    const reportsRow = within(rollup.getByTestId('readiness-row-reports'));
+    expect(reportsRow.getByText('Not verified')).toBeInTheDocument();
+    expect(rollup.getByTestId('fund-readiness-rollup-blocked-count')).toHaveTextContent(
+      '5 of 5 surfaces not actionable'
+    );
+  });
+
+  it('reads calculated-current scenario sets as actionable in the rollup', async () => {
+    const resp = readyResponse();
+    resp.sections.scenarios = validScenariosSection();
+    mockFundPageFetches({ results: resp });
+    await renderPage('/fund-model-results/123');
+
+    await screen.findByRole('heading', { level: 1, name: 'Test Fund' });
+    const rollup = within(screen.getByTestId('fund-readiness-rollup'));
+    const scenariosRow = within(rollup.getByTestId('readiness-row-scenarios'));
+    expect(scenariosRow.getByText('Actionable')).toBeInTheDocument();
+    expect(scenariosRow.getByText('2026-05-26')).toBeInTheDocument();
+  });
+
+  it('keeps the rollup mounted with fallback rows through loading and error states', async () => {
+    const fetchDeferred = createDeferred<Response>();
+    fetchSpy.mockReturnValue(fetchDeferred.promise);
+    await renderPage('/fund-model-results/123');
+
+    // Loading: the rollup is already the first section under the nav row.
+    expect(screen.getByTestId('workspace-nav').nextElementSibling).toBe(
+      screen.getByTestId('fund-readiness-rollup')
+    );
+
+    await act(async () => {
+      fetchDeferred.resolve(
+        new Response(JSON.stringify({ error: 'Fund not found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/not found/i);
+    const rollup = screen.getByTestId('fund-readiness-rollup');
+    expect(screen.getByTestId('workspace-nav').nextElementSibling).toBe(rollup);
+    // The failing spoke reads Facts unavailable in the Scenarios row, with
+    // the short cause — the page never blanks its dominant object (D-C).
+    expect(within(rollup).getByTestId('readiness-row-scenarios-reason')).toHaveTextContent(
+      'Fund not found'
+    );
   });
 
   it('opens the scenario evidence drawer with comparison evidence and restores focus on close', async () => {

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -21,7 +21,21 @@ import type { FundScenarioComparisonV1 } from '../../../shared/contracts/fund-sc
 // Plan 9 Wave 9B2: the readiness rollup's data-source hooks are mocked at the
 // module boundary (this file's fetch mock only covers the page's own reads).
 // Errored queries exercise the fail-closed "Facts unavailable" rows; the
-// Scenarios row still derives from the REAL /results fetch mock below.
+// Scenarios row still derives from the REAL /results fetch mock below. The
+// scenario-set LIST mock (fix round F1) is mutable so the actionable-join
+// test can present a matching inventory.
+const rollupHookMocks = vi.hoisted(() => {
+  const erroredScenarioSetList = () => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined as unknown,
+    error: new Error('scenario set list unavailable') as Error | null,
+  });
+  return { erroredScenarioSetList, scenarioSetList: erroredScenarioSetList() };
+});
+vi.mock('@/hooks/use-scenario-set-list', () => ({
+  useScenarioSetList: () => rollupHookMocks.scenarioSetList,
+}));
 vi.mock('@/hooks/useDualForecast', () => ({
   useDualForecast: () => ({
     isSuccess: false,
@@ -58,6 +72,7 @@ describe('FundModelResultsPage (server-backed)', () => {
     fetchSpy = vi.fn();
     globalThis.fetch = fetchSpy;
     sessionGetSpy = vi.spyOn(Storage.prototype, 'getItem');
+    rollupHookMocks.scenarioSetList = rollupHookMocks.erroredScenarioSetList();
   });
 
   afterEach(() => {
@@ -1524,9 +1539,17 @@ describe('FundModelResultsPage (server-backed)', () => {
     );
   });
 
-  it('reads calculated-current scenario sets as actionable in the rollup', async () => {
+  it('reads calculated-current scenario sets as actionable when the inventory agrees (F1)', async () => {
     const resp = readyResponse();
     resp.sections.scenarios = validScenariosSection();
+    // F1 join: the actionable claim requires the scenario-set LIST to confirm
+    // every active set is calculated.
+    rollupHookMocks.scenarioSetList = {
+      isSuccess: true,
+      isError: false,
+      data: [{ id: '00000000-0000-0000-0000-000000000111', archivedAt: null }],
+      error: null,
+    };
     mockFundPageFetches({ results: resp });
     await renderPage('/fund-model-results/123');
 
@@ -1535,6 +1558,22 @@ describe('FundModelResultsPage (server-backed)', () => {
     const scenariosRow = within(rollup.getByTestId('readiness-row-scenarios'));
     expect(scenariosRow.getByText('Actionable')).toBeInTheDocument();
     expect(scenariosRow.getByText('2026-05-26')).toBeInTheDocument();
+  });
+
+  it('caps calculated-current scenario sets at indicative when the inventory is unavailable (F1)', async () => {
+    const resp = readyResponse();
+    resp.sections.scenarios = validScenariosSection();
+    // Default list mock is errored: completeness unprovable -> never actionable.
+    mockFundPageFetches({ results: resp });
+    await renderPage('/fund-model-results/123');
+
+    await screen.findByRole('heading', { level: 1, name: 'Test Fund' });
+    const rollup = within(screen.getByTestId('fund-readiness-rollup'));
+    const scenariosRow = within(rollup.getByTestId('readiness-row-scenarios'));
+    expect(scenariosRow.queryByText('Actionable')).not.toBeInTheDocument();
+    expect(rollup.getByTestId('readiness-row-scenarios-reason')).toHaveTextContent(
+      'Scenario set inventory unavailable'
+    );
   });
 
   it('keeps the rollup mounted with fallback rows through loading and error states', async () => {

--- a/tests/unit/pages/fund-model-results/fund-readiness-rollup.test.tsx
+++ b/tests/unit/pages/fund-model-results/fund-readiness-rollup.test.tsx
@@ -194,12 +194,34 @@ describe('FundReadinessRollup', () => {
   it('renders as-of dates in tabular numerals and an em dash when undisclosed', () => {
     const rollup = renderRollup(modelFixture());
 
+    // F6: the surface cell is a row-header th, so data cells are the 4 tds.
     const forecastCells = rollup.getByTestId('readiness-row-forecast').querySelectorAll('td');
-    const asOfCell = forecastCells[3];
+    const asOfCell = forecastCells[2];
     expect(asOfCell?.textContent).toBe('2026-07-01');
     expect(asOfCell?.className).toContain('tabular-nums');
     const reportsCells = rollup.getByTestId('readiness-row-reports').querySelectorAll('td');
-    expect(reportsCells[3]?.textContent).toBe('—');
+    expect(reportsCells[2]?.textContent).toBe('—');
+  });
+
+  it('names each row with its surface as a row header (F6)', () => {
+    const rollup = renderRollup(modelFixture());
+
+    const rowHeaders = rollup.getAllByRole('rowheader');
+    expect(rowHeaders.map((header) => header.textContent)).toEqual([
+      'Forecast',
+      'Portfolio Actuals',
+      'Reserves',
+      'Scenarios',
+      'Reports',
+    ]);
+  });
+
+  it('gives every warnings disclosure a per-surface accessible name (F6)', () => {
+    const rollup = renderRollup(modelFixture());
+
+    expect(rollup.getByRole('button', { name: 'Warnings for Scenarios (2)' })).toBe(
+      rollup.getByTestId('readiness-row-scenarios-disclosure')
+    );
   });
 
   it('links each surface with a fund-carrying underlined text link', () => {

--- a/tests/unit/pages/fund-model-results/fund-readiness-rollup.test.tsx
+++ b/tests/unit/pages/fund-model-results/fund-readiness-rollup.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * Rendering tests for the Summary readiness rollup table (Plan 9 Wave 9B2).
+ *
+ * Pins the D-A dense-table grammar (dedicated Decision state column, neutral
+ * blocked-count line, muted inline primary reason), D-D disclosure keyboard
+ * parity, tabular-nums on numerics and skeletons, fund-carrying links, and
+ * the D-C loading/disabled fallbacks. Every query is scoped inside the
+ * rollup's own testid — the surface labels intentionally collide with the
+ * workspace nav row on the real page (L5).
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createWouterWrapper } from '../../../utils/withWouter';
+import { FundReadinessRollup } from '../../../../client/src/pages/fund-model-results/FundReadinessRollup';
+import type {
+  ReadinessRollupModel,
+  ReadinessRollupRow,
+} from '../../../../client/src/pages/fund-model-results/readiness-rollup';
+
+function row(overrides: Partial<ReadinessRollupRow> & Pick<ReadinessRollupRow, 'key' | 'label'>) {
+  return {
+    loading: false,
+    state: 'actionable' as const,
+    stateLabel: null,
+    primaryReason: null,
+    asOfDate: null,
+    href: null,
+    hrefDisabledReason: null,
+    blockedSummary: null,
+    details: [],
+    ...overrides,
+  };
+}
+
+function modelFixture(overrides: Partial<ReadinessRollupModel> = {}): ReadinessRollupModel {
+  const rows: ReadinessRollupRow[] = [
+    row({
+      key: 'forecast',
+      label: 'Forecast',
+      href: '/financial-modeling?fundId=42',
+      asOfDate: '2026-07-01',
+    }),
+    row({
+      key: 'portfolio-actuals',
+      label: 'Portfolio Actuals',
+      href: '/portfolio?tab=reserve-planning&fundId=42',
+      state: 'indicative',
+      primaryReason: '2 companies degraded',
+      blockedSummary: '3 drifted, 1 material',
+      asOfDate: '2026-07-02',
+    }),
+    row({
+      key: 'reserves',
+      label: 'Reserves',
+      href: '/fund-model-results/42/moic-analysis',
+      state: 'not_actionable',
+      stateLabel: 'Facts unavailable',
+      primaryReason: 'The reserve rankings read failed',
+    }),
+    row({
+      key: 'scenarios',
+      label: 'Scenarios',
+      href: '/fund-model-results/42/scenarios',
+      state: 'indicative',
+      primaryReason: 'first warning',
+      details: ['first warning', 'second warning'],
+    }),
+    row({
+      key: 'reports',
+      label: 'Reports',
+      href: '/fund-model-results/42/reports',
+      state: 'not_actionable',
+      stateLabel: 'Not verified',
+      primaryReason: 'Qualification is verified on the Reports surface',
+    }),
+  ];
+  return { rows, surfaceCount: 5, blockedCount: 2, ...overrides };
+}
+
+function renderRollup(model: ReadinessRollupModel) {
+  const { Wrapper } = createWouterWrapper('/fund-model-results/42');
+  render(<FundReadinessRollup model={model} />, { wrapper: Wrapper });
+  return within(screen.getByTestId('fund-readiness-rollup'));
+}
+
+afterEach(() => cleanup());
+
+describe('FundReadinessRollup', () => {
+  it('renders the outcome-bearing heading and all five surface rows', () => {
+    const rollup = renderRollup(modelFixture());
+
+    expect(
+      rollup.getByRole('heading', { level: 2, name: 'Readiness — what is blocked and where' })
+    ).toBeInTheDocument();
+    for (const key of ['forecast', 'portfolio-actuals', 'reserves', 'scenarios', 'reports']) {
+      expect(rollup.getByTestId(`readiness-row-${key}`)).toBeInTheDocument();
+    }
+  });
+
+  it('renders the neutral blocked-count line above the rows with tabular numerals', () => {
+    const rollup = renderRollup(modelFixture());
+
+    const line = rollup.getByTestId('fund-readiness-rollup-blocked-count');
+    expect(line).toHaveTextContent('2 of 5 surfaces not actionable');
+    expect(line.querySelectorAll('.tabular-nums')).toHaveLength(2);
+    // The line renders ABOVE the table rows.
+    expect(
+      line.compareDocumentPosition(rollup.getByTestId('readiness-row-forecast')) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('omits the blocked-count line when nothing is blocked', () => {
+    const model = modelFixture({
+      rows: modelFixture().rows.map((candidate) => ({
+        ...candidate,
+        state: 'actionable' as const,
+        stateLabel: null,
+      })),
+      blockedCount: 0,
+    });
+    const rollup = renderRollup(model);
+
+    expect(rollup.queryByTestId('fund-readiness-rollup-blocked-count')).not.toBeInTheDocument();
+  });
+
+  it('gives every row a dedicated Decision state column via the shared badge', () => {
+    const rollup = renderRollup(modelFixture());
+
+    expect(rollup.getByRole('columnheader', { name: 'Decision state' })).toBeInTheDocument();
+    // Actionable: full-ink label, no dot.
+    const forecastRow = within(rollup.getByTestId('readiness-row-forecast'));
+    expect(forecastRow.getByText('Actionable')).toBeInTheDocument();
+    expect(forecastRow.queryByTestId('readiness-forecast-dot')).not.toBeInTheDocument();
+    // Domain label + hollow dot for a facts failure; dot is aria-hidden with
+    // the visible text label alongside (DecisionStateBadge integration).
+    const reservesRow = within(rollup.getByTestId('readiness-row-reserves'));
+    expect(reservesRow.getByText('Facts unavailable')).toBeInTheDocument();
+    expect(reservesRow.getByTestId('readiness-reserves-dot')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+    // Indicative: amber dot present.
+    const scenariosRow = within(rollup.getByTestId('readiness-row-scenarios'));
+    expect(scenariosRow.getByTestId('readiness-scenarios-dot')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
+
+  it('shows the primary blocker inline muted with the counts summary beneath', () => {
+    const rollup = renderRollup(modelFixture());
+
+    const reason = rollup.getByTestId('readiness-row-portfolio-actuals-reason');
+    expect(reason).toHaveTextContent('2 companies degraded');
+    expect(reason.className).toContain('text-presson-textMuted');
+    const summary = rollup.getByTestId('readiness-row-portfolio-actuals-blocked-summary');
+    expect(summary).toHaveTextContent('3 drifted, 1 material');
+    expect(summary.className).toContain('tabular-nums');
+  });
+
+  it('keeps full warnings behind a keyboard-parity row disclosure (D-D)', async () => {
+    const user = userEvent.setup();
+    const rollup = renderRollup(modelFixture());
+
+    const disclosure = rollup.getByTestId('readiness-row-scenarios-disclosure');
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+    expect(rollup.queryByTestId('readiness-row-scenarios-details')).not.toBeInTheDocument();
+
+    await user.click(disclosure);
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+    const details = rollup.getByTestId('readiness-row-scenarios-details');
+    expect(within(details).getByText('second warning')).toBeInTheDocument();
+    expect(disclosure).toHaveAttribute('aria-controls', 'readiness-row-scenarios-details');
+
+    // Enter closes, Space reopens (native button parity).
+    disclosure.focus();
+    await user.keyboard('{Enter}');
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+    expect(rollup.queryByTestId('readiness-row-scenarios-details')).not.toBeInTheDocument();
+    await user.keyboard(' ');
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders no disclosure affordance for rows without warnings', () => {
+    const rollup = renderRollup(modelFixture());
+
+    expect(rollup.queryByTestId('readiness-row-forecast-disclosure')).not.toBeInTheDocument();
+  });
+
+  it('renders as-of dates in tabular numerals and an em dash when undisclosed', () => {
+    const rollup = renderRollup(modelFixture());
+
+    const forecastCells = rollup.getByTestId('readiness-row-forecast').querySelectorAll('td');
+    const asOfCell = forecastCells[3];
+    expect(asOfCell?.textContent).toBe('2026-07-01');
+    expect(asOfCell?.className).toContain('tabular-nums');
+    const reportsCells = rollup.getByTestId('readiness-row-reports').querySelectorAll('td');
+    expect(reportsCells[3]?.textContent).toBe('—');
+  });
+
+  it('links each surface with a fund-carrying underlined text link', () => {
+    const rollup = renderRollup(modelFixture());
+
+    expect(rollup.getByTestId('readiness-link-forecast')).toHaveAttribute(
+      'href',
+      '/financial-modeling?fundId=42'
+    );
+    expect(rollup.getByTestId('readiness-link-reserves')).toHaveAttribute(
+      'href',
+      '/fund-model-results/42/moic-analysis'
+    );
+    expect(rollup.getByTestId('readiness-link-reports')).toHaveAttribute(
+      'href',
+      '/fund-model-results/42/reports'
+    );
+    expect(rollup.getByTestId('readiness-link-scenarios').className).toContain('underline');
+  });
+
+  it('renders gated rows disabled with their reason, never dead links (D-C)', () => {
+    const model = modelFixture({
+      rows: modelFixture().rows.map((candidate) =>
+        candidate.key === 'reports'
+          ? {
+              ...candidate,
+              href: null,
+              hrefDisabledReason: 'Select a fund to open this view',
+            }
+          : candidate
+      ),
+    });
+    const rollup = renderRollup(model);
+
+    const disabled = rollup.getByTestId('readiness-link-reports-disabled');
+    expect(disabled).toHaveAttribute('aria-disabled', 'true');
+    expect(disabled).toHaveTextContent('Reports');
+    expect(disabled).toHaveTextContent('(Select a fund to open this view)');
+    expect(rollup.queryByTestId('readiness-link-reports')).not.toBeInTheDocument();
+  });
+
+  it('renders loading rows as skeletons with tabular-nums, motion-gated placeholders', () => {
+    const model = modelFixture({
+      rows: modelFixture().rows.map((candidate) =>
+        candidate.key === 'forecast'
+          ? { ...candidate, loading: true, state: 'not_actionable' as const }
+          : candidate
+      ),
+    });
+    const rollup = renderRollup(model);
+
+    const loadingRow = rollup.getByTestId('readiness-row-forecast');
+    expect(within(loadingRow).queryByText('Actionable')).not.toBeInTheDocument();
+    expect(within(loadingRow).queryByText('Not actionable')).not.toBeInTheDocument();
+    const skeletons = loadingRow.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+    for (const skeleton of skeletons) {
+      expect(skeleton.className).toContain('tabular-nums');
+      expect(skeleton.className).toContain('motion-reduce:animate-none');
+      expect(skeleton).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+});

--- a/tests/unit/pages/fund-model-results/readiness-rollup.test.tsx
+++ b/tests/unit/pages/fund-model-results/readiness-rollup.test.tsx
@@ -17,6 +17,10 @@ import {
   type FundMoicRankingsResponseV2,
 } from '../../../../shared/contracts/fund-moic-v2.contract';
 import { ScenariosSectionSchema } from '../../../../shared/contracts/fund-results-v1.contract';
+import {
+  FundScenarioSetSummaryV1Schema,
+  type FundScenarioSetSummaryV1,
+} from '../../../../shared/contracts/fund-scenario-sets-v1.contract';
 import type { AllocationsResponse } from '../../../../client/src/components/portfolio/tabs/types';
 import {
   deriveReadinessRollup,
@@ -136,14 +140,17 @@ function moicFixture(rankings: ReturnType<typeof moicRanking>[]): FundMoicRankin
 }
 
 function allocationsFixture(
-  drift: Partial<AllocationsResponse['metadata']['actuals_drift_summary']> = {}
+  drift: Partial<AllocationsResponse['metadata']['actuals_drift_summary']> = {},
+  // Fix round F4: the default fixture is POPULATED so the actionable branch
+  // is proven against a non-empty payload; the true-empty state is explicit.
+  companiesCount = 3
 ): AllocationsResponse {
   return {
     companies: [],
     metadata: {
       total_planned_cents: 0,
       total_deployed_cents: 0,
-      companies_count: 0,
+      companies_count: companiesCount,
       last_updated_at: null,
       actuals_drift_summary: {
         facts_status: 'available',
@@ -210,6 +217,39 @@ function scenariosUnavailable(
   return ScenariosSectionSchema.parse({ status: 'unavailable', reason, reasonCode });
 }
 
+let listEntrySequence = 0;
+
+function listEntry(overrides: Partial<FundScenarioSetSummaryV1> = {}): FundScenarioSetSummaryV1 {
+  listEntrySequence += 1;
+  const suffix = String(listEntrySequence).padStart(12, '0');
+  return FundScenarioSetSummaryV1Schema.parse({
+    id: `00000000-0000-4000-a000-${suffix}`,
+    fundId: 42,
+    name: `Listed set ${listEntrySequence}`,
+    description: null,
+    sourceConfigId: 1,
+    sourceConfigVersion: 1,
+    variantCount: 1,
+    archivedAt: null,
+    archivedByUserId: null,
+    archivedByLabel: null,
+    createdByUserId: null,
+    createdByLabel: null,
+    updatedByUserId: null,
+    updatedByLabel: null,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-15T12:00:00.000Z',
+    ...overrides,
+  });
+}
+
+/** List entries matching every calculated set in an available section (F1). */
+function listMatchingSection(section: ScenariosSection): FundScenarioSetSummaryV1[] {
+  return section.status === 'available'
+    ? section.payload.sets.map((set) => listEntry({ id: set.scenarioSetId, name: set.name }))
+    : [];
+}
+
 function data<T>(value: T): ReadinessSourceInput<T> {
   return { kind: 'data', data: value };
 }
@@ -221,12 +261,14 @@ function errorInput(message: string | null): ReadinessSourceInput<never> {
 }
 
 function baseInputs(overrides: Partial<ReadinessRollupInputs> = {}): ReadinessRollupInputs {
+  const section = scenariosAvailable([scenarioSet('CURRENT')]);
   return {
     fundId: '42',
     forecast: data(dualForecastFixture()),
     portfolioActuals: data(allocationsFixture()),
     reserves: data(moicFixture([moicRanking(1, 'actionable')])),
-    scenarios: data(scenariosAvailable([scenarioSet('CURRENT')])),
+    scenarios: data(section),
+    scenarioSetList: data(listMatchingSection(section)),
     ...overrides,
   };
 }
@@ -347,7 +389,7 @@ describe('forecast row', () => {
     expect(row.asOfDate).toBe('2026-07-01');
   });
 
-  it('fails closed to Facts unavailable when the facts fetch failed (null blocks)', () => {
+  it('fails closed to Facts unavailable when the facts fetch failed (both blocks null)', () => {
     const inputs = baseInputs({
       forecast: data(
         dualForecastFixture({
@@ -363,6 +405,28 @@ describe('forecast row', () => {
     expect(row.stateLabel).toBe('Facts unavailable');
     expect(row.primaryReason).toBe('actuals facts fetch failed');
     expect(row.details).toEqual(['actuals facts fetch failed', 'second warning']);
+  });
+
+  it('fails closed when ONLY actualsFacts is null (isolated block)', () => {
+    const inputs = baseInputs({
+      forecast: data(dualForecastFixture({ actualsFacts: null })),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('Company facts could not be resolved for this forecast');
+  });
+
+  it('fails closed when ONLY navAnchoring is null (isolated block)', () => {
+    const inputs = baseInputs({
+      forecast: data(dualForecastFixture({ navAnchoring: null })),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('Company facts could not be resolved for this forecast');
   });
 
   it('reads failed company facts as not actionable ahead of any softer signal', () => {
@@ -403,7 +467,22 @@ describe('forecast row', () => {
     expect(row.details).toEqual(['projection warning', 'engine failed']);
   });
 
-  it('pins the empty facts universe as indicative (untrusted, AMENDMENT 8)', () => {
+  it('keeps details unchanged when the projection fallback discloses no reason', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          currentProjection: { status: 'fallback_default', fallbackReason: null },
+          warnings: ['projection warning'],
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.details).toEqual(['projection warning']);
+  });
+
+  it('fails the empty facts universe closed (all-zero pinned UNAVAILABLE, AMENDMENT 8; F3)', () => {
     const inputs = baseInputs({
       forecast: data(
         dualForecastFixture({
@@ -417,8 +496,26 @@ describe('forecast row', () => {
     });
     const row = rowByKey(inputs, 'forecast');
 
-    expect(row.state).toBe('indicative');
+    expect(row.state).toBe('not_actionable');
     expect(row.primaryReason).toBe('No company facts disclosed');
+  });
+
+  it('fails closed when NO company is live even without failures (F3 ladder)', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          navAnchoring: {
+            blendedNav: '100.00',
+            countsByTrustState: { LIVE: 0, PARTIAL: 2, UNAVAILABLE: 1, FAILED: 0 },
+            companies: [],
+          },
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('3 of 3 companies below live facts');
   });
 
   it('reads partial or unavailable company facts as indicative with the count', () => {
@@ -507,6 +604,27 @@ describe('portfolio actuals row', () => {
     expect(row.state).toBe('actionable');
     expect(row.blockedSummary).toBe('2 drifted');
   });
+
+  it('renders the D-C empty state when zero companies are disclosed (F4)', () => {
+    const inputs = baseInputs({
+      portfolioActuals: data(allocationsFixture({}, 0)),
+    });
+    const row = rowByKey(inputs, 'portfolio-actuals');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('No portfolio actuals disclosed');
+  });
+
+  it('keeps a facts failure ahead of the empty state (fail-closed precedence)', () => {
+    const inputs = baseInputs({
+      portfolioActuals: data(allocationsFixture({ facts_status: 'failed' }, 0)),
+    });
+    const row = rowByKey(inputs, 'portfolio-actuals');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('Company facts failed to resolve for allocations');
+  });
 });
 
 // ── Reserves ──
@@ -574,19 +692,81 @@ describe('reserves row', () => {
 // ── Scenarios ──
 
 describe('scenarios row', () => {
-  it('is actionable when every set is CURRENT, as-of the max calculatedAt date', () => {
+  it('is actionable ONLY when list and results agree: all active sets calculated + CURRENT', () => {
+    const section = scenariosAvailable([
+      scenarioSet('CURRENT', '2026-06-10T00:00:00.000Z'),
+      scenarioSet('CURRENT', '2026-06-20T00:00:00.000Z'),
+    ]);
     const inputs = baseInputs({
-      scenarios: data(
-        scenariosAvailable([
-          scenarioSet('CURRENT', '2026-06-10T00:00:00.000Z'),
-          scenarioSet('CURRENT', '2026-06-20T00:00:00.000Z'),
-        ])
-      ),
+      scenarios: data(section),
+      scenarioSetList: data(listMatchingSection(section)),
     });
     const row = rowByKey(inputs, 'scenarios');
 
     expect(row.state).toBe('actionable');
     expect(row.asOfDate).toBe('2026-06-20');
+  });
+
+  it('degrades all-CURRENT results when active listed sets have no calculated results (F1)', () => {
+    const section = scenariosAvailable([scenarioSet('CURRENT')]);
+    const inputs = baseInputs({
+      scenarios: data(section),
+      scenarioSetList: data([...listMatchingSection(section), listEntry(), listEntry()]),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('2 of 3 sets have no calculated results');
+  });
+
+  it('ignores ARCHIVED listed sets in the completeness join (F1)', () => {
+    const section = scenariosAvailable([scenarioSet('CURRENT')]);
+    const inputs = baseInputs({
+      scenarios: data(section),
+      scenarioSetList: data([
+        ...listMatchingSection(section),
+        listEntry({ archivedAt: '2026-06-01T00:00:00.000Z' }),
+      ]),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('actionable');
+  });
+
+  it('caps at indicative when the set inventory fetch fails (completeness unprovable, F1)', () => {
+    const section = scenariosAvailable([scenarioSet('CURRENT')]);
+    const inputs = baseInputs({
+      scenarios: data(section),
+      scenarioSetList: errorInput('list boom'),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('Scenario set inventory unavailable');
+  });
+
+  it('stays a loading row while the set inventory is still resolving (F1)', () => {
+    const section = scenariosAvailable([scenarioSet('CURRENT')]);
+    const inputs = baseInputs({
+      scenarios: data(section),
+      scenarioSetList: LOADING,
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.loading).toBe(true);
+    expect(row.state).toBe('not_actionable');
+  });
+
+  it('does not consult the inventory for degraded results (failed beats the join)', () => {
+    const section = scenariosAvailable([scenarioSet('FAILED'), scenarioSet('CURRENT')]);
+    const inputs = baseInputs({
+      scenarios: data(section),
+      scenarioSetList: errorInput('list boom'),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('1 of 2 scenario sets failed');
   });
 
   it('renders the D-C empty copy when no scenario sets exist', () => {

--- a/tests/unit/pages/fund-model-results/readiness-rollup.test.tsx
+++ b/tests/unit/pages/fund-model-results/readiness-rollup.test.tsx
@@ -1,0 +1,674 @@
+/**
+ * Pure derivation tests for the Summary cross-surface readiness rollup
+ * (Plan 9 Wave 9B2, D-H). Pins every state mapping including error / empty /
+ * loading, deterministic reason ordering, fail-closed precedence, and the
+ * pre-decided static Reports row. Fixtures parse with the real Zod contracts
+ * where they exist (dual forecast, MOIC rankings v2, scenarios section);
+ * AllocationsResponse has no Zod contract (client TS interface only).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DualForecastResponseSchema,
+  type DualForecastResponse,
+} from '../../../../shared/contracts/dual-forecast/dual-forecast-response.contract';
+import {
+  FundMoicRankingsResponseV2Schema,
+  type FundMoicRankingsResponseV2,
+} from '../../../../shared/contracts/fund-moic-v2.contract';
+import { ScenariosSectionSchema } from '../../../../shared/contracts/fund-results-v1.contract';
+import type { AllocationsResponse } from '../../../../client/src/components/portfolio/tabs/types';
+import {
+  deriveReadinessRollup,
+  type ReadinessRollupInputs,
+  type ReadinessRollupRow,
+  type ReadinessSourceInput,
+  type ScenariosSection,
+} from '../../../../client/src/pages/fund-model-results/readiness-rollup';
+
+// ── Fixtures (contract-parsed where a contract exists) ──
+
+function dualForecastFixture(overrides: Partial<DualForecastResponse> = {}): DualForecastResponse {
+  return DualForecastResponseSchema.parse({
+    fundId: 42,
+    fundName: 'Fund 42',
+    asOfDate: '2026-07-01',
+    series: [],
+    sources: {
+      construction: 'construction_forecast_jcurve',
+      current: 'projected_metrics_calculator',
+      actual: 'actual_metrics_calculator',
+    },
+    config: {
+      source: 'published',
+      version: 3,
+      publishedAt: '2026-06-01T00:00:00.000Z',
+      fallbackReason: null,
+    },
+    actualsFacts: {
+      asOfDate: '2026-07-01',
+      generatedAt: '2026-07-01T00:00:00.000Z',
+      inputHash: 'a'.repeat(64),
+      companies: [],
+      warnings: [],
+    },
+    navAnchoring: {
+      blendedNav: '100.00',
+      countsByTrustState: { LIVE: 2, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 },
+      companies: [],
+    },
+    currentProjection: { status: 'projected', fallbackReason: null },
+    warnings: [],
+    ...overrides,
+  });
+}
+
+function moicRanking(
+  rank: number,
+  rankability: 'actionable' | 'indicative' | 'not_actionable' | null,
+  anchorAsOfDate: string | null = '2026-06-30'
+) {
+  return {
+    rank,
+    investmentId: `inv-${rank}`,
+    investmentName: `Company ${rank}`,
+    reservesMoic: { value: 1.5, description: 'Reserves MOIC', formula: 'proceeds / reserves' },
+    factsBasis:
+      rankability === null
+        ? null
+        : {
+            rankability,
+            reasons: [],
+            observedInitialInvestment: '100',
+            observedFollowOnInvestment: '0',
+            observedTotalInvestment: '100',
+            valuationAnchor: { kind: 'planning_fmv', value: '200', asOfDate: anchorAsOfDate },
+            planningFmvStatus: 'active',
+            currencyStatus: 'base_currency',
+            factsInputHash: 'b'.repeat(64),
+            warnings: [],
+          },
+  };
+}
+
+function moicFixture(rankings: ReturnType<typeof moicRanking>[]): FundMoicRankingsResponseV2 {
+  return FundMoicRankingsResponseV2Schema.parse({
+    contractVersion: '2.1.0',
+    fundId: 42,
+    rankings,
+    provenance: { mode: 'legacy', warnings: [] },
+    latestReconciliation: null,
+    materiality: { status: 'not_run', candidateMaterial: false, epsilon: 1e-8 },
+    modePreview: {
+      calculationKey: 'fund_moic_rankings_exit_probability',
+      configuredMode: 'off',
+      effectiveMode: 'off',
+      killSwitchActive: false,
+      shadowStartedAt: null,
+      eligibleAt: null,
+      residencyDaysRequired: 7,
+      residencyStatus: 'not_applicable',
+      currentSourceMatchesAccepted: true,
+      unreconciledEditsPresent: false,
+      blockers: [],
+      version: 0,
+    },
+    moicInputSummary: {
+      sourceVersion: 'moic-round-fmv-facts-v2',
+      explicitExitProbabilityCount: 0,
+      defaultedExitProbabilityCount: 0,
+      activationBlockingDefaultedExitProbabilityCount: 0,
+      explicitReserveExitMultipleCount: 0,
+      defaultedReserveExitMultipleCount: 0,
+      activationBlockingDefaultedReserveExitMultipleCount: 0,
+    },
+    actualsProvenanceSummary: {
+      factsStatus: 'available',
+      factsInputHash: null,
+      companyCount: 0,
+      trustStateCounts: { LIVE: 0, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 },
+      defaultedEconomicInputCount: 0,
+      warnings: [],
+    },
+    roundEvidenceSummary: { activeRoundCount: 0, activeOverrideCount: 0, warningCodes: [] },
+    generatedAt: '2026-07-01T00:00:00.000Z',
+  });
+}
+
+function allocationsFixture(
+  drift: Partial<AllocationsResponse['metadata']['actuals_drift_summary']> = {}
+): AllocationsResponse {
+  return {
+    companies: [],
+    metadata: {
+      total_planned_cents: 0,
+      total_deployed_cents: 0,
+      companies_count: 0,
+      last_updated_at: null,
+      actuals_drift_summary: {
+        facts_status: 'available',
+        drifted_company_count: 0,
+        material_company_count: 0,
+        degraded_company_count: 0,
+        facts_input_hash: null,
+        as_of_date: '2026-07-02',
+        ...drift,
+      },
+    },
+  };
+}
+
+let scenarioSetSequence = 0;
+
+function scenarioSet(
+  staleness:
+    'CURRENT' | 'STALE_PUBLISH' | 'STALE_CONFIG' | 'CALCULATING' | 'FAILED' | 'UNAVAILABLE',
+  calculatedAt = '2026-06-15T12:00:00.000Z'
+) {
+  scenarioSetSequence += 1;
+  const suffix = String(scenarioSetSequence).padStart(12, '0');
+  return {
+    scenarioSetId: `00000000-0000-4000-8000-${suffix}`,
+    name: `Set ${scenarioSetSequence}`,
+    calculationMode: 'async_reserve_allocation',
+    sourceConfigId: 1,
+    sourceConfigVersion: 1,
+    currentPublishedConfigVersion: 1,
+    calculatedAt,
+    staleness,
+    variantCount: 1,
+    variants: [
+      {
+        variantId: `00000000-0000-4000-9000-${suffix}`,
+        name: 'Variant',
+        overrideType: 'reserve_allocation',
+        reserveSummary: {
+          totalScenarioAllocationCents: 0,
+          totalAllocationDeltaCents: 0,
+          avgConfidence: 0.5,
+          highConfidenceCount: 0,
+          warningCount: 0,
+        },
+      },
+    ],
+  };
+}
+
+function scenariosAvailable(sets: ReturnType<typeof scenarioSet>[]): ScenariosSection {
+  return ScenariosSectionSchema.parse({
+    status: 'available',
+    source: 'fund_snapshots',
+    calculatedAt: null,
+    payload: { version: 'fund-scenarios-v1', aggregateStaleness: 'CURRENT', sets },
+  });
+}
+
+function scenariosUnavailable(
+  reasonCode: 'SCENARIOS_NONE_EXIST' | 'SCENARIOS_NONE_CALCULATED' | 'SCENARIOS_LOAD_FAILED',
+  reason = 'No scenario data'
+): ScenariosSection {
+  return ScenariosSectionSchema.parse({ status: 'unavailable', reason, reasonCode });
+}
+
+function data<T>(value: T): ReadinessSourceInput<T> {
+  return { kind: 'data', data: value };
+}
+
+const LOADING: ReadinessSourceInput<never> = { kind: 'loading' };
+
+function errorInput(message: string | null): ReadinessSourceInput<never> {
+  return { kind: 'error', message };
+}
+
+function baseInputs(overrides: Partial<ReadinessRollupInputs> = {}): ReadinessRollupInputs {
+  return {
+    fundId: '42',
+    forecast: data(dualForecastFixture()),
+    portfolioActuals: data(allocationsFixture()),
+    reserves: data(moicFixture([moicRanking(1, 'actionable')])),
+    scenarios: data(scenariosAvailable([scenarioSet('CURRENT')])),
+    ...overrides,
+  };
+}
+
+function rowByKey(inputs: ReadinessRollupInputs, key: ReadinessRollupRow['key']) {
+  const row = deriveReadinessRollup(inputs).rows.find((candidate) => candidate.key === key);
+  if (row === undefined) throw new Error(`missing row ${key}`);
+  return row;
+}
+
+// ── Shape / links ──
+
+describe('deriveReadinessRollup shape', () => {
+  it('always yields the five surface rows in workspace order with fund-carrying hrefs', () => {
+    const model = deriveReadinessRollup(baseInputs());
+
+    expect(model.surfaceCount).toBe(5);
+    expect(model.rows.map((row) => [row.key, row.label, row.href])).toEqual([
+      ['forecast', 'Forecast', '/financial-modeling?fundId=42'],
+      ['portfolio-actuals', 'Portfolio Actuals', '/portfolio?tab=reserve-planning&fundId=42'],
+      ['reserves', 'Reserves', '/fund-model-results/42/moic-analysis'],
+      ['scenarios', 'Scenarios', '/fund-model-results/42/scenarios'],
+      ['reports', 'Reports', '/fund-model-results/42/reports'],
+    ]);
+  });
+
+  it('gates fund-scoped links with the workspace reason when no fund resolves', () => {
+    const model = deriveReadinessRollup(
+      baseInputs({
+        fundId: null,
+        forecast: errorInput('No fund is resolved on this route'),
+        portfolioActuals: errorInput('No fund is resolved on this route'),
+        reserves: errorInput('No fund is resolved on this route'),
+        scenarios: errorInput('No fund is resolved on this route'),
+      })
+    );
+
+    const byKey = new Map(model.rows.map((row) => [row.key, row]));
+    for (const key of ['reserves', 'scenarios', 'reports'] as const) {
+      expect(byKey.get(key)?.href).toBeNull();
+      expect(byKey.get(key)?.hrefDisabledReason).toBe('Select a fund to open this view');
+    }
+    // Non-fund-scoped destinations stay live links (D-C: never dead links).
+    expect(byKey.get('forecast')?.href).toBe('/financial-modeling');
+    expect(byKey.get('portfolio-actuals')?.href).toBe('/portfolio?tab=reserve-planning');
+    // Every data row fails closed.
+    expect(model.rows.every((row) => row.state === 'not_actionable')).toBe(true);
+    expect(model.blockedCount).toBe(5);
+  });
+
+  it('counts only non-loading not_actionable rows as blocked', () => {
+    const model = deriveReadinessRollup(
+      baseInputs({
+        forecast: LOADING,
+        portfolioActuals: LOADING,
+        reserves: LOADING,
+        scenarios: LOADING,
+      })
+    );
+
+    const loadingRows = model.rows.filter((row) => row.loading);
+    expect(loadingRows.map((row) => row.key)).toEqual([
+      'forecast',
+      'portfolio-actuals',
+      'reserves',
+      'scenarios',
+    ]);
+    // Loading rows still read not_actionable (fail-closed) but never count.
+    expect(loadingRows.every((row) => row.state === 'not_actionable')).toBe(true);
+    expect(model.blockedCount).toBe(1); // the static Reports row only
+  });
+
+  it('marks every errored row Facts unavailable with the short cause', () => {
+    const model = deriveReadinessRollup(
+      baseInputs({
+        forecast: errorInput('HTTP 500'),
+        portfolioActuals: errorInput(null),
+        reserves: errorInput('rankings boom'),
+        scenarios: errorInput('Fund not found'),
+      })
+    );
+
+    for (const row of model.rows.filter((candidate) => candidate.key !== 'reports')) {
+      expect(row.state).toBe('not_actionable');
+      expect(row.stateLabel).toBe('Facts unavailable');
+    }
+    expect(model.rows.find((row) => row.key === 'forecast')?.primaryReason).toBe('HTTP 500');
+    expect(model.rows.find((row) => row.key === 'portfolio-actuals')?.primaryReason).toBe(
+      'The allocations read failed'
+    );
+    expect(model.blockedCount).toBe(5);
+  });
+});
+
+// ── Reports (static pre-decision) ──
+
+describe('reports row', () => {
+  it('is the honest static not-verified state and never claims export readiness', () => {
+    const row = rowByKey(baseInputs(), 'reports');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Not verified');
+    expect(row.primaryReason).toBe('Qualification is verified on the Reports surface');
+    expect(row.asOfDate).toBeNull();
+    expect(row.href).toBe('/fund-model-results/42/reports');
+    expect(row.loading).toBe(false);
+  });
+});
+
+// ── Forecast ──
+
+describe('forecast row', () => {
+  it('is actionable with the as-of date when facts are live and the projection is real', () => {
+    const row = rowByKey(baseInputs(), 'forecast');
+
+    expect(row.state).toBe('actionable');
+    expect(row.primaryReason).toBeNull();
+    expect(row.asOfDate).toBe('2026-07-01');
+  });
+
+  it('fails closed to Facts unavailable when the facts fetch failed (null blocks)', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          actualsFacts: null,
+          navAnchoring: null,
+          warnings: ['actuals facts fetch failed', 'second warning'],
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('actuals facts fetch failed');
+    expect(row.details).toEqual(['actuals facts fetch failed', 'second warning']);
+  });
+
+  it('reads failed company facts as not actionable ahead of any softer signal', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          navAnchoring: {
+            blendedNav: '100.00',
+            countsByTrustState: { LIVE: 1, PARTIAL: 1, UNAVAILABLE: 0, FAILED: 2 },
+            companies: [],
+          },
+          currentProjection: { status: 'fallback_default', fallbackReason: 'engine failed' },
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('2 of 4 companies have failed facts');
+  });
+
+  it('treats a defaulted Current projection as not actionable (never decision-grade)', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          currentProjection: { status: 'fallback_default', fallbackReason: 'engine failed' },
+          warnings: ['projection warning'],
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe(
+      'Current projection unavailable — a default projection is substituted'
+    );
+    expect(row.details).toEqual(['projection warning', 'engine failed']);
+  });
+
+  it('pins the empty facts universe as indicative (untrusted, AMENDMENT 8)', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          navAnchoring: {
+            blendedNav: '0',
+            countsByTrustState: { LIVE: 0, PARTIAL: 0, UNAVAILABLE: 0, FAILED: 0 },
+            companies: [],
+          },
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('No company facts disclosed');
+  });
+
+  it('reads partial or unavailable company facts as indicative with the count', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          navAnchoring: {
+            blendedNav: '100.00',
+            countsByTrustState: { LIVE: 2, PARTIAL: 1, UNAVAILABLE: 1, FAILED: 0 },
+            companies: [],
+          },
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('2 of 4 companies below live facts');
+  });
+
+  it('surfaces the FIRST warning as the primary blocker on live facts (deterministic order)', () => {
+    const inputs = baseInputs({
+      forecast: data(dualForecastFixture({ warnings: ['first warning', 'second warning'] })),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('first warning');
+    expect(row.details).toEqual(['first warning', 'second warning']);
+  });
+});
+
+// ── Portfolio Actuals ──
+
+describe('portfolio actuals row', () => {
+  it('is actionable with the drift as-of date when facts are clean', () => {
+    const row = rowByKey(baseInputs(), 'portfolio-actuals');
+
+    expect(row.state).toBe('actionable');
+    expect(row.asOfDate).toBe('2026-07-02');
+    expect(row.blockedSummary).toBeNull();
+  });
+
+  it('fails closed when the facts status is failed, even with zero counts', () => {
+    const inputs = baseInputs({
+      portfolioActuals: data(allocationsFixture({ facts_status: 'failed' })),
+    });
+    const row = rowByKey(inputs, 'portfolio-actuals');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('Company facts failed to resolve for allocations');
+  });
+
+  it('reads degraded companies as indicative and keeps drift counts as the summary', () => {
+    const inputs = baseInputs({
+      portfolioActuals: data(
+        allocationsFixture({
+          degraded_company_count: 2,
+          drifted_company_count: 3,
+          material_company_count: 1,
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'portfolio-actuals');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('2 companies degraded');
+    expect(row.blockedSummary).toBe('3 drifted, 1 material');
+  });
+
+  it('uses the singular noun for one degraded company', () => {
+    const inputs = baseInputs({
+      portfolioActuals: data(allocationsFixture({ degraded_company_count: 1 })),
+    });
+
+    expect(rowByKey(inputs, 'portfolio-actuals').primaryReason).toBe('1 company degraded');
+  });
+
+  it('shows nonzero drift counts even when the row stays actionable', () => {
+    const inputs = baseInputs({
+      portfolioActuals: data(allocationsFixture({ drifted_company_count: 2 })),
+    });
+    const row = rowByKey(inputs, 'portfolio-actuals');
+
+    expect(row.state).toBe('actionable');
+    expect(row.blockedSummary).toBe('2 drifted');
+  });
+});
+
+// ── Reserves ──
+
+describe('reserves row', () => {
+  it('is actionable when every ranking is actionable, as-of the max anchor date', () => {
+    const inputs = baseInputs({
+      reserves: data(
+        moicFixture([
+          moicRanking(1, 'actionable', '2026-06-01'),
+          moicRanking(2, 'actionable', '2026-06-30'),
+        ])
+      ),
+    });
+    const row = rowByKey(inputs, 'reserves');
+
+    expect(row.state).toBe('actionable');
+    expect(row.asOfDate).toBe('2026-06-30');
+  });
+
+  it('renders the D-C empty state when no rankings are disclosed', () => {
+    const row = rowByKey(baseInputs({ reserves: data(moicFixture([])) }), 'reserves');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('No reserve rankings disclosed');
+  });
+
+  it('fails closed when all rankings (including null facts bases) are not actionable', () => {
+    const inputs = baseInputs({
+      reserves: data(moicFixture([moicRanking(1, 'not_actionable'), moicRanking(2, null)])),
+    });
+    const row = rowByKey(inputs, 'reserves');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('All 2 rankings are not actionable');
+  });
+
+  it('reads a mixed set as indicative with the not-actionable count', () => {
+    const inputs = baseInputs({
+      reserves: data(
+        moicFixture([
+          moicRanking(1, 'actionable'),
+          moicRanking(2, null),
+          moicRanking(3, 'not_actionable'),
+        ])
+      ),
+    });
+    const row = rowByKey(inputs, 'reserves');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('2 of 3 rankings not actionable');
+  });
+
+  it('reads indicative-only degradation as indicative with its own count', () => {
+    const inputs = baseInputs({
+      reserves: data(moicFixture([moicRanking(1, 'actionable'), moicRanking(2, 'indicative')])),
+    });
+    const row = rowByKey(inputs, 'reserves');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('1 of 2 rankings indicative');
+  });
+});
+
+// ── Scenarios ──
+
+describe('scenarios row', () => {
+  it('is actionable when every set is CURRENT, as-of the max calculatedAt date', () => {
+    const inputs = baseInputs({
+      scenarios: data(
+        scenariosAvailable([
+          scenarioSet('CURRENT', '2026-06-10T00:00:00.000Z'),
+          scenarioSet('CURRENT', '2026-06-20T00:00:00.000Z'),
+        ])
+      ),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('actionable');
+    expect(row.asOfDate).toBe('2026-06-20');
+  });
+
+  it('renders the D-C empty copy when no scenario sets exist', () => {
+    const inputs = baseInputs({
+      scenarios: data(scenariosUnavailable('SCENARIOS_NONE_EXIST', 'none exist')),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('No scenario sets disclosed');
+  });
+
+  it('fails closed when sets exist but none are calculated (in-progress unprovable)', () => {
+    const inputs = baseInputs({
+      scenarios: data(scenariosUnavailable('SCENARIOS_NONE_CALCULATED', 'none calculated')),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('Scenario sets exist but none have calculated results');
+  });
+
+  it('reads a scenarios load failure as Facts unavailable with the section reason', () => {
+    const inputs = baseInputs({
+      scenarios: data(scenariosUnavailable('SCENARIOS_LOAD_FAILED', 'snapshot read failed')),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('snapshot read failed');
+  });
+
+  it('fails closed when every set failed', () => {
+    const inputs = baseInputs({
+      scenarios: data(scenariosAvailable([scenarioSet('FAILED'), scenarioSet('UNAVAILABLE')])),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('All 2 scenario sets failed');
+  });
+
+  it('reads partial failures as indicative with the count (failed beats calculating)', () => {
+    const inputs = baseInputs({
+      scenarios: data(
+        scenariosAvailable([
+          scenarioSet('FAILED'),
+          scenarioSet('CALCULATING'),
+          scenarioSet('CURRENT'),
+        ])
+      ),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('1 of 3 scenario sets failed');
+  });
+
+  it('reads in-flight calculation as indicative', () => {
+    const inputs = baseInputs({
+      scenarios: data(scenariosAvailable([scenarioSet('CALCULATING'), scenarioSet('CURRENT')])),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('Scenario calculation in progress');
+  });
+
+  it('reads stale sets as indicative with the stale count', () => {
+    const inputs = baseInputs({
+      scenarios: data(
+        scenariosAvailable([
+          scenarioSet('STALE_PUBLISH'),
+          scenarioSet('STALE_CONFIG'),
+          scenarioSet('CURRENT'),
+        ])
+      ),
+    });
+    const row = rowByKey(inputs, 'scenarios');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('2 of 3 scenario sets stale against the published config');
+  });
+});

--- a/tests/unit/pages/fund-model-results/use-readiness-rollup.test.tsx
+++ b/tests/unit/pages/fund-model-results/use-readiness-rollup.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Container-hook tests for useReadinessRollup (Plan 9 Wave 9B2 fix round F8).
+ *
+ * Pins the fail-closed fund-scope guard around the FundContext-sourced
+ * allocations hook (match / mismatch / unresolved-loading / unresolved-settled),
+ * the invalid-route-fund fallback, and the query-state -> input mapping. All
+ * data-source modules are mocked at the module boundary; the derivation runs
+ * for real.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { AllocationsResponse } from '../../../../client/src/components/portfolio/tabs/types';
+
+interface QueryLikeMock {
+  isSuccess: boolean;
+  isError: boolean;
+  data: unknown;
+  error: unknown;
+}
+
+const mocks = vi.hoisted(() => {
+  const errorQuery = (message: string) => ({
+    isSuccess: false,
+    isError: true,
+    data: undefined,
+    error: new Error(message),
+  });
+  return {
+    errorQuery,
+    forecast: errorQuery('dual forecast unavailable') as QueryLikeMock,
+    reserves: errorQuery('rankings unavailable') as QueryLikeMock,
+    allocations: errorQuery('allocations unavailable') as QueryLikeMock,
+    scenarioSetList: errorQuery('scenario set list unavailable') as QueryLikeMock,
+    fundContext: { fundId: 42 as number | null, isLoading: false },
+  };
+});
+
+vi.mock('@/hooks/useDualForecast', () => ({ useDualForecast: () => mocks.forecast }));
+vi.mock('@/hooks/use-moic', () => ({ useFundMoicRankingsV2: () => mocks.reserves }));
+vi.mock('@/hooks/use-scenario-set-list', () => ({
+  useScenarioSetList: () => mocks.scenarioSetList,
+}));
+vi.mock('@/components/portfolio/tabs/hooks/useLatestAllocations', () => ({
+  useLatestAllocations: () => mocks.allocations,
+}));
+vi.mock('@/contexts/FundContext', () => ({ useFundContext: () => mocks.fundContext }));
+
+import { useReadinessRollup } from '../../../../client/src/pages/fund-model-results/use-readiness-rollup';
+import type {
+  ReadinessSourceInput,
+  ScenariosSection,
+} from '../../../../client/src/pages/fund-model-results/readiness-rollup';
+
+const SCENARIOS_LOADING: ReadinessSourceInput<ScenariosSection> = { kind: 'loading' };
+
+function allocationsData(): AllocationsResponse {
+  return {
+    companies: [],
+    metadata: {
+      total_planned_cents: 0,
+      total_deployed_cents: 0,
+      companies_count: 2,
+      last_updated_at: null,
+      actuals_drift_summary: {
+        facts_status: 'available',
+        drifted_company_count: 0,
+        material_company_count: 0,
+        degraded_company_count: 0,
+        facts_input_hash: null,
+        as_of_date: '2026-07-02',
+      },
+    },
+  };
+}
+
+function successQuery(data: unknown): QueryLikeMock {
+  return { isSuccess: true, isError: false, data, error: null };
+}
+
+function renderRollup(routeFundId: string | null) {
+  return renderHook(() => useReadinessRollup(routeFundId, SCENARIOS_LOADING)).result.current;
+}
+
+function portfolioRow(routeFundId: string | null) {
+  const row = renderRollup(routeFundId).rows.find(
+    (candidate) => candidate.key === 'portfolio-actuals'
+  );
+  if (row === undefined) throw new Error('missing portfolio-actuals row');
+  return row;
+}
+
+beforeEach(() => {
+  mocks.forecast = mocks.errorQuery('dual forecast unavailable');
+  mocks.reserves = mocks.errorQuery('rankings unavailable');
+  mocks.allocations = mocks.errorQuery('allocations unavailable');
+  mocks.scenarioSetList = mocks.errorQuery('scenario set list unavailable');
+  mocks.fundContext = { fundId: 42, isLoading: false };
+});
+
+describe('useReadinessRollup fund-scope guard (allocations)', () => {
+  it('renders allocations data when the context fund IS the route fund', () => {
+    mocks.allocations = successQuery(allocationsData());
+
+    const row = portfolioRow('42');
+    expect(row.state).toBe('actionable');
+    expect(row.asOfDate).toBe('2026-07-02');
+  });
+
+  it('never renders a mismatched context fund, even with successful data', () => {
+    mocks.fundContext = { fundId: 7, isLoading: false };
+    mocks.allocations = successQuery(allocationsData());
+
+    const row = portfolioRow('42');
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Facts unavailable');
+    expect(row.primaryReason).toBe('Allocation facts are not resolved for this fund');
+    // No foreign-fund fact leaks through any field.
+    expect(row.asOfDate).toBeNull();
+    expect(row.blockedSummary).toBeNull();
+  });
+
+  it('reads a still-initializing fund context as a loading row', () => {
+    mocks.fundContext = { fundId: null, isLoading: true };
+    mocks.allocations = successQuery(allocationsData());
+
+    const row = portfolioRow('42');
+    expect(row.loading).toBe(true);
+    expect(row.state).toBe('not_actionable');
+  });
+
+  it('fails closed once the fund context settles without resolving the fund', () => {
+    mocks.fundContext = { fundId: null, isLoading: false };
+    mocks.allocations = successQuery(allocationsData());
+
+    const row = portfolioRow('42');
+    expect(row.loading).toBe(false);
+    expect(row.state).toBe('not_actionable');
+    expect(row.primaryReason).toBe('Allocation facts are not resolved for this fund');
+  });
+});
+
+describe('useReadinessRollup route-fund fallback and query mapping', () => {
+  it('fails every data row closed on an invalid route fund', () => {
+    for (const routeFundId of [null, 'latest', '0', '007']) {
+      const model = renderRollup(routeFundId);
+      for (const row of model.rows) {
+        expect(row.state).toBe('not_actionable');
+        expect(row.loading).toBe(false);
+      }
+      const forecast = model.rows.find((row) => row.key === 'forecast');
+      expect(forecast?.primaryReason).toBe('No fund is resolved on this route');
+      // Fund-scoped links gate with the workspace reason (D-C).
+      const reserves = model.rows.find((row) => row.key === 'reserves');
+      expect(reserves?.href).toBeNull();
+      expect(reserves?.hrefDisabledReason).toBe('Select a fund to open this view');
+    }
+  });
+
+  it('maps errored queries to Facts unavailable rows with the short cause', () => {
+    const model = renderRollup('42');
+    const forecast = model.rows.find((row) => row.key === 'forecast');
+    expect(forecast?.state).toBe('not_actionable');
+    expect(forecast?.stateLabel).toBe('Facts unavailable');
+    expect(forecast?.primaryReason).toBe('dual forecast unavailable');
+  });
+
+  it('maps pending queries to loading rows', () => {
+    mocks.forecast = { isSuccess: false, isError: false, data: undefined, error: null };
+
+    const model = renderRollup('42');
+    const forecast = model.rows.find((row) => row.key === 'forecast');
+    expect(forecast?.loading).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Plan 9 wave 9B2 (master plan D-H, ratified): the fund summary's dominant object is now a cross-surface readiness rollup — five rows (Forecast, Portfolio Actuals, Reserves, Scenarios, Reports), each row = surface link + DecisionStateBadge + primary blocker + as-of + link, derived from EXISTING endpoints only (dual-forecast, allocations/latest, moic rankings v2, scenario-set list + results section). The Reports row is an honest static not-actionable state per the recorded 9B1 endpoint gap (no unfiltered latest-metric-run read exists); an unqualified surface is never presented healthier than its data proves.

- Pure derivation module + presentational dense table + thin container hook; rollup mounts through all page states (loading/error/invalid), page never blank.
- Fail-closed grammar throughout: error beats empty beats partial; loading rows claim nothing; fund-scope guard never renders another fund's facts; scenarios completeness joins the set list against calculated results (actionable only on agreement).
- A11y: th scope=row, per-surface disclosure labels, aria-expanded keyboard parity, tabular-nums incl. skeletons, motion-reduce gating.

## Review + verification
- Adversarial codex review: 5 required findings (2 P1) all fixed in `bf213422` and independently re-verified (SHIP verdict).
- Full client project: 187 files / 1493 tests, 0 failures. Wizard integration flow 1/1. Skip-DB release:check 10/10. Lint/check clean. Design-compliance greps over added lines: zero new matches.
- Release-owned test edits inventoried in-wave (semantic re-scoping only, no assertion weakening).

Full evidence: wave artifacts `wave9b2-summary.md` (12 numbered deviations + fix-round dispositions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U63wU7NuJmCv4PdJQWA91h