### PR TITLE
feat(substrate): expose constrained-reserve shadow reconciliation ledger via read-only fund-scoped endpoint (ADR-051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Tranche 10 read the constrained-reserve substrate shadow reconciliation
+  ledger (ADR-051).** The Tranche 9 `substrate_shadow_reconciliations` trust
+  record, previously write-only, is now queryable: a NEW read-only, fund-scoped
+  `GET /api/v1/reserves/constrained/reconciliations?fundId=N[&limit=M]` on the
+  prod-live `reservesV1Router` returns the most recent reconciliation
+  observations (newest first via the `(fund_id, observed_at DESC)` index; limit
+  defaults to 50, hard-capped at 200) through a NEW injectable-seam read service
+  (`server/services/substrate-shadow-reconciliation-reader.ts`). Because the
+  ledger is per-fund STORED data - unlike `POST /calculate`, which stays
+  byte-identical and guard-free - the handler enforces fund scope (universal
+  non-LP team-member READ, else strict fail-closed grants) behind the global
+  Bearer boundary. PROD-SAFE before provisioning: migration `0035` is
+  local-only, so the default reader treats PG `42P01` (table absent, matched
+  through the error cause chain) as an empty ledger - a prod read is a 200 with
+  `[]`, never a 500; non-`42P01` errors propagate. No writes, no promotion, no
+  migration, no prod DB change.
 - **Tranche 9 persist the constrained-reserve substrate shadow reconciliation
   (ADR-050).** The Tranche 8 reconciliation outcome, previously logged and lost,
   is now durable: each value-producing (`available`/`indicative`) shadow run of

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -7662,3 +7662,134 @@ flow); no CI/workflow, credential, or prod-deploy change; no edits to any
 `reconciliation-runs.ts`, or the existing MOIC/facts/monte-carlo readers; no
 change to the `/calculate` response shape, status codes, or auth; no
 Phoenix-protected path edits; no new dependencies.
+
+## ADR-051: Tranche 10 Expose the Constrained-Reserve Substrate Shadow Reconciliation Ledger via a Read-Only Fund-Scoped Query Endpoint (Demo Scope)
+
+### Status
+
+Accepted.
+
+### Context
+
+Tranche 9 (ADR-050) made the substrate/legacy parity outcome durable: every
+opted-in, value-producing shadow run of `POST /api/v1/reserves/calculate` writes
+one append-only, fund-scoped, idempotent row into
+`substrate_shadow_reconciliations`. Re-auditing current main confirms the gap
+ADR-050 itself named: the table has NO READER. The only references anywhere are
+the Drizzle schema, the `0035` migration, the default writer's INSERT, and their
+tests - nothing queries it. The trust record exists but is inaccessible: "has
+fund N's constrained-reserve substrate ever diverged, and when?" is still
+unanswerable programmatically.
+
+The ledger is LOCAL-only: migration `0035` is authored + journaled locally and
+has NOT been applied to prod (it reaches prod only via the pre-existing gated
+`prod-schema-reconcile` apply flow, which remains untriggered). Any prod-live
+read surface therefore MUST tolerate the table being absent.
+
+### Decision
+
+Expose the ledger via ONE new read-only, fund-scoped, auth-guarded endpoint -
+`GET /api/v1/reserves/constrained/reconciliations?fundId=N[&limit=M]` - on the
+EXISTING `reservesV1Router` (mounted directly by `makeApp`, the Vercel prod
+entrypoint, so the new sub-path reaches prod without `mountCommonRoutes`),
+backed by ONE new read service. No writes, no `/calculate` change, no promotion,
+no second consumer, no migration, no prod DB change.
+
+Why READ now (not "promote", not "second consumer", not "provision-to-prod"):
+
+- Promotion (serving the substrate value when `mode=on`) would be the FIRST
+  response change in the arc and ADR-050 forbids it before an ACCUMULATED parity
+  record exists; T9 only just began accumulating.
+- The T9 table with no reader is inert; a read surface is the precondition any
+  future promotion decision must consult.
+- Second consumer stays deferred for the same reason it was in T9: no other
+  adapter has a clean prod-live route consuming its exact input.
+- Provisioning the table to prod (prod-schema manifest + the gated
+  `prod-schema-reconcile` apply) is a separate owner-triggered operation; the
+  read surface is instead made prod-SAFE against table absence.
+
+Design (pinned):
+
+- NEW read service `server/services/substrate-shadow-reconciliation-reader.ts`:
+  `readConstrainedReserveShadowReconciliations({ fundId, limit?, reader? })`
+  returns the most recent observations for the fund, newest first (served by the
+  T9 `(fund_id, observed_at DESC)` index), each projected to a stable read DTO
+  (all scalar columns + `mismatches` + `observedAt` as ISO-8601). `limit`
+  defaults to 50 and is clamped to `[1, 200]`. The `reader` seam is injectable
+  (mirroring the T6 `resolveMode` and T9 `persist` philosophy) and defaults to
+  the real Drizzle query, so all tests stay DB-free.
+- PROD-SAFETY (headline invariant): the DEFAULT reader treats PostgreSQL `42P01`
+  (undefined_table) as "no observations recorded" and returns `[]`, matching the
+  code through the error CAUSE CHAIN because drivers and Drizzle wrap the raw PG
+  error at varying depths. A prod read against the not-yet-provisioned ledger is
+  a 200 with an empty list, never a 500. Every non-`42P01` error propagates to
+  the route's standard error handling.
+- Key-scoped read: the default reader filters
+  `calculation_key = 'reserve-constrained'` IN ADDITION to `fund_id`, so the
+  response envelope's fixed `calculationKey` label can never mislabel rows a
+  future second substrate consumer might write under another key.
+- Route (EDIT `server/routes/v1/reserves.ts`):
+  `reservesV1Router.get('/constrained/reconciliations', ...)`. `?fundId` uses
+  the repo discipline `/^[1-9]\d*$/` (400 on absent/non-conforming); the
+  OPTIONAL `?limit` uses the same positive-integer discipline (400 when present
+  but non-conforming) and exists because the pinned service contract carries a
+  caller-facing limit - a seam reachable only from tests would be dead surface.
+  Response:
+  `{ fundId, calculationKey: 'reserve-constrained', observations, rid }` (rid
+  mirrors the sibling handlers).
+- Fund-scope authorization (UNLIKE `/calculate`): this endpoint reads per-fund
+  STORED rows, so it IS an existence oracle and is guarded IN THE HANDLER (RLS
+  does not enforce prod fund scope; `requireFundAccess` middleware reads a PATH
+  param and this route's fundId is a QUERY param, so the same universal-read
+  logic is mirrored in-handler): safe method + authenticated non-LP team member
+  (admin/partner/analyst without `lpId`) reads any fund; everyone else passes
+  the strict fail-closed `resolveFundScope` grant check; 403 otherwise.
+  Credential-less requests are already 401'd by the global `/api` Bearer
+  boundary in `makeApp` (the reserves paths are not in `isPublicApiPath`).
+  `POST /calculate` itself remains guard-free by design (it never reads per-fund
+  stored data) and byte-identical - re-proven by the untouched T7 route test.
+- Route governance: `reservesV1Router` is declared in
+  `shared/routes/api-runtime-specific-manifest.ts` (`make-app-reserves-v1`) at
+  ROUTER granularity (mount paths, not per-path routes), and the route-surface
+  inventory test pins only makeApp mount ORDER - so a new sub-path requires no
+  manifest/registry edit. Verified empirically: the full unit suite passes with
+  no route-policy/coverage/entrypoint-scan guard tripped.
+
+### Disposition table
+
+| Component                                                                  | Disposition                                            |
+| -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `substrate_shadow_reconciliations` table + `0035` migration                | reuse (unchanged)                                      |
+| T9 default writer + T8 shadow helper (persist seam)                        | reuse (unchanged)                                      |
+| `server/services/substrate-shadow-reconciliation-reader.ts` (read service) | new                                                    |
+| `GET /constrained/reconciliations` on `reservesV1Router`                   | new (route file edited)                                |
+| `requireFundAccess` middleware                                             | reject-reuse (path-param based; logic mirrored inline) |
+| runtime-specific manifest / route-policy registries                        | unchanged (router-level entry already covers)          |
+| promotion + second consumer + prod provisioning of `0035`                  | defer                                                  |
+
+### Consequences
+
+The accumulated trust record is now QUERYABLE: any authorized caller can answer
+"has fund N's constrained-reserve substrate ever diverged, and when?" from the
+prod-live API, which is the read surface a future promotion decision must
+consult. The endpoint is prod-safe BEFORE provisioning: with the table absent
+(prod today) it returns 200 with an empty list, proven by the `42P01`
+cause-chain tests; with the table present (local/test) it returns the
+fund-scoped observations newest first. Blast radius is one auth- and
+fund-scope-guarded SELECT; `/calculate` stays byte-identical. Likely Tranche 11:
+PROMOTE the substrate to authoritative behind `mode=on` once an accumulated
+parity record exists (the first response change of the arc), OR PROVISION the
+ledger to prod via the gated `prod-schema-reconcile` apply flow
+(owner-triggered) so this read surface serves real accumulated history.
+
+### Non-goals
+
+No writes or persistence changes; no promotion (the substrate value is never
+served; the `/calculate` response, status codes, and auth are unchanged); no
+second consumer; no migration/`db:push`/`db:migrate`; no provisioning the table
+to prod; no prod DB, CI/workflow, credential, or deploy change; no edits to any
+`*-substrate-adapter.ts`, `shared/core/calc-substrate/`,
+`substrate-calc-mode-resolver.ts`, `fund-calculation-mode-service.ts`,
+`ConstrainedReserveEngine.ts`, `reconciliation-runs.ts`, the T9
+writer/table/helper (beyond importing them), or the MOIC/facts/monte-carlo
+readers; no new dependencies; no Phoenix-protected path edits.

--- a/server/routes/v1/reserves.ts
+++ b/server/routes/v1/reserves.ts
@@ -2,8 +2,12 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { validateReserveInput } from '../../../shared/schemas.js';
 import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine.js';
+import { CONSTRAINED_RESERVE_CALCULATION_KEY } from '../../../shared/core/reserves/constrained-reserve-substrate-adapter.js';
 import logger from '../../utils/logger.js';
+import { isSafeReadMethod, resolveFundScope } from '../../lib/auth/fund-scope.js';
+import { isTeamMemberUser, principalFromUser } from '../../lib/auth/principal.js';
 import { observeConstrainedReserveSubstrateShadow } from '../../services/constrained-reserve-substrate-shadow.js';
+import { readConstrainedReserveShadowReconciliations } from '../../services/substrate-shadow-reconciliation-reader.js';
 
 export const reservesV1Router = Router();
 const engine = new ConstrainedReserveEngine();
@@ -137,4 +141,109 @@ reservesV1Router.get('/config', (_req: Request, res: Response) => {
     '/healthz': 'http://localhost:3001',
     '/readyz': 'http://localhost:3001',
   });
+});
+
+/** Positive-integer query parameter (`/^[1-9]\d*$/`), mirroring the fund-moic idiom. */
+function parsePositiveIntParam(value: unknown): number | null {
+  if (typeof value !== 'string' || !/^[1-9]\d*$/.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+/**
+ * @swagger
+ * /api/v1/reserves/constrained/reconciliations:
+ *   get:
+ *     summary: Read persisted constrained-reserve substrate shadow reconciliations
+ *     security:
+ *       - bearerAuth: []
+ *     description: |
+ *       Returns the most recent constrained-reserve substrate shadow
+ *       reconciliation observations persisted for one fund (ADR-050 ledger),
+ *       newest first. Read-only and fund-scoped; before the ledger table is
+ *       provisioned to an environment the endpoint returns an empty list.
+ *     tags: [Reserves]
+ *     parameters:
+ *       - in: query
+ *         name: fundId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+ *     responses:
+ *       200:
+ *         description: Reconciliation observations, newest first
+ *       400:
+ *         description: Missing or non-conforming fundId/limit
+ *       401:
+ *         description: Missing or invalid credential
+ *       403:
+ *         description: Caller lacks access to the requested fund
+ */
+reservesV1Router.get('/constrained/reconciliations', async (req: Request, res: Response) => {
+  const rid = (req as Request & { requestId?: string }).requestId || 'unknown';
+  try {
+    const fundId = parsePositiveIntParam(req.query['fundId']);
+    if (fundId === null) {
+      return res.status(400).json({
+        error: 'invalid_fund_id',
+        message: 'fundId must be a positive integer query parameter',
+        rid,
+      });
+    }
+
+    const rawLimit = req.query['limit'];
+    let limit: number | undefined;
+    if (rawLimit !== undefined) {
+      const parsedLimit = parsePositiveIntParam(rawLimit);
+      if (parsedLimit === null) {
+        return res.status(400).json({
+          error: 'invalid_limit',
+          message: 'limit must be a positive integer query parameter',
+          rid,
+        });
+      }
+      limit = parsedLimit;
+    }
+
+    // Fund-scope authorization (UNLIKE POST /calculate, which never reads
+    // per-fund stored data): this endpoint returns fund-scoped ledger rows, so
+    // it IS an existence oracle and must be guarded in the handler (RLS does
+    // not enforce prod fund scope). Mirrors requireFundAccess: universal READ
+    // for authenticated non-LP team members on safe methods, else the strict
+    // fail-closed fund-grant check.
+    if (
+      !(isSafeReadMethod(req.method) && isTeamMemberUser(req.user)) &&
+      resolveFundScope(principalFromUser(req.user), fundId) !== 'allow'
+    ) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: `You do not have access to fund ${fundId}`,
+        rid,
+      });
+    }
+
+    const observations = await readConstrainedReserveShadowReconciliations({
+      fundId,
+      ...(limit !== undefined && { limit }),
+    });
+
+    res.json({
+      fundId,
+      calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+      observations,
+      rid,
+    });
+  } catch (e: unknown) {
+    logger.error(
+      'Reserve reconciliation read error',
+      e instanceof Error ? e : new Error(String(e)),
+      {
+        requestId: rid,
+      }
+    );
+    res.status(500).json({ error: 'internal', rid });
+  }
 });

--- a/server/services/substrate-shadow-reconciliation-reader.ts
+++ b/server/services/substrate-shadow-reconciliation-reader.ts
@@ -1,0 +1,160 @@
+/**
+ * Read service for the constrained-reserve substrate shadow reconciliation
+ * ledger (Tranche 10, ADR-051).
+ *
+ * The FIRST reader of `substrate_shadow_reconciliations` (Tranche 9, ADR-050):
+ * it answers "has fund N's constrained-reserve substrate ever diverged, and
+ * when?" by returning the most recent reconciliation observations for one
+ * fund, newest first (served by the `(fund_id, observed_at DESC)` index), each
+ * projected to a stable read DTO with `observed_at` as an ISO-8601 string.
+ *
+ * Invariants (technical, enforced here and in tests, not by governance):
+ * - READ-ONLY: one SELECT; this module never inserts, updates, or deletes.
+ * - PROD-SAFE ON TABLE ABSENCE: migration `0035` exists locally but is NOT
+ *   provisioned to prod, so the DEFAULT reader treats PostgreSQL `42P01`
+ *   (undefined_table) - including when wrapped in a driver/ORM error `cause`
+ *   chain - as "no observations recorded" and returns `[]`. A prod read must
+ *   be a 200 with an empty list, never a 500. Any other error propagates.
+ * - Injectable reader seam (mirroring the Tranche 6 `resolveMode` and
+ *   Tranche 9 `persist` philosophy): tests drive row and failure cases with
+ *   no live DB; prod uses the real Drizzle query.
+ * - Key-scoped: rows are filtered to the constrained-reserve calculation key,
+ *   so a response envelope that labels these observations
+ *   `reserve-constrained` can never mislabel rows written by a future second
+ *   substrate consumer under another key.
+ */
+
+import { and, desc, eq } from 'drizzle-orm';
+import { CONSTRAINED_RESERVE_CALCULATION_KEY } from '@shared/core/reserves/constrained-reserve-substrate-adapter';
+import { substrateShadowReconciliations, type SubstrateShadowReconciliation } from '@shared/schema';
+import { db } from '../db';
+
+/** Default page size when the caller does not specify a limit. */
+export const DEFAULT_SHADOW_RECONCILIATION_READ_LIMIT = 50;
+
+/** Hard ceiling on rows per read, regardless of the caller-supplied limit. */
+export const MAX_SHADOW_RECONCILIATION_READ_LIMIT = 200;
+
+/** Stable read DTO for one persisted reconciliation observation. */
+export interface ConstrainedReserveShadowReconciliationObservation {
+  id: number;
+  fundId: number;
+  calculationKey: string;
+  configuredMode: string;
+  effectiveMode: string;
+  killSwitchActive: boolean;
+  substrateState: string;
+  reconciliationStatus: string;
+  inputHash: string;
+  resultHash: string;
+  assumptionsHash: string;
+  mismatches: string[];
+  /** ISO-8601 timestamp of the observation (`observed_at`). */
+  observedAt: string;
+}
+
+/**
+ * Injectable reader seam. The default queries the real ledger through Drizzle
+ * (and owns the `42P01` graceful-absence behavior); tests inject a fake to
+ * stay DB-free.
+ */
+export type ReadShadowReconciliationRowsFn = (args: {
+  fundId: number;
+  limit: number;
+}) => Promise<SubstrateShadowReconciliation[]>;
+
+/**
+ * PostgreSQL `undefined_table`, matched through the error `cause` chain
+ * because drivers and Drizzle wrap the raw PG error at varying depths.
+ */
+function isUndefinedTableError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current !== null && typeof current === 'object'; depth += 1) {
+    if ((current as { code?: unknown }).code === '42P01') {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
+ * Default reader: newest-first, fund- and key-scoped SELECT against the
+ * append-only ledger. Table absence (`42P01`) resolves to `[]` because the
+ * ledger is not yet provisioned to prod; every other failure propagates to
+ * the caller's standard error handling.
+ */
+async function queryShadowReconciliationRows(args: {
+  fundId: number;
+  limit: number;
+}): Promise<SubstrateShadowReconciliation[]> {
+  try {
+    return await db
+      .select()
+      .from(substrateShadowReconciliations)
+      .where(
+        and(
+          eq(substrateShadowReconciliations.fundId, args.fundId),
+          eq(substrateShadowReconciliations.calculationKey, CONSTRAINED_RESERVE_CALCULATION_KEY)
+        )
+      )
+      .orderBy(desc(substrateShadowReconciliations.observedAt))
+      .limit(args.limit);
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function toObservation(
+  row: SubstrateShadowReconciliation
+): ConstrainedReserveShadowReconciliationObservation {
+  return {
+    id: row.id,
+    fundId: row.fundId,
+    calculationKey: row.calculationKey,
+    configuredMode: row.configuredMode,
+    effectiveMode: row.effectiveMode,
+    killSwitchActive: row.killSwitchActive,
+    substrateState: row.substrateState,
+    reconciliationStatus: row.reconciliationStatus,
+    inputHash: row.inputHash,
+    resultHash: row.resultHash,
+    assumptionsHash: row.assumptionsHash,
+    mismatches: [...row.mismatches],
+    observedAt: row.observedAt.toISOString(),
+  };
+}
+
+export interface ReadConstrainedReserveShadowReconciliationsParams {
+  fundId: number;
+  /**
+   * Requested maximum rows. Defaults to
+   * `DEFAULT_SHADOW_RECONCILIATION_READ_LIMIT` and is clamped to
+   * `[1, MAX_SHADOW_RECONCILIATION_READ_LIMIT]`.
+   */
+  limit?: number;
+  /** Injectable reader seam; defaults to the real Drizzle query. */
+  reader?: ReadShadowReconciliationRowsFn;
+}
+
+/**
+ * Read the most recent constrained-reserve shadow reconciliation observations
+ * for one fund, newest first.
+ */
+export async function readConstrainedReserveShadowReconciliations({
+  fundId,
+  limit = DEFAULT_SHADOW_RECONCILIATION_READ_LIMIT,
+  reader = queryShadowReconciliationRows,
+}: ReadConstrainedReserveShadowReconciliationsParams): Promise<
+  ConstrainedReserveShadowReconciliationObservation[]
+> {
+  const boundedLimit = Math.min(
+    Math.max(Math.trunc(limit), 1),
+    MAX_SHADOW_RECONCILIATION_READ_LIMIT
+  );
+  const rows = await reader({ fundId, limit: boundedLimit });
+  return rows.map(toObservation);
+}

--- a/tests/unit/api/reserves-constrained-reconciliations-route.test.ts
+++ b/tests/unit/api/reserves-constrained-reconciliations-route.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Express, NextFunction, Request, Response } from 'express';
+
+// Deterministic global-boundary 401: a local `.env` can supply the
+// NODE_ENV=development / REQUIRE_AUTH=false combination that makes the REAL
+// requireAuth dev-bypass a credential-less request, so asserting the raw
+// middleware would be environment-dependent. Reproduce the canonical
+// fail-closed 401 for credential-less requests and DELEGATE to the real
+// middleware whenever a credential is present, so verification, the
+// claims->user mapping (role/fundIds/lpId), and the handler's fund-scope guard
+// stay genuinely exercised (fund-moic behavior-test pattern).
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
+      if (!req.headers.authorization) return res.sendStatus(401);
+      return actual.requireAuth()(req, res, next);
+    },
+  };
+});
+
+import { makeApp } from '../../../server/app';
+import { signToken } from '../../../server/lib/auth/jwt';
+// In test-mock-db mode `server/db` exports this exact singleton, so seeding it
+// here drives the route's DEFAULT reader end to end with no live database.
+import { databaseMock } from '../../helpers/database-mock';
+
+const ROUTE = '/api/v1/reserves/constrained/reconciliations';
+const LEDGER_TABLE = 'substrate_shadow_reconciliations';
+
+function bearer(claims: Record<string, unknown>): string {
+  return `Bearer ${signToken(claims)}`;
+}
+
+const TEAM_MEMBER = { sub: 'recon-read-analyst', role: 'analyst', fundIds: [] };
+
+function ledgerRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    fundId: 1,
+    calculationKey: 'reserve-constrained',
+    configuredMode: 'shadow',
+    effectiveMode: 'shadow',
+    killSwitchActive: false,
+    substrateState: 'indicative',
+    reconciliationStatus: 'match',
+    inputHash: 'a'.repeat(64),
+    resultHash: 'b'.repeat(64),
+    assumptionsHash: 'c'.repeat(64),
+    mismatches: [],
+    observedAt: new Date('2026-07-18T01:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('GET /api/v1/reserves/constrained/reconciliations (ADR-051)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = makeApp();
+  });
+
+  afterEach(() => {
+    databaseMock.setMockData(LEDGER_TABLE, []);
+  });
+
+  it('401 without a Bearer credential (global /api boundary)', async () => {
+    const res = await request(app).get(`${ROUTE}?fundId=1`);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('400 when fundId is absent or non-conforming', async () => {
+    for (const query of ['', '?fundId=abc', '?fundId=0', '?fundId=1.5']) {
+      const res = await request(app)
+        .get(`${ROUTE}${query}`)
+        .set('Authorization', bearer(TEAM_MEMBER));
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_fund_id');
+      expect(typeof res.body.rid).toBe('string');
+    }
+  });
+
+  it('400 when limit is present but non-conforming', async () => {
+    for (const query of ['?fundId=1&limit=abc', '?fundId=1&limit=0', '?fundId=1&limit=2.5']) {
+      const res = await request(app)
+        .get(`${ROUTE}${query}`)
+        .set('Authorization', bearer(TEAM_MEMBER));
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_limit');
+    }
+  });
+
+  it('200 with an empty list when no ledger rows exist (prod-safe table-absent posture)', async () => {
+    const res = await request(app)
+      .get(`${ROUTE}?fundId=1`)
+      .set('Authorization', bearer(TEAM_MEMBER));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      fundId: 1,
+      calculationKey: 'reserve-constrained',
+      observations: [],
+      rid: expect.any(String),
+    });
+  });
+
+  it('200 with fund-scoped observations projected to the read DTO', async () => {
+    databaseMock.setMockData(LEDGER_TABLE, [
+      ledgerRow({ id: 1, observedAt: new Date('2026-07-18T01:00:00.000Z') }),
+      ledgerRow({
+        id: 2,
+        reconciliationStatus: 'mismatch',
+        mismatches: ['remaining cents differ: substrate 100 vs legacy 101'],
+        observedAt: new Date('2026-07-18T03:00:00.000Z'),
+      }),
+      ledgerRow({ id: 3, fundId: 2, observedAt: new Date('2026-07-18T04:00:00.000Z') }),
+    ]);
+
+    const res = await request(app)
+      .get(`${ROUTE}?fundId=1`)
+      .set('Authorization', bearer(TEAM_MEMBER));
+
+    expect(res.status).toBe(200);
+    expect(res.body.fundId).toBe(1);
+    expect(res.body.calculationKey).toBe('reserve-constrained');
+
+    const observations = [...res.body.observations].sort(
+      (a: { id: number }, b: { id: number }) => a.id - b.id
+    );
+    expect(observations).toEqual([
+      {
+        id: 1,
+        fundId: 1,
+        calculationKey: 'reserve-constrained',
+        configuredMode: 'shadow',
+        effectiveMode: 'shadow',
+        killSwitchActive: false,
+        substrateState: 'indicative',
+        reconciliationStatus: 'match',
+        inputHash: 'a'.repeat(64),
+        resultHash: 'b'.repeat(64),
+        assumptionsHash: 'c'.repeat(64),
+        mismatches: [],
+        observedAt: '2026-07-18T01:00:00.000Z',
+      },
+      {
+        id: 2,
+        fundId: 1,
+        calculationKey: 'reserve-constrained',
+        configuredMode: 'shadow',
+        effectiveMode: 'shadow',
+        killSwitchActive: false,
+        substrateState: 'indicative',
+        reconciliationStatus: 'mismatch',
+        inputHash: 'a'.repeat(64),
+        resultHash: 'b'.repeat(64),
+        assumptionsHash: 'c'.repeat(64),
+        mismatches: ['remaining cents differ: substrate 100 vs legacy 101'],
+        observedAt: '2026-07-18T03:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('applies ?limit at the HTTP layer', async () => {
+    databaseMock.setMockData(LEDGER_TABLE, [
+      ledgerRow({ id: 1, observedAt: new Date('2026-07-18T01:00:00.000Z') }),
+      ledgerRow({ id: 2, observedAt: new Date('2026-07-18T02:00:00.000Z') }),
+      ledgerRow({ id: 3, observedAt: new Date('2026-07-18T03:00:00.000Z') }),
+    ]);
+
+    const res = await request(app)
+      .get(`${ROUTE}?fundId=1&limit=2`)
+      .set('Authorization', bearer(TEAM_MEMBER));
+
+    expect(res.status).toBe(200);
+    expect(res.body.observations).toHaveLength(2);
+  });
+
+  it('403 for a non-team caller without an explicit grant on the fund', async () => {
+    const res = await request(app)
+      .get(`${ROUTE}?fundId=1`)
+      .set('Authorization', bearer({ sub: 'recon-read-viewer', role: 'viewer', fundIds: [2] }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Forbidden');
+  });
+
+  it('200 for a non-team caller WITH an explicit grant (strict fund scope allow path)', async () => {
+    const res = await request(app)
+      .get(`${ROUTE}?fundId=1`)
+      .set('Authorization', bearer({ sub: 'recon-read-viewer', role: 'viewer', fundIds: [1] }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.observations).toEqual([]);
+  });
+
+  it('403 for an LP-affiliated caller even with a team-like role', async () => {
+    const res = await request(app)
+      .get(`${ROUTE}?fundId=1`)
+      .set(
+        'Authorization',
+        bearer({ sub: 'recon-read-lp', role: 'analyst', lpId: 12, fundIds: [] })
+      );
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/services/substrate-shadow-reconciliation-reader.test.ts
+++ b/tests/unit/services/substrate-shadow-reconciliation-reader.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { and, desc, eq } from 'drizzle-orm';
+
+// Mutable state consumed by the hoisted chain implementations below. Behavior
+// lives INSIDE the vi.fn factories (reading this state) rather than in
+// mockResolvedValue calls, so the global `restoreMocks: true` between tests
+// cannot strip it.
+const dbState = vi.hoisted(() => ({
+  rows: [] as unknown[],
+  failure: null as unknown,
+}));
+
+// Spies for the Drizzle select chain, hoisted so the vi.mock factory (itself
+// hoisted above imports) can close over them. Mocking `../../../server/db`
+// intercepts the reader's `import { db } from '../db'` at the same resolved
+// module, so the default-reader proofs are fully DB-free.
+const chain = vi.hoisted(() => {
+  const limit = vi.fn((_count: number) => {
+    if (dbState.failure) return Promise.reject(dbState.failure);
+    return Promise.resolve(dbState.rows);
+  });
+  const orderBy = vi.fn((_order: unknown) => ({ limit }));
+  const where = vi.fn((_condition: unknown) => ({ orderBy }));
+  const from = vi.fn((_table: unknown) => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return { select, from, where, orderBy, limit };
+});
+
+vi.mock('../../../server/db', () => ({ db: { select: chain.select } }));
+
+import {
+  DEFAULT_SHADOW_RECONCILIATION_READ_LIMIT,
+  MAX_SHADOW_RECONCILIATION_READ_LIMIT,
+  readConstrainedReserveShadowReconciliations,
+} from '../../../server/services/substrate-shadow-reconciliation-reader';
+import {
+  substrateShadowReconciliations,
+  type SubstrateShadowReconciliation,
+} from '../../../shared/schema';
+import { CONSTRAINED_RESERVE_CALCULATION_KEY } from '../../../shared/core/reserves/constrained-reserve-substrate-adapter';
+
+function ledgerRow(
+  overrides: Partial<SubstrateShadowReconciliation> = {}
+): SubstrateShadowReconciliation {
+  return {
+    id: 1,
+    fundId: 7,
+    calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+    configuredMode: 'shadow',
+    effectiveMode: 'shadow',
+    killSwitchActive: false,
+    substrateState: 'indicative',
+    reconciliationStatus: 'match',
+    inputHash: 'a'.repeat(64),
+    resultHash: 'b'.repeat(64),
+    assumptionsHash: 'c'.repeat(64),
+    mismatches: [],
+    observedAt: new Date('2026-07-18T01:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('readConstrainedReserveShadowReconciliations (ADR-051)', () => {
+  beforeEach(() => {
+    dbState.rows = [];
+    dbState.failure = null;
+  });
+
+  describe('injectable reader seam (DB-free)', () => {
+    it('projects rows to the stable read DTO in reader order, observedAt as ISO', async () => {
+      const newer = ledgerRow({
+        id: 2,
+        reconciliationStatus: 'mismatch',
+        mismatches: ['totalAllocated cents differ: substrate 100 vs legacy 101'],
+        observedAt: new Date('2026-07-18T02:00:00.000Z'),
+      });
+      const older = ledgerRow({ id: 1 });
+      const reader = vi.fn(async () => [newer, older]);
+
+      const observations = await readConstrainedReserveShadowReconciliations({
+        fundId: 7,
+        reader,
+      });
+
+      expect(reader).toHaveBeenCalledOnce();
+      expect(reader).toHaveBeenCalledWith({
+        fundId: 7,
+        limit: DEFAULT_SHADOW_RECONCILIATION_READ_LIMIT,
+      });
+      expect(observations).toEqual([
+        {
+          id: 2,
+          fundId: 7,
+          calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+          configuredMode: 'shadow',
+          effectiveMode: 'shadow',
+          killSwitchActive: false,
+          substrateState: 'indicative',
+          reconciliationStatus: 'mismatch',
+          inputHash: 'a'.repeat(64),
+          resultHash: 'b'.repeat(64),
+          assumptionsHash: 'c'.repeat(64),
+          mismatches: ['totalAllocated cents differ: substrate 100 vs legacy 101'],
+          observedAt: '2026-07-18T02:00:00.000Z',
+        },
+        {
+          id: 1,
+          fundId: 7,
+          calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+          configuredMode: 'shadow',
+          effectiveMode: 'shadow',
+          killSwitchActive: false,
+          substrateState: 'indicative',
+          reconciliationStatus: 'match',
+          inputHash: 'a'.repeat(64),
+          resultHash: 'b'.repeat(64),
+          assumptionsHash: 'c'.repeat(64),
+          mismatches: [],
+          observedAt: '2026-07-18T01:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('passes a conforming limit through to the reader', async () => {
+      const reader = vi.fn(async () => [] as SubstrateShadowReconciliation[]);
+
+      await readConstrainedReserveShadowReconciliations({ fundId: 7, limit: 5, reader });
+
+      expect(reader).toHaveBeenCalledWith({ fundId: 7, limit: 5 });
+    });
+
+    it('hard-caps the limit at 200', async () => {
+      const reader = vi.fn(async () => [] as SubstrateShadowReconciliation[]);
+
+      await readConstrainedReserveShadowReconciliations({ fundId: 7, limit: 5000, reader });
+
+      expect(reader).toHaveBeenCalledWith({
+        fundId: 7,
+        limit: MAX_SHADOW_RECONCILIATION_READ_LIMIT,
+      });
+    });
+
+    it('clamps a sub-1 limit up to 1', async () => {
+      const reader = vi.fn(async () => [] as SubstrateShadowReconciliation[]);
+
+      await readConstrainedReserveShadowReconciliations({ fundId: 7, limit: 0, reader });
+
+      expect(reader).toHaveBeenCalledWith({ fundId: 7, limit: 1 });
+    });
+
+    it('propagates an injected reader failure (the service adds no swallow)', async () => {
+      const reader = vi.fn(async () => {
+        throw new Error('boom');
+      });
+
+      await expect(
+        readConstrainedReserveShadowReconciliations({ fundId: 7, reader })
+      ).rejects.toThrow('boom');
+    });
+  });
+
+  describe('default reader (mocked db)', () => {
+    it('issues one fund- and key-scoped SELECT, newest first, with the bounded limit', async () => {
+      dbState.rows = [ledgerRow()];
+
+      const observations = await readConstrainedReserveShadowReconciliations({ fundId: 7 });
+
+      expect(chain.select).toHaveBeenCalledOnce();
+      expect(chain.from).toHaveBeenCalledWith(substrateShadowReconciliations);
+      expect(chain.where).toHaveBeenCalledWith(
+        and(
+          eq(substrateShadowReconciliations.fundId, 7),
+          eq(substrateShadowReconciliations.calculationKey, CONSTRAINED_RESERVE_CALCULATION_KEY)
+        )
+      );
+      expect(chain.orderBy).toHaveBeenCalledWith(desc(substrateShadowReconciliations.observedAt));
+      expect(chain.limit).toHaveBeenCalledWith(DEFAULT_SHADOW_RECONCILIATION_READ_LIMIT);
+      expect(observations).toHaveLength(1);
+      expect(observations[0]?.observedAt).toBe('2026-07-18T01:00:00.000Z');
+    });
+
+    it('caps the issued query limit at 200', async () => {
+      await readConstrainedReserveShadowReconciliations({ fundId: 7, limit: 999 });
+
+      expect(chain.limit).toHaveBeenCalledWith(MAX_SHADOW_RECONCILIATION_READ_LIMIT);
+    });
+
+    it('returns [] when the table is absent (bare PG 42P01)', async () => {
+      dbState.failure = Object.assign(
+        new Error('relation "substrate_shadow_reconciliations" does not exist'),
+        { code: '42P01' }
+      );
+
+      await expect(readConstrainedReserveShadowReconciliations({ fundId: 7 })).resolves.toEqual([]);
+    });
+
+    it('returns [] when 42P01 arrives wrapped in an error cause chain', async () => {
+      dbState.failure = Object.assign(new Error('Failed query: select ...'), {
+        cause: Object.assign(
+          new Error('relation "substrate_shadow_reconciliations" does not exist'),
+          {
+            code: '42P01',
+          }
+        ),
+      });
+
+      await expect(readConstrainedReserveShadowReconciliations({ fundId: 7 })).resolves.toEqual([]);
+    });
+
+    it('propagates non-42P01 database errors', async () => {
+      dbState.failure = Object.assign(new Error('permission denied for table'), {
+        code: '42501',
+      });
+
+      await expect(readConstrainedReserveShadowReconciliations({ fundId: 7 })).rejects.toThrow(
+        'permission denied for table'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 10 of the calc-substrate arc (ADR-042..051): the T9 `substrate_shadow_reconciliations` trust ledger (#1146) was write-only - nothing could answer "has fund N's constrained-reserve substrate ever diverged, and when?". This PR adds the first (read-only) reader:

- **New read service** `server/services/substrate-shadow-reconciliation-reader.ts`: newest-first, fund- and key-scoped SELECT over the ledger (served by the T9 `(fund_id, observed_at DESC)` index); `limit` defaults to 50, hard-capped at 200; injectable `reader` seam (T6 `resolveMode` / T9 `persist` philosophy) so all tests are DB-free; stable read DTO with ISO-8601 `observedAt`.
- **New route** `GET /api/v1/reserves/constrained/reconciliations?fundId=N[&limit=M]` on the existing prod-live `reservesV1Router` (mounted directly by `makeApp`). Strict `/^[1-9]\d*$/` validation (400), in-handler fund-scope guard, response `{ fundId, calculationKey: 'reserve-constrained', observations, rid }`.

## Invariants

- **Prod-safe on table absence (headline):** migration `0035` is local-only and NOT provisioned to prod, so the default reader treats PG `42P01` (undefined_table) - matched through the error cause chain, since drivers/Drizzle wrap the raw PG error - as an empty ledger. A prod read is a 200 with `[]`, never a 500. Non-`42P01` errors propagate.
- **Fund-scoped (unlike `/calculate`):** this endpoint reads per-fund STORED rows, so it is an existence oracle and is guarded in the handler (RLS does not enforce prod fund scope; `requireFundAccess` middleware is path-param-only): universal READ for authenticated non-LP team members on safe methods, else the strict fail-closed `resolveFundScope` grant check. Credential-less requests 401 at the global `/api` Bearer boundary.
- **Zero `/calculate` change:** the POST handler is untouched and byte-identical (re-proven by the untouched T7 route test).
- **Read-only:** no writes, no migration, no promotion, no second consumer, no prod DB / CI / workflow / credential change.

## Verification

- Full suite via 5 foreground shards (server 3 + client 2): **8951 passed / 90 skipped / 0 failed** = pre-change empirical baseline (8932/90/0) + exactly the 19 new tests (10 reader + 9 route).
- Untouched T7/T8/T9 suites green; `npm run check`, `npm run baseline:check`, `npx eslint <new+edited> --max-warnings 0`, and `npm run build` all clean.
- Diff scope: reader service (new), `server/routes/v1/reserves.ts` (edited), two new unit-test files, `DECISIONS.md` (ADR-051), `CHANGELOG.md`. No route-manifest edit required (`make-app-reserves-v1` is router-granular).

## Next (per ADR-051)

T11 = promote the substrate behind `mode=on` once an accumulated parity record exists (first response change of the arc; this endpoint is the surface that decision consults), OR provision the ledger to prod via the owner-triggered gated `prod-schema-reconcile`.

Generated with [Claude Code](https://claude.com/claude-code)