### PR TITLE
feat(reserves): Tranche 5 substrate adoption of ConstrainedReserveEngine (ADR-046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,39 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added (2026-07-18)
+
+- **Tranche 5 ConstrainedReserveEngine substrate adoption (ADR-046).** The
+  constrained greedy reserve engine now runs against an injected
+  `CalculationContext` via a WRAPPING adapter
+  `shared/core/reserves/constrained-reserve-substrate-adapter.ts`
+  (calculationKey `reserve-constrained`) with ZERO edits to the engine - the
+  first tranche whose adopted engine's source is touched zero times. The engine
+  draws no randomness, does no ambient read (Date.now / new Date / process.env /
+  Math.random all zero), holds no cache, and sets no global Decimal config
+  (exact BigInt cents), so unlike Tranche 4 it needs no capability seam and no
+  cache-identity fix. The synchronous adapter (mirroring Tranche 3, not Tranche
+  4's async form) wraps a fresh stateless engine per run, projects the result
+  JSON-safe with the three money fields as fixed 2-decimal strings (disclosed
+  deviation from Tranche 4's plain numbers, justified because the amounts are
+  exact cents), hashes the RAW input under `admitForHashing` with the
+  inadmissible-sentinel fallback (Tranche 3 pattern, not Tranche 4's
+  parsed-input hashing), and restates the frozen methodology (PV/score formula,
+  engine fallbacks 5/0.5/0.12, ConstraintsSchema documented defaults, cents
+  rounding, MAX_COMPANY_CAP_CENTS, tie-break, greedy fill) as the assumptions
+  hash - kept honest by an introspection parity test against the live
+  `ConstraintsSchema`. The value is seed-invariant (disclosed and pinned); no
+  fork label is consumed or reserved. 35 new tests
+  (`tests/unit/constrained-reserve-substrate/`) pin HAND-DERIVED goldens (a
+  return to the Tranche 2/3 discipline, contrasted with Tranche 4's captured
+  goldens) across every branch (score/name/id tie-break, per-company and
+  per-stage caps, minCheck skip, exhaustion, empty companies, cent precision,
+  and both engine throws), prove four-part
+  parity/determinism/seed-invariance/hash evidence against both result schemas,
+  and guard the adapter against ambient reads. With this tranche all four
+  reserve/pacing calc engines are adapter-backed; the engine file diff is empty
+  and no consumers were rewired.
+
 ### Added (2026-07-17)
 
 - **Tranche 4 DeterministicReserveEngine substrate adoption (ADR-045).** The

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6959,3 +6959,221 @@ engine suites and the pacing/reserve/calc-substrate suites byte-green):
 seam and cache-identity fix inside
 `shared/core/reserves/DeterministicReserveEngine.ts`, plus
 `tests/unit/deterministic-reserve-substrate/` (34 tests).
+
+## ADR-046: Tranche 5 Substrate Adoption of the ConstrainedReserveEngine (Demo Scope)
+
+**Date:** 2026-07-18 **Status:** [ACCEPTED] Implemented (demo scope)
+**Decision:** Adopt `shared/core/reserves/ConstrainedReserveEngine.ts` onto the
+ADR-042 calculation substrate via a WRAPPING (not restating) adapter
+(`shared/core/reserves/constrained-reserve-substrate-adapter.ts`, calculationKey
+`reserve-constrained`) and ZERO edits to the engine. Restating the pure greedy
+kernel was rejected (no reason to duplicate a deterministic function). A
+capability seam was rejected as unnecessary: the engine performs no ambient
+read. A cache-identity fix was rejected as unnecessary: there is no cache. This
+is the first tranche whose adopted engine's source is touched ZERO times - a
+disclosable property. Same owner-granted demo override of program-governance
+gates as ADR-042/043/044/045; technical invariants (determinism, hash integrity,
+disclosure of suppressed results, no silent financial fabrication) are enforced
+in code and tests. With this tranche all four reserve/pacing engines (pacing =
+T2, rule/ML reserve = T3, deterministic reserve = T4, constrained reserve = T5)
+are adapter-backed.
+
+### Context: verified audit (re-verified on the tranche branch)
+
+- **Zero ambient reads.** The engine (147 lines) has no `Date.now`, no
+  `new Date`, no `process.env`, no `Math.random` (all four scanned to zero
+  occurrences). No output field and no math branch depends on the wall clock, so
+  there is nothing to inject and no seam to add. The ambient-guard test scans
+  only the adapter.
+- **No randomness.** Ordering is a deterministic score sort with a stable
+  tie-break (descending `score`, ties broken by
+  `a.name.localeCompare(b.name) || a.id.localeCompare(b.id)`). Consequently the
+  adapter value is seed-invariant (disclosed and pinned, as ADR-044/045 did). NO
+  fork label is consumed and none is reserved: there is nothing to migrate onto
+  `ctx.rng`.
+- **No cache, no global mutation.** The engine holds no calculation cache, sets
+  no global `Decimal` config (it works in exact BigInt cents via
+  `shared/lib/cents.ts`), and mutates nothing module-scoped. The only module
+  constant is `MAX_COMPANY_CAP_CENTS = BigInt(Number.MAX_SAFE_INTEGER)`. There
+  is no cache-identity defect to repair (contrast ADR-045).
+- **Exact-cents money.** Every returned amount is `fromCents` of a BigInt, i.e.
+  an exact 2-decimal value, non-negative by construction; conservation
+  (`in == out`) holds to the cent, so `conservationOk` is always true.
+- **Math pinned in characterization.** `disc = discountRateAnnual ?? 0.12`; per
+  company `yearsToExit = graduationYears[stage] ?? 5`,
+  `exitProb = graduationProb[stage] ?? 0.5`,
+  `discountFactor = (1 + disc) ** yearsToExit`,
+  `pv = (reserveMultiple * exitProb) / discountFactor`, `score = pv * weight`;
+  then a single greedy pass fills each company up to
+  `min(remaining, stageRoom, companyCap)`. Reachable throws (mapped to
+  ENGINE_ERROR): `No policy for {stage}` (a schema-valid input can still hit
+  this, since the stage/policy cross-check lives in `validateReserveInput`, not
+  `ReserveInputSchema`) and `Invalid discount calculation for stage {stage}`
+  (reachable via `discountRateAnnual: 1` with a large `graduationYears`, which
+  overflows `discountFactor` to non-finite).
+- **Input-type note.** The engine consumes `ReserveInput` from
+  `shared/schemas.ts` (`ReserveInputSchema`), NOT the `reserves-schemas.ts`
+  `ReserveAllocationInput` used by ADR-045. It has no Date fields, so the RAW
+  input is directly hash-admissible - EXCEPT an explicit non-finite
+  `maxPerCompany` (`nonNegative()` admits `Infinity`). Because
+  `ConstraintsSchema` is `.partial()`, its field defaults (including
+  `maxPerCompany: Infinity`) are suppressed on parse, so the parsed input
+  reintroduces no Infinity of its own and the plan's stated premise (parsed
+  default Infinity) does not actually arise; raw-input hashing is still chosen
+  for ADR-043/044 consistency and to cover an explicitly-passed non-finite cap
+  via the sentinel.
+
+### Disposition table
+
+| Surface                                                                                                                       | Disposition | Notes                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| `shared/core/reserves/ConstrainedReserveEngine.ts`                                                                            | adapt       | WRAPPED with ZERO source edits; the engine file diff is empty (the whole point of this tranche) |
+| `shared/core/reserves/constrained-reserve-substrate-adapter.ts`                                                               | new         | Synchronous wrapping adapter, calculationKey `reserve-constrained`                              |
+| `client/src/core/reserves/ConstrainedReserveEngine.ts` (re-export shim)                                                       | reuse       | One-line re-export, no fork/drift risk; untouched                                               |
+| `server/routes/v1/reserves.ts`                                                                                                | defer       | Live consumer: constructs the engine and calls `.calculate()`; NOT rewired this tranche         |
+| `client/src/lib/excel-parity-validator.ts`                                                                                    | defer       | Constructs the engine for Excel parity tooling; unchanged                                       |
+| `server/core/reserves/adapter.ts`                                                                                             | defer       | Type-only import plus an injected engine instance; unchanged                                    |
+| `scripts/backtest.ts`, `scripts/validate-excel-parity.ts`                                                                     | defer       | Dev tooling (via the client shim), not production surfaces                                      |
+| Pre-existing tests (`ConstrainedReserveEngine.test.ts`, `adapter-unit-guard`, `phase3-critical-bugs`, `funds-boundary-guard`) | reuse       | Pass UNMODIFIED - the zero-edits proof                                                          |
+| `ReserveEngine.ts` / `DeterministicReserveEngine.ts`                                                                          | untouched   | Prior tranches (ADR-044/045); out of scope                                                      |
+
+### Decision details
+
+- **Wrapping, not restating (zero engine edits).** The adapter constructs a
+  fresh `ConstrainedReserveEngine` per run and calls its single synchronous
+  `calculate(parsedInput)`. The engine is stateless, so a fresh instance is
+  trivial and guarantees no cross-call state. The entry
+  `runConstrainedReserveWithSubstrate(ctx, input, options)` is SYNCHRONOUS
+  (mirroring the ADR-044 reserve adapter, not ADR-045's async one); `options` is
+  `{ configuredMode, killSwitchActive }` with no algorithm option (the engine
+  has no ML/env branch). Context contract-version and calculationKey are guarded
+  as in the precedents.
+- **Value boundary (disclosed money-as-2dp-string choice).** The value is the
+  engine result projected JSON-safe: `allocations`
+  (`{ id, name, stage, allocated }[]`), `totalAllocated`, `remaining`,
+  `conservationOk`, plus `asOfUtc` from `ctx.clock.isoNow()`. The three money
+  fields are emitted as fixed 2-decimal strings. This differs from ADR-045's
+  plain-numbers choice precisely because these outputs are exact cents rather
+  than irrational Decimal amounts: a 2dp string fabricates no precision and
+  restores the ADR-043/044 money-as-string discipline. Hash admission normalizes
+  "30000.00" -> "30000", so identities never depend on the padded spelling. The
+  value schema is strict; a test round-trips every emitted value through
+  `admitForHashing`, and a cents fixture ($100.55) proves the boundary is
+  cent-faithful, not whole-dollar-rounded. **Considered alternative:** plain
+  finite numbers a la ADR-045 - rejected because whole-dollar strings would lose
+  the cents while plain numbers would drop the money-as-string discipline the
+  exact-cents values make cheap to keep.
+- **Hashes (raw-input choice).** `inputHash` = `canonicalSha256` over
+  `{ domain: 'updog.reserve-constrained.input-hash', input: admitForHashing(rawInput) }`
+  with the inadmissible-sentinel fallback (`{ inadmissibleInput: true }`) - the
+  ADR-043/044 pattern, NOT ADR-045's parsed-input hashing. The common
+  omitted-constraints input is directly admissible. The one
+  schema-valid-but-inadmissible case is an explicit `maxPerCompany: Infinity`,
+  which collapses onto the sentinel; two inputs differing only elsewhere while
+  both pinning `maxPerCompany: Infinity` therefore share one input identity - a
+  disclosed consequence of raw hashing (as equivalent spellings were in
+  ADR-044), pinned by a collision test. `assumptionsHash` covers the domain
+  `updog.reserve-constrained.assumptions-hash`, the methodology version, and the
+  frozen methodology: the PV/score formula identity, the engine flat fallbacks
+  (`yearsToExit` 5, `exitProb` 0.5, `disc` 0.12), the ConstraintsSchema
+  documented defaults (minCheck 0, discountRateAnnual 0.12, maxPerStage {},
+  maxPerCompany "unbounded", the graduationYears/graduationProb per-stage
+  default maps), the cents rounding rule (half-away-from-zero to whole cents),
+  `MAX_COMPANY_CAP_CENTS`, the ranking tie-break, and the greedy-fill rule. A
+  restatement parity test extracts the live `ConstraintsSchema` defaults by
+  introspection and pins them against the restatement; the flat fallbacks are
+  kept honest by the characterization goldens (change one and the hand-derived
+  allocations move). **Honest subtlety recorded:** because `ConstraintsSchema`
+  is `.partial()`, the `graduationYears`/`graduationProb` per-stage default maps
+  never materialize on parse, so the engine's flat `?? 5` / `?? 0.5` fallbacks -
+  not those maps - govern an omitted-constraints run; both are recorded in the
+  assumptions hash for completeness. `resultHash` uses the substrate
+  `computeResultHash` unchanged.
+- **Goldens: hand-derived, not captured.** Every golden in
+  `tests/unit/constrained-reserve-substrate/fixtures.ts` is HAND-DERIVED in
+  cents from the formula and greedy fill - a deliberate return to the
+  ADR-043/044 discipline, in contrast with ADR-045's captured-then-frozen
+  goldens (necessary there because a 924-line Decimal.js kernel is not
+  pencil-derivable). The ordering rationale (pv/score) lives in comments; the
+  observable golden is the allocation set, which the engine exposes and the
+  characterization suite pins.
+- **Result semantics.** `on` -> `available`; `shadow` -> `indicative` with
+  `SHADOW_ONLY`; configured `off` -> `unavailable` with `MODE_OFF`; kill switch
+  -> effective `off`, `unavailable` with `KILL_SWITCH_ACTIVE` (both codes when
+  both apply); schema-invalid input (e.g. empty `stagePolicies`) -> `failed`
+  with `INPUT_INVALID` and a diagnostic; engine throw -> `failed` with
+  `ENGINE_ERROR`. Empty `companies` is a valid input -> `available` with empty
+  allocations, zero totals, and `remaining == availableReserves` (a faithful
+  empty result, not `unavailable`). Every non-available path carries at least
+  one registered reason code; there is no silent fallback.
+- **Versions.** `engineVersion: constrained-reserve-engine/1.0.0`,
+  `methodologyVersion: constrained-reserve-methodology/1.0.0`. Changing the
+  kernel math, the cents rounding rule, the tie-break, the caps, or the hash
+  domains bumps the methodology or engine version.
+
+### Alternatives considered
+
+- **Restate the kernel (ADR-043/044 style):** rejected; the engine is a pure,
+  ambient-free, deterministic function, so duplicating it into the adapter would
+  add a second copy to keep in sync for no benefit. Wrapping is strictly simpler
+  and needs zero engine edits.
+- **Add a capability seam (ADR-045 style):** rejected as unnecessary; the engine
+  reads no wall clock, env, or randomness.
+- **Fix a cache identity (ADR-045 style):** rejected as unnecessary; there is no
+  cache.
+- **Emit plain finite numbers (ADR-045 boundary):** rejected; the amounts are
+  exact cents, so a 2dp decimal string is faithful and keeps the money-as-string
+  discipline.
+- **Hash the schema-parsed input (ADR-045 boundary):** rejected; the raw input
+  has no Dates and (`.partial()` suppression) no Infinity of its own, so raw
+  hashing works with the sentinel fallback and matches ADR-043/044.
+- **Capture goldens (ADR-045 boundary):** rejected; the math is hand-derivable,
+  so hand-derived goldens double as a specification.
+
+### Parity evidence summary
+
+`tests/unit/constrained-reserve-substrate/` (35 tests, all green; the
+pacing/reserve/deterministic-reserve/calc-substrate suites and the pre-existing
+`ConstrainedReserveEngine` fast-check suite stay byte-green; the engine file
+diff is empty):
+
+- Characterization (12) pins the legacy engine BEFORE adoption on eight
+  hand-authored fixtures: score ordering across stages with reserve exhaustion
+  and the filtered-out zero; the per-company cap with the name tie-break; the
+  per-stage cap with a stage-room skip; the minCheck skip; the empty-companies
+  faithful-empty result; the full tie-break ladder (score -> name -> id); a
+  cent-precision case ($100.55); the `No policy` and invalid-discount throws
+  (message + status 400); and conservation/bounds/determinism invariants across
+  the value fixtures.
+- Adapter (22) proves: repeat-run byte-identical results with equal 64-hex
+  result hashes; different inputs change both hashes; a different asOf changes
+  the result hash but not the input hash; DISCLOSED seed-invariance (different
+  ctx seeds -> identical value and hash); field-for-field parity with a freshly
+  constructed engine plus the hand-derived 2dp-string goldens; cent-faithful
+  money and boundary-preserved tie-break order; mode/kill-switch/invalid-input/
+  engine-throw invariants against BOTH the tranche and generic result schemas;
+  value round-trips `admitForHashing`; the disclosed raw-hashing Infinity
+  collision; the assumptions restatement pinned against the live
+  `ConstraintsSchema`; and the context calculationKey guard.
+- An ambient-state source guard (1) scans ONLY the adapter for `Math.random`,
+  argless `new Date()`, `Date.now`, and `process.env` (the engine is clean and
+  not scanned).
+
+### Consequences
+
+- ConstrainedReserveEngine can now run against an injected `CalculationContext`
+  and emit a hash-bound `CalcResult`; `server/routes/v1/reserves.ts` and the
+  Excel parity validator keep the legacy `.calculate()` path (no consumer
+  rewiring this tranche).
+- All four reserve/pacing calc engines are now adapter-backed, which unblocks
+  the two still-open program slices for future tranches: **wire a consumer**
+  (route a live caller such as `server/routes/v1/reserves.ts` through the
+  adapter with a resolved mode) and **modes-registry wiring**
+  (`fund_calculation_modes` / kill-switch persistence feeding `configuredMode`
+  and `killSwitchActive`). Both remain out of scope here per the tranche plan,
+  alongside DB rows/migrations, flags registry, UI, queues, and Monte Carlo.
+
+**Implementation:**
+`shared/core/reserves/constrained-reserve-substrate-adapter.ts` (new; the engine
+is wrapped unchanged) plus `tests/unit/constrained-reserve-substrate/` (35
+tests: fixtures, characterization, adapter/evidence, ambient guard).

--- a/shared/core/reserves/constrained-reserve-substrate-adapter.ts
+++ b/shared/core/reserves/constrained-reserve-substrate-adapter.ts
@@ -1,0 +1,314 @@
+/**
+ * ConstrainedReserveEngine substrate adapter (Tranche 5, ADR-046).
+ *
+ * Runs the legacy ConstrainedReserveEngine against an injected
+ * CalculationContext and returns a CalcResult with a validated basis and result
+ * hash. Like Tranche 4 this adapter WRAPS the legacy class rather than
+ * restating its kernel; unlike Tranche 4 it touches the adopted engine's source
+ * ZERO times. The engine needs no capability seam and no cache-identity fix:
+ *
+ * - It draws NO randomness (no Math.random, no PRNG, no seed) - the greedy fill
+ *   runs in a deterministic score sort with a stable name/id tie-break. The
+ *   adapter value is therefore seed-invariant (disclosed and pinned, as
+ *   ADR-044/045 did); no fork label is consumed or reserved.
+ * - It performs NO ambient read (zero Date.now / new Date / process.env /
+ *   Math.random occurrences) and emits no wall-clock-derived value, so there is
+ *   nothing to inject and no seam to add.
+ * - It has NO calculation cache and NO global mutation (no Decimal config); it
+ *   works in exact BigInt cents via shared/lib/cents.ts, so there is no
+ *   cache-identity defect to repair.
+ *
+ * The adapter constructs a fresh (stateless) engine per call and invokes its
+ * single synchronous `calculate(input)` method. The entry point is SYNCHRONOUS,
+ * mirroring the Tranche 3 reserve adapter rather than Tranche 4's async one.
+ *
+ * Boundary conventions and disclosed deviations (ADR-046):
+ * - The three money fields (per-allocation `allocated`, `totalAllocated`,
+ *   `remaining`) are emitted as fixed 2-decimal strings. This differs from
+ *   Tranche 4's plain-numbers choice precisely because these outputs are exact
+ *   cents (`fromCents` of a BigInt), not irrational Decimal amounts: a 2dp
+ *   string fabricates no precision and restores the Tranche 2/3 money-as-string
+ *   discipline. Hash admission normalizes "30000.00" -> "30000", so identities
+ *   never depend on the padded spelling. Plain finite numbers (the Tranche 4
+ *   choice) were the considered alternative.
+ * - inputHash covers the RAW input under `admitForHashing` with an
+ *   inadmissible-sentinel fallback (the Tranche 3 pattern), NOT the schema-
+ *   parsed input as in Tranche 4. The raw input carries no Date instances, and
+ *   for the common omitted-constraints case no non-finite number either, so it
+ *   is directly admissible. The one schema-valid-but-inadmissible case is an
+ *   explicit non-finite `maxPerCompany` (nonNegative() admits Infinity); such
+ *   an input collapses onto the sentinel, so two inputs differing only
+ *   elsewhere while both pinning `maxPerCompany: Infinity` share one input
+ *   identity - a disclosed consequence of raw hashing (as equivalent spellings
+ *   were in Tranche 3). Hashing the parsed input would not help: Zod's
+ *   `.partial()` suppresses the ConstraintsSchema `maxPerCompany` default, so
+ *   the parsed input reintroduces no Infinity of its own.
+ *
+ * Result semantics (identical to ADR-043/044/045): on -> available; shadow ->
+ * indicative + SHADOW_ONLY; configured off -> unavailable + MODE_OFF; kill
+ * switch -> unavailable + KILL_SWITCH_ACTIVE (both codes when both apply);
+ * schema-invalid input -> failed + INPUT_INVALID with a diagnostic; engine
+ * throw (e.g. "No policy for {stage}", "Invalid discount calculation") ->
+ * failed + ENGINE_ERROR. Every non-available path carries at least one
+ * registered reason code; there is no silent fallback.
+ */
+
+import { z } from 'zod';
+import { canonicalSha256 } from '../../lib/canonical-hash';
+import { ReserveInputSchema } from '../../schemas';
+import {
+  CALC_SUBSTRATE_CONTRACT_VERSION,
+  CalcBasisSchema,
+  admitForHashing,
+  computeResultHash,
+  createCalcResultSchema,
+  type CalcBasis,
+  type CalcMode,
+  type CalcReasonCode,
+  type CalculationContext,
+} from '../calc-substrate';
+import { ConstrainedReserveEngine } from './ConstrainedReserveEngine';
+
+export const CONSTRAINED_RESERVE_CALCULATION_KEY = 'reserve-constrained';
+export const CONSTRAINED_RESERVE_ENGINE_VERSION = 'constrained-reserve-engine/1.0.0';
+export const CONSTRAINED_RESERVE_METHODOLOGY_VERSION = 'constrained-reserve-methodology/1.0.0';
+export const CONSTRAINED_RESERVE_INPUT_HASH_DOMAIN = 'updog.reserve-constrained.input-hash';
+export const CONSTRAINED_RESERVE_ASSUMPTIONS_HASH_DOMAIN =
+  'updog.reserve-constrained.assumptions-hash';
+
+/**
+ * Frozen methodology, hashed into every basis as the assumptions preimage.
+ *
+ * `engineFallbacks` are the flat values the engine substitutes when a
+ * constraint field is absent (ConstrainedReserveEngine.ts: `yearsToExit ?? 5`,
+ * `exitProb ?? 0.5`, `disc ?? 0.12`); the characterization goldens keep them
+ * honest (change one and the hand-derived allocations move). `constraintDefaults`
+ * are the ConstraintsSchema-ADVERTISED defaults - restated as documented and
+ * pinned by an introspection parity test. Note the honest subtlety: because
+ * ConstraintsSchema is `.partial()`, its `graduationYears`/`graduationProb`
+ * per-stage default maps never materialize on parse, so the engine's flat
+ * fallbacks (5, 0.5), not those maps, govern an omitted-constraints run. Both
+ * are recorded here for completeness. `maxCompanyCapCents` mirrors the engine's
+ * `MAX_COMPANY_CAP_CENTS = BigInt(Number.MAX_SAFE_INTEGER)` as an admissible
+ * finite number (bigint is not hash-admissible).
+ */
+const CONSTRAINED_RESERVE_ASSUMPTIONS = {
+  formula: {
+    discountFactor: '(1 + discountRateAnnual) ** yearsToExit',
+    presentValue: '(reserveMultiple * exitProb) / discountFactor',
+    score: 'presentValue * weight',
+  },
+  engineFallbacks: {
+    yearsToExit: 5,
+    exitProb: 0.5,
+    discountRateAnnual: 0.12,
+  },
+  constraintDefaults: {
+    minCheck: 0,
+    discountRateAnnual: 0.12,
+    maxPerStage: {},
+    maxPerCompany: 'unbounded',
+    graduationYears: {
+      preseed: 8,
+      seed: 7,
+      series_a: 6,
+      series_b: 5,
+      series_c: 4,
+      series_dplus: 3,
+    },
+    graduationProb: {
+      preseed: 0.1,
+      seed: 0.2,
+      series_a: 0.35,
+      series_b: 0.5,
+      series_c: 0.65,
+      series_dplus: 0.8,
+    },
+  },
+  centsRounding: 'half-away-from-zero-to-whole-cents',
+  maxCompanyCapCents: Number.MAX_SAFE_INTEGER,
+  ranking: 'score desc, then name asc (localeCompare), then id asc (localeCompare)',
+  greedyFill:
+    'single pass in ranked order; each company fills min(remaining, stageRoom, companyCap); skip when room <= 0 or (minCheck > 0 and room < minCheck)',
+  moneyBoundary: 'engine BigInt cents rendered as fixed 2-decimal strings',
+} as const;
+
+const MONEY_DECIMAL_RE = /^(0|[1-9]\d*)\.\d{2}$/;
+const MoneyDecimalSchema = z
+  .string()
+  .regex(MONEY_DECIMAL_RE, 'non-negative fixed 2-decimal dollar string');
+
+const ISO_UTC_MS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const IsoUtcStringSchema = z.string().regex(ISO_UTC_MS_RE, 'ISO-8601 UTC string (ms precision)');
+
+const ConstrainedReserveAllocationValueSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string(),
+    stage: z.string().min(1),
+    allocated: MoneyDecimalSchema,
+  })
+  .strict();
+
+export const ConstrainedReserveCalcValueSchema = z
+  .object({
+    allocations: z.array(ConstrainedReserveAllocationValueSchema),
+    totalAllocated: MoneyDecimalSchema,
+    remaining: MoneyDecimalSchema,
+    conservationOk: z.boolean(),
+    asOfUtc: IsoUtcStringSchema,
+  })
+  .strict();
+
+export type ConstrainedReserveCalcValue = z.infer<typeof ConstrainedReserveCalcValueSchema>;
+
+export const ConstrainedReserveCalcResultSchema = createCalcResultSchema(
+  ConstrainedReserveCalcValueSchema
+);
+export type ConstrainedReserveCalcResult = z.infer<typeof ConstrainedReserveCalcResultSchema>;
+
+export interface ConstrainedReserveSubstrateOptions {
+  configuredMode: CalcMode;
+  killSwitchActive: boolean;
+}
+
+/**
+ * Renders an engine money amount (an exact 2-decimal cents value produced by
+ * `fromCents`) as a fixed 2dp decimal string. Recovering the integer cents with
+ * Math.round before formatting avoids both a toFixed half-cent artifact and any
+ * exponential notation for large magnitudes; the amounts are non-negative by
+ * construction, but the sign is handled defensively.
+ */
+function toMoneyDecimalString(amount: number): string {
+  if (!Number.isFinite(amount)) {
+    throw new TypeError(`constrained reserve amount must be finite, received ${String(amount)}`);
+  }
+  const cents = Math.round(amount * 100);
+  const sign = cents < 0 ? '-' : '';
+  const abs = Math.abs(cents);
+  const whole = Math.trunc(abs / 100);
+  const frac = abs % 100;
+  return `${sign}${whole}.${frac.toString().padStart(2, '0')}`;
+}
+
+export function computeConstrainedReserveInputHash(input: unknown): string {
+  let admitted: unknown;
+  try {
+    admitted = admitForHashing(input);
+  } catch {
+    // The raw input cannot be canonically hashed (an explicit non-finite
+    // maxPerCompany, undefined, NaN, ...). The basis still needs a
+    // deterministic input identity, and any accompanying failure discloses the
+    // rejection via INPUT_INVALID (schema-invalid) or ENGINE_ERROR.
+    admitted = { inadmissibleInput: true };
+  }
+  return canonicalSha256({ domain: CONSTRAINED_RESERVE_INPUT_HASH_DOMAIN, input: admitted });
+}
+
+export function computeConstrainedReserveAssumptionsHash(): string {
+  return canonicalSha256({
+    domain: CONSTRAINED_RESERVE_ASSUMPTIONS_HASH_DOMAIN,
+    methodologyVersion: CONSTRAINED_RESERVE_METHODOLOGY_VERSION,
+    assumptions: admitForHashing(CONSTRAINED_RESERVE_ASSUMPTIONS),
+  });
+}
+
+/** Test-only view of the frozen methodology, for the restatement parity test. */
+export const CONSTRAINED_RESERVE_ASSUMPTIONS_VIEW = CONSTRAINED_RESERVE_ASSUMPTIONS;
+
+export function runConstrainedReserveWithSubstrate(
+  ctx: CalculationContext,
+  input: unknown,
+  options: ConstrainedReserveSubstrateOptions
+): ConstrainedReserveCalcResult {
+  if (ctx.contractVersion !== CALC_SUBSTRATE_CONTRACT_VERSION) {
+    throw new TypeError(
+      `constrained reserve adapter requires contract ${CALC_SUBSTRATE_CONTRACT_VERSION}, received ${String(
+        ctx.contractVersion
+      )}`
+    );
+  }
+  if (ctx.calculationKey !== CONSTRAINED_RESERVE_CALCULATION_KEY) {
+    throw new TypeError(
+      `constrained reserve adapter requires calculationKey '${CONSTRAINED_RESERVE_CALCULATION_KEY}', received '${ctx.calculationKey}'`
+    );
+  }
+
+  const effectiveMode: CalcMode = options.killSwitchActive ? 'off' : options.configuredMode;
+
+  const basis: CalcBasis = CalcBasisSchema.parse({
+    contractVersion: CALC_SUBSTRATE_CONTRACT_VERSION,
+    calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+    configuredMode: options.configuredMode,
+    effectiveMode,
+    killSwitchActive: options.killSwitchActive,
+    engineVersion: CONSTRAINED_RESERVE_ENGINE_VERSION,
+    methodologyVersion: CONSTRAINED_RESERVE_METHODOLOGY_VERSION,
+    inputHash: computeConstrainedReserveInputHash(input),
+    assumptionsHash: computeConstrainedReserveAssumptionsHash(),
+  });
+
+  if (effectiveMode === 'off') {
+    const reasonCodes: CalcReasonCode[] = [];
+    if (options.killSwitchActive) {
+      reasonCodes.push('KILL_SWITCH_ACTIVE');
+    }
+    if (options.configuredMode === 'off') {
+      reasonCodes.push('MODE_OFF');
+    }
+    return ConstrainedReserveCalcResultSchema.parse({ state: 'unavailable', basis, reasonCodes });
+  }
+
+  const parsed = ReserveInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return ConstrainedReserveCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['INPUT_INVALID'],
+      diagnostic: `constrained reserve input rejected: ${parsed.error.message}`,
+    });
+  }
+
+  try {
+    // Fresh instance per run; the engine is stateless so this is trivial and
+    // guarantees no cross-call state can leak in.
+    const engine = new ConstrainedReserveEngine();
+    const engineResult = engine.calculate(parsed.data);
+    const value = ConstrainedReserveCalcValueSchema.parse({
+      allocations: engineResult.allocations.map((allocation) => ({
+        id: allocation.id,
+        name: allocation.name,
+        stage: allocation.stage,
+        allocated: toMoneyDecimalString(allocation.allocated),
+      })),
+      totalAllocated: toMoneyDecimalString(engineResult.totalAllocated),
+      remaining: toMoneyDecimalString(engineResult.remaining),
+      conservationOk: engineResult.conservationOk,
+      asOfUtc: ctx.clock.isoNow(),
+    });
+    const resultHash = computeResultHash(basis, value);
+    if (effectiveMode === 'shadow') {
+      return ConstrainedReserveCalcResultSchema.parse({
+        state: 'indicative',
+        basis,
+        value,
+        resultHash,
+        reasonCodes: ['SHADOW_ONLY'],
+      });
+    }
+    return ConstrainedReserveCalcResultSchema.parse({
+      state: 'available',
+      basis,
+      value,
+      resultHash,
+      reasonCodes: [],
+    });
+  } catch (error) {
+    return ConstrainedReserveCalcResultSchema.parse({
+      state: 'failed',
+      basis,
+      reasonCodes: ['ENGINE_ERROR'],
+      diagnostic: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/tests/unit/constrained-reserve-substrate/ambient-guard.test.ts
+++ b/tests/unit/constrained-reserve-substrate/ambient-guard.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Ambient-state source guard for the constrained reserve substrate adapter
+ * (Tranche 5, ADR-046).
+ *
+ * Same pattern as tests/unit/reserve-substrate/ambient-guard.test.ts and the
+ * Tranche 4 guard: the adapter must receive every ambient capability through
+ * its CalculationContext, never via Math.random, argless new Date(), Date.now,
+ * or process.env. Only the adapter is scanned - there is no canonical-serializer
+ * module this tranche (the engine is wrapped, not restated). The legacy
+ * ConstrainedReserveEngine.ts is intentionally NOT scanned (it is clean anyway:
+ * this is the first tranche whose adopted engine needed zero source edits).
+ */
+
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+const GUARDED_FILES = ['constrained-reserve-substrate-adapter.ts'];
+
+describe('constrained reserve adapter ambient-state source guard', () => {
+  it('the adapter never reaches for Math.random, argless new Date(), Date.now, or process.env', async () => {
+    // The shared node-setup mocks fs.readFileSync; this guard needs the real one.
+    const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const reservesDir = path.join(process.cwd(), 'shared', 'core', 'reserves');
+    const ambientPatterns: [string, RegExp][] = [
+      ['Math.random', /Math\.random/],
+      ['argless new Date()', /new Date\(\s*\)/],
+      ['process.env', /process\.env/],
+      ['Date.now', /Date\.now/],
+    ];
+    const violations: string[] = [];
+    for (const file of GUARDED_FILES) {
+      const raw = fs.readFileSync(path.join(reservesDir, file), 'utf8');
+      // Guard executable code only: doc comments may name the forbidden APIs.
+      const text = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+      for (const [label, pattern] of ambientPatterns) {
+        if (pattern.test(text)) {
+          violations.push(`${file} uses ${label}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/constrained-reserve-substrate/constrained-reserve-engine-characterization.test.ts
+++ b/tests/unit/constrained-reserve-substrate/constrained-reserve-engine-characterization.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Characterization tests for the legacy ConstrainedReserveEngine
+ * (Tranche 5, ADR-046).
+ *
+ * These pin the engine's CURRENT behavior BEFORE substrate adoption; they are
+ * evidence, not aspiration. The engine is fully deterministic and ambient-free:
+ * no randomness, no wall-clock read, no process.env, no cache, no global
+ * mutation. Money is exact BigInt cents. Every golden in fixtures.ts is
+ * therefore hand-derived (see the derivation comments there), and the engine
+ * output is asserted against it here so the adapter parity suite can, in turn,
+ * pin itself to the same hand-derived numbers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine';
+import { toCents } from '../../../shared/lib/cents';
+import {
+  CENTS_PRECISION,
+  COMPANY_CAP,
+  EMPTY_COMPANIES,
+  INVALID_DISCOUNT_THROW,
+  INVALID_DISCOUNT_THROW_MESSAGE,
+  MIN_CHECK_SKIP,
+  NO_POLICY_THROW,
+  NO_POLICY_THROW_MESSAGE,
+  STAGE_CAP,
+  TIE_BREAK,
+  TWO_COMPANY_EXHAUST,
+  VALUE_FIXTURES,
+} from './fixtures';
+
+const engine = new ConstrainedReserveEngine();
+
+describe('ConstrainedReserveEngine characterization: hand-derived goldens', () => {
+  it('A: ranks by score across stages, exhausts reserves, drops the zero-allocation company', () => {
+    expect(engine.calculate(TWO_COMPANY_EXHAUST.input)).toEqual(TWO_COMPANY_EXHAUST.expected);
+  });
+
+  it('B: honors maxPerCompany and breaks the score tie on name (Alpha before Beta)', () => {
+    expect(engine.calculate(COMPANY_CAP.input)).toEqual(COMPANY_CAP.expected);
+  });
+
+  it('C: honors maxPerStage and skips a company left with zero stage room', () => {
+    expect(engine.calculate(STAGE_CAP.input)).toEqual(STAGE_CAP.expected);
+  });
+
+  it('D: skips a company whose remaining room is below minCheck', () => {
+    expect(engine.calculate(MIN_CHECK_SKIP.input)).toEqual(MIN_CHECK_SKIP.expected);
+  });
+
+  it('E: returns a faithful empty result for empty companies (zeros, full remaining)', () => {
+    expect(engine.calculate(EMPTY_COMPANIES.input)).toEqual(EMPTY_COMPANIES.expected);
+  });
+
+  it('H: applies the full tie-break ladder score -> name -> id', () => {
+    const result = engine.calculate(TIE_BREAK.input);
+    expect(result).toEqual(TIE_BREAK.expected);
+    // The ordering itself is the observable proof of the sort.
+    expect(result.allocations.map((a) => a.id)).toEqual(['m5', 'a1', 'z9']);
+  });
+
+  it('I: preserves cent-level precision (100.55, not a whole-dollar rounding)', () => {
+    expect(engine.calculate(CENTS_PRECISION.input)).toEqual(CENTS_PRECISION.expected);
+  });
+});
+
+describe('ConstrainedReserveEngine characterization: throwing paths', () => {
+  it('F: throws "No policy for {stage}" (status 400) when a company stage has no policy', () => {
+    expect(() => engine.calculate(NO_POLICY_THROW.input)).toThrow(NO_POLICY_THROW_MESSAGE);
+    try {
+      engine.calculate(NO_POLICY_THROW.input);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect((error as { status?: number }).status).toBe(400);
+    }
+  });
+
+  it('G: throws "Invalid discount calculation" when discountFactor overflows to non-finite', () => {
+    expect(() => engine.calculate(INVALID_DISCOUNT_THROW.input)).toThrow(
+      INVALID_DISCOUNT_THROW_MESSAGE
+    );
+    try {
+      engine.calculate(INVALID_DISCOUNT_THROW.input);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect((error as { status?: number }).status).toBe(400);
+    }
+  });
+});
+
+describe('ConstrainedReserveEngine characterization: invariants across value fixtures', () => {
+  it('conservation: totalAllocated + remaining equals availableReserves to the cent, conservationOk true', () => {
+    for (const { label, input, expected } of VALUE_FIXTURES) {
+      const result = engine.calculate(input);
+      expect(result.conservationOk, label).toBe(true);
+      const outCents = toCents(result.totalAllocated) + toCents(result.remaining);
+      expect(outCents === toCents(input.availableReserves), label).toBe(true);
+      // The golden itself must satisfy conservation.
+      expect(toCents(expected.totalAllocated) + toCents(expected.remaining), label).toBe(
+        toCents(input.availableReserves)
+      );
+    }
+  });
+
+  it('bounds: total never exceeds availableReserves and every allocation meets any minCheck', () => {
+    for (const { label, input } of VALUE_FIXTURES) {
+      const result = engine.calculate(input);
+      expect(toCents(result.totalAllocated) <= toCents(input.availableReserves), label).toBe(true);
+      const minCheck = input.constraints?.minCheck ?? 0;
+      for (const allocation of result.allocations) {
+        expect(
+          toCents(allocation.allocated) >= toCents(minCheck),
+          `${label}:${allocation.id}`
+        ).toBe(true);
+        expect(allocation.allocated >= 0, `${label}:${allocation.id}`).toBe(true);
+      }
+    }
+  });
+
+  it('determinism: repeated calls on the same input are byte-identical', () => {
+    for (const { label, input } of VALUE_FIXTURES) {
+      const first = JSON.stringify(engine.calculate(input));
+      const second = JSON.stringify(engine.calculate(input));
+      expect(second, label).toBe(first);
+    }
+  });
+});

--- a/tests/unit/constrained-reserve-substrate/constrained-reserve-substrate-adapter.test.ts
+++ b/tests/unit/constrained-reserve-substrate/constrained-reserve-substrate-adapter.test.ts
@@ -1,0 +1,344 @@
+/**
+ * ConstrainedReserveEngine substrate adapter tests (Tranche 5, ADR-046).
+ *
+ * Proves, per the tranche exit criteria:
+ * (a) same context + input -> byte-identical result and identical resultHash
+ *     across repeated runs;
+ * (b) different inputs -> different input+result hashes; a different asOf ->
+ *     different result hash but same input hash; and a disclosed seed-invariance
+ *     property (different ctx seeds -> identical value and hash, since the engine
+ *     draws no randomness);
+ * (c) the adapter value matches a freshly constructed engine field-for-field on
+ *     the shared fixtures, and matches the hand-derived goldens in fixtures.ts;
+ * (d) mode / kill-switch / invalid-input / engine-throw invariants validated
+ *     against BOTH the tranche result schema and GenericCalcResultSchema, with a
+ *     registered reason code on every non-available path.
+ *
+ * Plus: the assumptions restatement is pinned honest against the live
+ * ConstraintsSchema defaults; the emitted value round-trips through
+ * admitForHashing; and the money boundary is proven cent-faithful.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  GenericCalcResultSchema,
+  admitForHashing,
+  createCalculationContext,
+} from '../../../shared/core/calc-substrate';
+import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine';
+import {
+  CONSTRAINED_RESERVE_ASSUMPTIONS_VIEW,
+  CONSTRAINED_RESERVE_CALCULATION_KEY,
+  ConstrainedReserveCalcResultSchema,
+  computeConstrainedReserveAssumptionsHash,
+  runConstrainedReserveWithSubstrate,
+  type ConstrainedReserveSubstrateOptions,
+} from '../../../shared/core/reserves/constrained-reserve-substrate-adapter';
+import { ConstraintsSchema } from '../../../shared/schemas';
+import {
+  CENTS_PRECISION,
+  COMPANY_CAP,
+  EXPLICIT_INFINITY_CAP,
+  INVALID_DISCOUNT_THROW,
+  INVALID_EMPTY_STAGE_POLICIES,
+  NO_POLICY_THROW,
+  TIE_BREAK,
+  TWO_COMPANY_EXHAUST,
+  VALUE_FIXTURES,
+} from './fixtures';
+
+const AS_OF = '2026-07-18T00:00:00Z';
+const AS_OF_ISO = '2026-07-18T00:00:00.000Z';
+const ON: ConstrainedReserveSubstrateOptions = { configuredMode: 'on', killSwitchActive: false };
+
+function ctx(seed = 1, asOf: string = AS_OF) {
+  return createCalculationContext({
+    calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+    seed,
+    asOf,
+  });
+}
+
+/** Same 2dp rendering the adapter uses, to derive expected strings from goldens. */
+function money(amount: number): string {
+  const cents = Math.round(amount * 100);
+  const whole = Math.trunc(cents / 100);
+  const frac = cents % 100;
+  return `${whole}.${frac.toString().padStart(2, '0')}`;
+}
+
+describe('runConstrainedReserveWithSubstrate determinism and hash integrity', () => {
+  it('(a) repeated runs with the same context and input are byte-identical with equal hashes', () => {
+    const first = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, ON);
+    const second = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, ON);
+    expect(first.state).toBe('available');
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    if (first.state === 'available' && second.state === 'available') {
+      expect(first.resultHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(second.resultHash).toBe(first.resultHash);
+    }
+  });
+
+  it('(b) a different input changes both the input hash and the result hash', () => {
+    const a = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, ON);
+    const b = runConstrainedReserveWithSubstrate(ctx(), COMPANY_CAP.input, ON);
+    if (a.state !== 'available' || b.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(b.basis.inputHash).not.toBe(a.basis.inputHash);
+    expect(b.resultHash).not.toBe(a.resultHash);
+  });
+
+  it('(b) a different as-of instant changes the result hash but not the input hash', () => {
+    const base = runConstrainedReserveWithSubstrate(ctx(1, AS_OF), TWO_COMPANY_EXHAUST.input, ON);
+    const later = runConstrainedReserveWithSubstrate(
+      ctx(1, '2026-07-19T00:00:00Z'),
+      TWO_COMPANY_EXHAUST.input,
+      ON
+    );
+    if (base.state !== 'available' || later.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(later.basis.inputHash).toBe(base.basis.inputHash);
+    expect(later.resultHash).not.toBe(base.resultHash);
+    expect(base.value.asOfUtc).toBe(AS_OF_ISO);
+  });
+
+  it('(b, disclosed) the value is seed-invariant, so the result hash is too', () => {
+    // The engine draws no randomness and the seed is not part of the basis, so
+    // equal inputs yield equal values and hashes across different ctx seeds.
+    const seed1 = runConstrainedReserveWithSubstrate(ctx(1), TIE_BREAK.input, ON);
+    const seed999 = runConstrainedReserveWithSubstrate(ctx(999), TIE_BREAK.input, ON);
+    if (seed1.state !== 'available' || seed999.state !== 'available') {
+      throw new Error('expected available results');
+    }
+    expect(JSON.stringify(seed999.value)).toBe(JSON.stringify(seed1.value));
+    expect(seed999.resultHash).toBe(seed1.resultHash);
+    expect(seed999.basis.inputHash).toBe(seed1.basis.inputHash);
+  });
+
+  it('every emitted result revalidates against the tranche and generic result schemas', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, ON);
+    expect(() => ConstrainedReserveCalcResultSchema.parse(result)).not.toThrow();
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  });
+
+  it('the emitted value round-trips through admitForHashing (hash-admissible)', () => {
+    for (const fixture of VALUE_FIXTURES) {
+      const result = runConstrainedReserveWithSubstrate(ctx(), fixture.input, ON);
+      if (result.state !== 'available') {
+        throw new Error(`expected available for ${fixture.label}`);
+      }
+      expect(() => admitForHashing(result.value), fixture.label).not.toThrow();
+    }
+  });
+});
+
+describe('runConstrainedReserveWithSubstrate parity with the engine and hand-derived goldens', () => {
+  it('(c) the adapter value matches a freshly constructed engine field-for-field', () => {
+    const engine = new ConstrainedReserveEngine();
+    for (const fixture of VALUE_FIXTURES) {
+      const engineOut = engine.calculate(fixture.input);
+      const result = runConstrainedReserveWithSubstrate(ctx(), fixture.input, ON);
+      if (result.state !== 'available') {
+        throw new Error(`expected available for ${fixture.label}`);
+      }
+      expect(result.value.conservationOk, fixture.label).toBe(engineOut.conservationOk);
+      expect(Number(result.value.totalAllocated), fixture.label).toBe(engineOut.totalAllocated);
+      expect(Number(result.value.remaining), fixture.label).toBe(engineOut.remaining);
+      expect(result.value.allocations.length, fixture.label).toBe(engineOut.allocations.length);
+      result.value.allocations.forEach((allocation, index) => {
+        const engineAllocation = engineOut.allocations[index]!;
+        expect(allocation.id, fixture.label).toBe(engineAllocation.id);
+        expect(allocation.name, fixture.label).toBe(engineAllocation.name);
+        expect(allocation.stage, fixture.label).toBe(engineAllocation.stage);
+        expect(Number(allocation.allocated), fixture.label).toBe(engineAllocation.allocated);
+      });
+    }
+  });
+
+  it('(c) the adapter value matches the hand-derived goldens (2dp strings)', () => {
+    for (const fixture of VALUE_FIXTURES) {
+      const result = runConstrainedReserveWithSubstrate(ctx(), fixture.input, ON);
+      if (result.state !== 'available') {
+        throw new Error(`expected available for ${fixture.label}`);
+      }
+      expect(result.value.totalAllocated, fixture.label).toBe(
+        money(fixture.expected.totalAllocated)
+      );
+      expect(result.value.remaining, fixture.label).toBe(money(fixture.expected.remaining));
+      expect(
+        result.value.allocations.map((a) => [a.id, a.allocated]),
+        fixture.label
+      ).toEqual(fixture.expected.allocations.map((a) => [a.id, money(a.allocated)]));
+    }
+  });
+
+  it('(c) money is rendered cent-faithfully, not rounded to whole dollars', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), CENTS_PRECISION.input, ON);
+    if (result.state !== 'available') {
+      throw new Error('expected available');
+    }
+    expect(result.value.allocations[0]!.allocated).toBe('100.55');
+    expect(result.value.totalAllocated).toBe('100.55');
+    expect(result.value.remaining).toBe('0.00');
+  });
+
+  it('(c) the tie-break order survives the boundary (score -> name -> id)', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), TIE_BREAK.input, ON);
+    if (result.state !== 'available') {
+      throw new Error('expected available');
+    }
+    expect(result.value.allocations.map((a) => a.id)).toEqual(['m5', 'a1', 'z9']);
+  });
+});
+
+describe('runConstrainedReserveWithSubstrate mode and kill-switch invariants', () => {
+  function bothSchemas(result: unknown): void {
+    expect(() => ConstrainedReserveCalcResultSchema.parse(result)).not.toThrow();
+    expect(() => GenericCalcResultSchema.parse(result)).not.toThrow();
+  }
+
+  it('(d) configured off yields unavailable with MODE_OFF and no value', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, {
+      configuredMode: 'off',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['MODE_OFF']);
+    expect('value' in result).toBe(false);
+    expect('resultHash' in result).toBe(false);
+    expect(result.basis.effectiveMode).toBe('off');
+    bothSchemas(result);
+  });
+
+  it('(d) an active kill switch forces effective off and discloses KILL_SWITCH_ACTIVE', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, {
+      configuredMode: 'on',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE']);
+    expect(result.basis.effectiveMode).toBe('off');
+    expect(result.basis.configuredMode).toBe('on');
+    bothSchemas(result);
+  });
+
+  it('(d) kill switch plus configured off disclose both suppression codes', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, {
+      configuredMode: 'off',
+      killSwitchActive: true,
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE', 'MODE_OFF']);
+    bothSchemas(result);
+  });
+
+  it('(d) shadow mode yields an indicative value disclosed via SHADOW_ONLY', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), TWO_COMPANY_EXHAUST.input, {
+      configuredMode: 'shadow',
+      killSwitchActive: false,
+    });
+    expect(result.state).toBe('indicative');
+    expect(result.reasonCodes).toEqual(['SHADOW_ONLY']);
+    if (result.state === 'indicative') {
+      expect(result.value.totalAllocated).toBe('100000.00');
+      expect(result.resultHash).toMatch(/^[0-9a-f]{64}$/);
+    }
+    bothSchemas(result);
+  });
+
+  it('(d) schema-invalid input (empty stagePolicies) yields failed with INPUT_INVALID', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), INVALID_EMPTY_STAGE_POLICIES, ON);
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['INPUT_INVALID']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('constrained reserve input rejected');
+    }
+    expect(result.basis.inputHash).toMatch(/^[0-9a-f]{64}$/);
+    bothSchemas(result);
+  });
+
+  it('(d) a "No policy for {stage}" engine throw yields failed with ENGINE_ERROR', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), NO_POLICY_THROW.input, ON);
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['ENGINE_ERROR']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('No policy for series_b');
+    }
+    bothSchemas(result);
+  });
+
+  it('(d) an invalid-discount engine throw yields failed with ENGINE_ERROR', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), INVALID_DISCOUNT_THROW.input, ON);
+    expect(result.state).toBe('failed');
+    expect(result.reasonCodes).toEqual(['ENGINE_ERROR']);
+    if (result.state === 'failed') {
+      expect(result.diagnostic).toContain('Invalid discount calculation');
+    }
+    bothSchemas(result);
+  });
+
+  it('rejects a context built for a different calculation key', () => {
+    const wrongCtx = createCalculationContext({ calculationKey: 'reserve', seed: 1, asOf: AS_OF });
+    expect(() =>
+      runConstrainedReserveWithSubstrate(wrongCtx, TWO_COMPANY_EXHAUST.input, ON)
+    ).toThrow(TypeError);
+  });
+});
+
+describe('runConstrainedReserveWithSubstrate raw-input hashing (disclosed)', () => {
+  it('an explicit non-finite maxPerCompany still runs (available) via the sentinel input hash', () => {
+    const result = runConstrainedReserveWithSubstrate(ctx(), EXPLICIT_INFINITY_CAP, ON);
+    expect(result.state).toBe('available');
+    expect(result.basis.inputHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('two inputs that differ only elsewhere but both pin maxPerCompany: Infinity collide on input hash', () => {
+    const other = {
+      ...EXPLICIT_INFINITY_CAP,
+      companies: [{ id: 'zzz', name: 'Different', stage: 'seed', invested: 42, ownership: 0.9 }],
+    };
+    const a = runConstrainedReserveWithSubstrate(ctx(), EXPLICIT_INFINITY_CAP, ON);
+    const b = runConstrainedReserveWithSubstrate(ctx(), other, ON);
+    // Disclosed raw-hashing consequence: both collapse onto the inadmissible
+    // sentinel, so their input identities coincide despite different companies.
+    expect(b.basis.inputHash).toBe(a.basis.inputHash);
+  });
+});
+
+describe('constrained reserve assumptions restatement parity', () => {
+  /** Walk ZodOptional(ZodDefault(...)) to recover a field's documented default. */
+  function schemaDefault(field: unknown): unknown {
+    let node = field as { _def?: Record<string, unknown> } | undefined;
+    for (let i = 0; i < 6 && node?._def; i++) {
+      const def = node._def as Record<string, unknown>;
+      if (def['typeName'] === 'ZodDefault') {
+        return (def['defaultValue'] as () => unknown)();
+      }
+      node = (def['innerType'] ?? def['schema'] ?? def['type']) as typeof node;
+    }
+    throw new Error('no ZodDefault found in field chain');
+  }
+
+  it('restated constraint defaults match the live ConstraintsSchema', () => {
+    const shape = (ConstraintsSchema as unknown as { shape: Record<string, unknown> }).shape;
+    const documented = CONSTRAINED_RESERVE_ASSUMPTIONS_VIEW.constraintDefaults;
+    expect(schemaDefault(shape['minCheck'])).toBe(documented.minCheck);
+    expect(schemaDefault(shape['discountRateAnnual'])).toBe(documented.discountRateAnnual);
+    expect(schemaDefault(shape['maxPerStage'])).toEqual(documented.maxPerStage);
+    expect(schemaDefault(shape['graduationYears'])).toEqual(documented.graduationYears);
+    expect(schemaDefault(shape['graduationProb'])).toEqual(documented.graduationProb);
+    // maxPerCompany's schema default is Infinity, restated as the 'unbounded'
+    // sentinel because non-finite numbers are not hash-admissible.
+    expect(schemaDefault(shape['maxPerCompany'])).toBe(Number.POSITIVE_INFINITY);
+    expect(documented.maxPerCompany).toBe('unbounded');
+  });
+
+  it('the assumptions hash is a stable 64-hex digest', () => {
+    const first = computeConstrainedReserveAssumptionsHash();
+    const second = computeConstrainedReserveAssumptionsHash();
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(second).toBe(first);
+  });
+});

--- a/tests/unit/constrained-reserve-substrate/fixtures.ts
+++ b/tests/unit/constrained-reserve-substrate/fixtures.ts
@@ -1,0 +1,306 @@
+/**
+ * Hand-authored fixtures for the ConstrainedReserveEngine substrate adoption
+ * (Tranche 5, ADR-046).
+ *
+ * Every golden here is HAND-DERIVED (a return to the Tranche 2/3 discipline,
+ * in deliberate contrast with Tranche 4's captured-then-frozen goldens): the
+ * engine draws no randomness, does no ambient read, and its money math is exact
+ * BigInt cents (`shared/lib/cents.ts`), so allocations are reproducible with
+ * pencil and paper. The derivation of each is spelled out inline.
+ *
+ * Shared derivation constants. With `graduationYears` / `graduationProb`
+ * omitted from `constraints`, the engine takes its per-stage fallbacks for
+ * EVERY company (Zod's `.partial()` suppresses the ConstraintsSchema field
+ * defaults, so an omitted key never becomes the default map):
+ *
+ *   yearsToExit = 5            (ConstrainedReserveEngine.ts fallback)
+ *   exitProb    = 0.5          (fallback)
+ *   disc        = 0.12         (ConstraintsSchema-documented default, applied
+ *                               by the engine's own `?? 0.12`)
+ *   discountFactor = (1 + 0.12) ** 5 = 1.7623416832
+ *   pv    = (reserveMultiple * exitProb) / discountFactor
+ *   score = pv * weight
+ *
+ * Because every company in a default-constraint fixture shares one
+ * discountFactor and one exitProb, the score ORDER reduces to descending
+ * `reserveMultiple * weight`, with ties broken by name then id. Only the order
+ * feeds the greedy fill; the fill amounts themselves depend solely on
+ * availableReserves and the caps, so they are exact to the cent. The engine
+ * exposes neither pv nor score, so those values appear here only as the
+ * ordering rationale; the observable golden is the allocation set.
+ */
+
+import type { ReserveInput } from '../../../shared/schemas';
+
+export interface EngineAllocation {
+  id: string;
+  name: string;
+  stage: string;
+  allocated: number;
+}
+
+export interface EngineOutput {
+  allocations: EngineAllocation[];
+  totalAllocated: number;
+  remaining: number;
+  conservationOk: boolean;
+}
+
+export interface ConstrainedFixture {
+  readonly label: string;
+  readonly input: ReserveInput;
+  readonly expected: EngineOutput;
+}
+
+/**
+ * A: score ordering across stages, reserve exhaustion, and the filtered-out
+ * zero. Beta (series_a, rm 3) outranks Alpha (seed, rm 2): score 0.85119 vs
+ * 0.56746. Beta fills first and consumes the entire $100,000; Alpha then hits
+ * `remaining <= 0`, allocates 0, and is dropped from `allocations`.
+ */
+export const TWO_COMPANY_EXHAUST: ConstrainedFixture = {
+  label: 'two-company-exhaust',
+  input: {
+    availableReserves: 100_000,
+    companies: [
+      { id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+      { id: 'c2', name: 'Beta', stage: 'series_a', invested: 1_000_000, ownership: 0.1 },
+    ],
+    stagePolicies: [
+      { stage: 'seed', reserveMultiple: 2, weight: 1 },
+      { stage: 'series_a', reserveMultiple: 3, weight: 1 },
+    ],
+  },
+  expected: {
+    allocations: [{ id: 'c2', name: 'Beta', stage: 'series_a', allocated: 100_000 }],
+    totalAllocated: 100_000,
+    remaining: 0,
+    conservationOk: true,
+  },
+};
+
+/**
+ * B: per-company cap plus the name tie-break. Alpha and Beta share the seed
+ * policy, so their scores are equal; the tie breaks on name ('Alpha' < 'Beta').
+ * `maxPerCompany` caps each fill at $30,000, so both allocate $30,000 and
+ * $40,000 stays unallocated.
+ */
+export const COMPANY_CAP: ConstrainedFixture = {
+  label: 'company-cap',
+  input: {
+    availableReserves: 100_000,
+    companies: [
+      { id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+      { id: 'c2', name: 'Beta', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+    ],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+    constraints: { maxPerCompany: 30_000 },
+  },
+  expected: {
+    allocations: [
+      { id: 'c1', name: 'Alpha', stage: 'seed', allocated: 30_000 },
+      { id: 'c2', name: 'Beta', stage: 'seed', allocated: 30_000 },
+    ],
+    totalAllocated: 60_000,
+    remaining: 40_000,
+    conservationOk: true,
+  },
+};
+
+/**
+ * C: per-stage cap. Both companies are seed; `maxPerStage.seed` caps the
+ * combined seed fill at $50,000. Alpha (name tie-break winner) takes the full
+ * $50,000 of stage room; Beta then sees stage room 0 and is skipped even
+ * though $50,000 remains overall.
+ */
+export const STAGE_CAP: ConstrainedFixture = {
+  label: 'stage-cap',
+  input: {
+    availableReserves: 100_000,
+    companies: [
+      { id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+      { id: 'c2', name: 'Beta', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+    ],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+    constraints: { maxPerStage: { seed: 50_000 } },
+  },
+  expected: {
+    allocations: [{ id: 'c1', name: 'Alpha', stage: 'seed', allocated: 50_000 }],
+    totalAllocated: 50_000,
+    remaining: 50_000,
+    conservationOk: true,
+  },
+};
+
+/**
+ * D: minCheck skip combined with a per-company cap. Alpha (seed, rm 5) outranks
+ * Beta (series_a, rm 2). `maxPerCompany` caps Alpha at $70,000, leaving
+ * $30,000. Beta's remaining room ($30,000) is below `minCheck` ($60,000), so
+ * Beta is skipped rather than under-funded.
+ */
+export const MIN_CHECK_SKIP: ConstrainedFixture = {
+  label: 'min-check-skip',
+  input: {
+    availableReserves: 100_000,
+    companies: [
+      { id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+      { id: 'c2', name: 'Beta', stage: 'series_a', invested: 1_000_000, ownership: 0.1 },
+    ],
+    stagePolicies: [
+      { stage: 'seed', reserveMultiple: 5, weight: 1 },
+      { stage: 'series_a', reserveMultiple: 2, weight: 1 },
+    ],
+    constraints: { minCheck: 60_000, maxPerCompany: 70_000 },
+  },
+  expected: {
+    allocations: [{ id: 'c1', name: 'Alpha', stage: 'seed', allocated: 70_000 }],
+    totalAllocated: 70_000,
+    remaining: 30_000,
+    conservationOk: true,
+  },
+};
+
+/**
+ * E: empty companies. A schema-valid input (companies may be empty; stagePolicies
+ * must be non-empty) yields a faithful empty result, not an unavailable one:
+ * no allocations, zero allocated, and the full reserves left over.
+ */
+export const EMPTY_COMPANIES: ConstrainedFixture = {
+  label: 'empty-companies',
+  input: {
+    availableReserves: 50_000,
+    companies: [],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+  },
+  expected: {
+    allocations: [],
+    totalAllocated: 0,
+    remaining: 50_000,
+    conservationOk: true,
+  },
+};
+
+/**
+ * F: the "No policy for {stage}" throw. The company is series_b but the only
+ * policy is seed. This is schema-VALID (the stage/policy cross-check lives in
+ * validateReserveInput, not ReserveInputSchema), so the engine is reached and
+ * throws `Error({ status: 400 })`. The adapter maps it to failed + ENGINE_ERROR.
+ */
+export const NO_POLICY_THROW: ConstrainedFixture = {
+  label: 'no-policy-throw',
+  input: {
+    availableReserves: 50_000,
+    companies: [
+      { id: 'c1', name: 'Alpha', stage: 'series_b', invested: 1_000_000, ownership: 0.1 },
+    ],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+  },
+  // No `expected` output: this fixture throws. The message is pinned in tests.
+  expected: { allocations: [], totalAllocated: 0, remaining: 0, conservationOk: true },
+};
+
+export const NO_POLICY_THROW_MESSAGE = 'No policy for series_b';
+
+/**
+ * G: the invalid-discount throw. discountRateAnnual 1 with graduationYears
+ * 5000 makes discountFactor = 2 ** 5000 = Infinity, so the engine throws
+ * `Invalid discount calculation for stage seed`. Schema-valid (bounded01 caps
+ * disc at 1; graduationYears has no upper bound). Maps to failed + ENGINE_ERROR.
+ */
+export const INVALID_DISCOUNT_THROW: ConstrainedFixture = {
+  label: 'invalid-discount-throw',
+  input: {
+    availableReserves: 50_000,
+    companies: [{ id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 }],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+    constraints: { discountRateAnnual: 1, graduationYears: { seed: 5000 } },
+  },
+  expected: { allocations: [], totalAllocated: 0, remaining: 0, conservationOk: true },
+};
+
+export const INVALID_DISCOUNT_THROW_MESSAGE = 'Invalid discount calculation for stage seed';
+
+/**
+ * H: the full tie-break ladder (score desc, then name asc, then id asc). All
+ * three companies share the seed policy (equal score). 'Aardvark' sorts before
+ * 'Same' on name; the two 'Same' companies break on id ('a1' < 'z9'). With a
+ * $30,000 per-company cap and $90,000 available, all three fill equally, so the
+ * allocation ORDER is the observable proof of the sort: [m5, a1, z9].
+ */
+export const TIE_BREAK: ConstrainedFixture = {
+  label: 'tie-break',
+  input: {
+    availableReserves: 90_000,
+    companies: [
+      { id: 'z9', name: 'Same', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+      { id: 'a1', name: 'Same', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+      { id: 'm5', name: 'Aardvark', stage: 'seed', invested: 1_000_000, ownership: 0.1 },
+    ],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+    constraints: { maxPerCompany: 30_000 },
+  },
+  expected: {
+    allocations: [
+      { id: 'm5', name: 'Aardvark', stage: 'seed', allocated: 30_000 },
+      { id: 'a1', name: 'Same', stage: 'seed', allocated: 30_000 },
+      { id: 'z9', name: 'Same', stage: 'seed', allocated: 30_000 },
+    ],
+    totalAllocated: 90_000,
+    remaining: 0,
+    conservationOk: true,
+  },
+};
+
+/**
+ * I: cent-level precision. availableReserves $100.55 fully funds the single
+ * company. toCents(100.55) = 10055 cents exactly (Math.round absorbs the
+ * 100.55 * 100 = 10054.999... float artifact), so the allocation is $100.55 to
+ * the cent - the case that proves the adapter's 2dp decimal strings carry the
+ * cents faithfully rather than rounding to whole dollars.
+ */
+export const CENTS_PRECISION: ConstrainedFixture = {
+  label: 'cents-precision',
+  input: {
+    availableReserves: 100.55,
+    companies: [{ id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000, ownership: 0.1 }],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+  },
+  expected: {
+    allocations: [{ id: 'c1', name: 'Alpha', stage: 'seed', allocated: 100.55 }],
+    totalAllocated: 100.55,
+    remaining: 0,
+    conservationOk: true,
+  },
+};
+
+/** Schema-invalid: stagePolicies must have min length 1. Drives INPUT_INVALID. */
+export const INVALID_EMPTY_STAGE_POLICIES = {
+  availableReserves: 1_000,
+  companies: [],
+  stagePolicies: [],
+} as const;
+
+/**
+ * Schema-valid but hash-inadmissible RAW input: an explicit non-finite
+ * maxPerCompany. admitForHashing rejects Infinity, so the input hash falls back
+ * to the deterministic sentinel; the engine still runs (Infinity -> the max
+ * company cap) and returns an available result. Two such inputs that differ
+ * only elsewhere collide on inputHash - a disclosed consequence of raw hashing.
+ */
+export const EXPLICIT_INFINITY_CAP: ReserveInput = {
+  availableReserves: 100_000,
+  companies: [{ id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 }],
+  stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+  constraints: { maxPerCompany: Number.POSITIVE_INFINITY },
+};
+
+/** Fixtures whose engine call returns a value (excludes the two throwers). */
+export const VALUE_FIXTURES: readonly ConstrainedFixture[] = [
+  TWO_COMPANY_EXHAUST,
+  COMPANY_CAP,
+  STAGE_CAP,
+  MIN_CHECK_SKIP,
+  EMPTY_COMPANIES,
+  TIE_BREAK,
+  CENTS_PRECISION,
+];


### PR DESCRIPTION
## Description

Tranche 5 of the ADR-042 calculation-substrate adoption program: adopt
`ConstrainedReserveEngine` onto the substrate via a synchronous **wrapping**
adapter (calculationKey `reserve-constrained`) with **zero edits to the
engine**. This is the last untouched reserve engine; with it, all four
reserve/pacing calc engines (pacing = T2, rule/ML reserve = T3, deterministic
reserve = T4, constrained reserve = T5) are adapter-backed.

The engine draws no randomness, does no ambient read (`Date.now` / `new Date` /
`process.env` / `Math.random` all zero), holds no cache, and sets no global
`Decimal` config (it works in exact BigInt cents), so unlike Tranche 4 it needs
**no capability seam** and **no cache-identity fix** — the first tranche whose
adopted engine's source is touched zero times.

## Slice Summary

### Owned Files

- `shared/core/reserves/constrained-reserve-substrate-adapter.ts` (new adapter)
- `tests/unit/constrained-reserve-substrate/` (new: `fixtures.ts`,
  characterization, adapter/evidence, ambient-guard)
- `DECISIONS.md` (ADR-046), `CHANGELOG.md` (`## [Unreleased]` entry)

### Explicit Non-Goals

- No edits to `ConstrainedReserveEngine.ts`, `shared/schemas.ts`,
  `shared/lib/cents.ts`, or `shared/core/calc-substrate/` (the engine diff is
  empty by design).
- No consumer rewiring: `server/routes/v1/reserves.ts` and the Excel parity
  validator keep the legacy `.calculate()` path.
- No DB rows/migrations, `fund_calculation_modes` wiring, routes, flags
  registry, UI, queues, or Monte Carlo. No changes to the pacing / rule-ML /
  deterministic adapters or their suites. No new npm dependencies.

### Schema Or Contract Impact

None to existing contracts. The adapter emits an additive substrate
`CalcResult` under the existing `calc-substrate/1.0.0` contract; a new
calculationKey `reserve-constrained` and new tranche value/result Zod schemas
live entirely inside the new adapter file.

### Rollback Path

Fully additive and unreferenced by production code paths — revert the three
commits (or delete the adapter + test directory) with no consumer impact, since
no existing caller was rewired.

### Commands Actually Run

- `npx cross-env TZ=UTC vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/constrained-reserve-substrate tests/unit/reserve-substrate tests/unit/pacing-substrate tests/unit/deterministic-reserve-substrate tests/unit/calc-substrate tests/unit/reserves/ConstrainedReserveEngine.test.ts`
  → 19 files / 177 tests green.
- `npm test` (full suite) → **8885 passed | 90 skipped | 0 failed**; delta over
  the pre-change baseline (8850 / 90) is exactly the 35 new tests.
- `npm run check` → 0 new TypeScript errors (baseline 0, current 0).
- `npx eslint <new files> --max-warnings 0` → clean.
- `npm run build` → passes (also re-run and re-verified by the pre-push hook).

### Docs Or Guardrail Impact

ADR-046 added to `DECISIONS.md`; a dated entry added under `## [Unreleased]` in
`CHANGELOG.md`. No guardrail artifacts changed. No Phoenix-protected paths
touched.

### Archived Active Docs

None.

## Required Slice Checklist

- [x] Owned files are listed explicitly
- [x] Explicit non-goals are listed
- [x] Schema or contract impact is called out
- [x] Rollback path is documented
- [x] Commands actually run are listed
- [x] Docs or guardrail artifacts changed, with reason
- [x] Any active doc archived is named, with destination path (none)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Performance Impact

Not applicable — the adapter wraps a synchronous, cache-free engine and adds no
async or hot-path work. No production caller is rewired.

## Quality Checklist

### Testing

- [x] Unit tests added (`npm run test:unit`) — 35 new tests
- [x] Tests pass locally (full suite green, delta = the 35 new tests)

### Code Quality

- [x] TypeScript checks pass (`npm run check`, 0 new errors)
- [x] ESLint passes (`--max-warnings 0` on new files; repo forbids `any`)
- [x] No console.log or debug statements left

### Reserves v1.1 Specific

- [x] Conservation invariant maintained (allocated + remaining = available; the
      engine is wrapped unchanged and conservation is pinned to the cent in
      tests)

## Determinism / Truthfulness Evidence

- Repeat-run byte-identical results with equal 64-hex `resultHash`.
- Seed-invariance disclosed and pinned (the engine draws no randomness; no fork
  label consumed or reserved).
- Field-for-field parity with a freshly constructed engine and hand-derived
  cents goldens (a return to the T2/T3 discipline vs T4's captured goldens);
  cent-faithful money via fixed 2dp decimal strings.
- Every non-available path emits a registered reason code (MODE_OFF /
  KILL_SWITCH_ACTIVE / SHADOW_ONLY / INPUT_INVALID / ENGINE_ERROR) — zero silent
  fallback — validated against both the tranche and generic result schemas.
- Ambient-read source guard on the adapter.

## Disclosed Deviations

- **Money as fixed 2dp decimal strings** (vs Tranche 4's plain numbers):
  justified because the amounts are exact cents, so a 2dp string fabricates no
  precision and restores the T2/T3 money-as-string discipline.
- **Raw-input hashing with a sentinel fallback** (T3 pattern, vs T4's
  parsed-input hashing): the raw input has no Dates and no Infinity of its own;
  an explicitly-passed non-finite `maxPerCompany` collapses onto the sentinel (a
  disclosed collision, pinned by a test).
- **Hand-derived goldens** (vs T4's captured goldens): the greedy-fill math is
  pencil-derivable.

## Related Issues

N/A — continuation of the ADR-042 substrate-adoption program (ADR-043/044/045).

## Additional Notes

Remaining follow-ups for future tranches, now that all four calc engines are
adapter-backed: **wire a consumer** (route a live caller through an adapter with
a resolved mode) and **modes-registry wiring**
(`fund_calculation_modes` / kill-switch persistence feeding `configuredMode` /
`killSwitchActive`).

Note: commits in this environment are unsigned (no signing key material is
present in the sandbox), so GitHub may mark them "Unverified"; the committer
identity is `Claude <noreply@anthropic.com>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012YCYLVgiDCuRStLe9WKDvL)_