### PR TITLE
feat(reserves): Tranche 3 substrate adoption of the rule/ML ReserveEngine (ADR-044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ and this project adheres to
 
 ### Added (2026-07-17)
 
+- **Tranche 3 reserve substrate adoption (ADR-044).** New additive adapter
+  `shared/core/reserves/reserve-substrate-adapter.ts` runs the rule/ML
+  `ReserveEngine` domain against an injected `CalculationContext` and emits a
+  hash-bound `CalcResult` (calculationKey `reserve`): explicit typed algorithm
+  option replaces the `ALG_RESERVE` env read, the injected clock replaces
+  `generateReserveSummary`'s `new Date()`, allocations become whole-dollar
+  decimal strings and confidences 2dp decimal strings (legacy-identical
+  rounding), and domain-separated input/assumptions hashes feed the substrate
+  result hash. The ML stream replays the legacy LCG seeded from the context root
+  seed so a seed of 42 reproduces legacy output exactly;
+  `ctx.rng.fork('reserve')` is reserved for a future methodology bump. Two
+  disclosed boundary deviations: non-array input is `failed` + `INPUT_INVALID`
+  instead of the legacy silent `[]`, and an empty portfolio is `available` with
+  zero totals. 36 new tests (`tests/unit/reserve-substrate/`) characterize the
+  legacy engine (including the hand-derived seed-42 ML gate/adjustment stream),
+  prove adapter parity field-for-field on hand-authored fixtures (rule-based and
+  ML), prove repeat-run hash determinism plus disclosed rule-based
+  seed-invariance, prove mode/kill-switch disclosure invariants, and guard the
+  adapter against ambient reads. Legacy reserve engines and consumers unchanged;
+  `DeterministicReserveEngine` deferred to Tranche 4 with a verified defect list
+  recorded in the ADR.
+
 - **Tranche 2 pacing substrate adoption (ADR-043).** New additive adapter
   `shared/core/pacing/pacing-substrate-adapter.ts` runs the Pacing domain
   against an injected `CalculationContext` and emits a hash-bound `CalcResult`

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6558,3 +6558,194 @@ suppressed results, no silent fabrication) are enforced in code and tests.
 
 **Implementation:** `shared/core/pacing/pacing-substrate-adapter.ts` plus
 `tests/unit/pacing-substrate/` (25 tests).
+
+## ADR-044: Tranche 3 Substrate Adoption of the Rule/ML Reserve Engine (Demo Scope)
+
+**Date:** 2026-07-17 **Status:** [ACCEPTED] Implemented (demo scope)
+**Decision:** Adopt `shared/core/reserves/ReserveEngine.ts` (the simple rule/ML
+engine, sibling of PacingEngine) onto the ADR-042 calculation substrate via an
+additive context-receiving adapter
+(`shared/core/reserves/reserve-substrate-adapter.ts`, calculationKey `reserve`),
+and defer `DeterministicReserveEngine.ts` to Tranche 4. Legacy reserve engines
+and all their consumers are unchanged. Same owner-granted demo override of
+program-governance gates as ADR-042/043; technical invariants (determinism, hash
+integrity, disclosure of suppressed results, no silent financial fabrication)
+are enforced in code and tests.
+
+### Context: corrected audit (supersedes the ADR-043 defer rationale)
+
+ADR-043 deferred Reserve citing a "call-order-sensitive module-global PRNG (no
+per-call reset)". Re-verification against current code (2026-07-17) shows that
+claim no longer applies to THIS engine:
+
+- `ReserveEngine.ts` DOES reset its module-global PRNG to the hardcoded seed 42
+  on every call (line 93), so it is per-call deterministic under a fixed
+  environment. Its only ambient reads are `process.env['ALG_RESERVE']` /
+  `process.env['NODE_ENV']` selecting ML vs rule-based (lines 7-12) and
+  `generatedAt: new Date()` in `generateReserveSummary` (line 140). The
+  rule-based path draws NO randomness; the ML path draws, per company in
+  portfolio order, one gate value (`next() > 0.3` selects ML) and, only when the
+  gate passes, one adjustment value (`0.8 + next() * 0.4`), so the draw count
+  interleaves with gate outcomes.
+- `DeterministicReserveEngine.ts` (924 lines) remains defer, with verified
+  facts: `Date.now()` at lines 78/123/140/486 (timing) and line 766 INSIDE
+  calculation math (`ageMonths` derived from the wall clock, so risk multipliers
+  drift with real time); `process.env['NODE_ENV']` at line 85; `new Date()` at
+  line 485; and `generateDeterministicHash` (line 737) base64-JSONs only 5
+  coarse fields including `portfolioCount` - a count, not portfolio contents -
+  so two different portfolios of equal size collide on cache identity. These are
+  Tranche 4 work items, recorded here, not fixed now.
+
+### Disposition table
+
+| Surface                                                                  | Disposition | Notes                                                                                                     |
+| ------------------------------------------------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------- |
+| `shared/core/reserves/ReserveEngine.ts` (rule/ML kernel)                 | adapt       | Kernel math restated in the adapter in context-receiving form; legacy entry points and behavior untouched |
+| `ReserveEngine` / `generateReserveSummary` legacy signatures             | reuse       | Still exported, still consumed; adapter wraps the domain, does not replace the API                        |
+| `shared/utils/prng.ts` (LCG)                                             | reuse       | Adapter constructs a local instance per run; the `Date.now()` default seed path is never exercised        |
+| `shared/core/reserves/DeterministicReserveEngine.ts`                     | defer       | Tranche 4; verified ambient reads and cache-identity defects listed above                                 |
+| `shared/core/reserves/ConstrainedReserveEngine.ts`                       | defer       | Separate sibling engine; consumed by `server/routes/v1/reserves.ts` and client parity tooling             |
+| `server/services/reserve-calculation-service.ts`                         | defer       | Continues to call `generateReserveSummary`; substrate wiring is a later tranche                           |
+| `server/services/projected-metrics-calculator.ts`                        | defer       | Same                                                                                                      |
+| `server/services/fund-scenario-reserve-summary.ts`                       | defer       | Calls `ReserveEngine(input.portfolio)` directly; unchanged                                                |
+| `server/services/fund-scenario-reserve-optimization-workflow-service.ts` | defer       | Same                                                                                                      |
+| `server/routes/engine-summaries.ts`                                      | defer       | Continues to call `generateReserveSummary`                                                                |
+| `server/routes/v1/reserves.ts`                                           | defer       | ConstrainedReserveEngine consumer; out of this tranche's scope                                            |
+| `server/routes/scenario-analysis.ts`                                     | defer       | References DeterministicReserveEngine only in TODO comments                                               |
+| `server/core/reserves/` (ports/adapter/mlClient)                         | defer       | Type-level imports of Deterministic/Constrained engines; separate ML-service seam                         |
+| `client/src/core/reserves/ReserveEngine.ts` (re-export shim)             | reuse       | Untouched                                                                                                 |
+| `process.env['ALG_RESERVE']` algorithm selection                         | replace     | Adapter takes an explicit typed `algorithm: 'rule-based' \| 'ml'` option; never reads env                 |
+| `generatedAt: new Date()` in `generateReserveSummary`                    | replace     | Adapter emits `asOfUtc` from the injected `ctx.clock`                                                     |
+| Silent `[]` fallback for non-array input                                 | replace     | At the adapter boundary only: `failed` + `INPUT_INVALID` (legacy itself unchanged; see deviations)        |
+
+### Decision details
+
+- **Determinism and the RNG compatibility decision.** Exact-value parity with
+  the legacy engine is only achievable by replaying its LCG stream, so the
+  adapter's ML stream is a locally constructed `PRNG` seeded from the
+  calculation context's immutable root seed. A context seeded with 42 (the
+  legacy hardcoded seed) reproduces legacy output byte-for-byte. Substituting
+  the substrate Xorshift32 (`ctx.rng`) would change every ML-path value and is
+  deferred to a methodology-version bump.
+- **Fork-label registry (reserve).** `reserve` is RESERVED as the fork label for
+  the future migration of the ML stream onto `ctx.rng.fork('reserve')`, joining
+  the reserved `pacing` label from ADR-043. No fork labels are consumed by the
+  current adapter.
+- **Seed-invariance disclosure.** The rule-based path draws no randomness, so
+  its value - and therefore its result hash - is seed-invariant by construction
+  (the seed is not part of the basis). The different-seed hash evidence
+  therefore runs on the ML path, where the gate/adjustment draws consume the
+  stream. A dedicated test pins the rule-based seed-invariance so the property
+  is disclosed, not discovered.
+- **Kernel restatement, pinned both sides.** The adapter restates the kernel
+  rather than importing it, because the legacy entry point reads `process.env`
+  internally and its seed is not injectable. Characterization tests pin the
+  legacy engine and parity tests pin the adapter to the same hand-authored
+  fixtures (stage/sector multiplier table, both ownership branches, threshold
+  boundaries at ownership 0.1/0.05 and invested 1M, the confidence ladder, and
+  the seed-42 ML gate/adjustment interleave), so divergence of either copy fails
+  the suite.
+- **Rounding rules (boundary).** Allocations are whole-dollar decimal strings;
+  the rounding rule is legacy-identical `Math.round` on the non-negative float
+  amount (half-away-from-zero to a whole dollar). Confidence is emitted as a
+  decimal string rounded legacy-style to 2dp (`Math.round(c * 100) / 100`);
+  summary aggregation (avgConfidence, highConfidenceCount) runs on the unrounded
+  legacy confidence values first, exactly as `generateReserveSummary` does, and
+  only then renders. Hash admission normalizes decimal strings ("0.50" ->
+  "0.5"), so identities never rely on padded spellings.
+- **Input identity.** Portfolio array order is part of input identity: outputs
+  are positional and the ML draw stream interleaves with gate outcomes in
+  portfolio order. A parity test proves a reversed portfolio changes both the
+  input hash and the result hash.
+- **Hashes.** `inputHash` = `canonicalSha256` over
+  `{ domain: 'updog.reserve.input-hash', input: admitForHashing(rawInput) }`;
+  hash-inadmissible input hashes the deterministic sentinel
+  `{ inadmissibleInput: true }` and the result carries `INPUT_INVALID`.
+  `assumptionsHash` = `canonicalSha256` over the domain
+  `updog.reserve.assumptions-hash`, the methodology version, the algorithm
+  choice, and the frozen methodology constants (stage/sector multiplier tables
+  with defaults, ownership boost/penalty thresholds and factors, the confidence
+  ladder, ML gate/adjustment/confidence constants, the high-confidence
+  threshold, both rounding rules, and the RNG family and seed source).
+  `resultHash` uses the substrate `computeResultHash` unchanged.
+- **Result semantics.** `on` -> `available`; `shadow` -> `indicative` with
+  `SHADOW_ONLY`; configured `off` -> `unavailable` with `MODE_OFF`; kill switch
+  -> effective `off`, `unavailable` with `KILL_SWITCH_ACTIVE` (both codes when
+  both apply); schema-invalid input -> `failed` with `INPUT_INVALID` and a
+  diagnostic; kernel error -> `failed` with `ENGINE_ERROR`. Every non-available
+  path carries at least one registered reason code; there is no silent fallback.
+- **Versions.** `engineVersion: reserve-engine/1.0.0`,
+  `methodologyVersion: reserve-methodology/1.0.0`. Changing the kernel math, the
+  RNG family/seed source, the rounding rules, or the hash domains bumps the
+  methodology or engine version.
+
+### Deliberate boundary deviations (legacy engines unchanged)
+
+1. **Non-array input.** Legacy silently returns `[]` (pinned in the
+   characterization suite as a silent-fallback smell). The adapter returns
+   `failed` + `INPUT_INVALID` with a diagnostic: a disclosed-at-boundary fix.
+2. **Empty portfolio.** Legacy returns `[]` from the engine and zero aggregates
+   from `generateReserveSummary`. The adapter returns `available` with empty
+   allocations and zero totals - a faithful empty result, not fabrication -
+   because an empty portfolio is a valid input, not a failure.
+
+Schema-invalid company elements are NOT a deviation: the legacy engine throws,
+so `failed` + `INPUT_INVALID` is the faithful adaptation (same reasoning as
+ADR-043's invalid-input decision).
+
+### Parity evidence summary
+
+`tests/unit/reserve-substrate/` (36 tests, all green; pacing suite byte-green):
+
+- Characterization (13) pins the legacy engine before any adaptation:
+  multiplier-table allocations, both ownership branches, threshold boundaries,
+  the confidence ladder (via `ConfidenceLevel` imports, values not restated),
+  cold-start/enhanced rationale flip, the hand-derived seed-42 ML
+  gate/adjustment interleave (draws 0.2523/0.0881 fail, 0.5772 passes, 0.2226
+  prices round(9750000 * 0.8890217063948512) = 8667962), per-call reset
+  determinism and call-order independence, silent `[]` for empty and non-array
+  inputs, the invalid-element throw, and `generateReserveSummary` aggregates
+  with `generatedAt` characterized structurally only.
+- Parity (22, adapter suite) proves adapter-vs-legacy field-for-field equality
+  (allocation, confidence, rationale) for context seed 42 on the same fixtures,
+  rule-based AND ML, plus summary-aggregate parity against
+  `generateReserveSummary`, with expected values written as literals.
+- Determinism proves repeat-run byte-identical results with equal 64-hex result
+  hashes (both algorithms), and that different ML seeds, inputs, portfolio
+  order, as-of instants, and algorithm choices produce different hashes;
+  rule-based seed-invariance is pinned as a disclosed property.
+- Mode/kill-switch tests prove the suppression and disclosure invariants against
+  both the reserve and generic result schemas.
+- An ambient-state source guard (1) scans the adapter for `Math.random`, argless
+  `new Date()`, `Date.now`, and `process.env`.
+
+### Alternatives considered
+
+- **Adopt `DeterministicReserveEngine.ts` first:** rejected; its wall-clock
+  reads sit INSIDE calculation math (line 766) and its cache identity is
+  incomplete (line 737), so it cannot emit an honest basis without behavior
+  changes, which belong to their own tranche (Tranche 4).
+- **Fix the legacy silent `[]` fallback in place:** rejected; changing
+  `ReserveEngine.ts` behavior is out of scope and would ripple through five
+  server consumers; the adapter boundary discloses the rejection instead.
+- **Emit `unavailable` for an empty portfolio:** rejected; `unavailable` is
+  reserved for suppression/upstream-gap states, and an empty portfolio is a
+  computable input with a faithful empty result.
+- **Drive the ML stream from `ctx.rng.fork('reserve')` now:** rejected; changes
+  every ML value, violating behavior preservation. Reserved as the documented
+  follow-up migration.
+
+### Consequences
+
+- Reserve (rule/ML) can now run against an injected `CalculationContext` and
+  emit a hash-bound `CalcResult`; consumers keep their legacy path until a later
+  tranche wires them over.
+- Remaining for Tranche 4 (`DeterministicReserveEngine.ts`): remove `Date.now()`
+  from timing (78/123/140/486) and from calculation math (766, `ageMonths`);
+  replace `process.env['NODE_ENV']` (85) and `new Date()` (485) with injected
+  capabilities; replace the 5-field base64 cache key (737, `portfolioCount`
+  instead of portfolio contents) with complete canonical input identity - then
+  repeat this adoption pattern.
+
+**Implementation:** `shared/core/reserves/reserve-substrate-adapter.ts` plus
+`tests/unit/reserve-substrate/` (36 tests).

--- a/shared/core/reserves/reserve-substrate-adapter.ts
+++ b/shared/core/reserves/reserve-substrate-adapter.ts
@@ -1,0 +1,368 @@
+/**
+ * Reserve substrate adapter (Tranche 3, ADR-044).
+ *
+ * Runs the rule/ML reserve calculation against an injected CalculationContext
+ * and returns a CalcResult with a validated basis and result hash. The legacy
+ * ReserveEngine entry points are untouched: this adapter is an additive,
+ * context-receiving form of the same kernel.
+ *
+ * Behavior preservation contract:
+ * - The legacy engine resets its module-global LCG (shared/utils/prng.ts,
+ *   Numerical Recipes parameters) to a hardcoded seed of 42 on every call.
+ *   Exact-value parity is therefore only achievable by replaying the same
+ *   generator, so the ML stream here is a locally constructed PRNG seeded
+ *   from the context's immutable root seed. A context seeded with 42
+ *   reproduces the legacy engine's output exactly (proven by the parity tests
+ *   in tests/unit/reserve-substrate/). Migrating onto ctx.rng.fork('reserve')
+ *   would change every ML-path value and is deferred to a methodology-version
+ *   bump; the fork label 'reserve' is reserved for that migration in the
+ *   ADR-044 fork-label registry. The rule-based path draws no randomness at
+ *   all, so its value (and result hash) is seed-invariant by construction.
+ * - The kernel math is deliberately restated here rather than imported,
+ *   because the legacy entry point reads process.env internally and its seed
+ *   is not injectable. The characterization and parity suites pin both sides
+ *   to the same hand-authored fixtures, so any drift between the two copies
+ *   fails loudly.
+ *
+ * Boundary conventions:
+ * - Money at the adapter boundary is emitted as whole-dollar decimal strings.
+ *   Rounding rule (legacy-identical): Math.round applied to the non-negative
+ *   float amount, i.e. half-away-from-zero to a whole dollar.
+ * - Confidence is emitted as a decimal string rounded legacy-style to 2dp
+ *   (Math.round(c * 100) / 100). Hash admission normalizes decimal strings
+ *   ("0.50" -> "0.5"), so identities never rely on padded spellings. Summary
+ *   aggregation runs on the unrounded legacy confidence values first, exactly
+ *   as generateReserveSummary does, and only the rendered strings are rounded.
+ * - The ML-vs-rule-based choice is an explicit typed option; the adapter
+ *   never reads process.env.
+ * - Portfolio array order is part of input identity: outputs are positional
+ *   and the ML draw stream interleaves with gate outcomes in portfolio order.
+ * - Two deliberate deviations from the legacy boundary (ADR-044): non-array
+ *   input is failed + INPUT_INVALID instead of a silent [], and an empty
+ *   portfolio is available with empty allocations and zero totals (a faithful
+ *   empty result, not fabrication).
+ */
+
+import { z } from 'zod';
+import { canonicalSha256 } from '../../lib/canonical-hash';
+import { ReserveCompanyInputSchema, type ReserveCompanyInput } from '../../types';
+import { PRNG } from '../../utils/prng';
+import {
+  CALC_SUBSTRATE_CONTRACT_VERSION,
+  CalcBasisSchema,
+  admitForHashing,
+  computeResultHash,
+  createCalcResultSchema,
+  type CalcBasis,
+  type CalcMode,
+  type CalcReasonCode,
+  type CalculationContext,
+} from '../calc-substrate';
+
+export const RESERVE_CALCULATION_KEY = 'reserve';
+export const RESERVE_ENGINE_VERSION = 'reserve-engine/1.0.0';
+export const RESERVE_METHODOLOGY_VERSION = 'reserve-methodology/1.0.0';
+export const RESERVE_INPUT_HASH_DOMAIN = 'updog.reserve.input-hash';
+export const RESERVE_ASSUMPTIONS_HASH_DOMAIN = 'updog.reserve.assumptions-hash';
+
+export const ReserveAlgorithmSchema = z.enum(['rule-based', 'ml']);
+export type ReserveAlgorithm = z.infer<typeof ReserveAlgorithmSchema>;
+
+const WHOLE_DOLLAR_DECIMAL_RE = /^(0|[1-9]\d*)$/;
+// String(Math.round(c * 100) / 100) for c in [0, 1]: at most two decimals.
+const CONFIDENCE_DECIMAL_RE = /^(0|1|0\.\d{1,2})$/;
+
+export const ReserveAllocationEntrySchema = z
+  .object({
+    allocation: z.string().regex(WHOLE_DOLLAR_DECIMAL_RE, 'whole-dollar decimal string'),
+    confidence: z.string().regex(CONFIDENCE_DECIMAL_RE, '2dp confidence decimal string'),
+    rationale: z.string().min(1),
+  })
+  .strict();
+
+export const ReserveCalcValueSchema = z
+  .object({
+    allocations: z.array(ReserveAllocationEntrySchema),
+    totalAllocation: z.string().regex(WHOLE_DOLLAR_DECIMAL_RE, 'whole-dollar decimal string'),
+    avgConfidence: z.string().regex(CONFIDENCE_DECIMAL_RE, '2dp confidence decimal string'),
+    highConfidenceCount: z.number().int().min(0),
+    asOfUtc: z.string().min(1),
+  })
+  .strict();
+
+export type ReserveCalcValue = z.infer<typeof ReserveCalcValueSchema>;
+
+export const ReserveCalcResultSchema = createCalcResultSchema(ReserveCalcValueSchema);
+export type ReserveCalcResult = z.infer<typeof ReserveCalcResultSchema>;
+
+export interface ReserveSubstrateOptions {
+  configuredMode: CalcMode;
+  killSwitchActive: boolean;
+  /** Explicit replacement for the legacy ALG_RESERVE env read. Default: rule-based. */
+  algorithm?: ReserveAlgorithm;
+}
+
+/**
+ * Methodology constants, hashed into every basis. Restating them here (rather
+ * than referencing the legacy module or shared/types ConfidenceLevel) keeps
+ * the assumptions hash independent of incidental code layout; the parity
+ * suite guarantees they stay true.
+ */
+const RESERVE_ASSUMPTIONS = {
+  stageMultipliers: {
+    Seed: 1.5,
+    'Series A': 2.0,
+    'Series B': 2.5,
+    'Series C': 1.8,
+    Growth: 1.2,
+  },
+  stageMultiplierDefault: 2.0,
+  sectorMultipliers: {
+    SaaS: 1.1,
+    Fintech: 1.2,
+    Healthcare: 1.3,
+    Analytics: 1.0,
+    Infrastructure: 0.9,
+    Enterprise: 0.8,
+  },
+  sectorMultiplierDefault: 1.0,
+  ownership: {
+    boostThreshold: 0.1,
+    boostFactor: 1.2,
+    penaltyThreshold: 0.05,
+    penaltyFactor: 0.8,
+  },
+  confidenceLadder: {
+    base: 0.3,
+    stageAndSectorBonus: 0.2,
+    ownershipPositiveBonus: 0.15,
+    investedBonus: 0.1,
+    investedBonusThresholdDollars: 1_000_000,
+    cap: 0.7,
+    coldStartRationaleThreshold: 0.5,
+  },
+  ml: {
+    gateThreshold: 0.3,
+    adjustmentMin: 0.8,
+    adjustmentRange: 0.4,
+    confidenceBoost: 0.3,
+    confidenceCap: 0.95,
+  },
+  highConfidenceThreshold: 0.7,
+  rounding: {
+    allocation: 'half-away-from-zero-to-whole-dollar',
+    confidence: 'half-away-from-zero-to-2dp',
+  },
+  rng: {
+    family: 'lcg-numerical-recipes',
+    multiplier: 1664525,
+    increment: 1013904223,
+    modulus: 4294967296,
+    seedSource: 'calculation-context-root-seed',
+  },
+} as const;
+
+export function computeReserveInputHash(input: unknown): string {
+  let admitted: unknown;
+  try {
+    admitted = admitForHashing(input);
+  } catch {
+    // The raw input cannot be canonically hashed (undefined, NaN, class
+    // instances, ...). The basis still needs a deterministic input identity,
+    // and the accompanying result discloses the rejection via INPUT_INVALID.
+    admitted = { inadmissibleInput: true };
+  }
+  return canonicalSha256({ domain: RESERVE_INPUT_HASH_DOMAIN, input: admitted });
+}
+
+export function computeReserveAssumptionsHash(algorithm: ReserveAlgorithm): string {
+  return canonicalSha256({
+    domain: RESERVE_ASSUMPTIONS_HASH_DOMAIN,
+    methodologyVersion: RESERVE_METHODOLOGY_VERSION,
+    algorithm,
+    assumptions: admitForHashing(RESERVE_ASSUMPTIONS),
+  });
+}
+
+interface AllocationEntry {
+  allocation: number;
+  /** Unrounded legacy confidence; rounded only at the rendering boundary. */
+  confidence: number;
+  rationale: string;
+}
+
+/** Legacy-identical rule-based kernel; draws nothing from the ML stream. */
+function ruleBasedAllocation(company: ReserveCompanyInput): AllocationEntry {
+  const { stageMultipliers, sectorMultipliers, ownership, confidenceLadder } = RESERVE_ASSUMPTIONS;
+  const stageMultiplier =
+    stageMultipliers[company.stage as keyof typeof stageMultipliers] ||
+    RESERVE_ASSUMPTIONS.stageMultiplierDefault;
+  const sectorMultiplier =
+    sectorMultipliers[company.sector as keyof typeof sectorMultipliers] ||
+    RESERVE_ASSUMPTIONS.sectorMultiplierDefault;
+
+  let allocation = company.invested * stageMultiplier * sectorMultiplier;
+  if (company.ownership > ownership.boostThreshold) {
+    allocation *= ownership.boostFactor;
+  } else if (company.ownership < ownership.penaltyThreshold) {
+    allocation *= ownership.penaltyFactor;
+  }
+
+  let confidence: number = confidenceLadder.base;
+  if (company.stage && company.sector) confidence += confidenceLadder.stageAndSectorBonus;
+  if (company.ownership > 0) confidence += confidenceLadder.ownershipPositiveBonus;
+  if (company.invested > confidenceLadder.investedBonusThresholdDollars) {
+    confidence += confidenceLadder.investedBonus;
+  }
+  confidence = Math.min(confidence, confidenceLadder.cap);
+
+  let rationale = `${company.stage} stage, ${company.sector} sector`;
+  rationale +=
+    confidence <= confidenceLadder.coldStartRationaleThreshold
+      ? ' (cold-start mode)'
+      : ' (enhanced rules)';
+
+  return {
+    allocation: Math.round(allocation),
+    confidence: Math.round(confidence * 100) / 100,
+    rationale,
+  };
+}
+
+/** Legacy-identical ML overlay; draws one adjustment value from the stream. */
+function mlAllocation(company: ReserveCompanyInput, stream: PRNG): AllocationEntry {
+  const { ml } = RESERVE_ASSUMPTIONS;
+  const base = ruleBasedAllocation(company);
+  const mlAdjustment = ml.adjustmentMin + stream.next() * ml.adjustmentRange;
+  return {
+    allocation: Math.round(base.allocation * mlAdjustment),
+    confidence: Math.min(ml.confidenceCap, base.confidence + ml.confidenceBoost),
+    rationale: `ML-enhanced allocation (${base.rationale
+      .replace('(cold-start mode)', '')
+      .replace('(enhanced rules)', '')
+      .trim()})`,
+  };
+}
+
+function renderConfidence(confidence: number): string {
+  return String(Math.round(confidence * 100) / 100);
+}
+
+function computeReserveValue(
+  portfolio: ReserveCompanyInput[],
+  ctx: CalculationContext,
+  algorithm: ReserveAlgorithm
+): ReserveCalcValue {
+  const stream = new PRNG(ctx.rng.rootSeed);
+  const entries = portfolio.map((company) => {
+    if (algorithm === 'ml' && stream.next() > RESERVE_ASSUMPTIONS.ml.gateThreshold) {
+      return mlAllocation(company, stream);
+    }
+    return ruleBasedAllocation(company);
+  });
+
+  const totalAllocation = entries.reduce((sum, entry) => sum + entry.allocation, 0);
+  const avgConfidence =
+    entries.length > 0
+      ? entries.reduce((sum, entry) => sum + entry.confidence, 0) / entries.length
+      : 0;
+  const highConfidenceCount = entries.filter(
+    (entry) => entry.confidence >= RESERVE_ASSUMPTIONS.highConfidenceThreshold
+  ).length;
+
+  return {
+    allocations: entries.map((entry) => ({
+      allocation: String(entry.allocation),
+      confidence: renderConfidence(entry.confidence),
+      rationale: entry.rationale,
+    })),
+    totalAllocation: String(totalAllocation),
+    avgConfidence: renderConfidence(avgConfidence),
+    highConfidenceCount,
+    asOfUtc: ctx.clock.isoNow(),
+  };
+}
+
+export function runReserveWithSubstrate(
+  ctx: CalculationContext,
+  input: unknown,
+  options: ReserveSubstrateOptions
+): ReserveCalcResult {
+  if (ctx.contractVersion !== CALC_SUBSTRATE_CONTRACT_VERSION) {
+    throw new TypeError(
+      `reserve adapter requires contract ${CALC_SUBSTRATE_CONTRACT_VERSION}, received ${String(
+        ctx.contractVersion
+      )}`
+    );
+  }
+  if (ctx.calculationKey !== RESERVE_CALCULATION_KEY) {
+    throw new TypeError(
+      `reserve adapter requires calculationKey '${RESERVE_CALCULATION_KEY}', received '${ctx.calculationKey}'`
+    );
+  }
+  const algorithm = ReserveAlgorithmSchema.parse(options.algorithm ?? 'rule-based');
+  const effectiveMode: CalcMode = options.killSwitchActive ? 'off' : options.configuredMode;
+
+  const basis: CalcBasis = CalcBasisSchema.parse({
+    contractVersion: CALC_SUBSTRATE_CONTRACT_VERSION,
+    calculationKey: RESERVE_CALCULATION_KEY,
+    configuredMode: options.configuredMode,
+    effectiveMode,
+    killSwitchActive: options.killSwitchActive,
+    engineVersion: RESERVE_ENGINE_VERSION,
+    methodologyVersion: RESERVE_METHODOLOGY_VERSION,
+    inputHash: computeReserveInputHash(input),
+    assumptionsHash: computeReserveAssumptionsHash(algorithm),
+  });
+
+  if (effectiveMode === 'off') {
+    const reasonCodes: CalcReasonCode[] = [];
+    if (options.killSwitchActive) {
+      reasonCodes.push('KILL_SWITCH_ACTIVE');
+    }
+    if (options.configuredMode === 'off') {
+      reasonCodes.push('MODE_OFF');
+    }
+    return ReserveCalcResultSchema.parse({ state: 'unavailable', basis, reasonCodes });
+  }
+
+  // Boundary deviation (ADR-044): the legacy engine silently returns [] for
+  // non-array input; here the rejection is disclosed instead of swallowed.
+  const parsed = z.array(ReserveCompanyInputSchema).safeParse(input);
+  if (!parsed.success) {
+    return ReserveCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['INPUT_INVALID'],
+      diagnostic: `reserve input rejected: ${parsed.error.message}`,
+    });
+  }
+
+  try {
+    const value = computeReserveValue(parsed.data, ctx, algorithm);
+    const resultHash = computeResultHash(basis, value);
+    if (effectiveMode === 'shadow') {
+      return ReserveCalcResultSchema.parse({
+        state: 'indicative',
+        basis,
+        value,
+        resultHash,
+        reasonCodes: ['SHADOW_ONLY'],
+      });
+    }
+    return ReserveCalcResultSchema.parse({
+      state: 'available',
+      basis,
+      value,
+      resultHash,
+      reasonCodes: [],
+    });
+  } catch (error) {
+    return ReserveCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['ENGINE_ERROR'],
+      diagnostic: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/tests/unit/reserve-substrate/ambient-guard.test.ts
+++ b/tests/unit/reserve-substrate/ambient-guard.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Ambient-state source guard for the reserve substrate adapter (ADR-044).
+ *
+ * Same pattern as tests/unit/pacing-substrate/ambient-guard.test.ts: the
+ * adapter must receive every ambient capability through its
+ * CalculationContext, never via Math.random, argless new Date(), Date.now,
+ * or process.env. The legacy ReserveEngine.ts, DeterministicReserveEngine.ts,
+ * and ConstrainedReserveEngine.ts are intentionally NOT scanned: their env
+ * and clock reads are characterized legacy behavior, out of scope until
+ * their own adoption tranches.
+ */
+
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+const GUARDED_FILES = ['reserve-substrate-adapter.ts'];
+
+describe('reserve adapter ambient-state source guard', () => {
+  it('the adapter never reaches for Math.random, argless new Date(), Date.now, or process.env', async () => {
+    // The shared node-setup mocks fs.readFileSync; this guard needs the real one.
+    const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const reservesDir = path.join(process.cwd(), 'shared', 'core', 'reserves');
+    const ambientPatterns: [string, RegExp][] = [
+      ['Math.random', /Math\.random/],
+      ['argless new Date()', /new Date\(\s*\)/],
+      ['process.env', /process\.env/],
+      ['Date.now', /Date\.now/],
+    ];
+    const violations: string[] = [];
+    for (const file of GUARDED_FILES) {
+      const raw = fs.readFileSync(path.join(reservesDir, file), 'utf8');
+      // Guard executable code only: doc comments may name the forbidden APIs.
+      const text = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+      for (const [label, pattern] of ambientPatterns) {
+        if (pattern.test(text)) {
+          violations.push(`${file} uses ${label}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/reserve-substrate/reserve-engine-characterization.test.ts
+++ b/tests/unit/reserve-substrate/reserve-engine-characterization.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Characterization tests for the legacy ReserveEngine (Tranche 3, ADR-044).
+ *
+ * These pin the engine's CURRENT behavior before substrate adoption; they are
+ * evidence, not aspiration. The legacy engine resets its module-global LCG
+ * (shared/utils/prng.ts, Numerical Recipes parameters) to the hardcoded seed
+ * 42 on every call, so per-call output is fully deterministic given a fixed
+ * environment. The remaining ambient reads are:
+ *
+ * - process.env['ALG_RESERVE'] / process.env['NODE_ENV'] select the ML vs
+ *   rule-based path (controlled explicitly below);
+ * - generateReserveSummary stamps `generatedAt: new Date()` (characterized
+ *   structurally only; the wall-clock value is not blessed as truth).
+ *
+ * The rule-based path draws NO randomness. The ML path draws, per company in
+ * portfolio order, one gate value (`next() > 0.3` selects ML) and, only when
+ * the gate passes, one adjustment value (`0.8 + next() * 0.4`), so the draw
+ * count interleaves with gate outcomes. Hand-derived LCG(42) stream
+ * (state' = (1664525 * state + 1013904223) mod 2^32 starting at state 42):
+ *
+ *   draw1 = 0.2523451747838408   gate fails  -> company 1 rule-based
+ *   draw2 = 0.08812504541128874  gate fails  -> company 2 rule-based
+ *   draw3 = 0.5772811982315034   gate passes -> company 3 ML
+ *   draw4 = 0.22255426598712802  adjustment  -> 0.8 + 0.4 * draw4
+ *                                            = 0.8890217063948512
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ReserveEngine, generateReserveSummary } from '../../../shared/core/reserves/ReserveEngine';
+import { ConfidenceLevel, type ReserveCompanyInput } from '../../../shared/types';
+
+// Fixtures chosen to exercise the stage/sector multiplier tables, both
+// ownership branches, the between-thresholds band, and the confidence ladder.
+const SERIES_A_FINTECH_BOOST: ReserveCompanyInput = {
+  id: 1,
+  invested: 2_000_000,
+  ownership: 0.15,
+  stage: 'Series A',
+  sector: 'Fintech',
+};
+const SEED_SAAS_PENALTY: ReserveCompanyInput = {
+  id: 2,
+  invested: 500_000,
+  ownership: 0.02,
+  stage: 'Seed',
+  sector: 'SaaS',
+};
+const UNKNOWN_STAGE_SECTOR_COLD: ReserveCompanyInput = {
+  id: 3,
+  invested: 1_000_000,
+  ownership: 0,
+  stage: 'Series D',
+  sector: 'Robotics',
+};
+const SERIES_B_HEALTHCARE_MID: ReserveCompanyInput = {
+  id: 4,
+  invested: 3_000_000,
+  ownership: 0.08,
+  stage: 'Series B',
+  sector: 'Healthcare',
+};
+const GROWTH_ENTERPRISE_EDGE: ReserveCompanyInput = {
+  id: 5,
+  invested: 1_500_000,
+  ownership: 0.1,
+  stage: 'Growth',
+  sector: 'Enterprise',
+};
+const SERIES_C_INFRA_EDGE: ReserveCompanyInput = {
+  id: 6,
+  invested: 800_000,
+  ownership: 0.05,
+  stage: 'Series C',
+  sector: 'Infrastructure',
+};
+
+const RULE_BASED_PORTFOLIO = [
+  SERIES_A_FINTECH_BOOST,
+  SEED_SAAS_PENALTY,
+  UNKNOWN_STAGE_SECTOR_COLD,
+  SERIES_B_HEALTHCARE_MID,
+];
+const ML_PORTFOLIO = [SERIES_A_FINTECH_BOOST, SEED_SAAS_PENALTY, SERIES_B_HEALTHCARE_MID];
+
+function withSavedAlgReserve(): void {
+  const saved = process.env['ALG_RESERVE'];
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env['ALG_RESERVE'];
+    } else {
+      process.env['ALG_RESERVE'] = saved;
+    }
+  });
+}
+
+describe('legacy ReserveEngine characterization (rule-based path)', () => {
+  withSavedAlgReserve();
+
+  beforeEach(() => {
+    // NODE_ENV is 'test' under vitest; ALG_RESERVE unset selects rule-based.
+    delete process.env['ALG_RESERVE'];
+  });
+
+  it('pins exact allocations for the stage/sector multiplier table', () => {
+    const result = ReserveEngine(RULE_BASED_PORTFOLIO);
+    // 2M * 2.0 (Series A) * 1.2 (Fintech) * 1.2 (ownership 0.15 > 0.1)
+    // 500k * 1.5 (Seed) * 1.1 (SaaS) * 0.8 (ownership 0.02 < 0.05)
+    // 1M * 2.0 (unknown-stage default) * 1.0 (unknown-sector default) * 0.8 (ownership 0 < 0.05)
+    // 3M * 2.5 (Series B) * 1.3 (Healthcare), ownership 0.08 in the no-adjustment band
+    expect(result.map((o) => o.allocation)).toEqual([5_760_000, 660_000, 1_600_000, 9_750_000]);
+  });
+
+  it('pins the confidence ladder: base COLD_START, +0.2 stage&sector, +0.15 ownership>0, +0.1 invested>1M, capped at MEDIUM', () => {
+    const result = ReserveEngine(RULE_BASED_PORTFOLIO);
+    // Ladder sums are 2dp-rounded by the engine (Math.round(c * 100) / 100).
+    expect(result[0]!.confidence).toBe(ConfidenceLevel.MEDIUM); // 0.3+0.2+0.15+0.1 capped
+    expect(result[1]!.confidence).toBe(0.65); // 0.3+0.2+0.15; invested 500k earns no bonus
+    expect(result[2]!.confidence).toBe(ConfidenceLevel.LOW); // 0.3+0.2; ownership 0, invested exactly 1M
+    expect(result[3]!.confidence).toBe(ConfidenceLevel.MEDIUM);
+  });
+
+  it('pins rationale strings, including the cold-start/enhanced-rules suffix flip at LOW', () => {
+    const result = ReserveEngine(RULE_BASED_PORTFOLIO);
+    expect(result.map((o) => o.rationale)).toEqual([
+      'Series A stage, Fintech sector (enhanced rules)',
+      'Seed stage, SaaS sector (enhanced rules)',
+      'Series D stage, Robotics sector (cold-start mode)',
+      'Series B stage, Healthcare sector (enhanced rules)',
+    ]);
+  });
+
+  it('pins threshold boundaries: ownership exactly 0.1 or 0.05 takes no adjustment; invested exactly 1M earns no confidence bonus', () => {
+    const result = ReserveEngine([GROWTH_ENTERPRISE_EDGE, SERIES_C_INFRA_EDGE]);
+    // 1.5M * 1.2 (Growth) * 0.8 (Enterprise), ownership 0.1 is NOT > 0.1
+    // 800k * 1.8 (Series C) * 0.9 (Infrastructure), ownership 0.05 is NOT < 0.05
+    expect(result.map((o) => o.allocation)).toEqual([1_440_000, 1_296_000]);
+    expect(result[0]!.confidence).toBe(ConfidenceLevel.MEDIUM);
+    expect(result[1]!.confidence).toBe(0.65);
+  });
+
+  it('is deterministic across repeated calls (module PRNG resets to 42 per call)', () => {
+    const first = ReserveEngine(RULE_BASED_PORTFOLIO);
+    const second = ReserveEngine(RULE_BASED_PORTFOLIO);
+    expect(second).toEqual(first);
+  });
+
+  it('silently returns [] for an empty portfolio', () => {
+    expect(ReserveEngine([])).toEqual([]);
+  });
+
+  it('silently returns [] for non-array input (pinned legacy silent-fallback smell)', () => {
+    // The engine swallows a type error instead of surfacing it; the substrate
+    // adapter deliberately deviates and reports failed + INPUT_INVALID.
+    expect(ReserveEngine(null as unknown as unknown[])).toEqual([]);
+    expect(ReserveEngine({} as unknown as unknown[])).toEqual([]);
+  });
+
+  it('throws with the offending index for an invalid company element', () => {
+    expect(() => ReserveEngine([{ id: 1 }])).toThrow(/Invalid company data at index 0/);
+  });
+});
+
+describe('legacy ReserveEngine characterization (ML path via ALG_RESERVE)', () => {
+  withSavedAlgReserve();
+
+  it('pins the seed-42 gate/adjustment interleave: rule, rule, then ML on the third company', () => {
+    process.env['ALG_RESERVE'] = 'true';
+    const result = ReserveEngine(ML_PORTFOLIO);
+    // Gates for companies 1 and 2 fail (draws 0.2523..., 0.0881... are <= 0.3),
+    // so they emit rule-based outputs even in ML mode. The company-3 gate
+    // passes (0.5772... > 0.3) and draw4 prices the adjustment:
+    // round(9,750,000 * 0.8890217063948512) = 8,667,962.
+    expect(result.map((o) => o.allocation)).toEqual([5_760_000, 660_000, 8_667_962]);
+    expect(result[2]!.confidence).toBe(ConfidenceLevel.ML_ENHANCED); // min(0.95, 0.7 + 0.3)
+    expect(result[2]!.rationale).toBe('ML-enhanced allocation (Series B stage, Healthcare sector)');
+    // Gate-failed companies keep their rule-based confidence and rationale.
+    expect(result[0]!.confidence).toBe(ConfidenceLevel.MEDIUM);
+    expect(result[0]!.rationale).toBe('Series A stage, Fintech sector (enhanced rules)');
+  });
+
+  it('is deterministic across repeated ML calls (per-call reset to seed 42)', () => {
+    process.env['ALG_RESERVE'] = 'true';
+    const first = ReserveEngine(ML_PORTFOLIO);
+    const second = ReserveEngine(ML_PORTFOLIO);
+    expect(second).toEqual(first);
+  });
+
+  it('is call-order independent because each call resets the shared generator', () => {
+    process.env['ALG_RESERVE'] = 'true';
+    ReserveEngine(RULE_BASED_PORTFOLIO);
+    const afterOther = ReserveEngine(ML_PORTFOLIO);
+    expect(afterOther.map((o) => o.allocation)).toEqual([5_760_000, 660_000, 8_667_962]);
+  });
+});
+
+describe('legacy generateReserveSummary characterization', () => {
+  withSavedAlgReserve();
+
+  beforeEach(() => {
+    delete process.env['ALG_RESERVE'];
+  });
+
+  it('pins summary aggregates; generatedAt is an ambient new Date() read (structure only)', () => {
+    const summary = generateReserveSummary(7, RULE_BASED_PORTFOLIO);
+    expect(summary.fundId).toBe(7);
+    expect(summary.totalAllocation).toBe(17_770_000);
+    expect(summary.avgConfidence).toBe(0.64); // round(((0.7+0.65+0.5+0.7)/4)*100)/100
+    expect(summary.highConfidenceCount).toBe(2); // confidences >= MEDIUM
+    expect(summary.allocations.map((o) => o.allocation)).toEqual([
+      5_760_000, 660_000, 1_600_000, 9_750_000,
+    ]);
+    // Nondeterministic under fixed inputs: value intentionally not pinned.
+    expect(summary.generatedAt).toBeInstanceOf(Date);
+  });
+
+  it('pins zero aggregates for an empty portfolio', () => {
+    const summary = generateReserveSummary(7, []);
+    expect(summary.totalAllocation).toBe(0);
+    expect(summary.avgConfidence).toBe(0);
+    expect(summary.highConfidenceCount).toBe(0);
+    expect(summary.allocations).toEqual([]);
+  });
+});

--- a/tests/unit/reserve-substrate/reserve-substrate-adapter.test.ts
+++ b/tests/unit/reserve-substrate/reserve-substrate-adapter.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Reserve substrate adapter tests (Tranche 3, ADR-044).
+ *
+ * Proves, per the tranche exit criteria:
+ * (a) same context + inputs -> byte-identical result and identical resultHash
+ *     across repeated runs;
+ * (b) different seeds (ML path) / inputs / as-of instants / algorithm choices
+ *     -> different hashes;
+ * (c) adapter output matches the legacy ReserveEngine exactly for the legacy
+ *     effective seed (42) on hand-authored fixtures, rule-based AND ML;
+ * (d) basis cross-field behavior: off / kill-switched runs yield unavailable
+ *     with the registered disclosure codes, shadow yields indicative, and
+ *     invalid input yields failed with INPUT_INVALID - never a silent value.
+ *
+ * Seed caveat, disclosed deliberately: the rule-based kernel draws no
+ * randomness, so its value and result hash are seed-invariant; the
+ * different-seed evidence therefore runs on the ML path, where the LCG gate
+ * and adjustment draws consume the stream.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  GenericCalcResultSchema,
+  createCalculationContext,
+} from '../../../shared/core/calc-substrate';
+import { ReserveEngine, generateReserveSummary } from '../../../shared/core/reserves/ReserveEngine';
+import {
+  RESERVE_CALCULATION_KEY,
+  ReserveCalcResultSchema,
+  runReserveWithSubstrate,
+  type ReserveSubstrateOptions,
+} from '../../../shared/core/reserves/reserve-substrate-adapter';
+import type { ReserveCompanyInput } from '../../../shared/types';
+
+const LEGACY_SEED = 42;
+const AS_OF = '2026-07-17T00:00:00Z';
+
+// Same hand-authored fixtures pinned against the legacy engine in
+// reserve-engine-characterization.test.ts.
+const SERIES_A_FINTECH_BOOST: ReserveCompanyInput = {
+  id: 1,
+  invested: 2_000_000,
+  ownership: 0.15,
+  stage: 'Series A',
+  sector: 'Fintech',
+};
+const SEED_SAAS_PENALTY: ReserveCompanyInput = {
+  id: 2,
+  invested: 500_000,
+  ownership: 0.02,
+  stage: 'Seed',
+  sector: 'SaaS',
+};
+const UNKNOWN_STAGE_SECTOR_COLD: ReserveCompanyInput = {
+  id: 3,
+  invested: 1_000_000,
+  ownership: 0,
+  stage: 'Series D',
+  sector: 'Robotics',
+};
+const SERIES_B_HEALTHCARE_MID: ReserveCompanyInput = {
+  id: 4,
+  invested: 3_000_000,
+  ownership: 0.08,
+  stage: 'Series B',
+  sector: 'Healthcare',
+};
+
+const RULE_BASED_PORTFOLIO = [
+  SERIES_A_FINTECH_BOOST,
+  SEED_SAAS_PENALTY,
+  UNKNOWN_STAGE_SECTOR_COLD,
+  SERIES_B_HEALTHCARE_MID,
+];
+const ML_PORTFOLIO = [SERIES_A_FINTECH_BOOST, SEED_SAAS_PENALTY, SERIES_B_HEALTHCARE_MID];
+
+// Hand-authored from the multiplier tables and the LCG(42) recurrence;
+// identical constants are pinned against the legacy engine in
+// reserve-engine-characterization.test.ts.
+const EXPECTED_RULE_BASED_ALLOCATIONS = ['5760000', '660000', '1600000', '9750000'];
+const EXPECTED_RULE_BASED_CONFIDENCES = ['0.7', '0.65', '0.5', '0.7'];
+// Seed-42 ML stream: gates fail for companies 1-2, pass for company 3, whose
+// adjustment draw prices round(9750000 * 0.8890217063948512) = 8667962.
+const EXPECTED_ML_SEED42_ALLOCATIONS = ['5760000', '660000', '8667962'];
+// Seed-43 ML stream: every gate fails, so all three stay rule-based.
+const EXPECTED_ML_SEED43_ALLOCATIONS = ['5760000', '660000', '9750000'];
+
+const ON: ReserveSubstrateOptions = { configuredMode: 'on', killSwitchActive: false };
+
+function reserveContext(seed: number, asOf: string = AS_OF) {
+  return createCalculationContext({ calculationKey: RESERVE_CALCULATION_KEY, seed, asOf });
+}
+
+function allocationAmounts(result: ReturnType<typeof runReserveWithSubstrate>): string[] {
+  if (result.state !== 'available' && result.state !== 'indicative') {
+    throw new Error(`expected a value-bearing result, got ${result.state}`);
+  }
+  return result.value.allocations.map((entry) => entry.allocation);
+}
+
+describe('runReserveWithSubstrate determinism and hash integrity', () => {
+  it('(a) repeated runs with the same context and input are byte-identical with equal hashes', () => {
+    const first = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, ON);
+    const second = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, ON);
+
+    expect(first.state).toBe('available');
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    if (first.state === 'available' && second.state === 'available') {
+      expect(second.resultHash).toBe(first.resultHash);
+      expect(first.resultHash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('(a) repeated ML runs are also byte-identical with equal hashes', () => {
+    const first = runReserveWithSubstrate(reserveContext(LEGACY_SEED), ML_PORTFOLIO, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    const second = runReserveWithSubstrate(reserveContext(LEGACY_SEED), ML_PORTFOLIO, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    expect(first.state).toBe('available');
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+  });
+
+  it('(b) a different seed changes the ML-path value and result hash', () => {
+    const seed42 = runReserveWithSubstrate(reserveContext(42), ML_PORTFOLIO, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    const seed43 = runReserveWithSubstrate(reserveContext(43), ML_PORTFOLIO, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    if (seed42.state !== 'available' || seed43.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(allocationAmounts(seed42)).toEqual(EXPECTED_ML_SEED42_ALLOCATIONS);
+    expect(allocationAmounts(seed43)).toEqual(EXPECTED_ML_SEED43_ALLOCATIONS);
+    expect(seed43.resultHash).not.toBe(seed42.resultHash);
+  });
+
+  it('(b, disclosed caveat) the rule-based value is seed-invariant, so its hash is too', () => {
+    // The rule-based kernel draws nothing from the stream; the seed is not
+    // part of the basis, so equal inputs yield equal hashes across seeds.
+    const seed42 = runReserveWithSubstrate(reserveContext(42), RULE_BASED_PORTFOLIO, ON);
+    const seed999 = runReserveWithSubstrate(reserveContext(999), RULE_BASED_PORTFOLIO, ON);
+    if (seed42.state !== 'available' || seed999.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(JSON.stringify(seed999.value)).toBe(JSON.stringify(seed42.value));
+    expect(seed999.resultHash).toBe(seed42.resultHash);
+  });
+
+  it('(b) a different input changes the input hash and the result hash', () => {
+    const full = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, ON);
+    const partial = runReserveWithSubstrate(reserveContext(LEGACY_SEED), ML_PORTFOLIO, ON);
+    if (full.state !== 'available' || partial.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(partial.basis.inputHash).not.toBe(full.basis.inputHash);
+    expect(partial.resultHash).not.toBe(full.resultHash);
+  });
+
+  it('(b) portfolio order is part of input identity', () => {
+    const forward = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, ON);
+    const reversed = runReserveWithSubstrate(
+      reserveContext(LEGACY_SEED),
+      [...RULE_BASED_PORTFOLIO].reverse(),
+      ON
+    );
+    if (forward.state !== 'available' || reversed.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(reversed.basis.inputHash).not.toBe(forward.basis.inputHash);
+    expect(reversed.resultHash).not.toBe(forward.resultHash);
+  });
+
+  it('(b) a different as-of instant changes the result hash (asOfUtc is part of the value)', () => {
+    const base = runReserveWithSubstrate(
+      reserveContext(LEGACY_SEED, AS_OF),
+      RULE_BASED_PORTFOLIO,
+      ON
+    );
+    const later = runReserveWithSubstrate(
+      reserveContext(LEGACY_SEED, '2026-07-18T00:00:00Z'),
+      RULE_BASED_PORTFOLIO,
+      ON
+    );
+    if (base.state !== 'available' || later.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(later.resultHash).not.toBe(base.resultHash);
+    expect(later.basis.inputHash).toBe(base.basis.inputHash);
+  });
+
+  it('(b) rule-based and ml algorithms produce different assumptions hashes and result hashes', () => {
+    const ruleBased = runReserveWithSubstrate(reserveContext(LEGACY_SEED), ML_PORTFOLIO, ON);
+    const ml = runReserveWithSubstrate(reserveContext(LEGACY_SEED), ML_PORTFOLIO, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    if (ruleBased.state !== 'available' || ml.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(ml.basis.assumptionsHash).not.toBe(ruleBased.basis.assumptionsHash);
+    expect(ml.resultHash).not.toBe(ruleBased.resultHash);
+  });
+
+  it('every emitted result revalidates against the reserve and generic result schemas', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, ON);
+    expect(() => ReserveCalcResultSchema.parse(result)).not.toThrow();
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+});
+
+describe('runReserveWithSubstrate parity with the legacy engine (effective seed 42)', () => {
+  const savedAlgReserve = process.env['ALG_RESERVE'];
+
+  afterEach(() => {
+    if (savedAlgReserve === undefined) {
+      delete process.env['ALG_RESERVE'];
+    } else {
+      process.env['ALG_RESERVE'] = savedAlgReserve;
+    }
+  });
+
+  it('(c) rule-based parity: allocation, confidence, and rationale field-for-field', () => {
+    delete process.env['ALG_RESERVE'];
+    const legacy = ReserveEngine(RULE_BASED_PORTFOLIO);
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, ON);
+    if (result.state !== 'available') {
+      throw new Error(`expected available, got ${result.state}`);
+    }
+
+    // Both sides pinned to the same hand-authored constants...
+    expect(allocationAmounts(result)).toEqual(EXPECTED_RULE_BASED_ALLOCATIONS);
+    expect(legacy.map((o) => String(o.allocation))).toEqual(EXPECTED_RULE_BASED_ALLOCATIONS);
+    expect(result.value.allocations.map((e) => e.confidence)).toEqual(
+      EXPECTED_RULE_BASED_CONFIDENCES
+    );
+    // ...and field-for-field agreement between adapter and legacy engine. The
+    // boundary confidence rounding (2dp) is legacy-identical for rule-based
+    // outputs, which the engine already rounds.
+    result.value.allocations.forEach((entry, index) => {
+      expect(Number(entry.allocation)).toBe(legacy[index]!.allocation);
+      expect(Number(entry.confidence)).toBe(Math.round(legacy[index]!.confidence * 100) / 100);
+      expect(Number(entry.confidence)).toBe(legacy[index]!.confidence);
+      expect(entry.rationale).toBe(legacy[index]!.rationale);
+    });
+    expect(result.value.asOfUtc).toBe('2026-07-17T00:00:00.000Z');
+  });
+
+  it('(c) ML-path parity: gate interleave and adjustment via the explicit ml algorithm option', () => {
+    process.env['ALG_RESERVE'] = 'true';
+    const legacy = ReserveEngine(ML_PORTFOLIO);
+    delete process.env['ALG_RESERVE'];
+
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), ML_PORTFOLIO, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    if (result.state !== 'available') {
+      throw new Error(`expected available, got ${result.state}`);
+    }
+    expect(allocationAmounts(result)).toEqual(EXPECTED_ML_SEED42_ALLOCATIONS);
+    expect(legacy.map((o) => String(o.allocation))).toEqual(EXPECTED_ML_SEED42_ALLOCATIONS);
+    result.value.allocations.forEach((entry, index) => {
+      expect(Number(entry.allocation)).toBe(legacy[index]!.allocation);
+      expect(Number(entry.confidence)).toBe(Math.round(legacy[index]!.confidence * 100) / 100);
+      expect(entry.rationale).toBe(legacy[index]!.rationale);
+    });
+    expect(result.value.allocations[2]!.confidence).toBe('0.95');
+    expect(result.value.allocations[2]!.rationale).toBe(
+      'ML-enhanced allocation (Series B stage, Healthcare sector)'
+    );
+  });
+
+  it('(c) summary-aggregate parity with generateReserveSummary (rule-based)', () => {
+    delete process.env['ALG_RESERVE'];
+    const legacySummary = generateReserveSummary(7, RULE_BASED_PORTFOLIO);
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, ON);
+    if (result.state !== 'available') {
+      throw new Error(`expected available, got ${result.state}`);
+    }
+    expect(result.value.totalAllocation).toBe('17770000');
+    expect(Number(result.value.totalAllocation)).toBe(legacySummary.totalAllocation);
+    expect(result.value.avgConfidence).toBe('0.64');
+    expect(Number(result.value.avgConfidence)).toBe(legacySummary.avgConfidence);
+    expect(result.value.highConfidenceCount).toBe(2);
+    expect(result.value.highConfidenceCount).toBe(legacySummary.highConfidenceCount);
+  });
+
+  it('(c) ML summary aggregates restate the legacy math on unrounded confidences', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), ML_PORTFOLIO, {
+      ...ON,
+      algorithm: 'ml',
+    });
+    if (result.state !== 'available') {
+      throw new Error(`expected available, got ${result.state}`);
+    }
+    expect(result.value.totalAllocation).toBe('15087962');
+    expect(result.value.avgConfidence).toBe('0.77'); // round(((0.7+0.65+0.95)/3)*100)/100
+    expect(result.value.highConfidenceCount).toBe(2);
+  });
+});
+
+describe('runReserveWithSubstrate mode and kill-switch invariants', () => {
+  it('(d) configuredMode off yields unavailable with MODE_OFF and no value', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, {
+      configuredMode: 'off',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['MODE_OFF']);
+    expect('value' in result).toBe(false);
+    expect('resultHash' in result).toBe(false);
+    expect(result.basis.effectiveMode).toBe('off');
+  });
+
+  it('(d) an active kill switch forces effectiveMode off and discloses KILL_SWITCH_ACTIVE', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, {
+      configuredMode: 'on',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE']);
+    expect(result.basis.effectiveMode).toBe('off');
+    expect(result.basis.configuredMode).toBe('on');
+  });
+
+  it('(d) kill switch plus configured off disclose both suppression codes', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, {
+      configuredMode: 'off',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE', 'MODE_OFF']);
+  });
+
+  it('(d) shadow mode yields an indicative value disclosed via SHADOW_ONLY', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), RULE_BASED_PORTFOLIO, {
+      configuredMode: 'shadow',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('indicative');
+    expect(result.reasonCodes).toEqual(['SHADOW_ONLY']);
+    expect(allocationAmounts(result)).toEqual(EXPECTED_RULE_BASED_ALLOCATIONS);
+  });
+
+  it('(d) a schema-invalid company element yields failed with INPUT_INVALID and a diagnostic', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), [{ id: 1 }], ON);
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['INPUT_INVALID']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('reserve input rejected');
+    }
+    expect(result.basis.inputHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('(d, deviation) non-array input yields failed with INPUT_INVALID instead of the legacy silent []', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), null, ON);
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['INPUT_INVALID']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('reserve input rejected');
+    }
+  });
+
+  it('(d, deviation) an empty portfolio yields available with empty allocations and zero totals', () => {
+    const result = runReserveWithSubstrate(reserveContext(LEGACY_SEED), [], ON);
+    expect(result.state).toBe('available');
+    if (result.state !== 'available') {
+      throw new Error('expected available');
+    }
+    expect(result.value.allocations).toEqual([]);
+    expect(result.value.totalAllocation).toBe('0');
+    expect(result.value.avgConfidence).toBe('0');
+    expect(result.value.highConfidenceCount).toBe(0);
+    expect(result.reasonCodes).toEqual([]);
+    expect(result.resultHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('(d) hash-inadmissible input still gets a deterministic basis and INPUT_INVALID', () => {
+    const inadmissible = [
+      { id: 1, invested: Number.NaN, ownership: 0.1, stage: 'Seed', sector: 'SaaS' },
+    ];
+    const first = runReserveWithSubstrate(reserveContext(LEGACY_SEED), inadmissible, ON);
+    const second = runReserveWithSubstrate(reserveContext(LEGACY_SEED), inadmissible, ON);
+    expect(first.state).toBe('failed');
+    expect(first.reasonCodes).toEqual(['INPUT_INVALID']);
+    expect(first.basis.inputHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(second.basis.inputHash).toBe(first.basis.inputHash);
+  });
+
+  it('rejects a context built for a different calculation key', () => {
+    const ctx = createCalculationContext({ calculationKey: 'pacing', seed: 1, asOf: AS_OF });
+    expect(() => runReserveWithSubstrate(ctx, RULE_BASED_PORTFOLIO, ON)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
Adopt shared/core/reserves/ReserveEngine.ts onto the ADR-042 calculation
substrate via an additive context-receiving adapter (calculationKey
'reserve'), mirroring the ADR-043 pacing pattern. Legacy reserve engines
and all consumers unchanged; DeterministicReserveEngine deferred to
Tranche 4 with a verified defect list.

- shared/core/reserves/reserve-substrate-adapter.ts: typed
  rule-based/ml algorithm option replaces the ALG_RESERVE env read;
  injected clock replaces new Date(); ML stream replays the legacy
  LCG seeded from the context root seed (seed 42 = exact legacy
  parity; fork label 'reserve' reserved, not consumed); whole-dollar
  allocation strings and 2dp confidence strings with legacy-identical
  rounding; domain-separated input/assumptions hashes; full
  mode/kill-switch disclosure semantics with no silent fallback.
- Disclosed boundary deviations: non-array input -> failed +
  INPUT_INVALID (legacy silently returns []); empty portfolio ->
  available with zero totals. Rule-based seed-invariance pinned as a
  disclosed property (that path draws no randomness).
- tests/unit/reserve-substrate/ (36 tests): characterization pins
  legacy behavior first (multiplier tables, ownership branches,
  confidence ladder, hand-derived seed-42 ML gate/adjustment stream);
  parity proves adapter-vs-legacy field-for-field equality rule-based
  AND ML plus summary-aggregate parity; determinism proves repeat-run
  byte-identical results and hash sensitivity to ML seed, input,
  portfolio order, as-of, and algorithm; ambient guard scans the
  adapter for Math.random / new Date() / Date.now / process.env.
- ADR-044 in DECISIONS.md (corrected audit superseding the ADR-043
  defer rationale, disposition table, deviations, Tranche 4 work
  list) and CHANGELOG entry.

Full suite: 8816 passed / 90 skipped / 0 failed (baseline 8780 + 36 new).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WoZvUdy2QNgwU1rwVU9KXi