### PR TITLE
ADR-045: Tranche 4 substrate adoption of DeterministicReserveEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,36 @@ and this project adheres to
 
 ### Added (2026-07-17)
 
+- **Tranche 4 DeterministicReserveEngine substrate adoption (ADR-045).** The
+  924-line Decimal.js reserve kernel now runs against an injected
+  `CalculationContext` via a WRAPPING adapter
+  `shared/core/reserves/deterministic-reserve-substrate-adapter.ts`
+  (calculationKey `reserve-deterministic`), enabled by two disclosed edits to
+  the legacy class: a behavior-preserving capability seam
+  (`{ now?, debugMode? }` optional constructor parameter routing all five
+  `Date.now` sites - including the one INSIDE the age-based risk multiplier -
+  the metadata `new Date()`, and the NODE_ENV debugMode read) and a
+  cache-identity fix replacing the 5-field base64 cache key with a
+  domain-separated canonical sha256 over the complete serialized input (pre-fix,
+  equal-length portfolios with matching scalars collided and the second call
+  returned the first portfolio's allocations verbatim;
+  `metadata.deterministicHash` is now the 64-hex canonical key). The adapter
+  wraps a fresh seam-injected engine per run (clock pinned to `ctx.clock`,
+  `calculationDuration` deterministically 0), projects the result JSON-safe
+  (Dates to ISO UTC strings; plain finite numbers kept - disclosed deviation
+  from the whole-dollar-string precedent), and hashes the canonical
+  serialization of the schema-parsed input (disclosed deviation from raw-input
+  hashing) plus feature flags/calculation version/Decimal config/cache-key
+  domain as methodology. The engine draws no randomness, so the value is
+  seed-invariant (disclosed and pinned); no fork label is consumed or reserved.
+  34 new tests (`tests/unit/deterministic-reserve-substrate/`) pin
+  captured-then-frozen goldens at two frozen instants (labeled as captured -
+  disclosed deviation from hand-derivation), the wall-clock drift, both
+  cache-defect states (before/after), seam correctness, four-part
+  parity/determinism/hash evidence, mode/kill-switch disclosure against both
+  result schemas, and an ambient-read guard. Pre-existing engine suites pass
+  unmodified; no consumers rewired.
+
 - **Tranche 3 reserve substrate adoption (ADR-044).** New additive adapter
   `shared/core/reserves/reserve-substrate-adapter.ts` runs the rule/ML
   `ReserveEngine` domain against an injected `CalculationContext` and emits a

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6749,3 +6749,213 @@ ADR-043's invalid-input decision).
 
 **Implementation:** `shared/core/reserves/reserve-substrate-adapter.ts` plus
 `tests/unit/reserve-substrate/` (36 tests).
+
+## ADR-045: Tranche 4 Substrate Adoption of the DeterministicReserveEngine (Demo Scope)
+
+**Date:** 2026-07-17 **Status:** [ACCEPTED] Implemented (demo scope)
+**Decision:** Adopt `shared/core/reserves/DeterministicReserveEngine.ts` onto
+the ADR-042 calculation substrate via (i) a minimal injectable capability seam
+added to the legacy class, (ii) a WRAPPING (not restating) adapter
+(`shared/core/reserves/deterministic-reserve-substrate-adapter.ts`,
+calculationKey `reserve-deterministic`), and (iii) an in-place cache-identity
+fix. Restating the 924-line Decimal.js kernel was rejected; wrapping without
+seams was rejected because the wall clock sits INSIDE calculation math and would
+poison the basis. Same owner-granted demo override of program-governance gates
+as ADR-042/043/044; technical invariants (determinism, hash integrity,
+disclosure of suppressed results, no silent financial fabrication) are enforced
+in code and tests.
+
+### Context: verified audit (re-verified on the tranche branch)
+
+- Ambient reads (pre-seam): `Date.now()` at five sites - three timing sites, the
+  metadata `calculationDuration`, and one INSIDE `calculateRiskMultiplier`
+  (`ageMonths` derived from the wall clock, so risk multipliers drift with real
+  time); `new Date()` for `metadata.calculationDate`; `process.env['NODE_ENV']`
+  for debugMode only.
+- The calculation cache WAS functionally live and wrong: the pre-fix
+  `generateDeterministicHash` base64-JSONed only 5 coarse fields
+  (`portfolioCount`, `availableReserves`, `totalFundSize`, `scenarioType`,
+  `timeHorizon`), the digest was both the cache key and the stamped
+  `metadata.deterministicHash`, and a cache hit short-circuited to the cached
+  object. Two DIFFERENT portfolios of equal length with matching scalars
+  therefore returned the FIRST portfolio's allocations on the same engine
+  instance - a real wrong-output defect, pinned by a characterization test
+  before the fix and flipped by it.
+- The engine contains NO randomness (no Math.random, no PRNG, no seed): its only
+  nondeterminism was the wall clock. Consequently the adapter value is
+  seed-invariant (disclosed and pinned, as ADR-044 did for the rule-based path);
+  different-hash evidence comes from inputs, asOf instants, and feature flags,
+  never seeds. NO fork label is consumed and none is reserved: there is nothing
+  to migrate onto `ctx.rng`.
+- The constructor already takes injectable `featureFlags` and sets the GLOBAL
+  Decimal configuration (precision 28, ROUND_HALF_UP); left untouched this
+  tranche and hashed as methodology instead.
+
+### Disposition table
+
+| Surface                                                                                                                                                                                            | Disposition | Notes                                                                                                                                              |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shared/core/reserves/DeterministicReserveEngine.ts`                                                                                                                                               | adapt       | ONLY permitted edits applied: ADR-045 capability seam + canonical cache identity; kernel math untouched                                            |
+| `shared/core/reserves/deterministic-reserve-canonical.ts`                                                                                                                                          | new         | Canonical serializer + cache-key identity shared by engine and adapter (see placement note below)                                                  |
+| `shared/core/reserves/deterministic-reserve-substrate-adapter.ts`                                                                                                                                  | new         | Wrapping adapter, calculationKey `reserve-deterministic`                                                                                           |
+| `client/src/core/reserves/DeterministicReserveEngine.ts` (re-export shim)                                                                                                                          | reuse       | One-line shim, no fork/drift risk; untouched                                                                                                       |
+| `client/src/lib/wizard-reserve-bridge.ts` (+ wizard-calculations, hooks)                                                                                                                           | defer       | Constructs the engine with the 1-arg constructor; seam is backward-compatible, no rewiring this tranche                                            |
+| `server/core/reserves/adapter.ts` (ports/mlClient seam)                                                                                                                                            | defer       | Type-level import plus injected engine instance; unchanged                                                                                         |
+| `server/routes/scenario-analysis.ts`                                                                                                                                                               | defer       | References the engine in TODO comments only                                                                                                        |
+| `server/services/projected-metrics-calculator.ts`, `shared/types/metrics.ts`                                                                                                                       | defer       | Doc-comment references only                                                                                                                        |
+| Pre-existing engine suites (engines/deterministic-reserve-engine.test.ts, parity .tsx, reserves-engine.test.ts, wizard-reserve-bridge.test.ts, adapter-unit-guard, REFL-018, phase3-critical-bugs) | reuse       | Pass UNMODIFIED - that is the seam-correctness proof                                                                                               |
+| `scripts/` references (backtest, strategic-decisions, ...)                                                                                                                                         | defer       | Dev tooling, not production surfaces                                                                                                               |
+| `ReserveEngine.ts` / `ConstrainedReserveEngine.ts`                                                                                                                                                 | untouched   | Out of scope (ADR-044 covers the former; the latter awaits its own tranche)                                                                        |
+| Wall clock inside calculation math + NODE_ENV debugMode read                                                                                                                                       | replace     | At the adapter boundary: `now: () => ctx.clock.now().getTime()`, `debugMode: false`; legacy default path keeps the characterized ambient fallbacks |
+| 5-field base64 cache key                                                                                                                                                                           | replace     | In-place fix (disclosed behavior change): domain-separated canonical sha256 over the complete serialized input                                     |
+
+### Decision details
+
+- **Seam (behavior-preserving).** Optional second constructor parameter
+  `capabilities?: { now?: () => number; debugMode?: boolean }` defaulting to
+  `Date.now` and a per-call `NODE_ENV === 'development'` read. All five
+  `Date.now` sites, the metadata `new Date()`, and the debugMode read route
+  through it; zero call-site changes. Proof: every pre-existing engine suite
+  passes unmodified, plus a dedicated test in which a seam-injected fixed `now`
+  reproduces the legacy engine field-for-field while the SYSTEM clock is frozen
+  at a different instant that would flip the age-based risk multiplier.
+- **Cache identity (disclosed behavior change).** `generateDeterministicHash`
+  now returns `canonicalSha256` over
+  `{ domain: 'updog.reserve-deterministic.cache-key', input: <canonical serialization> }`.
+  BEFORE: base64 of 5 coarse fields; the characterization suite pinned
+  `secondPortfolioResult === firstPortfolioResult` (verbatim wrong-output
+  collision) and the base64 format. AFTER: complete canonical input identity;
+  the pins are flipped in the same files with the pre-fix state recorded in
+  comments. Outputs for identical inputs are unchanged;
+  `metadata.deterministicHash` becomes the 64-hex canonical key. No pre-existing
+  test pinned the old format (verified: the `det-` prefix pins belong to the
+  Monte Carlo orchestrator, a different engine).
+- **Serializer placement (documented deviation from the tranche plan sketch).**
+  The plan placed the canonical input serializer inside the adapter module;
+  implemented in `deterministic-reserve-canonical.ts` instead because the ENGINE
+  needs the cache-key function and the ADAPTER imports the engine - a
+  same-module placement would be a circular import. The adapter re-exports the
+  serializer and cache-key helpers, so the planned public surface is preserved.
+- **Wrapping, not restating.** The adapter constructs a fresh
+  `DeterministicReserveEngine` per run with
+  `{ now: () => ctx.clock.now().getTime(), debugMode: false }`, so no
+  calculation cache survives across calls and no ambient state leaks in. With
+  the fixed clock, `metadata.calculationDuration` is deterministically 0
+  (pinned).
+- **Value boundary (disclosed deviations).** The value is the engine result
+  projected JSON-safe (every Date to ISO-8601 UTC string, undefined stripped)
+  plus `asOfUtc` from the injected clock. Numbers stay PLAIN FINITE NUMBERS -
+  deviation from the Tranche 2/3 whole-dollar-decimal-string convention, because
+  this engine emits fractional Decimal-derived amounts and inventing a boundary
+  rounding policy would fabricate precision. The value schema is a strict
+  JSON-safe mirror of the legacy result shape, NOT the legacy
+  `ReserveCalculationResultSchema`: that schema requires a positive
+  `calculationDuration` (a fixed clock yields exactly 0) and strictly positive
+  money fields the engine does not guarantee, and the engine never parses its
+  own output. Structure and JSON-safety are enforced at the boundary; business
+  bounds remain the kernel's own.
+- **Hashes.** `inputHash` = `canonicalSha256` over
+  `{ domain: 'updog.reserve-deterministic.input-hash', input: <canonical serialization of the schema-PARSED input> }` -
+  a disclosed deviation from the ADR-043/044 raw-input precedent, because valid
+  inputs necessarily contain Date instances, which hash admission rejects;
+  raw-input hashing would collapse every valid input onto the sentinel.
+  Equivalent spellings (Date vs ISO string; omitted vs explicit schema defaults)
+  share one input identity - the "complete canonical input identity" follow-up
+  recorded in ADR-044. The inadmissible-sentinel fallback
+  (`{ inadmissibleInput: true }`) remains for unparseable garbage.
+  `assumptionsHash` covers the domain
+  `updog.reserve-deterministic.assumptions-hash`, the methodology version, the
+  restated CALCULATION_VERSION (1.0.0, pinned against `metadata.modelVersion`),
+  the engine's global Decimal configuration, the cache-key domain, and the
+  resolved feature flags (flags are methodology; the default set restates the
+  ENGINE constructor defaults, not the FeatureFlagSchema defaults, which differ
+  on `enableNewReserveEngine`). `resultHash` uses the substrate
+  `computeResultHash` unchanged.
+- **Captured goldens (disclosed deviation).** Characterization expectations for
+  the Decimal kernel are CAPTURED-then-frozen at the frozen instants and labeled
+  as such - a deviation from the Tranche 2/3 hand-derivation discipline;
+  hand-restating the kernel is exactly the rejected alternative. Goldens are
+  anchored by hand-checkable structure: the T2 golden equals the T1 golden times
+  exactly 0.9 on the age-crossing company, and conservation/ranking/bound
+  invariants are asserted alongside.
+- **Result semantics.** Identical to ADR-043/044: `on` -> `available`; `shadow`
+  -> `indicative` + `SHADOW_ONLY`; configured `off` -> `unavailable`
+  - `MODE_OFF`; kill switch -> `unavailable` + `KILL_SWITCH_ACTIVE` (both codes
+    when both apply); schema-invalid input -> `failed` + `INPUT_INVALID` with a
+    diagnostic; engine throw/rejection (including `ReserveCalculationError`,
+    e.g. the empty-portfolio guard) -> `failed` + `ENGINE_ERROR`. Every
+    non-available path carries at least one registered reason code; there is no
+    silent fallback.
+- **Versions.** `engineVersion: deterministic-reserve-engine/1.0.0`,
+  `methodologyVersion: deterministic-reserve-methodology/1.0.0`. Changing the
+  kernel math, the Decimal configuration, the serialization rules, or the hash
+  domains bumps the methodology or engine version.
+
+### Alternatives considered
+
+- **Restate the kernel in the adapter (Tranche 2/3 pattern):** rejected; 924
+  lines of Decimal.js allocation math is not a restatable boundary, and a
+  drifting copy would be a silent-fabrication risk rather than a hedge.
+- **Wrap without seams:** rejected; `Date.now()` INSIDE
+  `calculateRiskMultiplier` means outputs drift with real time, so a wrapped
+  engine could not emit an honest basis (the same instant could never be
+  replayed).
+- **Parse the value through the legacy `ReserveCalculationResultSchema`:**
+  rejected; it requires `calculationDuration > 0` (fixed clock yields 0) and
+  strictly positive money fields the engine can legitimately violate, so it
+  would fabricate failures for faithful results.
+- **Hash the raw input (ADR-043/044 precedent):** rejected here; every valid
+  input contains Date instances, so admission would reject it and all valid
+  inputs would collapse onto one sentinel identity.
+- **Round value amounts to whole-dollar strings (Tranche 2/3 precedent):**
+  rejected; the engine emits fractional amounts and a boundary rounding policy
+  would be fabricated precision, not preserved behavior.
+
+### Parity evidence summary
+
+`tests/unit/deterministic-reserve-substrate/` (34 tests, all green; pre-existing
+engine suites and the pacing/reserve/calc-substrate suites byte-green):
+
+- Characterization (9) pins the legacy engine BEFORE adoption: captured goldens
+  at T1, the T1->T2 age-threshold drift (exactly 0.9 on the crossing company,
+  others byte-identical), frozen-clock metadata, per-instance determinism, the
+  cache short-circuit, the collision defect and pre-fix base64 key (both since
+  flipped, pre-fix state recorded in comments), conservation/ranking/bound
+  invariants, and guard-clause throws.
+- Seam (1) proves a seam-injected fixed `now` reproduces the legacy engine while
+  the system clock sits at an instant that would change the output.
+- Adapter (23) proves: field-for-field parity with the seam-injected legacy
+  engine plus `asOfUtc`; golden equality at T1 and the asOf-driven 0.9
+  multiplier at T2; `calculationDuration === 0`; repeat-run byte-identical
+  results with equal 64-hex hashes; DISCLOSED seed-invariance (different seeds,
+  identical value and hash); different inputs/asOf/flags change the respective
+  hashes (asOf changes the result hash but not the input hash); canonical input
+  identity across Date/string spellings and omitted schema defaults;
+  flags-default equivalence; value round-trips `admitForHashing` and
+  `computeResultHash` recomputes; mode/kill-switch/invalid-input/engine- error
+  invariants against both the typed and generic result schemas; and context
+  contract/key guards.
+- An ambient-state source guard (1) scans the adapter AND the canonical module
+  for `Math.random`, argless `new Date()`, `Date.now`, and `process.env`.
+
+### Consequences
+
+- DeterministicReserveEngine can now run against an injected
+  `CalculationContext` and emit a hash-bound `CalcResult`; consumers keep the
+  legacy path until a later tranche wires them over (no consumer rewiring this
+  tranche).
+- The legacy default path retains its characterized ambient fallbacks (Date.now
+  / NODE_ENV) inside the seam; direct constructions such as
+  `wizard-reserve-bridge.ts` behave exactly as before.
+- Remaining follow-ups for future tranches: wire
+  `server/routes/scenario-analysis.ts` (currently TODO comments) and the wizard
+  bridge onto the adapter; adopt `ConstrainedReserveEngine.ts`; revisit the
+  engine's GLOBAL Decimal configuration (currently hashed as methodology,
+  deliberately not fixed); fund_calculation_modes integration, routes, flags
+  registry, and persistence remain out of scope per the tranche plan.
+
+**Implementation:** `shared/core/reserves/deterministic-reserve-canonical.ts`,
+`shared/core/reserves/deterministic-reserve-substrate-adapter.ts`, the ADR-045
+seam and cache-identity fix inside
+`shared/core/reserves/DeterministicReserveEngine.ts`, plus
+`tests/unit/deterministic-reserve-substrate/` (34 tests).

--- a/shared/core/reserves/DeterministicReserveEngine.ts
+++ b/shared/core/reserves/DeterministicReserveEngine.ts
@@ -20,6 +20,7 @@ import {
 import { normalizeStageOrUndefined } from '@shared/schemas/stage';
 import { getLogger, getPerf } from '@shared/instrumentation';
 import { validateReserveAllocationConservation } from '@shared/validation/conservation';
+import { computeDeterministicReserveCacheKey } from './deterministic-reserve-canonical';
 
 // Get instrumentation instances
 const logger = getLogger();
@@ -749,16 +750,11 @@ export class DeterministicReserveEngine {
   }
 
   private generateDeterministicHash(input: ReserveAllocationInput): string {
-    // Create deterministic hash for caching and verification
-    const hashInput = {
-      portfolioCount: input.portfolio.length,
-      availableReserves: input.availableReserves,
-      totalFundSize: input.totalFundSize,
-      scenarioType: input.scenarioType,
-      timeHorizon: input.timeHorizon,
-    };
-
-    return Buffer.from(JSON.stringify(hashInput)).toString('base64');
+    // Complete canonical input identity (ADR-045). Pre-fix, this base64-JSONed
+    // only { portfolioCount, availableReserves, totalFundSize, scenarioType,
+    // timeHorizon }, so equal-length portfolios with matching scalars collided
+    // and a cache hit returned the wrong portfolio's allocations.
+    return computeDeterministicReserveCacheKey(input);
   }
 
   private sanitizeForLogging(input: ReserveAllocationInput): Record<string, unknown> {

--- a/shared/core/reserves/DeterministicReserveEngine.ts
+++ b/shared/core/reserves/DeterministicReserveEngine.ts
@@ -48,9 +48,21 @@ interface MOICCalculation {
   allocationScore: Decimal;
 }
 
+/**
+ * Injectable ambient capabilities (ADR-045 seam). Defaults preserve the
+ * legacy ambient behavior exactly: wall-clock Date.now and a per-call
+ * NODE_ENV read for debugMode.
+ */
+export interface DeterministicReserveEngineCapabilities {
+  now?: () => number;
+  debugMode?: boolean;
+}
+
 export class DeterministicReserveEngine {
   private context: CalculationContext | null = null;
   private calculationCache = new Map<string, ReserveCalculationResult>();
+  private readonly now: () => number;
+  private readonly debugModeOverride: boolean | undefined;
 
   constructor(
     private featureFlags: FeatureFlags = {
@@ -62,8 +74,11 @@ export class DeterministicReserveEngine {
       enableLiquidationPreferences: true,
       enablePerformanceLogging: true,
       maxCalculationTimeMs: 5000,
-    }
+    },
+    capabilities: DeterministicReserveEngineCapabilities = {}
   ) {
+    this.now = capabilities.now ?? Date.now;
+    this.debugModeOverride = capabilities.debugMode;
     // Set high precision for financial calculations
     Decimal['set']({ precision: 28, rounding: Decimal.ROUND_HALF_UP });
   }
@@ -75,14 +90,14 @@ export class DeterministicReserveEngine {
   async calculateOptimalReserveAllocation(
     input: ReserveAllocationInput
   ): Promise<ReserveCalculationResult> {
-    const startTime = Date.now();
+    const startTime = this.now();
 
     // Initialize calculation context
     this.context = {
       startTime,
       deterministicSeed: this.generateDeterministicHash(input),
       featureFlags: this.featureFlags,
-      debugMode: process.env['NODE_ENV'] === 'development',
+      debugMode: this.debugModeOverride ?? process.env['NODE_ENV'] === 'development',
     };
 
     try {
@@ -120,7 +135,7 @@ export class DeterministicReserveEngine {
       this.calculationCache['set'](cacheKey, result);
 
       // Performance tracking
-      const duration = Date.now() - startTime;
+      const duration = this.now() - startTime;
       if (this.featureFlags.enablePerformanceLogging) {
         performanceMonitor.recordCalculationPerformance('reserve-calculation', duration, {
           portfolioSize: input.portfolio.length,
@@ -137,7 +152,7 @@ export class DeterministicReserveEngine {
 
       return result;
     } catch (error) {
-      const duration = Date.now() - startTime;
+      const duration = this.now() - startTime;
 
       if (this.featureFlags.enablePerformanceLogging) {
         performanceMonitor.recordCalculationPerformance('reserve-calculation', duration, {
@@ -482,8 +497,8 @@ export class DeterministicReserveEngine {
       riskAnalysis,
       scenarioResults,
       metadata: {
-        calculationDate: new Date(),
-        calculationDuration: Date.now() - this.context!.startTime,
+        calculationDate: new Date(this.now()),
+        calculationDuration: this.now() - this.context!.startTime,
         modelVersion: CALCULATION_VERSION,
         deterministicHash: this.context!.deterministicSeed,
         assumptions: this.getCalculationAssumptions(),
@@ -763,7 +778,7 @@ export class DeterministicReserveEngine {
     let multiplier = new Decimal(1);
 
     // Adjust for company age
-    const ageMonths = (Date.now() - company.investmentDate.getTime()) / (1000 * 60 * 60 * 24 * 30);
+    const ageMonths = (this.now() - company.investmentDate.getTime()) / (1000 * 60 * 60 * 24 * 30);
     if (ageMonths > 60) {
       // Over 5 years
       multiplier = multiplier.mul(0.9);

--- a/shared/core/reserves/deterministic-reserve-canonical.ts
+++ b/shared/core/reserves/deterministic-reserve-canonical.ts
@@ -1,0 +1,60 @@
+/**
+ * Canonical serialization and cache-key identity for the
+ * DeterministicReserveEngine (Tranche 4, ADR-045).
+ *
+ * This lives in its own module (rather than inside the substrate adapter, as
+ * the tranche plan sketched) because BOTH sides need it and importing in
+ * either direction alone would be circular: the engine consumes the cache-key
+ * function and the adapter consumes the serializer for its input hash and
+ * value projection. The adapter re-exports everything here, so the adapter
+ * module still exposes the serializer as planned.
+ *
+ * Serialization rules (JSON-safe projection):
+ * - Date instances become millisecond-precision ISO-8601 UTC strings;
+ * - undefined-valued object properties are stripped;
+ * - arrays are mapped element-wise; primitives pass through untouched.
+ *
+ * Cache-key identity: canonicalSha256 (sorted keys, canonical JSON, sha256
+ * hex) over a domain-separated envelope of the canonicalized input. This
+ * replaces the pre-fix key, which base64-JSONed only 5 coarse fields
+ * (portfolioCount/availableReserves/totalFundSize/scenarioType/timeHorizon)
+ * so equal-length portfolios with matching scalars collided and the second
+ * portfolio silently received the first portfolio's allocations.
+ */
+
+import { canonicalSha256 } from '../../lib/canonical-hash';
+
+export const DETERMINISTIC_RESERVE_CACHE_KEY_DOMAIN = 'updog.reserve-deterministic.cache-key';
+
+/**
+ * Project a value to JSON-safe form: Dates to ISO-8601 UTC strings,
+ * undefined properties stripped, arrays mapped, primitives untouched.
+ */
+export function serializeDeterministicReserveInput(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeDeterministicReserveInput);
+  }
+  const record = value as Record<string, unknown>;
+  const serialized: Record<string, unknown> = {};
+  for (const key of Object.keys(record)) {
+    const child = record[key];
+    if (child !== undefined) {
+      serialized[key] = serializeDeterministicReserveInput(child);
+    }
+  }
+  return serialized;
+}
+
+/** Complete canonical input identity for the engine's calculation cache. */
+export function computeDeterministicReserveCacheKey(input: unknown): string {
+  return canonicalSha256({
+    domain: DETERMINISTIC_RESERVE_CACHE_KEY_DOMAIN,
+    input: serializeDeterministicReserveInput(input),
+  });
+}

--- a/shared/core/reserves/deterministic-reserve-substrate-adapter.ts
+++ b/shared/core/reserves/deterministic-reserve-substrate-adapter.ts
@@ -1,0 +1,374 @@
+/**
+ * DeterministicReserveEngine substrate adapter (Tranche 4, ADR-045).
+ *
+ * Runs the legacy DeterministicReserveEngine against an injected
+ * CalculationContext and returns a CalcResult with a validated basis and
+ * result hash. Unlike the Tranche 2/3 adapters this one WRAPS the legacy
+ * class instead of restating it: the 924-line Decimal.js kernel stays the
+ * single implementation, and the ADR-045 capability seam
+ * (`{ now, debugMode }`) lets the adapter pin the engine's wall clock to
+ * `ctx.clock` - necessary because the clock sits INSIDE calculation math
+ * (the age-based risk multiplier), not just in timing metadata.
+ *
+ * Behavior preservation contract:
+ * - A fresh engine instance is constructed per run with
+ *   `now: () => ctx.clock.now().getTime()` and `debugMode: false`, so no
+ *   calculation cache survives across calls and no ambient state leaks in.
+ *   With a fixed clock, `metadata.calculationDuration` is deterministically 0.
+ * - The engine draws NO randomness: its only nondeterminism was the wall
+ *   clock. The adapter value is therefore seed-invariant (pinned as a
+ *   disclosed property, as ADR-044 did for the rule-based path); different
+ *   hashes come from inputs, asOf instants, and feature flags, never seeds.
+ *   No fork label is consumed and none is reserved - there is nothing to
+ *   migrate onto ctx.rng.
+ * - Feature flags are methodology: the resolved flags enter the
+ *   assumptions-hash preimage together with the calculation version, the
+ *   engine's global Decimal configuration, and the cache-key domain. The
+ *   default flag set restates the ENGINE constructor defaults (not the
+ *   FeatureFlagSchema defaults, which differ on enableNewReserveEngine);
+ *   the parity suite keeps the restatement honest.
+ *
+ * Boundary conventions and disclosed deviations (ADR-045):
+ * - Value numbers stay plain finite JSON numbers. This deviates from the
+ *   Tranche 2/3 whole-dollar-decimal-string convention because this engine
+ *   emits fractional Decimal-derived amounts; inventing a rounding policy at
+ *   the boundary would fabricate precision the engine does not produce.
+ * - The value is the engine result projected JSON-safe (every Date becomes an
+ *   ISO-8601 UTC string, undefined properties are stripped) plus `asOfUtc`
+ *   from the injected clock. The value schema is a strict JSON-safe mirror of
+ *   the legacy result shape, NOT the legacy ReserveCalculationResultSchema:
+ *   that schema requires a positive calculationDuration (a fixed clock yields
+ *   exactly 0) and strictly positive money fields the engine itself does not
+ *   guarantee (a fully-filtered portfolio legitimately allocates 0), and the
+ *   engine never parses its own output. Structure and JSON-safety are
+ *   enforced here; business bounds remain the kernel's own.
+ * - inputHash covers the CANONICAL SERIALIZATION of the schema-PARSED input
+ *   (dates as ISO strings, defaults filled), not the raw input as in
+ *   Tranches 2/3: valid inputs always contain Date instances, which hash
+ *   admission rejects, so raw-input hashing would collapse every valid input
+ *   onto the inadmissible sentinel. Two spellings of the same instant (Date
+ *   vs ISO string) therefore share one input identity, as do inputs relying
+ *   on schema defaults vs spelling them out. The inadmissible-sentinel
+ *   fallback remains for unparseable garbage.
+ *
+ * Result semantics (identical to ADR-043/044): on -> available; shadow ->
+ * indicative + SHADOW_ONLY; configured off -> unavailable + MODE_OFF; kill
+ * switch -> unavailable + KILL_SWITCH_ACTIVE (both codes when both apply);
+ * schema-invalid input -> failed + INPUT_INVALID with a diagnostic; engine
+ * throw/rejection (including ReserveCalculationError) -> failed +
+ * ENGINE_ERROR. Every non-available path carries at least one registered
+ * reason code; there is no silent fallback.
+ */
+
+import { z } from 'zod';
+import { canonicalSha256 } from '../../lib/canonical-hash';
+import {
+  FeatureFlagSchema,
+  ReserveAllocationInputSchema,
+  type FeatureFlags,
+} from '../../schemas/reserves-schemas';
+import {
+  CALC_SUBSTRATE_CONTRACT_VERSION,
+  CalcBasisSchema,
+  Sha256HexSchema,
+  admitForHashing,
+  computeResultHash,
+  createCalcResultSchema,
+  type CalcBasis,
+  type CalcMode,
+  type CalcReasonCode,
+  type CalculationContext,
+} from '../calc-substrate';
+import { DeterministicReserveEngine } from './DeterministicReserveEngine';
+import {
+  DETERMINISTIC_RESERVE_CACHE_KEY_DOMAIN,
+  serializeDeterministicReserveInput,
+} from './deterministic-reserve-canonical';
+
+export {
+  DETERMINISTIC_RESERVE_CACHE_KEY_DOMAIN,
+  computeDeterministicReserveCacheKey,
+  serializeDeterministicReserveInput,
+} from './deterministic-reserve-canonical';
+
+export const DETERMINISTIC_RESERVE_CALCULATION_KEY = 'reserve-deterministic';
+export const DETERMINISTIC_RESERVE_ENGINE_VERSION = 'deterministic-reserve-engine/1.0.0';
+export const DETERMINISTIC_RESERVE_METHODOLOGY_VERSION = 'deterministic-reserve-methodology/1.0.0';
+export const DETERMINISTIC_RESERVE_INPUT_HASH_DOMAIN = 'updog.reserve-deterministic.input-hash';
+export const DETERMINISTIC_RESERVE_ASSUMPTIONS_HASH_DOMAIN =
+  'updog.reserve-deterministic.assumptions-hash';
+
+/**
+ * Restates the engine's private CALCULATION_VERSION ('1.0.0', stamped into
+ * metadata.modelVersion). The parity suite pins the two against each other.
+ */
+export const DETERMINISTIC_RESERVE_CALCULATION_VERSION = '1.0.0';
+
+/**
+ * Restates the engine's global Decimal.js configuration (set in its
+ * constructor), hashed as methodology. Changing the engine's precision or
+ * rounding mode is a methodology-version bump.
+ */
+const DETERMINISTIC_RESERVE_DECIMAL_CONFIG = {
+  precision: 28,
+  rounding: 'ROUND_HALF_UP',
+} as const;
+
+/**
+ * The ENGINE constructor's default flags, restated. Deliberately NOT
+ * FeatureFlagSchema.parse({}) - the schema defaults differ (e.g.
+ * enableNewReserveEngine defaults false there, true here).
+ */
+export const DEFAULT_DETERMINISTIC_RESERVE_FEATURE_FLAGS: FeatureFlags = {
+  enableNewReserveEngine: true,
+  enableParityTesting: true,
+  enableRiskAdjustments: true,
+  enableScenarioAnalysis: true,
+  enableAdvancedDiversification: false,
+  enableLiquidationPreferences: true,
+  enablePerformanceLogging: true,
+  maxCalculationTimeMs: 5000,
+};
+
+const ISO_UTC_MS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const IsoUtcStringSchema = z.string().regex(ISO_UTC_MS_RE, 'ISO-8601 UTC string (ms precision)');
+const FiniteNumberSchema = z.number().finite();
+const RiskBandSchema = z.enum(['low', 'medium', 'high']);
+
+const DeterministicReserveAllocationValueSchema = z
+  .object({
+    companyId: z.string().uuid(),
+    companyName: z.string(),
+    recommendedAllocation: FiniteNumberSchema,
+    allocationRationale: z.string(),
+    priority: z.number().int().min(1),
+    expectedMOIC: FiniteNumberSchema,
+    expectedValue: FiniteNumberSchema,
+    riskAdjustedReturn: FiniteNumberSchema,
+    newOwnership: FiniteNumberSchema,
+    portfolioWeight: FiniteNumberSchema,
+    concentrationRisk: RiskBandSchema,
+    recommendedStage: z.string(),
+    timeToDeployment: FiniteNumberSchema,
+    followOnPotential: FiniteNumberSchema,
+    riskFactors: z.array(z.string()),
+    mitigationStrategies: z.array(z.string()),
+    calculationMetadata: z
+      .object({
+        graduationProbability: FiniteNumberSchema,
+        expectedExitMultiple: FiniteNumberSchema,
+        timeToExit: FiniteNumberSchema,
+        diversificationBonus: FiniteNumberSchema,
+        liquidationPrefImpact: FiniteNumberSchema.optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const ScenarioBandValueSchema = z
+  .object({
+    totalValue: FiniteNumberSchema,
+    portfolioMOIC: FiniteNumberSchema,
+    probability: FiniteNumberSchema,
+  })
+  .strict();
+
+export const DeterministicReserveCalcValueSchema = z
+  .object({
+    inputSummary: z
+      .object({
+        totalPortfolioCompanies: z.number().int().min(0),
+        availableReserves: FiniteNumberSchema,
+        totalAllocated: FiniteNumberSchema,
+        allocationEfficiency: FiniteNumberSchema,
+      })
+      .strict(),
+    allocations: z.array(DeterministicReserveAllocationValueSchema),
+    unallocatedReserves: FiniteNumberSchema,
+    portfolioMetrics: z
+      .object({
+        expectedPortfolioMOIC: FiniteNumberSchema,
+        expectedPortfolioValue: FiniteNumberSchema,
+        portfolioDiversification: FiniteNumberSchema,
+        concentrationRisk: RiskBandSchema,
+        averageTimeToExit: FiniteNumberSchema,
+      })
+      .strict(),
+    riskAnalysis: z
+      .object({
+        portfolioRisk: RiskBandSchema,
+        keyRiskFactors: z.array(z.string()),
+        riskMitigationActions: z.array(z.string()),
+        stressTestResults: z
+          .object({
+            downside10: FiniteNumberSchema,
+            upside90: FiniteNumberSchema,
+            expectedValue: FiniteNumberSchema,
+          })
+          .strict(),
+      })
+      .strict(),
+    scenarioResults: z
+      .object({
+        conservative: ScenarioBandValueSchema,
+        base: ScenarioBandValueSchema,
+        optimistic: ScenarioBandValueSchema,
+      })
+      .strict(),
+    metadata: z
+      .object({
+        calculationDate: IsoUtcStringSchema,
+        /** Deterministically 0 under the injected fixed clock. */
+        calculationDuration: z.number().int().min(0),
+        modelVersion: z.string().min(1),
+        deterministicHash: Sha256HexSchema,
+        assumptions: z.array(z.string()),
+        limitations: z.array(z.string()),
+      })
+      .strict(),
+    asOfUtc: IsoUtcStringSchema,
+  })
+  .strict();
+
+export type DeterministicReserveCalcValue = z.infer<typeof DeterministicReserveCalcValueSchema>;
+
+export const DeterministicReserveCalcResultSchema = createCalcResultSchema(
+  DeterministicReserveCalcValueSchema
+);
+export type DeterministicReserveCalcResult = z.infer<typeof DeterministicReserveCalcResultSchema>;
+
+export interface DeterministicReserveSubstrateOptions {
+  configuredMode: CalcMode;
+  killSwitchActive: boolean;
+  /** Engine feature flags (methodology). Default: the engine's own defaults. */
+  featureFlags?: FeatureFlags;
+}
+
+export function computeDeterministicReserveInputHash(input: unknown): string {
+  const parsed = ReserveAllocationInputSchema.safeParse(input);
+  if (parsed.success) {
+    // Canonical parsed-input identity (disclosed deviation from the ADR-043/
+    // 044 raw-input precedent): dates serialize to ISO UTC strings and schema
+    // defaults are filled, so equivalent spellings share one identity.
+    return canonicalSha256({
+      domain: DETERMINISTIC_RESERVE_INPUT_HASH_DOMAIN,
+      input: admitForHashing(serializeDeterministicReserveInput(parsed.data)),
+    });
+  }
+  let admitted: unknown;
+  try {
+    admitted = admitForHashing(input);
+  } catch {
+    // Unparseable garbage that also cannot be canonically hashed. The basis
+    // still needs a deterministic input identity, and the accompanying
+    // result discloses the rejection via INPUT_INVALID.
+    admitted = { inadmissibleInput: true };
+  }
+  return canonicalSha256({ domain: DETERMINISTIC_RESERVE_INPUT_HASH_DOMAIN, input: admitted });
+}
+
+export function computeDeterministicReserveAssumptionsHash(featureFlags: FeatureFlags): string {
+  return canonicalSha256({
+    domain: DETERMINISTIC_RESERVE_ASSUMPTIONS_HASH_DOMAIN,
+    methodologyVersion: DETERMINISTIC_RESERVE_METHODOLOGY_VERSION,
+    calculationVersion: DETERMINISTIC_RESERVE_CALCULATION_VERSION,
+    decimalConfig: DETERMINISTIC_RESERVE_DECIMAL_CONFIG,
+    cacheKeyDomain: DETERMINISTIC_RESERVE_CACHE_KEY_DOMAIN,
+    featureFlags: admitForHashing(featureFlags),
+  });
+}
+
+export async function runDeterministicReserveWithSubstrate(
+  ctx: CalculationContext,
+  input: unknown,
+  options: DeterministicReserveSubstrateOptions
+): Promise<DeterministicReserveCalcResult> {
+  if (ctx.contractVersion !== CALC_SUBSTRATE_CONTRACT_VERSION) {
+    throw new TypeError(
+      `deterministic reserve adapter requires contract ${CALC_SUBSTRATE_CONTRACT_VERSION}, received ${String(
+        ctx.contractVersion
+      )}`
+    );
+  }
+  if (ctx.calculationKey !== DETERMINISTIC_RESERVE_CALCULATION_KEY) {
+    throw new TypeError(
+      `deterministic reserve adapter requires calculationKey '${DETERMINISTIC_RESERVE_CALCULATION_KEY}', received '${ctx.calculationKey}'`
+    );
+  }
+
+  const featureFlags = FeatureFlagSchema.parse({
+    ...DEFAULT_DETERMINISTIC_RESERVE_FEATURE_FLAGS,
+    ...(options.featureFlags ?? {}),
+  });
+  const effectiveMode: CalcMode = options.killSwitchActive ? 'off' : options.configuredMode;
+
+  const basis: CalcBasis = CalcBasisSchema.parse({
+    contractVersion: CALC_SUBSTRATE_CONTRACT_VERSION,
+    calculationKey: DETERMINISTIC_RESERVE_CALCULATION_KEY,
+    configuredMode: options.configuredMode,
+    effectiveMode,
+    killSwitchActive: options.killSwitchActive,
+    engineVersion: DETERMINISTIC_RESERVE_ENGINE_VERSION,
+    methodologyVersion: DETERMINISTIC_RESERVE_METHODOLOGY_VERSION,
+    inputHash: computeDeterministicReserveInputHash(input),
+    assumptionsHash: computeDeterministicReserveAssumptionsHash(featureFlags),
+  });
+
+  if (effectiveMode === 'off') {
+    const reasonCodes: CalcReasonCode[] = [];
+    if (options.killSwitchActive) {
+      reasonCodes.push('KILL_SWITCH_ACTIVE');
+    }
+    if (options.configuredMode === 'off') {
+      reasonCodes.push('MODE_OFF');
+    }
+    return DeterministicReserveCalcResultSchema.parse({ state: 'unavailable', basis, reasonCodes });
+  }
+
+  const parsed = ReserveAllocationInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return DeterministicReserveCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['INPUT_INVALID'],
+      diagnostic: `deterministic reserve input rejected: ${parsed.error.message}`,
+    });
+  }
+
+  try {
+    // Fresh instance per run: no cross-call cache reuse, clock pinned to ctx.
+    const engine = new DeterministicReserveEngine(featureFlags, {
+      now: () => ctx.clock.now().getTime(),
+      debugMode: false,
+    });
+    const engineResult = await engine.calculateOptimalReserveAllocation(parsed.data);
+    const value = DeterministicReserveCalcValueSchema.parse({
+      ...(serializeDeterministicReserveInput(engineResult) as Record<string, unknown>),
+      asOfUtc: ctx.clock.isoNow(),
+    });
+    const resultHash = computeResultHash(basis, value);
+    if (effectiveMode === 'shadow') {
+      return DeterministicReserveCalcResultSchema.parse({
+        state: 'indicative',
+        basis,
+        value,
+        resultHash,
+        reasonCodes: ['SHADOW_ONLY'],
+      });
+    }
+    return DeterministicReserveCalcResultSchema.parse({
+      state: 'available',
+      basis,
+      value,
+      resultHash,
+      reasonCodes: [],
+    });
+  } catch (error) {
+    return DeterministicReserveCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['ENGINE_ERROR'],
+      diagnostic: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/tests/unit/deterministic-reserve-substrate/ambient-guard.test.ts
+++ b/tests/unit/deterministic-reserve-substrate/ambient-guard.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Ambient-state source guard for the deterministic reserve substrate adapter
+ * (Tranche 4, ADR-045).
+ *
+ * Same pattern as tests/unit/reserve-substrate/ambient-guard.test.ts: the
+ * adapter must receive every ambient capability through its
+ * CalculationContext, never via Math.random, argless new Date(), Date.now,
+ * or process.env. The canonical serializer module is scanned too - it is new
+ * substrate-side code this tranche. The legacy DeterministicReserveEngine.ts
+ * is intentionally NOT scanned: its remaining default-path ambient reads
+ * (the Date.now and NODE_ENV fallbacks inside the ADR-045 capability seam)
+ * are characterized, seam-gated behavior, and the adapter always overrides
+ * them with ctx-derived capabilities.
+ */
+
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+const GUARDED_FILES = [
+  'deterministic-reserve-substrate-adapter.ts',
+  'deterministic-reserve-canonical.ts',
+];
+
+describe('deterministic reserve adapter ambient-state source guard', () => {
+  it('the adapter never reaches for Math.random, argless new Date(), Date.now, or process.env', async () => {
+    // The shared node-setup mocks fs.readFileSync; this guard needs the real one.
+    const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const reservesDir = path.join(process.cwd(), 'shared', 'core', 'reserves');
+    const ambientPatterns: [string, RegExp][] = [
+      ['Math.random', /Math\.random/],
+      ['argless new Date()', /new Date\(\s*\)/],
+      ['process.env', /process\.env/],
+      ['Date.now', /Date\.now/],
+    ];
+    const violations: string[] = [];
+    for (const file of GUARDED_FILES) {
+      const raw = fs.readFileSync(path.join(reservesDir, file), 'utf8');
+      // Guard executable code only: doc comments may name the forbidden APIs.
+      const text = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+      for (const [label, pattern] of ambientPatterns) {
+        if (pattern.test(text)) {
+          violations.push(`${file} uses ${label}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/deterministic-reserve-substrate/deterministic-reserve-engine-characterization.test.ts
+++ b/tests/unit/deterministic-reserve-substrate/deterministic-reserve-engine-characterization.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Characterization tests for the legacy DeterministicReserveEngine
+ * (Tranche 4, ADR-045).
+ *
+ * These pin the engine's CURRENT behavior before substrate adoption; they are
+ * evidence, not aspiration. The engine draws NO randomness - its only
+ * nondeterminism is the wall clock, which sits INSIDE calculation math
+ * (calculateRiskMultiplier derives company age from Date.now()), so every
+ * test freezes time with fake timers and the clock dependence is itself
+ * pinned behavior: the same input at two frozen instants a year apart
+ * produces different allocations because one company crosses the 60-month
+ * age threshold in between.
+ *
+ * Numeric expectations are CAPTURED-then-frozen golden values (run at the
+ * frozen instants and transcribed), NOT hand-derived - a disclosed deviation
+ * from the Tranche 2/3 hand-derivation discipline, recorded in ADR-045: this
+ * is a 924-line Decimal.js kernel and restating it by hand is exactly the
+ * rejected alternative. Structural invariants (conservation, ranking order,
+ * allocation bounds) are asserted alongside so the goldens are anchored, not
+ * free-floating.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeterministicReserveEngine } from '../../../shared/core/reserves/DeterministicReserveEngine';
+import { ReserveCalculationError } from '../../../shared/schemas/reserves-schemas';
+import { ALPHA_ID, BETA_ID, GAMMA_ID, T1_ISO, T2_ISO, baseInput, collidingInput } from './fixtures';
+
+// CAPTURED golden values (frozen instant T1 = 2026-01-01T00:00:00.000Z).
+// Ranking by allocation score: Beta Bio, Alpha Analytics, Gamma Grid.
+const GOLDEN_T1 = {
+  companyIds: [BETA_ID, ALPHA_ID, GAMMA_ID],
+  recommendedAllocations: [1_054_687.5, 724_570.3125, 216_554.079],
+  totalAllocated: 1_995_811.8915,
+  unallocatedReserves: 8_004_188.1085,
+  allocationEfficiency: 0.19958118915,
+  expectedPortfolioMOIC: 18.954692153661817,
+  expectedPortfolioValue: 37_830_000,
+  expectedMOICs: [18.75, 18, 8.4],
+  expectedValues: [18_750_000, 9_000_000, 10_080_000],
+  riskAdjustedReturns: [11_250_000, 3_600_000, 7_056_000],
+};
+
+// CAPTURED golden values (frozen instant T2 = 2027-01-01T00:00:00.000Z).
+// Beta Bio's investment age crosses 60 engine-months between T1 and T2, so
+// its allocation and risk-adjusted return take the 0.9 age multiplier; the
+// other companies are byte-identical to T1.
+const GOLDEN_T2 = {
+  betaAllocation: 949_218.75, // exactly 0.9 * GOLDEN_T1 allocation
+  betaRiskAdjustedReturn: 10_125_000, // exactly 0.9 * 11_250_000
+  totalAllocated: 1_890_343.1415,
+};
+
+function freezeAt(iso: string): void {
+  vi.setSystemTime(new Date(iso));
+}
+
+describe('legacy DeterministicReserveEngine characterization', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('pins captured golden allocations and metrics at frozen instant T1', async () => {
+    freezeAt(T1_ISO);
+    const engine = new DeterministicReserveEngine();
+    const result = await engine.calculateOptimalReserveAllocation(baseInput());
+
+    expect(result.allocations.map((a) => a.companyId)).toEqual(GOLDEN_T1.companyIds);
+    expect(result.allocations.map((a) => a.recommendedAllocation)).toEqual(
+      GOLDEN_T1.recommendedAllocations
+    );
+    expect(result.allocations.map((a) => a.priority)).toEqual([1, 2, 3]);
+    expect(result.allocations.map((a) => a.expectedMOIC)).toEqual(GOLDEN_T1.expectedMOICs);
+    expect(result.allocations.map((a) => a.expectedValue)).toEqual(GOLDEN_T1.expectedValues);
+    expect(result.allocations.map((a) => a.riskAdjustedReturn)).toEqual(
+      GOLDEN_T1.riskAdjustedReturns
+    );
+    expect(result.inputSummary.totalAllocated).toBe(GOLDEN_T1.totalAllocated);
+    expect(result.inputSummary.allocationEfficiency).toBe(GOLDEN_T1.allocationEfficiency);
+    expect(result.unallocatedReserves).toBe(GOLDEN_T1.unallocatedReserves);
+    expect(result.portfolioMetrics.expectedPortfolioMOIC).toBe(GOLDEN_T1.expectedPortfolioMOIC);
+    expect(result.portfolioMetrics.expectedPortfolioValue).toBe(GOLDEN_T1.expectedPortfolioValue);
+    // No company is older than 60 engine-months at T1: no risk-factor entries.
+    expect(result.allocations.map((a) => a.riskFactors)).toEqual([[], [], []]);
+  });
+
+  it('pins metadata under a frozen clock: calculationDate is the instant, duration is 0', async () => {
+    freezeAt(T1_ISO);
+    const engine = new DeterministicReserveEngine();
+    const result = await engine.calculateOptimalReserveAllocation(baseInput());
+
+    expect(result.metadata.calculationDate).toEqual(new Date(T1_ISO));
+    // Frozen clock start == end. (The legacy ReserveCalculationResultSchema
+    // declares calculationDuration z.number().positive(), which a frozen run
+    // violates - the engine never parses its own output; pinned as-is.)
+    expect(result.metadata.calculationDuration).toBe(0);
+    expect(result.metadata.modelVersion).toBe('1.0.0');
+  });
+
+  it('pins wall-clock dependence: the 60-month age threshold flips the 0.9 risk multiplier between T1 and T2', async () => {
+    freezeAt(T1_ISO);
+    const engineT1 = new DeterministicReserveEngine();
+    const resultT1 = await engineT1.calculateOptimalReserveAllocation(baseInput());
+
+    freezeAt(T2_ISO);
+    // Fresh engine: the pre-fix per-instance cache would otherwise return the
+    // T1 result verbatim and mask the drift (same 5-field cache key).
+    const engineT2 = new DeterministicReserveEngine();
+    const resultT2 = await engineT2.calculateOptimalReserveAllocation(baseInput());
+
+    const betaT1 = resultT1.allocations.find((a) => a.companyId === BETA_ID)!;
+    const betaT2 = resultT2.allocations.find((a) => a.companyId === BETA_ID)!;
+    expect(betaT1.recommendedAllocation).toBe(GOLDEN_T1.recommendedAllocations[0]);
+    expect(betaT2.recommendedAllocation).toBe(GOLDEN_T2.betaAllocation);
+    expect(betaT2.recommendedAllocation).toBe(betaT1.recommendedAllocation * 0.9);
+    expect(betaT2.riskAdjustedReturn).toBe(GOLDEN_T2.betaRiskAdjustedReturn);
+    expect(betaT2.riskFactors).toEqual(['Risk adjustment applied due to company factors']);
+    expect(resultT2.inputSummary.totalAllocated).toBe(GOLDEN_T2.totalAllocated);
+
+    // Companies that do not cross the age threshold are unchanged.
+    const othersT1 = resultT1.allocations.filter((a) => a.companyId !== BETA_ID);
+    const othersT2 = resultT2.allocations.filter((a) => a.companyId !== BETA_ID);
+    expect(othersT2).toEqual(othersT1);
+  });
+
+  it('is deterministic across engine instances at a fixed instant', async () => {
+    freezeAt(T1_ISO);
+    const first = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(
+      baseInput()
+    );
+    const second = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(
+      baseInput()
+    );
+    expect(second).toEqual(first);
+  });
+
+  it('short-circuits repeat calls on the same instance through the calculation cache', async () => {
+    freezeAt(T1_ISO);
+    const engine = new DeterministicReserveEngine();
+    const first = await engine.calculateOptimalReserveAllocation(baseInput());
+    const second = await engine.calculateOptimalReserveAllocation(baseInput());
+    // A cache hit returns the cached object itself, not a copy.
+    expect(second).toBe(first);
+  });
+
+  it('pins the cache-identity defect: equal-length portfolios with matching scalars collide', async () => {
+    freezeAt(T1_ISO);
+    const engine = new DeterministicReserveEngine();
+    const first = await engine.calculateOptimalReserveAllocation(baseInput());
+    const second = await engine.calculateOptimalReserveAllocation(collidingInput());
+
+    // PRE-FIX PIN (flipped by the Tranche 4 cache-identity fix): the 5-field
+    // cache key ignores portfolio contents, so the second call returns the
+    // FIRST portfolio's result verbatim - a real wrong-output defect. The
+    // colliding portfolio contains Delta/Epsilon/Zeta, yet the allocations
+    // name Alpha/Beta/Gamma.
+    expect(second).toBe(first);
+    expect(second.allocations.map((a) => a.companyId)).toEqual(GOLDEN_T1.companyIds);
+  });
+
+  it('pins the pre-fix cache-key format: base64 JSON of 5 coarse fields, identical across different portfolios', async () => {
+    freezeAt(T1_ISO);
+    const input = baseInput();
+    const result = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(input);
+
+    // PRE-FIX PIN (flipped by the Tranche 4 cache-identity fix): the stamped
+    // deterministicHash covers only portfolioCount/availableReserves/
+    // totalFundSize/scenarioType/timeHorizon.
+    const expectedPreFixHash = Buffer.from(
+      JSON.stringify({
+        portfolioCount: input.portfolio.length,
+        availableReserves: input.availableReserves,
+        totalFundSize: input.totalFundSize,
+        scenarioType: input.scenarioType,
+        timeHorizon: input.timeHorizon,
+      })
+    ).toString('base64');
+    expect(result.metadata.deterministicHash).toBe(expectedPreFixHash);
+
+    // Same defect seen from the metadata side: a completely different
+    // portfolio of the same length carries the same "deterministic" hash.
+    const other = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(
+      collidingInput()
+    );
+    expect(other.metadata.deterministicHash).toBe(result.metadata.deterministicHash);
+  });
+
+  it('holds conservation, ranking, and bound invariants at both instants', async () => {
+    for (const iso of [T1_ISO, T2_ISO]) {
+      freezeAt(iso);
+      const input = baseInput();
+      const result = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(
+        input
+      );
+
+      // Conservation: allocated + unallocated == available reserves.
+      const allocated = result.allocations.reduce((sum, a) => sum + a.recommendedAllocation, 0);
+      expect(allocated + result.unallocatedReserves).toBeCloseTo(input.availableReserves, 6);
+      expect(result.inputSummary.totalAllocated).toBeCloseTo(allocated, 6);
+
+      // Ranking: priorities are 1..n in emitted order.
+      expect(result.allocations.map((a) => a.priority)).toEqual(
+        result.allocations.map((_, i) => i + 1)
+      );
+
+      // Bounds: every allocation clears the minimum threshold and the total
+      // never exceeds the available reserves.
+      for (const allocation of result.allocations) {
+        expect(allocation.recommendedAllocation).toBeGreaterThanOrEqual(
+          input.minAllocationThreshold
+        );
+      }
+      expect(allocated).toBeLessThanOrEqual(input.availableReserves);
+    }
+  });
+
+  it('pins guard-clause rejections: empty portfolio and non-positive reserves throw ReserveCalculationError', async () => {
+    freezeAt(T1_ISO);
+    const engine = new DeterministicReserveEngine();
+    await expect(
+      engine.calculateOptimalReserveAllocation(baseInput({ portfolio: [] }))
+    ).rejects.toThrow(ReserveCalculationError);
+    await expect(
+      engine.calculateOptimalReserveAllocation(baseInput({ availableReserves: -1 }))
+    ).rejects.toThrow(ReserveCalculationError);
+  });
+});

--- a/tests/unit/deterministic-reserve-substrate/deterministic-reserve-engine-characterization.test.ts
+++ b/tests/unit/deterministic-reserve-substrate/deterministic-reserve-engine-characterization.test.ts
@@ -22,8 +22,20 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeterministicReserveEngine } from '../../../shared/core/reserves/DeterministicReserveEngine';
+import { computeDeterministicReserveCacheKey } from '../../../shared/core/reserves/deterministic-reserve-canonical';
 import { ReserveCalculationError } from '../../../shared/schemas/reserves-schemas';
-import { ALPHA_ID, BETA_ID, GAMMA_ID, T1_ISO, T2_ISO, baseInput, collidingInput } from './fixtures';
+import {
+  ALPHA_ID,
+  BETA_ID,
+  DELTA_ID,
+  EPSILON_ID,
+  GAMMA_ID,
+  T1_ISO,
+  T2_ISO,
+  ZETA_ID,
+  baseInput,
+  collidingInput,
+} from './fixtures';
 
 // CAPTURED golden values (frozen instant T1 = 2026-01-01T00:00:00.000Z).
 // Ranking by allocation score: Beta Bio, Alpha Analytics, Gamma Grid.
@@ -146,46 +158,41 @@ describe('legacy DeterministicReserveEngine characterization', () => {
     expect(second).toBe(first);
   });
 
-  it('pins the cache-identity defect: equal-length portfolios with matching scalars collide', async () => {
+  it('no longer collides: equal-length portfolios with matching scalars keep their own results', async () => {
     freezeAt(T1_ISO);
     const engine = new DeterministicReserveEngine();
     const first = await engine.calculateOptimalReserveAllocation(baseInput());
     const second = await engine.calculateOptimalReserveAllocation(collidingInput());
 
-    // PRE-FIX PIN (flipped by the Tranche 4 cache-identity fix): the 5-field
-    // cache key ignores portfolio contents, so the second call returns the
-    // FIRST portfolio's result verbatim - a real wrong-output defect. The
-    // colliding portfolio contains Delta/Epsilon/Zeta, yet the allocations
-    // name Alpha/Beta/Gamma.
-    expect(second).toBe(first);
-    expect(second.allocations.map((a) => a.companyId)).toEqual(GOLDEN_T1.companyIds);
+    // POST-FIX PIN (ADR-045 cache-identity fix). PRE-FIX this asserted
+    // `expect(second).toBe(first)` and that the second call's allocations
+    // named Alpha/Beta/Gamma: the 5-field cache key ignored portfolio
+    // contents, so the second call returned the FIRST portfolio's result
+    // verbatim - a real wrong-output defect. The canonical input identity
+    // now keys each portfolio to its own result.
+    expect(second).not.toBe(first);
+    expect(second.allocations.map((a) => a.companyId)).toEqual([EPSILON_ID, DELTA_ID, ZETA_ID]);
   });
 
-  it('pins the pre-fix cache-key format: base64 JSON of 5 coarse fields, identical across different portfolios', async () => {
+  it('stamps the canonical 64-hex cache key, different across different portfolios', async () => {
     freezeAt(T1_ISO);
     const input = baseInput();
     const result = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(input);
 
-    // PRE-FIX PIN (flipped by the Tranche 4 cache-identity fix): the stamped
-    // deterministicHash covers only portfolioCount/availableReserves/
-    // totalFundSize/scenarioType/timeHorizon.
-    const expectedPreFixHash = Buffer.from(
-      JSON.stringify({
-        portfolioCount: input.portfolio.length,
-        availableReserves: input.availableReserves,
-        totalFundSize: input.totalFundSize,
-        scenarioType: input.scenarioType,
-        timeHorizon: input.timeHorizon,
-      })
-    ).toString('base64');
-    expect(result.metadata.deterministicHash).toBe(expectedPreFixHash);
+    // POST-FIX PIN (ADR-045 cache-identity fix). PRE-FIX the stamped
+    // deterministicHash was the base64 JSON of only portfolioCount/
+    // availableReserves/totalFundSize/scenarioType/timeHorizon
+    // ("eyJwb3J0Zm9saW9Db3VudCI6..."), identical across different
+    // equal-length portfolios. It is now the domain-separated canonical
+    // sha256 of the complete serialized input.
+    expect(result.metadata.deterministicHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.metadata.deterministicHash).toBe(computeDeterministicReserveCacheKey(input));
 
-    // Same defect seen from the metadata side: a completely different
-    // portfolio of the same length carries the same "deterministic" hash.
+    // A different portfolio of the same length now carries a different hash.
     const other = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(
       collidingInput()
     );
-    expect(other.metadata.deterministicHash).toBe(result.metadata.deterministicHash);
+    expect(other.metadata.deterministicHash).not.toBe(result.metadata.deterministicHash);
   });
 
   it('holds conservation, ranking, and bound invariants at both instants', async () => {

--- a/tests/unit/deterministic-reserve-substrate/deterministic-reserve-seam.test.ts
+++ b/tests/unit/deterministic-reserve-substrate/deterministic-reserve-seam.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Seam-correctness proof for the DeterministicReserveEngine capability seam
+ * (Tranche 4, ADR-045).
+ *
+ * The seam adds an optional second constructor parameter
+ * `{ now?: () => number; debugMode?: boolean }` whose defaults preserve the
+ * legacy ambient behavior (Date.now; per-call NODE_ENV read). Correctness is
+ * proven two ways:
+ *
+ * 1. The pre-existing engine suites pass UNMODIFIED (default path untouched).
+ * 2. Here: a seam-injected fixed `now` reproduces the legacy engine's output
+ *    at the same instant - while the SYSTEM clock is frozen at a DIFFERENT
+ *    instant that would change the age-based risk multiplier. Any ambient
+ *    Date.now/new Date() left behind would leak the system instant into
+ *    calculationDate, calculationDuration, or the risk multiplier and break
+ *    the field-for-field equality.
+ *
+ * debugMode has no output surface (it only gates logger.debug calls), so the
+ * capability is exercised (debugMode: false) but has no value assertion.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeterministicReserveEngine } from '../../../shared/core/reserves/DeterministicReserveEngine';
+import { T1_ISO, T1_MS, T2_ISO, baseInput } from './fixtures';
+
+describe('DeterministicReserveEngine capability seam', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('seam-injected fixed now reproduces the legacy engine at the same instant, ignoring the system clock', async () => {
+    // Legacy default path, system clock frozen at T1.
+    vi.setSystemTime(new Date(T1_ISO));
+    const legacy = await new DeterministicReserveEngine().calculateOptimalReserveAllocation(
+      baseInput()
+    );
+
+    // Seam path pinned to T1 while the system clock reads T2 - an instant at
+    // which the age-based risk multiplier WOULD differ (see the
+    // characterization suite), so any unrouted ambient clock read fails this.
+    vi.setSystemTime(new Date(T2_ISO));
+    const seamEngine = new DeterministicReserveEngine(undefined, {
+      now: () => T1_MS,
+      debugMode: false,
+    });
+    const seam = await seamEngine.calculateOptimalReserveAllocation(baseInput());
+
+    expect(seam).toEqual(legacy);
+    expect(seam.metadata.calculationDate).toEqual(new Date(T1_ISO));
+    expect(seam.metadata.calculationDuration).toBe(0);
+  });
+});

--- a/tests/unit/deterministic-reserve-substrate/deterministic-reserve-substrate-adapter.test.ts
+++ b/tests/unit/deterministic-reserve-substrate/deterministic-reserve-substrate-adapter.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Substrate adapter suite for the DeterministicReserveEngine
+ * (Tranche 4, ADR-045).
+ *
+ * Four-part evidence, mirroring Tranches 2/3:
+ * (a) repeat-run byte-identical results with equal 64-hex result hashes;
+ * (b) different inputs, asOf instants, and feature flags change hashes,
+ *     while different SEEDS do not - the engine draws no randomness, so
+ *     seed-invariance is pinned as a disclosed property (no fork label is
+ *     consumed or reserved);
+ * (c) the adapter matches the seam-injected legacy engine field-for-field at
+ *     the same instant, and matches the captured characterization goldens;
+ * (d) mode/kill-switch/invalid-input invariants validate against both the
+ *     deterministic-reserve result schema and GenericCalcResultSchema.
+ *
+ * No fake timers here: the adapter must be clock-injected via ctx, so these
+ * tests run under the REAL system clock and still come out deterministic -
+ * that is itself the point.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  GenericCalcResultSchema,
+  admitForHashing,
+  computeResultHash,
+  createCalculationContext,
+} from '../../../shared/core/calc-substrate';
+import { DeterministicReserveEngine } from '../../../shared/core/reserves/DeterministicReserveEngine';
+import {
+  DEFAULT_DETERMINISTIC_RESERVE_FEATURE_FLAGS,
+  DETERMINISTIC_RESERVE_CALCULATION_KEY,
+  DETERMINISTIC_RESERVE_CALCULATION_VERSION,
+  DETERMINISTIC_RESERVE_ENGINE_VERSION,
+  DETERMINISTIC_RESERVE_METHODOLOGY_VERSION,
+  computeDeterministicReserveCacheKey,
+  runDeterministicReserveWithSubstrate,
+  serializeDeterministicReserveInput,
+  type DeterministicReserveCalcResult,
+} from '../../../shared/core/reserves/deterministic-reserve-substrate-adapter';
+import { ReserveAllocationInputSchema } from '../../../shared/schemas/reserves-schemas';
+import {
+  ALPHA_ID,
+  BETA_ID,
+  GAMMA_ID,
+  T1_ISO,
+  T1_MS,
+  T2_ISO,
+  baseInput,
+  collidingInput,
+} from './fixtures';
+
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+// CAPTURED goldens (see the characterization suite): ranking B/A/C at T1,
+// with Beta Bio taking the 0.9 age multiplier at T2.
+const GOLDEN_T1_ALLOCATIONS = [1_054_687.5, 724_570.3125, 216_554.079];
+const GOLDEN_T1_TOTAL = 1_995_811.8915;
+const GOLDEN_T2_BETA_ALLOCATION = 949_218.75;
+
+function makeCtx(overrides: { seed?: number; asOf?: string } = {}) {
+  return createCalculationContext({
+    calculationKey: DETERMINISTIC_RESERVE_CALCULATION_KEY,
+    seed: overrides.seed ?? 42,
+    asOf: overrides.asOf ?? T1_ISO,
+  });
+}
+
+const ON = { configuredMode: 'on', killSwitchActive: false } as const;
+
+function expectAvailable(
+  result: DeterministicReserveCalcResult
+): Extract<DeterministicReserveCalcResult, { state: 'available' }> {
+  if (result.state !== 'available') {
+    throw new Error(`expected available result, got ${result.state}`);
+  }
+  return result;
+}
+
+describe('deterministic reserve adapter: context guards', () => {
+  it('rejects a context with the wrong calculationKey', async () => {
+    const ctx = createCalculationContext({ calculationKey: 'reserve', seed: 42, asOf: T1_ISO });
+    await expect(runDeterministicReserveWithSubstrate(ctx, baseInput(), ON)).rejects.toThrow(
+      TypeError
+    );
+  });
+
+  it('rejects a context with the wrong contract version', async () => {
+    const bogus = {
+      ...makeCtx(),
+      contractVersion: 'calc-substrate/0.0.1',
+    } as unknown as ReturnType<typeof makeCtx>;
+    await expect(runDeterministicReserveWithSubstrate(bogus, baseInput(), ON)).rejects.toThrow(
+      TypeError
+    );
+  });
+});
+
+describe('deterministic reserve adapter: mode and kill-switch disclosure (evidence d)', () => {
+  it('configured off is unavailable with MODE_OFF, valid under both schemas', async () => {
+    const result = await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), {
+      configuredMode: 'off',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['MODE_OFF']);
+    expect(result.basis.effectiveMode).toBe('off');
+    expect('value' in result).toBe(false);
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+
+  it('kill switch forces unavailable with KILL_SWITCH_ACTIVE even when configured on', async () => {
+    const result = await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), {
+      configuredMode: 'on',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE']);
+    expect(result.basis.effectiveMode).toBe('off');
+    expect(result.basis.killSwitchActive).toBe(true);
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+
+  it('kill switch plus configured off discloses both codes', async () => {
+    const result = await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), {
+      configuredMode: 'off',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE', 'MODE_OFF']);
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+
+  it('shadow mode is indicative with SHADOW_ONLY and carries a hash-bound value', async () => {
+    const result = await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), {
+      configuredMode: 'shadow',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('indicative');
+    expect(result.reasonCodes).toEqual(['SHADOW_ONLY']);
+    if (result.state === 'indicative') {
+      expect(result.resultHash).toMatch(SHA256_HEX_RE);
+      expect(result.value.allocations.length).toBeGreaterThan(0);
+    }
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+
+  it('on mode is available with empty reason codes', async () => {
+    const result = await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON);
+    const available = expectAvailable(result);
+    expect(available.reasonCodes).toEqual([]);
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+});
+
+describe('deterministic reserve adapter: failure disclosure (evidence d)', () => {
+  it('schema-invalid input is failed + INPUT_INVALID with a diagnostic', async () => {
+    const result = await runDeterministicReserveWithSubstrate(makeCtx(), 42, ON);
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['INPUT_INVALID']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('deterministic reserve input rejected');
+    }
+    expect(result.basis.inputHash).toMatch(SHA256_HEX_RE);
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+
+  it('hash-inadmissible garbage collapses onto the disclosed sentinel identity', async () => {
+    const garbageA = { portfolio: () => [] };
+    const garbageB = new Map([['portfolio', []]]);
+    const resultA = await runDeterministicReserveWithSubstrate(makeCtx(), garbageA, ON);
+    const resultB = await runDeterministicReserveWithSubstrate(makeCtx(), garbageB, ON);
+    expect(resultA.state).toBe('failed');
+    expect(resultA.reasonCodes).toEqual(['INPUT_INVALID']);
+    // Both are unparseable AND inadmissible, so both hash the sentinel.
+    expect(resultB.basis.inputHash).toBe(resultA.basis.inputHash);
+  });
+
+  it('an engine throw (ReserveCalculationError) is failed + ENGINE_ERROR, never a silent value', async () => {
+    // An empty portfolio passes the input schema but the engine rejects it.
+    const result = await runDeterministicReserveWithSubstrate(
+      makeCtx(),
+      baseInput({ portfolio: [] }),
+      ON
+    );
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['ENGINE_ERROR']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('Portfolio cannot be empty');
+    }
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+});
+
+describe('deterministic reserve adapter: legacy parity at a fixed instant (evidence c)', () => {
+  it('matches the seam-injected legacy engine field-for-field, plus asOfUtc', async () => {
+    const result = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+
+    const legacy = await new DeterministicReserveEngine(undefined, {
+      now: () => T1_MS,
+      debugMode: false,
+    }).calculateOptimalReserveAllocation(ReserveAllocationInputSchema.parse(baseInput()));
+
+    expect(result.value).toEqual({
+      ...(serializeDeterministicReserveInput(legacy) as Record<string, unknown>),
+      asOfUtc: T1_ISO,
+    });
+  });
+
+  it('matches the captured characterization goldens at T1', async () => {
+    const result = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    expect(result.value.allocations.map((a) => a.companyId)).toEqual([BETA_ID, ALPHA_ID, GAMMA_ID]);
+    expect(result.value.allocations.map((a) => a.recommendedAllocation)).toEqual(
+      GOLDEN_T1_ALLOCATIONS
+    );
+    expect(result.value.inputSummary.totalAllocated).toBe(GOLDEN_T1_TOTAL);
+    expect(result.value.metadata.calculationDate).toBe(T1_ISO);
+    expect(result.value.metadata.modelVersion).toBe(DETERMINISTIC_RESERVE_CALCULATION_VERSION);
+    expect(result.value.metadata.deterministicHash).toBe(
+      computeDeterministicReserveCacheKey(ReserveAllocationInputSchema.parse(baseInput()))
+    );
+    expect(result.value.asOfUtc).toBe(T1_ISO);
+  });
+
+  it('pins calculationDuration to exactly 0 under the injected fixed clock', async () => {
+    const result = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    expect(result.value.metadata.calculationDuration).toBe(0);
+  });
+
+  it('derives the age-based risk multiplier from ctx asOf: T2 applies the 0.9 multiplier', async () => {
+    const result = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx({ asOf: T2_ISO }), baseInput(), ON)
+    );
+    const beta = result.value.allocations.find((a) => a.companyId === BETA_ID)!;
+    expect(beta.recommendedAllocation).toBe(GOLDEN_T2_BETA_ALLOCATION);
+    expect(beta.riskFactors).toEqual(['Risk adjustment applied due to company factors']);
+    expect(result.value.metadata.calculationDate).toBe(T2_ISO);
+    expect(result.value.asOfUtc).toBe(T2_ISO);
+  });
+});
+
+describe('deterministic reserve adapter: determinism and hash evidence (a, b)', () => {
+  it('repeat runs are byte-identical with equal 64-hex result hashes (a)', async () => {
+    const first = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    const second = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    expect(second).toEqual(first);
+    expect(first.resultHash).toMatch(SHA256_HEX_RE);
+    expect(second.resultHash).toBe(first.resultHash);
+  });
+
+  it('is seed-invariant, disclosed: the engine draws no randomness (b)', async () => {
+    const seed42 = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx({ seed: 42 }), baseInput(), ON)
+    );
+    const seedOther = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx({ seed: 20260717 }), baseInput(), ON)
+    );
+    expect(seedOther.value).toEqual(seed42.value);
+    expect(seedOther.resultHash).toBe(seed42.resultHash);
+  });
+
+  it('different inputs change the input hash and the result hash (b)', async () => {
+    const one = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    const two = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), collidingInput(), ON)
+    );
+    expect(two.basis.inputHash).not.toBe(one.basis.inputHash);
+    expect(two.resultHash).not.toBe(one.resultHash);
+  });
+
+  it('a different asOf changes the value and result hash but not the input hash (b)', async () => {
+    const atT1 = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx({ asOf: T1_ISO }), baseInput(), ON)
+    );
+    const atT2 = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx({ asOf: T2_ISO }), baseInput(), ON)
+    );
+    expect(atT2.basis.inputHash).toBe(atT1.basis.inputHash);
+    expect(atT2.resultHash).not.toBe(atT1.resultHash);
+  });
+
+  it('different feature flags change the assumptions hash and the result hash (b)', async () => {
+    const defaults = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    const diversified = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), {
+        ...ON,
+        featureFlags: {
+          ...DEFAULT_DETERMINISTIC_RESERVE_FEATURE_FLAGS,
+          enableAdvancedDiversification: true,
+        },
+      })
+    );
+    expect(diversified.basis.assumptionsHash).not.toBe(defaults.basis.assumptionsHash);
+    expect(diversified.resultHash).not.toBe(defaults.resultHash);
+    // The flag is behavioral, not just declarative: unique-sector companies
+    // receive the 1.1 diversification bonus.
+    expect(diversified.value.allocations[0]!.calculationMetadata.diversificationBonus).toBe(0.1);
+  });
+
+  it('omitting the featureFlags option equals passing the engine defaults explicitly', async () => {
+    const implicit = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    const explicit = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), {
+        ...ON,
+        featureFlags: { ...DEFAULT_DETERMINISTIC_RESERVE_FEATURE_FLAGS },
+      })
+    );
+    expect(explicit).toEqual(implicit);
+    expect(explicit.resultHash).toBe(implicit.resultHash);
+  });
+
+  it('canonical input identity: Date instances, ISO strings, and schema defaults share one hash', async () => {
+    const withDates = baseInput();
+    // JSON round-trip spells every Date as its ISO string.
+    const withStrings = JSON.parse(JSON.stringify(baseInput())) as unknown;
+    // Dropping fields that sit at their schema defaults must not change
+    // identity: parsing fills them back in before hashing.
+    const withDefaultsOmitted = (() => {
+      const input = baseInput() as unknown as Record<string, unknown>;
+      delete input['scenarioType']; // schema default: 'base'
+      delete input['timeHorizon']; // schema default: 84
+      delete input['maxPortfolioConcentration']; // schema default: 0.1
+      return input;
+    })();
+
+    const a = expectAvailable(await runDeterministicReserveWithSubstrate(makeCtx(), withDates, ON));
+    const b = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), withStrings, ON)
+    );
+    const c = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), withDefaultsOmitted, ON)
+    );
+    expect(b.basis.inputHash).toBe(a.basis.inputHash);
+    expect(c.basis.inputHash).toBe(a.basis.inputHash);
+    expect(b.resultHash).toBe(a.resultHash);
+    expect(c.resultHash).toBe(a.resultHash);
+  });
+});
+
+describe('deterministic reserve adapter: hash integrity', () => {
+  it('the value round-trips hash admission and the result hash recomputes (no Dates, no undefined)', async () => {
+    const result = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    expect(() => admitForHashing(result.value)).not.toThrow();
+    expect(computeResultHash(result.basis, result.value)).toBe(result.resultHash);
+  });
+
+  it('pins the basis identity fields', async () => {
+    const result = expectAvailable(
+      await runDeterministicReserveWithSubstrate(makeCtx(), baseInput(), ON)
+    );
+    expect(result.basis.calculationKey).toBe('reserve-deterministic');
+    expect(result.basis.engineVersion).toBe(DETERMINISTIC_RESERVE_ENGINE_VERSION);
+    expect(result.basis.methodologyVersion).toBe(DETERMINISTIC_RESERVE_METHODOLOGY_VERSION);
+    expect(result.basis.inputHash).toMatch(SHA256_HEX_RE);
+    expect(result.basis.assumptionsHash).toMatch(SHA256_HEX_RE);
+  });
+});

--- a/tests/unit/deterministic-reserve-substrate/fixtures.ts
+++ b/tests/unit/deterministic-reserve-substrate/fixtures.ts
@@ -1,0 +1,249 @@
+/**
+ * Shared fixtures for the DeterministicReserveEngine substrate tranche
+ * (Tranche 4, ADR-045).
+ *
+ * All fixtures are schema-valid under ReserveAllocationInputSchema (canonical
+ * snake_case stages, uuid ids, strict graduation-matrix and stage-strategy
+ * shapes) so the SAME inputs drive both the legacy-engine characterization
+ * suite and the substrate adapter suite.
+ *
+ * Frozen instants:
+ * - T1/T2 are one year apart. BETA_BIO's investmentDate (2021-09-01) sits
+ *   ~52.8 engine-months (30-day months) before T1 and ~64.9 before T2, so the
+ *   age>60 risk multiplier (0.9) applies at T2 but not at T1. That single
+ *   crossing is the wall-clock-dependence proof: identical input, different
+ *   frozen instant, different allocations.
+ * - Every other company stays under 60 engine-months at both instants.
+ *
+ * PORTFOLIO_TWO deliberately matches PORTFOLIO_ONE on every field of the
+ * PRE-FIX cache key (portfolio length 3 and identical availableReserves /
+ * totalFundSize / scenarioType / timeHorizon scalars) while containing
+ * entirely different companies. It exists to pin, and then prove fixed, the
+ * cache-identity collision.
+ */
+
+import type {
+  GraduationMatrix,
+  PortfolioCompany,
+  ReserveAllocationInput,
+  StageStrategy,
+} from '../../../shared/schemas/reserves-schemas';
+
+export const T1_ISO = '2026-01-01T00:00:00.000Z';
+export const T2_ISO = '2027-01-01T00:00:00.000Z';
+export const T1_MS = Date.parse(T1_ISO);
+export const T2_MS = Date.parse(T2_ISO);
+
+export const ALPHA_ID = '11111111-1111-4111-8111-111111111111';
+export const BETA_ID = '22222222-2222-4222-8222-222222222222';
+export const GAMMA_ID = '33333333-3333-4333-8333-333333333333';
+export const DELTA_ID = '44444444-4444-4444-8444-444444444444';
+export const EPSILON_ID = '55555555-5555-4555-8555-555555555555';
+export const ZETA_ID = '66666666-6666-4666-8666-666666666666';
+
+function alphaAnalytics(): PortfolioCompany {
+  return {
+    id: ALPHA_ID,
+    name: 'Alpha Analytics',
+    sector: 'Analytics',
+    currentStage: 'seed',
+    totalInvested: 1_000_000,
+    currentValuation: 4_000_000,
+    ownershipPercentage: 0.12,
+    investmentDate: new Date('2024-03-01T00:00:00.000Z'),
+    isActive: true,
+    currentMOIC: 4,
+    confidenceLevel: 0.5,
+    tags: [],
+  };
+}
+
+/** The age-threshold-crossing company: <60 engine-months at T1, >60 at T2. */
+function betaBio(): PortfolioCompany {
+  return {
+    id: BETA_ID,
+    name: 'Beta Bio',
+    sector: 'Healthcare',
+    currentStage: 'series_a',
+    totalInvested: 2_000_000,
+    currentValuation: 10_000_000,
+    ownershipPercentage: 0.08,
+    investmentDate: new Date('2021-09-01T00:00:00.000Z'),
+    isActive: true,
+    currentMOIC: 5,
+    confidenceLevel: 0.5,
+    tags: [],
+  };
+}
+
+function gammaGrid(): PortfolioCompany {
+  return {
+    id: GAMMA_ID,
+    name: 'Gamma Grid',
+    sector: 'Infrastructure',
+    currentStage: 'series_b',
+    totalInvested: 3_000_000,
+    currentValuation: 9_000_000,
+    ownershipPercentage: 0.1,
+    investmentDate: new Date('2023-06-01T00:00:00.000Z'),
+    isActive: true,
+    currentMOIC: 3,
+    confidenceLevel: 0.5,
+    tags: [],
+  };
+}
+
+function deltaDevices(): PortfolioCompany {
+  return {
+    id: DELTA_ID,
+    name: 'Delta Devices',
+    sector: 'Robotics',
+    currentStage: 'seed',
+    totalInvested: 800_000,
+    currentValuation: 3_200_000,
+    ownershipPercentage: 0.09,
+    investmentDate: new Date('2024-05-01T00:00:00.000Z'),
+    isActive: true,
+    currentMOIC: 4,
+    confidenceLevel: 0.5,
+    tags: [],
+  };
+}
+
+function epsilonEnergy(): PortfolioCompany {
+  return {
+    id: EPSILON_ID,
+    name: 'Epsilon Energy',
+    sector: 'Fintech',
+    currentStage: 'series_a',
+    totalInvested: 1_500_000,
+    currentValuation: 9_000_000,
+    ownershipPercentage: 0.07,
+    investmentDate: new Date('2022-11-01T00:00:00.000Z'),
+    isActive: true,
+    currentMOIC: 6,
+    confidenceLevel: 0.5,
+    tags: [],
+  };
+}
+
+function zetaZip(): PortfolioCompany {
+  return {
+    id: ZETA_ID,
+    name: 'Zeta Zip',
+    sector: 'SaaS',
+    currentStage: 'series_b',
+    totalInvested: 2_500_000,
+    currentValuation: 7_500_000,
+    ownershipPercentage: 0.11,
+    investmentDate: new Date('2023-02-01T00:00:00.000Z'),
+    isActive: true,
+    currentMOIC: 3,
+    confidenceLevel: 0.5,
+    tags: [],
+  };
+}
+
+export function graduationMatrix(): GraduationMatrix {
+  return {
+    name: 'Tranche 4 fixture matrix',
+    rates: [
+      {
+        fromStage: 'seed',
+        toStage: 'series_a',
+        probability: 0.5,
+        timeToGraduation: 18,
+        valuationMultiple: 3.0,
+      },
+      {
+        fromStage: 'series_a',
+        toStage: 'series_b',
+        probability: 0.5,
+        timeToGraduation: 24,
+        valuationMultiple: 2.5,
+      },
+      {
+        fromStage: 'series_b',
+        toStage: 'series_c',
+        probability: 0.4,
+        timeToGraduation: 30,
+        valuationMultiple: 2.0,
+      },
+    ],
+  };
+}
+
+export function stageStrategies(): StageStrategy[] {
+  return [
+    {
+      stage: 'seed',
+      targetOwnership: 0.1,
+      maxInvestment: 2_000_000,
+      minInvestment: 100_000,
+      followOnProbability: 0.7,
+      reserveMultiple: 2,
+      failureRate: 0.6,
+      expectedMOIC: 10,
+      expectedTimeToExit: 84,
+      maxConcentration: 0.1,
+      diversificationWeight: 0.5,
+    },
+    {
+      stage: 'series_a',
+      targetOwnership: 0.08,
+      maxInvestment: 4_000_000,
+      minInvestment: 250_000,
+      followOnProbability: 0.8,
+      reserveMultiple: 1.5,
+      failureRate: 0.4,
+      expectedMOIC: 6,
+      expectedTimeToExit: 72,
+      maxConcentration: 0.12,
+      diversificationWeight: 0.6,
+    },
+    {
+      stage: 'series_b',
+      targetOwnership: 0.06,
+      maxInvestment: 6_000_000,
+      minInvestment: 500_000,
+      followOnProbability: 0.85,
+      reserveMultiple: 1.2,
+      failureRate: 0.3,
+      expectedMOIC: 4,
+      expectedTimeToExit: 60,
+      maxConcentration: 0.15,
+      diversificationWeight: 0.7,
+    },
+  ];
+}
+
+export function portfolioOne(): PortfolioCompany[] {
+  return [alphaAnalytics(), betaBio(), gammaGrid()];
+}
+
+export function portfolioTwo(): PortfolioCompany[] {
+  return [deltaDevices(), epsilonEnergy(), zetaZip()];
+}
+
+export function baseInput(overrides: Partial<ReserveAllocationInput> = {}): ReserveAllocationInput {
+  return {
+    portfolio: portfolioOne(),
+    availableReserves: 10_000_000,
+    totalFundSize: 100_000_000,
+    graduationMatrix: graduationMatrix(),
+    stageStrategies: stageStrategies(),
+    minAllocationThreshold: 50_000,
+    maxPortfolioConcentration: 0.1,
+    scenarioType: 'base',
+    timeHorizon: 84,
+    enableDiversification: true,
+    enableRiskAdjustment: true,
+    enableLiquidationPreferences: true,
+    ...overrides,
+  };
+}
+
+/** Same pre-fix cache-key scalars as baseInput, entirely different companies. */
+export function collidingInput(): ReserveAllocationInput {
+  return baseInput({ portfolio: portfolioTwo() });
+}


### PR DESCRIPTION
## Description

Adopts the legacy `DeterministicReserveEngine` (924-line Decimal.js reserve allocation kernel) onto the ADR-042 calculation substrate via a wrapping adapter and two disclosed edits to the engine class. This enables deterministic, auditable reserve calculations within the substrate's hash-bound result framework.

**Key changes:**

1. **Engine capability seam** (`DeterministicReserveEngine.ts`): Added optional constructor parameter `{ now?: () => number; debugMode?: boolean }` to inject ambient capabilities. Routes all five `Date.now()` sites (including the one inside `calculateRiskMultiplier` that derives company age for risk multipliers) and the `new Date()` metadata call through the seam. Defaults preserve legacy ambient behavior exactly.

2. **Cache-identity fix** (`DeterministicReserveEngine.ts`): Replaced the pre-fix 5-field base64 cache key (which caused collisions between different portfolios of equal length with matching scalars) with a domain-separated canonical sha256 over the complete serialized input. Pinned by characterization test.

3. **Wrapping adapter** (`deterministic-reserve-substrate-adapter.ts`): New substrate adapter (calculationKey `reserve-deterministic`) that constructs a fresh engine per run with `now: () => ctx.clock.now().getTime()` and `debugMode: false`, runs the engine against injected `CalculationContext`, and returns a `CalcResult` with validated basis and result hash. The adapter value is the engine result projected JSON-safe (Dates → ISO-8601 UTC strings, undefined properties stripped) plus `asOfUtc` from the injected clock.

4. **Canonical serializer** (`deterministic-reserve-canonical.ts`): Shared module for JSON-safe projection and cache-key identity, consumed by both engine and adapter to avoid circular imports.

## Slice Summary

### Owned Files

- `shared/core/reserves/DeterministicReserveEngine.ts` (modified: seam + cache fix only)
- `shared/core/reserves/deterministic-reserve-substrate-adapter.ts` (new)
- `shared/core/reserves/deterministic-reserve-canonical.ts` (new)
- `tests/unit/deterministic-reserve-substrate/deterministic-reserve-substrate-adapter.test.ts` (new)
- `tests/unit/deterministic-reserve-substrate/deterministic-reserve-engine-characterization.test.ts` (new)
- `tests/unit/deterministic-reserve-substrate/deterministic-reserve-seam.test.ts` (new)
- `tests/unit/deterministic-reserve-substrate/ambient-guard.test.ts` (new)
- `tests/unit/deterministic-reserve-substrate/fixtures.ts` (new)
- `DECISIONS.md` (modified: ADR-045 entry)
- `CHANGELOG.md` (modified: Tranche 4 entry)

### Explicit Non-Goals

- Restating the 924-line kernel (rejected; wrapping preserves single implementation)
- Modifying the engine's Decimal.js configuration or feature-flag defaults
- Consuming fork labels or seeding randomness (engine draws no randomness; seed-invariance is disclosed)
- Rewiring client-side wizard or server-side adapter instantiation (backward-compatible seam, deferred to later tranche)

### Schema Or Contract Impact

**New calculation key:** `reserve-deterministic` (substrate calculationKey)

**New result schema:** `DeterministicReserveCalcResultSchema` (strict JSON-safe mirror of legacy result shape, not the legacy `ReserveCalculationResultSchema` which requires positive `calculationDuration` and strictly positive money fields the engine does not guarantee)

**Disclosed deviations from Tranche 2/3:**
- Value numbers stay plain finite JSON numbers (not whole-dollar decimal strings) because the engine emits fractional Decimal-derived amounts
- `inputHash` covers canonical parsed-input serialization (dates as ISO strings, defaults filled), not raw input, so equivalent spellings share one identity
- `calculationDuration` is deterministically 0 under

https://claude.ai/code/session_01Sx4YqGyPvoGHPCDnxjyqov