### PR TITLE
feat(substrate): reconcile constrained-reserve shadow against legacy output (ADR-049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Tranche 8 reconcile the constrained-reserve substrate shadow (ADR-049).**
+  The Tranche 7 shadow on `POST /api/v1/reserves/calculate` now, when it runs
+  (on/shadow), RECONCILES the substrate allocation output against the legacy
+  `ConstrainedReserveEngine` output the route serves for the same request,
+  IN-PROCESS, and logs a structured parity disclosure (match -> info, mismatch
+  -> warn). A new EXPORTED PURE function
+  `reconcileConstrainedReserveShadow(substrateValue, legacy)` in
+  `server/services/constrained-reserve-substrate-shadow.ts` normalizes ALL money
+  to exact integer cents (substrate 2-decimal string split on `.` and
+  recombined; legacy number via `Math.round(n * 100)` - never `parseFloat`),
+  keys allocations by `id`, and reports divergences across the allocation id
+  set, per-allocation `allocated`, `totalAllocated`, `remaining`, and
+  `conservationOk`. The helper takes a NEW optional
+  `legacyResult?: LegacyConstrainedReserveResult`; absent, it behaves EXACTLY as
+  Tranche 7. The route wires it with ONE new field, `legacyResult: out`, on the
+  existing shadow call. The comparison is logged server-side only - the HTTP
+  response stays byte-identical with or without `?fundId`, and nothing is
+  persisted (no DB, no migration). This is the parity precursor to promotion;
+  likely Tranche 9 persists the reconciliation result (which requires lifting
+  the no-DB posture).
 - **Tranche 7 wire the first substrate consumer (ADR-048).** The prod-live route
   `POST /api/v1/reserves/calculate` (`server/routes/v1/reserves.ts`, mounted by
   `makeApp` at `/api/v1/reserves`, the Vercel runtime) now drives the Tranche 5

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -7405,3 +7405,114 @@ existing MOIC/facts/monte-carlo readers; no change to the `/calculate` response
 shape, status codes, or auth; no wiring of the other three adapters; no
 persisting or reconciling the shadow; no DB rows/writes/migrations; no
 flag-registry changes; no UI/queues/Monte Carlo; no new dependencies.
+
+## ADR-049: Tranche 8 Reconcile the Constrained-Reserve Substrate Shadow Against the Legacy Output (Demo Scope)
+
+### Status
+
+Accepted.
+
+### Context
+
+Tranche 7 (ADR-048) wired the first live substrate consumer: the prod-live route
+`POST /api/v1/reserves/calculate` drives the constrained-reserve adapter through
+the T6 read seam as a mode-gated, best-effort shadow that COMPUTES and LOGS a
+`resultHash` but never COMPARES the substrate allocation output against the
+legacy `ConstrainedReserveEngine` output the route actually serves. Re-reading
+the T7 helper confirmed the gap: there is no trust signal yet - nothing asserts
+the substrate path reproduces the legacy path. The whole substrate arc is
+building toward "is the substrate faithful to the legacy path?"; T7 answered it
+with zero signal (a hash only).
+
+### Decision
+
+Extend the T7 shadow so that, when it runs (on/shadow, i.e. a value exists), it
+also RECONCILES the substrate allocation output against the legacy engine output
+the route computed for the same request, IN-PROCESS, and logs a structured
+parity/divergence disclosure (match -> info, mismatch -> warn). The comparison
+is logged server-side only; the HTTP response stays byte-identical; nothing is
+persisted. No DB, no migration, no new route, no adapter/resolver/schema edit.
+
+Why COMPARE (not "second consumer", not "persist"):
+
+- Compare is the first tranche that yields a trust signal - the precondition for
+  ever promoting the substrate to authoritative. Wiring more consumers first
+  multiplies unvalidated shadows.
+- Compare is genuinely non-trivial here: the adapter re-parses the input
+  (`ReserveInputSchema` vs the route's `validateReserveInput`), renders money as
+  fixed 2-decimal strings, and runs hash admission. Reconciliation verifies
+  those transformations are lossless - a real prod-log regression guard against
+  future adapter/engine refactors.
+- Persist is deferred: it would require lifting the no-DB-writes/no-migrations
+  posture and is premature before parity is established. Second consumer is
+  deferred: the other adapters lack a clean prod-live route consuming their
+  exact input (engine-summaries is Docker-only and 404s in prod).
+
+Design (pinned):
+
+- A NEW EXPORTED PURE function
+  `reconcileConstrainedReserveShadow(substrateValue, legacy)` in the T7 helper
+  file compares the substrate `ConstrainedReserveCalcValue` against a structural
+  `LegacyConstrainedReserveResult` (`allocations[{ id, allocated }]`,
+  `totalAllocated`, `remaining`, `conservationOk`; the route's richer `out`
+  satisfies it structurally). ALL money is normalized to exact integer cents
+  before comparison: the substrate 2-decimal string is split on `.` and
+  recombined (`Number(whole) * 100 + Number(frac)` - exact, never `parseFloat`),
+  the legacy number is `Math.round(n * 100)`. Allocations are keyed by `id`, so
+  the comparison is order- and float-artifact-independent. It accumulates a
+  human-readable `mismatches` string per divergence across the allocation id SET
+  (ids present on one side only), per-shared-id `allocated`, `totalAllocated`,
+  `remaining`, and `conservationOk`; an empty list is a `match`.
+- The helper gains an OPTIONAL `legacyResult?: LegacyConstrainedReserveResult`
+  param. When ABSENT it behaves EXACTLY as T7 (fully backward compatible). When
+  present AND `result.state` is `available` or `indicative` (so `result.value`
+  exists), the helper - AFTER the existing shadow disclosure log and INSIDE the
+  same best-effort try/catch - reconciles and logs a SECOND line: on match
+  `log.info({ fundId, calculationKey, reconciliation: 'match', substrateState, resultHash }, 'constrained reserve substrate reconciliation')`,
+  on mismatch the same fields plus `mismatches` at `log.warn` with the
+  `MISMATCH` message. A reconcile defect can never surface; the return stays
+  `{ ran: boolean }` (unchanged - the route ignores it).
+- The route (`server/routes/v1/reserves.ts`) passes one new field,
+  `legacyResult: out`, into the EXISTING
+  `observeConstrainedReserveSubstrateShadow` call. Nothing else changes: same
+  `?fundId` guard, same
+  `res.json({ allocations, totalAllocated, remaining, rid })`, same catch.
+
+Zero-response-change invariant (unchanged headline): the reconciliation reads
+`out` (already computed) and the substrate value (already computed) and only
+logs; it never enters the response body or status code, and never runs when the
+shadow is skipped (no `?fundId`, or mode-gated off). With no `?fundId` the
+response is byte-identical AND does zero extra work, exactly as T7.
+
+### Disposition table
+
+| Component                                                              | Disposition      |
+| ---------------------------------------------------------------------- | ---------------- |
+| `resolveSubstrateCalcMode` (T6 read seam)                              | reuse            |
+| constrained-reserve adapter (`runConstrainedReserveWithSubstrate`, T5) | reuse            |
+| `server/services/constrained-reserve-substrate-shadow.ts` (T7 helper)  | edit             |
+| `reconcileConstrainedReserveShadow` (pure compare)                     | new              |
+| `server/routes/v1/reserves.ts` (route)                                 | edit (one field) |
+| persistence + second consumer + other three adapters                   | defer            |
+
+### Consequences
+
+The substrate constrained-reserve path is now, for the first time, checked for
+FAITHFULNESS against the legacy path it shadows: on every opted-in prod-live
+`/calculate` request the substrate value and the served legacy output are
+reconciled in exact cents and any divergence is disclosed at warn. This is the
+parity precursor to promotion; the blast radius remains one-or-two server log
+lines (no persistence, no response change). Likely Tranche 9: PERSIST the
+shadow/reconciliation result, which requires lifting the no-DB-writes /
+no-migrations posture held since Tranche 1.
+
+### Non-goals
+
+No persistence, no DB rows/writes, no migrations (that is T9 and requires
+lifting the posture); no new routes; no second consumer; no edits to any
+`*-substrate-adapter.ts`, `shared/core/calc-substrate/`,
+`shared/schema/fund-calculation-modes.ts`, `substrate-calc-mode-resolver.ts`,
+`fund-calculation-mode-service.ts`, `ConstrainedReserveEngine.ts`, or the
+existing MOIC/facts/monte-carlo readers; no change to the `/calculate` response
+shape, status codes, or auth; no flag-registry changes; no UI/queues/Monte
+Carlo; no new dependencies.

--- a/server/routes/v1/reserves.ts
+++ b/server/routes/v1/reserves.ts
@@ -82,6 +82,7 @@ reservesV1Router.post('/calculate', async (req: Request, res: Response) => {
       await observeConstrainedReserveSubstrateShadow({
         fundId: Number(rawFundId),
         input: val.data,
+        legacyResult: out,
       });
     }
 

--- a/server/services/constrained-reserve-substrate-shadow.ts
+++ b/server/services/constrained-reserve-substrate-shadow.ts
@@ -27,6 +27,7 @@ import { createCalculationContext } from '@shared/core/calc-substrate';
 import {
   CONSTRAINED_RESERVE_CALCULATION_KEY,
   runConstrainedReserveWithSubstrate,
+  type ConstrainedReserveCalcValue,
 } from '@shared/core/reserves/constrained-reserve-substrate-adapter';
 import { logger } from '../lib/logger';
 import {
@@ -49,12 +50,129 @@ export type ResolveSubstrateCalcModeFn = (args: {
   calculationKey: string;
 }) => Promise<SubstrateCalcModeResolution>;
 
+/**
+ * Structural view of the legacy `ConstrainedReserveEngine` output the prod-live
+ * route already computed and served for the same request. Only the fields the
+ * reconciliation compares are named; the route's richer `out` (whose allocations
+ * also carry `name`/`stage`) satisfies this shape structurally.
+ */
+export interface LegacyConstrainedReserveResult {
+  allocations: ReadonlyArray<{ id: string; allocated: number }>;
+  totalAllocated: number;
+  remaining: number;
+  conservationOk: boolean;
+}
+
+/** Outcome of comparing the substrate value against the legacy result. */
+export interface ConstrainedReserveShadowReconciliation {
+  status: 'match' | 'mismatch';
+  mismatches: string[];
+}
+
+/**
+ * Convert a fixed 2-decimal money string (`/^(0|[1-9]\d*)\.\d{2}$/`, as produced
+ * by the constrained-reserve adapter) into exact integer cents by splitting on
+ * the decimal point. This is lossless; `parseFloat`/`Number` on the whole string
+ * would reintroduce the binary-float artifacts the adapter deliberately avoids.
+ */
+function moneyStringToCents(value: string): number {
+  const [whole, frac] = value.split('.');
+  return Number(whole) * 100 + Number(frac);
+}
+
+/** Convert a legacy engine money number (exact 2dp cents) into integer cents. */
+function moneyNumberToCents(value: number): number {
+  return Math.round(value * 100);
+}
+
+/**
+ * Reconcile the substrate constrained-reserve value against the legacy engine
+ * result for the SAME request. Pure (no I/O, no ambient reads). All money is
+ * normalized to exact integer cents before comparison and allocations are keyed
+ * by `id`, so the comparison is order- and float-artifact-independent. An empty
+ * `mismatches` list means the substrate path reproduced the legacy path exactly.
+ */
+export function reconcileConstrainedReserveShadow(
+  substrateValue: ConstrainedReserveCalcValue,
+  legacy: LegacyConstrainedReserveResult
+): ConstrainedReserveShadowReconciliation {
+  const mismatches: string[] = [];
+
+  const substrateById = new Map(
+    substrateValue.allocations.map((allocation) => [allocation.id, allocation] as const)
+  );
+  const legacyById = new Map(
+    legacy.allocations.map((allocation) => [allocation.id, allocation] as const)
+  );
+
+  // Allocation id SET (order-independent): report ids present on one side only.
+  for (const id of substrateById.keys()) {
+    if (!legacyById.has(id)) {
+      mismatches.push(`allocation ${id} present in substrate but absent from legacy`);
+    }
+  }
+  for (const id of legacyById.keys()) {
+    if (!substrateById.has(id)) {
+      mismatches.push(`allocation ${id} present in legacy but absent from substrate`);
+    }
+  }
+
+  // Per shared id: `allocated` compared in exact cents.
+  for (const [id, substrateAllocation] of substrateById) {
+    const legacyAllocation = legacyById.get(id);
+    if (!legacyAllocation) {
+      continue;
+    }
+    const substrateCents = moneyStringToCents(substrateAllocation.allocated);
+    const legacyCents = moneyNumberToCents(legacyAllocation.allocated);
+    if (substrateCents !== legacyCents) {
+      mismatches.push(
+        `allocation ${id} allocated cents differ: substrate ${substrateCents} vs legacy ${legacyCents}`
+      );
+    }
+  }
+
+  const substrateTotal = moneyStringToCents(substrateValue.totalAllocated);
+  const legacyTotal = moneyNumberToCents(legacy.totalAllocated);
+  if (substrateTotal !== legacyTotal) {
+    mismatches.push(
+      `totalAllocated cents differ: substrate ${substrateTotal} vs legacy ${legacyTotal}`
+    );
+  }
+
+  const substrateRemaining = moneyStringToCents(substrateValue.remaining);
+  const legacyRemaining = moneyNumberToCents(legacy.remaining);
+  if (substrateRemaining !== legacyRemaining) {
+    mismatches.push(
+      `remaining cents differ: substrate ${substrateRemaining} vs legacy ${legacyRemaining}`
+    );
+  }
+
+  if (substrateValue.conservationOk !== legacy.conservationOk) {
+    mismatches.push(
+      `conservationOk differs: substrate ${substrateValue.conservationOk} vs legacy ${legacy.conservationOk}`
+    );
+  }
+
+  return {
+    status: mismatches.length === 0 ? 'match' : 'mismatch',
+    mismatches,
+  };
+}
+
 export interface ObserveConstrainedReserveSubstrateShadowParams {
   fundId: number;
   input: unknown;
   resolveMode?: ResolveSubstrateCalcModeFn;
   asOf?: string;
   log?: ShadowLogger;
+  /**
+   * The legacy engine output the route just computed and will serve. When
+   * present AND the substrate produced a value, the helper reconciles the two
+   * and logs a parity/divergence disclosure. Absent -> exactly the Tranche 7
+   * behavior (shadow disclosure only).
+   */
+  legacyResult?: LegacyConstrainedReserveResult;
 }
 
 /**
@@ -67,6 +185,7 @@ export async function observeConstrainedReserveSubstrateShadow({
   resolveMode = resolveSubstrateCalcMode,
   asOf,
   log = logger,
+  legacyResult,
 }: ObserveConstrainedReserveSubstrateShadowParams): Promise<{ ran: boolean }> {
   try {
     const resolution = await resolveMode({
@@ -103,6 +222,39 @@ export async function observeConstrainedReserveSubstrateShadow({
       },
       'constrained reserve substrate shadow'
     );
+
+    // Reconciliation (ADR-049): when the route supplied the legacy engine output
+    // it will serve AND the substrate produced a value (available/indicative),
+    // compare the two in exact cents and log a parity/divergence disclosure.
+    // Server-side only; never touches the response. Inside the same try/catch so
+    // a reconcile defect can never surface to the caller.
+    if (legacyResult && (result.state === 'available' || result.state === 'indicative')) {
+      const reconciliation = reconcileConstrainedReserveShadow(result.value, legacyResult);
+      if (reconciliation.status === 'match') {
+        log.info(
+          {
+            fundId,
+            calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+            reconciliation: reconciliation.status,
+            substrateState: result.state,
+            resultHash: result.resultHash,
+          },
+          'constrained reserve substrate reconciliation'
+        );
+      } else {
+        log.warn(
+          {
+            fundId,
+            calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+            reconciliation: reconciliation.status,
+            substrateState: result.state,
+            resultHash: result.resultHash,
+            mismatches: reconciliation.mismatches,
+          },
+          'constrained reserve substrate reconciliation MISMATCH'
+        );
+      }
+    }
 
     return { ran: true };
   } catch (error) {

--- a/tests/unit/services/constrained-reserve-substrate-reconcile.test.ts
+++ b/tests/unit/services/constrained-reserve-substrate-reconcile.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reconcileConstrainedReserveShadow,
+  type LegacyConstrainedReserveResult,
+} from '../../../server/services/constrained-reserve-substrate-shadow';
+import {
+  runConstrainedReserveWithSubstrate,
+  CONSTRAINED_RESERVE_CALCULATION_KEY,
+  ConstrainedReserveCalcValueSchema,
+  type ConstrainedReserveCalcValue,
+} from '../../../shared/core/reserves/constrained-reserve-substrate-adapter';
+import { createCalculationContext } from '../../../shared/core/calc-substrate';
+import { ReserveInputSchema } from '../../../shared/schemas';
+import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine';
+
+const AS_OF = '2026-07-18T00:00:00.000Z';
+
+// Two seed/series_a companies with no per-company or per-stage caps: the greedy
+// fill hands the full 1,000,000 to the top-ranked company, so the run yields a
+// non-trivial allocation set with a rendered money boundary to reconcile.
+const INPUT = {
+  availableReserves: 1_000_000,
+  companies: [
+    { id: 'c1', name: 'Alpha', stage: 'seed', invested: 250_000, ownership: 0.15 },
+    { id: 'c2', name: 'Beta', stage: 'series_a', invested: 1_000_000, ownership: 0.1 },
+  ],
+  stagePolicies: [
+    { stage: 'seed', reserveMultiple: 2.5, weight: 1 },
+    { stage: 'series_a', reserveMultiple: 2, weight: 1.2 },
+  ],
+};
+
+/**
+ * Build a REAL substrate value and the matching legacy engine result from the
+ * SAME parsed input. The substrate value renders money as fixed 2-decimal
+ * strings; the legacy result carries plain numbers. Any divergence between them
+ * would be a real transformation defect (the whole point of the reconciliation).
+ */
+function buildReal(): {
+  substrateValue: ConstrainedReserveCalcValue;
+  legacy: LegacyConstrainedReserveResult;
+} {
+  const parsed = ReserveInputSchema.parse(INPUT);
+  const ctx = createCalculationContext({
+    calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+    seed: 1,
+    asOf: AS_OF,
+  });
+  const result = runConstrainedReserveWithSubstrate(ctx, parsed, {
+    configuredMode: 'on',
+    killSwitchActive: false,
+  });
+  if (result.state !== 'available') {
+    throw new Error(`expected an available substrate result, got '${result.state}'`);
+  }
+  const legacy = new ConstrainedReserveEngine().calculate(parsed);
+  return { substrateValue: result.value, legacy };
+}
+
+describe('reconcileConstrainedReserveShadow', () => {
+  it('MATCH: a real substrate value reconciles with the legacy result it derives from', () => {
+    const { substrateValue, legacy } = buildReal();
+
+    const recon = reconcileConstrainedReserveShadow(substrateValue, legacy);
+
+    expect(recon.status).toBe('match');
+    expect(recon.mismatches).toEqual([]);
+  });
+
+  it('MATCH: cents precision - the "100.55" string reconciles with the number 100.55 exactly', () => {
+    const substrateValue = ConstrainedReserveCalcValueSchema.parse({
+      allocations: [{ id: 'p1', name: 'Precise', stage: 'seed', allocated: '100.55' }],
+      totalAllocated: '100.55',
+      remaining: '0.00',
+      conservationOk: true,
+      asOfUtc: AS_OF,
+    });
+    const legacy: LegacyConstrainedReserveResult = {
+      allocations: [{ id: 'p1', allocated: 100.55 }],
+      totalAllocated: 100.55,
+      remaining: 0,
+      conservationOk: true,
+    };
+
+    const recon = reconcileConstrainedReserveShadow(substrateValue, legacy);
+
+    expect(recon.status).toBe('match');
+    expect(recon.mismatches).toEqual([]);
+  });
+
+  it('MISMATCH: a per-allocation allocated divergence is reported', () => {
+    const { substrateValue, legacy } = buildReal();
+    const tampered: LegacyConstrainedReserveResult = {
+      ...legacy,
+      allocations: legacy.allocations.map((allocation, index) =>
+        index === 0 ? { ...allocation, allocated: allocation.allocated - 1 } : allocation
+      ),
+    };
+
+    const recon = reconcileConstrainedReserveShadow(substrateValue, tampered);
+
+    expect(recon.status).toBe('mismatch');
+    expect(recon.mismatches.some((m) => m.includes('allocated cents differ'))).toBe(true);
+  });
+
+  it('MISMATCH: a totalAllocated divergence is reported', () => {
+    const { substrateValue, legacy } = buildReal();
+    const tampered: LegacyConstrainedReserveResult = {
+      ...legacy,
+      totalAllocated: legacy.totalAllocated + 1,
+    };
+
+    const recon = reconcileConstrainedReserveShadow(substrateValue, tampered);
+
+    expect(recon.status).toBe('mismatch');
+    expect(recon.mismatches.some((m) => m.includes('totalAllocated cents differ'))).toBe(true);
+  });
+
+  it('MISMATCH: a remaining divergence is reported', () => {
+    const { substrateValue, legacy } = buildReal();
+    const tampered: LegacyConstrainedReserveResult = {
+      ...legacy,
+      remaining: legacy.remaining + 1,
+    };
+
+    const recon = reconcileConstrainedReserveShadow(substrateValue, tampered);
+
+    expect(recon.status).toBe('mismatch');
+    expect(recon.mismatches.some((m) => m.includes('remaining cents differ'))).toBe(true);
+  });
+
+  it('MISMATCH: a conservationOk divergence is reported', () => {
+    const { substrateValue, legacy } = buildReal();
+    const tampered: LegacyConstrainedReserveResult = {
+      ...legacy,
+      conservationOk: !legacy.conservationOk,
+    };
+
+    const recon = reconcileConstrainedReserveShadow(substrateValue, tampered);
+
+    expect(recon.status).toBe('mismatch');
+    expect(recon.mismatches.some((m) => m.includes('conservationOk differs'))).toBe(true);
+  });
+
+  it('MISMATCH: an allocation-id-set divergence (id present on one side only) is reported', () => {
+    const { substrateValue, legacy } = buildReal();
+    const tampered: LegacyConstrainedReserveResult = {
+      ...legacy,
+      allocations: [...legacy.allocations, { id: 'ghost', allocated: 0 }],
+    };
+
+    const recon = reconcileConstrainedReserveShadow(substrateValue, tampered);
+
+    expect(recon.status).toBe('mismatch');
+    expect(
+      recon.mismatches.some((m) => m.includes('ghost') && m.includes('absent from substrate'))
+    ).toBe(true);
+  });
+});

--- a/tests/unit/services/constrained-reserve-substrate-shadow.test.ts
+++ b/tests/unit/services/constrained-reserve-substrate-shadow.test.ts
@@ -4,6 +4,8 @@ import {
   type ShadowLogger,
 } from '../../../server/services/constrained-reserve-substrate-shadow';
 import type { SubstrateCalcModeResolution } from '../../../server/services/substrate-calc-mode-resolver';
+import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine';
+import { ReserveInputSchema } from '../../../shared/schemas';
 
 const FIXED_AS_OF = '2026-07-17T00:00:00.000Z';
 
@@ -127,5 +129,92 @@ describe('observeConstrainedReserveSubstrateShadow', () => {
     expect(result).toEqual({ ran: false });
     expect(log.warn).toHaveBeenCalledOnce();
     expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('reconciliation MATCH: a matching legacyResult logs the reconciliation line at info alongside the shadow line', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'shadow', killSwitchActive: false });
+    const log = makeLog();
+    // Computed from the SAME parse the adapter uses, so the substrate and legacy
+    // engine outputs are identical and the reconciliation must be a match.
+    const legacyResult = new ConstrainedReserveEngine().calculate(
+      ReserveInputSchema.parse(VALID_INPUT)
+    );
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 11,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      legacyResult,
+    });
+
+    expect(result).toEqual({ ran: true });
+    // The original shadow disclosure still logs.
+    expect(log.info.mock.calls.some((call) => call[0]!.state === 'indicative')).toBe(true);
+    // The reconciliation disclosure logs at info with status 'match'.
+    const reconCall = log.info.mock.calls.find((call) => call[0]!.reconciliation === 'match');
+    expect(reconCall).toBeDefined();
+    expect(reconCall![0]).toMatchObject({
+      fundId: 11,
+      calculationKey: 'reserve-constrained',
+      reconciliation: 'match',
+      substrateState: 'indicative',
+    });
+    expect(reconCall![0].resultHash).toEqual(expect.any(String));
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('reconciliation MISMATCH: a tampered legacyResult logs at warn with mismatch and non-empty mismatches', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: false });
+    const log = makeLog();
+    // Deliberately wrong legacy output for the same request: a real divergence
+    // (not a vacuous always-match) must fire the warn path.
+    const tamperedLegacy = {
+      allocations: [{ id: 'c1', allocated: 42 }],
+      totalAllocated: 42,
+      remaining: 0,
+      conservationOk: true,
+    };
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 12,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      legacyResult: tamperedLegacy,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(log.warn).toHaveBeenCalledOnce();
+    const warnPayload = log.warn.mock.calls[0]![0];
+    expect(warnPayload).toMatchObject({
+      fundId: 12,
+      calculationKey: 'reserve-constrained',
+      reconciliation: 'mismatch',
+      substrateState: 'available',
+    });
+    expect(Array.isArray(warnPayload.mismatches)).toBe(true);
+    expect((warnPayload.mismatches as string[]).length).toBeGreaterThan(0);
+  });
+
+  it('no legacyResult: behaves exactly as Tranche 7 - only the shadow line, no reconciliation line', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'shadow', killSwitchActive: false });
+    const log = makeLog();
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 13,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(log.info).toHaveBeenCalledOnce();
+    expect(log.info.mock.calls[0]![0]).toMatchObject({ state: 'indicative' });
+    expect(log.info.mock.calls[0]![0]).not.toHaveProperty('reconciliation');
+    expect(log.warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Tranche 8 — reconcile the constrained-reserve substrate shadow against the legacy output (ADR-049)

Extends the Tranche 7 shadow (ADR-048) with the first **trust signal** for the calc-substrate arc: when the shadow runs (on/shadow), it now compares the substrate allocation value against the legacy `ConstrainedReserveEngine` output the prod-live route actually serves for the same request — **in-process, server-side log only, HTTP response byte-identical, nothing persisted**.

### What changed (6 files, additive)
- **`server/services/constrained-reserve-substrate-shadow.ts`** — new exported pure `reconcileConstrainedReserveShadow(substrateValue, legacy)` + `LegacyConstrainedReserveResult` / `ConstrainedReserveShadowReconciliation` types; helper gains optional `legacyResult?` (absent ⇒ exactly T7). Reconcile runs after the shadow disclosure log, inside the same best-effort try/catch, only when the substrate produced a value.
- **`server/routes/v1/reserves.ts`** — one field, `legacyResult: out`, on the existing shadow call.
- **`tests/unit/services/constrained-reserve-substrate-reconcile.test.ts`** (new, 7 cases) + **`...-shadow.test.ts`** (edited, +3 additive cases).
- **`DECISIONS.md`** (ADR-049), **`CHANGELOG.md`**.

### Design
- **Cents-normalized parity:** substrate 2-decimal string split on `.` (`Number(whole)*100 + Number(frac)`, never `parseFloat`); legacy number via `Math.round(n*100)`. Allocations keyed by `id` (order-independent). Divergences reported across the allocation id set, per-allocation `allocated`, `totalAllocated`, `remaining`, `conservationOk`.
- **Disclosure:** match → `info`, mismatch → `warn` with `mismatches[]`.

### Invariants held
- Zero response change (route test: byte-identical body with/without `?fundId`, both 200, now with `legacyResult` flowing; run log shows the reconciliation line firing end-to-end).
- No persistence / no DB / no migration / no new route / no adapter-resolver-schema edit. Backward compatible.
- Real mismatch fires (non-vacuous): pure-fn drives every divergence class; helper test drives a tampered `legacyResult` to the warn path.

### Verification
- Targeted exit-criteria set: **91/91 passed**.
- Full suite (server 3 + client 2 foreground shards): **8924 passed, 90 skipped, 0 failed** → delta vs baseline = **exactly +10 tests / +1 file**.
- `npm run check`: 0 new TS errors. `eslint --max-warnings 0`: clean. `npm run build`: passed.

### Disposition
resolver `reuse` · constrained adapter `reuse` · T7 helper `edit` · pure reconcile fn `new` · route `edit (one field)` · persistence + second consumer + other three adapters `defer`.

Next: **T9 = persist** the reconciliation result (requires lifting the no-DB-writes / no-migrations posture held since T1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjuRJCQkudj3FtQwPkkCnp
