### PR TITLE
test(smoke): drop cross-fund isolation canary (internal universal-read model)

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -145,7 +145,6 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
-          PROD_SMOKE_UNGRANTED_FUND_ID: ${{ secrets.PROD_SMOKE_UNGRANTED_FUND_ID }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           RUM_ALLOWED_ORIGIN: ${{ vars.PRODUCTION_URL }}
         run: |
@@ -154,7 +153,6 @@ jobs:
           : "${METRICS_KEY:?METRICS_KEY is required}"
           : "${PROD_SMOKE_USERNAME:?PROD_SMOKE_USERNAME is required}"
           : "${PROD_SMOKE_PASSWORD:?PROD_SMOKE_PASSWORD is required}"
-          : "${PROD_SMOKE_UNGRANTED_FUND_ID:?PROD_SMOKE_UNGRANTED_FUND_ID is required}"
           : "${VERCEL_AUTOMATION_BYPASS_SECRET:?VERCEL_AUTOMATION_BYPASS_SECRET is required}"
           : "${RUM_ALLOWED_ORIGIN:?RUM_ALLOWED_ORIGIN is required}"
 
@@ -168,7 +166,6 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
-          PROD_SMOKE_UNGRANTED_FUND_ID: ${{ secrets.PROD_SMOKE_UNGRANTED_FUND_ID }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           RUM_ALLOWED_ORIGIN: ${{ vars.PRODUCTION_URL }}
         run: npx playwright test tests/smoke/production-boundaries.spec.ts --project=production --reporter=line
@@ -247,12 +244,10 @@ jobs:
           METRICS_KEY: ${{ secrets.METRICS_KEY }}
           PROD_SMOKE_USERNAME: ${{ secrets.PROD_SMOKE_USERNAME }}
           PROD_SMOKE_PASSWORD: ${{ secrets.PROD_SMOKE_PASSWORD }}
-          PROD_SMOKE_UNGRANTED_FUND_ID: ${{ secrets.PROD_SMOKE_UNGRANTED_FUND_ID }}
         run: |
           : "${PRODUCTION_URL:?PRODUCTION_URL is required}"
           : "${HEALTH_KEY:?HEALTH_KEY is required}"
           : "${METRICS_KEY:?METRICS_KEY is required}"
           : "${PROD_SMOKE_USERNAME:?PROD_SMOKE_USERNAME is required}"
           : "${PROD_SMOKE_PASSWORD:?PROD_SMOKE_PASSWORD is required}"
-          : "${PROD_SMOKE_UNGRANTED_FUND_ID:?PROD_SMOKE_UNGRANTED_FUND_ID is required}"
           npx playwright test tests/smoke/production-boundaries.spec.ts --project=production --reporter=line

--- a/tests/smoke/production-boundaries.spec.ts
+++ b/tests/smoke/production-boundaries.spec.ts
@@ -7,7 +7,6 @@ const HEALTH_KEY = process.env.HEALTH_KEY ?? '';
 const METRICS_KEY = process.env.METRICS_KEY ?? '';
 const PROD_SMOKE_USERNAME = process.env.PROD_SMOKE_USERNAME ?? '';
 const PROD_SMOKE_PASSWORD = process.env.PROD_SMOKE_PASSWORD ?? '';
-const PROD_SMOKE_UNGRANTED_FUND_ID = process.env.PROD_SMOKE_UNGRANTED_FUND_ID ?? '';
 const RUM_ALLOWED_ORIGIN = process.env.RUM_ALLOWED_ORIGIN ?? '';
 const RUM_BODY = {
   name: 'LCP',
@@ -208,7 +207,7 @@ test.describe('production boundary smoke', () => {
     expect(response.status()).not.toBe(403);
   });
 
-  test('authenticated GP surface returns fund-scoped reserves evidence', async ({ request }) => {
+  test('authenticated GP surface returns reserves evidence', async ({ request }) => {
     // SKIP: authenticated GP canary requires dedicated production smoke credentials.
     test.skip(
       !PROD_SMOKE_USERNAME || !PROD_SMOKE_PASSWORD,
@@ -227,25 +226,5 @@ test.describe('production boundary smoke', () => {
     // fund 1's data state, proving the real GP handler answered (not a SPA/error rewrite).
     const provenance = grantedBody['provenance'] as Record<string, unknown> | undefined;
     expect(provenance?.['metricBasis']).toBe('planned_reserves');
-  });
-
-  test('authenticated GP surface denies cross-fund access', async ({ request }) => {
-    // SKIP: cross-fund probe requires creds AND a real fund the smoke partner is not granted.
-    test.skip(
-      !PROD_SMOKE_USERNAME || !PROD_SMOKE_PASSWORD || !PROD_SMOKE_UNGRANTED_FUND_ID,
-      'Set PROD_SMOKE_USERNAME, PROD_SMOKE_PASSWORD, and PROD_SMOKE_UNGRANTED_FUND_ID (a real fund the smoke partner is not granted)'
-    );
-
-    await loginProdSmoke(request);
-
-    const ungrantedResponse = await request.get(
-      `${PRODUCTION_URL}/api/funds/${PROD_SMOKE_UNGRANTED_FUND_ID}/moic/rankings`
-    );
-    expectNotSpaRewrite(ungrantedResponse);
-    expect(ungrantedResponse.status()).toBe(403);
-    expectContentTypeStartsWith(ungrantedResponse, 'application/json');
-    const ungrantedBody = await expectJsonObject(ungrantedResponse);
-    expect(ungrantedBody['error']).toBe('Forbidden');
-    expect(String(ungrantedBody['message'])).toContain('do not have access to fund');
   });
 });


### PR DESCRIPTION
Follow-up to #1127. The internal access model is **universal read for team members** — fund-level read isolation between team members is not wanted (only writes are role-gated). The cross-fund 403 canary asserted that unwanted boundary, so this removes it and the `PROD_SMOKE_UNGRANTED_FUND_ID` secret wiring from both smoke jobs.

Kept: the authenticated GP reserves-evidence read (`GET /api/funds/1/moic/rankings` -> 200 + `provenance.metricBasis==='planned_reserves'`), which proves a team member can read fund data against the deployed target.

Net effect: the closure no longer needs the `PROD_SMOKE_UNGRANTED_FUND_ID` secret. Role-gated writes (the boundary the team actually wants) are delivered in a separate PR.

Verify: `git diff` = 2 files, removals only; `npx playwright test tests/smoke/production-boundaries.spec.ts --list` compiles (1 GP test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)