### PR TITLE
fix(pdf): official renderToBuffer adapter with frozen render baseline (Plan 9 wave 9E0)

### DIFF
--- a/server/services/pdf-generation/renderer.ts
+++ b/server/services/pdf-generation/renderer.ts
@@ -1,38 +1,12 @@
 /**
- * PDF rendering utilities: stream-to-buffer conversion and generic render helper.
+ * PDF rendering utilities.
  * @module server/services/pdf-generation/renderer
  */
 
-import { pdf } from '@react-pdf/renderer';
+import { renderToBuffer, type DocumentProps } from '@react-pdf/renderer';
 import type React from 'react';
-
-/** Convert ReadableStream to Buffer (for Node.js environment) */
-async function streamToBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (value) chunks.push(value);
-  }
-
-  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
-  }
-
-  return Buffer.from(result);
-}
 
 /** Render a React-PDF document element to a Buffer. */
 export async function renderPdfToBuffer(doc: React.ReactElement): Promise<Buffer> {
-  const pdfStream = await pdf(doc).toBuffer();
-  if (pdfStream instanceof ReadableStream) {
-    return streamToBuffer(pdfStream as ReadableStream<Uint8Array>);
-  }
-  return pdfStream as unknown as Buffer;
+  return renderToBuffer(doc as React.ReactElement<DocumentProps>);
 }

--- a/tests/unit/services/pdf-generation/quarterly-render-baseline.test.ts
+++ b/tests/unit/services/pdf-generation/quarterly-render-baseline.test.ts
@@ -1,0 +1,114 @@
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildQuarterlyReportData,
+  generateQuarterlyPDF,
+  type LPReportData,
+  type QuarterlyReportData,
+  type ReportMetrics,
+} from '../../../../server/services/pdf-generation-service';
+import { standardLPData } from '../../../fixtures/lp-report-fixtures';
+
+const BASELINE_PATH = resolve(process.cwd(), '.claude/artifacts/wave9e0-lp-report-baseline.pdf');
+// A complete one-page report with metrics, capital summary, and portfolio rows is
+// materially larger than an empty PDF; this floor catches truncated renders.
+const MINIMUM_PDF_BYTES = 4_000;
+
+function createFrozenQuarterlyFixture(): {
+  lpData: LPReportData;
+  metrics: ReportMetrics;
+  period: Readonly<{
+    quarter: string;
+    year: number;
+    cutoff: Date;
+    generatedAt: string;
+  }>;
+  reportData: QuarterlyReportData;
+} {
+  const period = Object.freeze({
+    quarter: 'Q3',
+    year: 2024,
+    cutoff: new Date('2024-09-30T23:59:59.999Z'),
+    generatedAt: '2024-09-30T23:59:59.999Z',
+  });
+
+  const lpData: LPReportData = {
+    lp: Object.freeze({ ...standardLPData.lp }),
+    commitments: standardLPData.commitments.map((commitment) => Object.freeze({ ...commitment })),
+    transactions: standardLPData.transactions
+      .filter((transaction) => transaction.date <= period.cutoff)
+      .map((transaction) =>
+        Object.freeze({ ...transaction, date: new Date(transaction.date.getTime()) })
+      ),
+  };
+  Object.freeze(lpData.commitments);
+  Object.freeze(lpData.transactions);
+  Object.freeze(lpData);
+
+  const metrics: ReportMetrics = {
+    irr: 0.15,
+    tvpi: 1.15,
+    dpi: 0.13,
+    portfolioCompanies: [
+      { name: 'AlphaAI', invested: 675_000, value: 900_000, moic: 1.33 },
+      { name: 'BetaCorp', invested: 562_500, value: 787_500, moic: 1.4 },
+      { name: 'GammaHealth', invested: 450_000, value: 562_500, moic: 1.25 },
+    ].map((company) => Object.freeze(company)),
+  };
+  Object.freeze(metrics.portfolioCompanies);
+  Object.freeze(metrics);
+
+  const reportData: QuarterlyReportData = {
+    ...buildQuarterlyReportData(lpData, 1, period.quarter, period.year, metrics),
+    generatedAt: period.generatedAt,
+  };
+  Object.freeze(reportData.summary);
+  Object.freeze(reportData.portfolioCompanies);
+  Object.freeze(reportData.cashFlows);
+  Object.freeze(reportData);
+
+  return Object.freeze({ lpData, metrics, period, reportData });
+}
+
+describe('quarterly PDF render baseline', () => {
+  it('renders byte-equal Q3 2024 output under a pinned clock through the public service', async () => {
+    const fixture = createFrozenQuarterlyFixture();
+
+    expect(fixture.lpData.transactions.every(({ date }) => date <= fixture.period.cutoff)).toBe(
+      true
+    );
+    expect(
+      fixture.lpData.transactions.some(
+        ({ date }) => date.toISOString() === '2024-10-15T00:00:00.000Z'
+      )
+    ).toBe(false);
+
+    // The current document does not expose metadata-date props through the service.
+    // Freeze Date so React-PDF's default creation date is stable for byte comparison.
+    // The server setup replaces fetch with a no-op mock; removing it makes Yoga use
+    // its embedded WASM bytes instead of calling an undefined mock result.
+    vi.stubGlobal('fetch', undefined);
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(fixture.period.generatedAt));
+
+    try {
+      const firstBuffer = await generateQuarterlyPDF(fixture.reportData);
+      const secondBuffer = await generateQuarterlyPDF(fixture.reportData);
+
+      expect(Buffer.isBuffer(firstBuffer)).toBe(true);
+      expect(firstBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
+      expect(firstBuffer.byteLength).toBeGreaterThan(MINIMUM_PDF_BYTES);
+      expect(firstBuffer.toString('latin1')).toMatch(/%%EOF\s*$/);
+      expect(secondBuffer.equals(firstBuffer)).toBe(true);
+
+      if (process.env['WAVE9E0_CAPTURE'] === '1') {
+        const realFs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+        await realFs.writeFile(BASELINE_PATH, firstBuffer);
+      }
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## Plan 9 Wave 9E0 — renderer-contract repair (pre-upgrade baseline)

Establishes the PDF render baseline BEFORE the PDFKit 4→5 dependency upgrade (9E, a
separate PR). No dependency changes here — application code only.

### What changed
- `server/services/pdf-generation/renderer.ts` — `renderPdfToBuffer` now delegates to
  the official `renderToBuffer(doc)` from `@react-pdf/renderer`. The previous adapter
  called `pdf(doc).toBuffer()` (installed type `Promise<NodeJS.ReadableStream>`),
  checked it against the **Web** `ReadableStream` class (wrong class), and on the
  normal path cast the Node stream to `Buffer`. Exported signature unchanged; dead
  `streamToBuffer` helper removed (no callers).
- `tests/unit/services/pdf-generation/quarterly-render-baseline.test.ts` — new
  server-project regression rendering the full quarterly report through the public
  `generateQuarterlyPDF` service from a frozen fixture: `standardLPData` filtered to a
  true Q3 2024 cutoff (`2024-09-30T23:59:59.999Z`, excludes the Oct-15 transaction),
  frozen metrics, frozen period/`generatedAt`. Asserts `Buffer.isBuffer`, `%PDF-`
  header, size floor, trailing `%%EOF`, and byte-equality of two renders under a
  pinned clock.

### Baseline artifact (inspected)
Rendered via the env-gated capture path (`WAVE9E0_CAPTURE=1`, real `node:fs/promises`).
Visually inspected: Q3 2024 report renders cleanly — performance cards, capital
summary, three portfolio rows, footer dated to the pinned clock, design-system colors
intact. No rendering regression from the adapter swap.
- SHA-256 `067E7F4569193A077FD066394A5DD7C495129FCBCDE0B7AE5837147D87F21737`, 5120 bytes.
- Resolved: `@react-pdf/renderer@4.5.1`, `@react-pdf/pdfkit@4.1.0` (overridden).

### Scope note
Renderer 4.5.1 declares `@react-pdf/pdfkit@^5.1.1` while the repo override forces
4.1.0 — outside that range. This baseline proves **adapter behavior**, not
supportability of the current override graph; supportability is 9E's job.
Production as-of filtering is NOT repaired here (the test filters locally); no
watermark path exists or is exercised.

### Verification
New regression green twice; focused server + client suites; full `npm test`; lint;
typecheck — all green, all TZ=UTC. Plan-review gate: 13 comments, all accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
