### PR TITLE
chore(deps): land @react-pdf/pdfkit 5.x, remove last pinning override (Plan 9 wave 9E, closes #1013)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2924,11 +2924,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -6390,28 +6401,21 @@
       }
     },
     "node_modules/@react-pdf/pdfkit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.1.0.tgz",
-      "integrity": "sha512-Wm/IOAv0h/U5Ra94c/PltFJGcpTUd/fwVMVeFD6X9tTTPCttIwg0teRG1Lqq617J8K4W7jpL/B0HTH0mjp3QpQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/png-js": "^3.0.0",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
         "browserify-zlib": "^0.2.0",
-        "crypto-js": "^4.2.0",
         "fontkit": "^2.0.2",
         "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
         "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
         "vite-compatible-readable-stream": "^3.6.1"
-      }
-    },
-    "node_modules/@react-pdf/png-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-3.0.0.tgz",
-      "integrity": "sha512-eSJnEItZ37WPt6Qv5pncQDxLJRK15eaRwPT+gZoujP548CodenOVp49GST8XJvKMFt9YqIBzGBV/j9AgrOQzVA==",
-      "license": "MIT",
-      "dependencies": {
-        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/@react-pdf/primitives": {
@@ -12566,12 +12570,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT"
-    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -18634,6 +18632,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -251,7 +251,6 @@
   },
   "overrides": {
     "esbuild": "^0.25.0",
-    "@react-pdf/pdfkit": "^4.1.0",
     "uuid": "^11.1.1",
     "ws": "^8.21.0",
     "@opentelemetry/core": "2.8.0"


### PR DESCRIPTION
## Plan 9 Wave 9E — @react-pdf/pdfkit 4.x → 5.x (dependency-only)

Closes #1013. Removes the last pinning override so the PDF stack runs a single supported
pdfkit. Builds on the 9E0 renderer-contract baseline (#1120).

### Change (tracked diff = exactly 2 files)
- `package.json` — remove the `@react-pdf/pdfkit` override (the other four stay).
- `package-lock.json` — pdfkit 4.1.0 → **5.1.1** (single deduped copy). Adds
  `@noble/ciphers` + `js-md5` (direct pdfkit 5.1.1 deps), drops `crypto-js` +
  `@react-pdf/png-js` (former 4.1.0 deps). Every changed lock entry is causally
  reachable from pdfkit 5.1.1 (`npm explain` verified); no unrelated churn. Dropping
  crypto-js is a security-positive.

### Validation
- `npm ls`: single `@react-pdf/pdfkit@5.1.1`; `npm ci` reproduces; `npm audit` **0**.
- Official React-PDF monorepo changelog reviewed (5.0.0 font-export removal, 5.1.0
  png-js swap, 5.1.1 png/table): no exposure on the repo's render paths.
- **Production PDF surfaces render clean under 5.1.1** (visually inspected):
  - Quarterly report: **byte-identical** to the 4.1.0 baseline (SHA match) — server
    render path provably unaffected.
  - K-1 summary + capital-account statement: clean multi-page renders, tables/negatives/
    footers correct.
- **Client tear-sheet (fonts + image) verified** under 5.1.1 (Inter/Poppins Type0
  subsets embed, logo renders) after a pre-existing dev-only placeholder-font bug was
  fixed in a separate PR (#1122). That bug (`font-family="Arial"` in a dev placeholder
  SVG) is upgrade-independent — its error originates in `@react-pdf/font@4.0.8`, unchanged
  by this PR.
- Determinism smoke green twice; focused server/client PDF+lp-reporting suites, full
  `npm test`, lint, typecheck — all green.

### Scope / process
- `git rev-list --count 58867790..HEAD` == 1. No renderer/report/test/app code here.
- Plan-review gate: 8 comments, all accepted. Full artifact/evidence trail in
  `wt-plan8/.claude/artifacts/wave9e-*`.
- New deps warrant the full suite: `run_full_suite=true` dispatched on the head and
  cited below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
