### PR TITLE
feat(substrate): promote constrained-reserve substrate behind mode=on with verified-parity seatbelt (ADR-052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Tranche 11 promoted the constrained-reserve substrate to authoritative
+  behind `mode=on`, with a verified-parity seatbelt - dormant by default
+  (ADR-052).** The arc's FIRST serving-path change: a NEW promotion service
+  (`server/services/constrained-reserve-substrate-promotion.ts`) now sits in the
+  `?fundId` opt-in branch of prod-live `POST /api/v1/reserves/calculate`. For a
+  fund resolving `configuredMode 'on'` (kill switch inactive) the substrate
+  result is SERVED - but only when it verifies cents-exact against the legacy
+  engine for that same request (`available` + reconciliation `match` +
+  `conservationOk`); every other outcome (off/shadow/kill/failed/ mismatch, or
+  any throw) fail-safes to the legacy response with a warn-level demotion
+  disclosure. Non-`on` modes delegate to the untouched T7-T10 shadow helper with
+  the pre-resolved mode (zero extra registry query), preserving
+  shadow/reconcile/persist behavior byte-for-byte, and the `on` path persists
+  its reconciliation through the same T9 writer seam. Served allocations are the
+  LEGACY objects spread with only `allocated` replaced by `Number(...)` of the
+  adapter's exact-2dp string (the pinned serving parse), so the envelope shape,
+  allocation keys, status codes, and auth posture are unchanged and any byte
+  difference is float-noise cleanup, never cents. DORMANT: no mode registry row
+  exists or is seeded anywhere, so every environment resolves `off` and
+  responses are byte-identical to pre-T11 (pinned by the untouched T7
+  byte-identity test plus new service/route tests).
 - **Tranche 10 read the constrained-reserve substrate shadow reconciliation
   ledger (ADR-051).** The Tranche 9 `substrate_shadow_reconciliations` trust
   record, previously write-only, is now queryable: a NEW read-only, fund-scoped

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -7793,3 +7793,147 @@ to prod; no prod DB, CI/workflow, credential, or deploy change; no edits to any
 `ConstrainedReserveEngine.ts`, `reconciliation-runs.ts`, the T9
 writer/table/helper (beyond importing them), or the MOIC/facts/monte-carlo
 readers; no new dependencies; no Phoenix-protected path edits.
+
+## ADR-052: Tranche 11 Promote the Constrained-Reserve Substrate to Authoritative Behind mode=on With a Verified-Parity Seatbelt, Dormant by Default (Demo Scope)
+
+### Status
+
+Accepted.
+
+### Context
+
+Tranches 7-10 (ADR-048..051) run the substrate as a mode-gated best-effort
+SHADOW inside prod-live `POST /api/v1/reserves/calculate` (opt-in via
+`?fundId`), reconcile it in-process against the legacy
+`ConstrainedReserveEngine` output for the same request, persist every
+value-producing reconciliation to the append-only
+`substrate_shadow_reconciliations` ledger, and expose that ledger read-only and
+fund-scoped. Re-auditing current main confirms the remaining gap: even when a
+fund is configured `mode=on`, the substrate value is computed, reconciled,
+persisted - and then DISCARDED. Nothing anywhere serves it; `mode=on` is
+behaviorally identical to `mode=shadow`, and the arc's end state ("substrate
+authoritative, legacy retired") has no serving path.
+
+### Decision
+
+Add promotion: for an opted-in request whose fund resolves
+`configuredMode === 'on'` with the kill switch inactive, the substrate result
+becomes the served source - but ONLY when it VERIFIES against the legacy engine
+for that same request (state `available` AND reconciliation `match` AND
+`conservationOk`); every other outcome fail-safes to the legacy response with a
+warn-level demotion disclosure. Non-`on` modes keep EXACTLY the T7-T10 shadow
+behavior. No fund is `on` anywhere (prod has no registry rows and this tranche
+seeds none), so this change is dormant until an operator flips a fund - a
+decision that consults the T10 read endpoint.
+
+Why PROMOTE now (not "provision-to-prod", not "second consumer"):
+
+- Provisioning `0035` to prod is an owner-triggered gated
+  `prod-schema-reconcile` OPERATION, not a code tranche; and in demo scope
+  parity evidence realistically accumulates in local/test exercise, which the
+  T10 endpoint already reads.
+- Promotion is the arc's terminal capability and can land with ZERO observable
+  change (dormant + seatbelt + cents-equality guarantee), which is the safest
+  possible crossing of the "first response change" threshold ADR-050 named.
+- Second consumer stays deferred: no other adapter has a clean prod-live route
+  consuming its exact input.
+
+Design (pinned):
+
+- NEW service `server/services/constrained-reserve-substrate-promotion.ts`:
+  `serveConstrainedReserveCalculation({ fundId, input, legacyResult, resolveMode?, persist?, log?, asOf? })`
+  returns `{ served: 'substrate' | 'legacy', reasonCodes, response }` where
+  `response` (`{ allocations, totalAllocated, remaining }`) is ALWAYS present
+  and the route serves it verbatim (plus `rid`). Seams default to the real
+  `resolveSubstrateCalcMode` / `persistSubstrateShadowReconciliation` / app
+  logger; the resolver default is imported from
+  `server/services/substrate-calc-mode-resolver`, so the T7 route test's
+  resolver-module mock keeps governing the route. T7-T10 service files are
+  byte-untouched (imported only).
+- Control flow (mode resolved ONCE):
+  `configuredMode !== 'on' || killSwitchActive` DELEGATES to
+  `observeConstrainedReserveSubstrateShadow` with the already-resolved mode
+  injected through its `resolveMode` seam (zero extra registry query),
+  preserving T7-T10 logging/reconciliation/persistence byte-for-byte, and serves
+  legacy with the adapter's reason-code semantics (KILL_SWITCH_ACTIVE and/or
+  MODE_OFF when effectively off; SHADOW_ONLY when effectively shadow). `on` and
+  not killed runs the adapter against a fresh calculation context, logs the
+  shadow-style disclosure, reconciles via the exported pure
+  `reconcileConstrainedReserveShadow`, and persists the observation through the
+  T9 seam in its OWN try/catch (warn + swallow) so the ledger keeps accumulating
+  under `on` exactly as under shadow.
+- Verified-parity seatbelt (fail-safe matrix): serve `substrate` ONLY on
+  `available` + `match` + `conservationOk`. `failed`/`unavailable` demote with
+  the adapter's reason codes; `mismatch` demotes with the literal
+  `RECONCILIATION_MISMATCH` (mismatches disclosed at warn); a conservation-false
+  value demotes with `CONSERVATION_FAILED` (unreachable through the route, which
+  500s on legacy conservation failure first, but enforced independently); ANY
+  throw anywhere (resolver, adapter, reconcile, projection) is caught, warned,
+  and demoted with `PROMOTION_ERROR`. Promotion can never 500 the route or alter
+  the no-fundId path.
+- Projection (the serving parse, pinned): for each LEGACY allocation in LEGACY
+  order, `{ ...legacyAllocation, allocated: Number(substrate.allocated) }` - the
+  spread preserves the exact legacy key set/order (incl. `name`/`stage`, which
+  the substrate value also carries but is not the source of);
+  `totalAllocated`/`remaining` are `Number(...)` of the adapter's exact-2dp
+  strings. `Number(...)` on a 2dp string is the canonical SERVING parse
+  (deterministic closest-double) and is permitted ONLY here; all COMPARISONS
+  remain cents-based via the existing split idiom. The match gate guarantees
+  id-set equality and cents equality, so any byte difference vs legacy is
+  float-noise cleanup of the representation (e.g. 599999.9999999999 -> 600000),
+  never the cents.
+- Auth posture unchanged - documented, not guarded: `/calculate` still takes no
+  fund-scope guard. T7's rationale ("the response never branches on fundId")
+  narrows in T11: the response now branches on per-fund OPERATOR CONFIG (the
+  mode registry), never on per-fund stored portfolio data, and the only
+  observable difference for an opted-in `on` fund is cents-preserving
+  float-noise cleanup of the caller-supplied input's computation. There is still
+  no existence oracle over stored fund data. The T10 GET keeps its fund-scope
+  guard; nothing changes there.
+- Dormancy guarantee: this tranche writes/seeds NO mode registry row, so every
+  real environment resolves the universal default `{ off, false }` and the
+  route's responses (with or without `?fundId`) are byte-identical to pre-T11 -
+  pinned by the untouched T7 byte-identity test (now exercising the delegation
+  path) and the new route tests for `off` and `on`+kill.
+
+### Disposition table
+
+| Component                                                                    | Disposition       |
+| ---------------------------------------------------------------------------- | ----------------- |
+| Constrained-reserve substrate adapter (ADR-046)                              | reuse (unchanged) |
+| Substrate calc-mode resolver (ADR-047)                                       | reuse (unchanged) |
+| T7/T8 shadow helper (observe + exported pure reconcile)                      | reuse (unchanged) |
+| T9 writer seam + `substrate_shadow_reconciliations` table + `0035` migration | reuse (unchanged) |
+| T10 reader service + GET `/constrained/reconciliations`                      | reuse (unchanged) |
+| `server/services/constrained-reserve-substrate-promotion.ts`                 | new               |
+| `POST /calculate` `?fundId` branch (serve promotion outcome)                 | edit (route file) |
+| Mode-registry writes/seeding (any fund becoming `on`)                        | defer             |
+| Provisioning `0035` to prod (gated `prod-schema-reconcile` apply)            | defer             |
+| Second substrate consumer                                                    | defer             |
+
+### Consequences
+
+The arc's terminal capability now exists: an operator can make the substrate
+authoritative for a fund by flipping its registry row to `on`, and the serving
+decision is seatbelted per-request - the substrate is served only when it just
+verified cents-exact against the legacy engine it replaces, and silently falls
+back to legacy (with warn disclosure and a persisted mismatch row) otherwise.
+Until that flip happens nowhere is anything observable: no registry row exists
+in any environment this change creates, the envelope shape, status codes, and
+auth posture are unchanged, and non-`on` modes delegate to the untouched shadow
+path. Likely Tranche 12: an operator flips a pilot fund to `on` after consulting
+the T10 reconciliation endpoint (an operational action, not a code tranche),
+and/or provision `0035` to prod via the gated `prod-schema-reconcile` apply flow
+so the ledger accumulates real history.
+
+### Non-goals
+
+No mode-registry rows written or seeded anywhere (no fund becomes `on`); no new
+DB writes beyond the existing T9 seam; no migration/`db:push`/ `db:migrate`; no
+provisioning to prod; no prod DB, CI/workflow, credential, or deploy change; no
+edits to any `*-substrate-adapter.ts`, `shared/core/calc-substrate/`,
+`substrate-calc-mode-resolver.ts`, `fund-calculation-mode-service.ts`,
+`ConstrainedReserveEngine.ts`, the T7/T8 helper file, the T9 writer/table, the
+T10 reader/GET route, or `reconciliation-runs.ts` (import-only); no
+response-envelope or allocation-key changes; no new npm dependencies; no UI; no
+Phoenix-protected path edits.

--- a/server/routes/v1/reserves.ts
+++ b/server/routes/v1/reserves.ts
@@ -6,7 +6,7 @@ import { CONSTRAINED_RESERVE_CALCULATION_KEY } from '../../../shared/core/reserv
 import logger from '../../utils/logger.js';
 import { isSafeReadMethod, resolveFundScope } from '../../lib/auth/fund-scope.js';
 import { isTeamMemberUser, principalFromUser } from '../../lib/auth/principal.js';
-import { observeConstrainedReserveSubstrateShadow } from '../../services/constrained-reserve-substrate-shadow.js';
+import { serveConstrainedReserveCalculation } from '../../services/constrained-reserve-substrate-promotion.js';
 import { readConstrainedReserveShadowReconciliations } from '../../services/substrate-shadow-reconciliation-reader.js';
 
 export const reservesV1Router = Router();
@@ -74,19 +74,29 @@ reservesV1Router.post('/calculate', async (req: Request, res: Response) => {
     const out = engine.calculate(val.data);
     if (!out.conservationOk) return res.status(500).json({ error: 'conservation_failed', rid });
 
-    // Best-effort, mode-gated substrate shadow (ADR-048): opt-in via ?fundId,
-    // computed and logged server-side only. The helper never throws, so it
-    // cannot affect the response body or status code; the response is
-    // byte-identical with or without ?fundId. No fund-scope guard is needed:
-    // the response never branches on fundId or mode, so there is no existence
-    // oracle and no per-fund stored data is read (only the caller-supplied
-    // ReserveInput is computed).
+    // Mode-gated substrate serving (ADR-052) behind the ?fundId opt-in: the
+    // promotion service serves the substrate result ONLY when the fund is
+    // configured `on` (kill switch inactive) AND the substrate verified
+    // cents-exact against the legacy output for THIS request; every other
+    // outcome (off/shadow/kill/failed/mismatch, or any throw) fail-safes to
+    // the legacy response and non-`on` modes keep the exact ADR-048/049/050
+    // shadow behavior, so the envelope shape, status codes, and the no-fundId
+    // path are unchanged. No fund-scope guard is needed: the response branches
+    // only on per-fund OPERATOR CONFIG (the mode registry), never on per-fund
+    // stored portfolio data, and a served substrate value is cents-identical
+    // to the legacy computation of the caller-supplied ReserveInput.
     const rawFundId = req.query['fundId'];
     if (typeof rawFundId === 'string' && /^[1-9]\d*$/.test(rawFundId)) {
-      await observeConstrainedReserveSubstrateShadow({
+      const outcome = await serveConstrainedReserveCalculation({
         fundId: Number(rawFundId),
         input: val.data,
         legacyResult: out,
+      });
+      return res.json({
+        allocations: outcome.response.allocations,
+        totalAllocated: outcome.response.totalAllocated,
+        remaining: outcome.response.remaining,
+        rid,
       });
     }
 

--- a/server/services/constrained-reserve-substrate-promotion.ts
+++ b/server/services/constrained-reserve-substrate-promotion.ts
@@ -1,0 +1,301 @@
+/**
+ * Constrained-reserve substrate promotion (Tranche 11, ADR-052).
+ *
+ * The arc's FIRST serving-path change, delivered dormant: for an opted-in
+ * request whose fund resolves `configuredMode === 'on'` with the kill switch
+ * inactive, the substrate result becomes the served source - but ONLY when it
+ * VERIFIES against the legacy engine output for that same request (state
+ * `available` AND reconciliation `match` AND `conservationOk`). Every other
+ * outcome fail-safes to the legacy response with a warn-level demotion
+ * disclosure, and non-`on` modes DELEGATE to the Tranche 7-10 shadow helper so
+ * their logging/reconciliation/persistence behavior is preserved byte-for-byte.
+ *
+ * Invariants (technical, enforced here and in tests, not by governance):
+ * - Verified-parity seatbelt: the substrate is served only on a same-request
+ *   cents-exact match against the legacy engine, so a served substrate response
+ *   can differ from legacy at most in float-noise representation (e.g.
+ *   599999.9999999999 -> 600000), never in cents.
+ * - Fail-safe to legacy: `response` is ALWAYS present and defaults to the
+ *   passed legacy result; any throw anywhere (resolver, adapter, reconcile,
+ *   projection) is logged at warn and demoted. Promotion can never 500 the
+ *   route.
+ * - Delegation: `configuredMode !== 'on' || killSwitchActive` routes through
+ *   `observeConstrainedReserveSubstrateShadow` with the ALREADY-resolved mode
+ *   injected through its `resolveMode` seam - zero extra registry query, and
+ *   the T7-T10 shadow/reconcile/persist path stays the single source of that
+ *   behavior.
+ * - Persistence continuity: the `on` path persists its value-producing
+ *   reconciliation through the SAME Tranche 9 writer seam with the same
+ *   best-effort own-try/catch swallow, so the append-only ledger keeps
+ *   accumulating under promotion exactly as it does under shadow.
+ * - Dormancy: with no `mode` registry row anywhere (prod has none and this
+ *   tranche seeds none), every request resolves `off` and this service is
+ *   behaviorally identical to the pre-T11 route.
+ */
+
+import { createCalculationContext } from '@shared/core/calc-substrate';
+import {
+  CONSTRAINED_RESERVE_CALCULATION_KEY,
+  runConstrainedReserveWithSubstrate,
+} from '@shared/core/reserves/constrained-reserve-substrate-adapter';
+import { logger } from '../lib/logger';
+import {
+  observeConstrainedReserveSubstrateShadow,
+  reconcileConstrainedReserveShadow,
+  type PersistSubstrateShadowReconciliationFn,
+  type ResolveSubstrateCalcModeFn,
+  type ShadowLogger,
+  type SubstrateShadowReconciliationRecord,
+} from './constrained-reserve-substrate-shadow';
+import { resolveSubstrateCalcMode } from './substrate-calc-mode-resolver';
+import { persistSubstrateShadowReconciliation } from './substrate-shadow-reconciliation-writer';
+
+/**
+ * Minimal structural view of one legacy allocation. The generic parameter
+ * preserves the route's richer allocation shape (`name`/`stage`/...) through
+ * the projection: served allocations are the LEGACY objects spread with only
+ * `allocated` replaced, so the key set and key order are exactly the legacy
+ * engine's.
+ */
+export interface ServeConstrainedReserveCalculationParams<
+  A extends { id: string; allocated: number },
+> {
+  fundId: number;
+  input: unknown;
+  /** The legacy engine output the route computed and will serve on demotion. */
+  legacyResult: {
+    allocations: ReadonlyArray<A>;
+    totalAllocated: number;
+    remaining: number;
+    conservationOk: boolean;
+  };
+  resolveMode?: ResolveSubstrateCalcModeFn;
+  persist?: PersistSubstrateShadowReconciliationFn;
+  log?: ShadowLogger;
+  asOf?: string;
+}
+
+export interface ServeConstrainedReserveCalculationOutcome<A> {
+  served: 'substrate' | 'legacy';
+  reasonCodes: string[];
+  /** Always present; the route serves this verbatim (plus `rid`). */
+  response: {
+    allocations: ReadonlyArray<A>;
+    totalAllocated: number;
+    remaining: number;
+  };
+}
+
+/**
+ * Serve one opted-in constrained-reserve calculation: substrate when `on`,
+ * verified, and conservation-clean; the passed legacy result otherwise.
+ */
+export async function serveConstrainedReserveCalculation<
+  A extends { id: string; allocated: number },
+>({
+  fundId,
+  input,
+  legacyResult,
+  resolveMode = resolveSubstrateCalcMode,
+  persist = persistSubstrateShadowReconciliation,
+  log = logger,
+  asOf,
+}: ServeConstrainedReserveCalculationParams<A>): Promise<
+  ServeConstrainedReserveCalculationOutcome<A>
+> {
+  // Built from the passed legacy fields so demoted responses stay
+  // byte-identical to what the route served before this tranche.
+  const legacyResponse = {
+    allocations: legacyResult.allocations,
+    totalAllocated: legacyResult.totalAllocated,
+    remaining: legacyResult.remaining,
+  };
+
+  try {
+    const resolution = await resolveMode({
+      fundId,
+      calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+    });
+
+    if (resolution.configuredMode !== 'on' || resolution.killSwitchActive) {
+      // Non-`on` (or kill-switched): EXACTLY the Tranche 7-10 shadow behavior,
+      // reached through the existing helper with the already-resolved mode.
+      await observeConstrainedReserveSubstrateShadow({
+        fundId,
+        input,
+        legacyResult,
+        resolveMode: async () => resolution,
+        persist,
+        log,
+        ...(asOf !== undefined && { asOf }),
+      });
+
+      // Mirror the adapter's reason-code semantics for the disclosure:
+      // KILL_SWITCH_ACTIVE and/or MODE_OFF when effectively off, SHADOW_ONLY
+      // when effectively shadow.
+      const reasonCodes: string[] = [];
+      if (resolution.killSwitchActive) reasonCodes.push('KILL_SWITCH_ACTIVE');
+      if (resolution.configuredMode === 'off') reasonCodes.push('MODE_OFF');
+      if (!resolution.killSwitchActive && resolution.configuredMode === 'shadow') {
+        reasonCodes.push('SHADOW_ONLY');
+      }
+      return { served: 'legacy', reasonCodes, response: legacyResponse };
+    }
+
+    const ctx = createCalculationContext({
+      calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+      // The constrained engine draws no randomness; cosmetic constant seed.
+      seed: 1,
+      asOf: asOf ?? new Date().toISOString(),
+    });
+
+    const result = runConstrainedReserveWithSubstrate(ctx, input, { ...resolution });
+
+    log.info(
+      {
+        fundId,
+        calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+        state: result.state,
+        reasonCodes: result.reasonCodes,
+        resultHash: 'resultHash' in result ? result.resultHash : null,
+        inputHash: result.basis.inputHash,
+        configuredMode: resolution.configuredMode,
+        killSwitchActive: resolution.killSwitchActive,
+      },
+      'constrained reserve substrate promotion'
+    );
+
+    if (result.state !== 'available') {
+      // `on` but no servable value (INPUT_INVALID / ENGINE_ERROR / ...):
+      // demote with the adapter's own reason codes. No value -> nothing to
+      // reconcile or persist, matching the T7-T10 value-producing-only gate.
+      log.warn(
+        {
+          fundId,
+          calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+          served: 'legacy',
+          state: result.state,
+          reasonCodes: result.reasonCodes,
+        },
+        'constrained reserve substrate promotion demoted to legacy'
+      );
+      return { served: 'legacy', reasonCodes: [...result.reasonCodes], response: legacyResponse };
+    }
+
+    const reconciliation = reconcileConstrainedReserveShadow(result.value, legacyResult);
+
+    // Persistence (ADR-050 seam, unchanged): durably record THIS
+    // reconciliation observation regardless of the serving decision, in its
+    // own try/catch so a persist failure warns once and never affects serving.
+    const record: SubstrateShadowReconciliationRecord = {
+      fundId,
+      calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+      configuredMode: resolution.configuredMode,
+      effectiveMode: result.basis.effectiveMode,
+      killSwitchActive: resolution.killSwitchActive,
+      substrateState: result.state,
+      reconciliationStatus: reconciliation.status,
+      inputHash: result.basis.inputHash,
+      resultHash: result.resultHash,
+      assumptionsHash: result.basis.assumptionsHash,
+      mismatches: reconciliation.mismatches,
+    };
+    try {
+      await persist(record);
+    } catch (persistError) {
+      log.warn(
+        {
+          fundId,
+          calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+          error: persistError instanceof Error ? persistError.message : String(persistError),
+        },
+        'constrained reserve substrate reconciliation persist failed'
+      );
+    }
+
+    if (reconciliation.status !== 'match') {
+      log.warn(
+        {
+          fundId,
+          calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+          served: 'legacy',
+          reconciliation: reconciliation.status,
+          mismatches: reconciliation.mismatches,
+          resultHash: result.resultHash,
+        },
+        'constrained reserve substrate promotion demoted to legacy'
+      );
+      return {
+        served: 'legacy',
+        reasonCodes: ['RECONCILIATION_MISMATCH'],
+        response: legacyResponse,
+      };
+    }
+
+    if (!result.value.conservationOk) {
+      // Unreachable through the route (a conservation failure 500s before this
+      // service is called, and a substrate/legacy conservation disagreement is
+      // a mismatch above), but the seatbelt is enforced independently.
+      log.warn(
+        {
+          fundId,
+          calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+          served: 'legacy',
+          resultHash: result.resultHash,
+        },
+        'constrained reserve substrate promotion demoted to legacy'
+      );
+      return { served: 'legacy', reasonCodes: ['CONSERVATION_FAILED'], response: legacyResponse };
+    }
+
+    // Projection (serving parse, pinned by ADR-052): LEGACY allocations in
+    // LEGACY order, spread-preserved key set/order, with only `allocated`
+    // replaced by `Number(...)` of the adapter's exact-2dp string - the
+    // canonical deterministic closest-double serving parse. The match gate
+    // guarantees id-set equality and cents equality, so any byte difference vs
+    // legacy is float-noise cleanup of the representation, never the cents.
+    const substrateById = new Map(
+      result.value.allocations.map((allocation) => [allocation.id, allocation] as const)
+    );
+    const allocations = legacyResult.allocations.map((legacyAllocation) => {
+      const substrateAllocation = substrateById.get(legacyAllocation.id);
+      if (!substrateAllocation) {
+        throw new Error(
+          `substrate allocation missing for id ${legacyAllocation.id} despite reconciliation match`
+        );
+      }
+      return { ...legacyAllocation, allocated: Number(substrateAllocation.allocated) };
+    });
+
+    log.info(
+      {
+        fundId,
+        calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+        served: 'substrate',
+        resultHash: result.resultHash,
+        inputHash: result.basis.inputHash,
+      },
+      'constrained reserve substrate promotion served'
+    );
+
+    return {
+      served: 'substrate',
+      reasonCodes: [],
+      response: {
+        allocations,
+        totalAllocated: Number(result.value.totalAllocated),
+        remaining: Number(result.value.remaining),
+      },
+    };
+  } catch (error) {
+    log.warn(
+      {
+        fundId,
+        calculationKey: CONSTRAINED_RESERVE_CALCULATION_KEY,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'constrained reserve substrate promotion failed'
+    );
+    return { served: 'legacy', reasonCodes: ['PROMOTION_ERROR'], response: legacyResponse };
+  }
+}

--- a/tests/unit/api/reserves-calculate-promotion-route.test.ts
+++ b/tests/unit/api/reserves-calculate-promotion-route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+
+// Hoisted mutable resolver state read INSIDE the vi.fn factory implementation,
+// which the global `restoreMocks: true` preserves across tests (declaration-time
+// mockResolvedValue would be stripped). Each test sets the mode it needs; the
+// no-fundId path never consults the resolver at all.
+const resolverState = vi.hoisted(() => ({
+  resolution: { configuredMode: 'off' as 'off' | 'shadow' | 'on', killSwitchActive: false },
+}));
+
+// Mock the Tranche 6 resolver MODULE (the same seam the T7 shadow route test
+// mocks): the promotion service imports its default resolver from this module,
+// so this mock keeps governing the route after the T11 rewire.
+vi.mock('../../../server/services/substrate-calc-mode-resolver', () => ({
+  resolveSubstrateCalcMode: vi.fn(async () => ({ ...resolverState.resolution })),
+}));
+
+import { makeApp } from '../../../server/app';
+import { signToken } from '../../../server/lib/auth/jwt';
+import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine';
+import { ReserveInputSchema } from '../../../shared/schemas';
+
+const VALID_BODY = {
+  availableReserves: 1_000_000,
+  companies: [
+    { id: 'c1', name: 'Alpha', stage: 'seed', invested: 250_000, ownership: 0.15 },
+    { id: 'c2', name: 'Beta', stage: 'series_a', invested: 1_000_000, ownership: 0.1 },
+  ],
+  stagePolicies: [
+    { stage: 'seed', reserveMultiple: 2.5, weight: 1 },
+    { stage: 'series_a', reserveMultiple: 2, weight: 1.2 },
+  ],
+};
+
+function stripRid(body: Record<string, unknown>) {
+  const { rid: _rid, ...rest } = body;
+  return rest;
+}
+
+describe('POST /api/v1/reserves/calculate substrate promotion (ADR-052)', () => {
+  let app: Express;
+  let authorization: string;
+
+  beforeAll(() => {
+    app = makeApp();
+    authorization = `Bearer ${signToken({
+      sub: 'reserves-promotion-route-test',
+      role: 'analyst',
+      fundIds: [],
+    })}`;
+  });
+
+  beforeEach(() => {
+    resolverState.resolution = { configuredMode: 'off', killSwitchActive: false };
+  });
+
+  function calculate(path: string) {
+    return request(app).post(path).set('Authorization', authorization).send(VALID_BODY);
+  }
+
+  it('resolver `on`: 200 and the promoted response deep-equals the no-fundId legacy response (verified-match, cents-equal by construction)', async () => {
+    const withoutFund = await calculate('/api/v1/reserves/calculate');
+    resolverState.resolution = { configuredMode: 'on', killSwitchActive: false };
+    const withFund = await calculate('/api/v1/reserves/calculate?fundId=1');
+
+    expect(withoutFund.status).toBe(200);
+    expect(withFund.status).toBe(200);
+    expect(stripRid(withFund.body)).toEqual(stripRid(withoutFund.body));
+  });
+
+  it('resolver `off`: byte-identical (modulo rid) to the no-fundId response', async () => {
+    const withoutFund = await calculate('/api/v1/reserves/calculate');
+    const withFund = await calculate('/api/v1/reserves/calculate?fundId=1');
+
+    expect(withoutFund.status).toBe(200);
+    expect(withFund.status).toBe(200);
+    expect(stripRid(withFund.body)).toEqual(stripRid(withoutFund.body));
+  });
+
+  it('resolver `on` + kill switch: byte-identical (modulo rid) to the no-fundId response', async () => {
+    const withoutFund = await calculate('/api/v1/reserves/calculate');
+    resolverState.resolution = { configuredMode: 'on', killSwitchActive: true };
+    const withFund = await calculate('/api/v1/reserves/calculate?fundId=1');
+
+    expect(withoutFund.status).toBe(200);
+    expect(withFund.status).toBe(200);
+    expect(stripRid(withFund.body)).toEqual(stripRid(withoutFund.body));
+  });
+
+  it('no-fundId: unchanged - serves exactly the legacy engine output for the request', async () => {
+    const response = await calculate('/api/v1/reserves/calculate');
+    const legacy = new ConstrainedReserveEngine().calculate(ReserveInputSchema.parse(VALID_BODY));
+
+    expect(response.status).toBe(200);
+    expect(Object.keys(response.body).sort()).toEqual([
+      'allocations',
+      'remaining',
+      'rid',
+      'totalAllocated',
+    ]);
+    expect(stripRid(response.body)).toEqual({
+      allocations: legacy.allocations,
+      totalAllocated: legacy.totalAllocated,
+      remaining: legacy.remaining,
+    });
+  });
+});

--- a/tests/unit/services/constrained-reserve-substrate-promotion.test.ts
+++ b/tests/unit/services/constrained-reserve-substrate-promotion.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi } from 'vitest';
+import { serveConstrainedReserveCalculation } from '../../../server/services/constrained-reserve-substrate-promotion';
+import type {
+  ShadowLogger,
+  SubstrateShadowReconciliationRecord,
+} from '../../../server/services/constrained-reserve-substrate-shadow';
+import type { SubstrateCalcModeResolution } from '../../../server/services/substrate-calc-mode-resolver';
+import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine';
+import { ReserveInputSchema } from '../../../shared/schemas';
+
+const FIXED_AS_OF = '2026-07-18T00:00:00.000Z';
+
+// One seed company + one seed policy; a valid ReserveInput that reaches
+// `available` under mode `on`. Same fixture family as the T7/T8/T9 helper
+// tests so the adapter (which runs REAL here - it is pure and deterministic)
+// produces a value the legacy engine reproduces exactly.
+const VALID_INPUT = {
+  availableReserves: 100_000,
+  companies: [{ id: 'c1', name: 'Alpha', stage: 'seed', invested: 1_000_000, ownership: 0.1 }],
+  stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+};
+
+/** The legacy engine output the route would compute and serve for VALID_INPUT. */
+function computeLegacy() {
+  return new ConstrainedReserveEngine().calculate(ReserveInputSchema.parse(VALID_INPUT));
+}
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn() } satisfies ShadowLogger;
+}
+
+function resolverReturning(resolution: SubstrateCalcModeResolution) {
+  return vi.fn(async () => resolution);
+}
+
+describe('serveConstrainedReserveCalculation', () => {
+  it('off: serves legacy with MODE_OFF; delegation short-circuits (no adapter run, no log, no persist) exactly as T7-T10', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'off', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacyResult = computeLegacy();
+
+    const outcome = await serveConstrainedReserveCalculation({
+      fundId: 1,
+      input: VALID_INPUT,
+      legacyResult,
+      resolveMode,
+      persist,
+      log,
+      asOf: FIXED_AS_OF,
+    });
+
+    expect(outcome.served).toBe('legacy');
+    expect(outcome.reasonCodes).toEqual(['MODE_OFF']);
+    expect(outcome.response).toEqual({
+      allocations: legacyResult.allocations,
+      totalAllocated: legacyResult.totalAllocated,
+      remaining: legacyResult.remaining,
+    });
+    // The mode was resolved exactly once and passed pre-resolved into the
+    // shadow helper (zero extra registry query).
+    expect(resolveMode).toHaveBeenCalledOnce();
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('shadow: serves legacy with SHADOW_ONLY; delegation preserves the T7-T10 shadow + reconcile + persist behavior', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'shadow', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacyResult = computeLegacy();
+
+    const outcome = await serveConstrainedReserveCalculation({
+      fundId: 2,
+      input: VALID_INPUT,
+      legacyResult,
+      resolveMode,
+      persist,
+      log,
+      asOf: FIXED_AS_OF,
+    });
+
+    expect(outcome.served).toBe('legacy');
+    expect(outcome.reasonCodes).toEqual(['SHADOW_ONLY']);
+    expect(outcome.response.allocations).toBe(legacyResult.allocations);
+    expect(resolveMode).toHaveBeenCalledOnce();
+    // T7 shadow disclosure + T8 reconciliation disclosure, both at info.
+    expect(log.info.mock.calls.some((call) => call[0]!.state === 'indicative')).toBe(true);
+    expect(log.info.mock.calls.some((call) => call[0]!.reconciliation === 'match')).toBe(true);
+    expect(log.warn).not.toHaveBeenCalled();
+    // T9 persistence: exactly one record with the shadow-mode identity.
+    expect(persist).toHaveBeenCalledOnce();
+    const record = persist.mock.calls[0]![0] as SubstrateShadowReconciliationRecord;
+    expect(record).toMatchObject({
+      fundId: 2,
+      calculationKey: 'reserve-constrained',
+      configuredMode: 'shadow',
+      effectiveMode: 'shadow',
+      killSwitchActive: false,
+      substrateState: 'indicative',
+      reconciliationStatus: 'match',
+      mismatches: [],
+    });
+  });
+
+  it('kill switch over configured `on`: serves legacy with KILL_SWITCH_ACTIVE; the shadow logs unavailable and persists nothing', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: true });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacyResult = computeLegacy();
+
+    const outcome = await serveConstrainedReserveCalculation({
+      fundId: 3,
+      input: VALID_INPUT,
+      legacyResult,
+      resolveMode,
+      persist,
+      log,
+      asOf: FIXED_AS_OF,
+    });
+
+    expect(outcome.served).toBe('legacy');
+    expect(outcome.reasonCodes).toEqual(['KILL_SWITCH_ACTIVE']);
+    expect(outcome.response.allocations).toBe(legacyResult.allocations);
+    // Delegated shadow ran the adapter to its unavailable + KILL_SWITCH_ACTIVE
+    // disclosure (non-collapse), produced no value, persisted nothing.
+    expect(log.info).toHaveBeenCalledOnce();
+    expect(log.info.mock.calls[0]![0]).toMatchObject({
+      state: 'unavailable',
+      configuredMode: 'on',
+      killSwitchActive: true,
+    });
+    expect(log.info.mock.calls[0]![0].reasonCodes).toContain('KILL_SWITCH_ACTIVE');
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('on + verified match: serves the substrate with the exact pinned projection and persists one effectiveMode-on match row', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacyResult = computeLegacy();
+
+    const outcome = await serveConstrainedReserveCalculation({
+      fundId: 4,
+      input: VALID_INPUT,
+      legacyResult,
+      resolveMode,
+      persist,
+      log,
+      asOf: FIXED_AS_OF,
+    });
+
+    expect(outcome.served).toBe('substrate');
+    expect(outcome.reasonCodes).toEqual([]);
+    // Projection: LEGACY allocations in LEGACY order with spread-preserved key
+    // set/order; `allocated` is Number(...) of the adapter's exact-2dp string,
+    // which for this clean fixture equals the legacy number exactly.
+    expect(outcome.response.allocations).not.toBe(legacyResult.allocations);
+    expect(outcome.response.allocations).toEqual(legacyResult.allocations);
+    expect(Object.keys(outcome.response.allocations[0]!)).toEqual([
+      'id',
+      'name',
+      'stage',
+      'allocated',
+    ]);
+    expect(outcome.response.totalAllocated).toBe(legacyResult.totalAllocated);
+    expect(outcome.response.remaining).toBe(legacyResult.remaining);
+    // Persistence continuity under `on`: one record through the T9 seam.
+    expect(persist).toHaveBeenCalledOnce();
+    const record = persist.mock.calls[0]![0] as SubstrateShadowReconciliationRecord;
+    expect(record).toMatchObject({
+      fundId: 4,
+      calculationKey: 'reserve-constrained',
+      configuredMode: 'on',
+      effectiveMode: 'on',
+      killSwitchActive: false,
+      substrateState: 'available',
+      reconciliationStatus: 'match',
+      mismatches: [],
+    });
+    // Served-substrate info disclosure carries the substrate identity.
+    const servedCall = log.info.mock.calls.find((call) => call[0]!.served === 'substrate');
+    expect(servedCall).toBeDefined();
+    expect(servedCall![0]).toMatchObject({ fundId: 4, calculationKey: 'reserve-constrained' });
+    expect(servedCall![0].resultHash).toEqual(expect.any(String));
+    expect(servedCall![0].inputHash).toEqual(expect.any(String));
+    expect(record.resultHash).toBe(servedCall![0].resultHash);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('on + mismatch: a one-cent doctored legacy demotes to the passed legacy with RECONCILIATION_MISMATCH, warns, and persists the mismatch row', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacy = computeLegacy();
+    // Doctored one cent off so the substrate CANNOT verify against it; the
+    // fail-safe must serve THIS object back untouched.
+    const doctoredLegacy = { ...legacy, totalAllocated: legacy.totalAllocated + 0.01 };
+
+    const outcome = await serveConstrainedReserveCalculation({
+      fundId: 5,
+      input: VALID_INPUT,
+      legacyResult: doctoredLegacy,
+      resolveMode,
+      persist,
+      log,
+      asOf: FIXED_AS_OF,
+    });
+
+    expect(outcome.served).toBe('legacy');
+    expect(outcome.reasonCodes).toEqual(['RECONCILIATION_MISMATCH']);
+    expect(outcome.response).toEqual({
+      allocations: doctoredLegacy.allocations,
+      totalAllocated: doctoredLegacy.totalAllocated,
+      remaining: doctoredLegacy.remaining,
+    });
+    // Demotion disclosure at warn, carrying the mismatches.
+    expect(log.warn).toHaveBeenCalledOnce();
+    const warnPayload = log.warn.mock.calls[0]![0];
+    expect(warnPayload).toMatchObject({ served: 'legacy', reconciliation: 'mismatch' });
+    expect((warnPayload.mismatches as string[]).length).toBeGreaterThan(0);
+    // The mismatch observation still reaches the ledger (T9 continuity).
+    expect(persist).toHaveBeenCalledOnce();
+    const record = persist.mock.calls[0]![0] as SubstrateShadowReconciliationRecord;
+    expect(record).toMatchObject({
+      effectiveMode: 'on',
+      substrateState: 'available',
+      reconciliationStatus: 'mismatch',
+    });
+    expect(record.mismatches).toEqual(warnPayload.mismatches);
+  });
+
+  it('on + verified match with a THROWING persist: still serves the substrate, warns once, never rejects', async () => {
+    const resolveMode = resolverReturning({ configuredMode: 'on', killSwitchActive: false });
+    const log = makeLog();
+    const persist = vi.fn(async () => {
+      throw new Error('insert boom');
+    });
+    const legacyResult = computeLegacy();
+
+    const outcome = await serveConstrainedReserveCalculation({
+      fundId: 6,
+      input: VALID_INPUT,
+      legacyResult,
+      resolveMode,
+      persist,
+      log,
+      asOf: FIXED_AS_OF,
+    });
+
+    expect(outcome.served).toBe('substrate');
+    expect(outcome.response.allocations).toEqual(legacyResult.allocations);
+    expect(persist).toHaveBeenCalledOnce();
+    // Exactly one warn (the persist failure); the serving decision is not
+    // affected by persistence.
+    expect(log.warn).toHaveBeenCalledOnce();
+    expect(log.warn.mock.calls[0]![0].error).toBe('insert boom');
+  });
+
+  it('throwing resolveMode: never rejects, warns, and fail-safes to the legacy response', async () => {
+    const resolveMode = vi.fn(async () => {
+      throw new Error('resolver boom');
+    });
+    const log = makeLog();
+    const persist = vi.fn(async () => {});
+    const legacyResult = computeLegacy();
+
+    const outcome = await serveConstrainedReserveCalculation({
+      fundId: 7,
+      input: VALID_INPUT,
+      legacyResult,
+      resolveMode,
+      persist,
+      log,
+      asOf: FIXED_AS_OF,
+    });
+
+    expect(outcome.served).toBe('legacy');
+    expect(outcome.reasonCodes).toEqual(['PROMOTION_ERROR']);
+    expect(outcome.response).toEqual({
+      allocations: legacyResult.allocations,
+      totalAllocated: legacyResult.totalAllocated,
+      remaining: legacyResult.remaining,
+    });
+    expect(log.warn).toHaveBeenCalledOnce();
+    expect(log.warn.mock.calls[0]![0].error).toBe('resolver boom');
+    expect(persist).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 11 of the calc-substrate arc (ADR-042..052): the arc's FIRST serving-path change, delivered dormant. A new promotion service sits in the ?fundId opt-in branch of prod-live POST /api/v1/reserves/calculate. For a fund whose registry row resolves configuredMode 'on' with the kill switch inactive, the substrate result becomes the served source - ONLY when it verifies cents-exact against the legacy ConstrainedReserveEngine output for that same request (state available AND reconciliation match AND conservationOk). Every other outcome fail-safes to the legacy response with a warn-level demotion disclosure.

- NEW server/services/constrained-reserve-substrate-promotion.ts: serveConstrainedReserveCalculation resolves the mode ONCE; non-'on' (or kill-switched) requests DELEGATE to the untouched T7-T10 observeConstrainedReserveSubstrateShadow with the pre-resolved mode injected through its resolveMode seam (zero extra registry query), preserving shadow/reconcile/persist behavior byte-for-byte.
- 'on' path: runs the adapter, logs the shadow-style disclosure, reconciles via the exported pure fn, persists the observation through the SAME T9 writer seam (own try/catch, warn + swallow), then serves the substrate only on the verified-match gate.
- Projection (pinned serving parse): LEGACY allocations in LEGACY order, spread-preserved key set/order, with only 'allocated' replaced by Number(...) of the adapter's exact-2dp string; totalAllocated/remaining likewise. The match gate guarantees cents equality, so any byte difference vs legacy is float-noise representation cleanup, never cents. All comparisons stay cents-based.
- Route edit: the ?fundId branch serves the promotion outcome verbatim (+rid). The no-fundId path is literally unchanged. Envelope keys, allocation keys, status codes, and auth posture unchanged.

## Invariants

- Dormant everywhere: NO mode registry row is written or seeded by this PR, so every environment resolves the universal default off and all responses are byte-identical to pre-T11. Promotion is unreachable until an operator flips a fund to 'on' (a decision that consults the T10 read endpoint).
- Fail-safe to legacy: response is ALWAYS present and defaults to the passed legacy result; any throw (resolver, adapter, reconcile, projection) is warned and demoted (PROMOTION_ERROR). Promotion can never 500 the route.
- Persistence continuity: the append-only substrate_shadow_reconciliations ledger keeps accumulating under 'on' through the unchanged T9 seam; mismatch rows persist before demotion.
- Auth posture documented, not guarded: /calculate still takes no fund-scope guard; the response now branches on per-fund OPERATOR CONFIG (mode registry), never on per-fund stored portfolio data (ADR-052 records the narrowed rationale). The T10 GET keeps its guard.
- T7/T8/T9/T10 service files and tests byte-untouched; no DB writes from new code; no migrations; no prod/CI/credential changes.

## Verification

- Targeted set green: 2 new test files (7 service + 4 route tests) plus the 5 untouched T7-T10 substrate test files - 47 tests, 0 failures. The untouched T7 byte-identity test now exercises the delegation path.
- Full suite green via 5 foreground shards (server 3 + client 2): 8962 passed / 90 skipped / 0 failed = the 8951/90/0 post-T10 baseline + exactly the 11 new tests.
- npm run check, baseline:check (0 errors, 3-project), eslint on new+edited files with --max-warnings 0, and npm run build all clean.
- git diff --stat origin/main: only the promotion service (new), server/routes/v1/reserves.ts (edited), 2 new test files, DECISIONS.md (ADR-052), CHANGELOG.md.

Generated with [Claude Code](https://claude.com/claude-code)