### PR TITLE
feat(reserves): ranked-reserve allocation flag + per-fund calc-mode resolver (ADR-056 NET-NEW #2, PR2)

### DIFF
--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -544,6 +544,20 @@ flags:
     expiresAt: null
     aliases: ['ENABLE_MONTE_CARLO_ACTUALS_INPUTS']
 
+  enable_ranked_reserve_allocation:
+    default: false
+    description: 'Gates the marginal-MOIC-ranked reserve allocation orchestrator (ADR-056 NET-NEW #2, shadow-first)'
+    owner: 'analytics'
+    risk: high
+    exposeToClient: false
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: null
+    aliases: ['ENABLE_RANKED_RESERVE_ALLOCATION']
+
   enable_faults:
     default: false
     description: 'Enable fault injection for testing'

--- a/server/services/ranked-reserve-calc-mode-resolver.ts
+++ b/server/services/ranked-reserve-calc-mode-resolver.ts
@@ -1,0 +1,37 @@
+import { db } from '../db';
+
+/** ADR-056 NET-NEW #2 per-fund calculation key. Free text; no migration. */
+export const RANKED_RESERVE_ALLOCATION_CALCULATION_KEY = 'ranked_reserve_allocation';
+
+export type RankedReserveCalculationMode = 'off' | 'shadow' | 'on';
+
+/** Narrow read seam so tests need no live DB. */
+export type RankedReserveModeReader = (
+  fundId: number
+) => Promise<{ configuredMode: string; killSwitchActive: boolean } | null | undefined>;
+
+export const defaultRankedReserveModeReader: RankedReserveModeReader = (fundId) =>
+  db.query.fundCalculationModes.findFirst({
+    columns: { configuredMode: true, killSwitchActive: true },
+    where: (row, { and, eq }) =>
+      and(
+        eq(row.fundId, fundId),
+        eq(row.calculationKey, RANKED_RESERVE_ALLOCATION_CALCULATION_KEY)
+      ),
+  });
+
+/**
+ * Resolve the per-fund ranked-reserve calc mode. Collapses the kill switch to
+ * `'off'` (mirroring `resolveReserveFactsCalculationMode`); unknown/absent values
+ * fail safe to `'off'`. The global flag gate is applied by the caller (PR4 seam).
+ */
+export async function resolveRankedReserveCalculationMode(
+  fundId: number,
+  reader: RankedReserveModeReader = defaultRankedReserveModeReader
+): Promise<RankedReserveCalculationMode> {
+  const mode = await reader(fundId);
+  if (mode?.killSwitchActive) return 'off';
+  return mode?.configuredMode === 'shadow' || mode?.configuredMode === 'on'
+    ? mode.configuredMode
+    : 'off';
+}

--- a/shared/generated/flag-defaults.ts
+++ b/shared/generated/flag-defaults.ts
@@ -604,6 +604,23 @@ export const FLAG_DEFINITIONS: Record<FlagKey, FlagDefinition> = {
     expiresAt: null,
     aliases: ['ENABLE_MONTE_CARLO_ACTUALS_INPUTS'],
   },
+  enable_ranked_reserve_allocation: {
+    default: false,
+    description:
+      'Gates the marginal-MOIC-ranked reserve allocation orchestrator (ADR-056 NET-NEW #2, shadow-first)',
+    owner: 'analytics',
+    risk: 'high',
+    exposeToClient: false,
+
+    environments: {
+      development: false,
+      staging: false,
+      production: false,
+    },
+    dependencies: [],
+    expiresAt: null,
+    aliases: ['ENABLE_RANKED_RESERVE_ALLOCATION'],
+  },
   enable_faults: {
     default: false,
     description: 'Enable fault injection for testing',
@@ -836,6 +853,7 @@ export const FLAG_DEFAULTS: FlagRecord = {
   enable_marginal_reserve_moic: false,
   enable_facts_sourced_reserve_inputs: false,
   enable_monte_carlo_actuals_inputs: false,
+  enable_ranked_reserve_allocation: false,
   enable_faults: false,
   enable_wizard_step_general: false,
   enable_wizard_step_sectors: false,
@@ -927,6 +945,7 @@ export const FLAG_ALIASES: Record<string, FlagKey> = {
   ENABLE_MARGINAL_RESERVE_MOIC: 'enable_marginal_reserve_moic',
   ENABLE_FACTS_SOURCED_RESERVE_INPUTS: 'enable_facts_sourced_reserve_inputs',
   ENABLE_MONTE_CARLO_ACTUALS_INPUTS: 'enable_monte_carlo_actuals_inputs',
+  ENABLE_RANKED_RESERVE_ALLOCATION: 'enable_ranked_reserve_allocation',
   ENABLE_WIZARD_STEP_GENERAL: 'enable_wizard_step_general',
   ENABLE_WIZARD_STEP_SIZING: 'enable_wizard_step_sizing',
   ENABLE_WIZARD_STEP_SECTORS: 'enable_wizard_step_sizing',

--- a/shared/generated/flag-types.ts
+++ b/shared/generated/flag-types.ts
@@ -48,6 +48,7 @@ export type FlagKey =
   | 'enable_marginal_reserve_moic'
   | 'enable_facts_sourced_reserve_inputs'
   | 'enable_monte_carlo_actuals_inputs'
+  | 'enable_ranked_reserve_allocation'
   | 'enable_faults'
   | 'enable_wizard_step_general'
   | 'enable_wizard_step_sectors'
@@ -119,6 +120,7 @@ export type ServerOnlyFlagKey =
   | 'enable_marginal_reserve_moic'
   | 'enable_facts_sourced_reserve_inputs'
   | 'enable_monte_carlo_actuals_inputs'
+  | 'enable_ranked_reserve_allocation'
   | 'enable_faults';
 
 /**
@@ -204,6 +206,7 @@ export const ALL_FLAG_KEYS: readonly FlagKey[] = [
   'enable_marginal_reserve_moic',
   'enable_facts_sourced_reserve_inputs',
   'enable_monte_carlo_actuals_inputs',
+  'enable_ranked_reserve_allocation',
   'enable_faults',
   'enable_wizard_step_general',
   'enable_wizard_step_sectors',

--- a/tests/unit/services/ranked-reserve-calc-mode-resolver.test.ts
+++ b/tests/unit/services/ranked-reserve-calc-mode-resolver.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRankedReserveCalculationMode,
+  RANKED_RESERVE_ALLOCATION_CALCULATION_KEY,
+  type RankedReserveModeReader,
+} from '../../../server/services/ranked-reserve-calc-mode-resolver';
+import { FLAG_DEFAULTS } from '../../../shared/generated/flag-defaults';
+
+const reader =
+  (row: { configuredMode: string; killSwitchActive: boolean } | null): RankedReserveModeReader =>
+  async () =>
+    row;
+
+describe('resolveRankedReserveCalculationMode', () => {
+  it('defaults to off when no row exists', async () => {
+    expect(await resolveRankedReserveCalculationMode(1, reader(null))).toBe('off');
+  });
+
+  it('returns shadow when configuredMode is shadow', async () => {
+    expect(
+      await resolveRankedReserveCalculationMode(
+        1,
+        reader({ configuredMode: 'shadow', killSwitchActive: false })
+      )
+    ).toBe('shadow');
+  });
+
+  it('returns on when configuredMode is on', async () => {
+    expect(
+      await resolveRankedReserveCalculationMode(
+        1,
+        reader({ configuredMode: 'on', killSwitchActive: false })
+      )
+    ).toBe('on');
+  });
+
+  it('collapses to off when the kill switch is active, even if configuredMode is on', async () => {
+    expect(
+      await resolveRankedReserveCalculationMode(
+        1,
+        reader({ configuredMode: 'on', killSwitchActive: true })
+      )
+    ).toBe('off');
+  });
+
+  it('fails safe to off on an unexpected configuredMode', async () => {
+    expect(
+      await resolveRankedReserveCalculationMode(
+        1,
+        reader({ configuredMode: 'bogus', killSwitchActive: false })
+      )
+    ).toBe('off');
+  });
+
+  it('exposes the calculation key constant', () => {
+    expect(RANKED_RESERVE_ALLOCATION_CALCULATION_KEY).toBe('ranked_reserve_allocation');
+  });
+
+  it('ships the flag default-off', () => {
+    expect(FLAG_DEFAULTS.enable_ranked_reserve_allocation).toBe(false);
+  });
+});


### PR DESCRIPTION
## ADR-056 NET-NEW #2 — PR2 of 5: flag + calc-mode + resolver (PURE ADDITIVE)

Scaffolds the two gates the ranked-allocation reserve orchestrator will sit behind. **Nothing is wired to `runReserveCalculation`** — that is PR4. Mirrors the existing `reserve_facts_inputs` flag+mode+resolver pattern exactly.

PR2 is orthogonal to [PR1 (#1155)](https://github.com/nikhillinit/Updog_restore/pull/1155) (flag/mode/resolver don't touch the engine); branched off `main` after #1155 merged.

### What changed

| File | Change |
|---|---|
| `flags/registry.yaml` | new `enable_ranked_reserve_allocation`, **default false** in every environment, `exposeToClient: false` |
| `shared/generated/flag-defaults.ts`, `shared/generated/flag-types.ts` | **machine-generated** by `npm run flags:generate` — do not hand-edit |
| `server/services/ranked-reserve-calc-mode-resolver.ts` *(new)* | `resolveRankedReserveCalculationMode` + `RANKED_RESERVE_ALLOCATION_CALCULATION_KEY` |
| `tests/unit/services/ranked-reserve-calc-mode-resolver.test.ts` *(new)* | 7 DB-free tests |

Diff is **+135 / −0** — additive only.

### Resolver semantics

Mirrors `resolveReserveFactsCalculationMode` (`reserve-calculation-service.ts:33-45`), the **kill-switch-collapsing** variant:

- `killSwitchActive` collapses to `'off'` regardless of `configuredMode`
- absent row or unknown mode fails safe to `'off'`
- only `'shadow'` / `'on'` pass the allowlist

Pure per-fund resolution — **no flag gate inside the resolver**. The global gate is applied by the caller at the PR4 seam, exactly as the facts path does (`isFlagEnabled(...) ? await resolve(fundId) : 'off'`). An injectable `RankedReserveModeReader` keeps it DB-free under test.

### No migration

`fund_calculation_modes.calculationKey` is free `text` (`shared/schema/fund-calculation-modes.ts:35`); a new key is just a value.

### Verification

- `npm run check` — 0 TypeScript errors
- 7/7 focused tests green; pre-push ran the broader suite: **810 passed / 9 skipped across 93 files**
- `eslint` clean on both new files
- Resolver assertions **mutation-checked**: dropping the kill-switch collapse, echoing `configuredMode` unfiltered, defaulting an absent row to `'on'`, and dropping `'shadow'` from the allowlist are each caught by a distinct assertion — no vacuous tests
- Confirmed unwired: no reference to `resolveRankedReserveCalculationMode` anywhere in `server/`, `shared/`, or `client/` outside its own file

### Expected-inert note

The flag is **declared-but-unused** until PR4 wires it at the seam. This is intended: `scripts/validate-flag-usage.ts` validates usage→flag in one direction only, and is not wired into any test or CI gate.

No fund promoted. No existing flag/mode default touched.
