### PR TITLE
feat(substrate): add generic substrate calc-mode resolver read seam (ADR-047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Tranche 6 generic substrate calculation-mode resolver (ADR-047).** New
+  additive server service `server/services/substrate-calc-mode-resolver.ts`
+  exporting `resolveSubstrateCalcMode({ fundId, calculationKey, reader? })`, the
+  READ seam that turns a `(fundId, calculationKey)` into the exact
+  `{ configuredMode, killSwitchActive }` shape the four ADR-042 substrate
+  adapters consume - unblocking Tranche 7 (wire the first substrate consumer)
+  without touching a route or changing any behavior. Unlike the two existing
+  per-key readers it does NOT collapse the kill switch into a single `'off'`
+  string: it returns both fields verbatim so the adapter can disclose
+  `KILL_SWITCH_ACTIVE` vs `MODE_OFF` correctly. Safe default when no row exists
+  (`{ off, false }`); fail-safe validation of the stored `configuredMode` via
+  `CalcModeSchema` (any drift/corruption falls back to `off`, never
+  `shadow`/`on`); strict-boolean kill switch; an injectable reader seam for
+  DB-free tests (default wraps `db.query.fundCalculationModes.findFirst` over
+  the two columns); and a `CalculationKeySchema` guard (invalid key ->
+  `TypeError`). The `fund_calculation_modes` registry (migration 0017)
+  pre-existed and is reused unchanged; no routes, consumer rewiring,
+  adapter/schema edits, DB rows, writes, or migrations. Proven by
+  `tests/unit/services/substrate-calc-mode-resolver.test.ts` (14 tests),
+  including an adapter-drop-in that spreads the resolution into
+  `runConstrainedReserveWithSubstrate` and asserts the correct disclosure across
+  available / SHADOW_ONLY / MODE_OFF / KILL_SWITCH_ACTIVE.
 - **Tranche 5 ConstrainedReserveEngine substrate adoption (ADR-046).** The
   constrained greedy reserve engine now runs against an injected
   `CalculationContext` via a WRAPPING adapter

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -7177,3 +7177,118 @@ diff is empty):
 `shared/core/reserves/constrained-reserve-substrate-adapter.ts` (new; the engine
 is wrapped unchanged) plus `tests/unit/constrained-reserve-substrate/` (35
 tests: fixtures, characterization, adapter/evidence, ambient guard).
+
+## ADR-047: Tranche 6 Generic Substrate Calculation-Mode Resolver (Read Seam, Demo Scope)
+
+**Date:** 2026-07-18 **Status:** [ACCEPTED] Implemented (demo scope)
+**Decision:** Add ONE additive server service
+`server/services/substrate-calc-mode-resolver.ts` exporting async
+`resolveSubstrateCalcMode({ fundId, calculationKey, reader? })`, which reads
+`fund_calculation_modes` and returns the exact
+`{ configuredMode: CalcMode, killSwitchActive: boolean }` shape the four ADR-042
+substrate adapters consume as the leading prefix of their `*SubstrateOptions`
+(exported as `SubstrateCalcModeResolution`). This is the READ half of the still-
+open "wire a consumer" slice (ADR-046 Consequences): it turns
+`(fundId, calculationKey)` into an adapter-ready mode. It runs NO adapter,
+mounts NO route, edits NO adapter/schema/existing-reader, and writes NO row.
+Routing a live caller through it is deferred to Tranche 7. Same owner-granted
+demo override of program-governance gates as ADR-042..046; technical invariants
+(fail-safe defaults, no silent financial fabrication, honest disclosure) are
+enforced in code and tests.
+
+### Context: verified audit (re-verified on the tranche branch)
+
+- **The modes registry already exists and is consumed - not greenfield.**
+  `fund_calculation_modes` (schema `shared/schema/fund-calculation-modes.ts`,
+  migration `0017`) is keyed uniquely by `(fund_id, calculation_key)` with
+  `configured_mode varchar(16) default 'off'` (check constraint
+  `configured_mode IN ('off','shadow','on')`),
+  `kill_switch_active boolean default false`, and `version`. It is read by
+  `resolveFundCalculationMode` (`fund-calculation-mode-service.ts`,
+  MOIC/H9-specific `FundCalculationModePreview`) and by two per-key
+  collapse-style readers, `resolveReserveFactsCalculationMode`
+  (`reserve-calculation-service.ts`) and
+  `resolveMonteCarloActualsCalculationMode` (`monte-carlo-simulation.ts`).
+- **The genuine gap is a consumer, not the registry.** A grep across `server/`,
+  `client/`, and `shared/` (excluding tests and the adapters themselves) finds
+  ZERO non-test consumers of any `*SubstrateOptions` / `run*WithSubstrate`
+  adapter. The four adapters (T2 `pacing`, T3 `reserve`, T4
+  `reserve-deterministic`, T5 `reserve-constrained`) are wired to nothing.
+- **The adapters already own the mode -> disclosure mapping.** Each computes
+  `effectiveMode = killSwitchActive ? 'off' : configuredMode` internally and
+  emits `on` -> available, `shadow` -> indicative + SHADOW_ONLY, configured
+  `off` -> unavailable + MODE_OFF, kill switch -> unavailable +
+  KILL_SWITCH_ACTIVE (both codes when both apply). So a resolver need only
+  surface the two raw fields; it must not pre-decide the effective mode.
+
+### Non-collapse (the whole point of this seam)
+
+The two existing per-key readers COLLAPSE the row into a single `'off'` mode
+string
+(`if (mode?.killSwitchActive) return 'off'; return mode?.configuredMode === 'shadow' || mode?.configuredMode === 'on' ? mode.configuredMode : 'off'`).
+That is correct for their own consumers, which only need a mode. It is WRONG for
+feeding an adapter: collapsing a kill-switched
+`{ configuredMode: 'on', killSwitchActive: true }` to `'off'` (with
+`killSwitchActive` implicitly false) would make the adapter disclose `MODE_OFF`
+instead of `KILL_SWITCH_ACTIVE` - a misreported reason code.
+`resolveSubstrateCalcMode` therefore returns `configuredMode` and
+`killSwitchActive` as two INDEPENDENT fields, verbatim from the row, and lets
+the adapter apply the effective-mode rule. The adapter-drop-in test proves this
+end to end: the uncollapsed `{ on, true }` yields
+`unavailable + KILL_SWITCH_ACTIVE` with NO `MODE_OFF`, whereas a collapsed value
+would invert both codes.
+
+### Pinned safety rules (technical invariants)
+
+- **Safe default (no row):**
+  `{ configuredMode: 'off', killSwitchActive: false }`. Absent an explicit
+  per-fund opt-in the substrate is off (adapter -> unavailable
+  - MODE_OFF); never default to a more permissive mode.
+- **Fail-safe validation:** the stored `configuredMode` is validated with
+  `CalcModeSchema.safeParse`; any unexpected value (the DB check should prevent
+  it, but drift/corruption is defended against) falls back to `'off'`, never
+  `'shadow'`/`'on'`. `killSwitchActive` coerces to a strict boolean (`=== true`,
+  default false).
+- **Injectable reader:** a narrow
+  `SubstrateCalcModeReader = (fundId, calculationKey) => Promise<SubstrateCalcModeRow | null | undefined>`
+  seam (default `defaultSubstrateCalcModeReader`, wrapping
+  `db.query.fundCalculationModes.findFirst` over the two columns) lets tests run
+  without a live DB.
+- **calculationKey correspondence:** the DB `calculation_key` value equals the
+  substrate calculationKey VERBATIM (a row with
+  `calculation_key = 'reserve-constrained'` governs the constrained adapter).
+  The passed `calculationKey` is guarded with `CalculationKeySchema` and a
+  `TypeError` is thrown on an invalid key (programmer error), mirroring the
+  adapters' guard style.
+- **Return type** is exactly the `{ configuredMode, killSwitchActive }` prefix
+  shared by all four `*SubstrateOptions`, so a caller spreads it straight into
+  any adapter:
+  `runConstrainedReserveWithSubstrate(ctx, input, { ...resolution })`.
+
+### Disposition table
+
+| Surface                                                                             | Disposition | Notes                                                                                                     |
+| ----------------------------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------- |
+| `fund_calculation_modes` registry (`shared/schema/fund-calculation-modes.ts`, 0017) | reuse       | Already exists and is read; this seam issues the same `(fund_id, calculation_key)` lookup, no schema edit |
+| `resolveFundCalculationMode` (`fund-calculation-mode-service.ts`)                   | reuse       | Untouched; MOIC/H9-specific, returns a different preview shape                                            |
+| `resolveReserveFactsCalculationMode` / `resolveMonteCarloActualsCalculationMode`    | reuse       | Untouched; their collapse is correct for THEIR consumers, wrong for adapters (see Non-collapse)           |
+| The four `*-substrate-adapter.ts` (`*SubstrateOptions`, `run*WithSubstrate`)        | reuse       | Consume the resolution unchanged; adapter owns the effective-mode / reason-code mapping                   |
+| `server/services/substrate-calc-mode-resolver.ts`                                   | new         | The uncollapsed read seam this ADR adds                                                                   |
+| Consumer wiring (route a live caller through the resolver + an adapter)             | defer       | Tranche 7 - this ADR is the read half only                                                                |
+
+### Consequences
+
+- A caller can now obtain an adapter-ready mode for any
+  `(fundId, calculationKey)` in one call, with the kill-switch distinction
+  intact. This is the keystone that unblocks Tranche 7 (wire the first substrate
+  consumer) without touching a route or changing any behavior in this tranche.
+- Out of scope here (unchanged from ADR-046): routes, consumer rewiring, adapter
+  edits, DB rows/writes/migrations, the flags registry, UI, queues, and Monte
+  Carlo.
+
+**Implementation:** `server/services/substrate-calc-mode-resolver.ts` (new) plus
+`tests/unit/services/substrate-calc-mode-resolver.test.ts` (14 tests: on/shadow/
+off mapping, non-collapse, safe default, calculationKey isolation, fail-safe
+invalid mode, strict-boolean kill switch, invalid-key TypeError, the default
+reader's column/where query shape, and the adapter-drop-in disclosure across all
+four states).

--- a/server/services/substrate-calc-mode-resolver.ts
+++ b/server/services/substrate-calc-mode-resolver.ts
@@ -1,0 +1,115 @@
+/**
+ * Generic substrate calculation-mode resolver (Tranche 6, ADR-047).
+ *
+ * Turns a `(fundId, calculationKey)` pair into the
+ * `{ configuredMode, killSwitchActive }` shape the four ADR-042 substrate
+ * adapters accept as the leading prefix of their `*SubstrateOptions`. This is
+ * the READ seam only: it runs no adapter, mounts no route, and writes no row.
+ * Routing a live consumer through it is Tranche 7.
+ *
+ * The `fund_calculation_modes` registry (schema
+ * `shared/schema/fund-calculation-modes.ts`, migration 0017) already exists and
+ * is already read by per-key readers; this seam does not rebuild it. What is new
+ * is the SHAPE it returns.
+ *
+ * Difference from the existing per-key readers
+ * (`resolveReserveFactsCalculationMode` in `reserve-calculation-service.ts`,
+ * `resolveMonteCarloActualsCalculationMode` in `monte-carlo-simulation.ts`):
+ * those COLLAPSE the kill switch into a single `'off'` mode string. This
+ * resolver must NOT collapse it. The substrate adapters compute
+ * `effectiveMode = killSwitchActive ? 'off' : configuredMode` themselves and
+ * disclose `KILL_SWITCH_ACTIVE` vs `MODE_OFF` based on WHICH of the two is set
+ * (both codes when both apply). Collapsing here would erase that distinction and
+ * misreport the reason code, so the uncollapsed two-field shape is the whole
+ * point of this seam.
+ *
+ * Safety posture (technical invariants, not governance):
+ * - Safe default: with no row, the substrate is off
+ *   (`{ configuredMode: 'off', killSwitchActive: false }`); the adapter then
+ *   returns unavailable + MODE_OFF. Absent an explicit per-fund opt-in the
+ *   substrate never runs, and this seam never defaults to a more permissive
+ *   mode.
+ * - Fail-safe validation: the stored `configuredMode` is validated with
+ *   `CalcModeSchema`; on any unexpected value (the DB check constraint should
+ *   prevent this, but drift/corruption is defended against) it falls back to
+ *   `'off'`, never `'shadow'`/`'on'`. `killSwitchActive` coerces to a strict
+ *   boolean (default false).
+ */
+
+import { CalcModeSchema, CalculationKeySchema, type CalcMode } from '@shared/core/calc-substrate';
+import { db } from '../db';
+
+/**
+ * The two fields every `*SubstrateOptions` shares as its leading prefix. A
+ * caller spreads this straight into any adapter's options object, e.g.
+ * `runConstrainedReserveWithSubstrate(ctx, input, { ...resolution })`.
+ */
+export interface SubstrateCalcModeResolution {
+  configuredMode: CalcMode;
+  killSwitchActive: boolean;
+}
+
+/**
+ * A raw `fund_calculation_modes` row projection over exactly the two columns
+ * this seam reads. `configuredMode` is typed as `string` on purpose: the reader
+ * returns whatever is stored and `resolveSubstrateCalcMode` validates it.
+ */
+export interface SubstrateCalcModeRow {
+  configuredMode: string;
+  killSwitchActive: boolean;
+}
+
+/** Narrow read seam so tests need no live DB. */
+export type SubstrateCalcModeReader = (
+  fundId: number,
+  calculationKey: string
+) => Promise<SubstrateCalcModeRow | null | undefined>;
+
+/**
+ * Default reader: the same `(fundId, calculationKey)`-keyed lookup the existing
+ * per-key readers issue, selecting only the two columns this seam needs.
+ */
+export const defaultSubstrateCalcModeReader: SubstrateCalcModeReader = (fundId, calculationKey) =>
+  db.query.fundCalculationModes.findFirst({
+    columns: { configuredMode: true, killSwitchActive: true },
+    where: (row, { and, eq }) =>
+      and(eq(row.fundId, fundId), eq(row.calculationKey, calculationKey)),
+  });
+
+export interface ResolveSubstrateCalcModeParams {
+  fundId: number;
+  calculationKey: string;
+  reader?: SubstrateCalcModeReader;
+}
+
+/**
+ * Resolve the substrate mode for a `(fundId, calculationKey)`. Returns the
+ * uncollapsed `{ configuredMode, killSwitchActive }` an adapter consumes.
+ *
+ * @throws {TypeError} if `calculationKey` is not a valid substrate calculation
+ *   key (programmer error, mirroring the adapters' key guard).
+ */
+export async function resolveSubstrateCalcMode({
+  fundId,
+  calculationKey,
+  reader = defaultSubstrateCalcModeReader,
+}: ResolveSubstrateCalcModeParams): Promise<SubstrateCalcModeResolution> {
+  if (!CalculationKeySchema.safeParse(calculationKey).success) {
+    throw new TypeError(
+      `substrate calc-mode resolver requires a valid calculationKey, received '${String(
+        calculationKey
+      )}'`
+    );
+  }
+
+  const row = await reader(fundId, calculationKey);
+  if (!row) {
+    return { configuredMode: 'off', killSwitchActive: false };
+  }
+
+  const parsedMode = CalcModeSchema.safeParse(row.configuredMode);
+  return {
+    configuredMode: parsedMode.success ? parsedMode.data : 'off',
+    killSwitchActive: row.killSwitchActive === true,
+  };
+}

--- a/tests/unit/services/substrate-calc-mode-resolver.test.ts
+++ b/tests/unit/services/substrate-calc-mode-resolver.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Substrate calculation-mode resolver tests (Tranche 6, ADR-047).
+ *
+ * Proves the read seam that turns a (fundId, calculationKey) into the
+ * uncollapsed { configuredMode, killSwitchActive } shape the ADR-042 substrate
+ * adapters consume:
+ * - on/shadow/off rows (killSwitch false) map to the matching mode;
+ * - killSwitch true with configuredMode 'on' stays { on, true } (NON-collapse) -
+ *   the distinction the existing per-key readers destroy;
+ * - no row -> safe default { off, false };
+ * - a row for a different calculationKey does not leak (query isolation);
+ * - an invalid stored configuredMode fails safe to off, never on/shadow;
+ * - the default reader selects the two columns and keys on (fundId, key);
+ * - the resolution spreads straight into runConstrainedReserveWithSubstrate and
+ *   drives the correct disclosure (available / SHADOW_ONLY / MODE_OFF /
+ *   KILL_SWITCH_ACTIVE), proving the uncollapsed shape is what the adapter needs.
+ *
+ * No live DB: db is mocked, and every case but the default-reader one injects a
+ * fake reader.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCalculationContext } from '../../../shared/core/calc-substrate';
+import {
+  CONSTRAINED_RESERVE_CALCULATION_KEY,
+  runConstrainedReserveWithSubstrate,
+} from '../../../shared/core/reserves/constrained-reserve-substrate-adapter';
+import {
+  resolveSubstrateCalcMode,
+  type SubstrateCalcModeResolution,
+  type SubstrateCalcModeRow,
+} from '../../../server/services/substrate-calc-mode-resolver';
+
+const { modeFindFirst } = vi.hoisted(() => ({ modeFindFirst: vi.fn() }));
+
+vi.mock('../../../server/db', () => ({
+  db: { query: { fundCalculationModes: { findFirst: modeFindFirst } } },
+}));
+
+beforeEach(() => {
+  modeFindFirst.mockReset();
+});
+
+/** Resolve against an injected reader that returns a fixed row (no live DB). */
+async function resolveWith(
+  row: SubstrateCalcModeRow | null | undefined,
+  calculationKey: string = CONSTRAINED_RESERVE_CALCULATION_KEY
+): Promise<SubstrateCalcModeResolution> {
+  return resolveSubstrateCalcMode({
+    fundId: 1,
+    calculationKey,
+    reader: async () => row,
+  });
+}
+
+describe('resolveSubstrateCalcMode', () => {
+  it.each(['on', 'shadow', 'off'] as const)(
+    'returns { %s, false } for a stored %s row with the kill switch off',
+    async (stored) => {
+      const resolution = await resolveWith({ configuredMode: stored, killSwitchActive: false });
+      expect(resolution).toEqual({ configuredMode: stored, killSwitchActive: false });
+    }
+  );
+
+  it('does NOT collapse the kill switch: configuredMode on + killSwitch true -> { on, true }', async () => {
+    const resolution = await resolveWith({ configuredMode: 'on', killSwitchActive: true });
+    // The existing per-key readers would collapse this to a single 'off' string,
+    // erasing whether the suppression is MODE_OFF or KILL_SWITCH_ACTIVE. This
+    // seam keeps both fields verbatim.
+    expect(resolution).toEqual({ configuredMode: 'on', killSwitchActive: true });
+  });
+
+  it('returns the safe default { off, false } when no row exists', async () => {
+    expect(await resolveWith(undefined)).toEqual({
+      configuredMode: 'off',
+      killSwitchActive: false,
+    });
+    expect(await resolveWith(null)).toEqual({ configuredMode: 'off', killSwitchActive: false });
+  });
+
+  it('isolates by calculationKey: a row for another key does not leak', async () => {
+    // Reader models the DB: it only returns a row for the 'reserve' key.
+    const keyedReader = async (
+      _fundId: number,
+      key: string
+    ): Promise<SubstrateCalcModeRow | undefined> =>
+      key === 'reserve' ? { configuredMode: 'on', killSwitchActive: false } : undefined;
+
+    const matched = await resolveSubstrateCalcMode({
+      fundId: 1,
+      calculationKey: 'reserve',
+      reader: keyedReader,
+    });
+    expect(matched).toEqual({ configuredMode: 'on', killSwitchActive: false });
+
+    const other = await resolveSubstrateCalcMode({
+      fundId: 1,
+      calculationKey: 'reserve-constrained',
+      reader: keyedReader,
+    });
+    expect(other).toEqual({ configuredMode: 'off', killSwitchActive: false });
+  });
+
+  it('fails safe to off on an invalid stored configuredMode, never on/shadow', async () => {
+    const resolution = await resolveWith({ configuredMode: 'bogus', killSwitchActive: false });
+    expect(resolution.configuredMode).toBe('off');
+    expect(resolution.configuredMode).not.toBe('on');
+    expect(resolution.configuredMode).not.toBe('shadow');
+
+    // The kill switch still passes through verbatim even when the mode is invalid.
+    const killed = await resolveWith({ configuredMode: 'bogus', killSwitchActive: true });
+    expect(killed).toEqual({ configuredMode: 'off', killSwitchActive: true });
+  });
+
+  it('coerces a non-boolean killSwitchActive to strict false', async () => {
+    // Defends against drift/corruption: only an explicit boolean true activates
+    // the kill switch.
+    const row = { configuredMode: 'on', killSwitchActive: 1 as unknown as boolean };
+    expect(await resolveWith(row)).toEqual({ configuredMode: 'on', killSwitchActive: false });
+  });
+
+  it('throws a TypeError on an invalid calculationKey and never reads', async () => {
+    const reader = vi.fn();
+    await expect(
+      resolveSubstrateCalcMode({ fundId: 1, calculationKey: '123-invalid', reader })
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(reader).not.toHaveBeenCalled();
+  });
+});
+
+describe('defaultSubstrateCalcModeReader (via the default-reader path)', () => {
+  it('selects only the two columns and keys the query on (fundId, calculationKey)', async () => {
+    interface FakeOperators {
+      and: (...conditions: unknown[]) => { op: 'and'; conditions: unknown[] };
+      eq: (column: unknown, value: unknown) => { op: 'eq'; column: unknown; value: unknown };
+    }
+    interface CapturedFindFirst {
+      columns: Record<string, boolean>;
+      where: (row: Record<string, unknown>, operators: FakeOperators) => unknown;
+    }
+
+    let captured: CapturedFindFirst | undefined;
+    modeFindFirst.mockImplementation((options: CapturedFindFirst) => {
+      captured = options;
+      return Promise.resolve({ configuredMode: 'shadow', killSwitchActive: false });
+    });
+
+    // No injected reader -> exercises the default reader over the mocked db.
+    const resolution = await resolveSubstrateCalcMode({
+      fundId: 42,
+      calculationKey: 'reserve-constrained',
+    });
+
+    expect(resolution).toEqual({ configuredMode: 'shadow', killSwitchActive: false });
+    expect(modeFindFirst).toHaveBeenCalledTimes(1);
+    expect(captured?.columns).toEqual({ configuredMode: true, killSwitchActive: true });
+
+    const eqCalls: Array<{ column: unknown; value: unknown }> = [];
+    const fakeRow = { fundId: 'FUND_ID_COL', calculationKey: 'CALC_KEY_COL' };
+    const operators: FakeOperators = {
+      and: (...conditions) => ({ op: 'and', conditions }),
+      eq: (column, value) => {
+        eqCalls.push({ column, value });
+        return { op: 'eq', column, value };
+      },
+    };
+    const whereResult = captured?.where(fakeRow, operators);
+
+    expect(whereResult).toEqual({
+      op: 'and',
+      conditions: [
+        { op: 'eq', column: 'FUND_ID_COL', value: 42 },
+        { op: 'eq', column: 'CALC_KEY_COL', value: 'reserve-constrained' },
+      ],
+    });
+    expect(eqCalls).toEqual([
+      { column: 'FUND_ID_COL', value: 42 },
+      { column: 'CALC_KEY_COL', value: 'reserve-constrained' },
+    ]);
+  });
+});
+
+describe('adapter drop-in: the resolution spreads straight into the adapter', () => {
+  const RESERVE_INPUT = {
+    availableReserves: 100_000,
+    companies: [{ id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 }],
+    stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+  };
+
+  function ctx() {
+    return createCalculationContext({
+      calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+      seed: 1,
+      asOf: '2026-07-18T00:00:00Z',
+    });
+  }
+
+  it('on -> available', async () => {
+    const resolution = await resolveWith({ configuredMode: 'on', killSwitchActive: false });
+    const result = runConstrainedReserveWithSubstrate(ctx(), RESERVE_INPUT, { ...resolution });
+    expect(result.state).toBe('available');
+    expect(result.reasonCodes).toEqual([]);
+  });
+
+  it('shadow -> indicative + SHADOW_ONLY', async () => {
+    const resolution = await resolveWith({ configuredMode: 'shadow', killSwitchActive: false });
+    const result = runConstrainedReserveWithSubstrate(ctx(), RESERVE_INPUT, { ...resolution });
+    expect(result.state).toBe('indicative');
+    expect(result.reasonCodes).toContain('SHADOW_ONLY');
+  });
+
+  it('off -> unavailable + MODE_OFF (no kill-switch code)', async () => {
+    const resolution = await resolveWith({ configuredMode: 'off', killSwitchActive: false });
+    const result = runConstrainedReserveWithSubstrate(ctx(), RESERVE_INPUT, { ...resolution });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toContain('MODE_OFF');
+    expect(result.reasonCodes).not.toContain('KILL_SWITCH_ACTIVE');
+  });
+
+  it('killSwitch true (configuredMode on) -> unavailable + KILL_SWITCH_ACTIVE only', async () => {
+    const resolution = await resolveWith({ configuredMode: 'on', killSwitchActive: true });
+    const result = runConstrainedReserveWithSubstrate(ctx(), RESERVE_INPUT, { ...resolution });
+    expect(result.state).toBe('unavailable');
+    expect(result.reasonCodes).toContain('KILL_SWITCH_ACTIVE');
+    // configuredMode was 'on', so MODE_OFF must NOT appear. A collapsed resolver
+    // (configuredMode -> 'off', killSwitch -> false) would invert both codes.
+    expect(result.reasonCodes).not.toContain('MODE_OFF');
+  });
+});


### PR DESCRIPTION
Add server/services/substrate-calc-mode-resolver.ts exporting
resolveSubstrateCalcMode({ fundId, calculationKey, reader? }), the read seam
that turns a (fundId, calculationKey) into the exact
{ configuredMode, killSwitchActive } shape the four ADR-042 substrate adapters
consume. Read-only: no routes, no consumer rewiring, no adapter/schema edits,
no DB writes or migrations. Unblocks Tranche 7 (wire the first consumer).

Unlike the two existing per-key readers, it does NOT collapse the kill switch
into a single 'off' string: it returns both fields verbatim so the adapter can
disclose KILL_SWITCH_ACTIVE vs MODE_OFF correctly. Safe default { off, false }
when no row exists; fail-safe validation of configuredMode via CalcModeSchema
(drift/corruption -> off, never shadow/on); strict-boolean kill switch;
injectable reader seam for DB-free tests; CalculationKeySchema guard
(invalid key -> TypeError).

Proven by tests/unit/services/substrate-calc-mode-resolver.test.ts (14 tests),
including an adapter drop-in that spreads the resolution into
runConstrainedReserveWithSubstrate and asserts the correct disclosure across
available / SHADOW_ONLY / MODE_OFF / KILL_SWITCH_ACTIVE.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JjuRJCQkudj3FtQwPkkCnp