### PR TITLE
feat(substrate): persist constrained-reserve shadow reconciliation to append-only ledger (ADR-050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,40 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Tranche 9 persist the constrained-reserve substrate shadow reconciliation
+  (ADR-050).** The Tranche 8 reconciliation outcome, previously logged and lost,
+  is now durable: each value-producing (`available`/`indicative`) shadow run of
+  `POST /api/v1/reserves/calculate` writes ONE append-only, fund-scoped,
+  idempotent row into a NEW `substrate_shadow_reconciliations` audit ledger,
+  BEST-EFFORT from inside the T8 helper. This tranche deliberately lifts the
+  no-DB-writes/no-migrations posture held since Tranche 1, within hard bounds:
+  ONE new Drizzle table (`shared/schema/substrate-shadow-reconciliations.ts`,
+  mirroring the `reconciliation_runs` conventions but a SEPARATE
+  MOIC-independent table - CHECK-constrained
+  `configured_mode`/`effective_mode`/`substrate_state`/ `reconciliation_status`,
+  dedicated typed hash columns, `mismatches jsonb`,
+  `unique(fund_id, calculation_key, input_hash, result_hash)` idempotency key,
+  `(fund_id, observed_at DESC)` index) and ONE new additive, replay-safe
+  migration (`migrations/0035_substrate_shadow_reconciliations.sql`,
+  `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`, shape-equal to
+  the Drizzle table, journaled at idx 36). The helper gains an exported
+  `SubstrateShadowReconciliationRecord` type and an injectable `persist?` writer
+  seam (default = `server/services/substrate-shadow-reconciliation-writer.ts`,
+  which issues `insert(...).values(record).onConflictDoNothing()`); persistence
+  runs ONLY on the same gate as the reconciliation log, ORDERED AFTER it, in its
+  OWN try/catch that logs one `warn` and swallows - a persist failure never
+  surfaces, never throws, never alters the response, and never blocks the log.
+  The route is UNCHANGED (it already passes `legacyResult: out`). ZERO response
+  change (byte-identical with/without `?fundId`) and best-effort-swallow remain
+  the headline invariants. The migration is LOCAL/test-DB only and reaches prod
+  ONLY via the untriggered, gated `prod-schema-reconcile` apply flow (NOT
+  invoked here); no prod DB, CI, credential, or deploy change. New tests: the
+  default writer's idempotent insert (mocked `db`, DB-free) and additive helper
+  cases (persist called exactly once with a correctly-shaped record on match and
+  on a synthetic mismatch; NOT called when `legacyResult` absent / mode-gated
+  off / no substrate value; a throwing writer swallowed to `{ ran: true }` with
+  one warn). Likely Tranche 10: expose/read the ledger OR promote the substrate
+  to authoritative behind `mode=on`.
 - **Tranche 8 reconcile the constrained-reserve substrate shadow (ADR-049).**
   The Tranche 7 shadow on `POST /api/v1/reserves/calculate` now, when it runs
   (on/shadow), RECONCILES the substrate allocation output against the legacy

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -7516,3 +7516,149 @@ lifting the posture); no new routes; no second consumer; no edits to any
 existing MOIC/facts/monte-carlo readers; no change to the `/calculate` response
 shape, status codes, or auth; no flag-registry changes; no UI/queues/Monte
 Carlo; no new dependencies.
+
+## ADR-050: Tranche 9 Persist the Constrained-Reserve Substrate Shadow Reconciliation to an Append-Only Audit Ledger (Demo Scope)
+
+### Status
+
+Accepted.
+
+### Context
+
+Tranche 8 (ADR-049) added IN-PROCESS reconciliation: when the
+constrained-reserve substrate shadow runs (on/shadow) inside prod-live
+`POST /api/v1/reserves/calculate` and produces a value, the helper compares the
+substrate allocation output against the legacy `ConstrainedReserveEngine` output
+the route serves for the same request and logs a parity/divergence disclosure
+(match -> info, mismatch -> warn). Re-reading the T8 helper confirms the gap:
+the reconciliation outcome is LOGGED and then LOST. There is no durable,
+queryable trust RECORD over time - you cannot answer "has fund N's
+constrained-reserve substrate ever diverged, and when?" without scraping logs.
+The whole substrate arc builds toward a future promotion decision ("is the
+substrate faithful over time?"); that decision must rest on an accumulated
+parity record, not on ephemeral log lines. T8 gave the first trust SIGNAL; it
+left no trust RECORD.
+
+This tranche deliberately LIFTS the no-DB-writes / no-migrations posture that
+was in force for Tranches 1-8, but only within hard bounds: ONE new journaled,
+additive, replay-safe migration and ONE new Drizzle table, plus a best-effort DB
+insert from inside the T8 helper. LOCAL/test DB only. The migration is
+authored + journaled locally and reaches production ONLY via the pre-existing
+gated `prod-schema-reconcile` apply flow, which this tranche does NOT trigger
+and does NOT invoke. No prod DB, no CI/workflow, no credential, and no
+prod-deploy change.
+
+### Decision
+
+Persist each value-producing constrained-reserve shadow reconciliation
+observation (the parity outcome + calc identity hashes + mode/state) into a NEW
+append-only, fund-scoped, idempotent audit-ledger table, written BEST-EFFORT
+from inside the T8 helper, LOCAL/test DB only. No reads, no response change, no
+route change, no second consumer, no promotion of the substrate to
+authoritative.
+
+Why PERSIST now (not "second consumer", not "promote", not "expose/read"):
+
+- Persistence is the audit ledger a future promotion decision must rest on. It
+  is the precondition ADR-049 named for T9: T8 produced a trust signal but no
+  trust record.
+- Second consumer stays deferred: the other adapters lack a clean prod-live
+  route consuming their exact input (engine-summaries is Docker-only and 404s in
+  prod).
+- Promotion (serving the substrate value when `mode=on`) stays deferred: it
+  would be the first response change in the whole arc and must not precede an
+  accumulated parity record.
+- Expose/read (an endpoint or UI over the ledger) stays deferred: it is a
+  separate read surface (likely T10) and is not needed to start accumulating the
+  record.
+
+Design (pinned):
+
+- A NEW Drizzle table `substrate_shadow_reconciliations`
+  (`shared/schema/substrate-shadow-reconciliations.ts`), mirroring the
+  `reconciliation_runs` (MOIC/rounds) conventions but a SEPARATE table (the
+  substrate-shadow domain, not the MOIC domain; it reuses none of that table's
+  columns): serial `id`; `fund_id` -> `funds.id` `ON DELETE cascade`;
+  `calculation_key text`; CHECK-constrained `configured_mode`/`effective_mode`
+  varchar(8) IN `('off','shadow','on')`; `kill_switch_active boolean`; CHECK-
+  constrained `substrate_state` varchar(16) IN `('available','indicative')`
+  (only value-producing runs are persisted); CHECK-constrained
+  `reconciliation_status` varchar(16) IN `('match','mismatch')`;
+  `input_hash`/`result_hash`/`assumptions_hash` text (from `result.basis.*` /
+  `result.resultHash`); `mismatches jsonb` (`string[]`, `[]` on match - a
+  variable-length list legitimately in jsonb; every scalar identity/mode/status
+  field is a DEDICATED typed column, never blobbed);
+  `observed_at timestamptz DEFAULT now()`. Idempotency key
+  `unique(fund_id, calculation_key, input_hash, result_hash)` - same request ->
+  same substrate result -> ONE row. Lookup index `(fund_id, observed_at DESC)`.
+- A NEW migration `migrations/0035_substrate_shadow_reconciliations.sql`,
+  additive and replay-safe (`CREATE TABLE IF NOT EXISTS` with inline
+  constraints + `CREATE INDEX IF NOT EXISTS`, so a second application is a
+  strict no-op), authored + journaled per the `0034` + `meta/_journal.json`
+  convention (idx 36) and SHAPE-EQUAL to the Drizzle table. The only FK targets
+  `funds.id` (a serial PRIMARY KEY), so there is no PG 42830
+  composite-FK-to-uniqueIndex risk; all identifiers are under the PG 63-byte
+  limit. `shared/schema` remains the shape source, `./migrations` the ledger.
+- The T8 helper (`server/services/constrained-reserve-substrate-shadow.ts`)
+  gains an exported record type `SubstrateShadowReconciliationRecord`, an
+  injectable `PersistSubstrateShadowReconciliationFn` seam, and an OPTIONAL
+  `persist?` param defaulting to the real writer (mirroring the `resolveMode`
+  philosophy so tests stay DB-free). The DEFAULT writer
+  (`server/services/substrate-shadow-reconciliation-writer.ts`) issues
+  `db.insert(substrateShadowReconciliations).values(record).onConflictDoNothing()` -
+  idempotent by construction. Persistence runs ONLY on the SAME gate as the
+  reconciliation log (a substrate value exists AND `legacyResult` supplied),
+  ORDERED AFTER that log, inside its OWN try/catch that logs one `warn` and
+  swallows: a persist failure never surfaces to the caller, never throws, never
+  alters the response, and never prevents the reconciliation log. The helper's
+  return stays `{ ran: boolean }` (unchanged).
+- The route (`server/routes/v1/reserves.ts`) is UNCHANGED: it already passes
+  `legacyResult: out`; the helper owns persistence.
+
+Zero-response-change + best-effort invariants (unchanged headline): persistence
+adds one idempotent insert on opted-in (`?fundId`), mode-on/shadow,
+value-producing requests; it is off the response path and swallowed on failure.
+With no `?fundId` the response is byte-identical AND does zero extra work,
+exactly as T7/T8. Proven by the existing route supertest (byte-identical body
+with/without `?fundId`, the best-effort insert swallowed under the memory-mode
+mock DB).
+
+### Disposition table
+
+| Component                                                                    | Disposition                |
+| ---------------------------------------------------------------------------- | -------------------------- |
+| `resolveSubstrateCalcMode` (T6 read seam)                                    | reuse                      |
+| constrained-reserve adapter (`runConstrainedReserveWithSubstrate`, T5)       | reuse                      |
+| `server/services/constrained-reserve-substrate-shadow.ts` (T8 helper)        | edit                       |
+| `substrate_shadow_reconciliations` table + `0035` migration + default writer | new                        |
+| `reconciliation_runs` (MOIC/rounds ledger)                                   | reject-reuse (MOIC-domain) |
+| `server/routes/v1/reserves.ts` (route)                                       | unchanged                  |
+| second consumer + promotion + read/expose surface                            | defer                      |
+
+### Consequences
+
+For the first time in the arc the substrate/legacy parity outcome is DURABLE:
+every opted-in prod-live `/calculate` request whose substrate shadow produces a
+value writes one append-only, fund-scoped, idempotent row recording the parity
+status and calc identity. A future promotion decision can now rest on an
+accumulated, queryable trust record instead of scraped logs. The blast radius
+stays one best-effort insert off the response path (swallowed on failure); the
+HTTP response is byte-identical to T8. The migration is LOCAL-only and reaches
+prod only via the untriggered, gated `prod-schema-reconcile` apply flow. Likely
+Tranche 10: EXPOSE/READ the ledger (a query endpoint or trust-dashboard surface)
+OR PROMOTE the substrate to authoritative behind `mode=on` (the first response
+change, which must not precede an accumulated parity record).
+
+### Non-goals
+
+No reads/queries/endpoints/UI over the ledger (that is T10); no second consumer;
+no promotion (the substrate value is never served; the response stays
+byte-identical); no migration/`db:push`/`db:migrate` against prod or any remote
+DB (LOCAL/test only, reaching prod only via the untriggered gated reconcile
+flow); no CI/workflow, credential, or prod-deploy change; no edits to any
+`*-substrate-adapter.ts`, `shared/core/calc-substrate/`,
+`shared/schema/fund-calculation-modes.ts`, `substrate-calc-mode-resolver.ts`,
+`fund-calculation-mode-service.ts`, `ConstrainedReserveEngine.ts`,
+`reconciliation-runs.ts`, or the existing MOIC/facts/monte-carlo readers; no
+change to the `/calculate` response shape, status codes, or auth; no
+Phoenix-protected path edits; no new dependencies.

--- a/migrations/0035_substrate_shadow_reconciliations.sql
+++ b/migrations/0035_substrate_shadow_reconciliations.sql
@@ -1,0 +1,33 @@
+-- @drift-patch
+-- Reason: add an append-only fund-scoped ledger of constrained-reserve substrate shadow reconciliation observations (ADR-050).
+
+CREATE TABLE IF NOT EXISTS "substrate_shadow_reconciliations" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "calculation_key" text NOT NULL,
+  "configured_mode" varchar(8) NOT NULL,
+  "effective_mode" varchar(8) NOT NULL,
+  "kill_switch_active" boolean NOT NULL,
+  "substrate_state" varchar(16) NOT NULL,
+  "reconciliation_status" varchar(16) NOT NULL,
+  "input_hash" text NOT NULL,
+  "result_hash" text NOT NULL,
+  "assumptions_hash" text NOT NULL,
+  "mismatches" jsonb NOT NULL,
+  "observed_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "substrate_shadow_reconciliations_fund_key_input_result_unique"
+    UNIQUE ("fund_id", "calculation_key", "input_hash", "result_hash"),
+  CONSTRAINT "substrate_shadow_reconciliations_configured_mode_check"
+    CHECK ("configured_mode" IN ('off', 'shadow', 'on')),
+  CONSTRAINT "substrate_shadow_reconciliations_effective_mode_check"
+    CHECK ("effective_mode" IN ('off', 'shadow', 'on')),
+  CONSTRAINT "substrate_shadow_reconciliations_substrate_state_check"
+    CHECK ("substrate_state" IN ('available', 'indicative')),
+  CONSTRAINT "substrate_shadow_reconciliations_reconciliation_status_check"
+    CHECK ("reconciliation_status" IN ('match', 'mismatch')),
+  CONSTRAINT "substrate_shadow_reconciliations_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_substrate_shadow_reconciliations_fund_observed"
+  ON "substrate_shadow_reconciliations" ("fund_id", "observed_at" DESC);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1784136334907,
       "tag": "0034_business_time_comparison_lineage",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1784376000000,
+      "tag": "0035_substrate_shadow_reconciliations",
+      "breakpoints": true
     }
   ]
 }

--- a/server/services/constrained-reserve-substrate-shadow.ts
+++ b/server/services/constrained-reserve-substrate-shadow.ts
@@ -23,7 +23,7 @@
  *   `KILL_SWITCH_ACTIVE` (not `MODE_OFF`) - carried end to end.
  */
 
-import { createCalculationContext } from '@shared/core/calc-substrate';
+import { createCalculationContext, type CalcMode } from '@shared/core/calc-substrate';
 import {
   CONSTRAINED_RESERVE_CALCULATION_KEY,
   runConstrainedReserveWithSubstrate,
@@ -34,6 +34,7 @@ import {
   resolveSubstrateCalcMode,
   type SubstrateCalcModeResolution,
 } from './substrate-calc-mode-resolver';
+import { persistSubstrateShadowReconciliation } from './substrate-shadow-reconciliation-writer';
 
 /** Minimal structural logger this helper needs; the pino app logger satisfies it. */
 export interface ShadowLogger {
@@ -160,6 +161,37 @@ export function reconcileConstrainedReserveShadow(
   };
 }
 
+/**
+ * The durable audit-ledger record persisted for one value-producing shadow
+ * reconciliation (Tranche 9, ADR-050). Built ONLY on the same gate as the
+ * reconciliation log (a substrate value exists AND the route supplied
+ * `legacyResult`), so `substrateState` is always `available` or `indicative`.
+ * Fed straight into the fund-scoped, append-only
+ * `substrate_shadow_reconciliations` table.
+ */
+export interface SubstrateShadowReconciliationRecord {
+  fundId: number;
+  calculationKey: string;
+  configuredMode: CalcMode;
+  effectiveMode: CalcMode;
+  killSwitchActive: boolean;
+  substrateState: 'available' | 'indicative';
+  reconciliationStatus: 'match' | 'mismatch';
+  inputHash: string;
+  resultHash: string;
+  assumptionsHash: string;
+  mismatches: string[];
+}
+
+/**
+ * Injectable writer seam, mirroring the `resolveMode` philosophy one level up:
+ * prod uses the real append-only DB writer; tests pass a fake so the
+ * persistence assertions stay DB-free.
+ */
+export type PersistSubstrateShadowReconciliationFn = (
+  record: SubstrateShadowReconciliationRecord
+) => Promise<void>;
+
 export interface ObserveConstrainedReserveSubstrateShadowParams {
   fundId: number;
   input: unknown;
@@ -173,6 +205,14 @@ export interface ObserveConstrainedReserveSubstrateShadowParams {
    * behavior (shadow disclosure only).
    */
   legacyResult?: LegacyConstrainedReserveResult;
+  /**
+   * Injectable persistence seam (Tranche 9, ADR-050). Defaults to the real
+   * append-only DB writer. A best-effort insert runs ONLY when the
+   * reconciliation itself runs (a substrate value exists AND `legacyResult` is
+   * supplied); a throwing writer is swallowed - persistence is off the response
+   * path and can never surface to the caller.
+   */
+  persist?: PersistSubstrateShadowReconciliationFn;
 }
 
 /**
@@ -186,6 +226,7 @@ export async function observeConstrainedReserveSubstrateShadow({
   asOf,
   log = logger,
   legacyResult,
+  persist = persistSubstrateShadowReconciliation,
 }: ObserveConstrainedReserveSubstrateShadowParams): Promise<{ ran: boolean }> {
   try {
     const resolution = await resolveMode({
@@ -252,6 +293,38 @@ export async function observeConstrainedReserveSubstrateShadow({
             mismatches: reconciliation.mismatches,
           },
           'constrained reserve substrate reconciliation MISMATCH'
+        );
+      }
+
+      // Persistence (ADR-050): durably record THIS reconciliation observation in
+      // the append-only, fund-scoped audit ledger. Best-effort and idempotent -
+      // ordered AFTER the reconciliation log, wrapped in its OWN try/catch so a
+      // persist failure logs one warn and is swallowed: it never surfaces to the
+      // caller, never throws, never alters the response, and never prevents the
+      // reconciliation log above.
+      const record: SubstrateShadowReconciliationRecord = {
+        fundId,
+        calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+        configuredMode: resolution.configuredMode,
+        effectiveMode: result.basis.effectiveMode,
+        killSwitchActive: resolution.killSwitchActive,
+        substrateState: result.state,
+        reconciliationStatus: reconciliation.status,
+        inputHash: result.basis.inputHash,
+        resultHash: result.resultHash,
+        assumptionsHash: result.basis.assumptionsHash,
+        mismatches: reconciliation.mismatches,
+      };
+      try {
+        await persist(record);
+      } catch (persistError) {
+        log.warn(
+          {
+            fundId,
+            calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+            error: persistError instanceof Error ? persistError.message : String(persistError),
+          },
+          'constrained reserve substrate reconciliation persist failed'
         );
       }
     }

--- a/server/services/substrate-shadow-reconciliation-writer.ts
+++ b/server/services/substrate-shadow-reconciliation-writer.ts
@@ -1,0 +1,26 @@
+/**
+ * Default persistence writer for constrained-reserve substrate shadow
+ * reconciliation observations (Tranche 9, ADR-050).
+ *
+ * The real writer behind the injectable `persist` seam on
+ * `observeConstrainedReserveSubstrateShadow`. It issues ONE idempotent,
+ * fund-scoped, append-only insert into `substrate_shadow_reconciliations`:
+ * `onConflictDoNothing()` makes a duplicate (same request -> same substrate
+ * result -> same `(fund_id, calculation_key, input_hash, result_hash)`) a no-op
+ * rather than an error, so replays and retries never double-write.
+ *
+ * This function does NOT catch its own errors: the caller (the shadow helper)
+ * owns the best-effort try/catch so a DB failure is logged once and swallowed
+ * off the response path. Keeping the swallow in the caller lets tests inject a
+ * throwing `persist` and prove the helper never rethrows.
+ */
+
+import { db } from '../db';
+import { substrateShadowReconciliations } from '@shared/schema';
+import type { SubstrateShadowReconciliationRecord } from './constrained-reserve-substrate-shadow';
+
+export async function persistSubstrateShadowReconciliation(
+  record: SubstrateShadowReconciliationRecord
+): Promise<void> {
+  await db.insert(substrateShadowReconciliations).values(record).onConflictDoNothing();
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -41,6 +41,7 @@ export * from './schema/user';
 export * from './schema/lp-reporting-evidence';
 export * from './schema/operating-objects';
 export * from './schema/reconciliation-runs';
+export * from './schema/substrate-shadow-reconciliations';
 export * from './schema/fund-calculation-modes';
 export * from './schema/fund-moic-input-update-requests';
 export * from './schema/investment-rounds';

--- a/shared/schema/substrate-shadow-reconciliations.ts
+++ b/shared/schema/substrate-shadow-reconciliations.ts
@@ -1,0 +1,88 @@
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  unique,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { funds } from './fund';
+
+/**
+ * Append-only audit ledger for constrained-reserve substrate SHADOW
+ * reconciliation observations (Tranche 9, ADR-050).
+ *
+ * Each row is one value-producing (`available`/`indicative`) run of the
+ * mode-gated shadow inside `POST /api/v1/reserves/calculate`: it records the
+ * parity outcome (`reconciliation_status`) against the legacy engine output for
+ * the SAME request, plus the calc identity hashes and mode/state, so a future
+ * promotion decision ("has fund N's substrate ever diverged, and when?") can
+ * rest on a durable trust record instead of scraped logs.
+ *
+ * Deliberately mirrors the `reconciliation_runs` (MOIC/rounds) conventions -
+ * serial pk, fund-scoped FK with cascade delete, CHECK-constrained enum columns,
+ * dedicated typed scalar columns (never a JSONB blob for known-domain fields),
+ * a fund-scoped idempotency unique, and a `(fund_id, observed_at desc)` lookup
+ * index - but is a SEPARATE table: it is the substrate-shadow domain, not the
+ * MOIC reconciliation domain, and reuses none of that table's columns.
+ *
+ * Written best-effort and OFF the response path: the HTTP response is
+ * byte-identical with or without persistence, and an insert failure is swallowed
+ * (never surfaces to the caller, never throws). No reads/queries/endpoints yet.
+ */
+export const substrateShadowReconciliations = pgTable(
+  'substrate_shadow_reconciliations',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    calculationKey: text('calculation_key').notNull(),
+    configuredMode: varchar('configured_mode', { length: 8 }).notNull(),
+    effectiveMode: varchar('effective_mode', { length: 8 }).notNull(),
+    killSwitchActive: boolean('kill_switch_active').notNull(),
+    substrateState: varchar('substrate_state', { length: 16 }).notNull(),
+    reconciliationStatus: varchar('reconciliation_status', { length: 16 }).notNull(),
+    inputHash: text('input_hash').notNull(),
+    resultHash: text('result_hash').notNull(),
+    assumptionsHash: text('assumptions_hash').notNull(),
+    mismatches: jsonb('mismatches').notNull().$type<string[]>(),
+    observedAt: timestamp('observed_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    configuredModeCheck: check(
+      'substrate_shadow_reconciliations_configured_mode_check',
+      sql`${table.configuredMode} IN ('off','shadow','on')`
+    ),
+    effectiveModeCheck: check(
+      'substrate_shadow_reconciliations_effective_mode_check',
+      sql`${table.effectiveMode} IN ('off','shadow','on')`
+    ),
+    substrateStateCheck: check(
+      'substrate_shadow_reconciliations_substrate_state_check',
+      sql`${table.substrateState} IN ('available','indicative')`
+    ),
+    reconciliationStatusCheck: check(
+      'substrate_shadow_reconciliations_reconciliation_status_check',
+      sql`${table.reconciliationStatus} IN ('match','mismatch')`
+    ),
+    fundObservedIdx: index('idx_substrate_shadow_reconciliations_fund_observed').on(
+      table.fundId,
+      table.observedAt.desc()
+    ),
+    fundKeyInputResultUnique: unique(
+      'substrate_shadow_reconciliations_fund_key_input_result_unique'
+    ).on(table.fundId, table.calculationKey, table.inputHash, table.resultHash),
+  })
+);
+
+export type SubstrateShadowReconciliation = typeof substrateShadowReconciliations.$inferSelect;
+export type InsertSubstrateShadowReconciliation =
+  typeof substrateShadowReconciliations.$inferInsert;

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -45,6 +45,7 @@ const expectedJournaledDriftPatchFiles = [
   '0032_scenario_case_seed_provenance.sql',
   '0033_company_scenario_create_requests.sql',
   '0034_business_time_comparison_lineage.sql',
+  '0035_substrate_shadow_reconciliations.sql',
 ].sort();
 
 afterEach(() => {

--- a/tests/unit/services/constrained-reserve-substrate-shadow.test.ts
+++ b/tests/unit/services/constrained-reserve-substrate-shadow.test.ts
@@ -217,4 +217,183 @@ describe('observeConstrainedReserveSubstrateShadow', () => {
     expect(log.info.mock.calls[0]![0]).not.toHaveProperty('reconciliation');
     expect(log.warn).not.toHaveBeenCalled();
   });
+
+  // Tranche 9 (ADR-050): best-effort, idempotent persistence of the value-producing
+  // reconciliation observation via the injectable `persist` seam. DB-free: a fake
+  // `persist` proves shape, gate, and swallow without touching a database.
+
+  it('persistence MATCH: persists exactly one correctly-shaped record (status match, empty mismatches)', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'shadow', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    // MATCH: legacy computed from the SAME parse the adapter uses.
+    const legacyResult = new ConstrainedReserveEngine().calculate(
+      ReserveInputSchema.parse(VALID_INPUT)
+    );
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 21,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      legacyResult,
+      persist,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(persist).toHaveBeenCalledOnce();
+    const record = persist.mock.calls[0]![0] as SubstrateShadowReconciliationRecord;
+    expect(record).toMatchObject({
+      fundId: 21,
+      calculationKey: 'reserve-constrained',
+      configuredMode: 'shadow',
+      effectiveMode: 'shadow',
+      killSwitchActive: false,
+      substrateState: 'indicative',
+      reconciliationStatus: 'match',
+      mismatches: [],
+    });
+    expect(record.inputHash).toEqual(expect.any(String));
+    expect(record.resultHash).toEqual(expect.any(String));
+    expect(record.assumptionsHash).toEqual(expect.any(String));
+    // The persisted identity/status equals the logged reconciliation disclosure.
+    const reconCall = log.info.mock.calls.find((call) => call[0]!.reconciliation === 'match');
+    expect(reconCall).toBeDefined();
+    expect(record.resultHash).toBe(reconCall![0].resultHash);
+  });
+
+  it('persistence MISMATCH: persists one record whose status/mismatches match the warn disclosure', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const tamperedLegacy = {
+      allocations: [{ id: 'c1', allocated: 42 }],
+      totalAllocated: 42,
+      remaining: 0,
+      conservationOk: true,
+    };
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 22,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      legacyResult: tamperedLegacy,
+      persist,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(persist).toHaveBeenCalledOnce();
+    const record = persist.mock.calls[0]![0] as SubstrateShadowReconciliationRecord;
+    expect(record).toMatchObject({
+      fundId: 22,
+      calculationKey: 'reserve-constrained',
+      configuredMode: 'on',
+      effectiveMode: 'on',
+      killSwitchActive: false,
+      substrateState: 'available',
+      reconciliationStatus: 'mismatch',
+    });
+    expect(record.mismatches.length).toBeGreaterThan(0);
+    // The persisted mismatches are exactly the ones logged at warn.
+    const warnPayload = log.warn.mock.calls[0]![0];
+    expect(record.mismatches).toEqual(warnPayload.mismatches);
+  });
+
+  it('persistence: NOT called when legacyResult is absent (no reconciliation, nothing to persist)', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'shadow', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 23,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      persist,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('persistence: NOT called when mode-gated off (the shadow never runs)', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'off', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacyResult = new ConstrainedReserveEngine().calculate(
+      ReserveInputSchema.parse(VALID_INPUT)
+    );
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 24,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      legacyResult,
+      persist,
+    });
+
+    expect(result).toEqual({ ran: false });
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('persistence: NOT called when the substrate produced no value (kill switch -> unavailable) even with legacyResult', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: true });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacyResult = new ConstrainedReserveEngine().calculate(
+      ReserveInputSchema.parse(VALID_INPUT)
+    );
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 25,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      legacyResult,
+      persist,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('persistence best-effort: a THROWING persist is swallowed to { ran: true } with one warn and no rethrow', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'shadow', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {
+      throw new Error('insert boom');
+    });
+    // A MATCH, so the only warn possible is the persist-failure warn.
+    const legacyResult = new ConstrainedReserveEngine().calculate(
+      ReserveInputSchema.parse(VALID_INPUT)
+    );
+
+    const result = await observeConstrainedReserveSubstrateShadow({
+      fundId: 26,
+      input: VALID_INPUT,
+      resolveMode,
+      asOf: FIXED_AS_OF,
+      log,
+      legacyResult,
+      persist,
+    });
+
+    expect(result).toEqual({ ran: true });
+    expect(persist).toHaveBeenCalledOnce();
+    // The reconciliation MATCH still logged at info; the persist failure logs
+    // exactly one warn and never rethrows.
+    expect(log.warn).toHaveBeenCalledOnce();
+    expect(log.warn.mock.calls[0]![0]).toMatchObject({
+      fundId: 26,
+      calculationKey: 'reserve-constrained',
+    });
+    expect(log.warn.mock.calls[0]![0].error).toBe('insert boom');
+  });
 });

--- a/tests/unit/services/substrate-shadow-reconciliation-writer.test.ts
+++ b/tests/unit/services/substrate-shadow-reconciliation-writer.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Spies for the Drizzle insert chain, hoisted so the vi.mock factory (itself
+// hoisted above imports) can close over them. Mocking `../../../server/db`
+// intercepts the writer's `import { db } from '../db'` at the same resolved
+// module, so this proof is fully DB-free (the real db.ts side effects never run).
+const { insert, values, onConflictDoNothing } = vi.hoisted(() => {
+  const onConflictDoNothing = vi.fn(() => Promise.resolve({ rowsAffected: 0 }));
+  const values = vi.fn(() => ({ onConflictDoNothing }));
+  const insert = vi.fn(() => ({ values }));
+  return { insert, values, onConflictDoNothing };
+});
+
+vi.mock('../../../server/db', () => ({ db: { insert } }));
+
+import { persistSubstrateShadowReconciliation } from '../../../server/services/substrate-shadow-reconciliation-writer';
+import { substrateShadowReconciliations } from '../../../shared/schema';
+import type { SubstrateShadowReconciliationRecord } from '../../../server/services/constrained-reserve-substrate-shadow';
+
+const RECORD: SubstrateShadowReconciliationRecord = {
+  fundId: 7,
+  calculationKey: 'reserve-constrained',
+  configuredMode: 'shadow',
+  effectiveMode: 'shadow',
+  killSwitchActive: false,
+  substrateState: 'indicative',
+  reconciliationStatus: 'match',
+  inputHash: 'a'.repeat(64),
+  resultHash: 'b'.repeat(64),
+  assumptionsHash: 'c'.repeat(64),
+  mismatches: [],
+};
+
+describe('persistSubstrateShadowReconciliation (default writer)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('issues insert(table).values(record).onConflictDoNothing() exactly once against the fund-scoped ledger', async () => {
+    await persistSubstrateShadowReconciliation(RECORD);
+
+    expect(insert).toHaveBeenCalledOnce();
+    expect(insert).toHaveBeenCalledWith(substrateShadowReconciliations);
+    expect(values).toHaveBeenCalledOnce();
+    expect(values).toHaveBeenCalledWith(RECORD);
+    // onConflictDoNothing is what makes the append-only insert idempotent.
+    expect(onConflictDoNothing).toHaveBeenCalledOnce();
+  });
+
+  it('is idempotent-by-construction: a duplicate record still routes through onConflictDoNothing (no throw)', async () => {
+    await persistSubstrateShadowReconciliation(RECORD);
+    await persistSubstrateShadowReconciliation(RECORD);
+
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(onConflictDoNothing).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Tranche 9 — persist the constrained-reserve substrate shadow reconciliation (ADR-050)

Continues the calc-substrate arc (ADR-042..049). T8 reconciled the substrate shadow against the legacy engine **in-process and logged** the parity outcome; that outcome was then **lost**. T9 makes it **durable**: each value-producing (`available`/`indicative`) shadow run of `POST /api/v1/reserves/calculate` writes **one** append-only, fund-scoped, idempotent row into a new audit ledger — best-effort, from inside the T8 helper.

This tranche deliberately **lifts the no-DB-writes / no-migrations posture** held since Tranche 1, within hard bounds: one new Drizzle table + one new additive, replay-safe migration, LOCAL/test-DB only. **Zero HTTP response change. Route unchanged.**

### What changed
- **Table** `shared/schema/substrate-shadow-reconciliations.ts` — mirrors the `reconciliation_runs` conventions but is a separate, MOIC-independent table: CHECK-constrained `configured_mode`/`effective_mode` (`off|shadow|on`), `substrate_state` (`available|indicative`), `reconciliation_status` (`match|mismatch`); dedicated typed hash columns; `mismatches jsonb`; `unique(fund_id, calculation_key, input_hash, result_hash)` idempotency key; `(fund_id, observed_at desc)` index. Re-exported from `shared/schema.ts` (mirroring how `reconciliation-runs` is exported).
- **Migration** `migrations/0035_substrate_shadow_reconciliations.sql` — additive + replay-safe (`CREATE TABLE/INDEX IF NOT EXISTS`), shape-equal to the Drizzle table, journaled at idx 36. Only FK targets `funds.id` (serial PK) → no PG 42830 risk; all identifiers < 63 bytes.
- **Writer** `server/services/substrate-shadow-reconciliation-writer.ts` — default `persist` = `db.insert(...).values(record).onConflictDoNothing()` (idempotent by construction).
- **Helper** `server/services/constrained-reserve-substrate-shadow.ts` — exports `SubstrateShadowReconciliationRecord` + an injectable `persist?` seam (default = the writer). Persist runs **only** on the reconciliation gate, **ordered after** the reconciliation log, in its **own try/catch** that logs one `warn` and swallows. Return stays `{ ran: boolean }`.
- **Route** — unchanged (already passes `legacyResult: out`).
- **Docs** — ADR-050 in `DECISIONS.md` (with disposition table); CHANGELOG entry at the top of today's `### Added`.

### Invariants proven
- **Zero response change** — the existing route supertest asserts a byte-identical body with/without `?fundId`; under the memory-mode mock DB the default writer's insert is swallowed.
- **Persistence** — a match and a synthetic mismatch each write exactly one correctly-shaped row; **not** written when `legacyResult` absent / mode-gated off / no substrate value; a **throwing** writer is swallowed to `{ ran: true }` with a single warn (best-effort).
- **Idempotency / replay-safety** — a disposable-DB replay (localhost-guarded, dropped afterward) applied `0035` twice with no error, confirmed the shape via `information_schema`, and proved a duplicate insert yields one row. `db-migration` agent reviewed: PASS on shape-equality, additive/replay-safety, PG gotchas, and journal.

### Migration posture — never touched prod
Authored + journaled locally only. It reaches production **only** via the pre-existing gated `prod-schema-reconcile` apply flow, which this PR does **not** trigger and does **not** modify. No prod DB, CI/workflow, credential, or deploy change.

### Verification
- Full suite: **8931 passed / 0 failed** (5 foreground shards). Delta over baseline = exactly the +8 new tests.
- `baseline:check` 0 new TS errors · `eslint --max-warnings 0` clean · `npm run build` passes.
- `tests/unit/migration-ledger.test.ts` (+1 line) registers `0035` in the drift-patch guard enumerator (required).

### Not in scope (deferred)
No second consumer; no promotion (the substrate value is never served); no read/query/UI over the ledger (that is **T10**). No edits to adapters/resolvers/other schemas/`reconciliation-runs`; no auth or response-shape change; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
