### PR TITLE
feat(auth): role-gate fund-config and scenario write routes

### DIFF
--- a/server/lib/auth/jwt.ts
+++ b/server/lib/auth/jwt.ts
@@ -317,6 +317,15 @@ export const requireAnyRole =
     next();
   };
 
+// Reads the granular role from whichever auth entrypoint populated it:
+// makeApp -> req.user.role ; createServer/dev/Docker -> req.context.role.
+export const requireWriteRole =
+  (roles: readonly string[]) => (req: Request, res: Response, next: NextFunction) => {
+    const role = req.user?.role ?? req.context?.role;
+    if (typeof role !== 'string' || !roles.includes(role)) return res.sendStatus(403);
+    next();
+  };
+
 /**
  * Require user to have access to a specific fund
  * Use after requireAuth to check fund-level permissions

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -981,7 +981,7 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
       '/api/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed'
     ),
     financialSurface: 'fund_modeling',
-    apiAuthBoundary: 'require_auth_and_fund_access',
+    apiAuthBoundary: 'require_auth_fund_access_and_role',
     fundScopeMode: 'route_param_fund_id',
     workflowRequirement: 'fund_scope_and_optimistic_lock_verified',
     exportPolicy: 'not_exportable',

--- a/server/routes/allocation-scenarios.ts
+++ b/server/routes/allocation-scenarios.ts
@@ -23,6 +23,10 @@ import { sendBodyValidationError } from '../lib/validation-response.js';
 import { parseFundIdParam } from '@shared/number';
 import { firstString } from '../lib/request-values';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { requireWriteRole } from '../lib/auth/jwt.js';
+
+const WRITE_CONFIG_ROLES = ['partner', 'admin'] as const;
+const WRITE_SCENARIO_ROLES = ['partner', 'admin', 'analyst'] as const;
 
 interface HttpError extends Error {
   statusCode?: number;
@@ -456,6 +460,7 @@ router.get(
 
 router.post(
   '/funds/:fundId/allocation-scenarios',
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   routeHandler(async (req: Request, res: Response) => {
     const route = parseFundRoute(req, res);
     if (!route) {
@@ -479,6 +484,7 @@ router.post(
 
 router.post(
   '/funds/:fundId/allocation-scenarios/:scenarioId/decisions',
+  requireWriteRole(WRITE_CONFIG_ROLES),
   routeHandler(async (req: Request, res: Response) => {
     const route = parseScenarioRoute(req, res);
     if (!route) {
@@ -506,6 +512,7 @@ router.post(
 
 router.patch(
   '/funds/:fundId/allocation-scenarios/:scenarioId',
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   routeHandler(async (req: Request, res: Response) => {
     const route = parseScenarioRoute(req, res);
     if (!route) {
@@ -529,6 +536,7 @@ router.patch(
 
 router.patch(
   '/funds/:fundId/allocation-scenarios/:scenarioId/decisions/:decisionId',
+  requireWriteRole(WRITE_CONFIG_ROLES),
   routeHandler(async (req: Request, res: Response) => {
     const route = parseDecisionRoute(req, res);
     if (!route) {
@@ -557,6 +565,7 @@ router.patch(
 
 router.post(
   '/funds/:fundId/allocation-scenarios/:scenarioId/sync',
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   routeHandler(async (req: Request, res: Response) => {
     const route = parseScenarioRoute(req, res);
     if (!route) {
@@ -583,6 +592,7 @@ router.post(
 
 router.post(
   '/funds/:fundId/allocation-scenarios/:scenarioId/apply',
+  requireWriteRole(WRITE_CONFIG_ROLES),
   routeHandler(async (req: Request, res: Response) => {
     const route = parseScenarioRoute(req, res);
     if (!route) {

--- a/server/routes/fund-config.ts
+++ b/server/routes/fund-config.ts
@@ -8,8 +8,10 @@ import { toNumber } from '@shared/number';
 import { getQueueConnectionOptions, getQueueConfig } from '../config/features';
 import { registerQueueRuntime } from '../queues/registry';
 import { createRouteLogger } from '../lib/route-logger.js';
+import { requireWriteRole } from '../lib/auth/jwt.js';
 
 const routeLog = createRouteLogger('fund-config');
+const WRITE_CONFIG_ROLES = ['partner', 'admin'] as const;
 
 const queueConfig = getQueueConfig();
 const connection = (() => {
@@ -50,7 +52,6 @@ function ensureProducerQueuesRegistered(): void {
     });
   }
 }
-
 import { FundDraftWriteV1Schema } from '@shared/contracts/fund-draft-write-v1.contract';
 import { sendApiError } from '../lib/apiError';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
@@ -95,174 +96,183 @@ export function registerFundConfigRoutes(app: Express) {
   ensureProducerQueuesRegistered();
 
   // Atomic finalize: create fund + save config + publish in one call
-  app.post('/api/funds/finalize', idempotency, async (req: Request, res: Response) => {
-    try {
-      const { FundFinalizeV1Schema: Schema } =
-        await import('@shared/contracts/fund-finalize-v1.contract');
-      const validation = Schema.safeParse(req.body);
-      if (!validation.success) {
-        return sendApiError(res, 400, {
-          error: 'Finalize payload is invalid',
-          code: 'FINALIZE_VALIDATION_ERROR',
-          issues: validation.error.issues.map((i) => ({ path: i.path, message: i.message })),
+  app.post(
+    '/api/funds/finalize',
+    requireWriteRole(WRITE_CONFIG_ROLES),
+    idempotency,
+    async (req: Request, res: Response) => {
+      try {
+        const { FundFinalizeV1Schema: Schema } =
+          await import('@shared/contracts/fund-finalize-v1.contract');
+        const validation = Schema.safeParse(req.body);
+        if (!validation.success) {
+          return sendApiError(res, 400, {
+            error: 'Finalize payload is invalid',
+            code: 'FINALIZE_VALIDATION_ERROR',
+            issues: validation.error.issues.map((i) => ({ path: i.path, message: i.message })),
+          });
+        }
+
+        const draftFundId = validation.data.draftFundId;
+        if (draftFundId != null && !(await enforceProvidedFundScope(req, res, draftFundId))) {
+          return;
+        }
+
+        const { fundPersistenceService } = await import('../services/fund-persistence-service');
+        const result = await fundPersistenceService.finalize(validation.data, {
+          reserve: reserveQueue,
+          pacing: pacingQueue,
+          cohort: cohortQueue,
         });
-      }
 
-      const draftFundId = validation.data.draftFundId;
-      if (draftFundId != null && !(await enforceProvidedFundScope(req, res, draftFundId))) {
-        return;
-      }
-
-      const { fundPersistenceService } = await import('../services/fund-persistence-service');
-      const result = await fundPersistenceService.finalize(validation.data, {
-        reserve: reserveQueue,
-        pacing: pacingQueue,
-        cohort: cohortQueue,
-      });
-
-      res.status(201).json({
-        success: true as const,
-        data: result,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === 'NoActiveDraftForFinalizeError') {
-        return sendApiError(res, 409, {
-          error: error.message,
-          code: 'NO_ACTIVE_DRAFT',
+        res.status(201).json({
+          success: true as const,
+          data: result,
         });
-      }
+      } catch (error) {
+        if (error instanceof Error && error.name === 'NoActiveDraftForFinalizeError') {
+          return sendApiError(res, 409, {
+            error: error.message,
+            code: 'NO_ACTIVE_DRAFT',
+          });
+        }
 
-      routeLog.error('Finalize error:', error);
-      const apiError: ApiError = {
-        error: 'Failed to finalize fund',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      };
-      res.status(500).json(apiError);
+        routeLog.error('Finalize error:', error);
+        const apiError: ApiError = {
+          error: 'Failed to finalize fund',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        };
+        res.status(500).json(apiError);
+      }
     }
-  });
+  );
 
   // Save draft configuration (upsert: UPDATE if draft exists, INSERT if not)
-  app.put('/api/funds/:id/draft', async (req: Request, res: Response) => {
-    try {
-      const fundId = await getScopedFundId(req, res);
-      if (fundId === null) {
-        return;
-      }
+  app.put(
+    '/api/funds/:id/draft',
+    requireWriteRole(WRITE_CONFIG_ROLES),
+    async (req: Request, res: Response) => {
+      try {
+        const fundId = await getScopedFundId(req, res);
+        if (fundId === null) {
+          return;
+        }
 
-      // Validate with strict FundDraftWriteV1Schema (rejects unknown keys)
-      const validation = FundDraftWriteV1Schema.safeParse(req.body);
-      if (!validation.success) {
-        return sendApiError(res, 400, {
-          error: 'Draft configuration is invalid',
-          code: 'DRAFT_VALIDATION_ERROR',
-          issues: validation.error.issues.map((i) => ({ path: i.path, message: i.message })),
-        });
-      }
+        // Validate with strict FundDraftWriteV1Schema (rejects unknown keys)
+        const validation = FundDraftWriteV1Schema.safeParse(req.body);
+        if (!validation.success) {
+          return sendApiError(res, 400, {
+            error: 'Draft configuration is invalid',
+            code: 'DRAFT_VALIDATION_ERROR',
+            issues: validation.error.issues.map((i) => ({ path: i.path, message: i.message })),
+          });
+        }
 
-      // Check if fund exists
-      const [fund] = await db.select().from(funds).where(eq(funds.id, fundId)).limit(1);
+        // Check if fund exists
+        const [fund] = await db.select().from(funds).where(eq(funds.id, fundId)).limit(1);
 
-      if (!fund) {
-        const error: ApiError = {
-          error: 'Fund not found',
-          message: `No fund exists with ID: ${fundId}`,
-        };
-        return res.status(404).json(error);
-      }
+        if (!fund) {
+          const error: ApiError = {
+            error: 'Fund not found',
+            message: `No fund exists with ID: ${fundId}`,
+          };
+          return res.status(404).json(error);
+        }
 
-      // Draft-safe upsert: UPDATE existing draft if found, INSERT if not
-      const [existingDraft] = await db
-        .select()
-        .from(fundConfigs)
-        .where(and(eq(fundConfigs.fundId, fundId), eq(fundConfigs.isDraft, true)))
-        .orderBy(desc(fundConfigs.version))
-        .limit(1);
-
-      const gatedConfig = omitEconomicsAssumptionsWhenDisabled(validation.data);
-      const fieldCount = Object.keys(gatedConfig).length;
-      let savedConfig;
-
-      if (existingDraft) {
-        const priorFieldCount = existingDraft.config
-          ? Object.keys(existingDraft.config as Record<string, unknown>).length
-          : 0;
-        routeLog.warn('draft-save', { fundId, fieldCount, priorFieldCount });
-
-        const updateValues: Partial<typeof fundConfigs.$inferInsert> = {
-          config: gatedConfig,
-          updatedAt: new Date(),
-        };
-        const [updated] = await db
-          .update(fundConfigs)
-          .set(updateValues)
-          .where(eq(fundConfigs.id, existingDraft.id))
-          .returning();
-        savedConfig = updated;
-      } else {
-        // No active draft: allocate next version (MAX(version)+1)
-        const [versionResult] = await db
-          .select({ maxVersion: max(fundConfigs.version) })
+        // Draft-safe upsert: UPDATE existing draft if found, INSERT if not
+        const [existingDraft] = await db
+          .select()
           .from(fundConfigs)
-          .where(eq(fundConfigs.fundId, fundId));
-        const nextVersion = (versionResult?.maxVersion ?? 0) + 1;
+          .where(and(eq(fundConfigs.fundId, fundId), eq(fundConfigs.isDraft, true)))
+          .orderBy(desc(fundConfigs.version))
+          .limit(1);
 
-        routeLog.warn('draft-save', { fundId, fieldCount, nextVersion });
+        const gatedConfig = omitEconomicsAssumptionsWhenDisabled(validation.data);
+        const fieldCount = Object.keys(gatedConfig).length;
+        let savedConfig;
 
-        try {
-          const [inserted] = await db
-            .insert(fundConfigs)
-            .values({
-              fundId,
-              version: nextVersion,
-              config: gatedConfig,
-            })
+        if (existingDraft) {
+          const priorFieldCount = existingDraft.config
+            ? Object.keys(existingDraft.config as Record<string, unknown>).length
+            : 0;
+          routeLog.warn('draft-save', { fundId, fieldCount, priorFieldCount });
+
+          const updateValues: Partial<typeof fundConfigs.$inferInsert> = {
+            config: gatedConfig,
+            updatedAt: new Date(),
+          };
+          const [updated] = await db
+            .update(fundConfigs)
+            .set(updateValues)
+            .where(eq(fundConfigs.id, existingDraft.id))
             .returning();
-          savedConfig = inserted;
-        } catch (insertErr) {
-          // Unique constraint race: retry as UPDATE targeting isDraft=true
-          const [retryDraft] = await db
-            .select()
+          savedConfig = updated;
+        } else {
+          // No active draft: allocate next version (MAX(version)+1)
+          const [versionResult] = await db
+            .select({ maxVersion: max(fundConfigs.version) })
             .from(fundConfigs)
-            .where(and(eq(fundConfigs.fundId, fundId), eq(fundConfigs.isDraft, true)))
-            .limit(1);
-          if (retryDraft) {
-            const retryValues: Partial<typeof fundConfigs.$inferInsert> = {
-              config: gatedConfig,
-              updatedAt: new Date(),
-            };
-            const [updated] = await db
-              .update(fundConfigs)
-              .set(retryValues)
-              .where(eq(fundConfigs.id, retryDraft.id))
+            .where(eq(fundConfigs.fundId, fundId));
+          const nextVersion = (versionResult?.maxVersion ?? 0) + 1;
+
+          routeLog.warn('draft-save', { fundId, fieldCount, nextVersion });
+
+          try {
+            const [inserted] = await db
+              .insert(fundConfigs)
+              .values({
+                fundId,
+                version: nextVersion,
+                config: gatedConfig,
+              })
               .returning();
-            savedConfig = updated;
-          } else {
-            throw insertErr;
+            savedConfig = inserted;
+          } catch (insertErr) {
+            // Unique constraint race: retry as UPDATE targeting isDraft=true
+            const [retryDraft] = await db
+              .select()
+              .from(fundConfigs)
+              .where(and(eq(fundConfigs.fundId, fundId), eq(fundConfigs.isDraft, true)))
+              .limit(1);
+            if (retryDraft) {
+              const retryValues: Partial<typeof fundConfigs.$inferInsert> = {
+                config: gatedConfig,
+                updatedAt: new Date(),
+              };
+              const [updated] = await db
+                .update(fundConfigs)
+                .set(retryValues)
+                .where(eq(fundConfigs.id, retryDraft.id))
+                .returning();
+              savedConfig = updated;
+            } else {
+              throw insertErr;
+            }
           }
         }
+
+        // Log event
+        await db.insert(fundEvents).values({
+          fundId,
+          eventType: 'DRAFT_SAVED',
+          eventTime: new Date(),
+        });
+
+        res.json({
+          success: true,
+          data: savedConfig,
+          message: 'Draft saved successfully',
+        });
+      } catch (error) {
+        routeLog.error('Draft save error:', error);
+        const apiError: ApiError = {
+          error: 'Failed to save draft',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        };
+        res.status(500).json(apiError);
       }
-
-      // Log event
-      await db.insert(fundEvents).values({
-        fundId,
-        eventType: 'DRAFT_SAVED',
-        eventTime: new Date(),
-      });
-
-      res.json({
-        success: true,
-        data: savedConfig,
-        message: 'Draft saved successfully',
-      });
-    } catch (error) {
-      routeLog.error('Draft save error:', error);
-      const apiError: ApiError = {
-        error: 'Failed to save draft',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      };
-      res.status(500).json(apiError);
     }
-  });
+  );
 
   // Get latest draft
   app['get']('/api/funds/:id/draft', async (req: Request, res: Response) => {
@@ -298,100 +308,108 @@ export function registerFundConfigRoutes(app: Express) {
   });
 
   // Publish configuration (delegates to FundPersistenceService)
-  app.post('/api/funds/:id/publish', async (req: Request, res: Response) => {
-    try {
-      const fundId = await getScopedFundId(req, res);
-      if (fundId === null) {
-        return;
-      }
+  app.post(
+    '/api/funds/:id/publish',
+    requireWriteRole(WRITE_CONFIG_ROLES),
+    async (req: Request, res: Response) => {
+      try {
+        const fundId = await getScopedFundId(req, res);
+        if (fundId === null) {
+          return;
+        }
 
-      const userId = optionalNumericUserId(req);
+        const userId = optionalNumericUserId(req);
 
-      const { fundPersistenceService } = await import('../services/fund-persistence-service');
-      const result = await fundPersistenceService.publishDraft(
-        fundId,
-        { reserve: reserveQueue, pacing: pacingQueue, cohort: cohortQueue },
-        userId
-      );
+        const { fundPersistenceService } = await import('../services/fund-persistence-service');
+        const result = await fundPersistenceService.publishDraft(
+          fundId,
+          { reserve: reserveQueue, pacing: pacingQueue, cohort: cohortQueue },
+          userId
+        );
 
-      res.json({
-        success: true,
-        data: result.published,
-        message: 'Configuration published and calculations started',
-        correlationId: result.correlationId,
-        runId: result.run.id,
-        dispatchState: result.run.dispatchState,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.message === 'No draft to publish') {
-        const apiError: ApiError = {
-          error: 'No draft to publish',
-          message: 'Create a draft configuration first',
-        };
-        return res.status(400).json(apiError);
-      }
-      if (error instanceof Error && error.name === 'ModelInputsAsOfDateRequiredError') {
-        return sendApiError(res, 422, {
-          error: error.message,
-          code: 'MODEL_INPUTS_AS_OF_DATE_REQUIRED',
+        res.json({
+          success: true,
+          data: result.published,
+          message: 'Configuration published and calculations started',
+          correlationId: result.correlationId,
+          runId: result.run.id,
+          dispatchState: result.run.dispatchState,
         });
+      } catch (error) {
+        if (error instanceof Error && error.message === 'No draft to publish') {
+          const apiError: ApiError = {
+            error: 'No draft to publish',
+            message: 'Create a draft configuration first',
+          };
+          return res.status(400).json(apiError);
+        }
+        if (error instanceof Error && error.name === 'ModelInputsAsOfDateRequiredError') {
+          return sendApiError(res, 422, {
+            error: error.message,
+            code: 'MODEL_INPUTS_AS_OF_DATE_REQUIRED',
+          });
+        }
+        routeLog.error('Publish error:', error);
+        const apiError: ApiError = {
+          error: 'Failed to publish configuration',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        };
+        res.status(500).json(apiError);
       }
-      routeLog.error('Publish error:', error);
-      const apiError: ApiError = {
-        error: 'Failed to publish configuration',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      };
-      res.status(500).json(apiError);
     }
-  });
+  );
 
   // Recalculate published configuration
-  app.post('/api/funds/:id/recalculate', async (req: Request, res: Response) => {
-    try {
-      const fundId = await getScopedFundId(req, res);
-      if (fundId === null) {
-        return;
-      }
+  app.post(
+    '/api/funds/:id/recalculate',
+    requireWriteRole(WRITE_CONFIG_ROLES),
+    async (req: Request, res: Response) => {
+      try {
+        const fundId = await getScopedFundId(req, res);
+        if (fundId === null) {
+          return;
+        }
 
-      const userId = optionalNumericUserId(req);
+        const userId = optionalNumericUserId(req);
 
-      const { fundPersistenceService } = await import('../services/fund-persistence-service');
+        const { fundPersistenceService } = await import('../services/fund-persistence-service');
 
-      const result = await fundPersistenceService.recalculatePublished(
-        fundId,
-        { reserve: reserveQueue, pacing: pacingQueue, cohort: cohortQueue },
-        userId
-      );
+        const result = await fundPersistenceService.recalculatePublished(
+          fundId,
+          { reserve: reserveQueue, pacing: pacingQueue, cohort: cohortQueue },
+          userId
+        );
 
-      res.json({
-        success: true,
-        correlationId: result.correlationId,
-        runId: result.run.id,
-        dispatchState: result.run.dispatchState,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === 'NoPublishedConfigError') {
+        res.json({
+          success: true,
+          correlationId: result.correlationId,
+          runId: result.run.id,
+          dispatchState: result.run.dispatchState,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.name === 'NoPublishedConfigError') {
+          const apiError: ApiError = {
+            error: 'No published configuration',
+            message: 'Publish a configuration first',
+          };
+          return res.status(400).json(apiError);
+        }
+        if (error instanceof Error && error.name === 'CalculationInProgressError') {
+          const apiError: ApiError = {
+            error: 'Calculation already in progress',
+            message: 'Wait for the current calculation to complete',
+          };
+          return res.status(409).json(apiError);
+        }
+        routeLog.error('Recalculate error:', error);
         const apiError: ApiError = {
-          error: 'No published configuration',
-          message: 'Publish a configuration first',
+          error: 'Failed to recalculate',
+          message: error instanceof Error ? error.message : 'Unknown error',
         };
-        return res.status(400).json(apiError);
+        res.status(500).json(apiError);
       }
-      if (error instanceof Error && error.name === 'CalculationInProgressError') {
-        const apiError: ApiError = {
-          error: 'Calculation already in progress',
-          message: 'Wait for the current calculation to complete',
-        };
-        return res.status(409).json(apiError);
-      }
-      routeLog.error('Recalculate error:', error);
-      const apiError: ApiError = {
-        error: 'Failed to recalculate',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      };
-      res.status(500).json(apiError);
     }
-  });
+  );
 
   // Get fund reserves (from snapshots)
   app['get']('/api/funds/:id/reserves', async (req: Request, res: Response) => {

--- a/server/routes/fund-scenario-sets.ts
+++ b/server/routes/fund-scenario-sets.ts
@@ -9,7 +9,7 @@ import {
   FundScenarioReserveCalculationRequestV1Schema,
 } from '@shared/contracts/fund-scenario-sets-v1.contract';
 import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
-import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
+import { requireAuth, requireFundAccess, requireWriteRole } from '../lib/auth/jwt.js';
 import { firstString } from '../lib/request-values.js';
 import { sendBodyValidationError } from '../lib/validation-response.js';
 import {
@@ -40,6 +40,8 @@ const scenarioSetReadLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+const WRITE_SCENARIO_ROLES = ['partner', 'admin', 'analyst'] as const;
 
 interface HttpError extends Error {
   statusCode?: number;
@@ -181,6 +183,7 @@ router.post(
   '/funds/:fundId/scenario-sets',
   scenarioSetWriteLimiter,
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
     const fundId = parseFundId(req, res);
@@ -205,6 +208,7 @@ router.post(
   '/funds/:fundId/scenario-sets/reserve-optimization',
   scenarioSetWriteLimiter,
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
     const fundId = parseFundId(req, res);
@@ -232,6 +236,7 @@ router.post(
   '/funds/:fundId/scenario-sets/:scenarioSetId/calculate',
   scenarioSetWriteLimiter,
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
     const fundId = parseFundId(req, res);
@@ -249,6 +254,7 @@ router.post(
   '/funds/:fundId/scenario-sets/:scenarioSetId/calculate-reserve',
   scenarioSetWriteLimiter,
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
     const fundId = parseFundId(req, res);
@@ -334,6 +340,7 @@ router.post(
   '/funds/:fundId/scenario-sets/:scenarioSetId/archive',
   scenarioSetWriteLimiter,
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   requireFundAccess,
   routeHandler(async (req: Request, res: Response) => {
     const fundId = parseFundId(req, res);

--- a/server/routes/scenario-analysis.ts
+++ b/server/routes/scenario-analysis.ts
@@ -33,7 +33,7 @@ import {
   addMOICToCases,
 } from '@shared/utils/scenario-math';
 import type { ScenarioCase } from '@shared/types/scenario';
-import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
+import { requireAuth, requireFundAccess, requireWriteRole } from '../lib/auth/jwt.js';
 import { FEATURES } from '../config/features.js';
 import { firstString } from '../lib/request-values';
 import { createRouteLogger } from '../lib/route-logger.js';
@@ -55,6 +55,7 @@ import {
 } from '../services/scenarios/company-scenario-create-service';
 
 const routeLog = createRouteLogger('scenario-analysis');
+const WRITE_SCENARIO_ROLES = ['partner', 'admin', 'analyst'] as const;
 
 const router = Router();
 
@@ -425,6 +426,7 @@ router['get'](
 router['post'](
   '/funds/:fundId/scenario-analysis/scenarios/:scenarioId/cases/from-seed',
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   validateScenarioSeedFundId,
   requireFundAccess,
   validateScenarioIdParam,
@@ -751,6 +753,7 @@ router['get'](
 router['post'](
   '/companies/:companyId/scenarios',
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   extractUserId,
   async (req: Request, res: Response) => {
     try {
@@ -826,6 +829,7 @@ router['post'](
 router['patch'](
   '/companies/:companyId/scenarios/:scenarioId',
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   extractUserId,
   async (req: Request, res: Response) => {
     try {
@@ -977,6 +981,7 @@ router['patch'](
 router['delete'](
   '/companies/:companyId/scenarios/:scenarioId',
   requireAuth(),
+  requireWriteRole(WRITE_SCENARIO_ROLES),
   extractUserId,
   async (req: Request, res: Response) => {
     try {

--- a/tests/unit/auth/write-route-role-gating.test.ts
+++ b/tests/unit/auth/write-route-role-gating.test.ts
@@ -1,0 +1,315 @@
+import express from 'express';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const TARGET_FUND_ID = 1;
+const ROLES = ['viewer', 'operator', 'service', 'analyst', 'partner', 'admin'] as const;
+
+type Role = (typeof ROLES)[number];
+type RoleSet = 'config' | 'scenario';
+type RouteMethod = 'delete' | 'patch' | 'post' | 'put';
+
+interface GatedRoute {
+  name: string;
+  method: RouteMethod;
+  path: string;
+  roleSet: RoleSet;
+}
+
+const GATED_ROUTES: readonly GatedRoute[] = [
+  {
+    name: 'finalize fund configuration',
+    method: 'post',
+    path: '/api/funds/finalize',
+    roleSet: 'config',
+  },
+  {
+    name: 'save fund configuration draft',
+    method: 'put',
+    path: '/api/funds/not-a-number/draft',
+    roleSet: 'config',
+  },
+  {
+    name: 'publish fund configuration',
+    method: 'post',
+    path: '/api/funds/not-a-number/publish',
+    roleSet: 'config',
+  },
+  {
+    name: 'recalculate fund configuration',
+    method: 'post',
+    path: '/api/funds/not-a-number/recalculate',
+    roleSet: 'config',
+  },
+  {
+    name: 'create fund scenario set',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/scenario-sets`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'create reserve optimization scenario set',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/scenario-sets/reserve-optimization`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'calculate fund scenario set',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/scenario-sets/not-a-uuid/calculate`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'calculate reserve fund scenario set',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/scenario-sets/not-a-uuid/calculate-reserve`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'archive fund scenario set',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/scenario-sets/not-a-uuid/archive`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'create scenario case from seed',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/scenario-analysis/scenarios/not-a-uuid/cases/from-seed`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'create company scenario',
+    method: 'post',
+    path: '/api/companies/not-a-number/scenarios',
+    roleSet: 'scenario',
+  },
+  {
+    name: 'update company scenario',
+    method: 'patch',
+    path: '/api/companies/not-a-number/scenarios/not-a-uuid',
+    roleSet: 'scenario',
+  },
+  {
+    name: 'delete company scenario',
+    method: 'delete',
+    path: '/api/companies/not-a-number/scenarios/not-a-uuid',
+    roleSet: 'scenario',
+  },
+  {
+    name: 'create allocation scenario',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/allocation-scenarios`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'create allocation scenario decision',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/allocation-scenarios/not-a-uuid/decisions`,
+    roleSet: 'config',
+  },
+  {
+    name: 'update allocation scenario',
+    method: 'patch',
+    path: `/api/funds/${TARGET_FUND_ID}/allocation-scenarios/not-a-uuid`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'update allocation scenario decision',
+    method: 'patch',
+    path: `/api/funds/${TARGET_FUND_ID}/allocation-scenarios/not-a-uuid/decisions/not-a-uuid`,
+    roleSet: 'config',
+  },
+  {
+    name: 'sync allocation scenario',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/allocation-scenarios/not-a-uuid/sync`,
+    roleSet: 'scenario',
+  },
+  {
+    name: 'apply allocation scenario',
+    method: 'post',
+    path: `/api/funds/${TARGET_FUND_ID}/allocation-scenarios/not-a-uuid/apply`,
+    roleSet: 'config',
+  },
+];
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+  'METRICS_KEY',
+  'METRICS_ALLOW_FROM',
+  'HEALTH_KEY',
+  'RATE_LIMIT_MAX',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+const authorizationHeaders = new Map<Role, string>();
+
+let app: express.Express;
+let requireWriteRole: (roles: readonly string[]) => express.RequestHandler;
+
+function saveEnv() {
+  for (const key of ENV_KEYS) originalEnv.set(key, process.env[key]);
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  originalEnv.clear();
+}
+
+function configureTestAuthEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '1';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'write-route-role-gating-secret-32-chars-min';
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'write-route-session-secret-32-chars-min';
+  process.env.METRICS_KEY = 'write-route-metrics-secret-32-chars-min';
+  delete process.env.METRICS_ALLOW_FROM;
+  process.env.HEALTH_KEY = 'write-route-health-secret-32-chars-min';
+  process.env.RATE_LIMIT_MAX = '1000';
+}
+
+function issueRequest(route: GatedRoute) {
+  switch (route.method) {
+    case 'delete':
+      return request(app).delete(route.path);
+    case 'patch':
+      return request(app).patch(route.path);
+    case 'post':
+      return request(app).post(route.path);
+    case 'put':
+      return request(app).put(route.path);
+  }
+}
+
+function expectedOutcome(role: Role, roleSet: RoleSet): 'allowed' | 'forbidden' {
+  if (role === 'admin' || role === 'partner') return 'allowed';
+  if (role === 'analyst' && roleSet === 'scenario') return 'allowed';
+  return 'forbidden';
+}
+
+const ROLE_ROUTE_CASES = ROLES.flatMap((role) =>
+  GATED_ROUTES.map((route) => ({
+    ...route,
+    role,
+    outcome: expectedOutcome(role, route.roleSet),
+  }))
+);
+
+beforeAll(async () => {
+  saveEnv();
+  configureTestAuthEnv();
+  vi.resetModules();
+
+  const [{ makeApp }, auth] = await Promise.all([
+    import('../../../server/app'),
+    import('../../../server/lib/auth/jwt'),
+  ]);
+  app = makeApp();
+  requireWriteRole = auth.requireWriteRole;
+
+  for (const role of ROLES) {
+    const token = auth.signToken({
+      sub: `${role}-1`,
+      email: `${role}@example.com`,
+      role,
+      fundIds: role === 'admin' ? [] : [TARGET_FUND_ID],
+    });
+    authorizationHeaders.set(role, `Bearer ${token}`);
+  }
+});
+
+afterAll(() => {
+  restoreEnv();
+  vi.restoreAllMocks();
+});
+
+describe('write-route-role-gating', () => {
+  it.each(ROLE_ROUTE_CASES)('$role is $outcome for $name', async ({ role, outcome, ...route }) => {
+    const authorization = authorizationHeaders.get(role);
+    if (!authorization) throw new Error(`Missing authorization header for ${role}`);
+
+    const response = await issueRequest(route).set('Authorization', authorization).send({});
+
+    if (outcome === 'forbidden') {
+      expect(response.status).toBe(403);
+      return;
+    }
+    expect(response.status).not.toBe(401);
+    expect(response.status).not.toBe(403);
+  });
+
+  it('returns 401 before role gating for an unauthenticated write', async () => {
+    const route = GATED_ROUTES.find((candidate) => candidate.name === 'create allocation scenario');
+    if (!route) throw new Error('Representative write route is missing');
+
+    const response = await issueRequest(route).send({});
+
+    expect(response.status).toBe(401);
+  });
+
+  it('accepts a createServer role supplied through req.context', async () => {
+    const contextApp = express();
+    contextApp.use((req, _res, next) => {
+      req.context = {
+        userId: 'partner-1',
+        email: 'partner@example.com',
+        role: 'partner',
+        orgId: 'test-org',
+      };
+      next();
+    });
+    contextApp.post('/probe', requireWriteRole(['partner', 'admin']), (_req, res) =>
+      res.sendStatus(204)
+    );
+
+    await request(contextApp).post('/probe').expect(204);
+  });
+});

--- a/tests/unit/contract/fund-draft-round-trip.test.ts
+++ b/tests/unit/contract/fund-draft-round-trip.test.ts
@@ -20,6 +20,19 @@ let app: express.Express;
 beforeAll(async () => {
   app = express();
   app.use(express.json({ limit: '1mb' }));
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'partner-1',
+      sub: 'partner-1',
+      email: 'partner@example.com',
+      role: 'partner',
+      roles: ['partner'],
+      fundIds: [1],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    };
+    next();
+  });
 
   // Mount funds router for POST /api/funds (creates funds in storage mock)
   const fundRoutes = await import('../../../server/routes/funds');
@@ -87,13 +100,11 @@ describe('PUT /api/funds/:id/draft validation', () => {
   });
 
   it('rejects nonpositive period values', async () => {
-    const putRes = await request(app)
-      .put('/api/funds/1/draft')
-      .send({
-        fundName: 'Invalid Period Fund',
-        fundLife: 0,
-        investmentPeriod: 0,
-      });
+    const putRes = await request(app).put('/api/funds/1/draft').send({
+      fundName: 'Invalid Period Fund',
+      fundLife: 0,
+      investmentPeriod: 0,
+    });
 
     expect(putRes.status).toBe(400);
     expect(putRes.body).toHaveProperty('code', 'DRAFT_VALIDATION_ERROR');

--- a/tests/unit/contract/fund-finalize.test.ts
+++ b/tests/unit/contract/fund-finalize.test.ts
@@ -592,6 +592,19 @@ describe('POST /api/funds/finalize route contract', () => {
   beforeAll(async () => {
     app = express();
     app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = {
+        id: 'partner-1',
+        sub: 'partner-1',
+        email: 'partner@example.com',
+        role: 'partner',
+        roles: ['partner'],
+        fundIds: [77],
+        ip: '127.0.0.1',
+        userAgent: 'vitest',
+      };
+      next();
+    });
     const { registerFundConfigRoutes } = await import('../../../server/routes/fund-config');
     registerFundConfigRoutes(app);
   });
@@ -633,7 +646,8 @@ describe('POST /api/funds/finalize route contract', () => {
         id: 'user-7',
         sub: 'user-7',
         email: 'user7@example.com',
-        roles: [],
+        role: 'partner',
+        roles: ['partner'],
         fundIds: [99],
         ip: '127.0.0.1',
         userAgent: 'vitest',

--- a/tests/unit/contract/fund-recalculate.test.ts
+++ b/tests/unit/contract/fund-recalculate.test.ts
@@ -532,6 +532,19 @@ describe('POST /api/funds/:id/recalculate route contract', () => {
   beforeAll(async () => {
     app = express();
     app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = {
+        id: 'partner-1',
+        sub: 'partner-1',
+        email: 'partner@example.com',
+        role: 'partner',
+        roles: ['partner'],
+        fundIds: [1],
+        ip: '127.0.0.1',
+        userAgent: 'vitest',
+      };
+      next();
+    });
 
     const { registerFundConfigRoutes } = await import('../../../server/routes/fund-config');
     registerFundConfigRoutes(app);
@@ -627,7 +640,8 @@ describe('POST /api/funds/:id/recalculate route contract', () => {
         id: 'auth0|user-7',
         sub: 'auth0|user-7',
         email: 'user7@example.com',
-        roles: [],
+        role: 'partner',
+        roles: ['partner'],
         fundIds: [1],
         ip: '127.0.0.1',
         userAgent: 'vitest',
@@ -674,7 +688,8 @@ describe('POST /api/funds/:id/recalculate route contract', () => {
         id: 'user-7',
         sub: 'user-7',
         email: 'user7@example.com',
-        roles: [],
+        role: 'partner',
+        roles: ['partner'],
         fundIds: [99],
         ip: '127.0.0.1',
         userAgent: 'vitest',

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -351,7 +351,7 @@ describe('route policy coverage', () => {
 
     expect(policy.governanceRef).toBe('/fund-model-results/:fundId/scenarios');
     expect(policy.financialSurface).toBe('fund_modeling');
-    expect(policy.apiAuthBoundary).toBe('require_auth_and_fund_access');
+    expect(policy.apiAuthBoundary).toBe('require_auth_fund_access_and_role');
     expect(policy.fundScopeMode).toBe('route_param_fund_id');
     expect(policy.exportPolicy).toBe('not_exportable');
     expect(policy.provenanceRequired).toBe(true);

--- a/tests/unit/routes/allocation-scenarios-api.test.ts
+++ b/tests/unit/routes/allocation-scenarios-api.test.ts
@@ -243,8 +243,10 @@ const reserveIcDecision = {
 
 describe('Allocation scenarios API', () => {
   let app: express.Express;
+  let role: 'analyst' | 'partner';
 
   beforeEach(() => {
+    role = 'analyst';
     app = express();
     app.use(express.json());
     app.use((req, _res, next) => {
@@ -252,8 +254,8 @@ describe('Allocation scenarios API', () => {
         id: '17',
         sub: '17',
         email: 'analyst@example.com',
-        role: 'analyst',
-        roles: ['analyst'],
+        role,
+        roles: [role],
         fundIds: [1],
         ip: '127.0.0.1',
         userAgent: 'vitest',
@@ -339,6 +341,7 @@ describe('Allocation scenarios API', () => {
   });
 
   it('creates a reserve IC decision scoped to the scenario route', async () => {
+    role = 'partner';
     createReserveIcDecisionMock.mockResolvedValue(reserveIcDecision);
 
     const payload = {
@@ -400,6 +403,7 @@ describe('Allocation scenarios API', () => {
   });
 
   it('updates a reserve IC decision', async () => {
+    role = 'partner';
     updateReserveIcDecisionMock.mockResolvedValue({
       ...reserveIcDecision,
       decisionStatus: 'approved',
@@ -467,6 +471,7 @@ describe('Allocation scenarios API', () => {
   });
 
   it('applies a scenario with a preview token', async () => {
+    role = 'partner';
     applyAllocationScenarioMock.mockResolvedValue(scenarioApplyResult);
 
     const payload = {
@@ -512,6 +517,7 @@ describe('Allocation scenarios API', () => {
   });
 
   it('rejects invalid decision ids before touching the service', async () => {
+    role = 'partner';
     const response = await request(app)
       .patch(`/funds/1/allocation-scenarios/${scenarioId}/decisions/not-a-uuid`)
       .send({ decisionStatus: 'approved' })
@@ -540,6 +546,7 @@ describe('Allocation scenarios API', () => {
   });
 
   it('rejects invalid apply payloads before touching the service', async () => {
+    role = 'partner';
     const response = await request(app)
       .post(`/funds/1/allocation-scenarios/${scenarioId}/apply`)
       .send({ preview_token: 'stale' })
@@ -554,6 +561,7 @@ describe('Allocation scenarios API', () => {
   });
 
   it('maps service conflicts to 409 responses', async () => {
+    role = 'partner';
     applyAllocationScenarioMock.mockRejectedValue(
       Object.assign(new Error('Apply preview has expired; refresh preview and try again'), {
         statusCode: 409,

--- a/tests/unit/routes/allocation-scenarios.contract.test.ts
+++ b/tests/unit/routes/allocation-scenarios.contract.test.ts
@@ -45,6 +45,19 @@ const DECISION_ID = '00000000-0000-0000-0000-000000000301';
 function makeApp() {
   const app = express();
   app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'analyst-1',
+      sub: 'analyst-1',
+      email: 'analyst@example.com',
+      role: 'analyst',
+      roles: ['analyst'],
+      fundIds: [1],
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    };
+    next();
+  });
   app.use(allocationScenarioRouter);
   app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
   return app;

--- a/tests/unit/routes/scenario-analysis.contract.test.ts
+++ b/tests/unit/routes/scenario-analysis.contract.test.ts
@@ -25,6 +25,7 @@ const fundAccessState = vi.hoisted(() => ({
 // route chain runs requireAuth() before any handler-level flag or param logic.
 const authState = vi.hoisted(() => ({
   authenticated: true,
+  role: 'analyst',
   requireAuthCalls: 0,
 }));
 
@@ -75,9 +76,7 @@ const scenarioCreateState = vi.hoisted(() => {
     readonly code = 'idempotency_conflict';
 
     constructor() {
-      super(
-        'Idempotency-Key is already associated with another company scenario creation request'
-      );
+      super('Idempotency-Key is already associated with another company scenario creation request');
       this.name = 'CompanyScenarioCreateIdempotencyConflictError';
     }
   }
@@ -150,14 +149,29 @@ vi.mock('../../../server/lib/auth/company-fund-scope', () => ({
 }));
 
 vi.mock('../../../server/lib/auth/jwt', () => ({
-  requireAuth: () => (_req: Request, res: Response, next: () => void) => {
+  requireAuth: () => (req: Request, res: Response, next: () => void) => {
     authState.requireAuthCalls += 1;
     if (!authState.authenticated) {
       res.status(401).json({ error: 'Unauthorized' });
       return;
     }
+    req.context = {
+      userId: 'scenario-user',
+      email: 'scenario-user@example.com',
+      role: authState.role,
+      orgId: 'test-org',
+    };
     next();
   },
+  requireWriteRole:
+    (roles: readonly string[]) => (req: Request, res: Response, next: () => void) => {
+      const role = req.user?.role ?? req.context?.role;
+      if (typeof role !== 'string' || !roles.includes(role)) {
+        res.sendStatus(403);
+        return;
+      }
+      next();
+    },
   requireFundAccess: fundAccessState.requireFundAccess,
 }));
 
@@ -244,6 +258,7 @@ function resetState() {
     (_req: Request, _res: Response, next: NextFunction) => next()
   );
   authState.authenticated = true;
+  authState.role = 'analyst';
   authState.requireAuthCalls = 0;
   factsState.buildFundCompanyActualsFacts.mockReset();
   persistenceState.createScenarioCaseFromSeed.mockReset();
@@ -861,9 +876,7 @@ describe('scenario-analysis company scenario creation', () => {
   });
 
   it('does not switch to a newly resolved ungranted fund between scope reads', async () => {
-    fundScopeState.resolveCompanyFundId
-      .mockResolvedValueOnce(7)
-      .mockResolvedValueOnce(8);
+    fundScopeState.resolveCompanyFundId.mockResolvedValueOnce(7).mockResolvedValueOnce(8);
     fundScopeState.enforceCompanyFundScope.mockImplementationOnce(
       async (_req: Request, res: Response, companyId: number) => {
         const currentFundId = await fundScopeState.resolveCompanyFundId(companyId);

--- a/tests/unit/server/cohort-routes-registration.test.ts
+++ b/tests/unit/server/cohort-routes-registration.test.ts
@@ -75,6 +75,9 @@ vi.mock('../../../server/lib/auth/jwt', () => ({
   requireAnyRole:
     () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
       next(),
+  requireWriteRole:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
   requireExportFundGrant: (
     _req: express.Request,
     _res: express.Response,

--- a/tests/unit/server/lp-dashboard-runtime-routes.test.ts
+++ b/tests/unit/server/lp-dashboard-runtime-routes.test.ts
@@ -84,6 +84,7 @@ vi.mock('../../../server/lib/auth/jwt', () => ({
   },
   requireRole: () => (_req: Request, _res: Response, next: NextFunction) => next(),
   requireAnyRole: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+  requireWriteRole: () => (_req: Request, _res: Response, next: NextFunction) => next(),
   requireFundAccess: (req: Request, res: Response, next: NextFunction) => {
     const fundId = Number(req.params['fundId']);
     if (Number.isFinite(fundId) && req.user?.fundIds?.includes(fundId)) return next();


### PR DESCRIPTION
Implements the internal auth model **universal read, role-gated writes**. Adds a `requireWriteRole` guard to mutating routes so *user level* governs who can change things.

## Matrix
| Routes | Roles |
|---|---|
| fund-config finalize/draft/publish/recalculate | partner, admin |
| allocation apply + IC decision create/update | partner, admin |
| scenario authoring (scenario-sets create/optimize/calculate/archive; company scenarios create/patch/delete/from-seed; allocation create/patch/sync) | partner, admin, analyst |
| reads / previews (incl. `reserves/optimize` suggestion, allocation apply-*preview*) | everyone (ungated) |

## Key design
- `requireWriteRole` reads `req.user?.role ?? req.context?.role` — works in **both** server entrypoints (`makeApp`→`req.user`; `createServer`/dev/Docker→`req.context`), which an earlier draft would have 403'd everyone in dev. Gate sits after `requireAuth`, before the handler; fund-scope unchanged.
- Route-policy registry now declares `require_auth_fund_access_and_role`.

## Tests
- New `tests/unit/auth/write-route-role-gating.test.ts`: full matrix (viewer/operator/service → 403 everywhere; analyst → 403 on config/commit, allowed on scenarios; partner/admin → allowed; unauthenticated → 401 before the gate; a `req.context` createServer-path case). Non-admin principals carry `fundIds:[TARGET_FUND_ID]` so fund-scope can't false-green.
- Repaired 9 existing suites that hit the gated routes (added an allowed role/context; **no assertion weakened**).

## Verification
- `npm run check`: 0 new TS errors. Local server run: **277 tests pass** (new + all repairs).
- Two codex reviews (spec + applied seam): matrix correct, 19/19 mutations gated + reserves-optimizer exempt, no bypass, no weakened assertions. One **non-blocking** LOW/WATCH note: `req.user`/`req.context` role precedence could reject-on-disagreement (both currently derive from the same verified credential — not exploitable).

Out of scope: LP-facing routes; client disable-with-reason UX; `POST /api/portfolio/scenarios` (a scenario-write in another file — verify + gate as follow-up); universal-read reads relaxation (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)