### PR TITLE
feat(reserves): reserve-envelope derivation service (ADR-056 NET-NEW #1, standalone/unwired)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -126,7 +126,8 @@ future session (or teammate) can pick them up without re-deriving the decision.
 - **Convergence decision:** superseded framing recorded in ADR-056 — the
   authoritative reserve workflow (not the caller-JSON `/calculate` route) is the
   convergence target; see the canonical-assembler entry below (rescoped).
-- **Depends on:** the canonical reserve-input assembler below (rescoped by ADR-056).
+- **Depends on:** the canonical reserve-input assembler below (rescoped by
+  ADR-056).
 - **Effort:** M (blocked on the assembler).
 
 ---
@@ -140,11 +141,26 @@ future session (or teammate) can pick them up without re-deriving the decision.
   provenance-controlled deal-level ranking inputs; (2) REUSE
   `calculateMarginalReserveMoic` to rank follow-on priority; (3) NET-NEW a
   server-side fee/expense/deployment/recycling-aware reserve ENVELOPE service
-  (replacing the naive `fundSize * reserveRatio`), with disclosed provenance;
-  (4) REUSE `ConstrainedReserveEngine.calculate` to allocate the envelope in the
-  ranked order, replacing `generateReserveSummary`'s hardcoded multipliers
-  behind a new calc-mode/flag, shadow-first. Records input provenance; no
-  client-manufactured synthetic portfolio.
+  (replacing the naive `fundSize * reserveRatio`), with disclosed provenance —
+  **[LANDED, UNWIRED]** `server/services/reserves/reserve-envelope-service.ts`
+  - `shared/contracts/reserve-envelope-v1.contract.ts` (cents-exact,
+    per-component provenance status observed/derived/defaulted/unavailable,
+    `trustedForActivation`, `canonicalSha256` inputHash; consumed by no live
+    path yet); (4) REUSE `ConstrainedReserveEngine.calculate` to allocate the
+    envelope in the ranked order, replacing `generateReserveSummary`'s hardcoded
+    multipliers behind a new calc-mode/flag, shadow-first. Records input
+    provenance; no client-manufactured synthetic portfolio.
+- **Progress (2026-07-19):** NET-NEW #1 (envelope) landed standalone/unwired.
+  Envelope source map — committed=`funds.size` (observed);
+  deployed=Σ`investments.amount` else `funds.deployed_capital`
+  (observed/derived) else 0 (defaulted); mgmt fees= `funds.management_fee` x
+  committed x `config.fundLife` (derived; flat committed basis,
+  step-downs/called-basis deferred) else 10y default (defaulted); expenses=
+  `config.expenses[]` (derived) else `unavailable`; exit
+  recycling=`config.recyclingCap` upper bound (derived) else `unavailable`.
+  Remaining: NET-NEW #2 (ranked-allocation orchestrator wiring the envelope into
+  `runReserveCalculation` behind a calc-mode/flag) and NET-NEW #3 (mode-aware
+  fund-moic route + un-gate `ENABLE_MARGINAL_RESERVE_MOIC`, H9-governed).
 - **Why:** Today the browser would have to manufacture the entire `ReserveInput`
   (Path B). The actuals seam exists but only yields company candidates, not the
   fund envelope, forecast assumptions, or constraints. Unifying these behind one
@@ -155,6 +171,7 @@ future session (or teammate) can pick them up without re-deriving the decision.
   (`generateReserveSummary` hardcoded multipliers) is the real thing being
   replaced. See DECISIONS.md ADR-056.
 - **Context:** Scoped 2026-07-19 from the code-review reconsideration of T14
-  (ADR-055). See memory `project_substrate_tranche_arc`. Convergence target and reuse map fixed by ADR-056.
+  (ADR-055). See memory `project_substrate_tranche_arc`. Convergence target and
+  reuse map fixed by ADR-056.
 - **Effort:** L (spans facts adapter reuse, fund cash-flow/envelope sourcing,
   forecast assumptions, and an engine-methodology decision).

--- a/server/services/reserves/reserve-envelope-service.ts
+++ b/server/services/reserves/reserve-envelope-service.ts
@@ -1,0 +1,337 @@
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../../db';
+import { fundConfigs, funds, investments } from '../../../shared/schema';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import Decimal from '../../../shared/lib/decimal-config';
+import {
+  ReserveEnvelopeV1Schema,
+  type ReserveEnvelopeComponent,
+  type ReserveEnvelopeComponentStatus,
+  type ReserveEnvelopeV1,
+} from '../../../shared/contracts/reserve-envelope-v1.contract';
+
+export const DEFAULT_FUND_LIFE_YEARS = 10;
+
+const BuildInputSchema = z
+  .object({
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+  })
+  .strict();
+
+const ConfigEnvelopeShapeSchema = z
+  .object({
+    fundLife: z.number().positive().optional(),
+    expenses: z
+      .array(
+        z
+          .object({
+            monthlyAmount: z.number(),
+            startMonth: z.number(),
+            endMonth: z.number().optional(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    recyclingEnabled: z.boolean().optional(),
+    recyclingCap: z.number().optional(),
+  })
+  .passthrough();
+
+export interface ReserveEnvelopeFundSource {
+  sizeDollars: string | number;
+  deployedCapitalDollars: string | number | null;
+  managementFeeRate: string | number;
+  baseCurrency: string;
+}
+
+export interface ReserveEnvelopeInvestmentSource {
+  amountDollars: string | number;
+}
+
+export interface ReserveEnvelopeExpenseSource {
+  monthlyAmountDollars: number;
+  startMonth: number;
+  endMonth: number | null;
+}
+
+export interface ReserveEnvelopeConfigSource {
+  fundLifeYears: number | null;
+  expenses: readonly ReserveEnvelopeExpenseSource[] | null;
+  recyclingEnabled: boolean | null;
+  recyclingCapDollars: number | null;
+}
+
+export interface ReserveEnvelopeSources {
+  fund: ReserveEnvelopeFundSource;
+  investments: readonly ReserveEnvelopeInvestmentSource[];
+  config: ReserveEnvelopeConfigSource | null;
+}
+
+function dollarsToCents(value: Decimal): number {
+  return value.times(100).toDecimalPlaces(0, Decimal.ROUND_HALF_UP).toNumber();
+}
+
+function component(
+  amountCents: number,
+  status: ReserveEnvelopeComponentStatus,
+  source: string,
+  reason: string | null
+): ReserveEnvelopeComponent {
+  return { amountCents, status, source, reason };
+}
+
+export function buildReserveEnvelopeFromSources(input: {
+  fundId: number;
+  asOfDate: string;
+  sources: ReserveEnvelopeSources;
+}): ReserveEnvelopeV1 {
+  const { fundId, asOfDate } = BuildInputSchema.parse({
+    fundId: input.fundId,
+    asOfDate: input.asOfDate,
+  });
+  const { fund, investments: investmentRows, config } = input.sources;
+  const baseCurrency = fund.baseCurrency;
+
+  const committed = new Decimal(fund.sizeDollars);
+  const committedCents = dollarsToCents(committed);
+  const committedCapital = component(committedCents, 'observed', 'funds.size', null);
+
+  // Deployed capital (outflow).
+  let deployedCapital: ReserveEnvelopeComponent;
+  if (investmentRows.length > 0) {
+    const deployed = investmentRows.reduce(
+      (sum, row) => sum.plus(new Decimal(row.amountDollars)),
+      new Decimal(0)
+    );
+    deployedCapital = component(
+      -dollarsToCents(deployed),
+      'derived',
+      'sum(investments.amount)',
+      'Deployed capital summed from investment rows'
+    );
+  } else if (fund.deployedCapitalDollars != null) {
+    deployedCapital = component(
+      -dollarsToCents(new Decimal(fund.deployedCapitalDollars)),
+      'observed',
+      'funds.deployed_capital',
+      null
+    );
+  } else {
+    deployedCapital = component(
+      0,
+      'defaulted',
+      'system_default_deployed',
+      'No investment rows or deployed_capital; assumes 0 deployed'
+    );
+  }
+
+  // Management fees (outflow): flat committed-capital basis over fund life.
+  const feeRate = new Decimal(fund.managementFeeRate);
+  const feeYears = config?.fundLifeYears ?? DEFAULT_FUND_LIFE_YEARS;
+  const feesDollars = committed.times(feeRate).times(feeYears);
+  const feesDefaulted = config?.fundLifeYears == null;
+  const managementFees = component(
+    -dollarsToCents(feesDollars),
+    feesDefaulted ? 'defaulted' : 'derived',
+    'funds.management_fee x funds.size x fundConfigs.config.fundLife',
+    feesDefaulted
+      ? `fundLife absent; assumes ${DEFAULT_FUND_LIFE_YEARS}-year fund life. Flat committed-capital basis; step-downs and called-capital basis are deferred (ADR-056 NET-NEW sophistication)`
+      : 'Lifetime management fee = rate x committed x fundLife years. Flat committed-capital basis; step-downs and called-capital basis are deferred (ADR-056 NET-NEW sophistication)'
+  );
+
+  // Fund expenses (outflow).
+  let fundExpenses: ReserveEnvelopeComponent;
+  if (config?.expenses && config.expenses.length > 0) {
+    const fundLifeMonths = feeYears * 12;
+    const expensesDollars = config.expenses.reduce((sum, expense) => {
+      const endMonth = expense.endMonth ?? fundLifeMonths;
+      const activeMonths = Math.max(0, endMonth - expense.startMonth);
+      return sum.plus(new Decimal(expense.monthlyAmountDollars).times(activeMonths));
+    }, new Decimal(0));
+    fundExpenses = component(
+      -dollarsToCents(expensesDollars),
+      'derived',
+      'fundConfigs.config.expenses',
+      'Sum of configured monthly fund expenses over their active months'
+    );
+  } else {
+    fundExpenses = component(
+      0,
+      'unavailable',
+      'fundConfigs.config.expenses',
+      'No fund expense schedule persisted; expense drag not modeled'
+    );
+  }
+
+  // Exit recycling (inflow): configured cap as an upper bound.
+  let exitRecycling: ReserveEnvelopeComponent;
+  if (
+    config?.recyclingEnabled &&
+    config.recyclingCapDollars != null &&
+    config.recyclingCapDollars > 0
+  ) {
+    exitRecycling = component(
+      dollarsToCents(new Decimal(config.recyclingCapDollars)),
+      'derived',
+      'fundConfigs.config.recyclingCap',
+      'Recycling headroom capped at configured recyclingCap; realized exit proceeds not yet modeled (upper bound)'
+    );
+  } else {
+    exitRecycling = component(
+      0,
+      'unavailable',
+      'fundConfigs.config.recyclingCap',
+      'Recycling not enabled or no cap configured; exit proceeds for recycling not persisted'
+    );
+  }
+
+  const components = {
+    committedCapital,
+    deployedCapital,
+    managementFees,
+    fundExpenses,
+    exitRecycling,
+  };
+
+  // Hard blocks.
+  let blocked = false;
+  let blockReason: string | null = null;
+  if (baseCurrency !== 'USD') {
+    blocked = true;
+    blockReason = `Non-USD base currency (${baseCurrency}); multi-currency reserve envelope is not supported`;
+  } else if (committedCents <= 0) {
+    blocked = true;
+    blockReason = 'Committed capital (funds.size) is not positive';
+  }
+
+  const signedSum = Object.values(components).reduce(
+    (sum, part) => sum + BigInt(part.amountCents),
+    0n
+  );
+  const availableReservesCents = blocked ? 0 : Number(signedSum < 0n ? 0n : signedSum);
+
+  const trustedForActivation =
+    !blocked &&
+    Object.values(components).every(
+      (part) => part.status === 'observed' || part.status === 'derived'
+    );
+
+  const inputHash = canonicalSha256({
+    contractVersion: 'reserve-envelope-v1',
+    fundId,
+    asOfDate,
+    baseCurrency,
+    committedDollars: committed.toString(),
+    deployed: {
+      hasInvestmentRows: investmentRows.length > 0,
+      investmentAmounts: investmentRows.map((row) => new Decimal(row.amountDollars).toString()),
+      deployedCapitalDollars:
+        fund.deployedCapitalDollars == null
+          ? null
+          : new Decimal(fund.deployedCapitalDollars).toString(),
+    },
+    managementFeeRate: feeRate.toString(),
+    feeYears,
+    feeYearsDefaulted: feesDefaulted,
+    expenses:
+      config?.expenses?.map((expense) => ({
+        monthlyAmountDollars: new Decimal(expense.monthlyAmountDollars).toString(),
+        startMonth: expense.startMonth,
+        endMonth: expense.endMonth,
+      })) ?? null,
+    recycling: {
+      enabled: config?.recyclingEnabled ?? null,
+      capDollars:
+        config?.recyclingCapDollars == null
+          ? null
+          : new Decimal(config.recyclingCapDollars).toString(),
+    },
+  });
+
+  return ReserveEnvelopeV1Schema.parse({
+    contractVersion: 'reserve-envelope-v1',
+    fundId,
+    asOfDate,
+    baseCurrency,
+    availableReservesCents,
+    components,
+    trustedForActivation,
+    blocked,
+    blockReason,
+    inputHash,
+  });
+}
+
+export async function loadReserveEnvelopeSources(input: {
+  fundId: number;
+  asOfDate: string;
+}): Promise<ReserveEnvelopeSources> {
+  const { fundId } = BuildInputSchema.parse(input);
+  const [fundRows, investmentRows, configRows] = await Promise.all([
+    db
+      .select({
+        sizeDollars: funds.size,
+        deployedCapitalDollars: funds.deployedCapital,
+        managementFeeRate: funds.managementFee,
+        baseCurrency: funds.baseCurrency,
+      })
+      .from(funds)
+      .where(eq(funds.id, fundId))
+      .limit(1),
+    db
+      .select({ amountDollars: investments.amount })
+      .from(investments)
+      .where(eq(investments.fundId, fundId)),
+    db
+      .select({ config: fundConfigs.config })
+      .from(fundConfigs)
+      .where(and(eq(fundConfigs.fundId, fundId), eq(fundConfigs.isPublished, true)))
+      .limit(1),
+  ]);
+
+  const fund = fundRows[0];
+  if (!fund) {
+    throw new Error(`Fund ${fundId} was not found`);
+  }
+
+  const parsedConfig = configRows[0]
+    ? ConfigEnvelopeShapeSchema.safeParse(configRows[0].config)
+    : null;
+  const cfg = parsedConfig?.success ? parsedConfig.data : null;
+  const config: ReserveEnvelopeConfigSource | null = cfg
+    ? {
+        fundLifeYears: cfg.fundLife ?? null,
+        expenses:
+          cfg.expenses?.map((expense) => ({
+            monthlyAmountDollars: expense.monthlyAmount,
+            startMonth: expense.startMonth,
+            endMonth: expense.endMonth ?? null,
+          })) ?? null,
+        recyclingEnabled: cfg.recyclingEnabled ?? null,
+        recyclingCapDollars: cfg.recyclingCap ?? null,
+      }
+    : null;
+
+  return {
+    fund: {
+      sizeDollars: fund.sizeDollars,
+      deployedCapitalDollars: fund.deployedCapitalDollars,
+      managementFeeRate: fund.managementFeeRate,
+      baseCurrency: fund.baseCurrency,
+    },
+    investments: investmentRows,
+    config,
+  };
+}
+
+export async function buildReserveEnvelope(input: {
+  fundId: number;
+  asOfDate: string;
+}): Promise<ReserveEnvelopeV1> {
+  const parsed = BuildInputSchema.parse(input);
+  const sources = await loadReserveEnvelopeSources(parsed);
+  return buildReserveEnvelopeFromSources({ ...parsed, sources });
+}

--- a/shared/contracts/reserve-envelope-v1.contract.ts
+++ b/shared/contracts/reserve-envelope-v1.contract.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/**
+ * Reserve Envelope V1 (ADR-056 NET-NEW #1)
+ *
+ * Fund-scoped, provenance-disclosing derivation of `availableReserves` =
+ * investable follow-on capital after fees / expenses / deployment, plus exit
+ * recycling headroom. Replaces the naive `fundSize * reserveRatio`.
+ *
+ * STANDALONE + UNWIRED: consumed by no live reserve path in this slice.
+ * All money is integer cents; component `amountCents` is the SIGNED
+ * contribution to availableReserves (inflows >= 0, outflows <= 0).
+ */
+
+export const ReserveEnvelopeComponentStatusSchema = z.enum([
+  'observed', // read directly from a persisted authoritative column
+  'derived', // computed from persisted inputs via a disclosed formula
+  'defaulted', // a disclosed default assumption substituted for a missing input
+  'unavailable', // cannot be computed honestly; contributes 0 and is disclosed
+]);
+
+export const ReserveEnvelopeComponentSchema = z
+  .object({
+    amountCents: z.number().int(),
+    status: ReserveEnvelopeComponentStatusSchema,
+    source: z.string().min(1),
+    reason: z.string().min(1).nullable(),
+  })
+  .strict();
+
+export const ReserveEnvelopeComponentsSchema = z
+  .object({
+    committedCapital: ReserveEnvelopeComponentSchema,
+    deployedCapital: ReserveEnvelopeComponentSchema,
+    managementFees: ReserveEnvelopeComponentSchema,
+    fundExpenses: ReserveEnvelopeComponentSchema,
+    exitRecycling: ReserveEnvelopeComponentSchema,
+  })
+  .strict();
+
+export const ReserveEnvelopeV1Schema = z
+  .object({
+    contractVersion: z.literal('reserve-envelope-v1'),
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+    baseCurrency: z.string().length(3),
+    availableReservesCents: z.number().int().nonnegative(),
+    components: ReserveEnvelopeComponentsSchema,
+    trustedForActivation: z.boolean(),
+    blocked: z.boolean(),
+    blockReason: z.string().min(1).nullable(),
+    inputHash: z.string().regex(/^[a-f0-9]{64}$/),
+  })
+  .strict();
+
+export type ReserveEnvelopeComponentStatus = z.infer<typeof ReserveEnvelopeComponentStatusSchema>;
+export type ReserveEnvelopeComponent = z.infer<typeof ReserveEnvelopeComponentSchema>;
+export type ReserveEnvelopeComponents = z.infer<typeof ReserveEnvelopeComponentsSchema>;
+export type ReserveEnvelopeV1 = z.infer<typeof ReserveEnvelopeV1Schema>;

--- a/tests/unit/services/reserves/reserve-envelope-service.test.ts
+++ b/tests/unit/services/reserves/reserve-envelope-service.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ReserveEnvelopeV1Schema,
+  type ReserveEnvelopeV1,
+} from '../../../../shared/contracts/reserve-envelope-v1.contract';
+import {
+  buildReserveEnvelopeFromSources,
+  DEFAULT_FUND_LIFE_YEARS,
+  type ReserveEnvelopeSources,
+} from '../../../../server/services/reserves/reserve-envelope-service';
+
+const FUND_ID = 1;
+const AS_OF = '2026-07-19';
+
+function baseSources(overrides: Partial<ReserveEnvelopeSources> = {}): ReserveEnvelopeSources {
+  return {
+    fund: {
+      sizeDollars: '100000000', // $100M committed
+      deployedCapitalDollars: '0',
+      managementFeeRate: '0.0200', // 2% (fraction)
+      baseCurrency: 'USD',
+    },
+    investments: [{ amountDollars: '40000000' }, { amountDollars: '20000000' }], // $60M deployed
+    config: {
+      fundLifeYears: 10,
+      expenses: [{ monthlyAmountDollars: 50000, startMonth: 0, endMonth: 120 }], // $50k * 120 = $6M
+      recyclingEnabled: true,
+      recyclingCapDollars: 5000000, // $5M
+    },
+    ...overrides,
+  };
+}
+
+function build(sources: ReserveEnvelopeSources): ReserveEnvelopeV1 {
+  return buildReserveEnvelopeFromSources({ fundId: FUND_ID, asOfDate: AS_OF, sources });
+}
+
+describe('buildReserveEnvelopeFromSources', () => {
+  it('computes a fully-sourced envelope with cents-exact conservation and trust', () => {
+    const envelope = build(baseSources());
+    // committed 100M - deployed 60M - fees (100M*0.02*10=20M) - expenses 6M + recycling 5M = 19M
+    expect(envelope.availableReservesCents).toBe(19_000_000_00);
+    expect(envelope.components.committedCapital.amountCents).toBe(100_000_000_00);
+    expect(envelope.components.deployedCapital.amountCents).toBe(-60_000_000_00);
+    expect(envelope.components.managementFees.amountCents).toBe(-20_000_000_00);
+    expect(envelope.components.fundExpenses.amountCents).toBe(-6_000_000_00);
+    expect(envelope.components.exitRecycling.amountCents).toBe(5_000_000_00);
+    expect(envelope.components.deployedCapital.status).toBe('derived');
+    expect(envelope.components.managementFees.status).toBe('derived');
+    expect(envelope.trustedForActivation).toBe(true);
+    expect(envelope.blocked).toBe(false);
+    expect(() => ReserveEnvelopeV1Schema.parse(envelope)).not.toThrow();
+  });
+
+  it('discloses defaulted fees and unavailable expenses/recycling when config is absent', () => {
+    const envelope = build(baseSources({ config: null }));
+    expect(envelope.components.managementFees.status).toBe('defaulted');
+    expect(envelope.components.fundExpenses.status).toBe('unavailable');
+    expect(envelope.components.fundExpenses.amountCents).toBe(0);
+    expect(envelope.components.exitRecycling.status).toBe('unavailable');
+    expect(envelope.components.exitRecycling.amountCents).toBe(0);
+    // fees default to DEFAULT_FUND_LIFE_YEARS: 100M * 0.02 * 10 = 20M
+    expect(envelope.components.managementFees.amountCents).toBe(-20_000_000_00);
+    expect(DEFAULT_FUND_LIFE_YEARS).toBe(10);
+    // committed 100M - deployed 60M - fees 20M - 0 + 0 = 20M
+    expect(envelope.availableReservesCents).toBe(20_000_000_00);
+    expect(envelope.trustedForActivation).toBe(false);
+  });
+
+  it('reads deployed capital from funds.deployed_capital when no investment rows exist', () => {
+    const envelope = build(
+      baseSources({
+        investments: [],
+        fund: {
+          sizeDollars: '100000000',
+          deployedCapitalDollars: '30000000',
+          managementFeeRate: '0.0200',
+          baseCurrency: 'USD',
+        },
+      })
+    );
+    expect(envelope.components.deployedCapital.status).toBe('observed');
+    expect(envelope.components.deployedCapital.amountCents).toBe(-30_000_000_00);
+  });
+
+  it('defaults deployed capital to 0 when neither investments nor deployed_capital exist', () => {
+    const envelope = build(
+      baseSources({
+        investments: [],
+        fund: {
+          sizeDollars: '100000000',
+          deployedCapitalDollars: null,
+          managementFeeRate: '0.0200',
+          baseCurrency: 'USD',
+        },
+      })
+    );
+    expect(envelope.components.deployedCapital.status).toBe('defaulted');
+    expect(envelope.components.deployedCapital.amountCents).toBe(0);
+    expect(envelope.trustedForActivation).toBe(false);
+  });
+
+  it('blocks non-USD base currency', () => {
+    const envelope = build(
+      baseSources({
+        fund: {
+          sizeDollars: '100000000',
+          deployedCapitalDollars: '0',
+          managementFeeRate: '0.0200',
+          baseCurrency: 'EUR',
+        },
+      })
+    );
+    expect(envelope.blocked).toBe(true);
+    expect(envelope.blockReason).toContain('EUR');
+    expect(envelope.availableReservesCents).toBe(0);
+    expect(envelope.trustedForActivation).toBe(false);
+    expect(() => ReserveEnvelopeV1Schema.parse(envelope)).not.toThrow();
+  });
+
+  it('blocks non-positive committed capital', () => {
+    const envelope = build(
+      baseSources({
+        fund: {
+          sizeDollars: '0',
+          deployedCapitalDollars: '0',
+          managementFeeRate: '0.0200',
+          baseCurrency: 'USD',
+        },
+      })
+    );
+    expect(envelope.blocked).toBe(true);
+    expect(envelope.availableReservesCents).toBe(0);
+  });
+
+  it('produces a stable inputHash for identical sources and a different hash when committed changes', () => {
+    const a = build(baseSources());
+    const b = build(baseSources());
+    expect(a.inputHash).toBe(b.inputHash);
+    const c = build(
+      baseSources({
+        fund: {
+          sizeDollars: '120000000',
+          deployedCapitalDollars: '0',
+          managementFeeRate: '0.0200',
+          baseCurrency: 'USD',
+        },
+      })
+    );
+    expect(c.inputHash).not.toBe(a.inputHash);
+  });
+
+  it('clamps availableReserves to zero when outflows exceed inflows', () => {
+    const envelope = build(
+      baseSources({
+        investments: [{ amountDollars: '95000000' }],
+        config: {
+          fundLifeYears: 10,
+          expenses: null,
+          recyclingEnabled: false,
+          recyclingCapDollars: null,
+        },
+      })
+    );
+    // 100M - 95M - 20M fees = -15M -> clamped 0
+    expect(envelope.availableReservesCents).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Builds **ADR-056 NET-NEW #1**: a fund-scoped, server-side, provenance-disclosing
reserve **envelope** service deriving `availableReserves` = investable follow-on
capital after fees/expenses/deployment plus exit-recycling headroom — replacing
the naive `fundSize * reserveRatio`.

**Standalone + UNWIRED.** Consumed by no live reserve path; grep confirms the new
exports are referenced only by their own test. No route, flag, schema,
`runReserveCalculation`, `ReserveEngine`, T13 registry, or scheduled-task change.
Wiring into the authoritative seam is the next slice (NET-NEW #2).

New files:
- `shared/contracts/reserve-envelope-v1.contract.ts` — Zod contract (cents-integer
  amounts, per-component provenance, `trustedForActivation`, `inputHash`).
- `server/services/reserves/reserve-envelope-service.ts` — pure
  `buildReserveEnvelopeFromSources` + async `loadReserveEnvelopeSources` +
  `buildReserveEnvelope` wrapper (mirrors the marginal-MOIC assembler; sources
  injectable for DB-free tests).
- `tests/unit/services/reserves/reserve-envelope-service.test.ts` — 8 DB-free unit tests.

## Phase 0 — verify-reuse (BUILD, not adapt)

Confirmed no existing server path derives a fee/expense/deployment/recycling-aware,
provenance-disclosing investable envelope from persisted fund state. Nearest
derivations (both rejected by ADR-056): `reserve-optimization-calculator.getCurrentFundState`
= `fundSize - totalInvestment` (float, no fees/recycling, no provenance); client
`capital-allocation-calculations.ts` = `fundSize * reserveRatio`. The metrics layer
(`projected-metrics-calculator`, `metrics-aggregator`) computes only a `reserveRatio`
target (default 0.5). So NET-NEW #1 is genuinely missing.

## Envelope source map

| Component | Source | Provenance status |
|---|---|---|
| Committed capital | `funds.size` (col) | **observed** |
| Deployed capital | Σ`investments.amount`, else `funds.deployed_capital`, else 0 | **derived** / **observed** / **defaulted** |
| Management fees | `funds.management_fee` x committed x `config.fundLife` (flat committed basis) | **derived**; **defaulted** (10y) when `fundLife` absent |
| Fund expenses | `config.expenses[]` (Σ monthly x active months) | **derived**, else **unavailable** |
| Exit recycling | `config.recyclingCap` (upper bound) | **derived**, else **unavailable** |

Disclosed gaps (honest, not silently defaulted): fee step-downs / called-capital &
FMV bases, standalone fund-expense persistence, and realized exit proceeds for
recycling are deferred (the ADR-056 "sophistication" that NET-NEW #2/#3 layer on).
`trustedForActivation` is true only when every component is observed/derived.
`blocked` (availableReserves = 0) on non-USD base currency or non-positive committed.
Cents-exact (`Decimal` -> integer cents, ROUND_HALF_UP), signed component
contributions summed via bigint and clamped at 0. Stable `canonicalSha256` inputHash.

## Verification

- `npm run check` — 0 TypeScript errors (client/server/shared).
- New unit test — 8/8 green (run independently; pre-push also ran it green).
- Source guards (`server-no-client-import`, `moic-dead-surface`, `facts-reserve-input-adapter`) — 16/16 green.
- `npm run calc-gate` — PASS.
- git status — only the 3 new files + a TODOS bookkeeping line.

## Remaining ADR-056 composition (not in this PR)

- **NET-NEW #2:** ranked-allocation orchestrator wiring B's marginal-MOIC order +
  this envelope + A's `ConstrainedReserveEngine` at `runReserveCalculation`, behind a
  new calc-mode/flag, shadow-first.
- **NET-NEW #3:** mode-aware fund-moic route + un-gate `ENABLE_MARGINAL_RESERVE_MOIC`
  (H9-governed). The T13 constrained-substrate promotion (eligible 2026-07-25) is
  untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)