### PR TITLE
feat(calc-substrate): Tranche 1 calculation substrate contracts (ADR-042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added (2026-07-17)
+
+- **Tranche 1 calculation substrate contracts (ADR-042).** New additive module
+  `shared/core/calc-substrate/`: injected deterministic RNG with labeled
+  call-order-independent forks (wraps existing `SeededRNG`/`deriveSeed`),
+  injected fixed clock with defensive copies, versioned calculation basis and
+  frozen calculation context, discriminated
+  `available | indicative | unavailable | failed` result union with a stable
+  reason-code registry and an adapter onto the existing `DatasetTrustState`
+  vocabulary, and a domain-separated hash-admission layer with the result hash
+  computed outside the basis via the canonical `canonicalSha256` utility. 40 new
+  unit tests (`tests/unit/calc-substrate/`) pin published RNG/SHA-256 contract
+  vectors and guard the substrate against ambient
+  `Math.random`/`new Date()`/`process.env`. Zero production consumers changed;
+  engines adopt the substrate in later tranches. Implements the first executable
+  slice of the reviewed multi-entity implementation procedure under an
+  owner-granted demo override of its program-governance gates.
+
 ### Added (2026-06-11)
 
 - **Reserve-allocation scenarios now compute in production.** Dedicated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ and this project adheres to
 
 ### Added (2026-07-17)
 
+- **Tranche 2 pacing substrate adoption (ADR-043).** New additive adapter
+  `shared/core/pacing/pacing-substrate-adapter.ts` runs the Pacing domain
+  against an injected `CalculationContext` and emits a hash-bound `CalcResult`
+  (calculationKey `pacing`): explicit typed algorithm option replaces the
+  `ALG_PACING` env read, the injected clock replaces `new Date()`, boundary
+  money becomes whole-dollar decimal strings (legacy-identical `Math.round`),
+  and domain-separated input/assumptions hashes feed the substrate result hash.
+  Variability replays the legacy LCG seeded from the context root seed so a seed
+  of 123 reproduces legacy output exactly; `ctx.rng.fork('pacing')` is reserved
+  for a future methodology bump. 25 new tests (`tests/unit/pacing-substrate/`)
+  characterize the legacy engine, prove adapter parity on hand-authored LCG(123)
+  fixtures, prove repeat-run hash determinism and mode/kill-switch disclosure
+  invariants, and guard the adapter against ambient reads. Legacy `PacingEngine`
+  entry points and consumers unchanged; Reserve deferred with audit list
+  recorded in the ADR.
+
 - **Tranche 1 calculation substrate contracts (ADR-042).** New additive module
   `shared/core/calc-substrate/`: injected deterministic RNG with labeled
   call-order-independent forks (wraps existing `SeededRNG`/`deriveSeed`),

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -55,6 +55,7 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-040: Report Qualification Semantics (Plan 9)](#adr-040-report-qualification-semantics-plan-9)
 - [ADR-041: Global Internal Fund Visibility with Role-Gated Consequences](#adr-041-global-internal-fund-visibility-with-role-gated-consequences)
 - [ADR-042: Tranche 1 Calculation Substrate Contracts (Demo Scope)](#adr-042-tranche-1-calculation-substrate-contracts-demo-scope)
+- [ADR-043: Tranche 2 Substrate Adoption Starts with Pacing (Demo Scope)](#adr-043-tranche-2-substrate-adoption-starts-with-pacing-demo-scope)
 
 ---
 
@@ -6419,3 +6420,141 @@ than waived.
 
 **Implementation:** `shared/core/calc-substrate/` plus
 `tests/unit/calc-substrate/` (40 tests).
+
+## ADR-043: Tranche 2 Substrate Adoption Starts with Pacing (Demo Scope)
+
+**Date:** 2026-07-17 **Status:** [ACCEPTED] Implemented (demo scope)
+**Decision:** Adopt the Pacing calculation domain onto the ADR-042 calculation
+substrate first, via an additive context-receiving adapter
+(`shared/core/pacing/pacing-substrate-adapter.ts`, calculationKey `pacing`), and
+defer Reserve. Legacy `PacingEngine` entry points and all their consumers are
+unchanged. Same owner-granted demo override of program-governance gates as
+ADR-042; technical invariants (determinism, hash integrity, disclosure of
+suppressed results, no silent fabrication) are enforced in code and tests.
+
+### Context: why Pacing, not Reserve
+
+- **Pacing is adoptable today.** The legacy engine
+  (`shared/core/pacing/PacingEngine.ts`) resets its module-global LCG
+  (`shared/utils/prng.ts`, Numerical Recipes parameters) to a hardcoded seed of
+  123 on every call, so per-call output is already deterministic under fixed
+  inputs. Its only ambient reads are `process.env['ALG_PACING']` /
+  `process.env['NODE_ENV']` (algorithm-path selection) and, in
+  `generatePacingSummary`, `generatedAt: new Date()`.
+- **Reserve is `defer`.** `shared/core/reserves/ReserveEngine.ts` carries a
+  call-order-sensitive module-global seeded PRNG (no per-call reset) plus
+  `process.env` (`ALG_RESERVE`, `NODE_ENV`) and `new Date()` reads;
+  `DeterministicReserveEngine.ts` reads `process.env` (~line 85) and
+  `new Date()` (~line 485), and its cache key is base64 JSON over only ~5 input
+  fields (incomplete cache identity). Those audits must pass before Reserve can
+  emit an honest basis. Cohort, Projected Metrics, and Monte Carlo were
+  forbidden as first adoptions by the tranche plan.
+
+### Disposition table
+
+| Surface                                                    | Disposition | Notes                                                                                                     |
+| ---------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------- |
+| `shared/core/pacing/PacingEngine.ts` (engine kernel)       | adapt       | Kernel math restated in the adapter in context-receiving form; legacy entry points and behavior untouched |
+| `PacingEngine` / `generatePacingSummary` legacy signatures | reuse       | Still exported, still consumed; adapter wraps the domain, does not replace the API                        |
+| `shared/utils/prng.ts` (LCG)                               | reuse       | Adapter constructs a local instance per run; the `Date.now()` default seed path is never exercised        |
+| `server/services/pacing-calculation-service.ts`            | defer       | Continues to call `generatePacingSummary`; substrate wiring is a later tranche                            |
+| `server/services/projected-metrics-calculator.ts`          | defer       | Same                                                                                                      |
+| `server/routes/engine-summaries.ts`                        | defer       | Same                                                                                                      |
+| `client/src/core/pacing/PacingEngine.ts` (re-export shim)  | reuse       | Untouched                                                                                                 |
+| `process.env['ALG_PACING']` algorithm selection            | replace     | Adapter takes an explicit typed `algorithm: 'rule-based' \| 'ml'` option; never reads env                 |
+| `generatedAt: new Date()` in `generatePacingSummary`       | replace     | Adapter emits `asOfUtc` from the injected `ctx.clock`                                                     |
+
+### Decision details
+
+- **Determinism and the RNG compatibility decision.** Exact-value parity with
+  the legacy engine is only achievable by replaying its LCG stream, so the
+  adapter's variability stream is a locally constructed `PRNG` seeded from the
+  calculation context's immutable root seed. A context seeded with 123 (the
+  legacy hardcoded seed) reproduces legacy output byte-for-byte. Substituting
+  the substrate Xorshift32 (`ctx.rng`) for the LCG would change every emitted
+  value and is therefore a behavior change, deferred to a methodology-version
+  bump. This is a deliberate, disclosed deviation from the tranche plan's "use
+  `ctx.rng.fork('pacing')`" default in favor of the behavior-preservation
+  invariant.
+- **Fork-label registry (pacing).** `pacing` is RESERVED as the fork label for
+  the future migration of the variability stream onto `ctx.rng.fork('pacing')`.
+  No fork labels are consumed by the current adapter.
+- **Kernel restatement, pinned both sides.** The adapter restates the ~30-line
+  kernel rather than importing it, because the legacy entry point reads
+  `process.env` internally and its seed is not injectable. Drift protection:
+  characterization tests pin the legacy engine and parity tests pin the adapter
+  to the same hand-authored LCG(123) fixtures (neutral 50M q1, bull 100M q3,
+  bear 20M q10, plus the ML path), so divergence of either copy fails the suite.
+- **Rounding rule (boundary money).** All money at the adapter boundary is
+  emitted as whole-dollar decimal strings; the rounding rule is legacy-identical
+  `Math.round` on the non-negative float amount (half-away-from-zero to a whole
+  dollar), applied per quarter before totals, then summed. The average is
+  `Math.round(total / 8)`. Hash admission strips leading zeros from decimal
+  strings, so identities never rely on zero-padded spellings.
+- **Hashes.** `inputHash` = `canonicalSha256` over
+  `{ domain: 'updog.pacing.input-hash', input: admitForHashing(rawInput) }`; if
+  the raw input is hash-inadmissible the deterministic sentinel
+  `{ inadmissibleInput: true }` is hashed and the result carries
+  `INPUT_INVALID`. `assumptionsHash` = `canonicalSha256` over the domain
+  `updog.pacing.assumptions-hash`, the methodology version, the algorithm
+  choice, and the frozen methodology constants (market adjustment table, divisor
+  8, variability window, ML trend window, rounding rule, RNG family and seed
+  source). `resultHash` uses the substrate `computeResultHash` unchanged.
+- **Result semantics.** `on` -> `available`; `shadow` -> `indicative` with
+  `SHADOW_ONLY`; configured `off` -> `unavailable` with `MODE_OFF`; kill switch
+  -> effective `off`, `unavailable` with `KILL_SWITCH_ACTIVE` (both codes when
+  both apply); schema-invalid input -> `failed` with `INPUT_INVALID` and a
+  diagnostic; kernel error -> `failed` with `ENGINE_ERROR`. Every non-available
+  path carries at least one registered reason code; there is no silent fallback.
+- **Versions.** `engineVersion: pacing-engine/1.0.0`,
+  `methodologyVersion: pacing-methodology/1.0.0`. Changing the kernel math, the
+  RNG family/seed source, the rounding rule, or the hash domains bumps the
+  methodology or engine version.
+
+### Parity evidence summary
+
+`tests/unit/pacing-substrate/` (25 tests, all green; full suite unchanged):
+
+- Characterization pins the legacy engine to hand-authored LCG(123) expectations
+  on 4 fixtures before any adaptation, and documents the `generatedAt` ambient
+  read structurally without blessing its value.
+- Parity proves adapter-vs-legacy field-for-field equality (deployment, quarter,
+  note, totals) on the same 4 fixtures, with expected values written as literals
+  in the tests.
+- Determinism proves repeat-run byte-identical results with equal 64-hex result
+  hashes, and that different seeds, inputs, as-of instants, and algorithm
+  choices produce different hashes.
+- Mode/kill-switch tests prove the suppression and disclosure invariants above
+  against both the pacing and generic result schemas.
+- An ambient-state source guard scans the adapter for `Math.random`, argless
+  `new Date()`, `Date.now`, and `process.env`.
+
+### Alternatives considered
+
+- **Adopt Reserve first:** rejected (see Context); its ambient-state and cache
+  identity audits are open.
+- **Drive variability from `ctx.rng.fork('pacing')` now:** rejected; changes
+  every output value, violating the behavior-preservation requirement of this
+  tranche. Reserved as the documented follow-up migration.
+- **Refactor `PacingEngine.ts` to export an injectable kernel:** rejected for
+  this tranche; touching the legacy file consumed by three server services and
+  the client shim expands blast radius for zero behavior benefit, and the parity
+  suite already pins the two copies together.
+- **Return `unavailable` (not `failed`) for invalid input:** rejected; the
+  legacy engine throws on invalid input, so `failed` + `INPUT_INVALID` with a
+  diagnostic is the faithful adaptation and keeps `unavailable` reserved for
+  suppression/upstream-gap states.
+
+### Consequences
+
+- Pacing can now run against an injected `CalculationContext` and emit a
+  hash-bound `CalcResult`; consumers keep their legacy path until a later
+  tranche wires them over.
+- Remaining for Reserve (Tranche 3 candidate): remove or gate the
+  call-order-sensitive module-global PRNG, eliminate `process.env` /
+  `new Date()` reads from both reserve engines, and replace the truncated base64
+  cache key with complete canonical input identity - then repeat this adoption
+  pattern.
+
+**Implementation:** `shared/core/pacing/pacing-substrate-adapter.ts` plus
+`tests/unit/pacing-substrate/` (25 tests).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -53,6 +53,8 @@ development of the Press On Ventures fund modeling platform.
 - [ADR-037: Browser HttpOnly JWT Cookie and Signed CSRF Contract (D4)](#adr-037-browser-httponly-jwt-cookie-and-signed-csrf-contract-d4)
 - [ADR-039: Planned-reserve MOIC candidate basis moves to Round/FMV facts (moic-round-fmv-facts-v2)](#adr-039-planned-reserve-moic-candidate-basis-moves-to-roundfmv-facts-moic-round-fmv-facts-v2)
 - [ADR-040: Report Qualification Semantics (Plan 9)](#adr-040-report-qualification-semantics-plan-9)
+- [ADR-041: Global Internal Fund Visibility with Role-Gated Consequences](#adr-041-global-internal-fund-visibility-with-role-gated-consequences)
+- [ADR-042: Tranche 1 Calculation Substrate Contracts (Demo Scope)](#adr-042-tranche-1-calculation-substrate-contracts-demo-scope)
 
 ---
 
@@ -6242,10 +6244,11 @@ named server-side gap fills.
 
 ## ADR-041: Global Internal Fund Visibility with Role-Gated Consequences
 
-**Date:** 2026-07-16 **Status:** [ACCEPTED] Partially implemented **Decision:** Give
-the three interactive investment-team roles—admin, partner, and analyst—global
-safe-read visibility across every fund; keep consequential mutations explicitly
-role-gated; and keep LP identities outside internal investment-team surfaces.
+**Date:** 2026-07-16 **Status:** [ACCEPTED] Partially implemented **Decision:**
+Give the three interactive investment-team roles—admin, partner, and
+analyst—global safe-read visibility across every fund; keep consequential
+mutations explicitly role-gated; and keep LP identities outside internal
+investment-team surfaces.
 
 ### Context
 
@@ -6301,11 +6304,11 @@ remove or redesign the separately isolated LP portal.
 - The eight GP-side qualified report render/export routes remain restricted to
   partner and admin. Analyst, viewer, operator, LP, and anonymous callers remain
   denied.
-- Partner and admin are global internal roles on these routes, so per-fund grants
-  are not required. This supersedes ADR-025's explicit partner export-grant rule
-  and ADR-040's export-grant wording, but preserves their partner/admin role
-  gate, workflow qualification, H9 validation, provenance, and artifact-serving
-  controls.
+- Partner and admin are global internal roles on these routes, so per-fund
+  grants are not required. This supersedes ADR-025's explicit partner
+  export-grant rule and ADR-040's export-grant wording, but preserves their
+  partner/admin role gate, workflow qualification, H9 validation, provenance,
+  and artifact-serving controls.
 
 ### Alternatives Considered
 
@@ -6317,8 +6320,9 @@ remove or redesign the separately isolated LP portal.
 - **Let analysts change any fund-scoped resource:** rejected because fund scope
   identifies the tenant/resource, while role gates decide whether an action is
   analytical or consequential.
-- **Remove the LP portal:** rejected as outside this baseline repair; LP-specific
-  surfaces remain separately isolated and receive no internal-team privilege.
+- **Remove the LP portal:** rejected as outside this baseline repair;
+  LP-specific surfaces remain separately isolated and receive no internal-team
+  privilege.
 
 ### Consequences
 
@@ -6327,8 +6331,91 @@ remove or redesign the separately isolated LP portal.
   funds regardless of token fund grants.
 - Partner/admin report exports no longer depend on legacy per-fund grants.
 - A follow-up authorization inventory must close known consequential-write gaps,
-  including official fund creation, before this ADR can become fully implemented.
+  including official fund creation, before this ADR can become fully
+  implemented.
 - Portfolio, import, evidence, narrative, approval, and analytical mutations are
   not claimed as fully classified by this baseline repair.
 
 **Implementation:** Gate -1 current-main CI baseline repair after PR #1130.
+
+---
+
+## ADR-042: Tranche 1 Calculation Substrate Contracts (Demo Scope)
+
+**Date:** 2026-07-17 **Status:** [ACCEPTED] Implemented (demo scope)
+**Decision:** Implement the "Tranche 1 - calculation substrate contracts only"
+slice of the Reinforced Multi-Entity Venture Fund Implementation Procedure as an
+additive module at `shared/core/calc-substrate/`, under an explicit
+owner-granted override of that procedure's program-governance prerequisites
+(named human role registry, Gate 0 premortem, capacity baselines) for
+demonstration purposes.
+
+### Context
+
+The reviewed procedure (uploaded plan, frontmatter `FINALIZED_FOR_GATE_0`) holds
+all implementation behind Gate -1/Gate 0 human-governance gates. The repository
+owner explicitly waived the process gates to allow demonstration development.
+Two of the plan's Gate -1 blockers had already been resolved on `origin/main`
+since its reviewed baseline `240663ea`: PR #1130 merged and the
+required-CI/write-role test regressions were repaired (#1131-#1133, ADR-041).
+The override was applied to process/approval gates only; every technical safety
+invariant the plan defines for Tranche 1 is enforced in code and tests rather
+than waived.
+
+### Decision Details
+
+- **Contract version:** `calc-substrate/1.0.0`. Changing preimage rules, reason
+  codes, or pinned vectors is a contract-version change.
+- **Result hash outside the basis:** `computeResultHash` hashes a
+  domain-separated preimage `{domain, contractVersion, basis, value}` with the
+  repository canonical utility `canonicalSha256`; the hash lives on the result
+  object, never inside the basis, so the preimage is non-circular.
+- **Hash admission:** only JSON primitives, dense arrays, and plain objects are
+  admissible. Decimal strings and Z-suffixed UTC timestamps are normalized;
+  `undefined`, sparse arrays, non-finite numbers, `bigint`, Date/Decimal/class
+  instances, Map/Set, functions, and symbol keys are rejected before hashing.
+  Any string fully matching the signed-decimal form is normalized (leading zeros
+  and trailing fractional zeros dropped), so identifiers must not rely on those
+  spellings for identity.
+- **Trust vocabulary adapter, not a parallel source:** the substrate result
+  union uses `available | indicative | unavailable | failed` and maps onto the
+  existing `DatasetTrustState` (`LIVE | PARTIAL | UNAVAILABLE | FAILED`) via
+  `toDatasetTrustState`. The existing provenance contracts remain the
+  presentation-layer authority.
+- **Determinism reuse:** the RNG wraps the existing `SeededRNG` (Xorshift32) and
+  `deriveSeed` (FNV-1a); fork seeds derive from the immutable root seed plus the
+  fork path, making fork sequences call-order independent. The fixed clock
+  stores epoch milliseconds only and returns defensive copies.
+- **Truthfulness invariants:** an engine whose effective mode is `off` or whose
+  kill switch is active cannot emit an `available` value, and suppression must
+  be disclosed via `MODE_OFF` / `KILL_SWITCH_ACTIVE` reason codes.
+
+### Alternatives Considered
+
+- **Wait for Gate 0 human governance:** rejected by explicit owner override for
+  demonstration; the substrate is additive with zero production consumers, so
+  the deferred governance applies to adoption (Tranche 2+), not to these
+  contracts.
+- **Extend `ProvenanceEnvelopeSchema` directly:** rejected; its per-state
+  invariants are domain-specific to presentation surfaces, and the plan requires
+  an ADR'd adapter rather than broadening an existing envelope.
+- **New standalone RNG/hash implementations:** rejected; parallel sources of
+  truth are the plan's REC-R2 failure mode. Existing `SeededRNG` and
+  `canonicalSha256` are wrapped instead.
+
+### Consequences
+
+- Engines can begin Tranche 2 adoption against a stable, tested seam; no
+  production behavior changed (full unit suite green, no existing test
+  modified).
+- The ambient-state source guard (`tests/unit/calc-substrate/`) fails the build
+  if the substrate ever reaches for `Math.random`, argless `new Date()`,
+  `Date.now`, or `process.env`.
+- Pinned RNG and SHA-256 vectors in the tests are published contract constants;
+  regenerating them requires a contract-version bump and a new ADR.
+- Program-governance items the override waived (role registry, baselines,
+  premortem, threshold registry) remain open if this work proceeds beyond
+  demonstration.
+
+**Implementation:** `shared/core/calc-substrate/` plus
+`tests/unit/calc-substrate/` (40 tests).

--- a/shared/core/calc-substrate/calc-basis.ts
+++ b/shared/core/calc-substrate/calc-basis.ts
@@ -1,0 +1,60 @@
+/**
+ * Versioned calculation basis (Tranche 1 substrate).
+ *
+ * The basis records everything that determined a calculation run: contract
+ * version, calculation key, configured/effective mode, kill-switch state,
+ * engine/methodology versions, and the input/assumptions hashes.
+ *
+ * The result hash is deliberately NOT part of the basis: it is computed over
+ * a preimage that includes the basis (see hash-admission.ts), so placing it
+ * inside the basis would make the hash self-referential.
+ */
+
+import { z } from 'zod';
+
+export const CALC_SUBSTRATE_CONTRACT_VERSION = 'calc-substrate/1.0.0';
+
+export const CalcModeSchema = z.enum(['off', 'shadow', 'on']);
+export type CalcMode = z.infer<typeof CalcModeSchema>;
+
+const MODE_RANK: Record<CalcMode, number> = { off: 0, shadow: 1, on: 2 };
+
+export const Sha256HexSchema = z
+  .string()
+  .regex(/^[0-9a-f]{64}$/, 'must be a lowercase 64-char sha256 hex digest');
+
+export const CalculationKeySchema = z
+  .string()
+  .regex(/^[a-z][a-z0-9_-]*$/, 'must be lowercase snake/kebab starting with a letter');
+
+export const CalcBasisSchema = z
+  .object({
+    contractVersion: z.literal(CALC_SUBSTRATE_CONTRACT_VERSION),
+    calculationKey: CalculationKeySchema,
+    configuredMode: CalcModeSchema,
+    effectiveMode: CalcModeSchema,
+    killSwitchActive: z.boolean(),
+    engineVersion: z.string().min(1),
+    methodologyVersion: z.string().min(1),
+    inputHash: Sha256HexSchema,
+    assumptionsHash: Sha256HexSchema,
+  })
+  .strict()
+  .superRefine((basis, ctx) => {
+    if (basis.killSwitchActive && basis.effectiveMode !== 'off') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['effectiveMode'],
+        message: 'effectiveMode must be off while the kill switch is active',
+      });
+    }
+    if (MODE_RANK[basis.effectiveMode] > MODE_RANK[basis.configuredMode]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['effectiveMode'],
+        message: `effectiveMode ${basis.effectiveMode} cannot exceed configuredMode ${basis.configuredMode}`,
+      });
+    }
+  });
+
+export type CalcBasis = z.infer<typeof CalcBasisSchema>;

--- a/shared/core/calc-substrate/calc-result.ts
+++ b/shared/core/calc-substrate/calc-result.ts
@@ -1,0 +1,148 @@
+/**
+ * Discriminated calculation result/trust union (Tranche 1 substrate).
+ *
+ * States:
+ * - available:   trusted value; hash-bound; no reason codes.
+ * - indicative:  value present but not decision-grade; must disclose why.
+ * - unavailable: no value could be produced; must disclose why.
+ * - failed:      the engine errored; must disclose why.
+ *
+ * Truthfulness invariants (enforced below) exist so that a result can never
+ * silently fabricate trust: an off/kill-switched engine cannot emit an
+ * available value, and kill-switch/mode-off suppression must be disclosed
+ * through reason codes.
+ *
+ * This union is the substrate-internal vocabulary. The presentation-layer
+ * vocabulary in shared/contracts/provenance-envelope.contract.ts is mapped
+ * via toDatasetTrustState (ADR-042 adapter decision), not duplicated.
+ */
+
+import { z } from 'zod';
+import type { DatasetTrustState } from '../../contracts/provenance-envelope.contract';
+import { CalcBasisSchema } from './calc-basis';
+import { Sha256HexSchema } from './calc-basis';
+import { CalcReasonCodeSchema } from './reason-codes';
+
+export const CalcResultStateSchema = z.enum(['available', 'indicative', 'unavailable', 'failed']);
+export type CalcResultState = z.infer<typeof CalcResultStateSchema>;
+
+const nonEmptyReasonCodes = z
+  .array(CalcReasonCodeSchema)
+  .min(1, 'non-available results must disclose at least one reason code');
+
+export function createCalcResultSchema<V extends z.ZodTypeAny>(valueSchema: V) {
+  const available = z
+    .object({
+      state: z.literal('available'),
+      basis: CalcBasisSchema,
+      value: valueSchema,
+      resultHash: Sha256HexSchema,
+      reasonCodes: z.array(CalcReasonCodeSchema).length(0),
+    })
+    .strict();
+
+  const indicative = z
+    .object({
+      state: z.literal('indicative'),
+      basis: CalcBasisSchema,
+      value: valueSchema,
+      resultHash: Sha256HexSchema,
+      reasonCodes: nonEmptyReasonCodes,
+    })
+    .strict();
+
+  const unavailable = z
+    .object({
+      state: z.literal('unavailable'),
+      basis: CalcBasisSchema,
+      reasonCodes: nonEmptyReasonCodes,
+    })
+    .strict();
+
+  const failed = z
+    .object({
+      state: z.literal('failed'),
+      basis: CalcBasisSchema,
+      reasonCodes: nonEmptyReasonCodes,
+      diagnostic: z.string().min(1).optional(),
+    })
+    .strict();
+
+  return z
+    .discriminatedUnion('state', [available, indicative, unavailable, failed])
+    .superRefine((result, ctx) => {
+      const { basis } = result;
+      const carriesValue = result.state === 'available' || result.state === 'indicative';
+      if (carriesValue && basis.effectiveMode === 'off') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['state'],
+          message: `a ${result.state} value cannot come from an engine whose effectiveMode is off`,
+        });
+      }
+      if (basis.killSwitchActive && !result.reasonCodes.includes('KILL_SWITCH_ACTIVE')) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['reasonCodes'],
+          message: 'an active kill switch must be disclosed via the KILL_SWITCH_ACTIVE reason code',
+        });
+      }
+      if (
+        basis.effectiveMode === 'off' &&
+        !basis.killSwitchActive &&
+        !result.reasonCodes.includes('MODE_OFF')
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['reasonCodes'],
+          message: 'effectiveMode off must be disclosed via the MODE_OFF reason code',
+        });
+      }
+    });
+}
+
+export const GenericCalcResultSchema = createCalcResultSchema(z.unknown());
+export type CalcResult<V> =
+  | {
+      state: 'available';
+      basis: z.infer<typeof CalcBasisSchema>;
+      value: V;
+      resultHash: string;
+      reasonCodes: [];
+    }
+  | {
+      state: 'indicative';
+      basis: z.infer<typeof CalcBasisSchema>;
+      value: V;
+      resultHash: string;
+      reasonCodes: z.infer<typeof CalcReasonCodeSchema>[];
+    }
+  | {
+      state: 'unavailable';
+      basis: z.infer<typeof CalcBasisSchema>;
+      reasonCodes: z.infer<typeof CalcReasonCodeSchema>[];
+    }
+  | {
+      state: 'failed';
+      basis: z.infer<typeof CalcBasisSchema>;
+      reasonCodes: z.infer<typeof CalcReasonCodeSchema>[];
+      diagnostic?: string;
+    };
+
+/**
+ * ADR-042 adapter: maps substrate result states onto the existing
+ * presentation-layer DatasetTrustState vocabulary instead of introducing a
+ * second persisted trust vocabulary.
+ */
+export function toDatasetTrustState(state: CalcResultState): DatasetTrustState {
+  switch (state) {
+    case 'available':
+      return 'LIVE';
+    case 'indicative':
+      return 'PARTIAL';
+    case 'unavailable':
+      return 'UNAVAILABLE';
+    case 'failed':
+      return 'FAILED';
+  }
+}

--- a/shared/core/calc-substrate/calculation-context.ts
+++ b/shared/core/calc-substrate/calculation-context.ts
@@ -1,0 +1,42 @@
+/**
+ * Versioned calculation context (Tranche 1 substrate).
+ *
+ * Bundles the injected deterministic RNG, the injected fixed clock, the
+ * calculation key, and a frozen flag snapshot so that a deterministic kernel
+ * receives every ambient capability explicitly and can never reach for
+ * Math.random, new Date(), or process.env.
+ */
+
+import { CALC_SUBSTRATE_CONTRACT_VERSION, CalculationKeySchema } from './calc-basis';
+import { createDeterministicRng, type CalcRng } from './deterministic-rng';
+import { createFixedClock, type CalcClock } from './fixed-clock';
+
+export interface CalculationContext {
+  readonly contractVersion: typeof CALC_SUBSTRATE_CONTRACT_VERSION;
+  readonly calculationKey: string;
+  readonly rng: CalcRng;
+  readonly clock: CalcClock;
+  readonly flags: Readonly<Record<string, boolean>>;
+}
+
+export interface CalculationContextOptions {
+  calculationKey: string;
+  seed: number;
+  /** Z-suffixed ISO-8601 UTC instant the calculation is pinned to. */
+  asOf: string;
+  flags?: Record<string, boolean>;
+}
+
+export function createCalculationContext(options: CalculationContextOptions): CalculationContext {
+  const calculationKey = CalculationKeySchema.parse(options.calculationKey);
+  const rng = createDeterministicRng(options.seed);
+  const clock = createFixedClock(options.asOf);
+  const flags = Object.freeze({ ...(options.flags ?? {}) });
+  return Object.freeze({
+    contractVersion: CALC_SUBSTRATE_CONTRACT_VERSION,
+    calculationKey,
+    rng,
+    clock,
+    flags,
+  });
+}

--- a/shared/core/calc-substrate/deterministic-rng.ts
+++ b/shared/core/calc-substrate/deterministic-rng.ts
@@ -1,0 +1,77 @@
+/**
+ * Injected deterministic random source with labeled forks (Tranche 1 substrate).
+ *
+ * Fork seeds are derived from the immutable root seed plus the full fork path,
+ * never from mutable generator state, so fork sequences are call-order
+ * independent: advancing the parent (or a sibling) before forking does not
+ * change the child sequence.
+ *
+ * Reuses the repository Xorshift32 generator and FNV-1a seed derivation from
+ * shared/core/optimization/SeededRNG rather than introducing a parallel RNG.
+ */
+
+import { SeededRNG, deriveSeed } from '../optimization/SeededRNG';
+
+const MAX_UINT32 = 0xffffffff;
+
+export interface CalcRng {
+  /** Uniform float in [0, 1). */
+  next(): number;
+  /** Uniform integer in [min, max] inclusive. */
+  nextInt(min: number, max: number): number;
+  /** Derive an isolated child generator for the given label. */
+  fork(label: string): CalcRng;
+  readonly rootSeed: number;
+  readonly forkPath: string;
+}
+
+export function assertValidSeed(seed: number): void {
+  if (typeof seed !== 'number' || !Number.isInteger(seed) || seed < 1 || seed > MAX_UINT32) {
+    throw new RangeError(
+      `calc-substrate seed must be an integer in [1, ${MAX_UINT32}], received: ${String(seed)}`
+    );
+  }
+}
+
+function assertValidForkLabel(label: string): void {
+  if (typeof label !== 'string' || label.length === 0) {
+    throw new RangeError('fork label must be a non-empty string');
+  }
+  // '/' delimits fork-path segments; allowing it in labels would let two
+  // different fork trees collapse onto the same derived path.
+  if (label.includes('/')) {
+    throw new RangeError(`fork label must not contain '/': ${label}`);
+  }
+}
+
+class DeterministicRng implements CalcRng {
+  readonly rootSeed: number;
+  readonly forkPath: string;
+  private readonly generator: SeededRNG;
+
+  constructor(rootSeed: number, forkPath: string, generatorSeed: number) {
+    this.rootSeed = rootSeed;
+    this.forkPath = forkPath;
+    this.generator = new SeededRNG(generatorSeed);
+  }
+
+  next(): number {
+    return this.generator.next();
+  }
+
+  nextInt(min: number, max: number): number {
+    return this.generator.nextInt(min, max);
+  }
+
+  fork(label: string): CalcRng {
+    assertValidForkLabel(label);
+    const childPath = `${this.forkPath}/${label}`;
+    const childSeed = deriveSeed(`${this.rootSeed}:${childPath}`);
+    return new DeterministicRng(this.rootSeed, childPath, childSeed);
+  }
+}
+
+export function createDeterministicRng(seed: number): CalcRng {
+  assertValidSeed(seed);
+  return new DeterministicRng(seed, 'root', seed);
+}

--- a/shared/core/calc-substrate/fixed-clock.ts
+++ b/shared/core/calc-substrate/fixed-clock.ts
@@ -1,0 +1,54 @@
+/**
+ * Injected fixed clock with defensive-copy behavior (Tranche 1 substrate).
+ *
+ * The clock stores only an epoch-milliseconds number, never a Date instance,
+ * so there is no shared mutable object: every now() call returns a fresh Date
+ * and mutating a returned Date cannot move the clock.
+ */
+
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+
+export interface CalcClock {
+  /** Fresh Date copy of the fixed instant; safe for callers to mutate. */
+  now(): Date;
+  /** Canonical ISO-8601 UTC representation of the fixed instant. */
+  isoNow(): string;
+}
+
+class FixedClock implements CalcClock {
+  private readonly epochMs: number;
+
+  constructor(epochMs: number) {
+    this.epochMs = epochMs;
+  }
+
+  now(): Date {
+    return new Date(this.epochMs);
+  }
+
+  isoNow(): string {
+    return new Date(this.epochMs).toISOString();
+  }
+}
+
+export function createFixedClock(isoUtc: string): CalcClock {
+  if (typeof isoUtc !== 'string' || !ISO_UTC_RE.test(isoUtc)) {
+    throw new RangeError(
+      `fixed clock requires a Z-suffixed ISO-8601 UTC timestamp, received: ${String(isoUtc)}`
+    );
+  }
+  const epochMs = Date.parse(isoUtc);
+  if (Number.isNaN(epochMs)) {
+    throw new RangeError(`fixed clock timestamp does not parse: ${isoUtc}`);
+  }
+  // Round-trip guard: rejects lexically valid but non-existent instants
+  // (e.g. month 13 or Feb 30) that Date.parse would silently roll over.
+  const canonical = new Date(epochMs).toISOString();
+  const normalizedInput = isoUtc.includes('.')
+    ? isoUtc.replace(/(\.\d{1,3})Z$/, (_m, frac: string) => `.${frac.slice(1).padEnd(3, '0')}Z`)
+    : isoUtc.replace('Z', '.000Z');
+  if (canonical !== normalizedInput) {
+    throw new RangeError(`fixed clock timestamp is not a real instant: ${isoUtc}`);
+  }
+  return new FixedClock(epochMs);
+}

--- a/shared/core/calc-substrate/hash-admission.ts
+++ b/shared/core/calc-substrate/hash-admission.ts
@@ -1,0 +1,175 @@
+/**
+ * Domain-separated hash admission and result-hash preimage (Tranche 1 substrate).
+ *
+ * Admission accepts only validated JSON primitives, dense arrays, and plain
+ * objects. It normalizes decimal strings ("1.10" -> "1.1", "-0" -> "0") and
+ * Z-suffixed UTC timestamps (to millisecond-precision toISOString form), and
+ * rejects undefined, sparse arrays, non-finite numbers, bigint, Date/Decimal/
+ * other class instances, Map, Set, functions, and symbol-keyed properties.
+ *
+ * Preimage rules (versioned; changing any of them is a contract-version bump):
+ * - domain tag `updog.calc-substrate.result-hash` separates this hash family
+ *   from every other sha256 use in the repository;
+ * - the preimage contains the validated basis and the admitted value;
+ * - the resultHash itself is excluded by construction: it lives on the result
+ *   object, outside both the basis and the value;
+ * - undeclared basis fields are rejected by the strict CalcBasisSchema before
+ *   hashing.
+ *
+ * Hashing itself reuses the repository canonical utility (sorted keys,
+ * canonical JSON, sha256 hex) from shared/lib/canonical-hash.ts.
+ */
+
+import { canonicalSha256 } from '../../lib/canonical-hash';
+import type { CALC_SUBSTRATE_CONTRACT_VERSION } from './calc-basis';
+import { CalcBasisSchema, type CalcBasis } from './calc-basis';
+
+export const RESULT_HASH_DOMAIN = 'updog.calc-substrate.result-hash';
+
+const DECIMAL_STRING_RE = /^[+-]?\d+(\.\d+)?$/;
+const ISO_UTC_STRING_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+
+export class HashAdmissionError extends Error {
+  readonly path: string;
+
+  constructor(path: string, reason: string) {
+    super(`hash admission rejected value at ${path}: ${reason}`);
+    this.name = 'HashAdmissionError';
+    this.path = path;
+  }
+}
+
+export function normalizeDecimalString(raw: string): string {
+  if (!DECIMAL_STRING_RE.test(raw)) {
+    throw new HashAdmissionError('$', `not a decimal string: ${raw}`);
+  }
+  const negative = raw.startsWith('-');
+  const unsigned = raw.replace(/^[+-]/, '');
+  const [rawInt, rawFrac = ''] = unsigned.split('.');
+  const intPart = rawInt!.replace(/^0+(?=\d)/, '');
+  const fracPart = rawFrac.replace(/0+$/, '');
+  const magnitude = fracPart.length > 0 ? `${intPart}.${fracPart}` : intPart;
+  if (/^0(\.0*)?$/.test(magnitude) || magnitude === '') {
+    return '0';
+  }
+  return negative ? `-${magnitude}` : magnitude;
+}
+
+function normalizeUtcTimestamp(raw: string, path: string): string {
+  const epochMs = Date.parse(raw);
+  if (Number.isNaN(epochMs)) {
+    throw new HashAdmissionError(path, `timestamp does not parse: ${raw}`);
+  }
+  const canonical = new Date(epochMs).toISOString();
+  const normalizedInput = raw.includes('.')
+    ? raw.replace(/(\.\d{1,3})Z$/, (_m, frac: string) => `.${frac.slice(1).padEnd(3, '0')}Z`)
+    : raw.replace('Z', '.000Z');
+  if (canonical !== normalizedInput) {
+    throw new HashAdmissionError(path, `timestamp is not a real instant: ${raw}`);
+  }
+  return canonical;
+}
+
+function admit(value: unknown, path: string): unknown {
+  if (value === undefined) {
+    throw new HashAdmissionError(path, 'undefined is not admissible');
+  }
+  if (value === null) {
+    return null;
+  }
+  switch (typeof value) {
+    case 'boolean':
+      return value;
+    case 'number':
+      if (!Number.isFinite(value)) {
+        throw new HashAdmissionError(path, `non-finite number: ${String(value)}`);
+      }
+      return Object.is(value, -0) ? 0 : value;
+    case 'string':
+      if (DECIMAL_STRING_RE.test(value)) {
+        return normalizeDecimalString(value);
+      }
+      if (ISO_UTC_STRING_RE.test(value)) {
+        return normalizeUtcTimestamp(value, path);
+      }
+      return value;
+    case 'bigint':
+      throw new HashAdmissionError(path, 'bigint is not admissible; use a decimal string');
+    case 'function':
+      throw new HashAdmissionError(path, 'functions are not admissible');
+    case 'symbol':
+      throw new HashAdmissionError(path, 'symbols are not admissible');
+    default:
+      break;
+  }
+
+  if (Array.isArray(value)) {
+    const admitted: unknown[] = [];
+    for (let i = 0; i < value.length; i++) {
+      if (!(i in value)) {
+        throw new HashAdmissionError(`${path}[${i}]`, 'sparse arrays are not admissible');
+      }
+      admitted.push(admit(value[i], `${path}[${i}]`));
+    }
+    return admitted;
+  }
+
+  if (value instanceof Date) {
+    throw new HashAdmissionError(
+      path,
+      'Date instances are not admissible; pass an ISO-8601 UTC string'
+    );
+  }
+  if (value instanceof Map || value instanceof Set) {
+    throw new HashAdmissionError(path, 'Map/Set are not admissible; use arrays or plain objects');
+  }
+  const proto: unknown = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    throw new HashAdmissionError(
+      path,
+      'class instances (including Decimal) are not admissible; serialize to JSON primitives first'
+    );
+  }
+  if (Object.getOwnPropertySymbols(value).length > 0) {
+    throw new HashAdmissionError(path, 'symbol-keyed properties are not admissible');
+  }
+
+  const record = value as Record<string, unknown>;
+  const admitted: Record<string, unknown> = {};
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) {
+      throw new HashAdmissionError(
+        `${path}.${key}`,
+        'undefined property values are not admissible'
+      );
+    }
+    admitted[key] = admit(record[key], `${path}.${key}`);
+  }
+  return admitted;
+}
+
+/** Validate and normalize a value for hashing; throws HashAdmissionError on any forbidden class. */
+export function admitForHashing(value: unknown): unknown {
+  return admit(value, '$');
+}
+
+export interface ResultHashPreimage {
+  domain: typeof RESULT_HASH_DOMAIN;
+  contractVersion: typeof CALC_SUBSTRATE_CONTRACT_VERSION;
+  basis: unknown;
+  value: unknown;
+}
+
+export function buildResultHashPreimage(basis: CalcBasis, value: unknown): ResultHashPreimage {
+  const validatedBasis = CalcBasisSchema.parse(basis);
+  return {
+    domain: RESULT_HASH_DOMAIN,
+    contractVersion: validatedBasis.contractVersion,
+    basis: admitForHashing(validatedBasis),
+    value: admitForHashing(value),
+  };
+}
+
+export function computeResultHash(basis: CalcBasis, value: unknown): string {
+  return canonicalSha256(buildResultHashPreimage(basis, value));
+}

--- a/shared/core/calc-substrate/index.ts
+++ b/shared/core/calc-substrate/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Tranche 1 calculation substrate (ADR-042).
+ *
+ * Additive contracts only: nothing here changes production calculation
+ * behavior. Engines adopt this substrate explicitly in later tranches.
+ */
+
+export {
+  CALC_SUBSTRATE_CONTRACT_VERSION,
+  CalcBasisSchema,
+  CalcModeSchema,
+  CalculationKeySchema,
+  Sha256HexSchema,
+  type CalcBasis,
+  type CalcMode,
+} from './calc-basis';
+export { CALC_REASON_CODES, CalcReasonCodeSchema, type CalcReasonCode } from './reason-codes';
+export {
+  CalcResultStateSchema,
+  GenericCalcResultSchema,
+  createCalcResultSchema,
+  toDatasetTrustState,
+  type CalcResult,
+  type CalcResultState,
+} from './calc-result';
+export {
+  HashAdmissionError,
+  RESULT_HASH_DOMAIN,
+  admitForHashing,
+  buildResultHashPreimage,
+  computeResultHash,
+  normalizeDecimalString,
+  type ResultHashPreimage,
+} from './hash-admission';
+export { assertValidSeed, createDeterministicRng, type CalcRng } from './deterministic-rng';
+export { createFixedClock, type CalcClock } from './fixed-clock';
+export {
+  createCalculationContext,
+  type CalculationContext,
+  type CalculationContextOptions,
+} from './calculation-context';

--- a/shared/core/calc-substrate/reason-codes.ts
+++ b/shared/core/calc-substrate/reason-codes.ts
@@ -1,0 +1,26 @@
+/**
+ * Stable reason-code registry for calculation results (Tranche 1 substrate).
+ *
+ * Codes are append-only: renaming or deleting a code is a contract-version
+ * change. These are calculation-result reasons; presentation-layer warning
+ * codes remain in shared/contracts/provenance-envelope.contract.ts.
+ */
+
+import { z } from 'zod';
+
+export const CALC_REASON_CODES = [
+  'INPUT_MISSING',
+  'INPUT_INVALID',
+  'ASSUMPTION_GAP',
+  'STALE_SOURCE',
+  'UPSTREAM_UNAVAILABLE',
+  'METHODOLOGY_UNSUPPORTED',
+  'ENGINE_ERROR',
+  'KILL_SWITCH_ACTIVE',
+  'MODE_OFF',
+  'SHADOW_ONLY',
+] as const;
+
+export const CalcReasonCodeSchema = z.enum(CALC_REASON_CODES);
+
+export type CalcReasonCode = z.infer<typeof CalcReasonCodeSchema>;

--- a/shared/core/pacing/pacing-substrate-adapter.ts
+++ b/shared/core/pacing/pacing-substrate-adapter.ts
@@ -1,0 +1,293 @@
+/**
+ * Pacing substrate adapter (Tranche 2, ADR-043).
+ *
+ * Runs the pacing calculation against an injected CalculationContext and
+ * returns a CalcResult with a validated basis and result hash. The legacy
+ * PacingEngine entry points are untouched: this adapter is an additive,
+ * context-receiving form of the same kernel.
+ *
+ * Behavior preservation contract:
+ * - The legacy engine resets its LCG (shared/utils/prng.ts, Numerical Recipes
+ *   parameters) to a hardcoded seed of 123 on every call. Exact-value parity
+ *   is therefore only achievable by replaying the same generator, so the
+ *   variability stream here is a locally constructed PRNG seeded from the
+ *   context's immutable root seed. A context seeded with 123 reproduces the
+ *   legacy engine's output exactly (proven by the parity tests in
+ *   tests/unit/pacing-substrate/). Migrating the variability stream onto
+ *   ctx.rng.fork('pacing') would change every emitted value and is deferred
+ *   to a methodology-version bump; the fork label 'pacing' is reserved for
+ *   that migration in the ADR-043 fork-label registry.
+ * - The kernel math is deliberately restated here rather than imported,
+ *   because the legacy entry point reads process.env internally and its seed
+ *   is not injectable. The characterization and parity suites pin both sides
+ *   to the same hand-authored fixtures, so any drift between the two copies
+ *   fails loudly.
+ *
+ * Boundary conventions:
+ * - Money at the adapter boundary is emitted as whole-dollar decimal strings.
+ *   Rounding rule (legacy-identical): Math.round applied to the non-negative
+ *   float amount, i.e. half-away-from-zero to a whole dollar.
+ * - The ML-vs-rule-based choice is an explicit typed option; the adapter
+ *   never reads process.env.
+ */
+
+import { z } from 'zod';
+import { canonicalSha256 } from '../../lib/canonical-hash';
+import { PacingInputSchema, type PacingInput } from '../../types';
+import { PRNG } from '../../utils/prng';
+import {
+  CALC_SUBSTRATE_CONTRACT_VERSION,
+  CalcBasisSchema,
+  admitForHashing,
+  computeResultHash,
+  createCalcResultSchema,
+  type CalcBasis,
+  type CalcMode,
+  type CalcReasonCode,
+  type CalculationContext,
+} from '../calc-substrate';
+
+export const PACING_CALCULATION_KEY = 'pacing';
+export const PACING_ENGINE_VERSION = 'pacing-engine/1.0.0';
+export const PACING_METHODOLOGY_VERSION = 'pacing-methodology/1.0.0';
+export const PACING_INPUT_HASH_DOMAIN = 'updog.pacing.input-hash';
+export const PACING_ASSUMPTIONS_HASH_DOMAIN = 'updog.pacing.assumptions-hash';
+
+export const PacingAlgorithmSchema = z.enum(['rule-based', 'ml']);
+export type PacingAlgorithm = z.infer<typeof PacingAlgorithmSchema>;
+
+const WHOLE_DOLLAR_DECIMAL_RE = /^(0|[1-9]\d*)$/;
+
+export const PacingScheduleEntrySchema = z
+  .object({
+    quarter: z.number().int().positive(),
+    deployment: z.string().regex(WHOLE_DOLLAR_DECIMAL_RE, 'whole-dollar decimal string'),
+    note: z.string().min(1),
+  })
+  .strict();
+
+export const PacingCalcValueSchema = z
+  .object({
+    schedule: z.array(PacingScheduleEntrySchema).length(8),
+    totalQuarters: z.literal(8),
+    totalDeployment: z.string().regex(WHOLE_DOLLAR_DECIMAL_RE, 'whole-dollar decimal string'),
+    avgQuarterlyDeployment: z
+      .string()
+      .regex(WHOLE_DOLLAR_DECIMAL_RE, 'whole-dollar decimal string'),
+    asOfUtc: z.string().min(1),
+  })
+  .strict();
+
+export type PacingCalcValue = z.infer<typeof PacingCalcValueSchema>;
+
+export const PacingCalcResultSchema = createCalcResultSchema(PacingCalcValueSchema);
+export type PacingCalcResult = z.infer<typeof PacingCalcResultSchema>;
+
+export interface PacingSubstrateOptions {
+  configuredMode: CalcMode;
+  killSwitchActive: boolean;
+  /** Explicit replacement for the legacy ALG_PACING env read. Default: rule-based. */
+  algorithm?: PacingAlgorithm;
+}
+
+/**
+ * Methodology constants, hashed into every basis. Restating them here (rather
+ * than referencing the legacy module) keeps the assumptions hash independent
+ * of incidental code layout; the parity suite guarantees they stay true.
+ */
+const PACING_ASSUMPTIONS = {
+  horizonQuarters: 8,
+  baseAmountDivisor: 8,
+  marketAdjustments: {
+    bull: { early: 1.3, mid: 1.1, late: 0.8 },
+    bear: { early: 0.7, mid: 0.9, late: 1.2 },
+    neutral: { early: 1.0, mid: 1.0, late: 1.0 },
+  },
+  variability: { min: 0.9, range: 0.2 },
+  mlTrend: { min: 0.85, range: 0.3 },
+  rounding: 'half-away-from-zero-to-whole-dollar',
+  rng: {
+    family: 'lcg-numerical-recipes',
+    multiplier: 1664525,
+    increment: 1013904223,
+    modulus: 4294967296,
+    seedSource: 'calculation-context-root-seed',
+  },
+} as const;
+
+export function computePacingInputHash(input: unknown): string {
+  let admitted: unknown;
+  try {
+    admitted = admitForHashing(input);
+  } catch {
+    // The raw input cannot be canonically hashed (undefined, NaN, class
+    // instances, ...). The basis still needs a deterministic input identity,
+    // and the accompanying result discloses the rejection via INPUT_INVALID.
+    admitted = { inadmissibleInput: true };
+  }
+  return canonicalSha256({ domain: PACING_INPUT_HASH_DOMAIN, input: admitted });
+}
+
+export function computePacingAssumptionsHash(algorithm: PacingAlgorithm): string {
+  return canonicalSha256({
+    domain: PACING_ASSUMPTIONS_HASH_DOMAIN,
+    methodologyVersion: PACING_METHODOLOGY_VERSION,
+    algorithm,
+    assumptions: admitForHashing(PACING_ASSUMPTIONS),
+  });
+}
+
+interface ScheduleEntry {
+  quarter: number;
+  deployment: number;
+  note: string;
+}
+
+/** Legacy-identical rule-based kernel; draws 8 variability values in order. */
+function ruleBasedSchedule(input: PacingInput, variability: PRNG): ScheduleEntry[] {
+  const { fundSize, deploymentQuarter, marketCondition } = input;
+  const adjustment = PACING_ASSUMPTIONS.marketAdjustments[marketCondition];
+  const baseAmount = fundSize / PACING_ASSUMPTIONS.baseAmountDivisor;
+
+  return Array.from({ length: PACING_ASSUMPTIONS.horizonQuarters }, (_, index) => {
+    const multiplier = index < 3 ? adjustment.early : index < 6 ? adjustment.mid : adjustment.late;
+    const factor =
+      PACING_ASSUMPTIONS.variability.min +
+      variability.next() * PACING_ASSUMPTIONS.variability.range;
+    const phaseNote =
+      index < 3
+        ? 'early-stage focus'
+        : index < 6
+          ? 'mid-stage deployment'
+          : 'late-stage optimization';
+    return {
+      quarter: deploymentQuarter + index,
+      deployment: Math.round(baseAmount * multiplier * factor),
+      note: `${marketCondition} market pacing (${phaseNote})`,
+    };
+  });
+}
+
+/** Legacy-identical ML overlay; draws 8 further values from the same stream. */
+function applyMlTrend(
+  schedule: ScheduleEntry[],
+  input: PacingInput,
+  variability: PRNG
+): ScheduleEntry[] {
+  return schedule.map((entry) => {
+    const trend =
+      PACING_ASSUMPTIONS.mlTrend.min + variability.next() * PACING_ASSUMPTIONS.mlTrend.range;
+    return {
+      quarter: entry.quarter,
+      deployment: Math.round(entry.deployment * trend),
+      note: `ML-optimized pacing (${input.marketCondition} trend analysis)`,
+    };
+  });
+}
+
+function computePacingValue(
+  input: PacingInput,
+  ctx: CalculationContext,
+  algorithm: PacingAlgorithm
+): PacingCalcValue {
+  const variability = new PRNG(ctx.rng.rootSeed);
+  const ruleBased = ruleBasedSchedule(input, variability);
+  const schedule = algorithm === 'ml' ? applyMlTrend(ruleBased, input, variability) : ruleBased;
+  const totalDeployment = schedule.reduce((sum, entry) => sum + entry.deployment, 0);
+
+  return {
+    schedule: schedule.map((entry) => ({
+      quarter: entry.quarter,
+      deployment: String(entry.deployment),
+      note: entry.note,
+    })),
+    totalQuarters: PACING_ASSUMPTIONS.horizonQuarters,
+    totalDeployment: String(totalDeployment),
+    avgQuarterlyDeployment: String(
+      Math.round(totalDeployment / PACING_ASSUMPTIONS.horizonQuarters)
+    ),
+    asOfUtc: ctx.clock.isoNow(),
+  };
+}
+
+export function runPacingWithSubstrate(
+  ctx: CalculationContext,
+  input: unknown,
+  options: PacingSubstrateOptions
+): PacingCalcResult {
+  if (ctx.contractVersion !== CALC_SUBSTRATE_CONTRACT_VERSION) {
+    throw new TypeError(
+      `pacing adapter requires contract ${CALC_SUBSTRATE_CONTRACT_VERSION}, received ${String(
+        ctx.contractVersion
+      )}`
+    );
+  }
+  if (ctx.calculationKey !== PACING_CALCULATION_KEY) {
+    throw new TypeError(
+      `pacing adapter requires calculationKey '${PACING_CALCULATION_KEY}', received '${ctx.calculationKey}'`
+    );
+  }
+  const algorithm = PacingAlgorithmSchema.parse(options.algorithm ?? 'rule-based');
+  const effectiveMode: CalcMode = options.killSwitchActive ? 'off' : options.configuredMode;
+
+  const basis: CalcBasis = CalcBasisSchema.parse({
+    contractVersion: CALC_SUBSTRATE_CONTRACT_VERSION,
+    calculationKey: PACING_CALCULATION_KEY,
+    configuredMode: options.configuredMode,
+    effectiveMode,
+    killSwitchActive: options.killSwitchActive,
+    engineVersion: PACING_ENGINE_VERSION,
+    methodologyVersion: PACING_METHODOLOGY_VERSION,
+    inputHash: computePacingInputHash(input),
+    assumptionsHash: computePacingAssumptionsHash(algorithm),
+  });
+
+  if (effectiveMode === 'off') {
+    const reasonCodes: CalcReasonCode[] = [];
+    if (options.killSwitchActive) {
+      reasonCodes.push('KILL_SWITCH_ACTIVE');
+    }
+    if (options.configuredMode === 'off') {
+      reasonCodes.push('MODE_OFF');
+    }
+    return PacingCalcResultSchema.parse({ state: 'unavailable', basis, reasonCodes });
+  }
+
+  const parsed = PacingInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return PacingCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['INPUT_INVALID'],
+      diagnostic: `pacing input rejected: ${parsed.error.message}`,
+    });
+  }
+
+  try {
+    const value = computePacingValue(parsed.data, ctx, algorithm);
+    const resultHash = computeResultHash(basis, value);
+    if (effectiveMode === 'shadow') {
+      return PacingCalcResultSchema.parse({
+        state: 'indicative',
+        basis,
+        value,
+        resultHash,
+        reasonCodes: ['SHADOW_ONLY'],
+      });
+    }
+    return PacingCalcResultSchema.parse({
+      state: 'available',
+      basis,
+      value,
+      resultHash,
+      reasonCodes: [],
+    });
+  } catch (error) {
+    return PacingCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['ENGINE_ERROR'],
+      diagnostic: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/tests/unit/calc-substrate/calc-result.test.ts
+++ b/tests/unit/calc-substrate/calc-result.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CALC_SUBSTRATE_CONTRACT_VERSION,
+  CalcBasisSchema,
+  type CalcBasis,
+} from '../../../shared/core/calc-substrate/calc-basis';
+import {
+  GenericCalcResultSchema,
+  toDatasetTrustState,
+} from '../../../shared/core/calc-substrate/calc-result';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+const SHA_C = 'c'.repeat(64);
+
+const validBasis: CalcBasis = {
+  contractVersion: CALC_SUBSTRATE_CONTRACT_VERSION,
+  calculationKey: 'demo_reserve',
+  configuredMode: 'shadow',
+  effectiveMode: 'shadow',
+  killSwitchActive: false,
+  engineVersion: 'demo-engine-1.0.0',
+  methodologyVersion: 'demo-methodology-1.0.0',
+  inputHash: SHA_A,
+  assumptionsHash: SHA_B,
+};
+
+describe('CalcBasisSchema', () => {
+  it('accepts a valid basis', () => {
+    expect(CalcBasisSchema.parse(validBasis)).toEqual(validBasis);
+  });
+
+  it('rejects unknown contract versions, modes, and calculation keys', () => {
+    expect(
+      CalcBasisSchema.safeParse({ ...validBasis, contractVersion: 'calc-substrate/9.9.9' }).success
+    ).toBe(false);
+    expect(CalcBasisSchema.safeParse({ ...validBasis, configuredMode: 'dry-run' }).success).toBe(
+      false
+    );
+    for (const key of ['', 'Demo', '9reserve', 'demo reserve']) {
+      expect(CalcBasisSchema.safeParse({ ...validBasis, calculationKey: key }).success).toBe(false);
+    }
+  });
+
+  it('rejects malformed hashes and undeclared fields', () => {
+    expect(CalcBasisSchema.safeParse({ ...validBasis, inputHash: 'abc' }).success).toBe(false);
+    expect(
+      CalcBasisSchema.safeParse({ ...validBasis, inputHash: SHA_A.toUpperCase() }).success
+    ).toBe(false);
+    expect(CalcBasisSchema.safeParse({ ...validBasis, resultHash: SHA_C }).success).toBe(false);
+    expect(CalcBasisSchema.safeParse({ ...validBasis, extra: true }).success).toBe(false);
+  });
+
+  it('rejects basis cross-field disagreements', () => {
+    expect(
+      CalcBasisSchema.safeParse({ ...validBasis, killSwitchActive: true, effectiveMode: 'shadow' })
+        .success
+    ).toBe(false);
+    expect(
+      CalcBasisSchema.safeParse({ ...validBasis, configuredMode: 'shadow', effectiveMode: 'on' })
+        .success
+    ).toBe(false);
+    expect(
+      CalcBasisSchema.safeParse({ ...validBasis, killSwitchActive: true, effectiveMode: 'off' })
+        .success
+    ).toBe(true);
+  });
+});
+
+describe('GenericCalcResultSchema', () => {
+  it('accepts a valid available result', () => {
+    const parsed = GenericCalcResultSchema.safeParse({
+      state: 'available',
+      basis: validBasis,
+      value: { totalReserve: '100' },
+      resultHash: SHA_C,
+      reasonCodes: [],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a valid indicative result that discloses why', () => {
+    const parsed = GenericCalcResultSchema.safeParse({
+      state: 'indicative',
+      basis: validBasis,
+      value: { totalReserve: '100' },
+      resultHash: SHA_C,
+      reasonCodes: ['SHADOW_ONLY'],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts valid unavailable and failed results', () => {
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: validBasis,
+        reasonCodes: ['INPUT_MISSING'],
+      }).success
+    ).toBe(true);
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'failed',
+        basis: validBasis,
+        reasonCodes: ['ENGINE_ERROR'],
+        diagnostic: 'divide by zero in tier 3',
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects an available result carrying reason codes or missing its hash', () => {
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'available',
+        basis: validBasis,
+        value: 1,
+        resultHash: SHA_C,
+        reasonCodes: ['STALE_SOURCE'],
+      }).success
+    ).toBe(false);
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'available',
+        basis: validBasis,
+        value: 1,
+        reasonCodes: [],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects non-available results that hide their reasons', () => {
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: validBasis,
+        reasonCodes: [],
+      }).success
+    ).toBe(false);
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'indicative',
+        basis: validBasis,
+        value: 1,
+        resultHash: SHA_C,
+        reasonCodes: [],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects unregistered reason codes', () => {
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: validBasis,
+        reasonCodes: ['NOT_A_CODE'],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects value smuggling on unavailable/failed results', () => {
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: validBasis,
+        reasonCodes: ['INPUT_MISSING'],
+        value: { totalReserve: '100' },
+      }).success
+    ).toBe(false);
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'failed',
+        basis: validBasis,
+        reasonCodes: ['ENGINE_ERROR'],
+        resultHash: SHA_C,
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects basis/result cross-field disagreements', () => {
+    const offBasis: CalcBasis = { ...validBasis, configuredMode: 'off', effectiveMode: 'off' };
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'available',
+        basis: offBasis,
+        value: 1,
+        resultHash: SHA_C,
+        reasonCodes: [],
+      }).success
+    ).toBe(false);
+
+    const killBasis: CalcBasis = { ...validBasis, killSwitchActive: true, effectiveMode: 'off' };
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: killBasis,
+        reasonCodes: ['UPSTREAM_UNAVAILABLE'],
+      }).success
+    ).toBe(false);
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: killBasis,
+        reasonCodes: ['KILL_SWITCH_ACTIVE'],
+      }).success
+    ).toBe(true);
+
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: offBasis,
+        reasonCodes: ['INPUT_MISSING'],
+      }).success
+    ).toBe(false);
+    expect(
+      GenericCalcResultSchema.safeParse({
+        state: 'unavailable',
+        basis: offBasis,
+        reasonCodes: ['MODE_OFF'],
+      }).success
+    ).toBe(true);
+  });
+});
+
+describe('toDatasetTrustState', () => {
+  it('maps every substrate state onto the existing envelope vocabulary', () => {
+    expect(toDatasetTrustState('available')).toBe('LIVE');
+    expect(toDatasetTrustState('indicative')).toBe('PARTIAL');
+    expect(toDatasetTrustState('unavailable')).toBe('UNAVAILABLE');
+    expect(toDatasetTrustState('failed')).toBe('FAILED');
+  });
+});

--- a/tests/unit/calc-substrate/calculation-context.test.ts
+++ b/tests/unit/calc-substrate/calculation-context.test.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { CALC_SUBSTRATE_CONTRACT_VERSION } from '../../../shared/core/calc-substrate/calc-basis';
+import { createCalculationContext } from '../../../shared/core/calc-substrate/calculation-context';
+
+describe('createCalculationContext', () => {
+  it('builds a frozen context with working injected capabilities', () => {
+    const ctx = createCalculationContext({
+      calculationKey: 'demo_reserve',
+      seed: 42,
+      asOf: '2026-07-17T00:00:00Z',
+      flags: { shadow_compare: true },
+    });
+    expect(ctx.contractVersion).toBe(CALC_SUBSTRATE_CONTRACT_VERSION);
+    expect(ctx.calculationKey).toBe('demo_reserve');
+    expect(ctx.rng.next()).toBe(0.002643892541527748);
+    expect(ctx.clock.isoNow()).toBe('2026-07-17T00:00:00.000Z');
+    expect(ctx.flags['shadow_compare']).toBe(true);
+    expect(Object.isFrozen(ctx)).toBe(true);
+    expect(Object.isFrozen(ctx.flags)).toBe(true);
+    expect(() => {
+      (ctx.flags as Record<string, boolean>)['injected'] = true;
+    }).toThrow(TypeError);
+  });
+
+  it('rejects invalid calculation keys, seeds, and instants', () => {
+    const valid = { calculationKey: 'demo_reserve', seed: 42, asOf: '2026-07-17T00:00:00Z' };
+    expect(() => createCalculationContext({ ...valid, calculationKey: 'Demo' })).toThrow();
+    expect(() => createCalculationContext({ ...valid, seed: 0 })).toThrow(RangeError);
+    expect(() => createCalculationContext({ ...valid, asOf: '2026-07-17' })).toThrow(RangeError);
+  });
+});
+
+describe('ambient-state source guard', () => {
+  it('the substrate never reaches for Math.random, argless new Date(), or process.env', async () => {
+    // The shared node-setup mocks fs.readFileSync; this guard needs the real one.
+    const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const substrateDir = path.join(process.cwd(), 'shared', 'core', 'calc-substrate');
+    const sources = fs.readdirSync(substrateDir).filter((f) => f.endsWith('.ts'));
+    expect(sources.length).toBeGreaterThanOrEqual(7);
+    const ambientPatterns: [string, RegExp][] = [
+      ['Math.random', /Math\.random/],
+      ['argless new Date()', /new Date\(\s*\)/],
+      ['process.env', /process\.env/],
+      ['Date.now', /Date\.now/],
+    ];
+    const violations: string[] = [];
+    for (const file of sources) {
+      const raw = fs.readFileSync(path.join(substrateDir, file), 'utf8');
+      // Guard executable code only: doc comments may name the forbidden APIs.
+      const text = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+      for (const [label, pattern] of ambientPatterns) {
+        if (pattern.test(text)) {
+          violations.push(`${file} uses ${label}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/calc-substrate/deterministic-rng.test.ts
+++ b/tests/unit/calc-substrate/deterministic-rng.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidSeed,
+  createDeterministicRng,
+} from '../../../shared/core/calc-substrate/deterministic-rng';
+
+// Pinned vectors: seed 42 through Xorshift32 with FNV-1a fork derivation.
+// These are contract constants; a change here is a contract-version change.
+const ROOT_VECTOR_SEED_42 = [0.002643892541527748, 0.660311977379024, 0.11095708678476512];
+const FORK_ALPHA_VECTOR = [0.6868107812479138, 0.3605633042752743, 0.9070068860892206];
+const FORK_BETA_VECTOR = [0.11061038030311465, 0.31423722696490586, 0.008342888206243515];
+const FORK_ALPHA_GAMMA_FIRST = 0.04258803394623101;
+
+describe('createDeterministicRng', () => {
+  it('produces the exact pinned vector for seed 42', () => {
+    const rng = createDeterministicRng(42);
+    expect([rng.next(), rng.next(), rng.next()]).toEqual(ROOT_VECTOR_SEED_42);
+  });
+
+  it('produces the exact pinned vector for the same seed and fork label', () => {
+    const alpha = createDeterministicRng(42).fork('alpha');
+    expect([alpha.next(), alpha.next(), alpha.next()]).toEqual(FORK_ALPHA_VECTOR);
+  });
+
+  it('keeps different fork labels stable and isolated from each other', () => {
+    const rng = createDeterministicRng(42);
+    const alpha = rng.fork('alpha');
+    const beta = rng.fork('beta');
+    expect([beta.next(), beta.next(), beta.next()]).toEqual(FORK_BETA_VECTOR);
+    expect([alpha.next(), alpha.next(), alpha.next()]).toEqual(FORK_ALPHA_VECTOR);
+    expect(FORK_ALPHA_VECTOR).not.toEqual(FORK_BETA_VECTOR);
+  });
+
+  it('fork sequences are call-order independent: advancing the parent does not move a fork', () => {
+    const untouched = createDeterministicRng(42);
+    const forkBefore = untouched.fork('alpha');
+
+    const advanced = createDeterministicRng(42);
+    advanced.next();
+    advanced.next();
+    advanced.fork('beta').next();
+    const forkAfter = advanced.fork('alpha');
+
+    expect([forkAfter.next(), forkAfter.next(), forkAfter.next()]).toEqual([
+      forkBefore.next(),
+      forkBefore.next(),
+      forkBefore.next(),
+    ]);
+  });
+
+  it('forking the same label twice yields identical independent sequences', () => {
+    const rng = createDeterministicRng(42);
+    const first = rng.fork('alpha');
+    const second = rng.fork('alpha');
+    expect(first.next()).toBe(second.next());
+    expect(first.next()).toBe(second.next());
+  });
+
+  it('supports nested forks with a stable derived path', () => {
+    const nested = createDeterministicRng(42).fork('alpha').fork('gamma');
+    expect(nested.forkPath).toBe('root/alpha/gamma');
+    expect(nested.next()).toBe(FORK_ALPHA_GAMMA_FIRST);
+  });
+
+  it('rejects invalid seeds', () => {
+    for (const seed of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 32]) {
+      expect(() => createDeterministicRng(seed)).toThrow(RangeError);
+      expect(() => assertValidSeed(seed)).toThrow(RangeError);
+    }
+    expect(() => createDeterministicRng(0xffffffff)).not.toThrow();
+  });
+
+  it('rejects invalid fork labels', () => {
+    const rng = createDeterministicRng(42);
+    expect(() => rng.fork('')).toThrow(RangeError);
+    expect(() => rng.fork('a/b')).toThrow(RangeError);
+  });
+});

--- a/tests/unit/calc-substrate/fixed-clock.test.ts
+++ b/tests/unit/calc-substrate/fixed-clock.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createFixedClock } from '../../../shared/core/calc-substrate/fixed-clock';
+
+const INSTANT = '2026-07-17T12:34:56.789Z';
+
+describe('createFixedClock', () => {
+  it('returns the pinned instant', () => {
+    const clock = createFixedClock(INSTANT);
+    expect(clock.now().toISOString()).toBe(INSTANT);
+    expect(clock.isoNow()).toBe(INSTANT);
+  });
+
+  it('normalizes second-precision input to canonical millisecond ISO output', () => {
+    const clock = createFixedClock('2026-07-17T00:00:00Z');
+    expect(clock.isoNow()).toBe('2026-07-17T00:00:00.000Z');
+    expect(createFixedClock('2026-07-17T00:00:00.5Z').isoNow()).toBe('2026-07-17T00:00:00.500Z');
+  });
+
+  it('cannot be mutated through a returned Date', () => {
+    const clock = createFixedClock(INSTANT);
+    const leaked = clock.now();
+    leaked.setFullYear(1999);
+    leaked.setTime(0);
+    expect(clock.now().toISOString()).toBe(INSTANT);
+    expect(clock.isoNow()).toBe(INSTANT);
+  });
+
+  it('returns a fresh Date object on every call', () => {
+    const clock = createFixedClock(INSTANT);
+    expect(clock.now()).not.toBe(clock.now());
+  });
+
+  it('rejects non-UTC, malformed, and non-existent instants', () => {
+    const invalid = [
+      'not-a-date',
+      '',
+      '2026-07-17T00:00:00',
+      '2026-07-17 00:00:00Z',
+      '2026-07-17T00:00:00+02:00',
+      '2026-02-30T00:00:00Z',
+      '2026-13-01T00:00:00Z',
+      '2026-07-17T24:00:00Z',
+    ];
+    for (const value of invalid) {
+      expect(() => createFixedClock(value), value).toThrow(RangeError);
+    }
+  });
+});

--- a/tests/unit/calc-substrate/hash-admission.test.ts
+++ b/tests/unit/calc-substrate/hash-admission.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import {
+  CALC_SUBSTRATE_CONTRACT_VERSION,
+  type CalcBasis,
+} from '../../../shared/core/calc-substrate/calc-basis';
+import {
+  HashAdmissionError,
+  admitForHashing,
+  buildResultHashPreimage,
+  computeResultHash,
+  normalizeDecimalString,
+} from '../../../shared/core/calc-substrate/hash-admission';
+
+const baseBasis: CalcBasis = {
+  contractVersion: CALC_SUBSTRATE_CONTRACT_VERSION,
+  calculationKey: 'demo_reserve',
+  configuredMode: 'shadow',
+  effectiveMode: 'shadow',
+  killSwitchActive: false,
+  engineVersion: 'demo-engine-1.0.0',
+  methodologyVersion: 'demo-methodology-1.0.0',
+  inputHash: 'a'.repeat(64),
+  assumptionsHash: 'b'.repeat(64),
+};
+
+const baseValue = {
+  totalReserve: '1250000.50',
+  companies: [
+    { id: 'c-1', allocation: '750000' },
+    { id: 'c-2', allocation: '500000.50' },
+  ],
+  asOf: '2026-07-17T00:00:00Z',
+};
+
+// Published contract vector: recomputable across processes from the persisted
+// canonical preimage below. A change here is a contract-version change.
+const PINNED_RESULT_HASH = '34c6a03abde9e341e89acef82202e34a9f65404a190568d841adc1bfc888c1b0';
+const PERSISTED_PREIMAGE_JSON =
+  '{"domain":"updog.calc-substrate.result-hash","contractVersion":"calc-substrate/1.0.0",' +
+  '"basis":{"contractVersion":"calc-substrate/1.0.0","calculationKey":"demo_reserve",' +
+  '"configuredMode":"shadow","effectiveMode":"shadow","killSwitchActive":false,' +
+  '"engineVersion":"demo-engine-1.0.0","methodologyVersion":"demo-methodology-1.0.0",' +
+  '"inputHash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",' +
+  '"assumptionsHash":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},' +
+  '"value":{"totalReserve":"1250000.5","companies":[{"id":"c-1","allocation":"750000"},' +
+  '{"id":"c-2","allocation":"500000.5"}],"asOf":"2026-07-17T00:00:00.000Z"}}';
+
+describe('computeResultHash', () => {
+  it('reproduces the published vector', () => {
+    expect(computeResultHash(baseBasis, baseValue)).toBe(PINNED_RESULT_HASH);
+  });
+
+  it('recomputes the published vector from the persisted canonical preimage', () => {
+    expect(canonicalSha256(JSON.parse(PERSISTED_PREIMAGE_JSON))).toBe(PINNED_RESULT_HASH);
+  });
+
+  it('is invariant to object key insertion order', () => {
+    const reorderedValue = {
+      asOf: '2026-07-17T00:00:00Z',
+      companies: [
+        { allocation: '750000', id: 'c-1' },
+        { allocation: '500000.50', id: 'c-2' },
+      ],
+      totalReserve: '1250000.50',
+    };
+    const reorderedBasis = Object.fromEntries(Object.entries(baseBasis).reverse()) as CalcBasis;
+    expect(computeResultHash(reorderedBasis, reorderedValue)).toBe(PINNED_RESULT_HASH);
+  });
+
+  it('changes when any declared basis field changes', () => {
+    const mutations: Partial<CalcBasis>[] = [
+      { calculationKey: 'demo_pacing' },
+      { configuredMode: 'on' },
+      { configuredMode: 'on', effectiveMode: 'on' },
+      { killSwitchActive: true, effectiveMode: 'off' },
+      { engineVersion: 'demo-engine-1.0.1' },
+      { methodologyVersion: 'demo-methodology-2.0.0' },
+      { inputHash: 'c'.repeat(64) },
+      { assumptionsHash: 'd'.repeat(64) },
+    ];
+    for (const mutation of mutations) {
+      const mutated = { ...baseBasis, ...mutation };
+      expect(computeResultHash(mutated, baseValue), JSON.stringify(mutation)).not.toBe(
+        PINNED_RESULT_HASH
+      );
+    }
+  });
+
+  it('changes when the value changes', () => {
+    expect(computeResultHash(baseBasis, { ...baseValue, totalReserve: '1250000.51' })).not.toBe(
+      PINNED_RESULT_HASH
+    );
+  });
+
+  it('is domain-separated: the preimage carries the domain tag and contract version', () => {
+    const preimage = buildResultHashPreimage(baseBasis, baseValue);
+    expect(preimage.domain).toBe('updog.calc-substrate.result-hash');
+    expect(preimage.contractVersion).toBe(CALC_SUBSTRATE_CONTRACT_VERSION);
+    expect(canonicalSha256(preimage)).not.toBe(
+      canonicalSha256({ basis: baseBasis, value: baseValue })
+    );
+  });
+
+  it('rejects an undeclared basis field before hashing', () => {
+    const smuggled = { ...baseBasis, resultHash: 'e'.repeat(64) } as CalcBasis;
+    expect(() => computeResultHash(smuggled, baseValue)).toThrow();
+  });
+});
+
+describe('normalizeDecimalString', () => {
+  it('normalizes equivalent decimal representations to one canonical form', () => {
+    expect(normalizeDecimalString('1.10')).toBe('1.1');
+    expect(normalizeDecimalString('007')).toBe('7');
+    expect(normalizeDecimalString('+42')).toBe('42');
+    expect(normalizeDecimalString('-0')).toBe('0');
+    expect(normalizeDecimalString('-0.000')).toBe('0');
+    expect(normalizeDecimalString('-12.3400')).toBe('-12.34');
+  });
+
+  it('makes equivalent decimal and timestamp spellings hash-equal', () => {
+    const spelled = {
+      ...baseValue,
+      totalReserve: '1250000.500',
+      asOf: '2026-07-17T00:00:00.000Z',
+    };
+    expect(computeResultHash(baseBasis, spelled)).toBe(PINNED_RESULT_HASH);
+  });
+});
+
+describe('admitForHashing', () => {
+  it('rejects every forbidden value class before hashing', () => {
+    class FakeDecimal {
+      constructor(readonly v: string) {}
+    }
+    const sparseArray = new Array<number>(3);
+    sparseArray[0] = 1;
+    sparseArray[2] = 3;
+    const forbidden: [string, unknown][] = [
+      ['undefined', undefined],
+      ['object with undefined property', { a: undefined }],
+      ['sparse array', sparseArray],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['bigint', 10n],
+      ['Map', new Map([['a', 1]])],
+      ['Set', new Set([1])],
+      ['Date instance', new Date(0)],
+      ['class instance', new FakeDecimal('1.5')],
+      ['function', () => 1],
+      ['symbol-keyed property', { [Symbol('k')]: 1, a: 1 }],
+      ['non-real timestamp string', '2026-02-30T00:00:00Z'],
+    ];
+    for (const [label, value] of forbidden) {
+      expect(() => admitForHashing(value), label).toThrow(HashAdmissionError);
+      expect(() => computeResultHash(baseBasis, { wrapped: value }), label).toThrow(
+        HashAdmissionError
+      );
+    }
+  });
+
+  it('normalizes -0 to 0 and accepts plain JSON values', () => {
+    expect(admitForHashing(-0)).toBe(0);
+    expect(admitForHashing({ a: [1, 'x', true, null] })).toEqual({ a: [1, 'x', true, null] });
+  });
+});

--- a/tests/unit/pacing-substrate/ambient-guard.test.ts
+++ b/tests/unit/pacing-substrate/ambient-guard.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Ambient-state source guard for the pacing substrate adapter (ADR-043).
+ *
+ * Same pattern as tests/unit/calc-substrate/calculation-context.test.ts: the
+ * adapter must receive every ambient capability through its
+ * CalculationContext, never via Math.random, argless new Date(), Date.now,
+ * or process.env. The legacy PacingEngine.ts is intentionally NOT scanned:
+ * its process.env read is characterized legacy behavior, out of scope until
+ * its own adoption tranche.
+ */
+
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+const GUARDED_FILES = ['pacing-substrate-adapter.ts'];
+
+describe('pacing adapter ambient-state source guard', () => {
+  it('the adapter never reaches for Math.random, argless new Date(), Date.now, or process.env', async () => {
+    // The shared node-setup mocks fs.readFileSync; this guard needs the real one.
+    const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const pacingDir = path.join(process.cwd(), 'shared', 'core', 'pacing');
+    const ambientPatterns: [string, RegExp][] = [
+      ['Math.random', /Math\.random/],
+      ['argless new Date()', /new Date\(\s*\)/],
+      ['process.env', /process\.env/],
+      ['Date.now', /Date\.now/],
+    ];
+    const violations: string[] = [];
+    for (const file of GUARDED_FILES) {
+      const raw = fs.readFileSync(path.join(pacingDir, file), 'utf8');
+      // Guard executable code only: doc comments may name the forbidden APIs.
+      const text = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+      for (const [label, pattern] of ambientPatterns) {
+        if (pattern.test(text)) {
+          violations.push(`${file} uses ${label}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/pacing-substrate/pacing-engine-characterization.test.ts
+++ b/tests/unit/pacing-substrate/pacing-engine-characterization.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Characterization tests for the legacy PacingEngine (Tranche 2, ADR-043).
+ *
+ * These pin the engine's CURRENT behavior before substrate adoption; they are
+ * evidence, not aspiration. The legacy engine resets its module-global LCG
+ * (shared/utils/prng.ts, Numerical Recipes parameters) to the hardcoded seed
+ * 123 on every call, so per-call output is fully deterministic given a fixed
+ * environment. The remaining ambient reads are:
+ *
+ * - process.env['ALG_PACING'] / process.env['NODE_ENV'] select the ML vs
+ *   rule-based path (controlled explicitly below);
+ * - generatePacingSummary stamps `generatedAt: new Date()` (characterized
+ *   structurally only; the wall-clock value is not blessed as truth).
+ *
+ * Expected deployment values are hand-authored from the LCG recurrence
+ * state' = (1664525 * state + 1013904223) mod 2^32 starting at state 123,
+ * variability = 0.9 + draw * 0.2, deployment = round(base * phase * variability).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PacingEngine, generatePacingSummary } from '../../../shared/core/pacing/PacingEngine';
+import type { PacingInput, PacingOutput } from '../../../shared/types';
+
+const NEUTRAL_50M_Q1: PacingInput = {
+  fundSize: 50_000_000,
+  deploymentQuarter: 1,
+  marketCondition: 'neutral',
+};
+const BULL_100M_Q3: PacingInput = {
+  fundSize: 100_000_000,
+  deploymentQuarter: 3,
+  marketCondition: 'bull',
+};
+const BEAR_20M_Q10: PacingInput = {
+  fundSize: 20_000_000,
+  deploymentQuarter: 10,
+  marketCondition: 'bear',
+};
+
+// Hand-authored expected deployments for the LCG(123) draw sequence.
+const EXPECTED_NEUTRAL_50M_Q1 = [
+  5_979_671, 6_168_913, 5_673_314, 5_901_100, 6_074_284, 6_362_805, 6_076_601, 6_033_562,
+];
+const EXPECTED_BULL_100M_Q3 = [
+  15_547_145, 16_039_173, 14_750_617, 12_982_420, 13_363_424, 13_998_171, 9_722_562, 9_653_700,
+];
+const EXPECTED_BEAR_20M_Q10 = [
+  1_674_308, 1_727_296, 1_588_528, 2_124_396, 2_186_742, 2_290_610, 2_916_769, 2_896_110,
+];
+const EXPECTED_NEUTRAL_50M_Q1_ML = [
+  5_225_765, 6_442_743, 5_851_990, 6_732_204, 6_562_221, 7_238_359, 5_330_876, 6_657_064,
+];
+
+function deployments(outputs: PacingOutput[]): number[] {
+  return outputs.map((o) => o.deployment);
+}
+
+describe('legacy PacingEngine characterization (rule-based path)', () => {
+  const savedAlgPacing = process.env['ALG_PACING'];
+
+  beforeEach(() => {
+    // NODE_ENV is 'test' under vitest; ALG_PACING unset selects rule-based.
+    delete process.env['ALG_PACING'];
+  });
+
+  afterEach(() => {
+    if (savedAlgPacing === undefined) {
+      delete process.env['ALG_PACING'];
+    } else {
+      process.env['ALG_PACING'] = savedAlgPacing;
+    }
+  });
+
+  it('pins exact neutral-market deployments for seed 123', () => {
+    const result = PacingEngine(NEUTRAL_50M_Q1);
+    expect(deployments(result)).toEqual(EXPECTED_NEUTRAL_50M_Q1);
+    expect(result.map((o) => o.quarter)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(result[0]!.note).toBe('neutral market pacing (early-stage focus)');
+    expect(result[3]!.note).toBe('neutral market pacing (mid-stage deployment)');
+    expect(result[7]!.note).toBe('neutral market pacing (late-stage optimization)');
+  });
+
+  it('pins exact bull-market deployments for seed 123', () => {
+    const result = PacingEngine(BULL_100M_Q3);
+    expect(deployments(result)).toEqual(EXPECTED_BULL_100M_Q3);
+    expect(result.map((o) => o.quarter)).toEqual([3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result[0]!.note).toBe('bull market pacing (early-stage focus)');
+  });
+
+  it('pins exact bear-market deployments for seed 123', () => {
+    const result = PacingEngine(BEAR_20M_Q10);
+    expect(deployments(result)).toEqual(EXPECTED_BEAR_20M_Q10);
+    expect(result.map((o) => o.quarter)).toEqual([10, 11, 12, 13, 14, 15, 16, 17]);
+    expect(result[7]!.note).toBe('bear market pacing (late-stage optimization)');
+  });
+
+  it('is deterministic across repeated calls (module PRNG resets to 123 per call)', () => {
+    const first = PacingEngine(NEUTRAL_50M_Q1);
+    const second = PacingEngine(NEUTRAL_50M_Q1);
+    expect(second).toEqual(first);
+  });
+
+  it('is call-order independent because each call resets the shared generator', () => {
+    PacingEngine(BULL_100M_Q3);
+    const afterOther = PacingEngine(NEUTRAL_50M_Q1);
+    expect(deployments(afterOther)).toEqual(EXPECTED_NEUTRAL_50M_Q1);
+  });
+});
+
+describe('legacy PacingEngine characterization (ML path via ALG_PACING)', () => {
+  const savedAlgPacing = process.env['ALG_PACING'];
+
+  afterEach(() => {
+    if (savedAlgPacing === undefined) {
+      delete process.env['ALG_PACING'];
+    } else {
+      process.env['ALG_PACING'] = savedAlgPacing;
+    }
+  });
+
+  it('pins exact ML-path deployments: 8 rule-based draws then 8 trend draws from one stream', () => {
+    process.env['ALG_PACING'] = 'true';
+    const result = PacingEngine(NEUTRAL_50M_Q1);
+    expect(deployments(result)).toEqual(EXPECTED_NEUTRAL_50M_Q1_ML);
+    expect(result[0]!.note).toBe('ML-optimized pacing (neutral trend analysis)');
+  });
+});
+
+describe('legacy generatePacingSummary characterization', () => {
+  const savedAlgPacing = process.env['ALG_PACING'];
+
+  beforeEach(() => {
+    delete process.env['ALG_PACING'];
+  });
+
+  afterEach(() => {
+    if (savedAlgPacing === undefined) {
+      delete process.env['ALG_PACING'];
+    } else {
+      process.env['ALG_PACING'] = savedAlgPacing;
+    }
+  });
+
+  it('pins summary aggregates; generatedAt is an ambient new Date() read (structure only)', () => {
+    const summary = generatePacingSummary(NEUTRAL_50M_Q1);
+    const expectedTotal = EXPECTED_NEUTRAL_50M_Q1.reduce((sum, d) => sum + d, 0);
+    expect(summary.totalQuarters).toBe(8);
+    expect(deployments(summary.deployments)).toEqual(EXPECTED_NEUTRAL_50M_Q1);
+    expect(summary.avgQuarterlyDeployment).toBe(Math.round(expectedTotal / 8));
+    expect(summary.fundSize).toBe(NEUTRAL_50M_Q1.fundSize);
+    expect(summary.marketCondition).toBe('neutral');
+    // Nondeterministic under fixed inputs: value intentionally not pinned.
+    expect(summary.generatedAt).toBeInstanceOf(Date);
+  });
+});

--- a/tests/unit/pacing-substrate/pacing-substrate-adapter.test.ts
+++ b/tests/unit/pacing-substrate/pacing-substrate-adapter.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Pacing substrate adapter tests (Tranche 2, ADR-043).
+ *
+ * Proves, per the tranche exit criteria:
+ * (a) same context + inputs -> byte-identical result and identical resultHash
+ *     across repeated runs;
+ * (b) different seeds / inputs / as-of instants -> different hashes;
+ * (c) adapter output matches the legacy PacingEngine exactly for the legacy
+ *     effective seed (123) on hand-authored fixtures;
+ * (d) basis cross-field behavior: off / kill-switched runs yield unavailable
+ *     with the registered disclosure codes, shadow yields indicative, and
+ *     invalid input yields failed with INPUT_INVALID - never a silent value.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  GenericCalcResultSchema,
+  createCalculationContext,
+} from '../../../shared/core/calc-substrate';
+import { PacingEngine } from '../../../shared/core/pacing/PacingEngine';
+import {
+  PACING_CALCULATION_KEY,
+  PacingCalcResultSchema,
+  runPacingWithSubstrate,
+  type PacingSubstrateOptions,
+} from '../../../shared/core/pacing/pacing-substrate-adapter';
+import type { PacingInput } from '../../../shared/types';
+
+const LEGACY_SEED = 123;
+const AS_OF = '2026-07-17T00:00:00Z';
+
+const NEUTRAL_50M_Q1: PacingInput = {
+  fundSize: 50_000_000,
+  deploymentQuarter: 1,
+  marketCondition: 'neutral',
+};
+const BULL_100M_Q3: PacingInput = {
+  fundSize: 100_000_000,
+  deploymentQuarter: 3,
+  marketCondition: 'bull',
+};
+const BEAR_20M_Q10: PacingInput = {
+  fundSize: 20_000_000,
+  deploymentQuarter: 10,
+  marketCondition: 'bear',
+};
+
+// Hand-authored from the LCG(123) recurrence; identical constants are pinned
+// against the legacy engine in pacing-engine-characterization.test.ts.
+const EXPECTED_NEUTRAL_50M_Q1 = [
+  '5979671',
+  '6168913',
+  '5673314',
+  '5901100',
+  '6074284',
+  '6362805',
+  '6076601',
+  '6033562',
+];
+const EXPECTED_BULL_100M_Q3 = [
+  '15547145',
+  '16039173',
+  '14750617',
+  '12982420',
+  '13363424',
+  '13998171',
+  '9722562',
+  '9653700',
+];
+const EXPECTED_BEAR_20M_Q10 = [
+  '1674308',
+  '1727296',
+  '1588528',
+  '2124396',
+  '2186742',
+  '2290610',
+  '2916769',
+  '2896110',
+];
+const EXPECTED_NEUTRAL_50M_Q1_ML = [
+  '5225765',
+  '6442743',
+  '5851990',
+  '6732204',
+  '6562221',
+  '7238359',
+  '5330876',
+  '6657064',
+];
+
+const ON: PacingSubstrateOptions = { configuredMode: 'on', killSwitchActive: false };
+
+function pacingContext(seed: number, asOf: string = AS_OF) {
+  return createCalculationContext({ calculationKey: PACING_CALCULATION_KEY, seed, asOf });
+}
+
+function scheduleDeployments(result: ReturnType<typeof runPacingWithSubstrate>): string[] {
+  if (result.state !== 'available' && result.state !== 'indicative') {
+    throw new Error(`expected a value-bearing result, got ${result.state}`);
+  }
+  return result.value.schedule.map((entry) => entry.deployment);
+}
+
+describe('runPacingWithSubstrate determinism and hash integrity', () => {
+  it('(a) repeated runs with the same context and input are byte-identical with equal hashes', () => {
+    const first = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, ON);
+    const second = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, ON);
+
+    expect(first.state).toBe('available');
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    if (first.state === 'available' && second.state === 'available') {
+      expect(second.resultHash).toBe(first.resultHash);
+      expect(first.resultHash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('(b) a different seed changes the result hash', () => {
+    const seed123 = runPacingWithSubstrate(pacingContext(123), NEUTRAL_50M_Q1, ON);
+    const seed456 = runPacingWithSubstrate(pacingContext(456), NEUTRAL_50M_Q1, ON);
+    if (seed123.state !== 'available' || seed456.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(seed456.resultHash).not.toBe(seed123.resultHash);
+  });
+
+  it('(b) a different input changes the input hash and the result hash', () => {
+    const neutral = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, ON);
+    const bull = runPacingWithSubstrate(pacingContext(LEGACY_SEED), BULL_100M_Q3, ON);
+    if (neutral.state !== 'available' || bull.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(bull.basis.inputHash).not.toBe(neutral.basis.inputHash);
+    expect(bull.resultHash).not.toBe(neutral.resultHash);
+  });
+
+  it('(b) a different as-of instant changes the result hash (asOfUtc is part of the value)', () => {
+    const base = runPacingWithSubstrate(pacingContext(LEGACY_SEED, AS_OF), NEUTRAL_50M_Q1, ON);
+    const later = runPacingWithSubstrate(
+      pacingContext(LEGACY_SEED, '2026-07-18T00:00:00Z'),
+      NEUTRAL_50M_Q1,
+      ON
+    );
+    if (base.state !== 'available' || later.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(later.resultHash).not.toBe(base.resultHash);
+    expect(later.basis.inputHash).toBe(base.basis.inputHash);
+  });
+
+  it('every emitted result revalidates against the pacing and generic result schemas', () => {
+    const result = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, ON);
+    expect(() => PacingCalcResultSchema.parse(result)).not.toThrow();
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+});
+
+describe('runPacingWithSubstrate parity with the legacy engine (effective seed 123)', () => {
+  const savedAlgPacing = process.env['ALG_PACING'];
+
+  afterEach(() => {
+    if (savedAlgPacing === undefined) {
+      delete process.env['ALG_PACING'];
+    } else {
+      process.env['ALG_PACING'] = savedAlgPacing;
+    }
+  });
+
+  const ruleBasedFixtures: Array<[string, PacingInput, string[]]> = [
+    ['neutral 50M q1', NEUTRAL_50M_Q1, EXPECTED_NEUTRAL_50M_Q1],
+    ['bull 100M q3', BULL_100M_Q3, EXPECTED_BULL_100M_Q3],
+    ['bear 20M q10', BEAR_20M_Q10, EXPECTED_BEAR_20M_Q10],
+  ];
+
+  it.each(ruleBasedFixtures)('(c) rule-based parity: %s', (_label, input, expectedDeployments) => {
+    delete process.env['ALG_PACING'];
+    const legacy = PacingEngine(input);
+    const result = runPacingWithSubstrate(pacingContext(LEGACY_SEED), input, ON);
+    if (result.state !== 'available') {
+      throw new Error(`expected available, got ${result.state}`);
+    }
+
+    // Both sides pinned to the same hand-authored constants...
+    expect(scheduleDeployments(result)).toEqual(expectedDeployments);
+    expect(legacy.map((o) => String(o.deployment))).toEqual(expectedDeployments);
+    // ...and field-for-field agreement between adapter and legacy engine.
+    result.value.schedule.forEach((entry, index) => {
+      expect(Number(entry.deployment)).toBe(legacy[index]!.deployment);
+      expect(entry.quarter).toBe(legacy[index]!.quarter);
+      expect(entry.note).toBe(legacy[index]!.note);
+    });
+    const expectedTotal = legacy.reduce((sum, o) => sum + o.deployment, 0);
+    expect(result.value.totalDeployment).toBe(String(expectedTotal));
+    expect(result.value.avgQuarterlyDeployment).toBe(String(Math.round(expectedTotal / 8)));
+    expect(result.value.asOfUtc).toBe('2026-07-17T00:00:00.000Z');
+  });
+
+  it('(c) ML-path parity: neutral 50M q1 with the explicit ml algorithm option', () => {
+    process.env['ALG_PACING'] = 'true';
+    const legacy = PacingEngine(NEUTRAL_50M_Q1);
+    delete process.env['ALG_PACING'];
+
+    const result = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    if (result.state !== 'available') {
+      throw new Error(`expected available, got ${result.state}`);
+    }
+    expect(scheduleDeployments(result)).toEqual(EXPECTED_NEUTRAL_50M_Q1_ML);
+    expect(legacy.map((o) => String(o.deployment))).toEqual(EXPECTED_NEUTRAL_50M_Q1_ML);
+    expect(result.value.schedule[0]!.note).toBe('ML-optimized pacing (neutral trend analysis)');
+  });
+
+  it('(b) rule-based and ml algorithms produce different assumptions hashes and result hashes', () => {
+    const ruleBased = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, ON);
+    const ml = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    if (ruleBased.state !== 'available' || ml.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(ml.basis.assumptionsHash).not.toBe(ruleBased.basis.assumptionsHash);
+    expect(ml.resultHash).not.toBe(ruleBased.resultHash);
+  });
+});
+
+describe('runPacingWithSubstrate mode and kill-switch invariants', () => {
+  it('(d) configuredMode off yields unavailable with MODE_OFF and no value', () => {
+    const result = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, {
+      configuredMode: 'off',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['MODE_OFF']);
+    expect('value' in result).toBe(false);
+    expect('resultHash' in result).toBe(false);
+    expect(result.basis.effectiveMode).toBe('off');
+  });
+
+  it('(d) an active kill switch forces effectiveMode off and discloses KILL_SWITCH_ACTIVE', () => {
+    const result = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, {
+      configuredMode: 'on',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE']);
+    expect(result.basis.effectiveMode).toBe('off');
+    expect(result.basis.configuredMode).toBe('on');
+  });
+
+  it('(d) kill switch plus configured off disclose both suppression codes', () => {
+    const result = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, {
+      configuredMode: 'off',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE', 'MODE_OFF']);
+  });
+
+  it('(d) shadow mode yields an indicative value disclosed via SHADOW_ONLY', () => {
+    const result = runPacingWithSubstrate(pacingContext(LEGACY_SEED), NEUTRAL_50M_Q1, {
+      configuredMode: 'shadow',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('indicative');
+    expect(result.reasonCodes).toEqual(['SHADOW_ONLY']);
+    expect(scheduleDeployments(result)).toEqual(EXPECTED_NEUTRAL_50M_Q1);
+  });
+
+  it('(d) schema-invalid input yields failed with INPUT_INVALID and a diagnostic', () => {
+    const result = runPacingWithSubstrate(
+      pacingContext(LEGACY_SEED),
+      { fundSize: -1, deploymentQuarter: 1, marketCondition: 'neutral' },
+      ON
+    );
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['INPUT_INVALID']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('pacing input rejected');
+    }
+    expect(result.basis.inputHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('(d) hash-inadmissible input still gets a deterministic basis and INPUT_INVALID', () => {
+    const inadmissible = { fundSize: Number.NaN, deploymentQuarter: 1, marketCondition: 'neutral' };
+    const first = runPacingWithSubstrate(pacingContext(LEGACY_SEED), inadmissible, ON);
+    const second = runPacingWithSubstrate(pacingContext(LEGACY_SEED), inadmissible, ON);
+    expect(first.state).toBe('failed');
+    expect(first.reasonCodes).toEqual(['INPUT_INVALID']);
+    expect(first.basis.inputHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(second.basis.inputHash).toBe(first.basis.inputHash);
+  });
+
+  it('rejects a context built for a different calculation key', () => {
+    const ctx = createCalculationContext({ calculationKey: 'reserve', seed: 1, asOf: AS_OF });
+    expect(() => runPacingWithSubstrate(ctx, NEUTRAL_50M_Q1, ON)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
Implements the first executable slice of the reviewed multi-entity
implementation procedure under an owner-granted demo override of its
program-governance gates. Additive only: zero production consumers changed.

- Injected deterministic RNG with labeled, call-order-independent forks
  (wraps existing SeededRNG/deriveSeed; no parallel RNG source)
- Injected fixed clock storing epoch ms only, defensive Date copies
- Versioned calc basis (contract/engine/methodology versions, modes,
  kill-switch state, input/assumptions hashes) with cross-field invariants
- Discriminated available/indicative/unavailable/failed result union with
  stable reason codes and truthfulness invariants (no silent fabrication);
  adapter onto existing DatasetTrustState vocabulary
- Domain-separated hash admission (decimal/UTC normalization; rejects
  undefined, sparse arrays, non-finite numbers, bigint, class instances,
  Map/Set); result hash computed outside the basis via canonicalSha256
- 40 unit tests pinning published RNG/SHA-256 contract vectors plus an
  ambient-state source guard (Math.random / argless new Date / process.env)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HFciv7cVr6iGaC2Vo8CXFV