### PR TITLE
fix: preserve historical scenario source compatibility

### DIFF
--- a/server/services/fund-scenario-calculation-service.ts
+++ b/server/services/fund-scenario-calculation-service.ts
@@ -32,6 +32,7 @@ import {
   type FundScenarioMutationActor,
 } from './fund-scenario-set-service.js';
 import { createScenarioInputHash } from '../lib/scenarios/scenario-input-hash';
+import { normalizeLegacyScenarioSourceConfig } from './fund-scenario-source-config-compat.js';
 import {
   acquireScenarioCalculationRun,
   findCompletedScenarioRun,
@@ -303,7 +304,9 @@ async function loadCurrentPublishedVersion(
 }
 
 function parseSourceConfig(fundId: number, sourceConfig: SourceConfigRow): FundDraftWriteV1 {
-  const parsed = FundDraftWriteV1Schema.safeParse(sourceConfig.config);
+  const parsed = FundDraftWriteV1Schema.safeParse(
+    normalizeLegacyScenarioSourceConfig(sourceConfig.config)
+  );
   if (!parsed.success) {
     throw createHttpError(409, `Scenario source config for fund ${fundId} is invalid`, {
       code: 'scenario_source_config_invalid',

--- a/server/services/fund-scenario-reserve-calculation-service.ts
+++ b/server/services/fund-scenario-reserve-calculation-service.ts
@@ -34,6 +34,7 @@ import {
   type FundScenarioMutationActor,
 } from './fund-scenario-set-service.js';
 import { createScenarioInputHash } from '../lib/scenarios/scenario-input-hash';
+import { normalizeLegacyScenarioSourceConfig } from './fund-scenario-source-config-compat.js';
 import {
   acquireScenarioCalculationRun,
   findCompletedScenarioRun,
@@ -180,7 +181,9 @@ async function loadSourceConfig(
 }
 
 function parseSourceConfig(fundId: number, sourceConfig: SourceConfigRow): FundDraftWriteV1 {
-  const parsed = FundDraftWriteV1Schema.safeParse(sourceConfig.config);
+  const parsed = FundDraftWriteV1Schema.safeParse(
+    normalizeLegacyScenarioSourceConfig(sourceConfig.config)
+  );
   if (parsed.success) {
     return parsed.data;
   }

--- a/server/services/fund-scenario-source-config-compat.ts
+++ b/server/services/fund-scenario-source-config-compat.ts
@@ -1,0 +1,17 @@
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+export function normalizeLegacyScenarioSourceConfig(value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  const config = value as Record<string, unknown>;
+  if (!hasOwn(config, 'name') || hasOwn(config, 'fundName')) {
+    return value;
+  }
+
+  const { name, ...canonicalConfig } = config;
+  return { ...canonicalConfig, fundName: name };
+}

--- a/tests/unit/services/fund-scenario-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-calculation-service.test.ts
@@ -127,6 +127,12 @@ const baseConfig = {
   },
 } as const;
 
+const { fundName: legacyFundName, ...legacyBaseConfigFields } = baseConfig;
+const legacyBaseConfig = {
+  ...legacyBaseConfigFields,
+  name: legacyFundName,
+} as const;
+
 const explicitFeeTierEconomicsAssumptions = {
   version: 'v1',
   timeline: {
@@ -302,10 +308,7 @@ function calculationRunRow(
   snapshotId: number | null = null,
   options: {
     calculationMode?:
-      | 'sync_fee_profile'
-      | 'sync_allocation'
-      | 'sync_sector_profile'
-      | 'sync_methodology';
+      'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile' | 'sync_methodology';
     overrideType?: 'fee_profile' | 'allocation' | 'sector_profile' | 'methodology';
     inputHash?: string;
     hashKind?: 'scenario-input-hash-v1' | 'scenario-input-hash-v2' | null;
@@ -324,12 +327,9 @@ function calculationRunRow(
     calculation_mode: calculationMode,
     override_type: overrideType,
     input_hash: options.inputHash ?? expectedInputHash(),
-    hash_kind:
-      options.hashKind === undefined ? 'scenario-input-hash-v2' : options.hashKind,
+    hash_kind: options.hashKind === undefined ? 'scenario-input-hash-v2' : options.hashKind,
     model_inputs_as_of_date:
-      options.modelInputsAsOfDate === undefined
-        ? '2026-06-30'
-        : options.modelInputsAsOfDate,
+      options.modelInputsAsOfDate === undefined ? '2026-06-30' : options.modelInputsAsOfDate,
     comparison_lineage_version:
       options.comparisonLineageVersion === undefined
         ? 'comparison-lineage-v1'
@@ -352,10 +352,7 @@ function expectedInputHashFor(
     | typeof sectorProfileOverride
     | typeof methodologyOverride,
   calculationMode:
-    | 'sync_fee_profile'
-    | 'sync_allocation'
-    | 'sync_sector_profile'
-    | 'sync_methodology',
+    'sync_fee_profile' | 'sync_allocation' | 'sync_sector_profile' | 'sync_methodology',
   overrideType: 'fee_profile' | 'allocation' | 'sector_profile' | 'methodology'
 ): string {
   return createScenarioInputHash({
@@ -396,95 +393,102 @@ describe('fund scenario calculation service', () => {
     runEconomicsModelMock.mockReset();
   });
 
-  it('applies fee-profile overrides, persists a scenario snapshot, and records an audit event', async () => {
-    queryMock
-      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
-      .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
-      .mockResolvedValueOnce({ rows: [variantRow()] })
-      .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config: baseConfig }] })
-      .mockResolvedValueOnce({ rows: [{ version: 4 }] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [calculationRunRow('queued')] })
-      .mockResolvedValueOnce({ rows: [calculationRunRow('running')] })
-      .mockImplementationOnce((_sql: string, params: unknown[]) => ({
-        rows: [
-          {
-            id: 42,
-            payload: params[1],
-            correlation_id: params[3],
-            created_at: new Date('2026-05-26T12:05:00.000Z'),
-            snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
-          },
-        ],
-      }))
-      .mockResolvedValueOnce({ rows: [calculationRunRow('completed', 42)] })
-      .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000124' }] });
+  it.each([
+    { label: 'canonical source config', config: baseConfig },
+    { label: 'legacy create-format source config', config: legacyBaseConfig },
+  ])(
+    'applies fee-profile overrides from a $label, persists a scenario snapshot, and records an audit event',
+    async ({ config }) => {
+      queryMock
+        .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+        .mockResolvedValueOnce({ rows: [scenarioSetRow()] })
+        .mockResolvedValueOnce({ rows: [variantRow()] })
+        .mockResolvedValueOnce({ rows: [{ id: 12, version: 4, config }] })
+        .mockResolvedValueOnce({ rows: [{ version: 4 }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [calculationRunRow('queued')] })
+        .mockResolvedValueOnce({ rows: [calculationRunRow('running')] })
+        .mockImplementationOnce((_sql: string, params: unknown[]) => ({
+          rows: [
+            {
+              id: 42,
+              payload: params[1],
+              correlation_id: params[3],
+              created_at: new Date('2026-05-26T12:05:00.000Z'),
+              snapshot_time: new Date('2026-05-26T12:05:00.000Z'),
+            },
+          ],
+        }))
+        .mockResolvedValueOnce({ rows: [calculationRunRow('completed', 42)] })
+        .mockResolvedValueOnce({ rows: [{ id: '00000000-0000-0000-0000-000000000124' }] });
 
-    const result = await calculateFundScenarioSet(1, scenarioSetId, {
-      userId: 17,
-      label: 'analyst@example.com',
-    });
+      const result = await calculateFundScenarioSet(1, scenarioSetId, {
+        userId: 17,
+        label: 'analyst@example.com',
+      });
 
-    expect(result.snapshotId).toBe(42);
-    expect(result.source).toBe('fund_snapshots');
-    expect(result.payload.variants[0]?.economics.summary.totalManagementFees).toBe(1);
-    expect(runEconomicsModelMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fundName: 'Test Fund',
-        feeProfiles: feeProfileOverride.payload.feeProfiles,
-        economicsAssumptions: expect.objectContaining({
-          feeModel: { source: 'legacy_fee_profiles' },
+      expect(result.snapshotId).toBe(42);
+      expect(result.source).toBe('fund_snapshots');
+      expect(result.payload.variants[0]?.economics.summary.totalManagementFees).toBe(1);
+      expect(runEconomicsModelMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fundName: 'Test Fund',
+          feeProfiles: feeProfileOverride.payload.feeProfiles,
+          economicsAssumptions: expect.objectContaining({
+            feeModel: { source: 'legacy_fee_profiles' },
+          }),
+        })
+      );
+      expect(runEconomicsModelMock.mock.calls[0]?.[0]).not.toHaveProperty('name');
+      expect(queryMock.mock.calls[1]?.[0]).toContain('FOR UPDATE OF s');
+      const snapshotInsertCall = queryMock.mock.calls.find((call) =>
+        String(call[0]).includes('INSERT INTO fund_snapshots')
+      );
+      const snapshotInsertSql = String(snapshotInsertCall?.[0] ?? '');
+      const snapshotInsertParams = snapshotInsertCall?.[1] as unknown[] | undefined;
+      const snapshotMetadata = snapshotInsertParams?.[4];
+
+      expect(snapshotInsertSql).toContain("VALUES ($1, 'SCENARIOS'");
+      expect(snapshotInsertSql).toContain('state_hash');
+      expect(snapshotInsertSql).toContain('scenario_set_id');
+      expect(snapshotInsertSql).toContain('fund_snapshots_scenarios_dedup_idx');
+      expect(snapshotInsertSql).toContain(
+        'ON CONFLICT (fund_id, scenario_set_id, config_id, config_version, state_hash)'
+      );
+      expect(snapshotInsertSql).not.toContain('ON CONFLICT (fund_id, scenario_set_id)');
+      expect(snapshotMetadata).toMatchObject({
+        input_hash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        calculation_mode: 'sync_fee_profile',
+        override_type: 'fee_profile',
+      });
+      expect(snapshotInsertParams?.[7]).toBe(expectedInputHash());
+      expect(snapshotInsertParams?.[8]).toBe(scenarioSetId);
+      const runInsertCall = queryMock.mock.calls.find((call) =>
+        String(call[0]).includes('INSERT INTO fund_scenario_calculation_runs')
+      );
+      const runInsertSql = String(runInsertCall?.[0] ?? '');
+      const runInsertParams = runInsertCall?.[1] as unknown[] | undefined;
+      expect(runInsertSql).toContain("COALESCE(hash_kind, 'scenario-input-hash-v1')");
+      expect(runInsertParams?.[7]).toBe('scenario-input-hash-v2');
+      expect(runInsertParams?.[8]).toBe('2026-06-30');
+      expect(runInsertParams?.[9]).toBe('comparison-lineage-v1');
+      const eventInsertCall = queryMock.mock.calls.find((call) =>
+        String(call[0]).includes('INSERT INTO fund_scenario_set_events')
+      );
+      expect(eventInsertCall?.[1]).toEqual([
+        scenarioSetId,
+        1,
+        'calculated',
+        17,
+        'analyst@example.com',
+        expect.objectContaining({
+          headline: 'Calculated fee-profile scenario set',
+          snapshot_id: 42,
+          variant_count: 1,
         }),
-      })
-    );
-    expect(queryMock.mock.calls[1]?.[0]).toContain('FOR UPDATE OF s');
-    const snapshotInsertCall = queryMock.mock.calls.find((call) =>
-      String(call[0]).includes('INSERT INTO fund_snapshots')
-    );
-    const snapshotInsertSql = String(snapshotInsertCall?.[0] ?? '');
-    const snapshotInsertParams = snapshotInsertCall?.[1] as unknown[] | undefined;
-    const snapshotMetadata = snapshotInsertParams?.[4];
-
-    expect(snapshotInsertSql).toContain("VALUES ($1, 'SCENARIOS'");
-    expect(snapshotInsertSql).toContain('state_hash');
-    expect(snapshotInsertSql).toContain('scenario_set_id');
-    expect(snapshotInsertSql).toContain('fund_snapshots_scenarios_dedup_idx');
-    expect(snapshotInsertSql).toContain(
-      'ON CONFLICT (fund_id, scenario_set_id, config_id, config_version, state_hash)'
-    );
-    expect(snapshotInsertSql).not.toContain('ON CONFLICT (fund_id, scenario_set_id)');
-    expect(snapshotMetadata).toMatchObject({
-      input_hash: expect.stringMatching(/^[a-f0-9]{64}$/),
-      calculation_mode: 'sync_fee_profile',
-      override_type: 'fee_profile',
-    });
-    expect(snapshotInsertParams?.[7]).toBe(expectedInputHash());
-    expect(snapshotInsertParams?.[8]).toBe(scenarioSetId);
-    const runInsertCall = queryMock.mock.calls.find((call) =>
-      String(call[0]).includes('INSERT INTO fund_scenario_calculation_runs')
-    );
-    const runInsertSql = String(runInsertCall?.[0] ?? '');
-    const runInsertParams = runInsertCall?.[1] as unknown[] | undefined;
-    expect(runInsertSql).toContain("COALESCE(hash_kind, 'scenario-input-hash-v1')");
-    expect(runInsertParams?.[7]).toBe('scenario-input-hash-v2');
-    expect(runInsertParams?.[8]).toBe('2026-06-30');
-    expect(runInsertParams?.[9]).toBe('comparison-lineage-v1');
-    const eventInsertCall = queryMock.mock.calls.find((call) =>
-      String(call[0]).includes('INSERT INTO fund_scenario_set_events')
-    );
-    expect(eventInsertCall?.[1]).toEqual([
-      scenarioSetId,
-      1,
-      'calculated',
-      17,
-      'analyst@example.com',
-      expect.objectContaining({
-        headline: 'Calculated fee-profile scenario set',
-        snapshot_id: 42,
-        variant_count: 1,
-      }),
-    ]);
-  });
+      ]);
+    }
+  );
 
   it('applies methodology overrides to nested economics assumptions before calculation', async () => {
     const methodologyHash = expectedInputHashFor(

--- a/tests/unit/services/fund-scenario-reserve-calculation-service.test.ts
+++ b/tests/unit/services/fund-scenario-reserve-calculation-service.test.ts
@@ -16,13 +16,63 @@ import {
 import { persistReserveScenarioSnapshot } from '../../../server/services/fund-scenario-reserve-snapshot-store';
 import type { FundScenarioCalculationPayloadV1 } from '../../../shared/contracts/fund-scenario-sets-v1.contract';
 
+const identityScenarioSetId = '11111111-1111-4111-8111-111111111111';
+
+function mockIdentityQueries(config: unknown): void {
+  identityQueryMock
+    .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          id: identityScenarioSetId,
+          fund_id: 1,
+          name: 'Reserve sensitivity',
+          description: null,
+          source_config_id: 2,
+          source_config_version: 3,
+          created_by_user_id: 7,
+          created_by_label: 'owner@example.com',
+          updated_by_user_id: 7,
+          updated_by_label: 'owner@example.com',
+          archived_at: null,
+          archived_by_user_id: null,
+          archived_by_label: null,
+          created_at: new Date('2026-06-01T00:00:00.000Z'),
+          updated_at: new Date('2026-06-01T00:00:00.000Z'),
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          id: '22222222-2222-4222-8222-222222222222',
+          scenario_set_id: identityScenarioSetId,
+          name: 'Reserve variant',
+          description: null,
+          sort_order: 0,
+          override_type: 'reserve_allocation',
+          override_payload: {
+            allocationVersion: null,
+            items: [{ companyId: 1, plannedReservesCents: 1000 }],
+          },
+          created_at: new Date('2026-06-01T00:00:00.000Z'),
+          updated_at: new Date('2026-06-01T00:00:00.000Z'),
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ rows: [{ id: 2, version: 3, config }] })
+    .mockResolvedValueOnce({ rows: [{ version: 3 }] });
+}
+
 describe('fund scenario reserve calculation service', () => {
   beforeEach(() => {
     identityQueryMock.mockReset();
-    transactionMock.mockReset().mockImplementation(
-      async (callback: (client: { query: typeof identityQueryMock }) => unknown) =>
-        callback({ query: identityQueryMock })
-    );
+    transactionMock
+      .mockReset()
+      .mockImplementation(
+        async (callback: (client: { query: typeof identityQueryMock }) => unknown) =>
+          callback({ query: identityQueryMock })
+      );
   });
 
   it.each([
@@ -44,57 +94,51 @@ describe('fund scenario reserve calculation service', () => {
         comparisonLineageVersion: null,
       },
     },
+    {
+      label: 'legacy create-format config',
+      config: { name: 'Legacy Reserve Fund' },
+      expectedLineage: {
+        hashKind: 'scenario-input-hash-v1',
+        modelInputsAsOfDate: null,
+        comparisonLineageVersion: null,
+      },
+    },
   ])('derives async run lineage from the pinned $label', async ({ config, expectedLineage }) => {
-    const scenarioSetId = '11111111-1111-4111-8111-111111111111';
-    identityQueryMock
-      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: scenarioSetId,
-            fund_id: 1,
-            name: 'Reserve sensitivity',
-            description: null,
-            source_config_id: 2,
-            source_config_version: 3,
-            created_by_user_id: 7,
-            created_by_label: 'owner@example.com',
-            updated_by_user_id: 7,
-            updated_by_label: 'owner@example.com',
-            archived_at: null,
-            archived_by_user_id: null,
-            archived_by_label: null,
-            created_at: new Date('2026-06-01T00:00:00.000Z'),
-            updated_at: new Date('2026-06-01T00:00:00.000Z'),
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: '22222222-2222-4222-8222-222222222222',
-            scenario_set_id: scenarioSetId,
-            name: 'Reserve variant',
-            description: null,
-            sort_order: 0,
-            override_type: 'reserve_allocation',
-            override_payload: {
-              allocationVersion: null,
-              items: [{ companyId: 1, plannedReservesCents: 1000 }],
-            },
-            created_at: new Date('2026-06-01T00:00:00.000Z'),
-            updated_at: new Date('2026-06-01T00:00:00.000Z'),
-          },
-        ],
-      })
-      .mockResolvedValueOnce({ rows: [{ id: 2, version: 3, config }] })
-      .mockResolvedValueOnce({ rows: [{ version: 3 }] });
+    mockIdentityQueries(config);
 
-    const result = await getReserveScenarioCalculationIdentity(1, scenarioSetId);
+    const result = await getReserveScenarioCalculationIdentity(1, identityScenarioSetId);
 
     expect(result.inputLineage).toEqual(expectedLineage);
     expect(result.inputHash).toMatch(/^[a-f0-9]{64}$/);
     expect(String(identityQueryMock.mock.calls[3]?.[0])).toContain('SELECT id, version, config');
+  });
+
+  it.each([
+    {
+      label: 'ambiguous canonical and legacy names',
+      config: { fundName: 'Canonical Fund', name: 'Legacy Fund' },
+      rejectedKey: 'name',
+    },
+    {
+      label: 'unrelated unknown fields on a legacy config',
+      config: { name: 'Legacy Fund', unexpected: true },
+      rejectedKey: 'unexpected',
+    },
+  ])('rejects $label', async ({ config, rejectedKey }) => {
+    mockIdentityQueries(config);
+
+    await expect(
+      getReserveScenarioCalculationIdentity(1, identityScenarioSetId)
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'scenario_source_config_invalid',
+      details: {
+        issues: expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringContaining(rejectedKey) }),
+        ]),
+      },
+    });
+    expect(identityQueryMock).toHaveBeenCalledTimes(4);
   });
 
   it('creates a stable input hash regardless of equivalent variant ordering', () => {
@@ -223,8 +267,7 @@ describe('fund scenario reserve calculation service', () => {
       ],
     };
     let capturedScenarioSnapshotMetadata:
-      | ({ reserve_input_trust_summary_hash?: string } & Record<string, unknown>)
-      | undefined;
+      ({ reserve_input_trust_summary_hash?: string } & Record<string, unknown>) | undefined;
     const queryMock = vi.fn(async (_sql: string, values: unknown[]) => {
       capturedScenarioSnapshotMetadata = values[4] as {
         reserve_input_trust_summary_hash?: string;
@@ -242,28 +285,25 @@ describe('fund scenario reserve calculation service', () => {
       };
     });
 
-    await persistReserveScenarioSnapshot(
-      { query: queryMock } as never,
-      {
-        fundId: 1,
-        scenarioSetId: '11111111-1111-4111-8111-111111111111',
-        sourceConfigId: 2,
-        sourceConfigVersion: 3,
-        correlationId: '11111111-1111-4111-8111-111111111113',
-        payload: reservePayload,
-        inputHash: 'b'.repeat(64),
-        variantCount: 1,
-        companyCount: 1,
-        warningCount: 0,
-        reserveInputTrustSummary: {
-          trustedForActivation: false,
-          defaultedInputCount: 2,
-          unavailableInputCount: 0,
-          defaultedFields: ['ownership', 'stage'],
-          unavailableFields: [],
-        },
-      }
-    );
+    await persistReserveScenarioSnapshot({ query: queryMock } as never, {
+      fundId: 1,
+      scenarioSetId: '11111111-1111-4111-8111-111111111111',
+      sourceConfigId: 2,
+      sourceConfigVersion: 3,
+      correlationId: '11111111-1111-4111-8111-111111111113',
+      payload: reservePayload,
+      inputHash: 'b'.repeat(64),
+      variantCount: 1,
+      companyCount: 1,
+      warningCount: 0,
+      reserveInputTrustSummary: {
+        trustedForActivation: false,
+        defaultedInputCount: 2,
+        unavailableInputCount: 0,
+        defaultedFields: ['ownership', 'stage'],
+        unavailableFields: [],
+      },
+    });
 
     expect(capturedScenarioSnapshotMetadata).toMatchObject({
       reserve_input_trust_summary: {
@@ -271,6 +311,8 @@ describe('fund scenario reserve calculation service', () => {
         defaultedFields: ['ownership', 'stage'],
       },
     });
-    expect(capturedScenarioSnapshotMetadata!.reserve_input_trust_summary_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(capturedScenarioSnapshotMetadata!.reserve_input_trust_summary_hash).toMatch(
+      /^[a-f0-9]{64}$/
+    );
   });
 });


### PR DESCRIPTION
## Summary

- normalize historical persisted scenario source configs from `name` to canonical `fundName`
- keep the public write schema strict and fail closed for ambiguous or unrelated keys
- cover both synchronous and BullMQ reserve-calculation readers

## Verification

- targeted scenario service tests: 29 passed
- pre-push server suite: 43 files, 425 tests passed
- full `npm test`
- `npm run lint`
- `npm run check`
- `npm run build`
- `npm run build:workers`
- `node scripts/build-vercel-api.mjs`