### PR TITLE
feat(reserves): ranked-reserve orchestrator service, unwired (ADR-056 NET-NEW #2, PR3)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8423,6 +8423,76 @@ answer). Borrow from "B-first productization" only its un-gating/actionability
 mechanics, not its premise that A's substrate is merely a legacy shadow to keep
 running unexamined.
 
+### Addendum — NET-NEW #2 PR3 implementation notes
+
+**C4 — distinction from `DeterministicReserveEngine`.**
+`shared/core/reserves/DeterministicReserveEngine.ts:127-128` composes a ranking
+step and an allocation step, but it does not compute a marginal reserve return
+and therefore does not duplicate NET-NEW #2. Despite its name,
+`rankByExitMOICOnPlannedReserves` (`:249`) sorts by `allocationScore`
+(`:254-256`), defined at `:639-642` as
+`projectedMOIC * graduationProbability * riskAdjustedReturn / currentValuation`,
+which expands to
+`projectedMOIC^2 * graduationProbability^2 * (1 - failureRate) / currentMOIC` —
+a static whole-position priority index containing no reserve, check, or
+allocation term, and therefore invariant to the reserve amount under
+consideration. Program B's `calculateMarginalReserveMoic`
+(`shared/core/moic/MarginalReserveMoic.ts:330`) instead computes
+`deltaE[proceeds] / deltaE[capital]` between explicit participate /
+do-not-participate counterfactuals (`:291-298`) — a finite-difference slope of
+the expected-value function with respect to reserve capital, i.e. the return on
+the next incremental reserve dollar. The two coincide only if expected proceeds
+were linear in reserve capital through the origin, which the dilution math at
+`:86-88` rules out for any company with a non-zero existing position — that is,
+for every follow-on candidate. Separately, `DeterministicReserveEngine` is
+disqualified from the authoritative path by answer #6 above, which rules out the
+client-manufactured synthetic portfolio of `wizard-reserve-bridge`; its only
+live consumer is the client modeling wizard's Capital Allocation step
+(`client/src/lib/wizard-reserve-bridge.ts:473` via `useEngineComparison`), it
+appears on no server route, and it does not touch the authoritative RESERVE
+snapshot. NET-NEW #2 introduces no new allocator — it reuses
+`ConstrainedReserveEngine.calculate` through PR1's `scoreOverride` — so
+`DeterministicReserveEngine`'s own fused greedy fill (`:258-299`) remains a
+pre-existing, non-authoritative duplicate to be retired or re-pointed under a
+later convergence step, not a reason to withhold this one.
+
+**Integer-rank convention (C2).** `scoreOverride` is fed DENSE DESCENDING
+INTEGERS (top rank = N, ... last = 1), never raw marginal-MOIC floats. `score`
+feeds no allocation amount, cap, or conservation arithmetic — it is consumed
+only by the sort comparator at `ConstrainedReserveEngine.ts:91`. Integer ranks
+make the realized order exactly Program B's order with zero float-precision
+exposure; raw floats risk collapsing two near-identical ranks into a tie that
+silently falls through to the engine's name/id tiebreak
+(`ConstrainedReserveEngine.ts:96`), producing a wrong order that still looks
+correct. Note that although `score` is sort-only, the allocator it orders is
+GREEDY and drains the envelope in rank order — so `scoreOverride` can fully
+redistribute the allocation. It is a load-bearing input, not a cosmetic one.
+
+**`indicative` exclusion (DD3).** Results with `status === 'indicative'` are
+excluded from allocation and disclosed, not allocated on. Two independent tiers
+produce `indicative` and BOTH are honored: the result tier
+(`marginalMoic > 100`, `MarginalReserveMoic.ts:331`) and the input-readiness
+tier (`STALE_ASSUMPTION`, assumption older than
+`MARGINAL_RESERVE_ASSUMPTION_STALE_AFTER_DAYS` = 120). The fold —
+result-actionable plus readiness-indicative yields indicative — follows the
+established precedent at `server/routes/fund-moic.ts:174-178`.
+
+**Identity join.** `MarginalReserveMoicResultV1` carries no company identifier
+(the schema is `.strict()`); identity exists only on the input. Results are
+therefore paired with `input.companyId` inside the same closure that computes
+them, per `server/routes/fund-moic.ts:171-185`. Company `id` on the allocator
+side is a string while `companyId` is a number, and a `scoreOverride` key miss
+fails SILENTLY by falling through to `pv * policy.weight`
+(`ConstrainedReserveEngine.ts:85`) — so the string conversion is applied from a
+single expression and is covered by a dedicated regression test.
+
+**Stage-space bridge.** The MOIC side is canonical (`pre_seed`, `series_d`,
+`growth`, `late_stage`); the allocator side is the legacy no-separator enum
+(`preseed`, `series_dplus`). Conversion uses the exported `toNoSeparatorStage`
+(`shared/schemas/stage.ts:273`). The map is MANY-TO-ONE — `series_d`, `growth`,
+and `late_stage` all collapse to `series_dplus` — so neutral stage policies are
+deduped in the LEGACY space; otherwise three policies contend for one stage key.
+
 ### Follow-on plan (concrete, file-named; not built in this slice)
 
 - REUSE (no rebuild): `buildMarginalReserveMoicInputs`

--- a/server/services/moic/marginal-reserve-moic-input-service.ts
+++ b/server/services/moic/marginal-reserve-moic-input-service.ts
@@ -438,7 +438,7 @@ export function buildMarginalReserveMoicInputsFromSources(input: {
   return { ready, unavailable, factsInputHash, assumptionsHash };
 }
 
-async function loadMarginalReserveInputSources(input: {
+export async function loadMarginalReserveInputSources(input: {
   fundId: number;
   asOfDate: string;
 }): Promise<MarginalReserveInputSources> {

--- a/server/services/reserves/ranked-reserve-orchestrator.ts
+++ b/server/services/reserves/ranked-reserve-orchestrator.ts
@@ -1,0 +1,437 @@
+import { z } from 'zod';
+
+import {
+  buildMarginalReserveMoicInputsFromSources,
+  loadMarginalReserveInputSources,
+  type MarginalReserveInputSources,
+} from '../moic/marginal-reserve-moic-input-service';
+import {
+  buildReserveEnvelopeFromSources,
+  loadReserveEnvelopeSources,
+} from './reserve-envelope-service';
+import { ConstrainedReserveEngine } from '../../../shared/core/reserves/ConstrainedReserveEngine';
+import { calculateMarginalReserveMoic } from '../../../shared/core/moic/MarginalReserveMoic';
+import type { ReserveEnvelopeV1 } from '../../../shared/contracts/reserve-envelope-v1.contract';
+import Decimal from '../../../shared/lib/decimal-config';
+import { ReserveInputSchema, type ReserveInput } from '../../../shared/schemas';
+import { type CanonicalStage, toNoSeparatorStage } from '../../../shared/schemas/stage';
+import { ConfidenceLevel, ReserveSummarySchema, type ReserveSummary } from '../../../shared/types';
+import { centsToDollars, dollarsToCents } from '../../../shared/units';
+
+const BuildInputSchema = z
+  .object({
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+  })
+  .strict();
+
+type LegacyReserveStage = ReturnType<typeof toNoSeparatorStage>;
+type RankedReserveExclusionReason = 'unavailable' | 'indicative';
+type RankedReserveFailSafeReason =
+  'envelope_blocked' | 'envelope_untrusted' | 'no_actionable_candidates' | 'engine_error';
+
+export interface RankedReserveCandidate {
+  companyId: number;
+  name: string;
+  canonicalStage: CanonicalStage;
+  invested: number;
+  ownership: number;
+  status: 'actionable' | 'indicative' | 'unavailable';
+  marginalMoic: string | null;
+}
+
+export interface ComposeRankedReserveInput {
+  envelope: ReserveEnvelopeV1;
+  candidates: readonly RankedReserveCandidate[];
+  constraints?: { maxPerCompany?: number; maxPerStage?: number; minCheck?: number };
+  factsInputHash: string;
+  assumptionsHash: string;
+}
+
+export interface RankedReserveAllocation {
+  companyId: number;
+  id: string;
+  name: string;
+  stage: LegacyReserveStage;
+  allocated: number;
+  rank: number;
+  marginalMoic: string;
+}
+
+export interface RankedReserveAllocationResult {
+  allocations: RankedReserveAllocation[];
+  totalAllocated: number;
+  remaining: number;
+  conservationOk: boolean;
+  excluded: Array<{ companyId: number; reason: RankedReserveExclusionReason }>;
+  neutralPolicies: Array<{
+    stage: LegacyReserveStage;
+    reserveMultiple: 1;
+    weight: 1;
+  }>;
+  disclosedDefaults: string[];
+  failSafe: boolean;
+  failSafeReason: RankedReserveFailSafeReason | null;
+  envelopeInputHash: string;
+  factsInputHash: string;
+  assumptionsHash: string;
+}
+
+export interface RankedReserveShadowTelemetry {
+  totalAllocationDeltaCents: number;
+  rankAgreement: boolean;
+  excludedCountsByReason: Record<RankedReserveExclusionReason, number>;
+  envelopeInputHash: string;
+  factsInputHash: string;
+  assumptionsHash: string;
+}
+
+const SOURCE_STAGE_ALIASES: Readonly<Record<string, CanonicalStage>> = {
+  preseed: 'pre_seed',
+  seed: 'seed',
+  seriesa: 'series_a',
+  seriesb: 'series_b',
+  seriesc: 'series_c',
+  seriesd: 'series_d',
+  seriesdplus: 'series_d',
+  growth: 'growth',
+  latestage: 'late_stage',
+};
+
+function canonicalStageFromSource(value: string | null | undefined): CanonicalStage | null {
+  if (!value) return null;
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+  return SOURCE_STAGE_ALIASES[normalized] ?? null;
+}
+
+function disclosedDefaults(input: ComposeRankedReserveInput): string[] {
+  const defaults: string[] = [];
+  if (input.constraints?.maxPerCompany === undefined) defaults.push('maxPerCompany:Infinity');
+  if (input.constraints?.maxPerStage === undefined) defaults.push('maxPerStage:{}');
+  if (input.constraints?.minCheck === undefined) defaults.push('minCheck:0');
+  return defaults;
+}
+
+function failSafeResult(
+  input: ComposeRankedReserveInput,
+  failSafeReason: RankedReserveFailSafeReason,
+  excluded: RankedReserveAllocationResult['excluded'] = [],
+  neutralPolicies: RankedReserveAllocationResult['neutralPolicies'] = []
+): RankedReserveAllocationResult {
+  return {
+    allocations: [],
+    totalAllocated: 0,
+    remaining: centsToDollars(input.envelope.availableReservesCents),
+    conservationOk: true,
+    excluded,
+    neutralPolicies,
+    disclosedDefaults: disclosedDefaults(input),
+    failSafe: true,
+    failSafeReason,
+    envelopeInputHash: input.envelope.inputHash,
+    factsInputHash: input.factsInputHash,
+    assumptionsHash: input.assumptionsHash,
+  };
+}
+
+export function composeRankedReserveAllocation(
+  input: ComposeRankedReserveInput
+): RankedReserveAllocationResult {
+  if (input.envelope.blocked) {
+    return failSafeResult(input, 'envelope_blocked');
+  }
+  if (!input.envelope.trustedForActivation) {
+    return failSafeResult(input, 'envelope_untrusted');
+  }
+
+  const excluded: RankedReserveAllocationResult['excluded'] = input.candidates.flatMap(
+    (candidate) =>
+      candidate.status === 'actionable'
+        ? []
+        : [{ companyId: candidate.companyId, reason: candidate.status }]
+  );
+  const eligible = input.candidates.filter((candidate) => candidate.status === 'actionable');
+  if (eligible.length === 0) {
+    return failSafeResult(input, 'no_actionable_candidates', excluded);
+  }
+
+  try {
+    const rankedCandidates = eligible
+      .filter((candidate) => {
+        if (candidate.marginalMoic !== null) return true;
+        excluded.push({ companyId: candidate.companyId, reason: 'unavailable' });
+        return false;
+      })
+      .sort((left, right) => {
+        const marginalMoicOrder = new Decimal(right.marginalMoic as string).comparedTo(
+          new Decimal(left.marginalMoic as string)
+        );
+        return (
+          marginalMoicOrder ||
+          left.name.localeCompare(right.name) ||
+          left.companyId - right.companyId
+        );
+      });
+
+    if (rankedCandidates.length === 0) {
+      return failSafeResult(input, 'no_actionable_candidates', excluded);
+    }
+
+    const scoreOverride: Record<string, number> = {};
+    const rankById = new Map<string, { companyId: number; rank: number; marginalMoic: string }>();
+    const companies = rankedCandidates.map((candidate, index) => {
+      const companyKey = String(candidate.companyId);
+      const rank = index + 1;
+      scoreOverride[companyKey] = rankedCandidates.length - index;
+      rankById.set(companyKey, {
+        companyId: candidate.companyId,
+        rank,
+        marginalMoic: candidate.marginalMoic as string,
+      });
+      return {
+        id: companyKey,
+        name: candidate.name,
+        stage: toNoSeparatorStage(candidate.canonicalStage),
+        invested: candidate.invested,
+        ownership: candidate.ownership,
+      };
+    });
+
+    const legacyStages = new Set(companies.map((company) => company.stage));
+    const neutralPolicies: RankedReserveAllocationResult['neutralPolicies'] = [...legacyStages].map(
+      (stage) => ({ stage, reserveMultiple: 1, weight: 1 })
+    );
+    const constraints: NonNullable<ReserveInput['constraints']> = {};
+    if (input.constraints?.maxPerCompany !== undefined) {
+      constraints.maxPerCompany = input.constraints.maxPerCompany;
+    }
+    if (input.constraints?.maxPerStage !== undefined) {
+      const maxPerStage = input.constraints.maxPerStage;
+      constraints.maxPerStage = Object.fromEntries(
+        [...legacyStages].map((stage) => [stage, maxPerStage])
+      );
+    }
+    if (input.constraints?.minCheck !== undefined) {
+      constraints.minCheck = input.constraints.minCheck;
+    }
+
+    const reserveInput = ReserveInputSchema.parse({
+      availableReserves: centsToDollars(input.envelope.availableReservesCents),
+      companies,
+      stagePolicies: neutralPolicies,
+      ...(Object.keys(constraints).length > 0 ? { constraints } : {}),
+      scoreOverride,
+    });
+    const engineResult = new ConstrainedReserveEngine().calculate(reserveInput);
+    const allocations = engineResult.allocations.map((allocation) => {
+      const ranking = rankById.get(allocation.id);
+      if (!ranking) throw new Error(`Missing rank metadata for company ${allocation.id}`);
+      return {
+        companyId: ranking.companyId,
+        id: allocation.id,
+        name: allocation.name,
+        stage: allocation.stage as LegacyReserveStage,
+        allocated: allocation.allocated,
+        rank: ranking.rank,
+        marginalMoic: ranking.marginalMoic,
+      };
+    });
+
+    return {
+      allocations,
+      totalAllocated: engineResult.totalAllocated,
+      remaining: engineResult.remaining,
+      conservationOk: engineResult.conservationOk,
+      excluded,
+      neutralPolicies,
+      disclosedDefaults: disclosedDefaults(input),
+      failSafe: false,
+      failSafeReason: null,
+      envelopeInputHash: input.envelope.inputHash,
+      factsInputHash: input.factsInputHash,
+      assumptionsHash: input.assumptionsHash,
+    };
+  } catch {
+    return failSafeResult(input, 'engine_error', excluded);
+  }
+}
+
+function investedDollars(sources: MarginalReserveInputSources, companyId: number): number {
+  const fact = sources.facts.facts.find((candidate) => candidate.companyId === companyId);
+  if (!fact) return 0;
+  // Match the facts-backed reserve convention: amount-only non-equity cash is not invested equity.
+  return new Decimal(fact.initialInvestmentAmount).plus(fact.followOnInvestmentAmount).toNumber();
+}
+
+function ownershipNumber(value: string | number | null): number {
+  try {
+    const parsed = new Decimal(value ?? 0);
+    return parsed.isFinite() && parsed.gte(0) && parsed.lte(1) ? parsed.toNumber() : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function candidateFromSources(input: {
+  sources: MarginalReserveInputSources;
+  companyId: number;
+  status: RankedReserveCandidate['status'];
+  marginalMoic: string | null;
+  ownership: string | number | null;
+}): RankedReserveCandidate {
+  const company = input.sources.companies.find(
+    (candidate) => candidate.companyId === input.companyId
+  );
+  const fact = input.sources.facts.facts.find(
+    (candidate) => candidate.companyId === input.companyId
+  );
+  const canonicalStage = canonicalStageFromSource(company?.currentStage ?? company?.stage);
+  const sourceComplete = company !== undefined && fact !== undefined && canonicalStage !== null;
+  return {
+    companyId: input.companyId,
+    name: fact?.companyName ?? `Company ${input.companyId}`,
+    canonicalStage: canonicalStage ?? 'seed',
+    invested: investedDollars(input.sources, input.companyId),
+    ownership: ownershipNumber(input.ownership),
+    status: sourceComplete ? input.status : 'unavailable',
+    marginalMoic: sourceComplete ? input.marginalMoic : null,
+  };
+}
+
+/**
+ * Folds the two independent "indicative" tiers into one candidate status.
+ *
+ * Tier 1 is the result tier (marginal MOIC > 100, MarginalReserveMoic.ts:331).
+ * Tier 2 is the input-readiness tier (STALE_ASSUMPTION, assumption older than
+ * MARGINAL_RESERVE_ASSUMPTION_STALE_AFTER_DAYS = 120).
+ *
+ * A stale assumption downgrades an otherwise-actionable result to indicative, but must never
+ * upgrade an unavailable result. Precedent: server/routes/fund-moic.ts:174-178.
+ */
+export function foldMarginalCandidateStatus(
+  resultStatus: RankedReserveCandidate['status'],
+  readinessStatus: Exclude<RankedReserveCandidate['status'], 'unavailable'>
+): RankedReserveCandidate['status'] {
+  return resultStatus === 'actionable' && readinessStatus === 'indicative'
+    ? 'indicative'
+    : resultStatus;
+}
+
+export async function buildRankedReserveAllocation(input: {
+  fundId: number;
+  asOfDate: string;
+}): Promise<RankedReserveAllocationResult> {
+  const parsed = BuildInputSchema.parse(input);
+  const [envelopeSources, marginalSources] = await Promise.all([
+    loadReserveEnvelopeSources(parsed),
+    loadMarginalReserveInputSources(parsed),
+  ]);
+  const envelope = buildReserveEnvelopeFromSources({ ...parsed, sources: envelopeSources });
+  const assembly = buildMarginalReserveMoicInputsFromSources({
+    ...parsed,
+    sources: marginalSources,
+  });
+  const candidates = [
+    ...assembly.ready.map((marginalInput) => {
+      const result = calculateMarginalReserveMoic(marginalInput);
+      const readiness = marginalInput.readiness ?? { status: 'actionable' as const, reasons: [] };
+      const status = foldMarginalCandidateStatus(result.status, readiness.status);
+      return candidateFromSources({
+        sources: marginalSources,
+        companyId: marginalInput.companyId,
+        status,
+        marginalMoic: result.marginalMoic,
+        ownership: marginalInput.currentOwnership,
+      });
+    }),
+    ...assembly.unavailable.map((failure) =>
+      candidateFromSources({
+        sources: marginalSources,
+        companyId: failure.companyId,
+        status: 'unavailable',
+        marginalMoic: null,
+        ownership:
+          marginalSources.companies.find((company) => company.companyId === failure.companyId)
+            ?.currentOwnership ?? null,
+      })
+    ),
+  ];
+
+  return composeRankedReserveAllocation({
+    envelope,
+    candidates,
+    factsInputHash: assembly.factsInputHash,
+    assumptionsHash: assembly.assumptionsHash,
+  });
+}
+
+export function toReserveSummary(
+  envelope: ReserveEnvelopeV1,
+  composed: RankedReserveAllocationResult
+): ReserveSummary {
+  const allocations = composed.allocations.map((allocation) => {
+    // This is a provenance proxy, not a model confidence. Composed allocations can only
+    // originate from candidates whose post-fold status is actionable.
+    const confidence =
+      Math.round(
+        Math.min(
+          ConfidenceLevel.LOW + (envelope.trustedForActivation ? 0.2 : 0) + 0.15,
+          ConfidenceLevel.MEDIUM
+        ) * 100
+      ) / 100;
+    return {
+      allocation: allocation.allocated,
+      confidence,
+      rationale: `ranked-allocation: marginal-MOIC rank ${allocation.rank} of ${composed.allocations.length}; envelope inputHash=${composed.envelopeInputHash.slice(0, 12)}`,
+    };
+  });
+  const avgConfidence =
+    allocations.length === 0
+      ? 0
+      : Math.round(
+          (allocations.reduce((sum, allocation) => sum + allocation.confidence, 0) /
+            allocations.length) *
+            100
+        ) / 100;
+
+  // These rollups are provenance proxies under this engine, not ML confidences.
+  return ReserveSummarySchema.parse({
+    fundId: envelope.fundId,
+    totalAllocation: composed.totalAllocated,
+    avgConfidence,
+    highConfidenceCount: allocations.filter(
+      (allocation) => allocation.confidence >= ConfidenceLevel.MEDIUM
+    ).length,
+    allocations,
+    generatedAt: new Date(),
+  });
+}
+
+export function buildRankedShadowTelemetry(
+  legacy: ReserveSummary,
+  composed: RankedReserveAllocationResult
+): RankedReserveShadowTelemetry {
+  const marginalMoicOrder = [...composed.allocations].sort((left, right) => left.rank - right.rank);
+  const realizedAllocationOrder = [...composed.allocations].sort(
+    (left, right) => right.allocated - left.allocated || left.rank - right.rank
+  );
+  const rankAgreement = marginalMoicOrder.every(
+    (allocation, index) => allocation.companyId === realizedAllocationOrder[index]?.companyId
+  );
+
+  return {
+    totalAllocationDeltaCents:
+      dollarsToCents(composed.totalAllocated) - dollarsToCents(legacy.totalAllocation),
+    rankAgreement,
+    excludedCountsByReason: {
+      unavailable: composed.excluded.filter((item) => item.reason === 'unavailable').length,
+      indicative: composed.excluded.filter((item) => item.reason === 'indicative').length,
+    },
+    envelopeInputHash: composed.envelopeInputHash,
+    factsInputHash: composed.factsInputHash,
+    assumptionsHash: composed.assumptionsHash,
+  };
+}

--- a/tests/unit/services/reserves/ranked-reserve-orchestrator.test.ts
+++ b/tests/unit/services/reserves/ranked-reserve-orchestrator.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ReserveEnvelopeV1Schema,
+  type ReserveEnvelopeV1,
+} from '../../../../shared/contracts/reserve-envelope-v1.contract';
+import { ReserveInputSchema } from '../../../../shared/schemas';
+import { ConfidenceLevel, ReserveSummarySchema } from '../../../../shared/types';
+import {
+  buildRankedShadowTelemetry,
+  composeRankedReserveAllocation,
+  foldMarginalCandidateStatus,
+  toReserveSummary,
+  type ComposeRankedReserveInput,
+  type RankedReserveAllocationResult,
+  type RankedReserveCandidate,
+} from '../../../../server/services/reserves/ranked-reserve-orchestrator';
+
+const FUND_ID = 1;
+const AS_OF = '2026-07-19';
+const ENVELOPE_HASH = 'a'.repeat(64);
+const FACTS_HASH = 'b'.repeat(64);
+const ASSUMPTIONS_HASH = 'c'.repeat(64);
+
+function baseEnvelope(overrides: Partial<ReserveEnvelopeV1> = {}): ReserveEnvelopeV1 {
+  return ReserveEnvelopeV1Schema.parse({
+    contractVersion: 'reserve-envelope-v1',
+    fundId: FUND_ID,
+    asOfDate: AS_OF,
+    baseCurrency: 'USD',
+    availableReservesCents: 100_00,
+    components: {
+      committedCapital: {
+        amountCents: 100_00,
+        status: 'observed',
+        source: 'test.committed',
+        reason: null,
+      },
+      deployedCapital: {
+        amountCents: 0,
+        status: 'observed',
+        source: 'test.deployed',
+        reason: null,
+      },
+      managementFees: {
+        amountCents: 0,
+        status: 'derived',
+        source: 'test.fees',
+        reason: null,
+      },
+      fundExpenses: {
+        amountCents: 0,
+        status: 'derived',
+        source: 'test.expenses',
+        reason: null,
+      },
+      exitRecycling: {
+        amountCents: 0,
+        status: 'derived',
+        source: 'test.recycling',
+        reason: null,
+      },
+    },
+    trustedForActivation: true,
+    blocked: false,
+    blockReason: null,
+    inputHash: ENVELOPE_HASH,
+    ...overrides,
+  });
+}
+
+function baseCandidate(overrides: Partial<RankedReserveCandidate> = {}): RankedReserveCandidate {
+  return {
+    companyId: 1,
+    name: 'Alpha',
+    canonicalStage: 'seed',
+    invested: 10,
+    ownership: 0.1,
+    status: 'actionable',
+    marginalMoic: '2',
+    ...overrides,
+  };
+}
+
+function baseComposeInput(
+  overrides: Partial<ComposeRankedReserveInput> = {}
+): ComposeRankedReserveInput {
+  return {
+    envelope: baseEnvelope(),
+    candidates: [baseCandidate()],
+    factsInputHash: FACTS_HASH,
+    assumptionsHash: ASSUMPTIONS_HASH,
+    ...overrides,
+  };
+}
+
+function build(overrides: Partial<ComposeRankedReserveInput> = {}): RankedReserveAllocationResult {
+  return composeRankedReserveAllocation(baseComposeInput(overrides));
+}
+
+describe('foldMarginalCandidateStatus', () => {
+  it.each([
+    ['actionable', 'actionable', 'actionable'],
+    ['actionable', 'indicative', 'indicative'],
+    ['indicative', 'actionable', 'indicative'],
+    ['indicative', 'indicative', 'indicative'],
+    ['unavailable', 'actionable', 'unavailable'],
+    ['unavailable', 'indicative', 'unavailable'],
+  ] as const)('%s + %s -> %s', (resultStatus, readinessStatus, expected) => {
+    expect(foldMarginalCandidateStatus(resultStatus, readinessStatus)).toBe(expected);
+  });
+});
+
+describe('composeRankedReserveAllocation', () => {
+  it("enforces Program B's order when the allocator's intrinsic stage score disagrees", () => {
+    const result = build({
+      candidates: [
+        baseCandidate({ companyId: 1, name: 'Zulu', canonicalStage: 'seed', marginalMoic: '2' }),
+        baseCandidate({
+          companyId: 2,
+          name: 'Alpha',
+          canonicalStage: 'series_d',
+          marginalMoic: '1',
+        }),
+      ],
+      constraints: { maxPerCompany: 60 },
+    });
+    expect(() =>
+      ReserveInputSchema.parse({
+        availableReserves: 100,
+        companies: [
+          { id: '1', name: 'Zulu', stage: 'seed', invested: 10, ownership: 0.1 },
+          { id: '2', name: 'Alpha', stage: 'series_dplus', invested: 10, ownership: 0.1 },
+        ],
+        stagePolicies: [
+          { stage: 'seed', reserveMultiple: 1, weight: 1 },
+          { stage: 'series_dplus', reserveMultiple: 1, weight: 1 },
+        ],
+        constraints: { maxPerCompany: 60 },
+        scoreOverride: { '1': 2, '2': 1 },
+      })
+    ).not.toThrow();
+    // B ranks seed first: $100 available -> Zulu capped at $60, then Alpha receives $40.
+    expect(result.allocations[0]?.companyId).toBe(1);
+    expect(result.allocations[0]?.allocated).toBe(60);
+    expect(result.allocations[1]?.companyId).toBe(2);
+    expect(result.allocations[1]?.allocated).toBe(40);
+    expect(result.totalAllocated).toBe(100);
+  });
+
+  it('preserves cent-exact conservation across allocation and remaining reserves', () => {
+    const result = build({ constraints: { maxPerCompany: 33.33 } });
+    // $100.00 available - $33.33 allocated = $66.67 remaining.
+    expect(result.totalAllocated).toBe(33.33);
+    expect(result.remaining).toBe(66.67);
+    expect(result.conservationOk).toBe(true);
+    expect(Math.round((result.totalAllocated + result.remaining) * 100)).toBe(100_00);
+  });
+
+  it('excludes and discloses an unavailable candidate', () => {
+    const result = build({
+      candidates: [
+        baseCandidate({ status: 'unavailable', marginalMoic: null }),
+        baseCandidate({ companyId: 2, name: 'Beta' }),
+      ],
+    });
+    expect(result.excluded).toContainEqual({ companyId: 1, reason: 'unavailable' });
+    expect(result.allocations).toHaveLength(1);
+    expect(result.allocations[0]?.companyId).toBe(2);
+  });
+
+  it('excludes and discloses a result-tier indicative candidate', () => {
+    const result = build({
+      candidates: [
+        baseCandidate({ status: 'indicative', marginalMoic: '100.1' }),
+        baseCandidate({ companyId: 2, name: 'Beta' }),
+      ],
+    });
+    expect(result.excluded).toContainEqual({ companyId: 1, reason: 'indicative' });
+    expect(result.allocations).toHaveLength(1);
+    expect(result.allocations[0]?.companyId).toBe(2);
+  });
+
+  it('fails safe before allocation when the envelope is blocked', () => {
+    const result = build({
+      envelope: baseEnvelope({ blocked: true, blockReason: 'blocked for test' }),
+    });
+    expect(result.failSafe).toBe(true);
+    expect(result.failSafeReason).toBe('envelope_blocked');
+    expect(result.allocations).toHaveLength(0);
+    expect(result.totalAllocated).toBe(0);
+    expect(result.conservationOk).toBe(true);
+  });
+
+  it('fails safe before allocation when the envelope is not trusted for activation', () => {
+    const result = build({ envelope: baseEnvelope({ trustedForActivation: false }) });
+    expect(result.failSafe).toBe(true);
+    expect(result.failSafeReason).toBe('envelope_untrusted');
+    expect(result.allocations).toHaveLength(0);
+    expect(result.totalAllocated).toBe(0);
+  });
+
+  it('fails safe when partitioning leaves no actionable candidates', () => {
+    const result = build({
+      candidates: [baseCandidate({ status: 'unavailable', marginalMoic: null })],
+    });
+    expect(result.failSafe).toBe(true);
+    expect(result.failSafeReason).toBe('no_actionable_candidates');
+    expect(result.excluded).toEqual([{ companyId: 1, reason: 'unavailable' }]);
+  });
+
+  it('fails safe on a composition or engine throw without leaking a partial allocation', () => {
+    const result = build({ constraints: { maxPerCompany: -1 } });
+    expect(result.failSafe).toBe(true);
+    expect(result.failSafeReason).toBe('engine_error');
+    expect(result.allocations).toHaveLength(0);
+    expect(result.totalAllocated).toBe(0);
+    expect(result.conservationOk).toBe(true);
+  });
+
+  it('ranks decimal values numerically when lexicographic string order disagrees', () => {
+    const result = build({
+      candidates: [
+        baseCandidate({ companyId: 1, name: 'Lexical Winner', marginalMoic: '9.5' }),
+        baseCandidate({ companyId: 2, name: 'Numeric Winner', marginalMoic: '100.0' }),
+      ],
+      constraints: { maxPerCompany: 60 },
+    });
+    // Numeric descending order: 100.0 receives $60 first; 9.5 receives the remaining $40.
+    expect(result.allocations[0]?.companyId).toBe(2);
+    expect(result.allocations[0]?.rank).toBe(1);
+    expect(result.allocations[0]?.allocated).toBe(60);
+    expect(result.allocations[1]?.allocated).toBe(40);
+  });
+
+  it('keeps near-identical decimal MOIC values distinct beyond Number precision', () => {
+    const result = build({
+      candidates: [
+        baseCandidate({
+          companyId: 1,
+          name: 'Alpha',
+          marginalMoic: '1.0000000000000000000000000000001',
+        }),
+        baseCandidate({
+          companyId: 2,
+          name: 'Zulu',
+          marginalMoic: '1.0000000000000000000000000000002',
+        }),
+      ],
+      constraints: { maxPerCompany: 60 },
+    });
+    expect(result.allocations[0]?.companyId).toBe(2);
+    expect(result.allocations[0]?.rank).toBe(1);
+    expect(result.allocations[1]?.companyId).toBe(1);
+    expect(result.allocations[1]?.rank).toBe(2);
+  });
+
+  it('uses one explicit string key bridge for both companies and score overrides', () => {
+    const composeSource = composeRankedReserveAllocation.toString();
+    expect(composeSource).toMatch(/companyKey = String\(candidate\.companyId\)/);
+    expect(composeSource).toMatch(/id: companyKey/);
+    expect(composeSource).toMatch(/scoreOverride\[companyKey\]/);
+  });
+
+  it('lands the score override when numeric company identity crosses the string-key boundary', () => {
+    const result = build({
+      candidates: [
+        baseCandidate({ companyId: 41, name: 'Zulu', canonicalStage: 'seed', marginalMoic: '2' }),
+        baseCandidate({
+          companyId: 42,
+          name: 'Alpha',
+          canonicalStage: 'series_d',
+          marginalMoic: '1',
+        }),
+      ],
+      constraints: { maxPerCompany: 60 },
+    });
+    // Intrinsic stage scoring favors series_dplus; the landed override instead gives seed $60 first.
+    expect(result.allocations[0]?.id).toBe('41');
+    expect(result.allocations[0]?.allocated).toBe(60);
+    expect(result.allocations[1]?.id).toBe('42');
+    expect(result.allocations[1]?.allocated).toBe(40);
+  });
+
+  it('dedupes canonical late stages after all collapse into legacy series_dplus', () => {
+    const result = build({
+      candidates: [
+        baseCandidate({ companyId: 1, canonicalStage: 'series_d', marginalMoic: '3' }),
+        baseCandidate({ companyId: 2, canonicalStage: 'growth', marginalMoic: '2' }),
+        baseCandidate({ companyId: 3, canonicalStage: 'late_stage', marginalMoic: '1' }),
+      ],
+      constraints: { maxPerCompany: 40 },
+    });
+    expect(result.failSafe).toBe(false);
+    expect(result.neutralPolicies).toEqual([
+      { stage: 'series_dplus', reserveMultiple: 1, weight: 1 },
+    ]);
+    expect(result.allocations[0]?.stage).toBe('series_dplus');
+  });
+
+  it('maps canonical pre_seed to legacy preseed without a missing-policy throw', () => {
+    const result = build({ candidates: [baseCandidate({ canonicalStage: 'pre_seed' })] });
+    expect(result.failSafe).toBe(false);
+    expect(result.neutralPolicies[0]?.stage).toBe('preseed');
+    expect(result.allocations[0]?.stage).toBe('preseed');
+  });
+
+  it('treats a null MOIC on an actionable candidate as unavailable', () => {
+    const result = build({ candidates: [baseCandidate({ marginalMoic: null })] });
+    expect(result.failSafe).toBe(true);
+    expect(result.failSafeReason).toBe('no_actionable_candidates');
+    expect(result.excluded).toEqual([{ companyId: 1, reason: 'unavailable' }]);
+  });
+});
+
+describe('toReserveSummary', () => {
+  it('maps the rich allocation into the validated summary provenance-confidence convention', () => {
+    const envelope = baseEnvelope();
+    const composed = build({
+      candidates: [
+        baseCandidate({ companyId: 1, marginalMoic: '2' }),
+        baseCandidate({ companyId: 2, name: 'Beta', marginalMoic: '1' }),
+      ],
+      constraints: { maxPerCompany: 60 },
+    });
+    const summary = toReserveSummary(envelope, composed);
+    expect(() => ReserveSummarySchema.parse(summary)).not.toThrow();
+    expect(summary.fundId).toBe(FUND_ID);
+    expect(summary.totalAllocation).toBe(100);
+    expect(summary.allocations[0]?.allocation).toBe(60);
+    expect(summary.allocations[0]?.confidence).toBe(ConfidenceLevel.MEDIUM);
+    expect(summary.allocations[0]?.rationale).toContain('marginal-MOIC rank 1 of 2');
+    expect(summary.avgConfidence).toBe(ConfidenceLevel.MEDIUM);
+    expect(summary.highConfidenceCount).toBe(2);
+    expect(summary.generatedAt).toBeInstanceOf(Date);
+
+    const untrustedSummary = toReserveSummary(
+      baseEnvelope({ trustedForActivation: false }),
+      composed
+    );
+    expect(untrustedSummary.allocations[0]?.confidence).toBe(0.65);
+    expect(untrustedSummary.highConfidenceCount).toBe(0);
+  });
+});
+
+describe('buildRankedShadowTelemetry', () => {
+  it('reports a cent delta and detects a known cap-driven realized-order reshuffle', () => {
+    const composed = build({
+      candidates: [
+        baseCandidate({ companyId: 1, marginalMoic: '2' }),
+        baseCandidate({ companyId: 2, name: 'Beta', marginalMoic: '1' }),
+      ],
+      constraints: { maxPerCompany: 60 },
+    });
+    const reshuffled: RankedReserveAllocationResult = {
+      ...composed,
+      allocations: [
+        { ...composed.allocations[0]!, allocated: 30 },
+        { ...composed.allocations[1]!, allocated: 70 },
+      ],
+      totalAllocated: 100,
+      excluded: [
+        { companyId: 3, reason: 'unavailable' },
+        { companyId: 4, reason: 'indicative' },
+      ],
+    };
+    const legacy = ReserveSummarySchema.parse({
+      fundId: FUND_ID,
+      totalAllocation: 90,
+      avgConfidence: 0,
+      highConfidenceCount: 0,
+      allocations: [],
+      generatedAt: new Date('2026-07-19T00:00:00.000Z'),
+    });
+    const telemetry = buildRankedShadowTelemetry(legacy, reshuffled);
+    // $100 composed - $90 legacy = $10 = 1,000 cents; realized $70/$30 reverses B rank.
+    expect(telemetry.totalAllocationDeltaCents).toBe(10_00);
+    expect(telemetry.rankAgreement).toBe(false);
+    expect(telemetry.excludedCountsByReason.unavailable).toBe(1);
+    expect(telemetry.excludedCountsByReason.indicative).toBe(1);
+    expect(telemetry.envelopeInputHash).toBe(ENVELOPE_HASH);
+    expect(telemetry.factsInputHash).toBe(FACTS_HASH);
+    expect(telemetry.assumptionsHash).toBe(ASSUMPTIONS_HASH);
+  });
+});


### PR DESCRIPTION
Composes the reserve envelope, Program B's marginal-MOIC rank, and Program A's constrained
fill (via PR1's `scoreOverride`) into a single orchestrator service. Pure core plus a thin
DB-backed wrapper, mirroring `reserve-envelope-service.ts`. **Nothing is wired to the seam** —
that is PR4.

Third of five PRs for ADR-056 NET-NEW #2. Depends only on PR1 (#1155), already on `main`.
PR2 (#1156) merged during this work; it was purely additive and touched none of this slice's
anchors.

## What landed

- `composeRankedReserveAllocation` — pure. Gate, partition, stage bridge, Decimal rank,
  integer overrides, neutral policies, constrained fill. Steps 5-11 wrapped so any throw
  becomes a total fail-safe; a partial composed result can never escape.
- `buildRankedReserveAllocation` — thin DB-backed wrapper.
- `toReserveSummary` — pure mapper to the canonical `ReserveSummary`.
- `buildRankedShadowTelemetry` — pure payload builder, defined and tested, **not called**.
- `foldMarginalCandidateStatus` — pure, exported, truth-table tested.
- One-word change exporting `loadMarginalReserveInputSources` (see G1).
- ADR-056 addendum recording the C4 distinction, the integer-rank convention, the
  `indicative` exclusion, the identity join, and the stage-space bridge.

## Parent-brief corrections (C1-C4)

The parent brief stated four things as verified that were wrong against live code; two did not
compile as written. All four were re-verified at HEAD before implementing.

- **C1** — `marginalMoic` on the result is a decimal **string**, not a `Decimal`.
  `result.marginalMoic.gt(x)` does not compile. Ranking parses with `new Decimal(...)` and
  compares via `.comparedTo`. Never sorts the raw strings: lexicographic order puts `'9.5'`
  above `'100.0'`, a silent mis-ranking no type error catches. Regression-guarded.
- **C2** — `scoreOverride` takes plain numbers, and `score` is sort-only. Fed **dense
  descending integers**, not MOIC floats, so the realized order is exactly B's with zero
  float-precision exposure. Raw floats risk collapsing near-identical ranks into a tie that
  falls through to the engine's name/id tiebreak — wrong order, still looks correct.
  Worth noting: `score` is sort-only but the allocator it orders is **greedy**, so
  `scoreOverride` fully redistributes the envelope. It is load-bearing, not cosmetic.
- **C3** — `fromCents` takes a `bigint` while the envelope emits a JS `number`, so the brief's
  bridge was a type error. Uses `centsToDollars` from `shared/units.ts` instead, which takes
  `number` directly. Note there are four same-named `centsToDollars` helpers in this repo with
  different parameter types; the import is explicit.
- **C4** — the brief's "no orchestrator exists" grep was not clean.
  `DeterministicReserveEngine` already ranks by a MOIC-ish metric and allocates.
  **Resolved as DISTINCT and recorded in the ADR addendum.** Despite its name,
  `rankByExitMOICOnPlannedReserves` sorts by `allocationScore`, a static whole-position index
  with no reserve, check, or allocation term in it — invariant to the reserve amount under
  consideration. Program B computes a finite-difference slope of expected value with respect
  to reserve capital. A level versus a slope; they coincide only if proceeds were linear in
  capital through the origin, which the dilution math rules out for every follow-on candidate.
  This PR also introduces **no new allocator** — it reuses `ConstrainedReserveEngine`.

Two claims were falsified while verifying C4, both now corrected in the addendum: the brief's
"12+ consumers" of `DeterministicReserveEngine` is actually three import sites with one live
call path (a client wizard panel, no server route), and ADR-056 itself was wrong that
`reserve-optimization-calculator.ts` participates — it references neither engine.

## Four gaps the brief missed

Verification surfaced four composition problems not in the brief. Three fail **silently**.

- **G1 — the identity join was not reachable.** `MarginalReserveMoicResultV1` carries no
  company id (schema is `.strict()`); identity lives only on the input. Company `name` and
  `stage` come from two different places, both inside `MarginalReserveInputSources`, which the
  public API did not return. The brief's one-new-file write-set was therefore not achievable.
  Resolved by exporting the loader — one word — mirroring `reserve-envelope-service.ts`, which
  already exports its equivalent. Re-querying independently would duplicate data access, which
  is what ADR-056 exists to prevent.
- **G2 — stage-space collapse.** MOIC is canonical (`pre_seed`, `series_d`, `growth`,
  `late_stage`); the allocator is legacy (`preseed`, `series_dplus`). `pre_seed !== preseed`,
  and three canonical stages collapse to `series_dplus`. Naively emitting one neutral policy
  per present stage produces three competing `series_dplus` policies. Converts via the exported
  `toNoSeparatorStage` and dedupes in **legacy** space.
- **G3 — key-type drift fails silently.** A `scoreOverride` key miss does not error; it falls
  through to `pv * policy.weight` and discards the entire ranking while the run still looks
  successful. Both the company id and the override key derive from one `String(companyId)`
  expression so they cannot drift, with a behavioral test asserting the override actually lands.
- **G4 — two independent `indicative` tiers.** Beyond the result tier (MOIC > 100) there is an
  input-readiness tier (stale assumption, >120 days). Missing the fold would allocate against a
  stale assumption. Both are honored; the fold follows the precedent in `fund-moic.ts`.

## Note for reviewers

One structural test remains: `:259` asserts against `composeRankedReserveAllocation.toString()`
to pin the single-string-key-bridge convention. This is deliberate — the mutation it guards
(numeric vs string override key) is **unkillable behaviorally**, because JS coerces numeric
object keys to strings, making `scoreOverride[123]` and `scoreOverride["123"]` the same
property. Actual drift between the two sides is caught by the behavioral test at `:270`. Happy
to drop the structural guard if reviewers prefer.

An equivalent `toString` test originally covered the G4 readiness fold. That one was replaced:
the fold was extracted into `foldMarginalCandidateStatus`, a pure exported function with a
six-row truth table, including the row asserting that readiness-indicative must **not** promote
an `unavailable` result into the allocation set.

## Out of scope

Not wired to `runReserveCalculation` (PR4). No fund promoted, no migration, no flag or mode
default touched. `package.json` untouched — adding the new test to `calc-gate`'s hardcoded list
is a PR4 decision, since this service is unwired and guards nothing yet.

`DeterministicReserveEngine` does contain its own ranked greedy fill — a genuine pre-existing
duplicate allocator, already scoped out by ADR-056. This PR neither creates nor worsens it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
