### PR TITLE
feat(reserves): optional score override on ConstrainedReserveEngine (ADR-056 NET-NEW #2, DD1)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8289,17 +8289,17 @@ framing that motivated this slice:
 
 - **Authoritative engine (hardcoded fallback), not A or B.** The reserve BullMQ
   worker (`workers/reserve-worker.ts`) and `fund-persistence-service.ts` both
-  call `runReserveCalculation` (`server/services/reserve-calculation-service.ts`),
-  which writes the authoritative `fundSnapshots` RESERVE row using
-  `generateReserveSummary` from `shared/core/reserves/ReserveEngine.ts`. That
-  function applies HARDCODED per-stage/per-sector multipliers
-  (`Seed: 1.5, Series A: 2.0, ...`) times invested, then a seeded-PRNG "ML"
-  jitter (`0.8 + prng.next() * 0.4`). This is the concrete meaning of memory
-  `project_h9_rounds_moic_feature_isolated` ("actionable outputs still run on
-  hardcoded fallbacks"). The facts flag (`enable_facts_sourced_reserve_inputs`,
-  off/shadow/on) can swap the INPUTS to a provenance-controlled actuals set via
-  `buildFactsReserveCandidates`, but the ENGINE remains the hardcoded
-  `generateReserveSummary`.
+  call `runReserveCalculation`
+  (`server/services/reserve-calculation-service.ts`), which writes the
+  authoritative `fundSnapshots` RESERVE row using `generateReserveSummary` from
+  `shared/core/reserves/ReserveEngine.ts`. That function applies HARDCODED
+  per-stage/per-sector multipliers (`Seed: 1.5, Series A: 2.0, ...`) times
+  invested, then a seeded-PRNG "ML" jitter (`0.8 + prng.next() * 0.4`). This is
+  the concrete meaning of memory `project_h9_rounds_moic_feature_isolated`
+  ("actionable outputs still run on hardcoded fallbacks"). The facts flag
+  (`enable_facts_sourced_reserve_inputs`, off/shadow/on) can swap the INPUTS to
+  a provenance-controlled actuals set via `buildFactsReserveCandidates`, but the
+  ENGINE remains the hardcoded `generateReserveSummary`.
 - **Program A — constrained-reserve substrate (ADR-042..055), the envelope
   allocator.** `ConstrainedReserveEngine.calculate` greedily fills
   `input.availableReserves` across companies ranked by a COARSE per-stage score
@@ -8311,11 +8311,11 @@ framing that motivated this slice:
   loads fund state. The T13 pilot's shadow/promotion machinery
   (`serveConstrainedReserveCalculation`) sits on this route, fail-safes to the
   legacy response, and NEVER touches the authoritative RESERVE snapshot.
-- **Program B — marginal-reserve MOIC (Plan 7 / ADR-033), the deal-level
-  ranker (Tactyc-aligned).** `calculateMarginalReserveMoic` answers "expected
-  return on the next reserve dollar" from per-stage graduation/exit
-  probabilities, pre-money valuation, round size, months-from-prior-stage,
-  dilution, and pro-rata participation. Its fund-scoped assembler
+- **Program B — marginal-reserve MOIC (Plan 7 / ADR-033), the deal-level ranker
+  (Tactyc-aligned).** `calculateMarginalReserveMoic` answers "expected return on
+  the next reserve dollar" from per-stage graduation/exit probabilities,
+  pre-money valuation, round size, months-from-prior-stage, dilution, and
+  pro-rata participation. Its fund-scoped assembler
   `buildMarginalReserveMoicInputs`
   (`server/services/moic/marginal-reserve-moic-input-service.ts`) loads fund,
   published config, portfolio companies, approved allocation IC decisions, and
@@ -8326,21 +8326,22 @@ framing that motivated this slice:
   `FEATURES.marginalReserveMoic` (`ENABLE_MARGINAL_RESERVE_MOIC`, default false)
   and HARDCODES `mode: 'shadow'` / `actionability: 'non_actionable_shadow'` in
   its response, so un-gating the flag ALONE does not make its output actionable.
-- **A fourth allocator exists.** `shared/core/reserves/DeterministicReserveEngine.ts`
-  plus `server/services/reserve-optimization-calculator.ts` (Monte-Carlo /
-  baseline driven) power the scenario-analysis and capital-allocation surfaces.
-  It is not the authoritative snapshot path and is out of scope for the first
-  convergence step, but confirms the landscape is a multi-engine one, not a
-  clean A-vs-B duel.
+- **A fourth allocator exists.**
+  `shared/core/reserves/DeterministicReserveEngine.ts` plus
+  `server/services/reserve-optimization-calculator.ts` (Monte-Carlo / baseline
+  driven) power the scenario-analysis and capital-allocation surfaces. It is not
+  the authoritative snapshot path and is out of scope for the first convergence
+  step, but confirms the landscape is a multi-engine one, not a clean A-vs-B
+  duel.
 - **The one genuinely-missing input.** The fund RESERVE ENVELOPE
   (`availableReserves` = investable follow-on capital after
   fees/expenses/deployments/recycling) is CONSUMED by the constrained allocator
   but DERIVED by no reserve-input assembler. The nearest existing derivation is
   the naive `availableReserves = fundSize * reserveRatio` in
   `client/src/lib/capital-allocation-calculations.ts`, which is NOT
-  fee/expense/deployment/recycling-aware. An authoritative, provenance-disclosing
-  envelope source is the real net-new work; the company candidates and the
-  deal-level ranking already exist.
+  fee/expense/deployment/recycling-aware. An authoritative,
+  provenance-disclosing envelope source is the real net-new work; the company
+  candidates and the deal-level ranking already exist.
 
 ### The complementarity insight (reframed)
 
@@ -8357,18 +8358,20 @@ allocation in ranked order (A, exists)."
 
 ### Decision (answers to the six questions)
 
-1. **Authoritative ranking.** Rank by Program B's deal-level marginal next-dollar
-   reserve MOIC. Reject Program A's coarse stage multiplier and reject the
-   hardcoded per-stage/per-sector multipliers of the current authoritative
-   `ReserveEngine`. B already models the Tactyc-grade deal-level inputs; A's
-   ranking is a stage-coarse proxy and the authoritative engine is a placeholder.
+1. **Authoritative ranking.** Rank by Program B's deal-level marginal
+   next-dollar reserve MOIC. Reject Program A's coarse stage multiplier and
+   reject the hardcoded per-stage/per-sector multipliers of the current
+   authoritative `ReserveEngine`. B already models the Tactyc-grade deal-level
+   inputs; A's ranking is a stage-coarse proxy and the authoritative engine is a
+   placeholder.
 2. **Envelope source.** The canonical `availableReserves` must be a
    fee/expense/deployment/recycling-aware derivation with disclosed provenance,
-   sourced from the fund-model layer (`shared/core/capitalAllocation/CapitalAllocationEngine.ts`,
-   `projected-metrics-calculator.ts`, `metrics-aggregator.ts`). It does NOT exist
-   as such today; the naive `fundSize * reserveRatio` is explicitly rejected for
-   the authoritative path. This is the genuinely net-new input and owns most of
-   the follow-on effort.
+   sourced from the fund-model layer
+   (`shared/core/capitalAllocation/CapitalAllocationEngine.ts`,
+   `projected-metrics-calculator.ts`, `metrics-aggregator.ts`). It does NOT
+   exist as such today; the naive `fundSize * reserveRatio` is explicitly
+   rejected for the authoritative path. This is the genuinely net-new input and
+   owns most of the follow-on effort.
 3. **Composition (reuse over rebuild).** The "canonical assembler" is a
    composition, not a new engine: reuse `buildMarginalReserveMoicInputs`
    (ranking inputs, provenance, hashes) + a new envelope service (net-new) + the
@@ -8382,14 +8385,15 @@ allocation in ranked order (A, exists)."
    affects ONLY the caller-JSON `/api/v1/reserves/calculate` route, is
    parity-gated (serves the substrate result only when it is cents-identical to
    the legacy computation of the caller's own input), fail-safes to legacy, and
-   NEVER touches the authoritative RESERVE snapshot. Recommendation to the owner:
-   T13 promotion MAY PROCEED on its own terms as a safe, parity-gated shadow->on
-   of a non-authoritative path — it does not change actionable app reserve
-   numbers — but it should be recorded as DEPRECATED-IN-PLACE: A's coarse ranking
-   is superseded by this ADR, and no further cent-parity shadowing of A's ranking
-   should be pursued (ADR-055 point 4). The convergence decision does not block
-   the 2026-07-25 gate, but the owner should promote (or stand down) with the
-   understanding that A is not the authoritative reserve workflow.
+   NEVER touches the authoritative RESERVE snapshot. Recommendation to the
+   owner: T13 promotion MAY PROCEED on its own terms as a safe, parity-gated
+   shadow->on of a non-authoritative path — it does not change actionable app
+   reserve numbers — but it should be recorded as DEPRECATED-IN-PLACE: A's
+   coarse ranking is superseded by this ADR, and no further cent-parity
+   shadowing of A's ranking should be pursued (ADR-055 point 4). The convergence
+   decision does not block the 2026-07-25 gate, but the owner should promote (or
+   stand down) with the understanding that A is not the authoritative reserve
+   workflow.
 5. **H9 / flags.** For Program B outputs to become actionable, three things must
    change and stay behind a flag for internal soak: (a) the fund-moic route's
    hardcoded `mode: 'shadow'` / `non_actionable_shadow` must become mode-aware;
@@ -8430,16 +8434,16 @@ running unexamined.
   (`shared/core/reserves/ConstrainedReserveEngine.ts`).
 - NET-NEW 1 (largest): a server-side reserve ENVELOPE service deriving
   fee/expense/deployment/recycling-aware `availableReserves` from the fund-model
-  layer with provenance + input hash, replacing the naive `fundSize *
-  reserveRatio`.
+  layer with provenance + input hash, replacing the naive
+  `fundSize * reserveRatio`.
 - NET-NEW 2: a ranked-allocation ORCHESTRATOR that feeds B's marginal-MOIC order
   into A's envelope fill at the `runReserveCalculation` seam
-  (`server/services/reserve-calculation-service.ts`), behind a new calc-mode/flag,
-  shadow-first with rank/cent telemetry, replacing `generateReserveSummary` for
-  opted-in funds.
+  (`server/services/reserve-calculation-service.ts`), behind a new
+  calc-mode/flag, shadow-first with rank/cent telemetry, replacing
+  `generateReserveSummary` for opted-in funds.
 - NET-NEW 3: make the fund-moic route mode-aware and un-gate
-  `ENABLE_MARGINAL_RESERVE_MOIC` for internal soak once the H9 actionability gate
-  passes.
+  `ENABLE_MARGINAL_RESERVE_MOIC` for internal soak once the H9 actionability
+  gate passes.
 - Sizing: L. The ranking and allocation engines exist; the envelope derivation
   and its provenance own most of the risk and effort.
 
@@ -8453,8 +8457,8 @@ running unexamined.
   adopted. Its actionability/un-gating mechanics are correct, but on its own it
   leaves the envelope-allocation step (A's role) unspecified.
 - **Single new orchestrator that rebuilds inputs from scratch:** rejected. It
-  would duplicate `buildMarginalReserveMoicInputs` and the facts adapter, exactly
-  the greenfield mistake this slice exists to prevent.
+  would duplicate `buildMarginalReserveMoicInputs` and the facts adapter,
+  exactly the greenfield mistake this slice exists to prevent.
 
 ### Consequences
 
@@ -8462,8 +8466,69 @@ No runtime surface changes in this slice. The two TODOS reserve entries are
 repointed at this ADR and the "canonical assembler" is rescoped from greenfield
 to composition. The authoritative reserve engine's replacement is now a scoped,
 reuse-first build targeting the `runReserveCalculation` seam rather than the
-caller-JSON `/calculate` route. The T13 pilot and the ADR-052 authoritative-serve
-path are unaffected; the 2026-07-25 promotion decision gains an explicit
-"deprecated-in-place, non-authoritative path" framing for the owner.
+caller-JSON `/calculate` route. The T13 pilot and the ADR-052
+authoritative-serve path are unaffected; the 2026-07-25 promotion decision gains
+an explicit "deprecated-in-place, non-authoritative path" framing for the owner.
+
+### Addendum (2026-07-19): NET-NEW #2 build decisions (DD1 engine extension, DD3 indicative, DD8 activation governance)
+
+This addendum records the concrete build decisions made while implementing
+NET-NEW #2 (the ranked-allocation orchestrator). It is landed shadow-first: no
+fund is promoted to `on`, and the authoritative reserve snapshot is unchanged
+except on the H9-governed `on` path (DD8), which ships inert.
+
+**DD1 — `ConstrainedReserveEngine.calculate` gains an optional score override,
+retiring ADR-046's "zero source edits" proof.** ADR-056 answer #3 and TODOS both
+require reusing A's `calculate` "run in B's ranked order," but `calculate`
+re-sorts by its own coarse score
+`(reserveMultiple*exitProb/(1+disc)^years)*weight` and accepts no external
+order. To realize the reuse honestly rather than duplicating A's
+cap/minCheck/stage-room/conservation/cents logic (the greenfield mistake this
+ADR forbids), the engine now accepts an **optional, backward-compatible
+per-company score override**: a top-level
+`scoreOverride?: Record<string, number>` on `ReserveInputSchema`. The single
+behavioral line becomes
+`score = input.scoreOverride?.[company.id] ?? pv * policy.weight` — when the map
+is absent the expression is byte-identical to the prior `pv * policy.weight`, so
+every existing caller (`server/routes/v1/reserves.ts`, the client re-export
+shim, `runConstrainedReserveWithSubstrate`, parity tooling) is unaffected. A
+regression test proves omission of the override reproduces current behavior
+exactly.
+
+This **explicitly supersedes the ADR-046 (Tranche 5) "zero source edits"
+narrative** (this file, disposition table row
+`shared/core/reserves/ConstrainedReserveEngine.ts` and the "Pass UNMODIFIED —
+the zero-edits proof" test row). ADR-046's invariant was that the substrate
+adopted the engine by _wrapping only_, with an empty engine diff. That invariant
+is retired here: the engine file now carries a minimal, additive, default-off
+edit. The `runConstrainedReserveWithSubstrate` wrapper and its byte-green
+fast-check suite continue to pass unmodified (they pass no override), so
+ADR-046's substrate-adoption guarantee survives in behavior — only its literal
+"empty diff" claim is what this addendum retires. parity-auditor and
+phoenix-precision-guardian review this edit before it lands.
+
+**DD3 — the `indicative` marginal-MOIC tier is excluded from the authoritative
+fill and disclosed.** `calculateMarginalReserveMoic` returns a three-tier status
+(`unavailable | actionable | indicative`), where `indicative` is emitted when
+`marginalMoic > 100` (an implausibly high marginal MOIC signaling a degenerate
+near-zero-capital case). The orchestrator ranks only `actionable` companies;
+`unavailable` and `indicative` are excluded from A's `companies[]` (zero
+allocation) and disclosed in telemetry/metadata (list + reason). Imputation is
+never used — per ADR-056 answer #6 no defaulted/undisclosed input feeds the
+authoritative path. If after exclusions B yields zero actionable rankings, the
+path fails safe to legacy `generateReserveSummary`. Revisiting the `indicative`
+exclusion requires phoenix-precision-guardian sign-off.
+
+**DD8 — promoting a fund to ranked `on` is an H9-governed decision, out of scope
+here.** The authoritative reserve snapshot is itself a downstream reserve
+surface, so ADR-056 answer #5c requires the H9 actionability gate to be
+satisfied before any B-derived ranking feeds it. Shadow mode is telemetry-only
+and feeds nothing into the snapshot (the entire scope of this slice). The `on`
+code path is built but inert: it writes the composed result only when
+`envelope.trustedForActivation && !envelope.blocked && B-has-actionable && H9 gate satisfied`;
+otherwise it stamps `h9ActionabilityStatus = 'non_actionable'` and/or fails safe
+to legacy. Promoting a real fund to ranked `on` is a governed decision in the
+same class as T13 and NET-NEW #3; this slice promotes no fund and does not touch
+`ENABLE_MARGINAL_RESERVE_MOIC`, the fund-moic route, or any H9 gate default.
 
 ---

--- a/shared/core/reserves/ConstrainedReserveEngine.ts
+++ b/shared/core/reserves/ConstrainedReserveEngine.ts
@@ -82,7 +82,7 @@ export class ConstrainedReserveEngine {
         stage: company.stage,
         capCompanyC,
         capStageC,
-        score: pv * policy.weight,
+        score: input.scoreOverride?.[company.id] ?? pv * policy.weight,
         allocatedC: 0n as Cents,
       };
     });

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -26,7 +26,14 @@ export {
  * This legacy schema uses no-separator format for backward compatibility.
  * Use normalizeStage() to convert to canonical format.
  */
-export const StageSchema = z.enum(['preseed', 'seed', 'series_a', 'series_b', 'series_c', 'series_dplus']);
+export const StageSchema = z.enum([
+  'preseed',
+  'seed',
+  'series_a',
+  'series_b',
+  'series_c',
+  'series_dplus',
+]);
 export const Dollars = nonNegative().finite();
 export const Percent = bounded01();
 
@@ -36,7 +43,7 @@ export const CompanySchema = z.object({
   stage: StageSchema,
   invested: nonNegative(),
   ownership: Percent,
-  reserveCap: nonNegative().optional()
+  reserveCap: nonNegative().optional(),
 });
 
 export const StagePolicySchema = z.object({
@@ -45,36 +52,60 @@ export const StagePolicySchema = z.object({
   weight: z.number().positive().default(1),
 });
 
-export const ConstraintsSchema = z.object({
-  minCheck: nonNegative().default(0),
-  maxPerCompany: nonNegative().default(Number.POSITIVE_INFINITY),
-  maxPerStage: z.record(StageSchema, nonNegative()).default({}),
-  discountRateAnnual: bounded01().default(0.12),
-  graduationYears: z.record(StageSchema, z.number().positive()).default({preseed:8,seed:7,series_a:6,series_b:5,series_c:4,series_dplus:3}),
-  graduationProb: z.record(StageSchema, bounded01()).default({preseed:0.1,seed:0.2,series_a:0.35,series_b:0.5,series_c:0.65,series_dplus:0.8})
-}).partial();
+export const ConstraintsSchema = z
+  .object({
+    minCheck: nonNegative().default(0),
+    maxPerCompany: nonNegative().default(Number.POSITIVE_INFINITY),
+    maxPerStage: z.record(StageSchema, nonNegative()).default({}),
+    discountRateAnnual: bounded01().default(0.12),
+    graduationYears: z
+      .record(StageSchema, z.number().positive())
+      .default({ preseed: 8, seed: 7, series_a: 6, series_b: 5, series_c: 4, series_dplus: 3 }),
+    graduationProb: z
+      .record(StageSchema, bounded01())
+      .default({
+        preseed: 0.1,
+        seed: 0.2,
+        series_a: 0.35,
+        series_b: 0.5,
+        series_c: 0.65,
+        series_dplus: 0.8,
+      }),
+  })
+  .partial();
 
 export const ReserveInputSchema = z.object({
   availableReserves: nonNegative(),
   companies: z.array(CompanySchema).min(0),
   stagePolicies: z.array(StagePolicySchema).min(1),
-  constraints: ConstraintsSchema.optional()
+  constraints: ConstraintsSchema.optional(),
+  // ADR-056 NET-NEW #2 (DD1): optional per-company score override keyed by company id.
+  // When present, ConstrainedReserveEngine ranks by this value instead of its internal
+  // pv*weight score, letting an external ranker (marginal-MOIC) drive allocation order.
+  // Absent => byte-identical to prior behavior. Backward-compatible.
+  scoreOverride: z.record(z.string(), z.number().finite()).optional(),
 });
 
 export type ReserveInput = z.infer<typeof ReserveInputSchema>;
 
 export function validateReserveInput(raw: unknown) {
   const parsed = ReserveInputSchema.safeParse(raw);
-  if (!parsed.success) return { ok:false as const, status:400, issues:[{code:'schema', message:parsed.error.message}] };
+  if (!parsed.success)
+    return {
+      ok: false as const,
+      status: 400,
+      issues: [{ code: 'schema', message: parsed.error.message }],
+    };
   const v = parsed.data;
 
   const issues: Array<{ code: string; companyId?: string; stage?: string }> = [];
-  const stages = new Set(v.stagePolicies.map(p=>p.stage));
+  const stages = new Set(v.stagePolicies.map((p) => p.stage));
   for (const c of v.companies) {
-    if (!stages.has(c.stage)) issues.push({code:'stage_policy', companyId:c.id, stage:c.stage});
+    if (!stages.has(c.stage))
+      issues.push({ code: 'stage_policy', companyId: c.id, stage: c.stage });
   }
-  if (issues.length) return { ok:false as const, status:422, issues };
-  return { ok:true as const, data:v };
+  if (issues.length) return { ok: false as const, status: 422, issues };
+  return { ok: true as const, data: v };
 }
 
 // Dual approval system for reserve strategy changes
@@ -90,27 +121,31 @@ export const ReserveStrategyApprovalSchema = z.object({
     impact: z.object({
       affectedFunds: z.array(z.string()),
       estimatedAmount: z.number(),
-      riskLevel: z.enum(['low', 'medium', 'high'])
-    })
+      riskLevel: z.enum(['low', 'medium', 'high']),
+    }),
   }),
-  approvals: z.array(z.object({
-    partnerEmail: z.string().email(),
-    approvedAt: z.date(),
-    signature: z.string(), // Digital signature or approval token
-    ipAddress: z.string().ip(),
-    userAgent: z.string().optional()
-  })),
+  approvals: z.array(
+    z.object({
+      partnerEmail: z.string().email(),
+      approvedAt: z.date(),
+      signature: z.string(), // Digital signature or approval token
+      ipAddress: z.string().ip(),
+      userAgent: z.string().optional(),
+    })
+  ),
   status: z.enum(['pending', 'approved', 'rejected', 'expired']),
   expiresAt: z.date(),
   metadata: z.object({
     calculationHash: z.string().optional(), // For determinism verification
-    auditTrail: z.array(z.object({
-      timestamp: z.date(),
-      action: z.string(),
-      actor: z.string().email(),
-      details: z.record(z.unknown())
-    }))
-  })
+    auditTrail: z.array(
+      z.object({
+        timestamp: z.date(),
+        action: z.string(),
+        actor: z.string().email(),
+        details: z.record(z.unknown()),
+      })
+    ),
+  }),
 });
 
 export type ReserveStrategyApproval = z.infer<typeof ReserveStrategyApprovalSchema>;

--- a/tests/unit/reserves/ConstrainedReserveEngine.test.ts
+++ b/tests/unit/reserves/ConstrainedReserveEngine.test.ts
@@ -6,8 +6,15 @@ import type { ReserveInput } from '../../../shared/schemas.js';
 describe('ConstrainedReserveEngine', () => {
   const engine = new ConstrainedReserveEngine();
 
-  const stageArb = fc.constantFrom('preseed', 'seed', 'series_a', 'series_b', 'series_c', 'series_dplus');
-  
+  const stageArb = fc.constantFrom(
+    'preseed',
+    'seed',
+    'series_a',
+    'series_b',
+    'series_c',
+    'series_dplus'
+  );
+
   const companyArb = fc.record({
     id: fc.string({ minLength: 1, maxLength: 20 }),
     name: fc.string({ minLength: 1, maxLength: 50 }),
@@ -22,90 +29,119 @@ describe('ConstrainedReserveEngine', () => {
     weight: fc.float({ min: Math.fround(0.1), max: Math.fround(5), noNaN: true }),
   });
 
-  const inputArb = fc.record({
-    availableReserves: fc.float({ min: Math.fround(0), max: Math.fround(100_000_000), noNaN: true }),
-    companies: fc.array(companyArb, { minLength: 0, maxLength: 20 }),
-    stagePolicies: fc.array(stagePolicyArb, { minLength: 1, maxLength: 6 })
-      .filter(policies => new Set(policies.map(p => p.stage)).size === policies.length), // unique stages
-    constraints: fc.record({
-      minCheck: fc.float({ min: Math.fround(0), max: Math.fround(1_000_000), noNaN: true }),
-      maxPerCompany: fc.float({ min: Math.fround(1), max: Math.fround(50_000_000), noNaN: true }),
-      discountRateAnnual: fc.float({ min: Math.fround(0), max: Math.fround(0.5), noNaN: true }),
-    }, { requiredKeys: [] })
-  }).filter(input => {
-    // Ensure all companies have corresponding stage policies
-    const stageSet = new Set(input.stagePolicies.map(p => p.stage));
-    return input.companies.every(c => stageSet.has(c.stage));
-  });
+  const inputArb = fc
+    .record({
+      availableReserves: fc.float({
+        min: Math.fround(0),
+        max: Math.fround(100_000_000),
+        noNaN: true,
+      }),
+      companies: fc.array(companyArb, { minLength: 0, maxLength: 20 }),
+      stagePolicies: fc
+        .array(stagePolicyArb, { minLength: 1, maxLength: 6 })
+        .filter((policies) => new Set(policies.map((p) => p.stage)).size === policies.length), // unique stages
+      constraints: fc.record(
+        {
+          minCheck: fc.float({ min: Math.fround(0), max: Math.fround(1_000_000), noNaN: true }),
+          maxPerCompany: fc.float({
+            min: Math.fround(1),
+            max: Math.fround(50_000_000),
+            noNaN: true,
+          }),
+          discountRateAnnual: fc.float({ min: Math.fround(0), max: Math.fround(0.5), noNaN: true }),
+        },
+        { requiredKeys: [] }
+      ),
+    })
+    .filter((input) => {
+      // Ensure all companies have corresponding stage policies
+      const stageSet = new Set(input.stagePolicies.map((p) => p.stage));
+      return input.companies.every((c) => stageSet.has(c.stage));
+    });
 
   it('conservation: money in equals money out', () => {
-    fc.assert(fc.property(inputArb, (input: ReserveInput) => {
-      const result = engine.calculate(input);
-      
-      expect(result.conservationOk).toBe(true);
-      
-      const totalIn = input.availableReserves;
-      const totalOut = result.totalAllocated + result.remaining;
-      
-      // Allow for small floating point differences (within 1 cent)
-      expect(Math.abs(totalIn - totalOut)).toBeLessThan(0.01);
-    }), { numRuns: 100 });
+    fc.assert(
+      fc.property(inputArb, (input: ReserveInput) => {
+        const result = engine.calculate(input);
+
+        expect(result.conservationOk).toBe(true);
+
+        const totalIn = input.availableReserves;
+        const totalOut = result.totalAllocated + result.remaining;
+
+        // Allow for small floating point differences (within 1 cent)
+        expect(Math.abs(totalIn - totalOut)).toBeLessThan(0.01);
+      }),
+      { numRuns: 100 }
+    );
   });
 
   it('allocations are non-negative', () => {
-    fc.assert(fc.property(inputArb, (input: ReserveInput) => {
-      const result = engine.calculate(input);
-      
-      expect(result.totalAllocated).toBeGreaterThanOrEqual(0);
-      expect(result.remaining).toBeGreaterThanOrEqual(0);
-      
-      result.allocations.forEach(alloc => {
-        expect(alloc.allocated).toBeGreaterThanOrEqual(0);
-      });
-    }), { numRuns: 100 });
+    fc.assert(
+      fc.property(inputArb, (input: ReserveInput) => {
+        const result = engine.calculate(input);
+
+        expect(result.totalAllocated).toBeGreaterThanOrEqual(0);
+        expect(result.remaining).toBeGreaterThanOrEqual(0);
+
+        result.allocations.forEach((alloc) => {
+          expect(alloc.allocated).toBeGreaterThanOrEqual(0);
+        });
+      }),
+      { numRuns: 100 }
+    );
   });
 
   it('respects minCheck constraint', () => {
-    fc.assert(fc.property(inputArb, (input: ReserveInput) => {
-      if (!input.constraints?.minCheck) return true;
-      
-      const result = engine.calculate(input);
-      const minCheck = input.constraints.minCheck;
-      
-      result.allocations.forEach(alloc => {
-        expect(alloc.allocated).toBeGreaterThanOrEqual(minCheck - 0.01); // allow floating point precision
-      });
-    }), { numRuns: 100 });
+    fc.assert(
+      fc.property(inputArb, (input: ReserveInput) => {
+        if (!input.constraints?.minCheck) return true;
+
+        const result = engine.calculate(input);
+        const minCheck = input.constraints.minCheck;
+
+        result.allocations.forEach((alloc) => {
+          expect(alloc.allocated).toBeGreaterThanOrEqual(minCheck - 0.01); // allow floating point precision
+        });
+      }),
+      { numRuns: 100 }
+    );
   });
 
   it('does not exceed available reserves', () => {
-    fc.assert(fc.property(inputArb, (input: ReserveInput) => {
-      const result = engine.calculate(input);
-      
-      expect(result.totalAllocated).toBeLessThanOrEqual(input.availableReserves + 0.01); // allow floating point precision
-    }), { numRuns: 100 });
+    fc.assert(
+      fc.property(inputArb, (input: ReserveInput) => {
+        const result = engine.calculate(input);
+
+        expect(result.totalAllocated).toBeLessThanOrEqual(input.availableReserves + 0.01); // allow floating point precision
+      }),
+      { numRuns: 100 }
+    );
   });
 
   it('deterministic: same input produces same output', () => {
-    fc.assert(fc.property(inputArb, (input: ReserveInput) => {
-      const result1 = engine.calculate(input);
-      const result2 = engine.calculate(input);
-      
-      expect(result1.totalAllocated).toBeCloseTo(result2.totalAllocated, 10);
-      expect(result1.remaining).toBeCloseTo(result2.remaining, 10);
-      expect(result1.allocations).toEqual(result2.allocations);
-    }), { numRuns: 50 });
+    fc.assert(
+      fc.property(inputArb, (input: ReserveInput) => {
+        const result1 = engine.calculate(input);
+        const result2 = engine.calculate(input);
+
+        expect(result1.totalAllocated).toBeCloseTo(result2.totalAllocated, 10);
+        expect(result1.remaining).toBeCloseTo(result2.remaining, 10);
+        expect(result1.allocations).toEqual(result2.allocations);
+      }),
+      { numRuns: 50 }
+    );
   });
 
   it('empty companies returns zero allocations', () => {
     const input: ReserveInput = {
       availableReserves: 1000000,
       companies: [],
-      stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }]
+      stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
     };
-    
+
     const result = engine.calculate(input);
-    
+
     expect(result.allocations).toEqual([]);
     expect(result.totalAllocated).toBe(0);
     expect(result.remaining).toBe(1000000);
@@ -115,13 +151,58 @@ describe('ConstrainedReserveEngine', () => {
     const input: ReserveInput = {
       availableReserves: 0,
       companies: [{ id: 'c1', name: 'Company 1', stage: 'seed', invested: 100000, ownership: 0.1 }],
-      stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }]
+      stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
     };
-    
+
     const result = engine.calculate(input);
-    
+
     expect(result.allocations).toEqual([]);
     expect(result.totalAllocated).toBe(0);
     expect(result.remaining).toBe(0);
+  });
+
+  it('omitting scoreOverride is byte-identical to prior behavior (backward-compatible)', () => {
+    const input: ReserveInput = {
+      availableReserves: 1_000_000,
+      companies: [
+        { id: 'a', name: 'Alpha', stage: 'seed', invested: 100_000, ownership: 0.1 },
+        { id: 'b', name: 'Bravo', stage: 'series_a', invested: 200_000, ownership: 0.2 },
+      ],
+      stagePolicies: [
+        { stage: 'seed', reserveMultiple: 2, weight: 1 },
+        { stage: 'series_a', reserveMultiple: 3, weight: 1 },
+      ],
+      constraints: { maxPerCompany: 400_000 },
+    };
+
+    const baseline = engine.calculate(input);
+    const withUndefinedOverride = engine.calculate({ ...input, scoreOverride: undefined });
+
+    // Passing an absent/undefined override reproduces the baseline result exactly.
+    expect(withUndefinedOverride).toEqual(baseline);
+    // series_a scores strictly higher than seed under the engine's internal pv*weight,
+    // so it is funded first. Pins the baseline ordering as a regression guard.
+    expect(baseline.allocations.map((allocation) => allocation.id)).toEqual(['b', 'a']);
+  });
+
+  it('scoreOverride drives allocation order instead of the internal score', () => {
+    const input: ReserveInput = {
+      availableReserves: 400_000, // only enough for ONE company at the cap
+      companies: [
+        { id: 'a', name: 'Alpha', stage: 'seed', invested: 100_000, ownership: 0.1 },
+        { id: 'b', name: 'Bravo', stage: 'seed', invested: 200_000, ownership: 0.2 },
+      ],
+      stagePolicies: [{ stage: 'seed', reserveMultiple: 2, weight: 1 }],
+      constraints: { maxPerCompany: 400_000 },
+    };
+
+    // Same stage/policy => identical internal score => name/id tie-break funds 'a' first.
+    const natural = engine.calculate(input);
+    expect(natural.allocations[0]?.id).toBe('a');
+
+    // Override ranks 'b' strictly above 'a' => 'b' consumes the whole envelope, 'a' gets 0.
+    const overridden = engine.calculate({ ...input, scoreOverride: { a: 1, b: 100 } });
+    expect(overridden.allocations.map((allocation) => allocation.id)).toEqual(['b']);
+    expect(overridden.totalAllocated).toBe(400_000);
   });
 });


### PR DESCRIPTION
## ADR-056 NET-NEW #2 — PR1 of 5: `ConstrainedReserveEngine` optional score override (DD1)

Shadow-first convergence of the reserve engines (ADR-056). This is the foundational PR: it lets an external ranker (Program B marginal-MOIC) drive Program A's allocation order **without duplicating** A's cap / minCheck / stage-room / conservation / cents logic. PRs 2–5 (flag+mode, orchestrator, seam wiring, docs) build on it.

### What changed
- `shared/schemas.ts` — `ReserveInputSchema` gains an optional `scoreOverride?: Record<string, number>` (keyed by company id).
- `shared/core/reserves/ConstrainedReserveEngine.ts` — single line: `score: input.scoreOverride?.[company.id] ?? pv * policy.weight`. Only `undefined` falls through `??`, so a supplied `0` is a valid override; **omitting the map is byte-identical to prior behavior.**
- `tests/unit/reserves/ConstrainedReserveEngine.test.ts` — two tests: backward-compat proof (undefined override deep-equals baseline) + override-order enforcement through the fill.
- `DECISIONS.md` — ADR-056 addendum recording DD1 (this edit), DD3 (indicative exclusion), DD8 (H9-governed activation).

### ADR-046 supersession (needs specialist review)
This retires ADR-046 (Tranche 5)'s literal **"zero source edits"** proof for this engine. The substrate wrapper (`runConstrainedReserveWithSubstrate`) and its characterization suite pass **unmodified** — so ADR-046's *behavioral* guarantee still holds; only the empty-diff claim is retired. Per DD1, requesting:
- `parity-auditor` — Excel/truth-case parity unaffected by the additive override
- `phoenix-precision-guardian` — cents/precision path unchanged when no override is supplied

### Verification (local)
- `npm run check` — 0 TS errors
- `npm run calc-gate` — PASS (196 + 20 tests, incl. `phoenix:truth`)
- Blast radius (13 files importing the engine / `ReserveInput`) — 143 passed / 1 skipped; **characterization (zero-edits) suite unchanged**
- Pre-push related-tests batch — 358 passed / 1 skipped
- ESLint clean on all touched files

### Notes for the reviewer
- The `DECISIONS.md` diff is larger than the addendum because the lint-staged prettier hook reflowed the pre-existing ADR-056 section (pure re-wrapping, no prose change). The substantive addition is the "Addendum (2026-07-19)" block.
- **Scope: shadow-first. No fund is promoted to `on`.** No runtime seam is wired in this PR — the engine simply gains an unused-by-default capability. `ENABLE_MARGINAL_RESERVE_MOIC`, the fund-moic route, the T13 pilot, and all H9 gate defaults are untouched.

Generated with Claude Code (https://claude.com/claude-code)
