### PR TITLE
feat(substrate): wire first substrate consumer as constrained-reserve shadow (ADR-048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,32 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Tranche 7 wire the first substrate consumer (ADR-048).** The prod-live route
+  `POST /api/v1/reserves/calculate` (`server/routes/v1/reserves.ts`, mounted by
+  `makeApp` at `/api/v1/reserves`, the Vercel runtime) now drives the Tranche 5
+  constrained-reserve adapter (`runConstrainedReserveWithSubstrate`,
+  calculationKey `reserve-constrained`) through the Tranche 6 read seam
+  (`resolveSubstrateCalcMode`) as a MODE-GATED, BEST-EFFORT SHADOW via a new
+  injectable helper `server/services/constrained-reserve-substrate-shadow.ts` -
+  the FIRST non-test consumer of the substrate (previously nothing consumed any
+  adapter or the resolver). The fund id comes from a NEW optional `?fundId`
+  query param parsed with the repo's `/^[1-9]\d*$/` discipline; absent or
+  non-conforming `fundId` skips the shadow entirely (no resolver call, no DB
+  read, no 400). When a valid `fundId` is present the shadow resolves the mode,
+  short-circuits the universal `off`-and-not-kill-switched default before any
+  adapter run (one `findFirst`), otherwise runs the adapter and logs one
+  disclosure line (`state`, `reasonCodes`, `resultHash`, `inputHash`,
+  `configuredMode`, `killSwitchActive`) at info; any error is logged at warn and
+  swallowed. The HTTP response is byte-identical with or without `?fundId` (the
+  shadow is logged, not served) - proven by a real supertest request test - and
+  the non-collapse disclosure (kill-switched `on` -> `KILL_SWITCH_ACTIVE`, not
+  `MODE_OFF`) is proven end to end through resolver -> adapter. No new routes;
+  no adapter/resolver/schema edits; no DB rows, writes, or migrations; no auth
+  or response-shape change. New tests:
+  `tests/unit/services/constrained-reserve-substrate-shadow.test.ts` (5 cases)
+  and `tests/unit/api/reserves-calculate-shadow-route.test.ts` (zero response
+  change).
+
 - **Tranche 6 generic substrate calculation-mode resolver (ADR-047).** New
   additive server service `server/services/substrate-calc-mode-resolver.ts`
   exporting `resolveSubstrateCalcMode({ fundId, calculationKey, reader? })`, the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -7292,3 +7292,116 @@ off mapping, non-collapse, safe default, calculationKey isolation, fail-safe
 invalid mode, strict-boolean kill switch, invalid-key TypeError, the default
 reader's column/where query shape, and the adapter-drop-in disclosure across all
 four states).
+
+## ADR-048: Tranche 7 Wire the First Substrate Consumer (Prod-Live Constrained-Reserve Shadow, Demo Scope)
+
+### Status
+
+Accepted.
+
+### Context
+
+Tranches 1-6 built the calculation substrate (ADR-042 contracts; ADR-043..046
+pacing/reserve/deterministic/constrained adapters exposing
+`run*WithSubstrate(ctx, input, options)`; ADR-047 the generic read seam
+`resolveSubstrateCalcMode({ fundId, calculationKey })` returning the uncollapsed
+`{ configuredMode, killSwitchActive }`). A grep across `server/`, `client/`, and
+`shared/` (excluding tests and the adapters/resolver themselves) confirmed the
+verified gap: ZERO non-test code consumed any adapter or the resolver. The
+substrate was fully built and fully unwired. Tranche 7 wires the FIRST consumer.
+
+### Decision
+
+Wire the constrained-reserve adapter (`runConstrainedReserveWithSubstrate`,
+calculationKey `reserve-constrained`) as a MODE-GATED, BEST-EFFORT SHADOW into
+the prod-live route `POST /api/v1/reserves/calculate`
+(`server/routes/v1/reserves.ts`), sourcing the fund id from a NEW optional
+`?fundId` query param, via a NEW injectable helper
+`server/services/constrained-reserve-substrate-shadow.ts`. The shadow result is
+computed and logged server-side only; the HTTP response is byte-identical to
+today in every case.
+
+Why this route, not `engine-summaries`:
+
+- `POST /api/v1/reserves/calculate` is PROD-LIVE. `server/app.ts` (the `makeApp`
+  factory that backs the Vercel deployment) mounts `reservesV1Router` at
+  `/api/v1/reserves`. By contrast `server/routes/engine-summaries.ts`
+  (`GET /reserves/:fundId`) is mounted only in `server/routes.ts` (the
+  Docker-only path) and 404s in prod; wiring it would be a hollow "consumer".
+- Its request body validates (via `validateReserveInput`) to exactly the
+  `ReserveInput` that `runConstrainedReserveWithSubstrate` re-parses and
+  consumes, so no input translation is needed.
+- It is the route ADR-046/047 named as the "wire a consumer" target.
+
+Design (pinned):
+
+- The helper resolves the mode through the T6 seam, then MODE-GATES: if
+  `configuredMode === 'off' && !killSwitchActive` (the universal default until a
+  fund opts into the `fund_calculation_modes` registry) it returns
+  `{ ran: false }` without building a context or running the adapter - one
+  `findFirst` and nothing more. Otherwise it builds a `CalculationContext`
+  (`seed: 1`, cosmetic because the constrained engine draws no randomness;
+  `asOf` = `new Date().toISOString()`, a Z-suffixed UTC instant accepted by
+  `createFixedClock`) and runs the adapter, spreading the uncollapsed resolution
+  straight into the adapter options. It logs one disclosure line (`state`,
+  `reasonCodes`, `resultHash`, `inputHash`, `configuredMode`,
+  `killSwitchActive`) at info.
+- Best-effort: the whole helper body is wrapped in try/catch; ANY error is
+  logged at warn and swallowed to `{ ran: false }`. A shadow failure never
+  surfaces to the caller.
+- The route reads `?fundId` and parses it with the repo's fund-id discipline
+  (`/^[1-9]\d*$/` -> `Number`). Absent or non-conforming `fundId` skips the
+  shadow entirely (no resolver call, no DB read, no behavior change - it does
+  NOT 400, because the param did not exist before). The shadow runs on the
+  success path, after the conservation check, before `res.json`.
+
+Zero-response-change invariant: with no `?fundId` (the existing contract) the
+response is byte-identical AND does zero extra work. With `?fundId=N` the
+response is STILL byte-identical - the shadow is logged, not served - and only
+server-side logging plus one `findFirst` differ. No fund-scope guard is added
+and none is needed: the response never branches on `fundId` or the mode, so
+there is no existence oracle and no cross-fund disclosure (only the
+caller-supplied `ReserveInput` is computed; no per-fund stored data is read).
+The route's existing auth is preserved.
+
+Injectable resolver seam: the helper's `resolveMode` parameter (default
+`resolveSubstrateCalcMode`) lets tests drive every mode / kill-switch case with
+no live DB, mirroring T6's injectable-reader philosophy one level up.
+
+DB `calculation_key` correspondence: the registry column
+`fund_calculation_modes.calculation_key` and the substrate `calculationKey`
+share the literal value `reserve-constrained` (the adapter's
+`CONSTRAINED_RESERVE_CALCULATION_KEY`), so a per-fund row keyed on that string
+governs this shadow's mode.
+
+### Disposition table
+
+| Component                                                              | Disposition                |
+| ---------------------------------------------------------------------- | -------------------------- |
+| `resolveSubstrateCalcMode` (T6 read seam)                              | reuse                      |
+| constrained-reserve adapter (`runConstrainedReserveWithSubstrate`, T5) | reuse                      |
+| `server/services/constrained-reserve-substrate-shadow.ts` (helper)     | new                        |
+| `server/routes/v1/reserves.ts` (route)                                 | edit (additive)            |
+| pacing / rule-reserve / deterministic adapters                         | defer                      |
+| `server/routes/engine-summaries.ts` (Docker-only)                      | defer (rejected as target) |
+
+### Consequences
+
+This is the FIRST live consumer of the substrate: the read seam and the
+constrained adapter now run end to end against a prod-live request, and the
+non-collapse disclosure (kill-switched `on` -> `KILL_SWITCH_ACTIVE`, not
+`MODE_OFF`) is proven all the way through resolver -> adapter. Nothing is
+persisted or reconciled and the response is unchanged, so the blast radius is
+one server log line plus one indexed `findFirst`. Likely Tranche 8: wire a
+SECOND consumer and/or persist-or-compare the shadow result against the legacy
+allocation output.
+
+### Non-goals
+
+No new routes; no edits to any `*-substrate-adapter.ts`,
+`shared/core/calc-substrate/`, `shared/schema/fund-calculation-modes.ts`,
+`substrate-calc-mode-resolver.ts`, `fund-calculation-mode-service.ts`, or the
+existing MOIC/facts/monte-carlo readers; no change to the `/calculate` response
+shape, status codes, or auth; no wiring of the other three adapters; no
+persisting or reconciling the shadow; no DB rows/writes/migrations; no
+flag-registry changes; no UI/queues/Monte Carlo; no new dependencies.

--- a/server/routes/v1/reserves.ts
+++ b/server/routes/v1/reserves.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { validateReserveInput } from '../../../shared/schemas.js';
 import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine.js';
 import logger from '../../utils/logger.js';
+import { observeConstrainedReserveSubstrateShadow } from '../../services/constrained-reserve-substrate-shadow.js';
 
 export const reservesV1Router = Router();
 const engine = new ConstrainedReserveEngine();
@@ -59,7 +60,7 @@ const engine = new ConstrainedReserveEngine();
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-reservesV1Router.post('/calculate', (req: Request, res: Response) => {
+reservesV1Router.post('/calculate', async (req: Request, res: Response) => {
   const rid = (req as Request & { requestId?: string }).requestId || 'unknown';
   try {
     const val = validateReserveInput(req.body);
@@ -68,6 +69,21 @@ reservesV1Router.post('/calculate', (req: Request, res: Response) => {
 
     const out = engine.calculate(val.data);
     if (!out.conservationOk) return res.status(500).json({ error: 'conservation_failed', rid });
+
+    // Best-effort, mode-gated substrate shadow (ADR-048): opt-in via ?fundId,
+    // computed and logged server-side only. The helper never throws, so it
+    // cannot affect the response body or status code; the response is
+    // byte-identical with or without ?fundId. No fund-scope guard is needed:
+    // the response never branches on fundId or mode, so there is no existence
+    // oracle and no per-fund stored data is read (only the caller-supplied
+    // ReserveInput is computed).
+    const rawFundId = req.query['fundId'];
+    if (typeof rawFundId === 'string' && /^[1-9]\d*$/.test(rawFundId)) {
+      await observeConstrainedReserveSubstrateShadow({
+        fundId: Number(rawFundId),
+        input: val.data,
+      });
+    }
 
     res.json({
       allocations: out.allocations,

--- a/server/services/constrained-reserve-substrate-shadow.ts
+++ b/server/services/constrained-reserve-substrate-shadow.ts
@@ -1,0 +1,119 @@
+/**
+ * Constrained-reserve substrate shadow observer (Tranche 7, ADR-048).
+ *
+ * The FIRST live consumer of the ADR-042 calculation substrate. It routes the
+ * prod-live `POST /api/v1/reserves/calculate` request through the Tranche 6 read
+ * seam (`resolveSubstrateCalcMode`, ADR-047) into the Tranche 5 constrained
+ * reserve adapter (`runConstrainedReserveWithSubstrate`, ADR-046) as a
+ * MODE-GATED, BEST-EFFORT SHADOW: the substrate result is computed and logged
+ * server-side only and NEVER enters the HTTP response.
+ *
+ * Invariants (technical, enforced here and in tests, not by governance):
+ * - Zero response change: this helper returns only `{ ran: boolean }` reporting
+ *   whether the shadow executed; it never returns a value the route could serve.
+ * - Mode gate: the universal safe default (no per-fund registry row -> off) is
+ *   short-circuited BEFORE any context build or adapter run, so a fund that has
+ *   not opted in via the registry costs exactly one `findFirst` and nothing more.
+ * - Best-effort: the whole body is wrapped in try/catch; any error (resolver
+ *   rejection, adapter throw, ...) is logged at warn and swallowed to
+ *   `{ ran: false }`. A shadow failure can never surface to the caller.
+ * - Non-collapse disclosure: the resolver returns the uncollapsed
+ *   `{ configuredMode, killSwitchActive }` and the adapter derives `effectiveMode`
+ *   and reason codes itself, so a kill-switched `on` fund logs `unavailable` +
+ *   `KILL_SWITCH_ACTIVE` (not `MODE_OFF`) - carried end to end.
+ */
+
+import { createCalculationContext } from '@shared/core/calc-substrate';
+import {
+  CONSTRAINED_RESERVE_CALCULATION_KEY,
+  runConstrainedReserveWithSubstrate,
+} from '@shared/core/reserves/constrained-reserve-substrate-adapter';
+import { logger } from '../lib/logger';
+import {
+  resolveSubstrateCalcMode,
+  type SubstrateCalcModeResolution,
+} from './substrate-calc-mode-resolver';
+
+/** Minimal structural logger this helper needs; the pino app logger satisfies it. */
+export interface ShadowLogger {
+  info: (obj: Record<string, unknown>, msg?: string) => void;
+  warn: (obj: Record<string, unknown>, msg?: string) => void;
+}
+
+/**
+ * Injectable resolver seam, mirroring Tranche 6's injectable-reader philosophy
+ * one level up: tests drive every mode / kill-switch case with no live DB.
+ */
+export type ResolveSubstrateCalcModeFn = (args: {
+  fundId: number;
+  calculationKey: string;
+}) => Promise<SubstrateCalcModeResolution>;
+
+export interface ObserveConstrainedReserveSubstrateShadowParams {
+  fundId: number;
+  input: unknown;
+  resolveMode?: ResolveSubstrateCalcModeFn;
+  asOf?: string;
+  log?: ShadowLogger;
+}
+
+/**
+ * Observe (compute + log, never serve) the constrained-reserve substrate shadow
+ * for one prod-live reserve calculation. Returns whether the shadow executed.
+ */
+export async function observeConstrainedReserveSubstrateShadow({
+  fundId,
+  input,
+  resolveMode = resolveSubstrateCalcMode,
+  asOf,
+  log = logger,
+}: ObserveConstrainedReserveSubstrateShadowParams): Promise<{ ran: boolean }> {
+  try {
+    const resolution = await resolveMode({
+      fundId,
+      calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+    });
+
+    // Mode gate: `off` and not kill-switched is the universal default until a
+    // fund opts in via the registry. Skip the context build and adapter run.
+    if (resolution.configuredMode === 'off' && !resolution.killSwitchActive) {
+      return { ran: false };
+    }
+
+    const ctx = createCalculationContext({
+      calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+      // The constrained engine draws no randomness, so this seed is a valid,
+      // cosmetic constant.
+      seed: 1,
+      asOf: asOf ?? new Date().toISOString(),
+    });
+
+    const result = runConstrainedReserveWithSubstrate(ctx, input, { ...resolution });
+
+    log.info(
+      {
+        fundId,
+        calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+        state: result.state,
+        reasonCodes: result.reasonCodes,
+        resultHash: 'resultHash' in result ? result.resultHash : null,
+        inputHash: result.basis.inputHash,
+        configuredMode: resolution.configuredMode,
+        killSwitchActive: resolution.killSwitchActive,
+      },
+      'constrained reserve substrate shadow'
+    );
+
+    return { ran: true };
+  } catch (error) {
+    log.warn(
+      {
+        fundId,
+        calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'constrained reserve substrate shadow failed'
+    );
+    return { ran: false };
+  }
+}

--- a/tests/unit/api/reserves-calculate-shadow-route.test.ts
+++ b/tests/unit/api/reserves-calculate-shadow-route.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+
+// Mock the Tranche 6 resolver so the shadow actually runs (in `shadow` mode)
+// with no live DB. The only runtime consumer of this module is the shadow
+// helper, so replacing the whole module is safe.
+vi.mock('../../../server/services/substrate-calc-mode-resolver', () => ({
+  resolveSubstrateCalcMode: vi.fn(async () => ({
+    configuredMode: 'shadow',
+    killSwitchActive: false,
+  })),
+}));
+
+import { makeApp } from '../../../server/app';
+
+const VALID_BODY = {
+  availableReserves: 1_000_000,
+  companies: [
+    { id: 'c1', name: 'Alpha', stage: 'seed', invested: 250_000, ownership: 0.15 },
+    { id: 'c2', name: 'Beta', stage: 'series_a', invested: 1_000_000, ownership: 0.1 },
+  ],
+  stagePolicies: [
+    { stage: 'seed', reserveMultiple: 2.5, weight: 1 },
+    { stage: 'series_a', reserveMultiple: 2, weight: 1.2 },
+  ],
+};
+
+function stripRid(body: Record<string, unknown>) {
+  const { rid: _rid, ...rest } = body;
+  return rest;
+}
+
+describe('POST /api/v1/reserves/calculate substrate shadow (ADR-048)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = makeApp();
+  });
+
+  it('is byte-identical (modulo rid) and 200 with and without ?fundId', async () => {
+    const withoutFund = await request(app).post('/api/v1/reserves/calculate').send(VALID_BODY);
+    const withFund = await request(app)
+      .post('/api/v1/reserves/calculate?fundId=1')
+      .send(VALID_BODY);
+
+    expect(withoutFund.status).toBe(200);
+    expect(withFund.status).toBe(200);
+    expect(stripRid(withFund.body)).toEqual(stripRid(withoutFund.body));
+  });
+});

--- a/tests/unit/api/reserves-calculate-shadow-route.test.ts
+++ b/tests/unit/api/reserves-calculate-shadow-route.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../../server/services/substrate-calc-mode-resolver', () => ({
 }));
 
 import { makeApp } from '../../../server/app';
+import { signToken } from '../../../server/lib/auth/jwt';
 
 const VALID_BODY = {
   availableReserves: 1_000_000,
@@ -39,9 +40,18 @@ describe('POST /api/v1/reserves/calculate substrate shadow (ADR-048)', () => {
   });
 
   it('is byte-identical (modulo rid) and 200 with and without ?fundId', async () => {
-    const withoutFund = await request(app).post('/api/v1/reserves/calculate').send(VALID_BODY);
+    const authorization = `Bearer ${signToken({
+      sub: 'reserves-shadow-route-test',
+      role: 'analyst',
+      fundIds: [],
+    })}`;
+    const withoutFund = await request(app)
+      .post('/api/v1/reserves/calculate')
+      .set('Authorization', authorization)
+      .send(VALID_BODY);
     const withFund = await request(app)
       .post('/api/v1/reserves/calculate?fundId=1')
+      .set('Authorization', authorization)
       .send(VALID_BODY);
 
     expect(withoutFund.status).toBe(200);

--- a/tests/unit/services/constrained-reserve-substrate-shadow.test.ts
+++ b/tests/unit/services/constrained-reserve-substrate-shadow.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  observeConstrainedReserveSubstrateShadow,
+  type ShadowLogger,
+} from '../../../server/services/constrained-reserve-substrate-shadow';
+import type { SubstrateCalcModeResolution } from '../../../server/services/substrate-calc-mode-resolver';
+
+const FIXED_AS_OF = '2026-07-17T00:00:00.000Z';
+
+// One seed company + one seed policy; a valid ReserveInput that reaches
+// `available` under mode `on`.
+const VALID_INPUT = {
+  availableReserves: 100_000,
+  companies: [{ id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 }],
+  stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+};
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn() } satisfies ShadowLogger;
+}
+
+function resolverReturning(resolution: SubstrateCalcModeResolution) {
+  return vi.fn(async () => resolution);
+}
+
+describe('observeConstrainedReserveSubstrateShadow', () => {
+  it('mode gate: off and not kill-switched returns { ran: false } without running the adapter or logging', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'off', killSwitchActive: false });
+    const log = makeLog();
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 1,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+    });
+
+    expect(result).toEqual({ ran: false });
+    expect(resolveMode).toHaveBeenCalledOnce();
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('shadow: runs the adapter, logs one indicative + SHADOW_ONLY line, returns { ran: true }', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'shadow', killSwitchActive: false });
+    const log = makeLog();
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 7,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(log.info).toHaveBeenCalledOnce();
+    const payload = log.info.mock.calls[0]![0];
+    expect(payload).toMatchObject({
+      fundId: 7,
+      calculationKey: 'reserve-constrained',
+      state: 'indicative',
+      reasonCodes: ['SHADOW_ONLY'],
+      configuredMode: 'shadow',
+      killSwitchActive: false,
+    });
+    expect(payload.resultHash).toEqual(expect.any(String));
+    expect(payload.inputHash).toEqual(expect.any(String));
+  });
+
+  it('on: runs the adapter and logs an available result', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: false });
+    const log = makeLog();
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 2,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+    });
+
+    expect(result).toEqual({ ran: true });
+    const payload = log.info.mock.calls[0]![0];
+    expect(payload).toMatchObject({ state: 'available', reasonCodes: [] });
+    expect(payload.resultHash).toEqual(expect.any(String));
+  });
+
+  it('non-collapse: kill switch over configuredMode `on` yields unavailable + KILL_SWITCH_ACTIVE and NOT MODE_OFF', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: true });
+    const log = makeLog();
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 3,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+    });
+
+    expect(result).toEqual({ ran: true });
+    const payload = log.info.mock.calls[0]![0];
+    expect(payload).toMatchObject({
+      state: 'unavailable',
+      configuredMode: 'on',
+      killSwitchActive: true,
+    });
+    expect(payload.reasonCodes).toContain('KILL_SWITCH_ACTIVE');
+    expect(payload.reasonCodes).not.toContain('MODE_OFF');
+  });
+
+  it('best-effort: a rejecting resolver is swallowed to { ran: false } and warns, never rethrows', async () => {
+    const resolveMode = vi.fn(async () => {
+      throw new Error('resolver boom');
+    });
+    const log = makeLog();
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 4,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+    });
+
+    expect(result).toEqual({ ran: false });
+    expect(log.warn).toHaveBeenCalledOnce();
+    expect(log.info).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 7 wires the **first live consumer** of the ADR-042 calculation substrate. The prod-live route `POST /api/v1/reserves/calculate` (`server/routes/v1/reserves.ts`, mounted by `makeApp` at `/api/v1/reserves` — the Vercel runtime) now drives the Tranche 5 constrained-reserve adapter (`runConstrainedReserveWithSubstrate`, calculationKey `reserve-constrained`) through the Tranche 6 read seam (`resolveSubstrateCalcMode`) as a **mode-gated, best-effort shadow** via a new injectable helper `server/services/constrained-reserve-substrate-shadow.ts`.

Before this change, zero non-test code consumed any substrate adapter or the resolver (verified by grep across `server/`, `client/`, `shared/`).

## Why this route (not `engine-summaries`)

- `POST /api/v1/reserves/calculate` is **prod-live** via `makeApp` (Vercel). `server/routes/engine-summaries.ts` (`GET /reserves/:fundId`) is mounted only in `server/routes.ts` (Docker-only) and 404s in prod — wiring it would be a hollow "consumer".
- Its request body validates (`validateReserveInput`) to exactly the `ReserveInput` the adapter re-parses, so no input translation is needed.
- It is the route ADR-046/047 named as the "wire a consumer" target.

## Design

- New optional `?fundId` query param, parsed with the repo's `/^[1-9]\d*$/` fund-id discipline. Absent or non-conforming `fundId` **skips the shadow entirely** (no resolver call, no DB read, no 400 — the param did not exist before).
- The helper resolves the mode, then **mode-gates**: `off && !killSwitch` (the universal default until a fund opts into `fund_calculation_modes`) returns `{ ran: false }` before any context build or adapter run — one `findFirst` and nothing more. Otherwise it runs the adapter and logs one disclosure line (`state`, `reasonCodes`, `resultHash`, `inputHash`, `configuredMode`, `killSwitchActive`) at info.
- **Best-effort:** the whole helper body is wrapped in try/catch; any error is logged at warn and swallowed to `{ ran: false }`. A shadow failure never surfaces to the caller.

## Zero-response-change invariant

With or without `?fundId`, the HTTP response is **byte-identical** (the shadow is logged, not served) and the status code is unchanged. Proven by a real supertest request test asserting identical bodies (modulo `rid`) and both 200. The **non-collapse** disclosure (a kill-switched `on` fund logs `unavailable` + `KILL_SWITCH_ACTIVE`, not `MODE_OFF`) is carried end to end through resolver -> adapter. No fund-scope guard is added or needed: the response never branches on `fundId` or the mode, so there is no existence oracle and no per-fund stored data is read.

## Disposition

| Component | Disposition |
| --- | --- |
| `resolveSubstrateCalcMode` (T6 read seam) | reuse |
| constrained-reserve adapter (T5) | reuse |
| `constrained-reserve-substrate-shadow.ts` (helper) | new |
| `server/routes/v1/reserves.ts` (route) | edit (additive) |
| pacing / rule-reserve / deterministic adapters | defer |
| `engine-summaries.ts` (Docker-only) | defer (rejected as target) |

## Verification

- Full `npm test`: **8914 passed / 90 skipped, 0 failures** — delta over the T6 baseline (8908) is **exactly +6** (the 6 new tests: 5 helper + 1 route).
- Targeted substrate + route suite: 81/81. ESLint clean (`--max-warnings 0`). `npm run check`: 0 new TS errors. `npm run build`: passes.
- `git diff --stat origin/main`: exactly six files (helper, route, two tests, DECISIONS.md, CHANGELOG.md).

## Non-goals (enforced)

No new routes; no edits to any `*-substrate-adapter.ts`, `shared/core/calc-substrate/`, the resolver, schema, or existing readers; no response-shape/status/auth change; no other adapter wired; no persistence/reconciliation; no DB rows/writes/migrations; no flag-registry, UI, queue, or dependency changes.

## Unblocks next (Tranche 8)

Wire a second consumer and/or persist-or-compare the shadow result against the legacy allocation output (T7 only computes + logs; nothing is persisted or reconciled).

Recorded as ADR-048 in `DECISIONS.md` with a dated `CHANGELOG.md` entry.

Generated with Claude Code (https://claude.com/claude-code)
