### PR TITLE
feat(auth): universal fund read for team members (method-aware, writes scoped)

### DIFF
--- a/server/lib/auth/fund-scope.ts
+++ b/server/lib/auth/fund-scope.ts
@@ -3,10 +3,14 @@ import type { RequestPrincipal } from './principal';
 export type ScopeDecision = 'allow' | 'deny';
 
 /**
- * Pure, fail-closed fund-scope resolution. `admin`/`service` allow any fund; a
- * `user` principal allows only funds in its explicit fundIds; `anonymous` (or
- * any unresolved principal) DENIES. There is no `undefined -> allow` path and no
- * `empty-fundIds -> unrestricted` path.
+ * Pure, fail-closed STRICT fund-scope resolution. `admin`/`service` allow any
+ * fund; a `user` principal allows only funds in its explicit fundIds;
+ * `anonymous` (or any unresolved principal) DENIES. There is no
+ * `undefined -> allow` path and no `empty-fundIds -> unrestricted` path.
+ *
+ * Universal READ for team members is layered in middleware via
+ * isSafeReadMethod + isTeamMemberUser; this strict predicate remains unchanged
+ * for writes and exports that mutate.
  */
 export function resolveFundScope(principal: RequestPrincipal, fundId: number): ScopeDecision {
   switch (principal.kind) {
@@ -18,4 +22,9 @@ export function resolveFundScope(principal: RequestPrincipal, fundId: number): S
     case 'anonymous':
       return 'deny';
   }
+}
+
+/** Safe (non-mutating by HTTP contract) methods. Universal read applies only to these. */
+export function isSafeReadMethod(method: string | undefined): boolean {
+  return method === 'GET' || method === 'HEAD';
 }

--- a/server/lib/auth/jwt.ts
+++ b/server/lib/auth/jwt.ts
@@ -17,8 +17,8 @@ import { parseFundIdParam } from '@shared/number';
 import { getConfig } from '../../config';
 import { authMetrics } from '../../telemetry';
 import { firstString } from '../request-values';
-import { resolveFundScope } from './fund-scope';
-import { principalFromUser } from './principal';
+import { isSafeReadMethod, resolveFundScope } from './fund-scope';
+import { isTeamMemberUser, principalFromUser } from './principal';
 import {
   extractRequestCredential,
   requestCredentialError,
@@ -339,6 +339,11 @@ export const requireFundAccess = (req: Request, res: Response, next: NextFunctio
       error: 'Bad Request',
       message: fundIdParam ? 'Invalid fund ID' : 'Fund ID is required',
     });
+  }
+
+  // Universal READ (team-only): any authenticated non-LP caller may read any fund on safe methods.
+  if (isSafeReadMethod(req.method) && isTeamMemberUser(req.user)) {
+    return next();
   }
 
   if (resolveFundScope(principalFromUser(req.user), fundId) === 'allow') {

--- a/server/lib/auth/principal.ts
+++ b/server/lib/auth/principal.ts
@@ -32,3 +32,13 @@ export function principalFromUser(user: Express.User | undefined): RequestPrinci
     fundIds: user.fundIds ?? [],
   };
 }
+
+/**
+ * Team-member predicate for universal READ. True for any authenticated non-LP
+ * caller (admin/service/analyst/partner/viewer). False for anonymous (no user)
+ * and for LP principals (role 'lp' or an lpId claim) -- LPs remain fund-scoped
+ * via the separate requireLPFundAccess path.
+ */
+export function isTeamMemberUser(user: Express.User | undefined): boolean {
+  return !!user && user.role !== 'lp' && user.lpId == null;
+}

--- a/server/lib/auth/provided-fund-scope.ts
+++ b/server/lib/auth/provided-fund-scope.ts
@@ -2,9 +2,9 @@ import type { NextFunction, Request, Response } from 'express';
 
 import { parseFundIdParam } from '@shared/number';
 
-import { resolveFundScope } from './fund-scope';
+import { isSafeReadMethod, resolveFundScope } from './fund-scope';
 import { userFromClaims, verifyRequestCredential } from './jwt';
-import { principalFromUser } from './principal';
+import { isTeamMemberUser, principalFromUser } from './principal';
 import { RequestCredentialError } from './request-credentials';
 
 function assertTokenRequiredOutsideDevelopment(): void {
@@ -25,13 +25,20 @@ function denyFundAccess(res: Response, fundId: number): void {
 export async function enforceProvidedFundScope(
   req: Request,
   res: Response,
-  fundId: number
+  fundId: number,
+  opts: { forWrite?: boolean } = {}
 ): Promise<boolean> {
   try {
     const verified = await verifyRequestCredential(req);
     if (verified === null) {
       assertTokenRequiredOutsideDevelopment();
-      if (req.user && resolveFundScope(principalFromUser(req.user), fundId) === 'deny') {
+      const universalRead =
+        !opts.forWrite && isSafeReadMethod(req.method) && isTeamMemberUser(req.user);
+      if (
+        req.user &&
+        !universalRead &&
+        resolveFundScope(principalFromUser(req.user), fundId) === 'deny'
+      ) {
         denyFundAccess(res, fundId);
         return false;
       }
@@ -46,7 +53,11 @@ export async function enforceProvidedFundScope(
       ...verifiedUser,
     };
 
-    if (resolveFundScope(principalFromUser(req.user), fundId) !== 'allow') {
+    const universalRead =
+      !opts.forWrite && isSafeReadMethod(req.method) && isTeamMemberUser(req.user);
+    const allowed =
+      universalRead || resolveFundScope(principalFromUser(req.user), fundId) === 'allow';
+    if (!allowed) {
       denyFundAccess(res, fundId);
       return false;
     }
@@ -73,7 +84,10 @@ function developmentVerifiedFundScope(req: Request): VerifiedFundScope {
   if (req.user) {
     const fundIds = req.user.fundIds ?? [];
     const principal = principalFromUser(req.user);
-    const unrestricted = principal.kind === 'admin' || principal.kind === 'service';
+    const unrestricted =
+      isSafeReadMethod(req.method) && isTeamMemberUser(req.user)
+        ? true
+        : principal.kind === 'admin' || principal.kind === 'service';
     return { unrestricted, fundIds };
   }
   return { unrestricted: true, fundIds: [] };
@@ -96,7 +110,10 @@ async function verifiedFundScopeFromCredential(
   req.user = { ...req.user, ...verifiedUser };
   const fundIds = verifiedUser.fundIds ?? [];
   const principal = principalFromUser(verifiedUser);
-  const unrestricted = principal.kind === 'admin' || principal.kind === 'service';
+  const unrestricted =
+    isSafeReadMethod(req.method) && isTeamMemberUser(verifiedUser)
+      ? true
+      : principal.kind === 'admin' || principal.kind === 'service';
   return { unrestricted, fundIds };
 }
 
@@ -154,8 +171,9 @@ export interface VerifiedFundScope {
  * enforceProvidedFundScope's no-token contract: throws outside development/test,
  * and in development/test falls back to the upstream user (or an unrestricted dev
  * bypass when none is present). Returns null only for an invalid or expired token
- * so the caller can respond 401. unrestricted === true means an admin/service
- * role; a non-admin with empty grants is not unrestricted and is denied.
+ * so the caller can respond 401. On safe read methods, unrestricted === true
+ * for authenticated non-LP team members; otherwise it means an admin/service
+ * role. A non-admin with empty grants is not unrestricted for mutations.
  */
 export async function getVerifiedFundScope(req: Request): Promise<VerifiedFundScope | null> {
   try {

--- a/server/routes/backtesting.ts
+++ b/server/routes/backtesting.ts
@@ -16,6 +16,8 @@ import type { z } from 'zod';
 import type { Request, Response, NextFunction } from 'express';
 import { backtestingService } from '../services/backtesting-service';
 import { requireAuth, requireFundAccess } from '../lib/auth/jwt';
+import { isSafeReadMethod } from '../lib/auth/fund-scope';
+import { isTeamMemberUser } from '../lib/auth/principal';
 import { recordHttpMetrics } from '../metrics';
 import {
   enqueueBacktestJob,
@@ -123,6 +125,7 @@ const asyncHandler = (
 };
 
 const hasFundAccess = (req: Request, fundId: number): boolean => {
+  if (isSafeReadMethod(req.method) && isTeamMemberUser(req.user)) return true; // universal read (team-only)
   const userFundIds = req.user?.fundIds || [];
 
   // Empty fundIds means unrestricted access (admin/superuser pattern).

--- a/server/routes/monte-carlo.ts
+++ b/server/routes/monte-carlo.ts
@@ -785,7 +785,7 @@ router['get'](
     try {
       const fundId = toNumber(req.params['fundId'], 'Fund ID');
 
-      if (!(await enforceProvidedFundScope(req, res, fundId))) {
+      if (!(await enforceProvidedFundScope(req, res, fundId, { forWrite: true }))) {
         return;
       }
 

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -23,6 +23,8 @@ import {
 import { LP_HIDDEN_METRICS } from '@shared/sharing-schema';
 import { firstString } from '../lib/request-values';
 import { parseETag } from '../lib/http-preconditions';
+import { isSafeReadMethod } from '../lib/auth/fund-scope';
+import { isTeamMemberUser } from '../lib/auth/principal';
 import {
   createShareSnapshot,
   getLatestShareSnapshot,
@@ -153,6 +155,7 @@ function requireAuthenticatedUser(req: Request, res: Response): string | undefin
 }
 
 function canManageFund(req: Request, fundId: string): boolean {
+  if (isSafeReadMethod(req.method) && isTeamMemberUser(req.user)) return true; // universal read (team-only)
   if (req.context?.role === 'admin' || req.user?.isAdmin) return true;
   if (req.context?.fundId && req.context.fundId === fundId) return true;
 

--- a/tests/e2e/gp-decision-spine.spec.ts
+++ b/tests/e2e/gp-decision-spine.spec.ts
@@ -149,19 +149,17 @@ test('partner completes the truthful GP decision spine with fail-closed gaps dis
   await expect(evidencePanel).toBeHidden();
   await expect(evidenceTrigger).toBeFocused();
 
-  const ungrantedResponse = await page.context().request.get('/api/funds/2');
-  expect(ungrantedResponse.status()).toBe(403);
-  const ungrantedResultsResponse = page.waitForResponse(
+  const missingFundResponse = await page.context().request.get('/api/funds/2');
+  expect(missingFundResponse.status()).toBe(404);
+  const missingFundResultsResponse = page.waitForResponse(
     (response) =>
       new URL(response.url()).pathname === '/api/funds/2/results' &&
       response.request().method() === 'GET'
   );
   await page.goto('/fund-model-results/2', { waitUntil: 'domcontentloaded' });
-  expect((await ungrantedResultsResponse).status()).toBe(403);
+  expect((await missingFundResultsResponse).status()).toBe(404);
   await expect(page.getByText('Error loading results', { exact: true })).toBeVisible();
-  await expect(
-    page.getByRole('alert').getByText('Server error (403)', { exact: true })
-  ).toBeVisible();
+  await expect(page.getByRole('alert')).toContainText('Fund not found');
   await expect(page.getByTestId('workspace-nav-fund')).toHaveText('Fund 2');
 
   const healthResponse = await page.context().request.get('/healthz');

--- a/tests/integration/backtesting-api.test.ts
+++ b/tests/integration/backtesting-api.test.ts
@@ -460,7 +460,7 @@ describe('Backtesting API', () => {
       expect(response.body.error).toBe('BACKTEST_NOT_FOUND');
     });
 
-    it('returns 403 when the backtest belongs to an inaccessible fund', async () => {
+    it('returns 200 when a team member reads a backtest from another fund', async () => {
       mockGetBacktestById.mockResolvedValueOnce(
         makeBacktestResult({
           config: { ...validBacktestConfig, fundId: 9 },
@@ -471,8 +471,8 @@ describe('Backtesting API', () => {
         '/api/backtesting/result/550e8400-e29b-41d4-a716-446655440000'
       );
 
-      expect(response.status).toBe(403);
-      expect(response.body.error).toBe('FORBIDDEN');
+      expect(response.status).toBe(200);
+      expect(response.body.result.config.fundId).toBe(9);
     });
 
     it('returns 200 and preserves scenarioComparisonSummary on the detail payload', async () => {

--- a/tests/unit/api/portfolio-overview-route.test.ts
+++ b/tests/unit/api/portfolio-overview-route.test.ts
@@ -160,14 +160,13 @@ describe('portfolio overview route', () => {
     expect(serviceState.getPortfolioOverview).not.toHaveBeenCalled();
   });
 
-  it('denies cross-fund access before calling the service', async () => {
+  it('allows a team member to read another fund overview (universal read)', async () => {
     const app = await makeApp();
     const response = await request(app)
       .get('/api/portfolio-overview?fundId=1')
       .set('Authorization', `Bearer ${signToken([2])}`);
 
-    expect(response.status).toBe(403);
-    expect(serviceState.getPortfolioOverview).not.toHaveBeenCalled();
+    expect(response.status).not.toBe(403);
   });
 
   it('returns 404 when the fund does not exist', async () => {

--- a/tests/unit/auth/fund-scope.test.ts
+++ b/tests/unit/auth/fund-scope.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { principalFromUser } from '../../../server/lib/auth/principal';
-import { resolveFundScope } from '../../../server/lib/auth/fund-scope';
+import { isTeamMemberUser, principalFromUser } from '../../../server/lib/auth/principal';
+import { isSafeReadMethod, resolveFundScope } from '../../../server/lib/auth/fund-scope';
 
 const user = (over: Partial<Express.User> = {}): Express.User =>
   ({
@@ -34,6 +34,36 @@ describe('principalFromUser', () => {
       userId: 'u1',
       fundIds: [1, 2],
     });
+  });
+});
+
+describe('isTeamMemberUser', () => {
+  it.each(['admin', 'analyst', 'partner'])(
+    'recognizes authenticated non-LP role=%s as a team member',
+    (role) => {
+      expect(isTeamMemberUser(user({ role }))).toBe(true);
+    }
+  );
+
+  it('rejects anonymous callers', () => {
+    expect(isTeamMemberUser(undefined)).toBe(false);
+  });
+
+  it('rejects callers with the LP role', () => {
+    expect(isTeamMemberUser(user({ role: 'lp' }))).toBe(false);
+  });
+
+  it('rejects callers with an LP claim', () => {
+    expect(isTeamMemberUser(user({ lpId: 1 }))).toBe(false);
+  });
+});
+
+describe('isSafeReadMethod', () => {
+  it('allows only GET and HEAD', () => {
+    expect(isSafeReadMethod('GET')).toBe(true);
+    expect(isSafeReadMethod('HEAD')).toBe(true);
+    expect(isSafeReadMethod('POST')).toBe(false);
+    expect(isSafeReadMethod(undefined)).toBe(false);
   });
 });
 

--- a/tests/unit/auth/providedFundScope.test.ts
+++ b/tests/unit/auth/providedFundScope.test.ts
@@ -259,6 +259,62 @@ describe('enforceProvidedFundScope', () => {
     });
   });
 
+  it('allows a team-member GET across funds and exposes unrestricted read scope', async () => {
+    setJwtEnv();
+    const token = signToken({ role: 'analyst', fundIds: [78] });
+    const { enforceProvidedFundScope, getVerifiedFundScope } = await import(
+      '@/server/lib/auth/provided-fund-scope'
+    );
+    const { res, status } = makeResponse();
+    const req = makeRequest(`Bearer ${token}`);
+    req.method = 'GET';
+
+    await expect(enforceProvidedFundScope(req, res, 77)).resolves.toBe(true);
+    await expect(getVerifiedFundScope(req)).resolves.toEqual({
+      unrestricted: true,
+      fundIds: [78],
+    });
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('keeps a persisting GET strict when forWrite is set', async () => {
+    setJwtEnv();
+    const token = signToken({ role: 'analyst', fundIds: [78] });
+    const { enforceProvidedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status } = makeResponse();
+    const req = makeRequest(`Bearer ${token}`);
+    req.method = 'GET';
+
+    await expect(
+      enforceProvidedFundScope(req, res, 77, { forWrite: true })
+    ).resolves.toBe(false);
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it('keeps cross-fund POST requests strict', async () => {
+    setJwtEnv();
+    const token = signToken({ role: 'analyst', fundIds: [78] });
+    const { enforceProvidedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status } = makeResponse();
+    const req = makeRequest(`Bearer ${token}`);
+    req.method = 'POST';
+
+    await expect(enforceProvidedFundScope(req, res, 77)).resolves.toBe(false);
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it('keeps LP GET requests fund-scoped', async () => {
+    setJwtEnv();
+    const token = signToken({ role: 'lp', fundIds: [78] });
+    const { enforceProvidedFundScope } = await import('@/server/lib/auth/provided-fund-scope');
+    const { res, status } = makeResponse();
+    const req = makeRequest(`Bearer ${token}`);
+    req.method = 'GET';
+
+    await expect(enforceProvidedFundScope(req, res, 77)).resolves.toBe(false);
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
   it('returns 401 for wrong-secret tokens', async () => {
     setJwtEnv();
     const token = signToken({ fundIds: [77] }, { secret: OTHER_SECRET });

--- a/tests/unit/auth/requireFundAccess.test.ts
+++ b/tests/unit/auth/requireFundAccess.test.ts
@@ -33,6 +33,26 @@ describe('requireFundAccess Middleware', () => {
   });
 
   describe('Authorized Access', () => {
+    it('allows a team member to read a fund outside their explicit scope', () => {
+      req.method = 'GET';
+      req.params = { fundId: '2' };
+      req.user = {
+        id: 'user-1',
+        sub: 'user-1',
+        email: 'user@example.com',
+        role: 'analyst',
+        roles: ['analyst'],
+        ip: '127.0.0.1',
+        userAgent: 'test',
+        fundIds: [1],
+      };
+
+      requireFundAccess(req as Request, res as Response, next);
+
+      expect(next).toHaveBeenCalledOnce();
+      expect(statusMock).not.toHaveBeenCalled();
+    });
+
     it('should call next() when user has access to the requested fund', () => {
       req.params = { fundId: '123' };
       req.user = {
@@ -194,6 +214,57 @@ describe('requireFundAccess Middleware', () => {
   });
 
   describe('Unauthorized Access', () => {
+    it('keeps cross-fund writes scoped', () => {
+      req.method = 'POST';
+      req.params = { fundId: '2' };
+      req.user = {
+        id: 'user-1',
+        sub: 'user-1',
+        email: 'user@example.com',
+        role: 'analyst',
+        roles: ['analyst'],
+        ip: '127.0.0.1',
+        userAgent: 'test',
+        fundIds: [1],
+      };
+
+      requireFundAccess(req as Request, res as Response, next);
+
+      expect(statusMock).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('keeps LP reads fund-scoped', () => {
+      req.method = 'GET';
+      req.params = { fundId: '2' };
+      req.user = {
+        id: 'lp-1',
+        sub: 'lp-1',
+        email: 'lp@example.com',
+        role: 'lp',
+        roles: ['lp'],
+        ip: '127.0.0.1',
+        userAgent: 'test',
+        fundIds: [1],
+      };
+
+      requireFundAccess(req as Request, res as Response, next);
+
+      expect(statusMock).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('denies anonymous reads', () => {
+      req.method = 'GET';
+      req.params = { fundId: '2' };
+      req.user = undefined;
+
+      requireFundAccess(req as Request, res as Response, next);
+
+      expect(statusMock).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+
     it('should return 403 when user does not have access to the requested fund', () => {
       req.params = { fundId: '99999' };
       req.user = {

--- a/tests/unit/contract/fund-results-route.test.ts
+++ b/tests/unit/contract/fund-results-route.test.ts
@@ -122,7 +122,7 @@ describe('GET /api/funds/:id/results', () => {
     expect(res.body).toHaveProperty('error', 'Invalid fund ID');
   });
 
-  it('returns 403 without reading results when user lacks fund scope', async () => {
+  it('allows a team member to read results for another fund (universal read)', async () => {
     const { fundResultsReadService } =
       await import('../../../server/services/fund-results-read-service');
     const getResultsSpy = vi.mocked(fundResultsReadService.getResults);
@@ -146,13 +146,8 @@ describe('GET /api/funds/:id/results', () => {
 
     const res = await request(restrictedApp).get('/api/funds/1/results');
 
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({
-      error: 'Forbidden',
-      code: 'FUND_ACCESS_DENIED',
-      message: 'You do not have access to fund 1',
-    });
-    expect(getResultsSpy).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(403);
+    expect(getResultsSpy).toHaveBeenCalled();
   });
 
   it('returns 500 when service throws', async () => {

--- a/tests/unit/contract/funds-endpoint-snapshots.test.ts
+++ b/tests/unit/contract/funds-endpoint-snapshots.test.ts
@@ -246,16 +246,13 @@ describe('GET /api/funds/:id contract snapshot', () => {
     expect(res.body).toHaveProperty('error');
   });
 
-  it('returns 403 for fund detail outside the provided user scope', async () => {
+  it('allows a team member to read fund detail outside their explicit scope', async () => {
     const scopedApp = await makeScopedFundsApp([2]);
 
     const res = await request(scopedApp).get('/api/funds/1');
 
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({
-      error: 'Forbidden',
-      code: 'FUND_ACCESS_DENIED',
-    });
+    // Universal read: a team member may read any fund on safe methods.
+    expect(res.status).not.toBe(403);
   });
 });
 

--- a/tests/unit/lp-reporting/report-qualification-characterization.test.ts
+++ b/tests/unit/lp-reporting/report-qualification-characterization.test.ts
@@ -904,6 +904,8 @@ describe('marginal MOIC and report-sharing boundaries', () => {
   it('pins public share delivery to immutable snapshots without LP-reporting dependencies', () => {
     expect(productionImportSpecifiers('server/routes/shares.ts')).toEqual([
       '../db',
+      '../lib/auth/fund-scope',
+      '../lib/auth/principal',
       '../lib/http-preconditions',
       '../lib/logger.js',
       '../lib/request-values',

--- a/tests/unit/routes/backtesting.contract.test.ts
+++ b/tests/unit/routes/backtesting.contract.test.ts
@@ -176,15 +176,15 @@ describe('backtesting route fund-scope contracts', () => {
     expect(res.body).toMatchObject({ error: 'JOB_NOT_FOUND' });
   });
 
-  it('GET /jobs/:jobId forbids a job owned by another fund', async () => {
+  it('GET /jobs/:jobId allows the requester to read a job from another fund', async () => {
     queueState.getBacktestJobStatus.mockResolvedValueOnce(
       jobSnapshot({ fundId: 2, requesterUserId: 'alice' })
     );
     const res = await request(makeApp())
       .get('/api/backtesting/jobs/job-1')
       .set(identity('1', 'alice'));
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({ error: 'FORBIDDEN' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ jobId: 'job-1', fundId: 2, status: 'completed' });
   });
 
   it('GET /jobs/:jobId binds a scoped caller to jobs they requested', async () => {
@@ -236,24 +236,33 @@ describe('backtesting route fund-scope contracts', () => {
     expect(res.status).toBe(404);
   });
 
-  it('GET /jobs/:jobId/stream forbids a cross-fund job before streaming', async () => {
+  it('GET /jobs/:jobId/stream opens for the requester across funds', async () => {
     queueState.getBacktestJobStatus.mockResolvedValueOnce(
       jobSnapshot({ fundId: 2, requesterUserId: 'alice' })
     );
-    const res = await request(makeApp())
+    // SSE streams stay open, so bound the request with a short deadline instead of
+    // awaiting termination (which would hang). The guard runs before subscribing, so a
+    // successful open is proven by subscribeToBacktestJob being called; a 403 would
+    // short-circuit before subscribing.
+    await request(makeApp())
       .get('/api/backtesting/jobs/job-1/stream')
-      .set(identity('1', 'alice'));
-    expect(res.status).toBe(403);
-    expect(queueState.subscribeToBacktestJob).not.toHaveBeenCalled();
+      .set(identity('1', 'alice'))
+      .timeout({ deadline: 300 })
+      .then(
+        () => undefined,
+        () => undefined
+      );
+
+    expect(queueState.subscribeToBacktestJob).toHaveBeenCalledWith('job-1', expect.any(Object));
   });
 
   // --- GET /fund/:fundId/history (requireFundAccess; guard before service) ---
-  it('GET /fund/:fundId/history denies a cross-fund read before the service', async () => {
+  it('GET /fund/:fundId/history allows a team member to read another fund history', async () => {
     const res = await request(makeApp())
       .get('/api/backtesting/fund/2/history')
       .set(identity('1', 'alice'));
-    expect(res.status).toBe(403);
-    expect(serviceState.getBacktestHistory).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(serviceState.getBacktestHistory).toHaveBeenCalledWith(2, expect.anything());
   });
 
   it('GET /fund/:fundId/history reads in-scope history', async () => {
@@ -282,13 +291,13 @@ describe('backtesting route fund-scope contracts', () => {
     expect(res.body).toMatchObject({ error: 'BACKTEST_NOT_FOUND' });
   });
 
-  it('GET /result/:backtestId forbids a cross-fund result', async () => {
+  it('GET /result/:backtestId allows a team member to read a cross-fund result', async () => {
     serviceState.getBacktestById.mockResolvedValueOnce({ config: { fundId: 2 } });
     const res = await request(makeApp())
       .get(`/api/backtesting/result/${RESULT_ID}`)
       .set(identity('1', 'alice'));
-    expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({ error: 'FORBIDDEN' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ result: { config: { fundId: 2 } } });
   });
 
   it('GET /result/:backtestId rejects a malformed id before the service', async () => {

--- a/tests/unit/routes/cashflow-real-auth.test.ts
+++ b/tests/unit/routes/cashflow-real-auth.test.ts
@@ -86,7 +86,7 @@ describe('cashflow route real bearer fund scope', () => {
     }
   });
 
-  it('denies an out-of-scope fund using the real bearer-token helper', async () => {
+  it('allows a team member to read an out-of-scope fund using the real bearer-token helper', async () => {
     const app = await makeApp();
     const token = signToken({ fundIds: [1] });
 
@@ -94,8 +94,8 @@ describe('cashflow route real bearer fund scope', () => {
       .get('/api/cashflow/2/transactions')
       .set('Authorization', `Bearer ${token}`);
 
-    expect(response.status).toBe(403);
-    expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
+    // Universal read: a team member may read any fund on safe methods.
+    expect(response.status).not.toBe(403);
   });
 
   it('rejects a non-canonical route fundId instead of authorizing its numeric alias', async () => {

--- a/tests/unit/routes/cohort-analysis.contract.test.ts
+++ b/tests/unit/routes/cohort-analysis.contract.test.ts
@@ -109,13 +109,17 @@ function makeApp() {
   return app;
 }
 
-const deniedEndpoints = [
+// Writes stay fund-scoped; reads are universal for team members (safe methods).
+const deniedWriteEndpoints = [
   { method: 'post', path: '/analyze', source: 'body' },
-  { method: 'get', path: '/unmapped', source: 'query' },
   { method: 'post', path: '/sector-mappings', source: 'body' },
-  { method: 'get', path: '/definitions', source: 'query' },
   { method: 'post', path: '/definitions', source: 'body' },
   { method: 'post', path: '/seed', source: 'body' },
+] as const;
+
+const allowedReadEndpoints = [
+  { method: 'get', path: '/unmapped', source: 'query' },
+  { method: 'get', path: '/definitions', source: 'query' },
 ] as const;
 
 describe('cohort-analysis fund-scope adapter contract', () => {
@@ -126,15 +130,13 @@ describe('cohort-analysis fund-scope adapter contract', () => {
     dbState.state.updateValues = [];
   });
 
-  it.each(deniedEndpoints)(
-    '$method $path denies cross-fund access before handler work',
-    async ({ method, path, source }) => {
-      const pendingRequest =
-        method === 'post' ? request(makeApp()).post(path) : request(makeApp()).get(path);
+  it.each(deniedWriteEndpoints)(
+    '$method $path denies cross-fund write before handler work',
+    async ({ path, source }) => {
       const response =
         source === 'body'
-          ? await pendingRequest.send({ fundId: 2 })
-          : await pendingRequest.query({ fundId: 2 });
+          ? await request(makeApp()).post(path).send({ fundId: 2 })
+          : await request(makeApp()).post(path).query({ fundId: 2 });
 
       expect(response.status).toBe(403);
       expect(response.body).toEqual(
@@ -147,6 +149,15 @@ describe('cohort-analysis fund-scope adapter contract', () => {
       expect(dbState.db.insert).not.toHaveBeenCalled();
       expect(dbState.db.update).not.toHaveBeenCalled();
       expect(analyzeCohorts).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(allowedReadEndpoints)(
+    '$method $path allows a team member cross-fund read',
+    async ({ path }) => {
+      const response = await request(makeApp()).get(path).query({ fundId: 2 });
+
+      expect(response.status).not.toBe(403);
     }
   );
 

--- a/tests/unit/routes/deal-pipeline.contract.test.ts
+++ b/tests/unit/routes/deal-pipeline.contract.test.ts
@@ -366,7 +366,7 @@ describe('deal pipeline route contracts', () => {
     expect(mockState.db.update).not.toHaveBeenCalled();
   });
 
-  it('rejects provided fund scope across body and query surfaces before DB access', async () => {
+  it('keeps cross-fund writes scoped while allowing team-member reads across surfaces', async () => {
     const app = makeApp([1]);
 
     const createBodyScope = await request(app)
@@ -384,21 +384,18 @@ describe('deal pipeline route contracts', () => {
       .post('/api/deals/opportunities/import')
       .send({ fundId: 2, rows: [validDealPayload({ companyName: 'Import Co' })] });
 
-    for (const response of [
-      createBodyScope,
-      listQueryScope,
-      updateBodyScope,
-      pipelineQueryScope,
-      previewBodyScope,
-      confirmBodyScope,
-    ]) {
+    // Writes (non-safe methods) stay fund-scoped: cross-fund mutations denied before DB access.
+    for (const response of [createBodyScope, updateBodyScope, previewBodyScope, confirmBodyScope]) {
       expect(response.status).toBe(403);
       expect(response.body).toMatchObject({
         error: 'Forbidden',
         code: 'FUND_ACCESS_DENIED',
       });
     }
-    expect(mockState.db.select).not.toHaveBeenCalled();
+    // Universal read: cross-fund GET reads are allowed for team members.
+    for (const response of [listQueryScope, pipelineQueryScope]) {
+      expect(response.status).not.toBe(403);
+    }
     expect(mockState.db.insert).not.toHaveBeenCalled();
     expect(mockState.db.update).not.toHaveBeenCalled();
   });

--- a/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
@@ -144,17 +144,13 @@ describe('marginal reserve MOIC shadow route', () => {
     expect(inputService.build).not.toHaveBeenCalled();
   });
 
-  it('rejects users without access to the requested fund', async () => {
+  it('allows a team member to read another fund rankings (universal read)', async () => {
     authState.user = { id: 101, role: 'gp', fundIds: [2] };
 
     const response = await getRankings();
 
-    expect(response.status).toBe(403);
-    expect(response.body).toEqual({
-      error: 'Forbidden',
-      message: 'You do not have access to fund 1',
-    });
-    expect(inputService.build).not.toHaveBeenCalled();
+    // Universal read: a team member (non-LP) may read any fund on safe methods.
+    expect(response.status).not.toBe(403);
   });
 
   it('rejects a non-numeric fund ID with the sibling guard status', async () => {

--- a/tests/unit/routes/investments-access-boundary.test.ts
+++ b/tests/unit/routes/investments-access-boundary.test.ts
@@ -3,11 +3,10 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import jwt from 'jsonwebtoken';
 
-// PR-H1: direct investment reads must enforce the same fund scope as the round
-// routes. These tests exercise the REAL enforceProvidedFundScope helper (signed
-// bearer tokens) while mocking storage so we control which fund an investment
-// belongs to. Cross-fund/cross-org reads must be denied; the unscoped list path
-// must be closed; the scoped ?fundId= behavior must be preserved.
+// Direct investment reads exercise the REAL enforceProvidedFundScope helper
+// (signed bearer tokens) while storage is mocked so fund ownership is explicit.
+// Authenticated non-LP team members may read across funds; the unscoped list
+// path remains closed and explicit ?fundId= behavior remains required.
 
 const TEST_SECRET = 'investments-route-auth-test-secret-minimum-32-chars';
 const TEST_ISSUER = 'updog-test';
@@ -110,7 +109,7 @@ describe('investments direct-read fund-scope boundary (PR-H1)', () => {
   });
 
   describe('GET /api/investments/:id', () => {
-    it('denies a cross-fund direct read (investment belongs to a fund the caller cannot access)', async () => {
+    it('allows a team member to read an investment from another fund', async () => {
       storageState.getInvestment.mockResolvedValue({ id: 5, fundId: 2, name: 'Secret Co' });
       const app = await makeApp();
       const token = signToken({ fundIds: [1] });
@@ -119,10 +118,8 @@ describe('investments direct-read fund-scope boundary (PR-H1)', () => {
         .get('/api/investments/5')
         .set('Authorization', `Bearer ${token}`);
 
-      expect(response.status).toBe(403);
-      expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
-      // No investment detail leaks in a denied response.
-      expect(JSON.stringify(response.body)).not.toContain('Secret Co');
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({ id: 5, fundId: 2, name: 'Secret Co' });
     });
 
     it('returns the investment when it belongs to a fund in the caller scope', async () => {
@@ -179,7 +176,8 @@ describe('investments direct-read fund-scope boundary (PR-H1)', () => {
       expect(storageState.getInvestments).not.toHaveBeenCalled();
     });
 
-    it('denies a cross-fund list (?fundId= for a fund outside the caller scope)', async () => {
+    it('allows a team member to list investments for another fund', async () => {
+      storageState.getInvestments.mockResolvedValue([{ id: 10, fundId: 2, name: 'Other Fund' }]);
       const app = await makeApp();
       const token = signToken({ fundIds: [1] });
 
@@ -187,9 +185,9 @@ describe('investments direct-read fund-scope boundary (PR-H1)', () => {
         .get('/api/investments?fundId=2')
         .set('Authorization', `Bearer ${token}`);
 
-      expect(response.status).toBe(403);
-      expect(response.body).toMatchObject({ error: 'Forbidden', code: 'FUND_ACCESS_DENIED' });
-      expect(storageState.getInvestments).not.toHaveBeenCalled();
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([{ id: 10, fundId: 2, name: 'Other Fund' }]);
+      expect(storageState.getInvestments).toHaveBeenCalledWith(2);
     });
 
     it('preserves the scoped list for ?fundId= within the caller scope', async () => {

--- a/tests/unit/routes/lp-reporting-metric-runs.contract.test.ts
+++ b/tests/unit/routes/lp-reporting-metric-runs.contract.test.ts
@@ -109,16 +109,15 @@ describe('lp-reporting metric-runs fund-scope guard contract', () => {
     resetDbCalls();
   });
 
+  // Writes stay fund-scoped: a cross-fund mutation is denied before any db work.
   it.each<DeniedEndpoint>([
     { method: 'POST', path: '/api/funds/2/metric-runs/commit', body: {} },
-    { method: 'GET', path: '/api/funds/2/metric-runs/123' },
-    { method: 'GET', path: '/api/funds/2/metric-runs/123/evidence-records' },
     {
       method: 'PATCH',
       path: '/api/funds/2/metric-runs/123/narrative-runs/456',
       body: {},
     },
-  ])('denies cross-fund $method $path before db work', async (endpoint) => {
+  ])('denies cross-fund write $method $path before db work', async (endpoint) => {
     const res = await requestEndpoint(endpoint);
 
     expect(res.status).toBe(403);
@@ -132,6 +131,16 @@ describe('lp-reporting metric-runs fund-scope guard contract', () => {
     expect(dbState.calls.insert).toBe(0);
     expect(dbState.calls.update).toBe(0);
     expect(dbState.calls.delete).toBe(0);
+  });
+
+  // Universal read: a team member may read another fund's metric-runs (safe methods).
+  it.each<DeniedEndpoint>([
+    { method: 'GET', path: '/api/funds/2/metric-runs/123' },
+    { method: 'GET', path: '/api/funds/2/metric-runs/123/evidence-records' },
+  ])('allows a team member cross-fund read $method $path', async (endpoint) => {
+    const res = await requestEndpoint(endpoint);
+
+    expect(res.status).not.toBe(403);
   });
 
   it('allows same-fund metric-run requests past the guard', async () => {

--- a/tests/unit/routes/monte-carlo-api.test.ts
+++ b/tests/unit/routes/monte-carlo-api.test.ts
@@ -386,7 +386,8 @@ describe('Monte Carlo routes', () => {
     expect(enforceProvidedFundScopeMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      2
+      2,
+      { forWrite: true }
     );
     expect(runSimulationMock).not.toHaveBeenCalled();
   });

--- a/tests/unit/routes/performance-api.contract.test.ts
+++ b/tests/unit/routes/performance-api.contract.test.ts
@@ -185,17 +185,16 @@ function expectNoCalculatorCalls() {
 describe('performance API fund-access contract', () => {
   beforeEach(() => resetState());
 
+  // Universal read: an authenticated team member may read any fund (safe methods),
+  // so a cross-fund GET is no longer denied at the fund-scope guard.
   it.each(protectedRoutes)(
-    'denies unauthorized fund access for %s',
+    'allows a team member to read another fund for %s',
     async (_route, pathForFund) => {
+      dbState.state.selectResults.push([]);
+
       const response = await request(makeApp()).get(pathForFund(2));
 
-      expect(response.status).toBe(403);
-      expect(response.status).not.toBe(404);
-      expect(response.body.error).toBe('Forbidden');
-      expect(dbState.db.select).not.toHaveBeenCalled();
-      expect(getFundMock).not.toHaveBeenCalled();
-      expectNoCalculatorCalls();
+      expect(response.status).not.toBe(403);
     }
   );
 

--- a/tests/unit/routes/performance-api.contract.test.ts
+++ b/tests/unit/routes/performance-api.contract.test.ts
@@ -176,12 +176,6 @@ function resetState() {
   loggerErrorMock.mockReset();
 }
 
-function expectNoCalculatorCalls() {
-  expect(calculateTimeseriesMock).not.toHaveBeenCalled();
-  expect(calculateBreakdownMock).not.toHaveBeenCalled();
-  expect(calculateComparisonMock).not.toHaveBeenCalled();
-}
-
 describe('performance API fund-access contract', () => {
   beforeEach(() => resetState());
 

--- a/tests/unit/routes/shares.contract.test.ts
+++ b/tests/unit/routes/shares.contract.test.ts
@@ -327,14 +327,6 @@ describe('shares management boundary contracts', () => {
       expectedSelects: 0,
     },
     {
-      name: 'GET /?fundId=2',
-      act: () =>
-        request(makeManagementApp({ user: deniedUser }))
-          .get('/')
-          .query({ fundId: '2' }),
-      expectedSelects: 0,
-    },
-    {
       name: 'PATCH /:shareId',
       act: () => {
         dbState.state.selectResults.push([makeShare({ id: 'share-deny-patch', fundId: '2' })]);
@@ -352,18 +344,8 @@ describe('shares management boundary contracts', () => {
       },
       expectedSelects: 1,
     },
-    {
-      name: 'GET /:shareId/analytics',
-      act: () => {
-        dbState.state.selectResults.push([makeShare({ id: 'share-deny-analytics', fundId: '2' })]);
-        return request(makeManagementApp({ user: deniedUser })).get(
-          '/share-deny-analytics/analytics'
-        );
-      },
-      expectedSelects: 1,
-    },
   ])(
-    '$name returns 403 for cross-fund management access without mutation',
+    '$name returns 403 for cross-fund write access without mutation',
     async ({ act, expectedSelects }) => {
       const response = await act();
 
@@ -373,6 +355,36 @@ describe('shares management boundary contracts', () => {
       expectNoShareMutation();
     }
   );
+
+  it('GET /?fundId=2 allows a team member to list another fund shares', async () => {
+    dbState.state.selectResults.push([makeShare({ id: 'cross-fund-share', fundId: '2' })]);
+
+    const response = await request(makeManagementApp({ user: deniedUser }))
+      .get('/')
+      .query({ fundId: '2' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.shares).toHaveLength(1);
+    expect(response.body.shares[0]).toMatchObject({ id: 'cross-fund-share', fundId: '2' });
+    expect(dbState.db.select).toHaveBeenCalledTimes(1);
+    expectNoShareMutation();
+  });
+
+  it('GET /:shareId/analytics allows a team member to read another fund analytics', async () => {
+    dbState.state.selectResults.push(
+      [makeShare({ id: 'cross-fund-analytics', fundId: '2' })],
+      []
+    );
+
+    const response = await request(makeManagementApp({ user: deniedUser })).get(
+      '/cross-fund-analytics/analytics'
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ success: true, views: [] });
+    expect(dbState.db.select).toHaveBeenCalledTimes(2);
+    expectNoShareMutation();
+  });
 
   it('POST / denies a non-numeric string fundId without reaching idempotency or writes', async () => {
     const response = await request(makeManagementApp({ user: deniedUser }))
@@ -554,13 +566,8 @@ describe('shares management boundary contracts', () => {
       act: (shareId: string) =>
         request(makeManagementApp({ user: deniedUser })).delete(`/${shareId}`),
     },
-    {
-      name: 'GET /:shareId/analytics',
-      act: (shareId: string) =>
-        request(makeManagementApp({ user: deniedUser })).get(`/${shareId}/analytics`),
-    },
   ])(
-    '$name documents the current management existence-leak ordering without changing it',
+    '$name preserves the current write-path existence-leak ordering',
     async ({ act }) => {
       dbState.state.selectResults.push([]);
 
@@ -574,6 +581,25 @@ describe('shares management boundary contracts', () => {
       expectNoShareMutation();
     }
   );
+
+  it('GET /:shareId/analytics preserves 404 ordering and allows an existing cross-fund read', async () => {
+    dbState.state.selectResults.push([]);
+    const missing = await request(makeManagementApp({ user: deniedUser })).get(
+      '/missing-share/analytics'
+    );
+
+    dbState.state.selectResults.push(
+      [makeShare({ id: 'real-share', fundId: '2' })],
+      []
+    );
+    const existingWrongFund = await request(makeManagementApp({ user: deniedUser })).get(
+      '/real-share/analytics'
+    );
+
+    expect(missing.status).toBe(404);
+    expect(existingWrongFund.status).toBe(200);
+    expectNoShareMutation();
+  });
 });
 
 describe('public shares anonymous token boundary contracts', () => {

--- a/tests/unit/server/route-surface-inventory.test.ts
+++ b/tests/unit/server/route-surface-inventory.test.ts
@@ -885,15 +885,15 @@ describe('route surface inventory', () => {
   // own unit contracts.
   // ==========================================================================
 
-  it('denies a scoped token cross-fund, allows its own fund, and allows an unrestricted token', async () => {
+  it('allows a scoped token cross-fund read, allows its own fund, and allows an unrestricted token', async () => {
     const makeApp = await makeAppWithTestAuth();
 
-    // Scoped to fund 1, requesting fund 2 -> fund-scope denial before any service.
+    // Scoped to fund 1, READING fund 2 -> universal read: the guard passes (never a
+    // fund denial) for a team member on a safe method.
     const crossFund = await request(makeApp)
       .get('/api/funds/2/allocation-scenarios')
       .set('Authorization', await scopedAuthorizationHeader([1]));
-    expect(crossFund.status).toBe(403);
-    expect(crossFund.body).toMatchObject({ code: 'FUND_ACCESS_DENIED' });
+    expect(crossFund.status).not.toBe(403);
 
     // Scoped to fund 1, requesting fund 1 -> guard passes. Status may vary on
     // memory storage (200/4xx/5xx) but it is never a fund denial.


### PR DESCRIPTION
## Universal fund read for team members (method-aware; writes stay scoped)

Any authenticated **non-LP team member** may now READ or EXPORT any fund. Writes and any
mutating operation remain fund-scoped exactly as before. This is an internal, single-tenant tool
(~5 trusted team members, no LP accounts); the owner ratified "universal read + universal export,
role-gated writes."

### Design
`resolveFundScope` stays **strict and unchanged** — it remains the authority for writes/exports.
Universal read is layered on top, in the guard middleware, gated by two predicates:
- `isSafeReadMethod(method)` — GET/HEAD only (server/lib/auth/fund-scope.ts)
- `isTeamMemberUser(user)` — authenticated, `role !== 'lp'`, no `lpId` (server/lib/auth/principal.ts)

Relaxed sites (safe method + team member => allow any fund):
- `requireFundAccess` (jwt.ts)
- `enforceProvidedFundScope` + the `getVerifiedFundScope` `unrestricted` derivation
  (provided-fund-scope.ts) — this also covers the enumeration/stream/company-read consumers
  (activities, sse-events, scenario-analysis company GETs)
- local fund guards in `backtesting.ts` (`hasFundAccess`) and `shares.ts` (`canManageFund`)

### Why not a one-line `resolveFundScope` flip (two review gates blocked it)
1. The guard is **operation-blind** (shared by reads, writes, exports). `server/routes/investments.ts`
   POST routes have **no** `requireWriteRole` — a naive flip would open **cross-fund writes**. Export
   routes rely on `requireFundAccess` for per-fund matching, so a flip would break export scoping.
2. **HTTP method is not a reliable read/write signal** here: `GET /api/monte-carlo/funds/:fundId/simulate`
   persists a simulation run. It is explicitly **denylisted** (`enforceProvidedFundScope(..., { forWrite: true })`)
   so it stays fund-scoped. Verified by three independent passes that this is the only persisting
   safe-method route behind a relaxed guard. Residual risk: a service-mediated persist inside a GET
   missed by all three passes would become cross-fund — accepted per the chosen pragmatic approach for
   a trusted 5-person tool.
3. `principalFromUser` maps role `lp` to a `user` principal, so an "any authenticated" predicate would
   grant an **LP universal read**. `isTeamMemberUser` excludes LP (role or `lpId`).

### Intentional reversal (documented)
This relaxes, for READS only, the deliberate "empty-fundIds -> deny" footgun-fix
(principal.ts / fund-scope.ts). Acceptable **only** because every `user` principal here is a trusted
team member and writes/exports-that-mutate stay scoped. If untrusted or LP users are ever modeled as
non-LP `user` principals, this must be revisited.

### Preserved (unchanged)
- `resolveFundScope` strict logic; anonymous + LP still denied
- LP path (`requireLPFundAccess`), `requireExportFundGrant` role/grant bar, param validation
  (`parseFundIdParam`)
- All write/mutation guards (`requireWriteRole`, cross-fund POST/PUT/PATCH/DELETE stay 403)
- `timeline /events/latest` stays admin-only (a role gate, not fund-scope)

### Tests
- New positive/negative unit coverage: team-member GET cross-fund allowed; POST cross-fund 403; LP GET
  403; anonymous GET 403; `getVerifiedFundScope` unrestricted for team GET; `{ forWrite: true }` keeps
  simulate strict; `isSafeReadMethod`/`isTeamMemberUser` unit tests.
- Straggler contract tests updated to the new read behavior (cross-fund GET reads allowed; cross-fund
  writes still denied).
- `npm run check` clean; full `--project=server` unit suite green. Integration acceptance matrix is
  gated to main (exercise via `ci-unified.yml -f run_full_suite=true`).

Implemented under the Hermes flow (plan -> two codex plan-review gates -> codex implementation ->
adversarial review + full suite). Straggler test flips applied directly after repeated dispatch-infra
interruptions (retry-once + documented-fallback).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)