### PR TITLE
test: restore release proof after write-role enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test": "npm run test:unit",
     "test:unit": "cross-env TZ=UTC vitest run --config vitest.config.mjs --configLoader native --project=server --project=client",
     "test:integration": "cross-env TZ=UTC vitest run -c vitest.config.int.ts",
+    "test:testcontainers": "cross-env TZ=UTC vitest run -c vitest.config.testcontainers.ts",
     "test:integration:routes": "cross-env TZ=UTC vitest run -c vitest.config.int.ts tests/integration/fund-results-comparison-route.test.ts tests/integration/flags-routes.test.ts tests/integration/sensitivity-routes.test.ts",
     "test:scenario-release-gate": "cross-env TZ=UTC vitest run -c vitest.config.int.ts tests/integration/scenarios/scenario-release-gate.integration.test.ts",
     "test:integration:phase0-dbproof": "cross-env TZ=UTC vitest run -c vitest.config.phase0-dbproof.ts tests/integration/phase0-migrated-postgres.test.ts",

--- a/scripts/test-smart.mjs
+++ b/scripts/test-smart.mjs
@@ -18,6 +18,10 @@ const BROAD_IMPACT_PATTERNS = [
   /^(?:package(?:-lock)?\.json|tsconfig[^/]*\.json|vite\.config\.|vitest\.config\.)/,
   /^Dockerfile/,
 ];
+const TESTCONTAINERS_ONLY_PATHS = new Set([
+  'tests/integration/migration-runner.test.ts',
+  'tests/integration/fund-lifecycle-db.test.ts',
+]);
 
 function normalizeRepoPath(value) {
   return value.split(path.sep).join('/').replace(/^\.\//, '');
@@ -302,6 +306,10 @@ function isIntegrationTestPath(testPath) {
   return testPath.startsWith('tests/integration/') || testPath.startsWith('tests/api/');
 }
 
+function isTestcontainersOnlyTestPath(testPath) {
+  return TESTCONTAINERS_ONLY_PATHS.has(testPath);
+}
+
 function isUnitTestPath(testPath) {
   return (
     testPath.startsWith('tests/unit/') ||
@@ -323,11 +331,15 @@ export async function executeSelectedPlan(plan, { root = process.cwd(), spawn = 
     throw new Error(`No affected-test runner is configured for ${unsupportedTest}.`);
   }
 
-  const integrationTests = plan.tests.filter(isIntegrationTestPath);
+  const testcontainersTests = plan.tests.filter(isTestcontainersOnlyTestPath);
+  const integrationTests = plan.tests.filter(
+    (test) => isIntegrationTestPath(test) && !isTestcontainersOnlyTestPath(test)
+  );
   const unitTests = plan.tests.filter(isUnitTestPath);
   for (const [script, tests] of [
     ['test:unit', unitTests],
     ['test:integration', integrationTests],
+    ['test:testcontainers', testcontainersTests],
   ]) {
     if (tests.length === 0) {
       continue;

--- a/tests/integration/fund-lifecycle-db.test.ts
+++ b/tests/integration/fund-lifecycle-db.test.ts
@@ -122,10 +122,11 @@ async function startRuntime(): Promise<Runtime> {
   process.env._EXPLICIT_JWT_ALG = 'HS256';
 
   const { registerFundConfigRoutes } = await import('../../server/routes/fund-config');
-  const { signToken } = await import('../../server/lib/auth/jwt');
+  const { requireAuth, signToken } = await import('../../server/lib/auth/jwt');
 
   const app = express();
   app.use(express.json({ limit: '1mb' }));
+  app.use('/api', requireAuth());
   registerFundConfigRoutes(app);
 
   return { app, pool, postgres, signToken };
@@ -162,12 +163,12 @@ function finalizeFixture(): FundFinalizeV1 {
   };
 }
 
-function authHeader(active: Runtime, fundId: number): string {
+function authHeader(active: Runtime, fundId?: number): string {
   return `Bearer ${active.signToken({
     sub: 'fund-lifecycle-db',
     email: 'integration@example.com',
     role: 'admin',
-    fundIds: [fundId],
+    fundIds: fundId === undefined ? [] : [fundId],
   })}`;
 }
 
@@ -264,9 +265,11 @@ describe('fund lifecycle DB proof', () => {
     const active = runtime!;
     const idempotencyKey = 'lean-lifecycle-db-proof-1';
     const body = finalizeFixture();
+    const adminToken = authHeader(active);
 
     const first = await request(active.app)
       .post('/api/funds/finalize')
+      .set('Authorization', adminToken)
       .set('Idempotency-Key', idempotencyKey)
       .send(body);
 
@@ -377,6 +380,7 @@ describe('fund lifecycle DB proof', () => {
 
     const replay = await request(active.app)
       .post('/api/funds/finalize')
+      .set('Authorization', adminToken)
       .set('Idempotency-Key', idempotencyKey)
       .send(body);
 

--- a/tests/regressions/ci-unified-playwright-install.test.ts
+++ b/tests/regressions/ci-unified-playwright-install.test.ts
@@ -56,6 +56,7 @@ describe('CI Unified scenario release gate', () => {
     const fullRun =
       workflow.jobs?.['test-full']?.steps?.find((step) => step.name === 'Run tests')?.run ?? '';
     const integrationConfig = await readRepoFile('vitest.config.int.ts');
+    const smartTestRunner = await readRepoFile('scripts/test-smart.mjs');
     const integrationIncludeBlock =
       integrationConfig.match(/include:\s*\[([\s\S]*?)\],/)?.[1] ?? '';
     const integrationExcludeBlock =
@@ -67,12 +68,17 @@ describe('CI Unified scenario release gate', () => {
     expect(fullRun).toContain('integration)');
     expect(fullRun).toContain('npm run test:integration');
     expect(integrationConfig).toContain(`'${scenarioReleaseGatePath}'`);
-    expect(integrationConfig).toContain("'tests/integration/fund-lifecycle-db.test.ts'");
     expect(integrationIncludeBlock).toContain('scenarioReleaseGatePath');
     expect(integrationExcludeBlock).not.toContain(scenarioReleaseGatePath);
     expect(integrationExcludeBlock).not.toContain('scenarioReleaseGatePath');
     expect(integrationExcludeBlock).toContain('...testcontainersOnlyPaths');
-    expect(testcontainersOnlyBlock).toContain('tests/integration/fund-lifecycle-db.test.ts');
+    for (const testPath of [
+      'tests/integration/migration-runner.test.ts',
+      'tests/integration/fund-lifecycle-db.test.ts',
+    ]) {
+      expect(testcontainersOnlyBlock).toContain(testPath);
+      expect(smartTestRunner).toContain(`'${testPath}'`);
+    }
     expect(testcontainersOnlyBlock).not.toContain(scenarioReleaseGatePath);
     expect(testcontainersOnlyBlock).not.toContain('scenarioReleaseGatePath');
   });

--- a/tests/unit/scripts/test-smart.test.mjs
+++ b/tests/unit/scripts/test-smart.test.mjs
@@ -150,6 +150,29 @@ describe('affected-test execution', () => {
     ]);
   });
 
+  it('runs a Testcontainers-only selection with its owning configuration', async () => {
+    const root = await makeRoot();
+    await write(root, 'tests/integration/fund-lifecycle-db.test.ts');
+    const plan = {
+      version: 1,
+      mode: 'selected',
+      tests: ['tests/integration/fund-lifecycle-db.test.ts'],
+      reason: 'changed Testcontainers-only test',
+    };
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    const status = await executeSelectedPlan(plan, { root, spawn });
+
+    expect(status).toBe(0);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0][1]).toEqual([
+      'run',
+      'test:testcontainers',
+      '--',
+      'tests/integration/fund-lifecycle-db.test.ts',
+    ]);
+  });
+
   it('runs mixed unit and API selections with their owning configurations', async () => {
     const root = await makeRoot();
     await write(root, 'tests/unit/selected.test.ts');


### PR DESCRIPTION
## Failure

Exact-main `Release Production` run [29498061786](https://github.com/nikhillinit/Updog_restore/actions/runs/29498061786) stopped safely in `Full Release Proof / Full DB-backed Release Proof` before schema audit, approval, or promotion. The release-only `fund-lifecycle-db` harness received `403` instead of `201` on the first finalize request after write-role enforcement.

The first PR head then exposed a separate affected-test routing defect: CI selected that Testcontainers-only file but invoked it through `vitest.config.int.ts`, where it is explicitly excluded, producing `No test files found` even though the dedicated Testcontainers job passed.

## Repair

- Mirror the production `/api` authentication boundary in the direct Express test harness.
- Authenticate both finalize and idempotent replay requests with an admin JWT.
- Retain the fund-scoped admin token for state/results reads.
- Add a named Testcontainers test runner.
- Route `fund-lifecycle-db` and `migration-runner` affected selections through their owning Testcontainers configuration.
- Lock runner/config ownership with behavioral and configuration-sync regressions.
- Leave production route and authorization behavior unchanged.

## Proof

- Smart-selector and configuration regressions: 18/18 passed.
- Live smart-selector invocation of the Testcontainers lifecycle proof: 1/1 passed.
- `npm test`: passed after the selector repair.
- `CI=true TZ=UTC npm run release:check`: all 16 stages passed after the selector repair, including zero-error typecheck, lint/guardrails, fund lifecycle DB proof, migration/schema clone, scenario release gate, and production build.

## Scope

Five test/infrastructure files changed. No deployment, approval, promotion, schema mutation, or production migration was performed.