### PR TITLE
test(smoke): add Plan 9 GP-surface production canary (Wave 9F)

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -145,6 +145,7 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
+          PROD_SMOKE_UNGRANTED_FUND_ID: ${{ secrets.PROD_SMOKE_UNGRANTED_FUND_ID }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           RUM_ALLOWED_ORIGIN: ${{ vars.PRODUCTION_URL }}
         run: |
@@ -153,6 +154,7 @@ jobs:
           : "${METRICS_KEY:?METRICS_KEY is required}"
           : "${PROD_SMOKE_USERNAME:?PROD_SMOKE_USERNAME is required}"
           : "${PROD_SMOKE_PASSWORD:?PROD_SMOKE_PASSWORD is required}"
+          : "${PROD_SMOKE_UNGRANTED_FUND_ID:?PROD_SMOKE_UNGRANTED_FUND_ID is required}"
           : "${VERCEL_AUTOMATION_BYPASS_SECRET:?VERCEL_AUTOMATION_BYPASS_SECRET is required}"
           : "${RUM_ALLOWED_ORIGIN:?RUM_ALLOWED_ORIGIN is required}"
 
@@ -166,6 +168,7 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
+          PROD_SMOKE_UNGRANTED_FUND_ID: ${{ secrets.PROD_SMOKE_UNGRANTED_FUND_ID }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           RUM_ALLOWED_ORIGIN: ${{ vars.PRODUCTION_URL }}
         run: npx playwright test tests/smoke/production-boundaries.spec.ts --project=production --reporter=line
@@ -244,10 +247,12 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
+          PROD_SMOKE_UNGRANTED_FUND_ID: ${{ secrets.PROD_SMOKE_UNGRANTED_FUND_ID }}
         run: |
           : "${PRODUCTION_URL:?PRODUCTION_URL is required}"
           : "${HEALTH_KEY:?HEALTH_KEY is required}"
           : "${METRICS_KEY:?METRICS_KEY is required}"
           : "${PROD_SMOKE_USERNAME:?PROD_SMOKE_USERNAME is required}"
           : "${PROD_SMOKE_PASSWORD:?PROD_SMOKE_PASSWORD is required}"
+          : "${PROD_SMOKE_UNGRANTED_FUND_ID:?PROD_SMOKE_UNGRANTED_FUND_ID is required}"
           npx playwright test tests/smoke/production-boundaries.spec.ts --project=production --reporter=line

--- a/client/src/app/app-routes.tsx
+++ b/client/src/app/app-routes.tsx
@@ -43,7 +43,7 @@ export const SharedDashboard = React.lazy(() => import('@/pages/shared-dashboard
 const PipelinePage = React.lazy(() => import('@/pages/pipeline'));
 const SettingsPage = React.lazy(() => import('@/pages/settings'));
 const HelpPage = React.lazy(() => import('@/pages/help'));
-// LP Reporting (Phase 1b) -- placeholder pages
+// LP Reporting
 const LpReportingLedgerPage = React.lazy(() =>
   import('@/pages/lp-reporting').then((mod) => ({ default: mod.LpReportingLedgerPage }))
 );

--- a/tests/smoke/production-boundaries.spec.ts
+++ b/tests/smoke/production-boundaries.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIResponse } from '@playwright/test';
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test';
 
 // Authoritative post-#800/#801 deployed boundary gate.
 const PRODUCTION_URL =
@@ -7,6 +7,7 @@ const HEALTH_KEY = process.env.HEALTH_KEY ?? '';
 const METRICS_KEY = process.env.METRICS_KEY ?? '';
 const PROD_SMOKE_USERNAME = process.env.PROD_SMOKE_USERNAME ?? '';
 const PROD_SMOKE_PASSWORD = process.env.PROD_SMOKE_PASSWORD ?? '';
+const PROD_SMOKE_UNGRANTED_FUND_ID = process.env.PROD_SMOKE_UNGRANTED_FUND_ID ?? '';
 const RUM_ALLOWED_ORIGIN = process.env.RUM_ALLOWED_ORIGIN ?? '';
 const RUM_BODY = {
   name: 'LCP',
@@ -52,6 +53,21 @@ function rumProbeOrigin(): string {
 test.describe('production boundary smoke', () => {
   // SKIP: deployed boundary smoke requires an explicit production target URL.
   test.skip(!PRODUCTION_URL, 'Set PRODUCTION_URL to run deployed boundary smoke tests');
+
+  async function loginProdSmoke(request: APIRequestContext): Promise<void> {
+    const csrfResponse = await request.get(`${PRODUCTION_URL}/api/auth/csrf`);
+    expectNotSpaRewrite(csrfResponse);
+    expect(csrfResponse.status()).toBe(200);
+    const csrfBody = await expectJsonObject(csrfResponse);
+    expect(csrfBody['csrfToken']).toEqual(expect.any(String));
+
+    const loginResponse = await request.post(`${PRODUCTION_URL}/api/auth/login`, {
+      headers: { 'X-CSRF-Token': String(csrfBody['csrfToken']) },
+      data: { username: PROD_SMOKE_USERNAME, password: PROD_SMOKE_PASSWORD },
+    });
+    expectNotSpaRewrite(loginResponse);
+    expect(loginResponse.status()).toBe(200);
+  }
 
   test('public probe uses the real api health handler', async ({ request }) => {
     const response = await request.get(`${PRODUCTION_URL}/api/health`);
@@ -190,5 +206,46 @@ test.describe('production boundary smoke', () => {
     // (strict-CORS perimeter or rumOriginGuard). Non-403 schema/validation
     // responses are acceptable; verified live as 204 on 2026-06-12.
     expect(response.status()).not.toBe(403);
+  });
+
+  test('authenticated GP surface returns fund-scoped reserves evidence', async ({ request }) => {
+    // SKIP: authenticated GP canary requires dedicated production smoke credentials.
+    test.skip(
+      !PROD_SMOKE_USERNAME || !PROD_SMOKE_PASSWORD,
+      'Set PROD_SMOKE_USERNAME and PROD_SMOKE_PASSWORD to verify the GP surface canary'
+    );
+
+    await loginProdSmoke(request);
+
+    const grantedResponse = await request.get(`${PRODUCTION_URL}/api/funds/1/moic/rankings`);
+    expectNotSpaRewrite(grantedResponse);
+    expect(grantedResponse.status()).toBe(200);
+    expectContentTypeStartsWith(grantedResponse, 'application/json');
+    const grantedBody = await expectJsonObject(grantedResponse);
+    expect(grantedBody['fundId']).toBe(1);
+    // Evidence field: the reserves-MOIC provenance basis is a response literal present regardless of
+    // fund 1's data state, proving the real GP handler answered (not a SPA/error rewrite).
+    const provenance = grantedBody['provenance'] as Record<string, unknown> | undefined;
+    expect(provenance?.['metricBasis']).toBe('planned_reserves');
+  });
+
+  test('authenticated GP surface denies cross-fund access', async ({ request }) => {
+    // SKIP: cross-fund probe requires creds AND a real fund the smoke partner is not granted.
+    test.skip(
+      !PROD_SMOKE_USERNAME || !PROD_SMOKE_PASSWORD || !PROD_SMOKE_UNGRANTED_FUND_ID,
+      'Set PROD_SMOKE_USERNAME, PROD_SMOKE_PASSWORD, and PROD_SMOKE_UNGRANTED_FUND_ID (a real fund the smoke partner is not granted)'
+    );
+
+    await loginProdSmoke(request);
+
+    const ungrantedResponse = await request.get(
+      `${PRODUCTION_URL}/api/funds/${PROD_SMOKE_UNGRANTED_FUND_ID}/moic/rankings`
+    );
+    expectNotSpaRewrite(ungrantedResponse);
+    expect(ungrantedResponse.status()).toBe(403);
+    expectContentTypeStartsWith(ungrantedResponse, 'application/json');
+    const ungrantedBody = await expectJsonObject(ungrantedResponse);
+    expect(ungrantedBody['error']).toBe('Forbidden');
+    expect(String(ungrantedBody['message'])).toContain('do not have access to fund');
   });
 });


### PR DESCRIPTION
## Wave 9F — production closure smoke + narrow docs prune

Final closure wave of Plan 9 (Integrated GP Workspace + Reporting Qualification). Waves 9A-9E are
merged; this adds the one delta the **9F0 read-only audit** proved missing, plus the one
demonstrably-stale comment. Flow: Claude planned + reviewed, Codex implemented (Hermes production
lane), Claude verified. Scale = ~5-user internal tool (KISS/YAGNI — the original 5-surface 200/403
matrix was cut as duplication; 9C E2E proves the integrated flow, 9D proves export authz).

### Changes (3 files, +64/-2)
1. **`tests/smoke/production-boundaries.spec.ts`** — two authenticated GP canary tests appended to
   the existing release-owned smoke (reusing its CSRF -> `/api/auth/login` flow):
   - *granted-fund evidence read*: `GET /api/funds/1/moic/rankings` -> 200 +
     `provenance.metricBasis === 'planned_reserves'` (a response literal, so the assertion holds
     regardless of fund 1's data state — it proves the real GP handler answered, not a SPA/error
     rewrite).
   - *cross-fund denial*: same route for an ungranted fund -> 403 with the fund-access guard's exact
     `{ error: 'Forbidden', message: '...do not have access to fund...' }` body. Asserting the body
     (not just the status) rules out an infra/CORS 403 and makes an over-privileged admin smoke user
     (who would get 200) fail loudly — so this leg is also the non-admin/fund-scope guard.
2. **`.github/workflows/release-production.yml`** — wire `secrets.PROD_SMOKE_UNGRANTED_FUND_ID` into
   both smoke jobs (`staged-smoke` + `post-promotion-smoke`) and **hard-require it** in each
   credential gate, so a release run cannot go vacuously green without the genuine cross-fund proof.
3. **`client/src/app/app-routes.tsx:46`** — prune the stale
   `// LP Reporting (Phase 1b) -- placeholder pages` comment to `// LP Reporting`.
   **Archive-gate evidence:** the pages are fully live — `client/src/pages/lp-reporting/metrics.tsx:4`
   records "Replaces the 1b.1 placeholder"; the four pages implement the full metric-run pipeline.
   Historical "Phase 1b.N" labels elsewhere are left intact (not stale — pruning them would be churn).

### Verification
- `npm run check` — 0 new TypeScript errors (client/server/shared).
- `npx playwright test tests/smoke/production-boundaries.spec.ts --list` — both new tests compile
  and list (exit 0). The smoke is release-owned (runs in `release-production.yml`, not PR CI); it
  `test.skip`s without `PROD_SMOKE_*`, so it is inert on this PR by design.
- Two adversarial `codex exec` reviews (Plan Review Gate on the spec + auth-seam review on the
  applied diff); all valid findings addressed (403-vs-404 rationale, Playwright `test.skip`
  semantics -> two tests, `secrets.*` source, ambiguous-403 body assertion, vacuous-green secret
  requirement).

### Closure is owner-gated and NOT in this PR
The 9F0 audit found prod is promoted at `f11f8d65` (2026-07-13), **6 commits behind** main, and its
schema lacks migrations **0033 + 0034** (landed 2026-07-15, additive-safe). Plan 9 closes only after,
post-merge:
1. Dispatch **`prod-schema-reconcile.yml` (mode=apply, expected_sha=post-merge main)** -> applies
   0033/0034 to prod.
2. Dispatch **`release-production.yml` (expected_sha=post-merge main)** -> schema audit clean, stage,
   staged-smoke (with this canary), promote, post-promotion-smoke (with this canary).
Both are Production-gated. Set the `PROD_SMOKE_UNGRANTED_FUND_ID` secret first (a real prod fund the
smoke partner is not granted). Full audit: `.claude/artifacts/plan9-9f0-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
