### PR TITLE
test: keep scenario persistence fixture loadable after write-role gating

### DIFF
--- a/scripts/test-smart.mjs
+++ b/scripts/test-smart.mjs
@@ -298,12 +298,46 @@ function runNpm(args, { root = process.cwd(), spawn = spawnSync } = {}) {
   return typeof result.status === 'number' ? result.status : 1;
 }
 
+function isIntegrationTestPath(testPath) {
+  return testPath.startsWith('tests/integration/') || testPath.startsWith('tests/api/');
+}
+
+function isUnitTestPath(testPath) {
+  return (
+    testPath.startsWith('tests/unit/') ||
+    testPath.startsWith('tests/perf/') ||
+    testPath.startsWith('tests/regressions/')
+  );
+}
+
 export async function executeSelectedPlan(plan, { root = process.cwd(), spawn = spawnSync } = {}) {
   await validateAffectedTestPlan(plan, { root });
   if (plan.mode !== 'selected') {
     throw new Error(`Cannot execute selected tests for plan mode ${plan.mode}.`);
   }
-  return runNpm(['run', 'test:unit', '--', ...plan.tests], { root, spawn });
+
+  const unsupportedTest = plan.tests.find(
+    (test) => !isUnitTestPath(test) && !isIntegrationTestPath(test)
+  );
+  if (unsupportedTest !== undefined) {
+    throw new Error(`No affected-test runner is configured for ${unsupportedTest}.`);
+  }
+
+  const integrationTests = plan.tests.filter(isIntegrationTestPath);
+  const unitTests = plan.tests.filter(isUnitTestPath);
+  for (const [script, tests] of [
+    ['test:unit', unitTests],
+    ['test:integration', integrationTests],
+  ]) {
+    if (tests.length === 0) {
+      continue;
+    }
+    const status = runNpm(['run', script, '--', ...tests], { root, spawn });
+    if (status !== 0) {
+      return status;
+    }
+  }
+  return 0;
 }
 
 function gitOutput(args, root) {

--- a/tests/integration/scenarios/company-scenario-create-persistence.test.ts
+++ b/tests/integration/scenarios/company-scenario-create-persistence.test.ts
@@ -65,6 +65,7 @@ async function loadRouteApp(fundId: number) {
   vi.doMock('../../../server/lib/auth/jwt', () => ({
     requireAuth: () => (_req: unknown, _res: unknown, next: () => void) => next(),
     requireFundAccess: (_req: unknown, _res: unknown, next: () => void) => next(),
+    requireWriteRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
   }));
   vi.doMock('../../../server/lib/auth/company-fund-scope', () => ({
     enforceCompanyFundScope: async () => true,

--- a/tests/unit/scripts/test-smart.test.mjs
+++ b/tests/unit/scripts/test-smart.test.mjs
@@ -126,4 +126,66 @@ describe('affected-test execution', () => {
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(spawn.mock.calls[0][1]).toContain('tests/unit/failing.test.ts');
   });
+
+  it('runs a selected integration test with the integration configuration', async () => {
+    const root = await makeRoot();
+    await write(root, 'tests/integration/selected.test.ts');
+    const plan = {
+      version: 1,
+      mode: 'selected',
+      tests: ['tests/integration/selected.test.ts'],
+      reason: 'changed integration test',
+    };
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    const status = await executeSelectedPlan(plan, { root, spawn });
+
+    expect(status).toBe(0);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0][1]).toEqual([
+      'run',
+      'test:integration',
+      '--',
+      'tests/integration/selected.test.ts',
+    ]);
+  });
+
+  it('runs mixed unit and API selections with their owning configurations', async () => {
+    const root = await makeRoot();
+    await write(root, 'tests/unit/selected.test.ts');
+    await write(root, 'tests/api/selected.test.ts');
+    const plan = {
+      version: 1,
+      mode: 'selected',
+      tests: ['tests/api/selected.test.ts', 'tests/unit/selected.test.ts'],
+      reason: 'changed tests',
+    };
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    const status = await executeSelectedPlan(plan, { root, spawn });
+
+    expect(status).toBe(0);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn.mock.calls.map((call) => call[1])).toEqual([
+      ['run', 'test:unit', '--', 'tests/unit/selected.test.ts'],
+      ['run', 'test:integration', '--', 'tests/api/selected.test.ts'],
+    ]);
+  });
+
+  it('rejects selected tests that have no configured affected-test runner', async () => {
+    const root = await makeRoot();
+    await write(root, 'tests/e2e/selected.spec.ts');
+    const plan = {
+      version: 1,
+      mode: 'selected',
+      tests: ['tests/e2e/selected.spec.ts'],
+      reason: 'changed test',
+    };
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    await expect(executeSelectedPlan(plan, { root, spawn })).rejects.toThrow(
+      'No affected-test runner is configured for tests/e2e/selected.spec.ts.'
+    );
+    expect(spawn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Intent

Repair the exact-main scenario persistence fixture regression and keep its affected-test proof executable under the Vitest configuration that owns it.

## Changes

- add an export-complete pass-through `requireWriteRole` factory to the persistence test's full JWT module replacement
- dispatch selected `tests/integration/**` and `tests/api/**` paths through `test:integration`, while unit/perf/regression paths remain on `test:unit`
- batch mixed selections deterministically, fail fast, and reject unsupported test roots
- keep production scenario authorization, accepted roles, workflow topology, and GET ordering/case-count assertions unchanged

## Proof

- fixture negative control: 1 file / 8 tests selected; 7 passed, 1 failed with the exact missing `requireWriteRole` export
- selector negative control: 1 file / 13 tests selected; 12 passed, 1 failed because the integration path was sent to `test:unit`
- selector post-fix: 1 file / 15 tests passed
- selected scenario persistence through the repaired executor: 1 file / 8 tests passed
- scenario route contract: 1 file / 63 tests passed
- CI-parity full integration: 75 files / 889 tests selected; 68 files and 755 tests passed; 7 files and 134 tests skipped; zero failures
- lint and all guardrails: passed
- TypeScript baseline: 0 current and 0 new errors
- `validate:core`: passed
- configured suite: 734 files / 8,800 tests selected; 728 files and 8,710 tests passed; 6 files and 90 tests skipped; zero failures
- production build and bundle verification: passed after transforming 3,921 modules
- independent architecture review: ACCEPT
- changed-files cleanup review: no cleanup changes required

## Scope and hold

Changed files:

- `scripts/test-smart.mjs`
- `tests/integration/scenarios/company-scenario-create-persistence.test.ts`
- `tests/unit/scripts/test-smart.test.mjs`

Do not merge from this automation lane. Gate -1 remains HOLD pending authorized merge, green exact resulting main, and separate production-perimeter/schema prerequisite reconciliation.