### PR TITLE
test(e2e): GP decision spine characterization + release-check registration (Plan 9 wave 9C)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,6 +57,11 @@ export default defineConfig({
       testMatch: '**/cookie-session-csrf.spec.ts',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'gp-spine',
+      testMatch: '**/gp-decision-spine.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
 
     // Smoke tests - fastest, run first
     {

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -51,12 +51,14 @@ const releaseOwnedPaths = [
   'shared/migrations',
   'scripts/prod-schema-manifests',
   'scripts/release-check.mjs',
+  'scripts/run-gp-spine-e2e.mjs',
   'scripts/db-push.mjs',
   'scripts/db-push-core.mjs',
   'server/lib/auth/csrf.ts',
   'server/lib/auth/request-credentials.ts',
   'tests/helpers/browser-auth.ts',
   'tests/e2e/cookie-session-csrf.spec.ts',
+  'tests/e2e/gp-decision-spine.spec.ts',
   'tests/integration/cookie-session-auth-runtime.test.ts',
   'tests/integration/fund-lifecycle-db.test.ts',
   'tests/integration/migration-drift.test.ts',
@@ -122,6 +124,10 @@ const steps = [
     name: 'Cookie-session browser lifecycle',
     command:
       'cross-env CI=1 TZ=UTC PORT=4199 playwright test tests/e2e/cookie-session-csrf.spec.ts --project=d4-auth',
+  },
+  {
+    name: 'GP decision spine (E2E)',
+    command: 'cross-env CI=1 TZ=UTC node scripts/run-gp-spine-e2e.mjs',
   },
   {
     name: 'Lean release server and CI surface lock',

--- a/scripts/run-gp-spine-e2e.mjs
+++ b/scripts/run-gp-spine-e2e.mjs
@@ -1,0 +1,214 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const playwrightCli = path.join(repoRoot, 'node_modules', 'playwright', 'cli.js');
+const apiPort = process.env.GP_SPINE_E2E_API_PORT ?? '5091';
+const clientPort = process.env.GP_SPINE_E2E_CLIENT_PORT ?? '5191';
+const host = 'localhost';
+const baseUrl = `http://${host}:${clientPort}`;
+const apiUrl = `http://${host}:${apiPort}`;
+const commitRef = execFileSync('git', ['rev-parse', 'HEAD'], {
+  cwd: repoRoot,
+  encoding: 'utf8',
+  windowsHide: true,
+}).trim();
+
+const inheritedEnv = { ...process.env };
+delete inheritedEnv.BASE_URL;
+
+const apiEnv = {
+  ...inheritedEnv,
+  NODE_ENV: 'test',
+  _EXPLICIT_NODE_ENV: 'test',
+  HOST: host,
+  PORT: apiPort,
+  _EXPLICIT_PORT: apiPort,
+  ENABLE_SCENARIO_SEED_PICKER: '1',
+  COMMIT_REF: commitRef,
+  CLIENT_URL: baseUrl,
+  CORS_ORIGIN: `${baseUrl},http://127.0.0.1:${clientPort}`,
+};
+
+const clientEnv = { ...inheritedEnv };
+delete clientEnv.NODE_ENV;
+delete clientEnv._EXPLICIT_NODE_ENV;
+Object.assign(clientEnv, {
+  VITE_API_PORT: apiPort,
+  VITE_CLIENT_PORT: clientPort,
+  VITE_ENABLE_SCENARIO_SEED_PICKER: '1',
+});
+
+const managedProcesses = [];
+
+function spawnManaged(label, command, args, env) {
+  const spawnCommand = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : command;
+  const spawnArgs =
+    process.platform === 'win32' ? ['/d', '/s', '/c', [command, ...args].join(' ')] : args;
+  const child = spawn(spawnCommand, spawnArgs, {
+    cwd: repoRoot,
+    env,
+    stdio: 'inherit',
+    windowsHide: true,
+    detached: process.platform !== 'win32',
+  });
+
+  const exit = new Promise((resolve) => {
+    child.once('error', (error) => resolve({ error }));
+    child.once('exit', (code, signal) => resolve({ code, signal }));
+  });
+  const managedProcess = { label, child, expectedExit: false, fatalExit: null };
+  managedProcess.fatalExit = exit.then((result) => {
+    if (managedProcess.expectedExit) return;
+
+    const detail =
+      'error' in result
+        ? result.error.message
+        : result.signal
+          ? `signal ${result.signal}`
+          : `code ${String(result.code)}`;
+    throw new Error(`[gp-spine-e2e] ${label} exited unexpectedly (${detail})`);
+  });
+
+  managedProcesses.push(managedProcess);
+  return managedProcess;
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForHttp(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { redirect: 'manual' });
+      if (response.status < 500) {
+        return;
+      }
+      lastError = new Error(`${url} returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await wait(500);
+  }
+
+  throw lastError ?? new Error(`Timed out waiting for ${url}`);
+}
+
+async function assertRuntimeWiring() {
+  const unauthenticatedFund = await fetch(`${apiUrl}/api/funds/1`, { redirect: 'manual' });
+  if (unauthenticatedFund.status !== 401) {
+    throw new Error(
+      `[gp-spine-e2e] auth sanity failed: GET /api/funds/1 returned ${unauthenticatedFund.status}, expected 401`
+    );
+  }
+
+  const healthResponse = await fetch(`${apiUrl}/healthz`);
+  if (!healthResponse.ok) {
+    throw new Error(`[gp-spine-e2e] SHA sanity failed: /healthz returned ${healthResponse.status}`);
+  }
+  const health = await healthResponse.json();
+  if (health.commit_sha !== commitRef) {
+    throw new Error(
+      `[gp-spine-e2e] SHA sanity failed: /healthz exposed ${String(health.commit_sha)}, expected ${commitRef}`
+    );
+  }
+}
+
+function killProcessTree(pid) {
+  return new Promise((resolve) => {
+    if (pid === undefined) {
+      resolve();
+      return;
+    }
+
+    if (process.platform === 'win32') {
+      execFile('taskkill.exe', ['/PID', String(pid), '/T', '/F'], { windowsHide: true }, () =>
+        resolve()
+      );
+      return;
+    }
+
+    try {
+      process.kill(-pid, 'SIGTERM');
+    } catch {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {
+        // Process already exited.
+      }
+    }
+    resolve();
+  });
+}
+
+async function cleanup() {
+  await Promise.all(
+    managedProcesses.map((managedProcess) => {
+      managedProcess.expectedExit = true;
+      return killProcessTree(managedProcess.child.pid);
+    })
+  );
+}
+
+async function main() {
+  const apiProcess = spawnManaged('api', npxCommand, ['tsx', 'server/index.ts'], apiEnv);
+  const clientProcess = spawnManaged(
+    'client',
+    npmCommand,
+    ['run', 'dev:client', '--', '--host', host, '--strictPort'],
+    clientEnv
+  );
+  const fatalServiceExits = [apiProcess.fatalExit, clientProcess.fatalExit];
+  await Promise.race([
+    (async () => {
+      await Promise.all([
+        waitForHttp(`${apiUrl}/healthz`, 120_000),
+        waitForHttp(baseUrl, 120_000),
+      ]);
+      await assertRuntimeWiring();
+    })(),
+    ...fatalServiceExits,
+  ]);
+
+  const result = spawn(process.execPath, [playwrightCli, 'test', '--project=gp-spine'], {
+    cwd: repoRoot,
+    env: {
+      ...inheritedEnv,
+      BASE_URL: baseUrl,
+      COMMIT_REF: commitRef,
+    },
+    stdio: 'inherit',
+    windowsHide: true,
+  });
+
+  const playwrightExit = new Promise((resolve, reject) => {
+    result.once('error', reject);
+    result.once('exit', (code) => resolve(code ?? 1));
+  });
+
+  return Promise.race([playwrightExit, ...fatalServiceExits]);
+}
+
+process.on('SIGINT', () => {
+  cleanup().finally(() => process.exit(130));
+});
+process.on('SIGTERM', () => {
+  cleanup().finally(() => process.exit(143));
+});
+
+let exitCode = 1;
+try {
+  exitCode = await main();
+} finally {
+  await cleanup();
+}
+process.exit(exitCode);

--- a/scripts/run-gp-spine-e2e.mjs
+++ b/scripts/run-gp-spine-e2e.mjs
@@ -19,7 +19,23 @@ const commitRef = execFileSync('git', ['rev-parse', 'HEAD'], {
 }).trim();
 
 const inheritedEnv = { ...process.env };
-delete inheritedEnv.BASE_URL;
+const scrubbedInheritedEnvNames = new Set([
+  'BASE_URL',
+  'VITE_API_URL',
+  'VITE_API_BASE_URL',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'PGHOST',
+  'PGPORT',
+  'PGUSER',
+  'PGPASSWORD',
+  'PGDATABASE',
+]);
+for (const key of Object.keys(inheritedEnv)) {
+  if (scrubbedInheritedEnvNames.has(key.toUpperCase())) {
+    delete inheritedEnv[key];
+  }
+}
 
 const apiEnv = {
   ...inheritedEnv,
@@ -88,7 +104,10 @@ async function waitForHttp(url, timeoutMs) {
 
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(url, { redirect: 'manual' });
+      const response = await fetch(url, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(5_000),
+      });
       if (response.status < 500) {
         return;
       }
@@ -119,6 +138,21 @@ async function assertRuntimeWiring() {
   if (health.commit_sha !== commitRef) {
     throw new Error(
       `[gp-spine-e2e] SHA sanity failed: /healthz exposed ${String(health.commit_sha)}, expected ${commitRef}`
+    );
+  }
+
+  const proxyHealthResponse = await fetch(`${baseUrl}/healthz`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!proxyHealthResponse.ok) {
+    throw new Error(
+      `[gp-spine-e2e] proxy SHA sanity failed: ${baseUrl}/healthz returned ${proxyHealthResponse.status}`
+    );
+  }
+  const proxyHealth = await proxyHealthResponse.json();
+  if (proxyHealth.commit_sha !== commitRef) {
+    throw new Error(
+      `[gp-spine-e2e] proxy SHA sanity failed: /healthz exposed ${String(proxyHealth.commit_sha)}, expected ${commitRef}`
     );
   }
 }
@@ -179,7 +213,7 @@ async function main() {
     ...fatalServiceExits,
   ]);
 
-  const result = spawn(process.execPath, [playwrightCli, 'test', '--project=gp-spine'], {
+  const playwrightChild = spawn(process.execPath, [playwrightCli, 'test', '--project=gp-spine'], {
     cwd: repoRoot,
     env: {
       ...inheritedEnv,
@@ -189,10 +223,16 @@ async function main() {
     stdio: 'inherit',
     windowsHide: true,
   });
+  managedProcesses.push({
+    label: 'playwright',
+    child: playwrightChild,
+    expectedExit: true,
+    fatalExit: null,
+  });
 
   const playwrightExit = new Promise((resolve, reject) => {
-    result.once('error', reject);
-    result.once('exit', (code) => resolve(code ?? 1));
+    playwrightChild.once('error', reject);
+    playwrightChild.once('exit', (code) => resolve(code ?? 1));
   });
 
   return Promise.race([playwrightExit, ...fatalServiceExits]);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -189,6 +189,7 @@ export class MemStorage implements IStorage {
   } as const satisfies StorageCapabilities;
 
   private users: Map<number, User>;
+  private userFundGrants: Map<number, number[]>;
   private funds: Map<number, Fund>;
   private portfolioCompanies: Map<number, PortfolioCompany>;
   private investments: Map<number, Investment>;
@@ -203,6 +204,7 @@ export class MemStorage implements IStorage {
 
   constructor() {
     this.users = new Map();
+    this.userFundGrants = new Map();
     this.funds = new Map();
     this.portfolioCompanies = new Map();
     this.investments = new Map();
@@ -370,6 +372,9 @@ export class MemStorage implements IStorage {
     seedUsers.forEach((seedUser, index) => {
       const id = index + 1;
       this.users.set(id, materializeMemoryUser(seedUser, id));
+      if (seedUser.username === 'partner') {
+        this.userFundGrants.set(id, [1]);
+      }
     });
     this.currentUserId = seedUsers.length + 1;
   }
@@ -383,8 +388,8 @@ export class MemStorage implements IStorage {
     return Array.from(this.users.values()).find((user) => user.username === username);
   }
 
-  async getUserFundGrants(_userId: number): Promise<number[]> {
-    return [];
+  async getUserFundGrants(userId: number): Promise<number[]> {
+    return [...(this.userFundGrants.get(userId) ?? [])];
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {

--- a/tests/e2e/gp-decision-spine.spec.ts
+++ b/tests/e2e/gp-decision-spine.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const WORKSPACE_ITEMS = [
+  'Summary',
+  'Forecast',
+  'Portfolio Actuals',
+  'Reserves',
+  'Scenarios',
+  'Reports',
+] as const;
+
+type WorkspaceKey =
+  'summary' | 'forecast' | 'portfolio-actuals' | 'reserves' | 'scenarios' | 'reports';
+
+async function expectWorkspaceNav(page: Page, active: WorkspaceKey, basis: string) {
+  const nav = page.getByTestId('workspace-nav');
+  await expect(nav).toBeVisible();
+  await expect(nav.getByTestId(`workspace-nav-${active}`)).toHaveAttribute('aria-current', 'page');
+  for (const label of WORKSPACE_ITEMS) {
+    await expect(nav.getByRole('link', { name: label, exact: true })).toBeVisible();
+  }
+  await expect(nav.getByText(basis, { exact: true })).toBeVisible();
+  await expect(nav.getByText(/^Scenario:/)).toHaveCount(0);
+}
+
+async function expectReadinessState(row: Locator, expected: string) {
+  await expect(row).toBeVisible();
+  await expect(row.getByText(expected, { exact: true })).toBeVisible();
+  await expect(row).not.toHaveText('');
+}
+
+test('partner completes the truthful GP decision spine with fail-closed gaps disclosed', async ({
+  page,
+}) => {
+  test.setTimeout(240_000);
+
+  await page.goto('/login', { waitUntil: 'domcontentloaded' });
+  await page.getByLabel('Username').fill('partner');
+  await page.getByLabel('Password').fill('partner-dev-2026');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page).toHaveURL(/\/dashboard$/);
+  await expect(page.getByRole('button', { name: 'Log out' })).toBeVisible();
+  const sessionCookie = (await page.context().cookies()).find(
+    (cookie) => cookie.name === 'updog.session'
+  );
+  expect(sessionCookie).toMatchObject({ httpOnly: true, sameSite: 'Lax' });
+
+  const summaryResponse = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === '/api/funds/1/results' &&
+      response.request().method() === 'GET'
+  );
+  await page.goto('/fund-model-results/1', { waitUntil: 'domcontentloaded' });
+  expect((await summaryResponse).status()).toBe(200);
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Test Fund I', exact: true })
+  ).toBeVisible();
+  await expectWorkspaceNav(page, 'summary', 'Basis: Construction');
+
+  const rollup = page.getByTestId('fund-readiness-rollup');
+  await expect(
+    rollup.getByRole('heading', { name: 'Readiness — what is blocked and where' })
+  ).toBeVisible();
+  await expectReadinessState(page.getByTestId('readiness-row-forecast'), 'Facts unavailable');
+  await expectReadinessState(
+    page.getByTestId('readiness-row-portfolio-actuals'),
+    'Facts unavailable'
+  );
+  await expectReadinessState(page.getByTestId('readiness-row-reserves'), 'Not actionable');
+  await expectReadinessState(page.getByTestId('readiness-row-scenarios'), 'Facts unavailable');
+  await expectReadinessState(page.getByTestId('readiness-row-reports'), 'Not verified');
+  await expect(rollup.locator('tbody > tr[data-testid^="readiness-row-"]')).toHaveCount(5);
+
+  await page.goto('/financial-modeling?fundId=1', { waitUntil: 'domcontentloaded' });
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Financial Modeling & Forecasting', exact: true })
+  ).toBeVisible();
+  await expectWorkspaceNav(page, 'forecast', 'Basis: Construction and Current — side by side');
+  await expect(page.getByText('Fund Value Forecast', { exact: true })).toBeVisible();
+  await expect(page.getByText('Construction Plan', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('Current Forecast', { exact: true }).first()).toBeVisible();
+  const allocationEvidence = page.getByRole('note', { name: 'Portfolio allocation evidence' });
+  await expect(allocationEvidence).toContainText('Valuation freshness unavailable:');
+  await expect(page.getByText('Recorded valuations', { exact: true })).toBeVisible();
+  for (const company of ['TechCorp', 'HealthAI', 'DataFlow']) {
+    await expect(page.getByText(company, { exact: true }).first()).toBeVisible();
+  }
+
+  await page.goto('/portfolio?tab=reserve-planning&fundId=1', {
+    waitUntil: 'domcontentloaded',
+  });
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Portfolio', exact: true })
+  ).toBeVisible();
+  await expectWorkspaceNav(page, 'portfolio-actuals', 'Basis: Current');
+  await expect(page.getByRole('alert')).toContainText(
+    'We could not load reserve allocations. Retry in a moment or check that this fund is still available.'
+  );
+  await expect(page.getByRole('region', { name: 'Actuals drift summary' })).toHaveCount(0);
+  await expect(page.getByTestId('reserve-planning-empty-state')).toHaveCount(0);
+  await expect(page.locator('[data-testid^="allocation-seed-link-"]')).toHaveCount(0);
+
+  await page.goto('/fund-model-results/1/moic-analysis', { waitUntil: 'domcontentloaded' });
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'MOIC Analysis', exact: true })
+  ).toBeVisible();
+  await expectWorkspaceNav(page, 'reserves', 'Basis: Construction');
+  const emptyRankings = page.getByText('No rankings disclosed', { exact: true });
+  await expect(emptyRankings).toBeVisible();
+  await expect(page.getByTestId('moic-planned-marginal-crossref')).toHaveCount(0);
+  await expect(page.getByText(/currency blocked/i)).toHaveCount(0);
+
+  await page.goto('/fund-model-results/1/scenarios?seedPicker=1&seedCompany=1', {
+    waitUntil: 'domcontentloaded',
+  });
+  await expectWorkspaceNav(page, 'scenarios', 'Basis: Construction');
+  await expect(page.getByRole('alert')).toContainText(
+    'Scenario workspace data could not be loaded.'
+  );
+  await expect(page.getByRole('dialog', { name: 'Start case from portfolio actuals' })).toHaveCount(
+    0
+  );
+  await expect(page.getByRole('button', { name: 'Create case' })).toHaveCount(0);
+
+  await page.goto('/fund-model-results/1/reports', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { level: 1, name: 'Reports', exact: true })).toBeVisible();
+  await expectWorkspaceNav(page, 'reports', 'Basis: Current');
+  const qualification = page.getByTestId('gp-qualification-strip');
+  await expect(qualification).toContainText('Not export-ready');
+  await expect(qualification).toContainText(
+    'No metric run disclosed on this surface yet. Run and qualify metrics below.'
+  );
+  await expect(page.getByRole('heading', { level: 1, name: 'Metrics', exact: true })).toBeVisible();
+  await expect(page.getByRole('form', { name: 'Metric-run dry-run form' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Run metrics', exact: true })).toBeVisible();
+
+  await page.goto('/fund-model-results/1', { waitUntil: 'domcontentloaded' });
+  const evidenceTrigger = page.getByTestId('scenario-evidence-trigger');
+  await expect(evidenceTrigger).toBeVisible();
+  await evidenceTrigger.click();
+  const evidencePanel = page.getByRole('dialog', { name: 'Scenario comparison' });
+  await expect(evidencePanel).toBeVisible();
+  await expect(evidencePanel).toContainText('No scenario comparisons disclosed');
+  await page.keyboard.press('Escape');
+  await expect(evidencePanel).toBeHidden();
+  await expect(evidenceTrigger).toBeFocused();
+
+  const ungrantedResponse = await page.context().request.get('/api/funds/2');
+  expect(ungrantedResponse.status()).toBe(403);
+  const ungrantedResultsResponse = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === '/api/funds/2/results' &&
+      response.request().method() === 'GET'
+  );
+  await page.goto('/fund-model-results/2', { waitUntil: 'domcontentloaded' });
+  expect((await ungrantedResultsResponse).status()).toBe(403);
+  await expect(page.getByText('Error loading results', { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole('alert').getByText('Server error (403)', { exact: true })
+  ).toBeVisible();
+  await expect(page.getByTestId('workspace-nav-fund')).toHaveText('Fund 2');
+
+  const healthResponse = await page.context().request.get('/healthz');
+  expect(healthResponse.ok()).toBe(true);
+  const health = (await healthResponse.json()) as { commit_sha?: unknown };
+  expect(health.commit_sha).toBe(process.env.COMMIT_REF);
+});

--- a/tests/e2e/gp-decision-spine.spec.ts
+++ b/tests/e2e/gp-decision-spine.spec.ts
@@ -77,14 +77,17 @@ test('partner completes the truthful GP decision spine with fail-closed gaps dis
     page.getByRole('heading', { level: 1, name: 'Financial Modeling & Forecasting', exact: true })
   ).toBeVisible();
   await expectWorkspaceNav(page, 'forecast', 'Basis: Construction and Current — side by side');
-  await expect(page.getByText('Fund Value Forecast', { exact: true })).toBeVisible();
-  await expect(page.getByText('Construction Plan', { exact: true }).first()).toBeVisible();
-  await expect(page.getByText('Current Forecast', { exact: true }).first()).toBeVisible();
+  const fundValueForecastTitle = page.getByText('Fund Value Forecast', { exact: true });
+  const fundValueForecastCard = fundValueForecastTitle.locator('..').locator('..');
+  await expect(fundValueForecastTitle).toBeVisible();
+  await expect(fundValueForecastCard.getByText('Construction Plan', { exact: true })).toBeVisible();
+  await expect(fundValueForecastCard.getByText('Current Forecast', { exact: true })).toBeVisible();
   const allocationEvidence = page.getByRole('note', { name: 'Portfolio allocation evidence' });
+  const allocationCard = allocationEvidence.locator('..').locator('..');
   await expect(allocationEvidence).toContainText('Valuation freshness unavailable:');
-  await expect(page.getByText('Recorded valuations', { exact: true })).toBeVisible();
+  await expect(allocationCard.getByText('Recorded valuations', { exact: true })).toBeVisible();
   for (const company of ['TechCorp', 'HealthAI', 'DataFlow']) {
-    await expect(page.getByText(company, { exact: true }).first()).toBeVisible();
+    await expect(allocationCard.getByText(company, { exact: true })).toBeVisible();
   }
 
   await page.goto('/portfolio?tab=reserve-planning&fundId=1', {

--- a/tests/unit/infra/vite-proxy-policy.test.ts
+++ b/tests/unit/infra/vite-proxy-policy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiProxyChangeOrigin } from '../../../vite.proxy-policy';
+
+describe('apiProxyChangeOrigin', () => {
+  it.each(['http://localhost:5091', 'http://127.0.0.1:5000', 'http://[::1]:4000'])(
+    'preserves Host for loopback target %s',
+    (target) => {
+      expect(apiProxyChangeOrigin(target)).toBe(false);
+    }
+  );
+
+  it.each(['https://staging.example.com', 'http://10.0.0.5:8080'])(
+    'rewrites origin for remote target %s',
+    (target) => {
+      expect(apiProxyChangeOrigin(target)).toBe(true);
+    }
+  );
+
+  it('defaults to origin rewriting for a malformed target', () => {
+    expect(apiProxyChangeOrigin('not a URL')).toBe(true);
+  });
+});

--- a/tests/unit/server/storage-user-identity.test.ts
+++ b/tests/unit/server/storage-user-identity.test.ts
@@ -3,10 +3,16 @@ import { MemStorage } from '../../../server/storage';
 import { TEST_LOGIN_CREDENTIALS } from '../../../server/lib/seed-users';
 
 describe('MemStorage user identity support', () => {
-  it('returns an empty explicit grant list for in-memory users', async () => {
+  it('grants only the seeded partner access to Fund 1', async () => {
     const storage = new MemStorage();
+    const partner = await storage.getUserByUsername('partner');
+    const admin = await storage.getUserByUsername('admin');
 
-    await expect(storage.getUserFundGrants(1)).resolves.toEqual([]);
+    expect(partner).toBeDefined();
+    expect(admin).toBeDefined();
+    await expect(storage.getUserFundGrants(partner!.id)).resolves.toEqual([1]);
+    await expect(storage.getUserFundGrants(admin!.id)).resolves.toEqual([]);
+    await expect(storage.getUserFundGrants(999_999)).resolves.toEqual([]);
   });
 
   it('materializes each dev seed user with its declared role', async () => {

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -49,6 +49,7 @@
     "client/src/app/app-route-definitions.ts",
     "client/src/app/route-governance-registry.ts",
     "tests/fixtures/portfolio-intelligence-route-classification.ts",
+    "vite.proxy-policy.ts",
     "vite.config.ts"
   ],
   "exclude": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,8 @@ import { defineConfig, type Plugin } from 'vite';
 import virtual from 'vite-plugin-virtual';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+import { apiProxyChangeOrigin } from './vite.proxy-policy';
+
 // Comprehensive winston mock
 const winstonMock = `
 export const format = {
@@ -216,25 +218,24 @@ export default defineConfig(({ mode }: { mode: string }) => {
   const clientPort = parsePort(process.env['VITE_CLIENT_PORT'], 5173);
   const apiPort = parsePort(process.env['VITE_API_PORT'] ?? process.env['PORT'], 5000);
   const apiTarget = process.env['VITE_API_URL'] ?? `http://localhost:${apiPort}`;
-  const apiTargetHostname = new URL(apiTarget).hostname.replace(/^\[|\]$/g, '');
-  const apiTargetIsLoopback = ['localhost', '127.0.0.1', '::1'].includes(apiTargetHostname);
   // Cookie-session CSRF needs loopback proxies to preserve Host; remote targets need origin rewriting.
+  const changeOrigin = apiProxyChangeOrigin(apiTarget);
   const apiProxy = {
     '/api': {
       target: apiTarget,
-      changeOrigin: !apiTargetIsLoopback,
+      changeOrigin,
     },
     '/metrics': {
       target: apiTarget,
-      changeOrigin: !apiTargetIsLoopback,
+      changeOrigin,
     },
     '/healthz': {
       target: apiTarget,
-      changeOrigin: !apiTargetIsLoopback,
+      changeOrigin,
     },
     '/readyz': {
       target: apiTarget,
-      changeOrigin: !apiTargetIsLoopback,
+      changeOrigin,
     },
   };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -216,23 +216,25 @@ export default defineConfig(({ mode }: { mode: string }) => {
   const clientPort = parsePort(process.env['VITE_CLIENT_PORT'], 5173);
   const apiPort = parsePort(process.env['VITE_API_PORT'] ?? process.env['PORT'], 5000);
   const apiTarget = process.env['VITE_API_URL'] ?? `http://localhost:${apiPort}`;
-  // Cookie-session CSRF compares browser Origin to request Host; local proxies must preserve Host.
+  const apiTargetHostname = new URL(apiTarget).hostname.replace(/^\[|\]$/g, '');
+  const apiTargetIsLoopback = ['localhost', '127.0.0.1', '::1'].includes(apiTargetHostname);
+  // Cookie-session CSRF needs loopback proxies to preserve Host; remote targets need origin rewriting.
   const apiProxy = {
     '/api': {
       target: apiTarget,
-      changeOrigin: false,
+      changeOrigin: !apiTargetIsLoopback,
     },
     '/metrics': {
       target: apiTarget,
-      changeOrigin: false,
+      changeOrigin: !apiTargetIsLoopback,
     },
     '/healthz': {
       target: apiTarget,
-      changeOrigin: false,
+      changeOrigin: !apiTargetIsLoopback,
     },
     '/readyz': {
       target: apiTarget,
-      changeOrigin: false,
+      changeOrigin: !apiTargetIsLoopback,
     },
   };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -216,22 +216,23 @@ export default defineConfig(({ mode }: { mode: string }) => {
   const clientPort = parsePort(process.env['VITE_CLIENT_PORT'], 5173);
   const apiPort = parsePort(process.env['VITE_API_PORT'] ?? process.env['PORT'], 5000);
   const apiTarget = process.env['VITE_API_URL'] ?? `http://localhost:${apiPort}`;
+  // Cookie-session CSRF compares browser Origin to request Host; local proxies must preserve Host.
   const apiProxy = {
     '/api': {
       target: apiTarget,
-      changeOrigin: true,
+      changeOrigin: false,
     },
     '/metrics': {
       target: apiTarget,
-      changeOrigin: true,
+      changeOrigin: false,
     },
     '/healthz': {
       target: apiTarget,
-      changeOrigin: true,
+      changeOrigin: false,
     },
     '/readyz': {
       target: apiTarget,
-      changeOrigin: true,
+      changeOrigin: false,
     },
   };
 

--- a/vite.proxy-policy.ts
+++ b/vite.proxy-policy.ts
@@ -1,0 +1,10 @@
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+export function apiProxyChangeOrigin(target: string): boolean {
+  try {
+    const hostname = new URL(target).hostname.replace(/^\[|\]$/g, '');
+    return !LOOPBACK_HOSTNAMES.has(hostname);
+  } catch {
+    return true;
+  }
+}


### PR DESCRIPTION
## Plan 9 Wave 9C — GP decision spine E2E + release-check registration

First real-login browser E2E in the repo: a partner cookie-session logs in against the
**production application surface** (`makeApp` via `server/index.ts`) and walks the full
hub-and-spokes GP workspace, asserting only truthful runtime states (D-C). Registered as
release-check step 5 so the release gate fails closed if the decision spine regresses.

### What this adds
- `tests/e2e/gp-decision-spine.spec.ts` (project `gp-spine`) — real partner login
  (cookie + CSRF, no mocks), Summary readiness rollup (five truthful rows), Forecast
  side-by-side basis, Portfolio Actuals fail-closed alert, Reserves "No rankings
  disclosed", Scenarios fail-closed workspace, Reports "Not export-ready" strip,
  evidence dialog + Esc focus restore, ungranted-fund 403 (API + page), `/healthz`
  `commit_sha` === runner-pinned `COMMIT_REF`.
- `scripts/run-gp-spine-e2e.mjs` — boots the prod surface (`npx tsx server/index.ts`,
  NODE_ENV=test + `_EXPLICIT_*` markers so `.env.development` cannot flip REQUIRE_AUTH
  off) + Vite on isolated ports (5091/5191), strips ambient BASE_URL, sanity-probes
  401-unauthenticated and the /healthz SHA before Playwright, kills process trees on
  exit.
- `server/storage.ts` — MemStorage seeds a deterministic partner → Fund 1 grant
  (fail-closed default preserved for every other user; DatabaseStorage untouched), so a
  SCOPED user can truthfully exercise the flow (master plan exit gate).
- `vite.config.ts` — local API proxy is now Host-preserving (`changeOrigin: false`):
  cookie-session CSRF compares browser Origin to request Host, so a Host-rewriting
  local proxy made real login impossible (403 `csrf_validation_failed`). No auth code
  changed.
- `playwright.config.ts` + `scripts/release-check.mjs` — `gp-spine` project and release
  step registration (releaseOwnedPaths updated).
- `tests/unit/server/storage-user-identity.test.ts` — narrow repair: the blanket
  empty-grants assertion re-scoped to pin partner `[1]`, admin `[]`, unknown `[]`.

### Findings recorded (not fixed here)
- **Docker-surface contract note:** the org/RLS wrapper (`server/server.ts` only)
  requires an `org_id` claim that login-issued sessions never carry — any
  REQUIRE_AUTH=1 boot of the Docker surface 403s all fund routes
  (`missing_org_context`). Prod (`makeApp`) has no such gate. Follow-up candidate
  outside Plan 9.
- **Withheld-coverage ledger** (memory-mode cannot truthfully exercise):
  create→run→facts-hash, blocked-currency, missing-ownership reserve status,
  ready-evidence fields, allocation seed-link traversal. Each ledgered with unblock
  conditions in the wave artifacts (`wt-plan5/.claude/artifacts/blockers.md`).

### Changed-file manifest (generated from `git diff origin/main...HEAD --stat`)
```
playwright.config.ts                            |   5 +
scripts/release-check.mjs                       |   6 +
scripts/run-gp-spine-e2e.mjs                    | 254 ++++++++++++++++++++++++
server/storage.ts                               |   9 +-
tests/e2e/gp-decision-spine.spec.ts             | 171 ++++++++++++++++
tests/unit/infra/vite-proxy-policy.test.ts      |  23 +++
tests/unit/server/storage-user-identity.test.ts |  10 +-
tsconfig.server.json                            |   1 +
vite.config.ts                                  |  12 +-
vite.proxy-policy.ts                            |  10 +
10 files changed, 493 insertions(+), 8 deletions(-)
```
`vite.proxy-policy.ts` + its 6-case test extract the loopback-vs-remote Host policy
(owner-review requirement: characterized, not comment-asserted). The one-line
`tsconfig.server.json` include is required by the composite baseline typecheck for the
new root module (documented in the commit).

### Withheld coverage (memory mode cannot truthfully exercise — ledgered for 9C2b)
1. Allocation seed-link traversal and create → calculation-read → facts-hash readback
2. Blocked-currency produces no facts money (exercised fixture)
3. Missing ownership prevents actionable reserve status (exercised fixture)
4. Ready scenario-evidence fields (as-of, source, hash, axis labels)
5. Marginal cross-ref disabled-with-reason copy (needs actionable rankings)

### Review rounds
Plan-review gate (14 comments dispositioned) → 3 Codex fix rounds with orchestrator
rulings (CSRF/Vite topology; prod-surface switch; ambient-env hardening) → adversarial
codex review (7 findings dispositioned, 2 P1 accepted) → owner red-team review (9C0
closeout: rebase, proxy-policy characterization, distinct hardening commits).

### Verification
- GP E2E green 3 consecutive runs (2 by the implementation lane, 1 independent
  orchestrator rerun).
- `UPDOG_RELEASE_CHECK_SKIP_DB=1 npm run release:check`: all 11 steps green including
  the new step 5.
- Full no-bail unit suite green (8,493 passed / 90 skipped); dependent grant/auth
  suites re-verified independently (16 tests).
- `npm run lint` + `npm run check` green.
- Plan-review gate + adversarial codex review both executed (dispositions in
  `wave9c-plan-review-assessment.md`).
- New e2e tests do not run on their own PR: full-suite dispatch cited in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
