### PR TITLE
feat(reserves): ranked-reserve orchestrator seam wiring, shadow-first (ADR-056 NET-NEW #2, PR4)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8601,4 +8601,52 @@ to legacy. Promoting a real fund to ranked `on` is a governed decision in the
 same class as T13 and NET-NEW #3; this slice promotes no fund and does not touch
 `ENABLE_MARGINAL_RESERVE_MOIC`, the fund-moic route, or any H9 gate default.
 
+### Addendum — NET-NEW #2 PR4 seam wiring
+
+**H9 gate predicate (closes B2).** DD8's fourth condition, "H9 gate satisfied,"
+is implemented at the reserve seam as
+`resolveMoicActionability({fundId, sources}).actionability === 'actionable'`
+(`server/services/fund-calculation-mode-service.ts:371-375`, predicate
+`:343-352`). The gate is written as a POSITIVE equality, never as a negation of
+`non_actionable`: `H9ActionabilityStatus` is five-valued at the type level
+(`shared/contracts/financial-provenance.contract.ts:13-19`) while the resolver
+currently emits only two, so a negated gate would be non-total and would
+silently admit `input_only`, `quarantined`, or `unknown_legacy` if anything ever
+begins emitting them. This matches the shipped export-side precedent at
+`h9-export-gate.ts:72`. The seam reuses the actionability result already
+computed for the H9 stamp rather than resolving a second time, preserving the
+exact-argument characterization tests at
+`tests/unit/services/reserve-calculation-h9-stamp.test.ts:157,:228`.
+
+**Gate placement.** The ranked `on` path applies all four DD8 conditions as a
+PRE-WRITE conditional. It deliberately does NOT mirror the post-hoc stamp
+demotion at `reserve-calculation-service.ts:244-246`, which demotes the stamp
+while still writing the payload — that pattern satisfies the local convention
+but would violate ADR-056 #5c by landing a B-derived payload in the
+authoritative snapshot regardless of the stamp.
+
+**Shadow emission tier.** Option A: pino structured log only
+(`server/services/reserves/ranked-reserve-shadow-telemetry.ts`), mirroring the
+wired fund-moic lane. No DB ledger, no Prometheus counter, no zod contract for
+the payload — none of the three existing shadow lanes has any of those. A ledger
+was rejected because `substrate_shadow_reconciliations`' migration 0035 exists
+locally but is not provisioned to production. The three provenance hashes are
+truncated to 12 characters at emit time.
+
+**Snapshot metadata scope.** Ranked provenance enters `fund_snapshots.metadata`
+only as the aggregate `rankedBasis` block (mode, candidate count, excluded
+count, three hashes). No per-allocation detail is written: `metadata` is plain
+nullable `jsonb` with no size limit, CHECK constraint, or zod contract, and all
+three existing shadow lanes keep per-item detail in logs exclusively.
+Per-allocation values including `marginalMoic` remain in the structured log
+only.
+
+**Legacy-summary binding.** `generateReserveSummary` at the seam is bound to
+`legacyReserves`, which is written once and never reassigned; the authoritative
+`reserves` binding is what the ranked `on` path may swap. The facts-shadow
+comparison is pinned to `legacyReserves` so that enabling ranked mode on a fund
+already in `reserve_facts_inputs` shadow mode cannot silently change what the
+pre-existing `reserve_facts_inputs_shadow` metric measures — with both sides
+equal, `summaryValueDeltaPct` would return 0 with no error and no failing test.
+
 ---

--- a/server/services/reserve-calculation-service.ts
+++ b/server/services/reserve-calculation-service.ts
@@ -18,6 +18,15 @@ import {
   buildFactsReserveCandidates,
   type FactsReserveCandidate,
 } from './reserves/facts-reserve-input-adapter';
+import { resolveRankedReserveCalculationMode } from './ranked-reserve-calc-mode-resolver';
+import {
+  buildRankedReserveAllocation,
+  buildRankedShadowTelemetry,
+  toReserveSummary,
+  type RankedReserveShadowTelemetry,
+} from './reserves/ranked-reserve-orchestrator';
+import { buildReserveEnvelope } from './reserves/reserve-envelope-service';
+import { emitRankedShadowTelemetry } from './reserves/ranked-reserve-shadow-telemetry';
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
@@ -28,6 +37,14 @@ type FactsBasisMetadata = {
   factsInputHash: string | null;
   trustedForActivation: boolean;
   mode: 'on';
+};
+type RankedBasisMetadata = {
+  mode: 'on';
+  candidateCount: number;
+  excludedCount: number;
+  envelopeInputHash: string;
+  factsInputHash: string;
+  assumptionsHash: string;
 };
 
 async function resolveReserveFactsCalculationMode(
@@ -94,6 +111,17 @@ function summaryValueDeltaPct(
 function logReserveFactsShadowEvent(event: Record<string, unknown>): void {
   try {
     logger.info(event, 'reserve facts inputs shadow comparison generated');
+  } catch {
+    return;
+  }
+}
+
+function logRankedReserveWarning(
+  message: string,
+  input: { fundId: number; mode: 'shadow' | 'on'; error?: unknown }
+): void {
+  try {
+    logger.warn(input, message);
   } catch {
     return;
   }
@@ -195,9 +223,16 @@ export async function runReserveCalculation({
   const reserveFactsMode = reserveFactsFlagEnabled
     ? await resolveReserveFactsCalculationMode(fundId)
     : 'off';
+  const rankedReserveFlagEnabled = isFlagEnabled('enable_ranked_reserve_allocation');
+  const rankedReserveMode = rankedReserveFlagEnabled
+    ? await resolveRankedReserveCalculationMode(fundId)
+    : 'off';
   let portfolio: ReserveCompanyInput[];
   let reserveInputTrustSummary: ReserveInputTrustSummary;
   let factsBasis: FactsBasisMetadata | undefined;
+  let rankedBasis: RankedBasisMetadata | undefined;
+  let rankedShadowEmission:
+    { asOfDate: string; telemetry: RankedReserveShadowTelemetry } | undefined;
   let factsInputsTrustedForActivation = true;
   let moicSources: FundMoicRankingSources | undefined;
   let factsAsOfDate: string | undefined;
@@ -228,7 +263,8 @@ export async function runReserveCalculation({
     reserveInputTrustSummary = legacy.reserveInputTrustSummary;
   }
 
-  const reserves = generateReserveSummary(fundId, portfolio);
+  const legacyReserves = generateReserveSummary(fundId, portfolio);
+  let reserves = legacyReserves;
   if (reserveFactsMode === 'shadow') {
     const factsNow = new Date();
     factsAsOfDate = factsNow.toISOString().slice(0, 10);
@@ -243,6 +279,50 @@ export async function runReserveCalculation({
   const h9Columns = toH9SnapshotColumns(actionability);
   if (reserveFactsMode === 'on' && !factsInputsTrustedForActivation) {
     h9Columns.h9ActionabilityStatus = 'non_actionable';
+  }
+
+  if (rankedReserveMode !== 'off') {
+    const rankedAsOfDate = new Date().toISOString().slice(0, 10);
+    try {
+      const composed = await buildRankedReserveAllocation({
+        fundId,
+        asOfDate: rankedAsOfDate,
+      });
+      if (rankedReserveMode === 'shadow') {
+        rankedShadowEmission = {
+          asOfDate: rankedAsOfDate,
+          telemetry: buildRankedShadowTelemetry(legacyReserves, composed),
+        };
+      } else {
+        // composed.failSafe encodes the envelope trust/block and actionable-candidate conditions.
+        const rankedGatePasses = !composed.failSafe && actionability.actionability === 'actionable';
+        if (rankedGatePasses) {
+          const envelope = await buildReserveEnvelope({ fundId, asOfDate: rankedAsOfDate });
+          if (envelope.inputHash === composed.envelopeInputHash) {
+            reserves = toReserveSummary(envelope, composed);
+            rankedBasis = {
+              mode: rankedReserveMode,
+              candidateCount: composed.allocations.length,
+              excludedCount: composed.excluded.length,
+              envelopeInputHash: composed.envelopeInputHash,
+              factsInputHash: composed.factsInputHash,
+              assumptionsHash: composed.assumptionsHash,
+            };
+          } else {
+            logRankedReserveWarning('ranked reserve input hash diverged; using legacy reserves', {
+              fundId,
+              mode: rankedReserveMode,
+            });
+          }
+        }
+      }
+    } catch (error) {
+      logRankedReserveWarning('ranked reserve calculation failed; using legacy reserves', {
+        fundId,
+        mode: rankedReserveMode,
+        error,
+      });
+    }
   }
 
   // ADR-022: authoritative-only writer. scenario_set_id intentionally omitted (defaults to NULL).
@@ -264,6 +344,7 @@ export async function runReserveCalculation({
         engineRuntime: performance.now() - startTime,
         reserveInputTrustSummary,
         ...(factsBasis !== undefined && { factsBasis }),
+        ...(rankedBasis !== undefined && { rankedBasis }),
       },
     })
     .returning();
@@ -283,8 +364,24 @@ export async function runReserveCalculation({
       asOfDate: factsAsOfDate,
       factsSource: moicSources.factsSource,
       legacyCompanyCount: portfolio.length,
-      legacySummary: reserves,
+      legacySummary: legacyReserves,
     });
+  }
+
+  if (rankedReserveMode === 'shadow' && rankedShadowEmission !== undefined) {
+    try {
+      emitRankedShadowTelemetry({
+        fundId,
+        asOfDate: rankedShadowEmission.asOfDate,
+        telemetry: rankedShadowEmission.telemetry,
+      });
+    } catch (error) {
+      logRankedReserveWarning('ranked reserve shadow telemetry failed', {
+        fundId,
+        mode: rankedReserveMode,
+        error,
+      });
+    }
   }
 
   return {

--- a/server/services/reserves/ranked-reserve-shadow-telemetry.ts
+++ b/server/services/reserves/ranked-reserve-shadow-telemetry.ts
@@ -1,0 +1,34 @@
+import { logger } from '../../lib/logger';
+import type { RankedReserveShadowTelemetry } from './ranked-reserve-orchestrator';
+
+export interface RankedReserveShadowTelemetryEvent extends RankedReserveShadowTelemetry {
+  fundId: number;
+  asOfDate: string;
+}
+
+export interface RankedReserveShadowLogger {
+  info(bindings: RankedReserveShadowTelemetryEvent, message: string): void;
+}
+
+export function emitRankedShadowTelemetry(
+  input: { fundId: number; asOfDate: string; telemetry: RankedReserveShadowTelemetry },
+  log: RankedReserveShadowLogger = logger
+): void {
+  try {
+    log.info(
+      {
+        fundId: input.fundId,
+        asOfDate: input.asOfDate,
+        totalAllocationDeltaCents: input.telemetry.totalAllocationDeltaCents,
+        rankAgreement: input.telemetry.rankAgreement,
+        excludedCountsByReason: input.telemetry.excludedCountsByReason,
+        envelopeInputHash: input.telemetry.envelopeInputHash.slice(0, 12),
+        factsInputHash: input.telemetry.factsInputHash.slice(0, 12),
+        assumptionsHash: input.telemetry.assumptionsHash.slice(0, 12),
+      },
+      'ranked reserve shadow comparison generated'
+    );
+  } catch {
+    return;
+  }
+}

--- a/tests/unit/services/reserve-calculation-facts-inputs.test.ts
+++ b/tests/unit/services/reserve-calculation-facts-inputs.test.ts
@@ -286,7 +286,7 @@ describe('runReserveCalculation facts-sourced inputs', () => {
   });
 
   it('uses the legacy path when the flag is on but no mode row exists', async () => {
-    isFlagEnabled.mockReturnValue(true);
+    isFlagEnabled.mockImplementation((key) => key === 'enable_facts_sourced_reserve_inputs');
 
     const result = await runReserveCalculation({ fundId: 7, correlationId: 'corr-no-mode' });
 
@@ -411,7 +411,12 @@ describe('runReserveCalculation facts-sourced inputs', () => {
   });
 
   it('returns to byte-identical legacy behavior on the run after the flag is disabled', async () => {
-    isFlagEnabled.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false);
+    const factsFlagByRun = [false, true, false];
+    let factsFlagCall = 0;
+    isFlagEnabled.mockImplementation((key) => {
+      if (key !== 'enable_facts_sourced_reserve_inputs') return false;
+      return factsFlagByRun[factsFlagCall++] ?? false;
+    });
     modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
     generateReserveSummary.mockImplementation((_fundId, portfolio) =>
       portfolio[0]?.invested === FACTS_COMPANY.invested ? FACTS_RESERVES : LEGACY_RESERVES

--- a/tests/unit/services/reserve-calculation-facts-inputs.test.ts
+++ b/tests/unit/services/reserve-calculation-facts-inputs.test.ts
@@ -298,7 +298,7 @@ describe('runReserveCalculation facts-sourced inputs', () => {
   });
 
   it('threads one facts snapshot through on-mode reserve inputs and H9', async () => {
-    isFlagEnabled.mockReturnValue(true);
+    isFlagEnabled.mockImplementation((key) => key === 'enable_facts_sourced_reserve_inputs');
     modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
     generateReserveSummary.mockReturnValue(FACTS_RESERVES);
 
@@ -323,7 +323,7 @@ describe('runReserveCalculation facts-sourced inputs', () => {
   });
 
   it('threads one facts snapshot through shadow H9 and post-persist telemetry', async () => {
-    isFlagEnabled.mockReturnValue(true);
+    isFlagEnabled.mockImplementation((key) => key === 'enable_facts_sourced_reserve_inputs');
     modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
     buildFactsReserveCandidates.mockImplementation(async () => {
       eventOrder.push('shadow');
@@ -397,7 +397,7 @@ describe('runReserveCalculation facts-sourced inputs', () => {
   });
 
   it('does not fail a persisted shadow calculation when facts telemetry cannot be logged', async () => {
-    isFlagEnabled.mockReturnValue(true);
+    isFlagEnabled.mockImplementation((key) => key === 'enable_facts_sourced_reserve_inputs');
     modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
     buildFactsReserveCandidates.mockRejectedValue(new Error('facts unavailable'));
     loggerInfo.mockImplementation(() => {

--- a/tests/unit/services/reserve-calculation-h9-stamp.test.ts
+++ b/tests/unit/services/reserve-calculation-h9-stamp.test.ts
@@ -182,7 +182,7 @@ describe('runReserveCalculation H9 stamp', () => {
   });
 
   it('rechecks engine-fed facts provenance before retaining an actionable H9 stamp', async () => {
-    isFlagEnabled.mockReturnValue(true);
+    isFlagEnabled.mockImplementation((key) => key === 'enable_facts_sourced_reserve_inputs');
     modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
     buildFactsReserveCandidates.mockResolvedValue({
       candidates: [
@@ -249,7 +249,7 @@ describe('runReserveCalculation H9 stamp', () => {
   });
 
   it('forces non-actionable H9 when on-mode facts evidence has no input hash', async () => {
-    isFlagEnabled.mockReturnValue(true);
+    isFlagEnabled.mockImplementation((key) => key === 'enable_facts_sourced_reserve_inputs');
     modeFindFirst.mockResolvedValue({ configuredMode: 'on', killSwitchActive: false });
     buildFactsReserveCandidates.mockResolvedValue({
       candidates: [

--- a/tests/unit/services/reserve-calculation-ranked-reserve.test.ts
+++ b/tests/unit/services/reserve-calculation-ranked-reserve.test.ts
@@ -1,0 +1,524 @@
+import { readFile } from 'node:fs/promises';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MoicActionabilityResult } from '../../../server/services/fund-calculation-mode-service';
+import type { H9ActionabilityStatus } from '../../../shared/contracts/h9-actionability.contract';
+import type { ReserveSummary } from '../../../shared/types';
+
+const {
+  buildFactsReserveCandidates,
+  buildRankedReserveAllocation,
+  buildRankedShadowTelemetry,
+  buildReserveEnvelope,
+  buildReservePortfolioInputWithProvenance,
+  emitRankedShadowTelemetry,
+  enabledFlags,
+  eventOrder,
+  generateReserveSummary,
+  getFundMoicRankingSources,
+  isFlagEnabled,
+  loggerInfo,
+  loggerWarn,
+  markCalcRunCompletedIfReady,
+  modeFindFirst,
+  persistedSnapshots,
+  resolveMoicActionability,
+  resolveRankedReserveCalculationMode,
+  toReserveSummary,
+} = vi.hoisted(() => ({
+  buildFactsReserveCandidates: vi.fn(),
+  buildRankedReserveAllocation: vi.fn(),
+  buildRankedShadowTelemetry: vi.fn(),
+  buildReserveEnvelope: vi.fn(),
+  buildReservePortfolioInputWithProvenance: vi.fn(),
+  emitRankedShadowTelemetry: vi.fn(),
+  enabledFlags: new Set<string>(),
+  eventOrder: [] as string[],
+  generateReserveSummary: vi.fn(),
+  getFundMoicRankingSources: vi.fn(),
+  isFlagEnabled: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  markCalcRunCompletedIfReady: vi.fn(async () => undefined),
+  modeFindFirst: vi.fn(),
+  persistedSnapshots: [] as Record<string, unknown>[],
+  resolveMoicActionability: vi.fn(),
+  resolveRankedReserveCalculationMode: vi.fn(),
+  toReserveSummary: vi.fn(),
+}));
+
+vi.mock('../../../server/db', () => ({
+  db: {
+    query: {
+      fundConfigs: { findFirst: vi.fn(async () => ({ version: 3, isPublished: true })) },
+      funds: { findFirst: vi.fn(async () => ({ id: 7, size: '100000000' })) },
+      fundCalculationModes: { findFirst: modeFindFirst },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        persistedSnapshots.push(values);
+        eventOrder.push('persist');
+        return {
+          returning: vi.fn(async () => [
+            {
+              id: 101,
+              createdAt: new Date('2026-07-19T00:00:00.000Z'),
+              calcVersion: '1.0.0',
+            },
+          ]),
+        };
+      }),
+    })),
+  },
+}));
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
+  return { ...actual, resolveMoicActionability };
+});
+
+vi.mock('../../../server/services/fund-moic-ranking-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-moic-ranking-service')>();
+  return { ...actual, getFundMoicRankingSources };
+});
+
+vi.mock('../../../server/services/reserve-input-builder', () => ({
+  buildReservePortfolioInputWithProvenance,
+}));
+
+vi.mock('../../../server/services/reserves/facts-reserve-input-adapter', () => ({
+  buildFactsReserveCandidates,
+}));
+
+vi.mock('../../../server/services/ranked-reserve-calc-mode-resolver', () => ({
+  resolveRankedReserveCalculationMode,
+}));
+
+vi.mock('../../../server/services/reserves/ranked-reserve-orchestrator', () => ({
+  buildRankedReserveAllocation,
+  buildRankedShadowTelemetry,
+  toReserveSummary,
+}));
+
+vi.mock('../../../server/services/reserves/reserve-envelope-service', () => ({
+  buildReserveEnvelope,
+}));
+
+vi.mock('../../../server/services/reserves/ranked-reserve-shadow-telemetry', () => ({
+  emitRankedShadowTelemetry,
+}));
+
+vi.mock('@shared/core/reserves/ReserveEngine', () => ({ generateReserveSummary }));
+
+vi.mock('@shared/flags/getFlag', () => ({ isFlagEnabled }));
+
+vi.mock('../../../server/lib/logger', () => ({
+  logger: {
+    info: loggerInfo,
+    warn: loggerWarn,
+    child: vi.fn(() => ({ info: loggerInfo, warn: loggerWarn, error: vi.fn() })),
+  },
+}));
+
+vi.mock('../../../server/services/calc-run-tracking', () => ({
+  markCalcRunCompletedIfReady,
+}));
+
+import { runReserveCalculation } from '../../../server/services/reserve-calculation-service';
+
+const LEGACY_PORTFOLIO = [
+  { id: 11, invested: 100, ownership: 0.15, stage: 'Seed' as const, sector: 'SaaS' },
+];
+const LEGACY_TRUST_SUMMARY = {
+  trustedForActivation: false,
+  defaultedInputCount: 1,
+  unavailableInputCount: 0,
+  defaultedFields: ['ownership'] as const,
+  unavailableFields: [] as const,
+};
+const LEGACY_RESERVES: ReserveSummary = {
+  fundId: 7,
+  totalAllocation: 100,
+  avgConfidence: 0.5,
+  highConfidenceCount: 0,
+  allocations: [{ allocation: 100, confidence: 0.5, rationale: 'legacy' }],
+  generatedAt: new Date('2026-07-19T00:00:00.000Z'),
+};
+const FACTS_RESERVES: ReserveSummary = {
+  fundId: 7,
+  totalAllocation: 125,
+  avgConfidence: 0.6,
+  highConfidenceCount: 1,
+  allocations: [{ allocation: 125, confidence: 0.6, rationale: 'facts' }],
+  generatedAt: new Date('2026-07-19T00:00:00.000Z'),
+};
+const RANKED_RESERVES: ReserveSummary = {
+  fundId: 7,
+  totalAllocation: 250,
+  avgConfidence: 0.7,
+  highConfidenceCount: 2,
+  allocations: [
+    { allocation: 150, confidence: 0.7, rationale: 'ranked first' },
+    { allocation: 100, confidence: 0.7, rationale: 'ranked second' },
+  ],
+  generatedAt: new Date('2026-07-19T00:00:00.000Z'),
+};
+const ENVELOPE_INPUT_HASH = 'e'.repeat(64);
+const FACTS_INPUT_HASH = 'f'.repeat(64);
+const ASSUMPTIONS_HASH = 'a'.repeat(64);
+const COMPOSED = {
+  allocations: [
+    {
+      companyId: 11,
+      id: '11',
+      name: 'First',
+      stage: 'seed' as const,
+      allocated: 150,
+      rank: 1,
+      marginalMoic: '3.5',
+    },
+    {
+      companyId: 12,
+      id: '12',
+      name: 'Second',
+      stage: 'series_a' as const,
+      allocated: 100,
+      rank: 2,
+      marginalMoic: '2.5',
+    },
+  ],
+  totalAllocated: 250,
+  remaining: 0,
+  conservationOk: true,
+  excluded: [{ companyId: 13, reason: 'indicative' as const }],
+  neutralPolicies: [],
+  disclosedDefaults: [],
+  failSafe: false,
+  failSafeReason: null,
+  envelopeInputHash: ENVELOPE_INPUT_HASH,
+  factsInputHash: FACTS_INPUT_HASH,
+  assumptionsHash: ASSUMPTIONS_HASH,
+};
+const ENVELOPE = {
+  contractVersion: 'reserve-envelope-v1' as const,
+  fundId: 7,
+  asOfDate: '2026-07-19',
+  baseCurrency: 'USD',
+  availableReservesCents: 25000,
+  components: {},
+  trustedForActivation: true,
+  blocked: false,
+  blockReason: null,
+  inputHash: ENVELOPE_INPUT_HASH,
+};
+const RANKED_TELEMETRY = {
+  totalAllocationDeltaCents: 15000,
+  rankAgreement: true,
+  excludedCountsByReason: { unavailable: 0, indicative: 1 },
+  envelopeInputHash: ENVELOPE_INPUT_HASH,
+  factsInputHash: FACTS_INPUT_HASH,
+  assumptionsHash: ASSUMPTIONS_HASH,
+};
+const FACTS_SOURCE = {
+  status: 'available' as const,
+  response: {
+    fundId: 7,
+    asOfDate: '2026-07-19',
+    facts: [],
+    inputHash: FACTS_INPUT_HASH,
+    generatedAt: '2026-07-19T00:00:00.000Z',
+  },
+};
+const MOIC_SOURCES = { factsSource: FACTS_SOURCE };
+const FACTS_COMPANY = {
+  id: 11,
+  invested: 125,
+  ownership: 0.2,
+  stage: 'Series A' as const,
+  sector: 'SaaS',
+  provenance: {
+    invested: { status: 'observed' as const, source: 'facts.invested', reason: null },
+    ownership: { status: 'observed' as const, source: 'facts.ownership', reason: null },
+    stage: { status: 'observed' as const, source: 'facts.stage', reason: null },
+    sector: { status: 'observed' as const, source: 'companies.sector', reason: null },
+  },
+};
+
+function actionabilityResult(
+  actionability: H9ActionabilityStatus = 'actionable'
+): MoicActionabilityResult {
+  return {
+    sourceFingerprintMatches: actionability === 'actionable',
+    actionability,
+    actionabilityStatus: actionability,
+    sourceFingerprint: {
+      moicSourceInputHash: 'moic-src-hash',
+      roundEvidenceInputHash: 'round-evidence-hash',
+      roundEvidenceAssumptionsHash: 'assumptions-hash',
+      fingerprintHash: 'fingerprint-hash',
+      policyVersion: 'h9-policy-v1',
+    },
+    acceptedReconciliationRunId: actionability === 'actionable' ? '42' : null,
+  };
+}
+
+function withoutPersistenceTiming(values: Record<string, unknown>): Record<string, unknown> {
+  const { snapshotTime: _snapshotTime, metadata, ...snapshot } = values;
+  if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error('Expected reserve snapshot metadata');
+  }
+  const { engineRuntime: _engineRuntime, ...stableMetadata } = metadata as Record<string, unknown>;
+  return { ...snapshot, metadata: stableMetadata };
+}
+
+function enableRankedMode(mode: 'shadow' | 'on'): void {
+  enabledFlags.add('enable_ranked_reserve_allocation');
+  resolveRankedReserveCalculationMode.mockResolvedValue(mode);
+}
+
+function enableFactsShadow(): void {
+  enabledFlags.add('enable_facts_sourced_reserve_inputs');
+  modeFindFirst.mockResolvedValue({ configuredMode: 'shadow', killSwitchActive: false });
+}
+
+describe('runReserveCalculation ranked-reserve seam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    enabledFlags.clear();
+    eventOrder.length = 0;
+    persistedSnapshots.length = 0;
+    isFlagEnabled.mockImplementation((key: string) => enabledFlags.has(key));
+    modeFindFirst.mockResolvedValue(undefined);
+    resolveRankedReserveCalculationMode.mockResolvedValue('off');
+    buildReservePortfolioInputWithProvenance.mockResolvedValue({
+      portfolio: LEGACY_PORTFOLIO,
+      reserveInputTrustSummary: LEGACY_TRUST_SUMMARY,
+    });
+    generateReserveSummary.mockReturnValue(LEGACY_RESERVES);
+    resolveMoicActionability.mockResolvedValue(actionabilityResult());
+    buildRankedReserveAllocation.mockResolvedValue(COMPOSED);
+    buildRankedShadowTelemetry.mockReturnValue(RANKED_TELEMETRY);
+    emitRankedShadowTelemetry.mockImplementation(() => eventOrder.push('shadow'));
+    buildReserveEnvelope.mockResolvedValue(ENVELOPE);
+    toReserveSummary.mockReturnValue(RANKED_RESERVES);
+    getFundMoicRankingSources.mockResolvedValue(MOIC_SOURCES);
+    buildFactsReserveCandidates.mockResolvedValue({
+      candidates: [
+        {
+          status: 'eligible',
+          companyId: 11,
+          input: FACTS_COMPANY,
+          factsInputHash: FACTS_INPUT_HASH,
+        },
+      ],
+      factsInputHash: FACTS_INPUT_HASH,
+      trustSummary: {
+        trustedForActivation: true,
+        defaultedInputCount: 0,
+        unavailableInputCount: 0,
+        defaultedFields: [],
+        unavailableFields: [],
+      },
+    });
+  });
+
+  it('does not read ranked mode state when the ranked flag is off', async () => {
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-flag-off' });
+
+    expect(resolveRankedReserveCalculationMode).not.toHaveBeenCalled();
+    expect(buildRankedReserveAllocation).not.toHaveBeenCalled();
+  });
+
+  it('keeps the shadow snapshot byte-identical to the flag-off snapshot', async () => {
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-parity' });
+    enableRankedMode('shadow');
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-parity' });
+
+    expect(persistedSnapshots).toHaveLength(2);
+    expect(withoutPersistenceTiming(persistedSnapshots[1] ?? {})).toEqual(
+      withoutPersistenceTiming(persistedSnapshots[0] ?? {})
+    );
+    expect(persistedSnapshots[1]?.payload).toEqual(LEGACY_RESERVES);
+    expect(persistedSnapshots[1]?.metadata).not.toHaveProperty('rankedBasis');
+  });
+
+  it('emits ranked shadow telemetry only after persistence and calc-run completion', async () => {
+    enableRankedMode('shadow');
+
+    await runReserveCalculation({
+      fundId: 7,
+      correlationId: 'corr-shadow-order',
+      runId: 91,
+    });
+
+    expect(eventOrder).toEqual(['persist', 'shadow']);
+    expect(markCalcRunCompletedIfReady).toHaveBeenCalledWith(91);
+    expect(markCalcRunCompletedIfReady.mock.invocationCallOrder[0]).toBeLessThan(
+      emitRankedShadowTelemetry.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    );
+  });
+
+  it('keeps both shadow lanes authoritative on legacy and preserves a non-zero facts delta', async () => {
+    enableFactsShadow();
+    enableRankedMode('shadow');
+    generateReserveSummary.mockImplementation((_fundId, portfolio) =>
+      portfolio[0]?.invested === FACTS_COMPANY.invested ? FACTS_RESERVES : LEGACY_RESERVES
+    );
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-both-shadow' });
+
+    expect(persistedSnapshots[0]?.payload).toEqual(LEGACY_RESERVES);
+    expect(loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ summaryValueDeltaPct: 0.25 }),
+      'reserve facts inputs shadow comparison generated'
+    );
+    expect(loggerInfo.mock.calls[0]?.[0]).not.toMatchObject({ summaryValueDeltaPct: 0 });
+  });
+
+  it('pins facts-shadow comparison to legacy while ranked on writes authority', async () => {
+    enableFactsShadow();
+    enableRankedMode('on');
+    generateReserveSummary.mockImplementation((_fundId, portfolio) =>
+      portfolio[0]?.invested === FACTS_COMPANY.invested ? FACTS_RESERVES : LEGACY_RESERVES
+    );
+    toReserveSummary.mockReturnValue(FACTS_RESERVES);
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-overlap-on' });
+
+    expect(persistedSnapshots[0]?.payload).toEqual(FACTS_RESERVES);
+    expect(loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ summaryValueDeltaPct: 0.25 }),
+      'reserve facts inputs shadow comparison generated'
+    );
+    expect(loggerInfo.mock.calls[0]?.[0]).not.toMatchObject({ summaryValueDeltaPct: 0 });
+  });
+
+  it('writes the ranked payload and aggregate rankedBasis only when the on gate passes', async () => {
+    enableRankedMode('on');
+
+    const result = await runReserveCalculation({ fundId: 7, correlationId: 'corr-on' });
+
+    expect(result.reserves).toEqual(RANKED_RESERVES);
+    expect(persistedSnapshots[0]).toMatchObject({
+      payload: RANKED_RESERVES,
+      metadata: {
+        rankedBasis: {
+          mode: 'on',
+          candidateCount: 2,
+          excludedCount: 1,
+          envelopeInputHash: ENVELOPE_INPUT_HASH,
+          factsInputHash: FACTS_INPUT_HASH,
+          assumptionsHash: ASSUMPTIONS_HASH,
+        },
+      },
+    });
+    expect(buildReserveEnvelope).toHaveBeenCalledWith({
+      fundId: 7,
+      asOfDate: expect.any(String),
+    });
+    expect(JSON.stringify(persistedSnapshots[0]?.metadata)).not.toMatch(/marginal/i);
+  });
+
+  it('keeps legacy authority when composed fail-safe is true', async () => {
+    enableRankedMode('on');
+    buildRankedReserveAllocation.mockResolvedValue({
+      ...COMPOSED,
+      allocations: [],
+      failSafe: true,
+      failSafeReason: 'engine_error',
+    });
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-failsafe' });
+
+    expect(persistedSnapshots[0]?.payload).toEqual(LEGACY_RESERVES);
+    expect(persistedSnapshots[0]?.metadata).not.toHaveProperty('rankedBasis');
+    expect(buildReserveEnvelope).not.toHaveBeenCalled();
+  });
+
+  it('keeps legacy authority for the third H9 status quarantined', async () => {
+    enableRankedMode('on');
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('quarantined'));
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-quarantined' });
+
+    expect(persistedSnapshots[0]?.payload).toEqual(LEGACY_RESERVES);
+    expect(persistedSnapshots[0]?.metadata).not.toHaveProperty('rankedBasis');
+    expect(buildReserveEnvelope).not.toHaveBeenCalled();
+  });
+
+  it('keeps legacy authority when H9 is non_actionable', async () => {
+    enableRankedMode('on');
+    resolveMoicActionability.mockResolvedValue(actionabilityResult('non_actionable'));
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-non-actionable' });
+
+    expect(persistedSnapshots[0]?.payload).toEqual(LEGACY_RESERVES);
+    expect(persistedSnapshots[0]?.metadata).not.toHaveProperty('rankedBasis');
+    expect(buildReserveEnvelope).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy and completes the run when the ranked path throws', async () => {
+    enableRankedMode('on');
+    buildRankedReserveAllocation.mockRejectedValue(new Error('ranked unavailable'));
+
+    await expect(
+      runReserveCalculation({ fundId: 7, correlationId: 'corr-ranked-throws' })
+    ).resolves.toMatchObject({ reserves: LEGACY_RESERVES });
+    expect(persistedSnapshots[0]?.payload).toEqual(LEGACY_RESERVES);
+    expect(loggerWarn).toHaveBeenCalled();
+  });
+
+  it('falls back to legacy when the mapper envelope hash diverges', async () => {
+    enableRankedMode('on');
+    buildReserveEnvelope.mockResolvedValue({ ...ENVELOPE, inputHash: 'd'.repeat(64) });
+
+    await runReserveCalculation({ fundId: 7, correlationId: 'corr-hash-divergence' });
+
+    expect(persistedSnapshots[0]?.payload).toEqual(LEGACY_RESERVES);
+    expect(persistedSnapshots[0]?.metadata).not.toHaveProperty('rankedBasis');
+    expect(toReserveSummary).not.toHaveBeenCalled();
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { fundId: 7, mode: 'on' },
+      'ranked reserve input hash diverged; using legacy reserves'
+    );
+  });
+
+  it.each([
+    ['worker', 'corr-worker', 91, 31, 4],
+    ['inline', 'corr-inline', 92, 32, 5],
+  ])(
+    'accepts the %s caller input shape',
+    async (_caller, correlationId, runId, configId, configVersion) => {
+      await runReserveCalculation({ fundId: 7, correlationId, runId, configId, configVersion });
+
+      expect(persistedSnapshots[0]).toMatchObject({
+        correlationId,
+        runId,
+        configId,
+        configVersion,
+      });
+      expect(markCalcRunCompletedIfReady).toHaveBeenCalledWith(runId);
+    }
+  );
+
+  it('keeps the worker and inline dispatch surfaces wired to the authoritative seam', async () => {
+    const [workerSource, persistenceSource] = await Promise.all([
+      readFile('workers/reserve-worker.ts', 'utf8'),
+      readFile('server/services/fund-persistence-service.ts', 'utf8'),
+    ]);
+
+    expect(workerSource).toContain(
+      "import { runReserveCalculation } from '../server/services/reserve-calculation-service'"
+    );
+    expect(workerSource).toContain('const result = await runReserveCalculation({');
+    expect(persistenceSource).toContain(
+      "import { runReserveCalculation } from './reserve-calculation-service'"
+    );
+    expect(persistenceSource).toMatch(
+      /inlineExecutionByEngine[\s\S]*reserve: runReserveCalculation/
+    );
+  });
+});

--- a/tests/unit/services/reserves/ranked-reserve-shadow-telemetry.test.ts
+++ b/tests/unit/services/reserves/ranked-reserve-shadow-telemetry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  emitRankedShadowTelemetry,
+  type RankedReserveShadowLogger,
+} from '../../../../server/services/reserves/ranked-reserve-shadow-telemetry';
+import type { RankedReserveShadowTelemetry } from '../../../../server/services/reserves/ranked-reserve-orchestrator';
+
+describe('emitRankedShadowTelemetry', () => {
+  it('emits the aggregate comparison with truncated hashes without mutating the builder output', () => {
+    const telemetry: RankedReserveShadowTelemetry = {
+      totalAllocationDeltaCents: 125,
+      rankAgreement: true,
+      excludedCountsByReason: { unavailable: 2, indicative: 1 },
+      envelopeInputHash: 'e'.repeat(64),
+      factsInputHash: 'f'.repeat(64),
+      assumptionsHash: 'a'.repeat(64),
+    };
+    const original = structuredClone(telemetry);
+    const info = vi.fn();
+
+    emitRankedShadowTelemetry({ fundId: 7, asOfDate: '2026-07-19', telemetry }, { info });
+
+    expect(info).toHaveBeenCalledOnce();
+    expect(info).toHaveBeenCalledWith(
+      {
+        fundId: 7,
+        asOfDate: '2026-07-19',
+        totalAllocationDeltaCents: 125,
+        rankAgreement: true,
+        excludedCountsByReason: { unavailable: 2, indicative: 1 },
+        envelopeInputHash: 'e'.repeat(12),
+        factsInputHash: 'f'.repeat(12),
+        assumptionsHash: 'a'.repeat(12),
+      },
+      'ranked reserve shadow comparison generated'
+    );
+    expect(telemetry).toEqual(original);
+  });
+
+  it('swallows logger failures', () => {
+    const throwingLogger: RankedReserveShadowLogger = {
+      info: () => {
+        throw new Error('logger unavailable');
+      },
+    };
+
+    expect(() =>
+      emitRankedShadowTelemetry(
+        {
+          fundId: 7,
+          asOfDate: '2026-07-19',
+          telemetry: {
+            totalAllocationDeltaCents: 0,
+            rankAgreement: false,
+            excludedCountsByReason: { unavailable: 0, indicative: 0 },
+            envelopeInputHash: 'e'.repeat(64),
+            factsInputHash: 'f'.repeat(64),
+            assumptionsHash: 'a'.repeat(64),
+          },
+        },
+        throwingLogger
+      )
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## ADR-056 NET-NEW #2, PR4 of 5 — seam wiring (shadow-first)

Wires the PR3 ranked-reserve orchestrator into `runReserveCalculation` behind PR2's flag + calc-mode resolver, **shadow-first**. Builds the `on` path but leaves it inert.

### Behavior by mode
- **flag off** (default everywhere) — zero DB reads for the ranked lane; authoritative path unchanged.
- **shadow** — computes the composed allocation alongside legacy, emits pino telemetry after persistence, and leaves the authoritative snapshot **byte-identical** to the flag-off case. Proven by a real `.toEqual` of the shadow snapshot against the flag-off snapshot.
- **on** — built but inert (flag default-false, no fund promoted). Pre-write gate on all four DD8 conditions; falls back to legacy otherwise.

### Key decisions
- **H9 gate** is a **pre-write** conditional, not a post-hoc stamp demotion: `!composed.failSafe && actionability.actionability === 'actionable'`. Positive equality is deliberate — `H9ActionabilityStatus` is 5-valued at the type level while the resolver emits 2, so a `!== 'non_actionable'` gate would be non-total. Reuses the actionability already resolved for the H9 stamp (no second call → the exact-argument H9 characterization tests stay green).
- `composed.failSafe` encodes DD8 conditions 1–3 (its `failSafeReason` union is exactly envelope-blocked / envelope-untrusted / no-actionable-candidates / engine-error), so the gate does not re-fetch the envelope.
- **Legacy binding split** (`legacyReserves`) so the pre-existing `reserve_facts_inputs_shadow` comparison stays pinned to the legacy engine's output even when a fund is simultaneously in facts-shadow mode.
- **Fail-safe to legacy** on `composed.failSafe`, on a thrown ranked path, and on an envelope `inputHash` divergence.
- **Emission tier A** (pino log only; no DB ledger — migration 0035 is unprovisioned to prod). Hashes truncated to 12 chars at emit.
- **Snapshot metadata** carries only an aggregate `rankedBasis` block (mode, candidate/excluded counts, three hashes); per-allocation detail stays in the log, matching all three existing shadow lanes.

### Not in this PR
No promotion, no migration, no flag-default change, no admin route. NET-NEW #3 surfaces, the T13 pilot, and H9 defaults untouched.

### Verification (run locally; neither calc-gate nor the reserves suites are in CI)
- `npm run check` — 0 errors
- new seam + telemetry tests 16/16; facts-inputs 7/7; h9-stamp + 3 source-text tripwires 57/57
- LP-reporting boundary characterization 17/17
- `calc-gate` — 282 + 196 + 20, pass
- fund-finalize / fund-recalculate / fund-persistence-behavior 47/47
- **all 7 gate mutations killed** with distinct assertions (incl. a ranked-`on` + facts-`shadow` fixture that discriminates the legacy-binding swap the both-`shadow` case cannot)

Companion Phase-0 records: `docs/superpowers/plans/2026-07-19-adr056-net-new-2-pr4-seam-wiring-handoff.md` and `...-adr056-pr3-phase0-verification-record.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
