### PR TITLE
fix(nav): derive position FMV from ownership x post-money across all surfaces (ADR-054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to
 
 ### Added (2026-07-18)
 
+- **Ownership-aware position FMV is now consistent across current NAV surfaces
+  (ADR-054).** Header KPIs, portfolio overview rows, and the dual-forecast NAV
+  blend now derive position value from explicitly recorded `ownershipCurrentPct`
+  x company `currentValuation`. The forecast attribution contract discloses
+  scaled legacy contributions separately, while null- or zero-ownership legacy
+  rows retain their prior unscaled behavior; ownership is never estimated or
+  defaulted.
+
 - **Tranche 12 rehearsed full-stack activation and manifested the
   constrained-reserve reconciliation ledger for gated prod provisioning
   (ADR-053).** Phase 1 (disposable, uncommitted): a zero-mock rehearsal on a

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8090,3 +8090,58 @@ or edited migrations (0035 byte-identical); no edits to T1-T11 substrate
 services/routes/tests, `scripts/reconcile-prod-schema.mjs`, or
 `.github/workflows/prod-schema-reconcile.yml`; no UI; no new dependencies; no
 auto-merge; no Phoenix-protected path edits.
+
+## ADR-054: Ownership-Scaled Legacy NAV Fallback (amends ADR-029)
+
+**Date:** 2026-07-18 **Status:** [ACCEPTED] Accepted **Decision:** Rung 3 of the
+ADR-029 NAV anchor ladder scales `currentValuation` by `ownershipCurrentPct`
+only when ownership is explicitly recorded (non-null and greater than zero), and
+discloses that contribution with the new
+`legacy_current_valuation_ownership_scaled` anchor. Null or zero ownership keeps
+the unscaled rung-3 behavior and `legacy_current_valuation` label. Ownership is
+never defaulted; the H9 guard remains intact.
+
+### Context
+
+Demo/import data records company post-money valuation in `currentValuation` and
+the fund's position slice in `ownershipCurrentPct`. Summing raw company
+valuations therefore inflated dual-forecast NAV - for example, approximately
+$391.4M instead of the approximately $6.54M position total already persisted in
+`fund_metrics.totalvalue` and now shown by the corrected header and portfolio
+overview surfaces.
+
+ADR-029 rejected a different derivation: converting rounds-derived pre-money
+valuation and compounding it with DEFAULTED ownership, including the H9 `0.15`
+pathology. This amendment performs no pre-money conversion and introduces no
+ownership default. `latestRoundValuation` still never enters NAV.
+
+### Decision
+
+- Rung 1 (`planning_fmv`) and rung 2 (`planning_fmv_stale`) remain unchanged.
+- At rung 3, a non-null `currentValuation` is multiplied by
+  `ownershipCurrentPct` only when the recorded ownership is greater than zero.
+  The contribution is attributed as `legacy_current_valuation_ownership_scaled`,
+  keeping mixed-anchor NAV visibly mixed.
+- Null or zero ownership preserves the exact ADR-029 unscaled rung-3 fallback
+  and `legacy_current_valuation` attribution. Missing ownership is never
+  estimated or defaulted.
+- The same recorded-ownership derivation applies in `ActualMetricsCalculator`,
+  `portfolio-overview-service`, and the dual-forecast NAV blend so header,
+  table, and forecast surfaces remain consistent.
+- Rung 4 (`none`) and the live-company NAV universe remain unchanged.
+
+### Alternatives Considered
+
+- **Fix the data instead:** rejected because the demo author intent stores two
+  distinct facts - company post-money valuation and the fund's recorded
+  ownership - and reader-side derivation preserves both without rewriting source
+  data.
+- **Marks-only NAV:** already rejected in ADR-029 because missing mark coverage
+  would create a valuation cliff unrelated to economic value.
+
+### Consequences
+
+Recorded ownership now produces position-level legacy NAV consistently across
+all three read surfaces, with a distinct disclosed anchor. Legacy rows without
+positive recorded ownership remain byte-for-byte equivalent at rung 3, and no
+round valuation, estimated ownership, or default ownership enters NAV.

--- a/client/src/lib/dual-forecast-display.ts
+++ b/client/src/lib/dual-forecast-display.ts
@@ -361,6 +361,11 @@ export const ANCHOR_RUNG_COPY: Record<DualForecastNavAnchor, { label: string; to
     label: 'Recorded valuation (legacy)',
     tooltip: 'Anchored to the recorded valuation, which has no provenance trail.',
   },
+  legacy_current_valuation_ownership_scaled: {
+    label: 'Recorded valuation x recorded ownership (legacy)',
+    tooltip:
+      'Company-level recorded valuation scaled by the explicitly recorded ownership percentage; used only when ownership is recorded and positive; never estimated or defaulted (ADR-054).',
+  },
   none: {
     label: 'None (zero)',
     tooltip: 'No usable valuation source; contributes zero to NAV rather than a silent fill.',

--- a/server/services/actual-metrics-calculator.ts
+++ b/server/services/actual-metrics-calculator.ts
@@ -191,10 +191,10 @@ export class ActualMetricsCalculator {
 
   /**
    * Calculate current Net Asset Value from portfolio companies
-   * Only requires status and currentValuation fields
+   * Only requires status, currentValuation, and ownershipCurrentPct fields
    */
   private calculateNAV(
-    companies: Pick<PortfolioCompany, 'status' | 'currentValuation'>[]
+    companies: Pick<PortfolioCompany, 'status' | 'currentValuation' | 'ownershipCurrentPct'>[]
   ): Decimal {
     return companies
       .filter((c) => this.isLivePortfolioCompany(c))
@@ -202,7 +202,13 @@ export class ActualMetricsCalculator {
         const valuation = company.currentValuation
           ? this.parseDecimal(company.currentValuation)
           : new Decimal(0);
-        return sum.plus(valuation);
+        const ownership =
+          company.ownershipCurrentPct != null
+            ? this.parseDecimal(company.ownershipCurrentPct)
+            : null;
+        const positionValue =
+          ownership != null && ownership.gt(0) ? valuation.mul(ownership) : valuation;
+        return sum.plus(positionValue);
       }, new Decimal(0));
   }
 

--- a/server/services/metrics-aggregator.ts
+++ b/server/services/metrics-aggregator.ts
@@ -583,9 +583,11 @@ export class MetricsAggregator {
   }
 
   /**
-   * ADR-029 anchor ladder. UNAVAILABLE/FAILED envelopes and currency-blocked
-   * companies contribute no facts-derived money (ADR-030/ADR-032) and descend
-   * to the legacy rungs. `latestRoundValuation` (pre-money) NEVER enters NAV.
+   * ADR-029 anchor ladder, amended by ADR-054. UNAVAILABLE/FAILED envelopes and
+   * currency-blocked companies contribute no facts-derived money
+   * (ADR-030/ADR-032) and descend to the legacy rungs. Explicitly recorded
+   * positive ownership scales rung 3; ownership is never defaulted.
+   * `latestRoundValuation` (pre-money) NEVER enters NAV.
    */
   private resolveNavAnchor(
     company: MetricsPortfolioCompany,
@@ -610,10 +612,16 @@ export class MetricsAggregator {
     }
 
     if (company.currentValuation != null) {
-      return {
-        anchor: 'legacy_current_valuation',
-        contribution: toDecimal(company.currentValuation),
-      };
+      const valuation = toDecimal(company.currentValuation);
+      const ownership =
+        company.ownershipCurrentPct != null ? toDecimal(company.ownershipCurrentPct) : null;
+      if (ownership != null && ownership.gt(0)) {
+        return {
+          anchor: 'legacy_current_valuation_ownership_scaled',
+          contribution: valuation.times(ownership),
+        };
+      }
+      return { anchor: 'legacy_current_valuation', contribution: valuation };
     }
 
     return { anchor: 'none', contribution: toDecimal(0) };

--- a/server/services/portfolio-overview-service.ts
+++ b/server/services/portfolio-overview-service.ts
@@ -58,8 +58,12 @@ export async function getPortfolioOverview(
 
   const computed = companies.map((company) => {
     const invested = toDecimal(company.investmentAmount ?? '0');
-    const currentValue =
+    const companyValuation =
       company.currentValuation == null ? new Decimal(0) : toDecimal(company.currentValuation);
+    const ownership =
+      company.ownershipCurrentPct == null ? null : toDecimal(company.ownershipCurrentPct);
+    const currentValue =
+      ownership != null && ownership.gt(0) ? companyValuation.times(ownership) : companyValuation;
     // Preserve the original client guard: MOIC is 0 unless a positive amount was invested.
     const moic = invested.lte(0) ? new Decimal(0) : currentValue.dividedBy(invested);
     return { company, invested, currentValue, moic };
@@ -98,6 +102,7 @@ export async function getPortfolioOverview(
       id: company.id,
       investmentAmount: company.investmentAmount ?? null,
       currentValuation: company.currentValuation ?? null,
+      ownershipCurrentPct: company.ownershipCurrentPct ?? null,
       status: company.status,
     }))
     .sort((left, right) => left.id - right.id);
@@ -106,6 +111,7 @@ export async function getPortfolioOverview(
   const assumptionsHash = canonicalSha256({
     calculationVersion: CALCULATION_VERSION,
     averageMoicBasis: 'simple_average_of_per_company_moic',
+    positionValueBasis: 'ownership_current_pct_times_current_valuation_when_present',
     zeroInvestedGuard: 'moic_zero_when_investment_amount_le_0',
     zeroCompanyGuard: 'average_zero_when_no_companies',
     exitedStatuses: EXITED_STATUSES,

--- a/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
+++ b/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
@@ -125,13 +125,16 @@ export const DualForecastActualsFactsSchema = z
  * ADR-029 anchor ladder attribution: which value anchored a company's NAV
  * contribution. `planning_fmv` = active Planning FMV mark; `planning_fmv_stale`
  * = stale mark, disclosed; `legacy_current_valuation` = the un-provenanced
- * `portfolio_companies.currentValuation` fallback; `none` = the disclosed zero
- * that used to be silent.
+ * `portfolio_companies.currentValuation` fallback;
+ * `legacy_current_valuation_ownership_scaled` = that legacy valuation scaled by
+ * explicitly recorded `ownershipCurrentPct` (never defaulted), introduced by
+ * ADR-054; `none` = the disclosed zero that used to be silent.
  */
 export const DualForecastNavAnchorSchema = z.enum([
   'planning_fmv',
   'planning_fmv_stale',
   'legacy_current_valuation',
+  'legacy_current_valuation_ownership_scaled',
   'none',
 ]);
 

--- a/tests/unit/lib/dual-forecast-display.test.ts
+++ b/tests/unit/lib/dual-forecast-display.test.ts
@@ -602,6 +602,12 @@ describe('disclosure copy map', () => {
 
   it('names the legacy rung "Recorded valuation (legacy)" — one name across surfaces', () => {
     expect(ANCHOR_RUNG_COPY.legacy_current_valuation.label).toBe('Recorded valuation (legacy)');
+    expect(ANCHOR_RUNG_COPY.legacy_current_valuation_ownership_scaled.label).toBe(
+      'Recorded valuation x recorded ownership (legacy)'
+    );
+    expect(ANCHOR_RUNG_COPY.legacy_current_valuation_ownership_scaled.tooltip).toContain(
+      'never estimated or defaulted'
+    );
     expect(ANCHOR_RUNG_COPY.planning_fmv_stale.label).toBe('Planning FMV (stale)');
     expect(ANCHOR_RUNG_COPY.none.label).toBe('None (zero)');
   });

--- a/tests/unit/services/actual-metrics-calculator.test.ts
+++ b/tests/unit/services/actual-metrics-calculator.test.ts
@@ -152,6 +152,39 @@ describe('ActualMetricsCalculator actual fact plumbing', () => {
     expect(metrics.dpi).toBeNull();
   });
 
+  it('derives live position FMV from ownership and preserves null-ownership legacy NAV', async () => {
+    storageMock.getPortfolioCompanies.mockResolvedValue([
+      {
+        id: 10,
+        fundId: 1,
+        name: 'Owned Position',
+        sector: 'Consumer',
+        stage: 'Series A',
+        status: 'active',
+        investmentAmount: '500000.00',
+        currentValuation: '50000000.00',
+        ownershipCurrentPct: '0.0208',
+      },
+      {
+        id: 11,
+        fundId: 1,
+        name: 'Legacy Position',
+        sector: 'SaaS',
+        stage: 'Seed',
+        status: 'active',
+        investmentAmount: '1000000.00',
+        currentValuation: '3000000.00',
+        ownershipCurrentPct: null,
+      },
+    ]);
+    dbMock.select.mockReturnValue(distributionQuery(Promise.resolve([])));
+
+    const metrics = await calculator.calculate(1);
+
+    expect(metrics.currentNAV).toBe(4_040_000);
+    expect(metrics.totalValue).toBe(4_040_000);
+  });
+
   it('uses establishment date before vintage-year fallback for fund age', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T00:00:00.000Z'));

--- a/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
+++ b/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
@@ -636,33 +636,61 @@ describe('MetricsAggregator dual forecast', () => {
       );
     });
 
-    it('rung 3: no usable mark falls back to currentValuation, disclosed', async () => {
+    it('rung 3: explicitly recorded ownership scales currentValuation, disclosed', async () => {
+      storageMock.getPortfolioCompanies.mockResolvedValue([
+        {
+          ...baseStorageCompany(),
+          currentValuation: '50000000.00',
+          ownershipCurrentPct: '0.0208',
+        },
+      ]);
       buildFundCompanyActualsFactsMock.mockResolvedValue(makeFacts({ planningMarks: [] }));
 
       const aggregator = new MetricsAggregator();
       const result = await aggregator.getDualForecast(1);
 
       expect(result.series[0]?.actual).toEqual({
-        nav: 10_000_000,
+        nav: 1_040_000,
         calledCapital: 25_000_000,
         distributions: 2_000_000,
-        tvpi: 0.48, // (10M + 2M) / 25M
+        tvpi: 0.1216, // (1.04M + 2M) / 25M
         dpi: 0.08,
-        rvpi: 0.4, // 10M / 25M
+        rvpi: 0.0416, // 1.04M / 25M
         irr: 0.14,
       });
       expect(result.navAnchoring).toMatchObject({
-        blendedNav: '10000000.000000',
+        blendedNav: '1040000.000000',
         countsByTrustState: trustCounts({ PARTIAL: 1 }), // PLANNING_FMV_MISSING
       });
       expect(result.navAnchoring?.companies[0]).toMatchObject({
-        anchor: 'legacy_current_valuation',
-        contribution: '10000000.000000',
+        anchor: 'legacy_current_valuation_ownership_scaled',
+        contribution: '1040000.000000',
         trustState: 'PARTIAL',
       });
       expect(result.actualsFacts?.warnings).toEqual(
         expect.arrayContaining([expect.objectContaining({ code: 'PLANNING_FMV_MISSING' })])
       );
+    });
+
+    it('rung 3: null ownership preserves the full legacy currentValuation', async () => {
+      storageMock.getPortfolioCompanies.mockResolvedValue([
+        {
+          ...baseStorageCompany(),
+          currentValuation: '50000000.00',
+          ownershipCurrentPct: null,
+        },
+      ]);
+      buildFundCompanyActualsFactsMock.mockResolvedValue(makeFacts({ planningMarks: [] }));
+
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      expect(result.navAnchoring?.blendedNav).toBe('50000000.000000');
+      expect(result.navAnchoring?.companies[0]).toMatchObject({
+        anchor: 'legacy_current_valuation',
+        contribution: '50000000.000000',
+        trustState: 'PARTIAL',
+      });
     });
 
     it('rung 4: no mark and no legacy value is a DISCLOSED zero, and pre-money never enters NAV', async () => {
@@ -707,22 +735,22 @@ describe('MetricsAggregator dual forecast', () => {
       const result = await aggregator.getDualForecast(1);
 
       // The 999M mark is CARRIED by the facts but contributes nothing; the
-      // company descends to the base-currency legacy fallback (rung 3).
+      // company descends to the ownership-scaled legacy fallback (rung 3).
       expect(result.actualsFacts?.companies[0]).toMatchObject({
         currencyStatus: 'mismatch_blocked',
         planningFmvStatus: 'blocked',
         latestPlanningFmvValue: '999000000.000000',
       });
-      expect(result.series[0]?.actual).toMatchObject({ nav: 10_000_000, tvpi: 0.48, rvpi: 0.4 });
+      expect(result.series[0]?.actual).toMatchObject({ nav: 1_000_000, tvpi: 0.12, rvpi: 0.04 });
       expect(result.navAnchoring).toMatchObject({
-        blendedNav: '10000000.000000',
+        blendedNav: '1000000.000000',
         countsByTrustState: trustCounts({ UNAVAILABLE: 1 }),
       });
       expect(result.navAnchoring?.companies[0]).toMatchObject({
         inNavUniverse: true,
         trustState: 'UNAVAILABLE',
-        anchor: 'legacy_current_valuation',
-        contribution: '10000000.000000',
+        anchor: 'legacy_current_valuation_ownership_scaled',
+        contribution: '1000000.000000',
       });
       expect(result.actualsFacts?.warnings).toEqual(
         expect.arrayContaining([expect.objectContaining({ code: 'CURRENCY_MISMATCH_BLOCK' })])
@@ -773,9 +801,9 @@ describe('MetricsAggregator dual forecast', () => {
         ],
       });
       // Money refused: neither the 999M mark nor the 150M pre-money enters;
-      // the company descends to the legacy fallback.
-      expect(result.series[0]?.actual?.nav).toBe(10_000_000);
-      expect(result.navAnchoring?.blendedNav).toBe('10000000.000000');
+      // the company descends to the ownership-scaled legacy fallback.
+      expect(result.series[0]?.actual?.nav).toBe(1_000_000);
+      expect(result.navAnchoring?.blendedNav).toBe('1000000.000000');
       expect(result.navAnchoring?.countsByTrustState).toEqual(trustCounts({ UNAVAILABLE: 1 }));
     });
 
@@ -866,16 +894,16 @@ describe('MetricsAggregator dual forecast', () => {
       const aggregator = new MetricsAggregator();
       const result = await aggregator.getDualForecast(1);
 
-      expect(result.navAnchoring?.blendedNav).toBe('47000000.000000');
-      expect(result.series[0]?.actual?.nav).toBe(47_000_000);
+      expect(result.navAnchoring?.blendedNav).toBe('42500000.000000');
+      expect(result.series[0]?.actual?.nav).toBe(42_500_000);
       const legacyCo = result.navAnchoring?.companies.find((entry) => entry.companyId === 30);
       expect(legacyCo).toEqual({
         companyId: 30,
         companyName: 'Legacy Co',
         inNavUniverse: true,
         trustState: null, // no facts entry for this company
-        anchor: 'legacy_current_valuation',
-        contribution: '5000000.000000',
+        anchor: 'legacy_current_valuation_ownership_scaled',
+        contribution: '500000.000000',
       });
     });
 

--- a/tests/unit/services/portfolio-overview-service.test.ts
+++ b/tests/unit/services/portfolio-overview-service.test.ts
@@ -75,6 +75,31 @@ describe('getPortfolioOverview', () => {
     expect(PortfolioOverviewResponseV1Schema.parse(result)).toEqual(result);
   });
 
+  it('derives position FMV from ownership and preserves null-ownership legacy values', async () => {
+    mockFund();
+    mockCompanies([
+      company({
+        id: 1,
+        investmentAmount: '500000.00',
+        currentValuation: '50000000.00',
+        ownershipCurrentPct: '0.0208',
+      }),
+      company({
+        id: 2,
+        investmentAmount: '1000000.00',
+        currentValuation: '3000000.00',
+        ownershipCurrentPct: null,
+      }),
+    ]);
+
+    const result = await getPortfolioOverview(10, { now: NOW });
+
+    expect(result.companies[0]?.currentValue).toBe('1040000');
+    expect(result.companies[0]?.moic).toBe('2.08');
+    expect(result.companies[1]?.currentValue).toBe('3000000');
+    expect(result.metrics.totalValue).toBe('4040000');
+  });
+
   it('matches the former client formulas at display precision (parity)', async () => {
     mockFund();
     const rows = [
@@ -176,6 +201,17 @@ describe('getPortfolioOverview', () => {
     const reversed = await getPortfolioOverview(10, { now: NOW });
 
     expect(forward.provenance.inputHash).toBe(reversed.provenance.inputHash);
+  });
+
+  it('changes inputHash when ownership changes', async () => {
+    mockFund();
+    mockCompanies([company({ ownershipCurrentPct: '0.0208' })]);
+    const lowerOwnership = await getPortfolioOverview(10, { now: NOW });
+
+    mockCompanies([company({ ownershipCurrentPct: '0.0416' })]);
+    const higherOwnership = await getPortfolioOverview(10, { now: NOW });
+
+    expect(lowerOwnership.provenance.inputHash).not.toBe(higherOwnership.provenance.inputHash);
   });
 
   it('produces different inputHashes for different resolver meta (live vs snapshot)', async () => {


### PR DESCRIPTION
## Summary

- Calculators were summing raw `current_valuation` (company post-money) as fund NAV, producing $391.4M / 56x TVPI instead of the correct $6.54M / 0.94x for the demo portfolio
- Fix applies ownership-aware position FMV (`ownershipCurrentPct x currentValuation` when explicitly recorded and > 0; passthrough for null/zero ownership) uniformly across all three NAV surfaces
- New dual-forecast rung-3 anchor `legacy_current_valuation_ownership_scaled` added to contract and client display copy; ADR-054 amends ADR-029 (H9 defaulted-ownership guard intact — only scales on recorded, non-null, >0 ownership)

## Files changed

- `server/services/portfolio-overview-service.ts` — Portfolio Actuals table currentValue + moic per company
- `server/services/actual-metrics-calculator.ts` — header NAV / TVPI (calculateNAV)
- `server/services/metrics-aggregator.ts` — dual-forecast resolveNavAnchor rung 3
- `shared/contracts/dual-forecast/dual-forecast-response.contract.ts` — new anchor in z.enum
- `client/src/lib/dual-forecast-display.ts` — rung copy for new anchor
- `DECISIONS.md` — ADR-054
- `CHANGELOG.md`
- 4 test files (portfolio-overview-service, actual-metrics-calculator, metrics-aggregator-dual-forecast, dual-forecast-display)

## Verification

All three surfaces confirmed against povc_dev (fund 9):
- Portfolio Actuals: 10Beauty $1.04M / 2.08x (matches demo-profile stated NAV exactly)
- Header: currentNAV $6,540,100, TVPI 0.944 (ties to fund_metrics.totalvalue)
- Dual-forecast actuals: nav $6,540,100

Suite: 8,964 tests across 5 shards — green (2 shard-2 timeouts are pre-existing resource-ceiling flakes, pass standalone).

## Test plan

- [x] `npm test -- --project=server` passes all services tests
- [x] `npm test -- --project=client` passes dual-forecast-display test
- [x] Live API verification against real portfolio data
- [x] TypeScript baseline: 0 new errors
- [x] Lint: clean

https://claude.ai/code/session_01NSMSutuhBjqmSehpX49dST