### PR TITLE
feat(substrate): manifest the constrained-reserve reconciliation ledger for gated prod provisioning (ADR-053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Tranche 12 rehearsed full-stack activation and manifested the
+  constrained-reserve reconciliation ledger for gated prod provisioning
+  (ADR-053).** Phase 1 (disposable, uncommitted): a zero-mock rehearsal on a
+  throwaway localhost Postgres proved the real chain end to end for the first
+  time - registry row -> `resolveSubstrateCalcMode` -> shadow observe +
+  reconcile + persist -> `mode=on` serving the substrate under the
+  verified-parity seatbelt -> kill-switch demotion -> T10 GET reading the
+  history. One pinned expectation was corrected by evidence: the substrate value
+  embeds `asOfUtc`, so a re-POST of the same body appends a NEW observation
+  (same input/assumptions hashes, different result hash); the ledger's unique
+  key guarantees same-OBSERVATION replay safety (proven via the real ADR-050
+  writer), not temporal re-POST dedup. Phase 2: NEW manifest
+  `scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json` (all
+  13 columns typed; exactly the 6 SQL-named constraints + 1 index; NO pkey
+  sentinel - 0035 never names it) plus the pinned manifest-list edit in
+  `tests/unit/prod-schema-manifest-sentinels.test.ts`, enabling the
+  owner-approved `prod-schema-reconcile` apply of byte-unchanged migration 0035.
+  Prod `fund_calculation_modes` stays EMPTY (dormancy preserved), and production
+  releases fail closed between manifest merge and apply success by design (the
+  release workflow audits schema via the same reconcile tooling).
+
 - **Tranche 11 promoted the constrained-reserve substrate to authoritative
   behind `mode=on`, with a verified-parity seatbelt - dormant by default
   (ADR-052).** The arc's FIRST serving-path change: a NEW promotion service

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -7937,3 +7937,156 @@ edits to any `*-substrate-adapter.ts`, `shared/core/calc-substrate/`,
 T10 reader/GET route, or `reconciliation-runs.ts` (import-only); no
 response-envelope or allocation-key changes; no new npm dependencies; no UI; no
 Phoenix-protected path edits.
+
+## ADR-053: Tranche 12 Activation Rehearsal and Gated Prod Provisioning of the Constrained-Reserve Reconciliation Ledger, Prod Dormant (Demo Scope)
+
+### Status
+
+Accepted.
+
+### Context
+
+Two gaps remained after Tranche 11 (ADR-042..052 all merged):
+
+1. **No environment had ever activated the arc through a real registry row.**
+   Every T6-T11 proof used injected seams, a mocked resolver module, or the
+   database mock. The chain "operator writes a `fund_calculation_modes` row ->
+   real resolver reads it -> shadow/promotion serves and persists through a real
+   database -> T10 GET returns the history" had never executed end-to-end
+   anywhere.
+2. **Prod cannot accumulate or serve reconciliation history.** Migration
+   `0035_substrate_shadow_reconciliations.sql` is local-only; the prod T10
+   endpoint serves `[]` via the `42P01` graceful-absence path, and the
+   `prod-schema-reconcile` tooling had no manifest covering the table, so the
+   gated apply pathway could not provision it.
+
+### Decision
+
+Tranche 12 closes both gaps without changing prod behavior:
+
+**Phase 1 (executed 2026-07-18, disposable environment, nothing committed):** a
+zero-mock full-stack activation rehearsal on a throwaway `postgres:16` container
+(WSL Docker, localhost:5433, refused non-localhost hosts). The full 37-migration
+journal chain was replayed (777 statements, 107 public tables), one fund (id 1)
+and one `fund_calculation_modes` row (`reserve-constrained`,
+`configured_mode='shadow'`) were seeded, and the REAL `makeApp` was driven with
+supertest under `npx tsx` (no vitest, so no database mock). Environment traps
+discovered and pinned for future rehearsals: the config loader override-loads
+`.env`/`.env.development` and preserves pre-set values only when the
+`_EXPLICIT_<VAR>` markers are set (without `_EXPLICIT_DATABASE_URL` the
+rehearsal URL is silently replaced by `.env.development`'s mock URL), and
+`ALLOW_MEMORY_STORAGE` must be pinned `0` because any truthy value resolves the
+`explicit-memory` boot mode, which installs the database MOCK in `server/db.ts`
+(`.env` sets it to `1`).
+
+**Phase 2 (this change):** manifest the ledger for the pre-existing gated apply
+pathway - NEW
+`scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json` (order
+9, `missingTablePolicy: "create_or_repair"`, sqlFiles = byte-unchanged
+`migrations/0035_substrate_shadow_reconciliations.sql`) plus the pinned
+manifest-list edit in `tests/unit/prod-schema-manifest-sentinels.test.ts`. After
+merge the owner dispatches `prod-schema-reconcile` in apply mode at the merged
+SHA and approves the `production-schema` environment gate. **Prod
+`fund_calculation_modes` stays EMPTY** - provisioning the table leaves prod
+behaviorally dormant; the real pilot flip is Tranche 13, a separate owner
+decision.
+
+### Phase 1 rehearsal evidence (2026-07-18, all five assertions PASS)
+
+- **(a) shadow:** `POST /api/v1/reserves/calculate?fundId=1` returned 200 with a
+  body deep-equal (modulo `rid`) to the no-fundId POST of the same input; the
+  ledger held exactly one row:
+  `configured_mode='shadow', effective_mode='shadow', kill_switch_active=false, substrate_state='indicative', reconciliation_status='match', mismatches=[]`,
+  `input_hash=36f89f91366a...`, `assumptions_hash=6ff6cdf97196...`.
+- **(b) idempotency - AMENDED against the pinned expectation.** The T12 plan
+  pinned "re-POST the SAME body -> row count UNCHANGED"; that is empirically
+  FALSE by design. The substrate VALUE embeds `asOfUtc`
+  (`constrained-reserve-substrate-adapter.ts:287`) and `resultHash` hashes the
+  value, so a re-POST of the same body is a NEW observation: the rehearsal
+  proved same `input_hash` + same `assumptions_hash` with a DIFFERENT
+  `result_hash`, appending a second row. What the unique key
+  `(fund_id, calculation_key, input_hash, result_hash)` + `onConflictDoNothing`
+  actually guarantees - proven by calling the real ADR-050 writer twice with row
+  1's exact record (no-op, count unchanged) - is same-OBSERVATION replay safety,
+  not temporal re-POST dedup. A distinct body changed `input_hash` and appended
+  (+1). T13 consequence: a prod fund in `shadow` appends one ledger row per
+  opted-in POST - bounded by request volume and fund-scoped.
+- **(c) T10 GET:** `/api/v1/reserves/constrained/reconciliations?fundId=1`
+  returned 200 with envelope
+  `{ fundId: 1, calculationKey: 'reserve-constrained', observations, rid }`,
+  observations newest-first, each carrying the full 13-field read DTO.
+- **(d) promotion:** after
+  `UPDATE fund_calculation_modes SET configured_mode='on'`, a POST with a third
+  distinct body returned 200 deep-equal to its no-fundId legacy twin; the server
+  logged `constrained reserve substrate promotion served` (exactly once in the
+  run); the new ledger row was
+  `configured_mode='on', effective_mode='on', substrate_state='available', reconciliation_status='match'`.
+- **(e) kill switch:** after `SET kill_switch_active=true`, a POST with a fourth
+  distinct body returned the legacy-identical 200 (delegation demotion) and
+  produced NO new ledger row (count unchanged - the kill-switched adapter yields
+  no value, so nothing reconciles or persists).
+- **Teardown:** the container was removed (`docker rm -f t12-rehearsal-pg`,
+  verified absent); the rehearsal scripts were deleted; nothing from Phase 1 is
+  committed beyond this evidence.
+
+### Manifest and sentinel facts (pinned)
+
+- Manifest 09 lists exactly the SIX constraints and ONE index that 0035's SQL
+  NAMES (`substrate_shadow_reconciliations_fund_key_input_result_unique`,
+  `_configured_mode_check`, `_effective_mode_check`, `_substrate_state_check`,
+  `_reconciliation_status_check`, `_fund_id_funds_id_fk`;
+  `idx_substrate_shadow_reconciliations_fund_observed`) and MUST NOT list
+  `substrate_shadow_reconciliations_pkey`: 0035 never names its serial PRIMARY
+  KEY, and the sentinel-survival pin only credits names appearing in the
+  manifest's own SQL - a pkey sentinel would fail the unit pin and, post-apply,
+  the reconcile audit.
+- Every column carries a `type` (un-typed manifest columns silently skip
+  type-drift detection); the vocabulary matches the reconcile normalization
+  (`serial` -> `integer`, `character varying` -> `varchar`,
+  `timestamp with time zone` -> `timestamptz`).
+- **Release-gate coupling:** `release-production.yml` invokes
+  `prod-schema-reconcile` (audit mode) as a promotion gate, and audit passes
+  only when ALL manifests are SKIP. From the moment this manifest merges until
+  the apply succeeds, production releases fail closed BY DESIGN - hence the
+  merge-then-apply-immediately sequencing.
+- **Hard-stop conditions:** apply proceeds only when the pre-apply audit reads
+  exactly `01..08: SKIP` +
+  `substrate-shadow-reconciliations: APPLY-MISSING-DDL`. Any REFUSE-FOR-HUMAN,
+  any 01-08 non-SKIP (unexpected prod drift), or 09 SKIP (table unexpectedly
+  present) stops the operation for the owner.
+
+### Disposition table
+
+| Component                                                                | Disposition               |
+| ------------------------------------------------------------------------ | ------------------------- |
+| `migrations/0035_substrate_shadow_reconciliations.sql`                   | reuse (byte-unchanged)    |
+| `scripts/reconcile-prod-schema.mjs`                                      | reuse (unchanged)         |
+| `.github/workflows/prod-schema-reconcile.yml`                            | reuse (unchanged)         |
+| `scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json` | new                       |
+| `tests/unit/prod-schema-manifest-sentinels.test.ts` (pinned list)        | edit                      |
+| Prod `fund_calculation_modes` row (any prod fund `shadow`/`on`)          | defer (Tranche 13, owner) |
+| Manifests for 0033/0034 (invisible to reconcile tooling)                 | defer                     |
+| Second substrate consumer                                                | defer                     |
+
+### Consequences
+
+After the gated apply, prod has the empty append-only ledger table with its six
+named constraints and index; the T10 endpoint transitions from 42P01-absence
+`[]` to real (initially empty) reads; and prod behavior is otherwise unchanged
+because the mode registry remains EMPTY, so every request resolves the universal
+`{ off, false }` default. The last infrastructure gap between "dormant" and
+"operator can flip a pilot fund" is closed. Tranche 13 = the owner flips ONE
+prod pilot fund to `shadow` FIRST (not `on`), lets real traffic accumulate
+parity history, consults `GET /api/v1/reserves/constrained/reconciliations`, and
+only then promotes that fund to `on` - at which point the T11 verified-parity
+seatbelt governs every served response.
+
+### Non-goals
+
+No prod `fund_calculation_modes` rows (no prod fund becomes `shadow`/`on` - prod
+stays dormant); no prod data writes of any kind (the ONLY prod change is the
+workflow's own gated apply of manifest 09); no manifests for 0033/0034; no new
+or edited migrations (0035 byte-identical); no edits to T1-T11 substrate
+services/routes/tests, `scripts/reconcile-prod-schema.mjs`, or
+`.github/workflows/prod-schema-reconcile.yml`; no UI; no new dependencies; no
+auto-merge; no Phoenix-protected path edits.

--- a/scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json
+++ b/scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json
@@ -1,0 +1,41 @@
+{
+  "name": "substrate-shadow-reconciliations",
+  "order": 9,
+  "description": "Append-only fund-scoped ledger of constrained-reserve substrate shadow reconciliation observations (ADR-050).",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0035_substrate_shadow_reconciliations.sql"],
+  "allowedCreateTables": ["substrate_shadow_reconciliations"],
+  "expectedTables": [
+    {
+      "name": "substrate_shadow_reconciliations",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "calculation_key", "type": "text", "nullable": false },
+        { "name": "configured_mode", "type": "varchar", "nullable": false },
+        { "name": "effective_mode", "type": "varchar", "nullable": false },
+        { "name": "kill_switch_active", "type": "boolean", "nullable": false },
+        { "name": "substrate_state", "type": "varchar", "nullable": false },
+        {
+          "name": "reconciliation_status",
+          "type": "varchar",
+          "nullable": false
+        },
+        { "name": "input_hash", "type": "text", "nullable": false },
+        { "name": "result_hash", "type": "text", "nullable": false },
+        { "name": "assumptions_hash", "type": "text", "nullable": false },
+        { "name": "mismatches", "type": "jsonb", "nullable": false },
+        { "name": "observed_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "substrate_shadow_reconciliations_fund_key_input_result_unique",
+        "substrate_shadow_reconciliations_configured_mode_check",
+        "substrate_shadow_reconciliations_effective_mode_check",
+        "substrate_shadow_reconciliations_substrate_state_check",
+        "substrate_shadow_reconciliations_reconciliation_status_check",
+        "substrate_shadow_reconciliations_fund_id_funds_id_fk"
+      ],
+      "indexes": ["idx_substrate_shadow_reconciliations_fund_observed"]
+    }
+  ]
+}

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -79,6 +79,10 @@ const ALLOCATION_SCENARIO_MANIFEST_TABLES = [
   'allocation_scenario_ic_decisions',
 ] as const;
 const SCENARIO_CASE_SEED_PROVENANCE_MANIFEST_TABLES = ['scenario_case_seed_provenance'] as const;
+// M9 (09-substrate-shadow-reconciliations): ADR-050 append-only ledger (journal 0035).
+const SUBSTRATE_SHADOW_RECONCILIATION_MANIFEST_TABLES = [
+  'substrate_shadow_reconciliations',
+] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
   'flags_state',
@@ -701,6 +705,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...H9_MANIFEST_TABLES,
         ...ALLOCATION_SCENARIO_MANIFEST_TABLES,
         ...SCENARIO_CASE_SEED_PROVENANCE_MANIFEST_TABLES,
+        ...SUBSTRATE_SHADOW_RECONCILIATION_MANIFEST_TABLES,
       ])
     );
 

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -81,7 +81,7 @@ function namesSurvivingSql(sqlFiles: string[]): Set<string> {
 describe('prod-schema manifest sentinels', () => {
   const manifests = loadManifestFiles();
 
-  it('finds the four PR-1 manifests and all additive production manifests through scenario seed provenance', () => {
+  it('finds the four PR-1 manifests and all additive production manifests through substrate shadow reconciliations', () => {
     expect(manifests.map((entry) => entry.file)).toEqual([
       '01-cohort.json',
       '02-fund-moic.json',
@@ -91,6 +91,7 @@ describe('prod-schema manifest sentinels', () => {
       '06-h9-actionability.json',
       '07-allocation-scenarios.json',
       '08-scenario-case-seed-provenance.json',
+      '09-substrate-shadow-reconciliations.json',
     ]);
   });
 


### PR DESCRIPTION
## Summary

Tranche 12 of the calc-substrate arc (ADR-042..052 merged, T11 = #1148): close the last infrastructure gap between "dormant" and "operator can flip a pilot fund" while leaving prod behaviorally unchanged.

- NEW `scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json` - manifests byte-unchanged migration `0035_substrate_shadow_reconciliations.sql` for the pre-existing gated `prod-schema-reconcile` apply pathway (`missingTablePolicy: create_or_repair`; all 13 columns typed; exactly the 6 SQL-named constraints + 1 named index; NO pkey sentinel - 0035 never names its serial primary key and the sentinel-survival pin only credits SQL-named objects).
- `tests/unit/prod-schema-manifest-sentinels.test.ts` - the pinned manifest list (and its `it()` title) now runs through manifest 09.
- `DECISIONS.md` ADR-053 + `CHANGELOG.md` entry.

**Prod `fund_calculation_modes` stays EMPTY** - no prod fund becomes `shadow`/`on`; the ONLY prod change is the workflow's own gated apply of manifest 09 after this merges.

## Phase 1 rehearsal (executed first, disposable, uncommitted)

Zero-mock full-stack activation rehearsal on a throwaway `postgres:16` (WSL Docker, localhost:5433, localhost-guarded scripts, full 37-migration journal replay). First time the real chain executed anywhere: registry row -> `resolveSubstrateCalcMode` -> shadow observe/reconcile/persist -> `mode=on` SERVING the substrate under the T11 verified-parity seatbelt -> kill-switch demotion -> T10 GET reading the history. All five assertions passed; full evidence (hashes, ledger rows, log lines) in ADR-053.

One pinned expectation was corrected by evidence: the substrate value embeds `asOfUtc`, so a re-POST of the same body appends a NEW observation (same input/assumptions hashes, different result hash). The ledger unique key + `onConflictDoNothing` guarantee same-OBSERVATION replay safety (proven by double-calling the real ADR-050 writer), not temporal re-POST dedup. Documented in ADR-053 with the T13 consequence (one ledger row per opted-in POST on a shadow fund).

## Sequencing after merge (owner)

`release-production.yml` audits prod schema via this same reconcile tooling, and audit passes only when ALL manifests are SKIP - so from this merge until apply succeeds, production releases fail closed BY DESIGN. Immediately after merging: dispatch `prod-schema-reconcile.yml` with `mode=apply` + the full merged SHA and approve the `production-schema` environment. Hard-stop unless the pre-apply audit reads exactly `01..08: SKIP` + `substrate-shadow-reconciliations: APPLY-MISSING-DDL`.

## Validation

- Targeted: `prod-schema-manifest-sentinels` + `reconcile-prod-schema` + `migration-ledger` + `mount-parity-migrations` - 48/48 passed
- Full 5-shard suite: **8962 passed / 90 skipped / 0 failed** (equals the post-T11 baseline exactly; this tranche adds no tests)
- `npm run check` OK, `npm run baseline:check` OK (0 new), eslint clean on the edited test file, `npm run build` passed

Generated with [Claude Code](https://claude.com/claude-code)