### PR TITLE
ci: fail-closed pre-promote live-main re-fence (release-production)

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -177,6 +177,27 @@ jobs:
     timeout-minutes: 10
     environment: Production
     steps:
+      - name: Re-fence live main before promotion # <-- NEW, first step
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"; then
+            echo "::error::Could not resolve live main HEAD; refusing to promote (fail-closed)."
+            exit 1
+          fi
+          if [[ ! "$LIVE_MAIN" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Unexpected live main SHA '${LIVE_MAIN}'; refusing to promote (fail-closed)."
+            exit 1
+          fi
+          if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
+            echo "::error::main advanced from ${EXPECTED_SHA} to ${LIVE_MAIN} during this release run; refusing to promote a stale deployment. Re-dispatch Release Production for the current main SHA."
+            exit 1
+          fi
+          echo "Live main still equals release target ${EXPECTED_SHA}; promotion authorized."
+
       - name: Promote verified deployment
         env:
           DEPLOYMENT_URL: ${{ needs.validate-deployment.outputs.deployment_url }}


### PR DESCRIPTION
## What

Adds a deterministic, **fail-closed** re-fence as the **first step of the `promote` job** in `release-production.yml`. It re-derives live `main` HEAD (`gh api commits/main`) at promote-execution time and compares it to the immutable release pin (`inputs.expected_sha`); any mismatch / unresolved / non-40-hex value exits 1 and blocks promotion.

## Why

`validate-target` pins `expected_sha == GITHUB_SHA` **only at dispatch time**. Every downstream job is gated on the `Production` environment (manual approval), so `promote` can sit pending for an arbitrarily long approval window during which `main` may advance (a new PR merges). Nothing between dispatch and the actual `vercel promote` call re-checked that the target was still current `main` — so an **older, now-stale SHA could be promoted** to the production alias.

The existing #1091 no-op guard only catches drift *after* Vercel has already auto-promoted the newer deployment (`prod_id != staged_id`); if the newer deployment hasn't been production-promoted yet, `vercel promote "$OLD"` succeeds and prod goes stale. That guard is timing-dependent; this one fires on the **fact** of drift.

## Scope / safety

- Additive, single job, first step only. **No other job or step changed** (one 21-line hunk).
- No new permissions — `contents: read` already covers `gh api commits/main`; `gh` is preinstalled on `ubuntu-latest`.
- Worst case of a bug in the step is a **false-positive block** of a legitimate promote (safe — re-dispatch), never a false-negative promote.
- Two-release safety holds: with `concurrency.group: release-production` + `cancel-in-progress: false`, a queued second dispatch makes run A fail closed (live `main` = run B's SHA != A's `expected_sha`).

## Verification done

- `actionlint` 1.7.12 — clean (exit 0).
- YAML parses; `promote` now has 2 steps, re-fence first.
- `npm run check` green (Hermes pre/postflight).

Note: this repo does not run actionlint in CI, so the static lint above was run locally against the exact committed file.

## Acceptance — manual drift proof (out-of-band, NOT part of PR CI)

Requires a live production dispatch, so it is documented here rather than run in CI:

1. Dispatch **Release Production** for current `main`.
2. After `staged-smoke` passes and the `promote` gate is pending approval, push a trivial commit to `main`.
3. Approve `promote`.
4. **Expect:** the `promote` job **fails at the re-fence step** with `main advanced from <old> to <new> …` and **no `vercel promote` call** is made.

Happy path (no drift): the step logs `Live main still equals release target <sha>; promotion authorized.` and everything else is identical.

## Origin

Closes pre-mortem item 1 of the Gate -1 reproof ralplan ("Target advances after dispatch and the old SHA reaches promotion"). Spec: `.omx/plans/gate0-pre-promote-live-main-check-20260717.md`.

The YAML edit was dispatched via Hermes per the repo workflow contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
