### PR TITLE
ci: fail-fast live-main re-fence on validate-deployment and staged-smoke (release-production)

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -62,6 +62,27 @@ jobs:
     outputs:
       deployment_url: ${{ steps.verify.outputs.deployment_url }}
     steps:
+      - name: Re-fence live main before validation
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"; then
+            echo "::error::Could not resolve live main HEAD; refusing to proceed (fail-closed)."
+            exit 1
+          fi
+          if [[ ! "$LIVE_MAIN" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Unexpected live main SHA '${LIVE_MAIN}'; refusing to proceed (fail-closed)."
+            exit 1
+          fi
+          if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
+            echo "::error::main advanced from ${EXPECTED_SHA} to ${LIVE_MAIN} during this release run; refusing to proceed with a stale target. Re-dispatch Release Production for the current main SHA."
+            exit 1
+          fi
+          echo "Live main still equals release target ${EXPECTED_SHA}; proceeding."
+
       - name: Normalize and verify exact staged deployment
         id: verify
         env:
@@ -130,6 +151,27 @@ jobs:
     timeout-minutes: 15
     environment: Production
     steps:
+      - name: Re-fence live main before staged smoke
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"; then
+            echo "::error::Could not resolve live main HEAD; refusing to proceed (fail-closed)."
+            exit 1
+          fi
+          if [[ ! "$LIVE_MAIN" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Unexpected live main SHA '${LIVE_MAIN}'; refusing to proceed (fail-closed)."
+            exit 1
+          fi
+          if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
+            echo "::error::main advanced from ${EXPECTED_SHA} to ${LIVE_MAIN} during this release run; refusing to proceed with a stale target. Re-dispatch Release Production for the current main SHA."
+            exit 1
+          fi
+          echo "Live main still equals release target ${EXPECTED_SHA}; proceeding."
+
       - name: Checkout exact release commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

Extends the fail-closed pre-promote live-main re-fence shipped in #1136 to fire **early**, as the FIRST step of two more Production-gated jobs in `.github/workflows/release-production.yml`:

- `validate-deployment` — new step `Re-fence live main before validation`
- `staged-smoke` — new step `Re-fence live main before staged smoke`

Each block re-derives live main HEAD (`gh api repos/${REPO}/commits/main --jq .sha`) at job-execution time and exits 1 on mismatch / unresolved / non-40-hex vs the immutable pin `inputs.expected_sha`. Drift during the manual-approval window now aborts the release at the **first** Production gate instead of only at `promote`, saving the ~15-min `staged-smoke` Playwright run.

This is a **fail-fast nicety, not a safety fix** — only `promote` is irreversible, and it is already fenced by #1136. See "Optional hardening (v2)" in `.omx/plans/gate0-pre-promote-live-main-check-20260717.md` (local/gitignored spec).

## Design

- **Inline, not a composite action.** `validate-deployment` intentionally does no `actions/checkout`, so a local `uses: ./.github/actions/...` action.yml would not be on disk. Inline `run:` matches every other job in this workflow. Three near-identical fences accepted.
- **No permissions change.** Workflow-level `contents: read` already covers `gh api commits/main`.
- **The `promote` re-fence from #1136 is byte-unchanged.** Diff is purely additive (42 insertions, 0 deletions). No other job is fenced.

## Explicitly not fenced (by design)

- `promote` — already fenced by #1136.
- `post-promotion-smoke` — main advancing *after* a successful promote is fine by contract.
- `validate-target` — already pins `expected_sha == GITHUB_SHA` at dispatch.
- `release-proof` / `schema-audit` — reusable-workflow (`uses:`) calls; cannot add a step, and they validate the pinned SHA regardless.

## Considered and deferred

Re-asserting the staged deployment's `meta.githubCommitSha == expected_sha` via the Vercel API immediately before promote. Deferred (low value): a Vercel `dpl_` is immutable and `validate-deployment` already asserts that exact equality.

## Verification

- `actionlint` (not in repo CI; run locally): exit 0
- js-yaml: first-step of `validate-deployment` = "Re-fence live main before validation", `staged-smoke` = "Re-fence live main before staged smoke", `promote` = "Re-fence live main before promotion" (unchanged)
- `npm run check`: 0 TypeScript errors
- Diff scoped to `.github/workflows/release-production.yml` only; purely additive

### Manual drift proof (out-of-band — NOT in PR CI; needs a live production dispatch)

Dispatch Release Production; when the FIRST Production gate (`validate-deployment`) is pending, push a trivial commit to main, then approve. Expect `validate-deployment` to FAIL at the re-fence with `main advanced from <old> to <new> ...` and NO `staged-smoke` / `promote` to run. Happy path: the step logs `Live main still equals release target <sha>; proceeding.`

Builds on #1136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
