### PR TITLE
feat(moic): make governed shadow soak observable

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -81,13 +81,13 @@ Humans AND Agents **Last Updated**: 2026-05-28
 
 **Status**: [ACTIVE] **Audience**: Humans + Agents
 
-| Document                                                                                                                 | Description                                                                             | When to Use                                                 |
-| ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| [tests/README.md](../tests/README.md)                                                                                    | Testing strategy (Unit, Integration, E2E)                                               | Writing tests, fixing test failures                         |
-| [cheatsheets/service-testing-patterns.md](../cheatsheets/service-testing-patterns.md)                                    | API/service test patterns, integration testing                                          | When writing integration tests                              |
-| [cheatsheets/testcontainers-guide.md](../cheatsheets/testcontainers-guide.md)                                            | Testcontainers setup and usage guide                                                    | Setting up Docker-based integration tests                   |
-| [ARCHITECTURAL-DEBT.md](ARCHITECTURAL-DEBT.md)                                                                           | Complex refactoring registry (10+ files, architectural)                                 | Documenting deferred architectural work                     |
-| [cheatsheets/pr-merge-verification.md](../cheatsheets/pr-merge-verification.md)                                          | PR verification baseline (74.7% pass rate)                                              | Before merging PRs                                          |
+| Document                                                                              | Description                                             | When to Use                               |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------- |
+| [tests/README.md](../tests/README.md)                                                 | Testing strategy (Unit, Integration, E2E)               | Writing tests, fixing test failures       |
+| [cheatsheets/service-testing-patterns.md](../cheatsheets/service-testing-patterns.md) | API/service test patterns, integration testing          | When writing integration tests            |
+| [cheatsheets/testcontainers-guide.md](../cheatsheets/testcontainers-guide.md)         | Testcontainers setup and usage guide                    | Setting up Docker-based integration tests |
+| [ARCHITECTURAL-DEBT.md](ARCHITECTURAL-DEBT.md)                                        | Complex refactoring registry (10+ files, architectural) | Documenting deferred architectural work   |
+| [cheatsheets/pr-merge-verification.md](../cheatsheets/pr-merge-verification.md)       | PR verification baseline (74.7% pass rate)              | Before merging PRs                        |
 
 **Key Commands**:
 
@@ -105,13 +105,14 @@ Hardening baseline)
 
 **Status**: [ACTIVE] **Audience**: Humans + Agents
 
-| Document                                                           | Description                                               | When to Use                                  |
-| ------------------------------------------------------------------ | --------------------------------------------------------- | -------------------------------------------- |
-| [scripts/README.md](../scripts/README.md)                          | Deployment scripts (progressive rollout, smoke tests)     | Deploying to staging/production              |
-| [workflows/PRODUCTION_SCRIPTS.md](workflows/PRODUCTION_SCRIPTS.md) | Production deployment system details                      | Understanding deployment process             |
-| [runbooks/rollback.md](runbooks/rollback.md)                       | Step-by-step rollback runbook                             | Executing or supervising production rollback |
-| [OPERATOR_RUNBOOK.md](OPERATOR_RUNBOOK.md)                         | Unified metrics diagnostic runbook                        | Investigating production metrics anomalies   |
-| [observability.md](observability.md)                               | Monitoring, health checks, metrics, and alerting overview | Understanding runtime observability surfaces |
+| Document                                                                                                   | Description                                               | When to Use                                           |
+| ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------- |
+| [scripts/README.md](../scripts/README.md)                                                                  | Deployment scripts (progressive rollout, smoke tests)     | Deploying to staging/production                       |
+| [workflows/PRODUCTION_SCRIPTS.md](workflows/PRODUCTION_SCRIPTS.md)                                         | Production deployment system details                      | Understanding deployment process                      |
+| [runbooks/rollback.md](runbooks/rollback.md)                                                               | Step-by-step rollback runbook                             | Executing or supervising production rollback          |
+| [runbooks/marginal-moic-nonproduction-shadow-soak.md](runbooks/marginal-moic-nonproduction-shadow-soak.md) | Governed marginal MOIC shadow-soak and rollback           | Preparing or running the approved non-production soak |
+| [OPERATOR_RUNBOOK.md](OPERATOR_RUNBOOK.md)                                                                 | Unified metrics diagnostic runbook                        | Investigating production metrics anomalies            |
+| [observability.md](observability.md)                                                                       | Monitoring, health checks, metrics, and alerting overview | Understanding runtime observability surfaces          |
 
 **Key Scripts**:
 

--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-07-14T00:00:00.000Z",
+  "generatedAt": "2026-07-20T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -257,11 +257,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -272,11 +272,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 197,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 109,
+      "staleDays": 115,
       "status": "ACTIVE"
     },
     {
@@ -359,11 +359,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 87,
+      "staleDays": 93,
       "status": "ACTIVE"
     },
     {
@@ -403,11 +403,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -418,11 +418,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -433,11 +433,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 87,
+      "staleDays": 93,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -490,7 +490,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -508,7 +508,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -526,7 +526,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -543,7 +543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -561,7 +561,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -579,7 +579,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -597,7 +597,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -615,7 +615,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -633,7 +633,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -651,7 +651,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -669,7 +669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -687,7 +687,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -705,7 +705,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/general-purpose.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -723,7 +723,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -741,7 +741,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -761,7 +761,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -779,7 +779,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -799,7 +799,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -821,7 +821,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -843,7 +843,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -865,7 +865,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -887,7 +887,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -909,7 +909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -931,7 +931,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -953,7 +953,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -973,7 +973,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -991,7 +991,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1011,7 +1011,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1029,7 +1029,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1047,7 +1047,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1065,7 +1065,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1083,7 +1083,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1101,7 +1101,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1122,7 +1122,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1139,7 +1139,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1161,7 +1161,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1179,7 +1179,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-rubric-v33.md",
-      "staleDays": 21,
+      "staleDays": 27,
       "status": "REFERENCE"
     },
     {
@@ -1197,7 +1197,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-synthesis-v33.md",
-      "staleDays": 21,
+      "staleDays": 27,
       "status": "REFERENCE"
     },
     {
@@ -1220,11 +1220,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1240,7 +1240,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1256,7 +1256,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1271,7 +1271,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1288,7 +1288,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1300,11 +1300,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1319,7 +1319,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1336,7 +1336,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1353,7 +1353,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 99,
+      "staleDays": 105,
       "status": "UNKNOWN"
     },
     {
@@ -1371,7 +1371,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1388,7 +1388,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1405,7 +1405,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1421,7 +1421,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1436,7 +1436,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1447,11 +1447,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1462,11 +1462,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -1482,7 +1482,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1497,7 +1497,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1512,7 +1512,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1523,11 +1523,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1538,11 +1538,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1570,7 +1570,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 197,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1586,7 +1586,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "UNKNOWN"
     },
     {
@@ -1609,11 +1609,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -1624,11 +1624,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -1639,11 +1639,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1654,11 +1654,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1669,11 +1669,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1726,7 +1726,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 197,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1740,7 +1740,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1754,7 +1754,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1768,7 +1768,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1782,7 +1782,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1796,7 +1796,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1810,7 +1810,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1824,7 +1824,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -1835,11 +1835,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1850,11 +1850,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1865,11 +1865,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -1880,11 +1880,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1895,11 +1895,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1910,11 +1910,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1925,11 +1925,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1940,11 +1940,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1955,11 +1955,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -1978,7 +1978,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ready"
     },
     {
@@ -1997,7 +1997,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ready"
     },
     {
@@ -2016,7 +2016,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ready"
     },
     {
@@ -2027,11 +2027,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2042,11 +2042,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2081,11 +2081,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -2096,11 +2096,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -2111,11 +2111,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2141,7 +2141,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 54,
+      "staleDays": 60,
       "status": "UNKNOWN"
     },
     {
@@ -2152,11 +2152,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2179,11 +2179,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2194,11 +2194,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2209,11 +2209,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2224,11 +2224,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2244,7 +2244,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2260,7 +2260,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2271,11 +2271,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2286,11 +2286,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2301,11 +2301,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2316,11 +2316,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2336,7 +2336,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -2347,11 +2347,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2362,11 +2362,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2377,11 +2377,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2397,7 +2397,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2408,11 +2408,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2423,11 +2423,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2438,11 +2438,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2456,7 +2456,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2467,11 +2467,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2487,7 +2487,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2503,7 +2503,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2519,7 +2519,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2535,7 +2535,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2551,7 +2551,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2567,7 +2567,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2583,7 +2583,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2599,7 +2599,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2610,11 +2610,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2630,7 +2630,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2641,11 +2641,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2656,11 +2656,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2671,11 +2671,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2691,7 +2691,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2707,7 +2707,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2718,11 +2718,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2740,7 +2740,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2751,11 +2751,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2766,11 +2766,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2781,11 +2781,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2796,11 +2796,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2816,7 +2816,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -2827,11 +2827,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2842,11 +2842,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2861,7 +2861,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -2872,11 +2872,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2887,11 +2887,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2902,11 +2902,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2917,11 +2917,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2932,11 +2932,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2947,11 +2947,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2966,7 +2966,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "ACTIVE"
     },
     {
@@ -2977,11 +2977,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -2992,11 +2992,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3032,7 +3032,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 109,
+      "staleDays": 115,
       "status": "ACTIVE"
     },
     {
@@ -3049,7 +3049,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "ACTIVE"
     },
     {
@@ -3064,7 +3064,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "ACTIVE"
     },
     {
@@ -3075,11 +3075,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3090,11 +3090,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3123,7 +3123,7 @@
       "lastUpdated": "2026-07-13",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 1,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -3138,7 +3138,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "DESIGN.md",
-      "staleDays": 41,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -3149,11 +3149,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3168,7 +3168,7 @@
       "lastUpdated": "2026-07-14",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 0,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -3191,11 +3191,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3206,11 +3206,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3221,11 +3221,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3236,11 +3236,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3251,11 +3251,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3266,11 +3266,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3285,7 +3285,7 @@
       "lastUpdated": "2026-07-11",
       "owner": null,
       "path": "README.md",
-      "staleDays": 3,
+      "staleDays": 9,
       "status": "ACTIVE"
     },
     {
@@ -3300,7 +3300,7 @@
       "lastUpdated": "2026-07-12",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 2,
+      "staleDays": 8,
       "status": "ACTIVE"
     },
     {
@@ -3311,12 +3311,24 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "TODOS.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
     },
     {
       "docType": "doc",
@@ -3326,11 +3338,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3347,7 +3359,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 109,
+      "staleDays": 115,
       "status": "ACTIVE"
     },
     {
@@ -3362,7 +3374,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3377,7 +3389,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -3392,7 +3404,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3407,7 +3419,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3422,7 +3434,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3437,7 +3449,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3452,7 +3464,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -3467,7 +3479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3482,7 +3494,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3497,7 +3509,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -3512,7 +3524,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3527,7 +3539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3542,7 +3554,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3557,7 +3569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3572,7 +3584,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -3587,7 +3599,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3602,7 +3614,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -3617,7 +3629,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3632,7 +3644,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3647,7 +3659,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3662,7 +3674,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -3677,7 +3689,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3692,7 +3704,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3707,7 +3719,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3722,7 +3734,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3738,7 +3750,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "active"
     },
     {
@@ -3753,7 +3765,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3768,7 +3780,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3783,7 +3795,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3798,7 +3810,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3813,7 +3825,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 99,
+      "staleDays": 105,
       "status": "ACTIVE"
     },
     {
@@ -3828,7 +3840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3843,7 +3855,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -3858,7 +3870,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3873,7 +3885,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -3888,7 +3900,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3903,7 +3915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3918,7 +3930,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3933,7 +3945,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3948,7 +3960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3963,7 +3975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3974,11 +3986,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -3989,11 +4001,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4004,11 +4016,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4023,7 +4035,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 41,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -4038,7 +4050,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -4053,7 +4065,7 @@
       "lastUpdated": "2026-07-12",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 2,
+      "staleDays": 8,
       "status": "ACTIVE"
     },
     {
@@ -4064,11 +4076,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4091,11 +4103,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4106,11 +4118,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4121,11 +4133,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4148,11 +4160,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4163,11 +4175,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4178,11 +4190,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4193,11 +4205,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4236,7 +4248,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 87,
+      "staleDays": 93,
       "status": "ACTIVE"
     },
     {
@@ -4247,11 +4259,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4262,11 +4274,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4277,11 +4289,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4317,7 +4329,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 47,
+      "staleDays": 53,
       "status": "ACTIVE"
     },
     {
@@ -4332,7 +4344,7 @@
       "lastUpdated": "2026-07-01",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 13,
+      "staleDays": 19,
       "status": "HISTORICAL"
     },
     {
@@ -4347,7 +4359,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 85,
+      "staleDays": 91,
       "status": "HISTORICAL"
     },
     {
@@ -4358,11 +4370,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4373,11 +4385,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4388,11 +4400,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4407,7 +4419,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -4418,11 +4430,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4433,11 +4445,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4448,11 +4460,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4463,11 +4475,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4478,11 +4490,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4493,11 +4505,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4538,7 +4550,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -4553,7 +4565,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4568,7 +4580,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4583,7 +4595,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 100,
+      "staleDays": 106,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4598,7 +4610,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4613,7 +4625,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4628,7 +4640,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4643,7 +4655,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4657,7 +4669,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -4672,7 +4684,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4683,11 +4695,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4698,11 +4710,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4713,11 +4725,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4728,11 +4740,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -4743,11 +4755,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4758,11 +4770,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4773,11 +4785,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4788,11 +4800,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4803,11 +4815,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4818,11 +4830,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4833,11 +4845,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4848,11 +4860,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4881,7 +4893,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -4892,11 +4904,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4907,11 +4919,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4922,11 +4934,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4937,11 +4949,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4952,11 +4964,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4967,11 +4979,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -4982,11 +4994,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -4997,11 +5009,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5012,11 +5024,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5027,11 +5039,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5042,11 +5054,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5057,11 +5069,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5076,7 +5088,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -5087,11 +5099,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5102,11 +5114,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5117,11 +5129,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5132,11 +5144,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5151,7 +5163,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 67,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -5166,7 +5178,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 67,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -5181,7 +5193,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -5196,7 +5208,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 53,
+      "staleDays": 59,
       "status": "ACTIVE"
     },
     {
@@ -5207,11 +5219,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5222,11 +5234,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5237,11 +5249,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5252,11 +5264,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5282,7 +5294,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -5297,7 +5309,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "Implemented"
     },
     {
@@ -5312,7 +5324,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/adr/ADR-023-investment-event-persistence.md",
-      "staleDays": 23,
+      "staleDays": 29,
       "status": "ACCEPTED (amended 2026-06-21)"
     },
     {
@@ -5339,7 +5351,7 @@
       "lastUpdated": "2026-07-10",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 4,
+      "staleDays": 10,
       "status": "ACTIVE"
     },
     {
@@ -5350,11 +5362,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5401,11 +5413,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5420,7 +5432,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 119,
+      "staleDays": 125,
       "status": "ARCHIVED"
     },
     {
@@ -5431,11 +5443,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5446,11 +5458,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5465,7 +5477,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -5480,7 +5492,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 48,
+      "staleDays": 54,
       "status": "HISTORICAL"
     },
     {
@@ -5495,7 +5507,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 48,
+      "staleDays": 54,
       "status": "HISTORICAL"
     },
     {
@@ -5506,11 +5518,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5521,11 +5533,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5536,11 +5548,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5551,11 +5563,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5566,11 +5578,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5581,11 +5593,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5596,11 +5608,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5611,11 +5623,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5626,11 +5638,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5641,11 +5653,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5656,11 +5668,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5671,11 +5683,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5686,11 +5698,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5701,11 +5713,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5716,11 +5728,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5731,11 +5743,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5746,11 +5758,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5765,7 +5777,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 106,
+      "staleDays": 112,
       "status": "ACTIVE"
     },
     {
@@ -5776,11 +5788,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5791,11 +5803,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5809,7 +5821,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -5823,7 +5835,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -5834,11 +5846,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -5849,11 +5861,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5864,11 +5876,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5879,11 +5891,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5894,11 +5906,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5909,11 +5921,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5924,11 +5936,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5939,11 +5951,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5954,11 +5966,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5969,11 +5981,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5984,11 +5996,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -5999,11 +6011,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6014,11 +6026,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6029,11 +6041,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6044,11 +6056,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6059,11 +6071,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6074,11 +6086,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -6089,11 +6101,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6104,11 +6116,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6150,7 +6162,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 42,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -6198,7 +6210,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 42,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -6243,7 +6255,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 41,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -6276,7 +6288,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-22-entity-access-boundary.md",
-      "staleDays": 22,
+      "staleDays": 28,
       "status": "ACTIVE"
     },
     {
@@ -6309,7 +6321,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-entity-access-boundary.md",
-      "staleDays": 21,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -6342,7 +6354,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-trust-audit.md",
-      "staleDays": 21,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -6373,7 +6385,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/client-derived-math-inventory.md",
-      "staleDays": 21,
+      "staleDays": 27,
       "status": "ACTIVE"
     },
     {
@@ -6404,7 +6416,7 @@
       "lastUpdated": "2026-06-15",
       "owner": "Platform Team",
       "path": "docs/design/audits/server-object-readiness.md",
-      "staleDays": 29,
+      "staleDays": 35,
       "status": "ACTIVE"
     },
     {
@@ -6443,7 +6455,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 87,
+      "staleDays": 93,
       "status": "ACTIVE"
     },
     {
@@ -6459,7 +6471,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -6470,11 +6482,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6485,11 +6497,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6500,11 +6512,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6515,11 +6527,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6533,7 +6545,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -6544,11 +6556,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6559,11 +6571,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6574,11 +6586,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6589,11 +6601,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6607,7 +6619,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -6618,11 +6630,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6637,7 +6649,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -6648,11 +6660,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6663,11 +6675,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6678,11 +6690,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6693,11 +6705,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6708,11 +6720,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6723,11 +6735,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6738,11 +6750,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6753,11 +6765,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6768,11 +6780,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -6783,11 +6795,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6820,7 +6832,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 47,
+      "staleDays": 53,
       "status": "ACTIVE"
     },
     {
@@ -6831,11 +6843,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6868,7 +6880,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 47,
+      "staleDays": 53,
       "status": "ACTIVE"
     },
     {
@@ -6879,11 +6891,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6894,11 +6906,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6909,11 +6921,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6928,7 +6940,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 85,
+      "staleDays": 91,
       "status": "HISTORICAL"
     },
     {
@@ -6943,7 +6955,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 58,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -6954,11 +6966,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6969,11 +6981,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6984,11 +6996,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -6999,11 +7011,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7014,11 +7026,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7029,11 +7041,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7044,11 +7056,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7059,11 +7071,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7074,11 +7086,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7089,11 +7101,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7104,11 +7116,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7119,11 +7131,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7134,11 +7146,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -7149,11 +7161,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7164,11 +7176,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7179,11 +7191,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7194,11 +7206,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7209,11 +7221,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7224,11 +7236,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -7239,11 +7251,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7254,11 +7266,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7269,11 +7281,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7294,7 +7306,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "active"
     },
     {
@@ -7308,7 +7320,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -7319,11 +7331,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7334,11 +7346,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7353,7 +7365,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7368,7 +7380,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7383,7 +7395,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7398,7 +7410,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7413,7 +7425,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7428,7 +7440,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7443,7 +7455,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7458,7 +7470,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -7473,7 +7485,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -7488,7 +7500,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -7503,7 +7515,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -7518,7 +7530,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7533,7 +7545,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7548,7 +7560,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7563,7 +7575,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7578,7 +7590,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7593,7 +7605,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7608,7 +7620,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7623,7 +7635,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7638,7 +7650,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7653,7 +7665,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7664,11 +7676,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7679,11 +7691,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7698,7 +7710,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7709,11 +7721,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7724,11 +7736,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7739,11 +7751,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7754,11 +7766,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7769,11 +7781,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7784,11 +7796,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7799,11 +7811,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7837,7 +7849,7 @@
       "lastUpdated": "2026-06-16",
       "owner": "Platform Team",
       "path": "docs/parity/convention-matrix.md",
-      "staleDays": 28,
+      "staleDays": 34,
       "status": "ACTIVE"
     },
     {
@@ -7848,11 +7860,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7863,11 +7875,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7883,7 +7895,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 100,
+      "staleDays": 106,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -7894,11 +7906,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7909,11 +7921,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7924,11 +7936,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7939,11 +7951,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7954,11 +7966,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7981,11 +7993,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -7996,11 +8008,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8015,7 +8027,7 @@
       "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 22,
+      "staleDays": 28,
       "status": "ACTIVE"
     },
     {
@@ -8032,7 +8044,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 98,
+      "staleDays": 104,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -8047,7 +8059,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 58,
+      "staleDays": 64,
       "status": "BACKLOG"
     },
     {
@@ -8061,7 +8073,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -8078,7 +8090,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 44,
+      "staleDays": 50,
       "status": "ACTIVE"
     },
     {
@@ -8098,7 +8110,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 42,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -8127,7 +8139,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-13-gp-trust-readiness-register.md",
-      "staleDays": 31,
+      "staleDays": 37,
       "status": "ACTIVE"
     },
     {
@@ -8161,7 +8173,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/plans/2026-06-22-current-state-steelman-roadmap.md",
-      "staleDays": 22,
+      "staleDays": 28,
       "status": "DRAFT"
     },
     {
@@ -8198,7 +8210,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -8213,7 +8225,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -8224,11 +8236,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8243,7 +8255,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -8254,11 +8266,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8269,11 +8281,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8284,11 +8296,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8299,11 +8311,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8314,11 +8326,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8329,11 +8341,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8344,11 +8356,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8359,11 +8371,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8374,11 +8386,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8389,11 +8401,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8404,11 +8416,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8419,11 +8431,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8434,11 +8446,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8449,11 +8461,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8464,11 +8476,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8479,11 +8491,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8498,7 +8510,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 54,
+      "staleDays": 60,
       "status": "ACTIVE"
     },
     {
@@ -8509,11 +8521,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8527,7 +8539,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -8550,11 +8562,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8569,7 +8581,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -8580,11 +8592,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8595,11 +8607,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8610,11 +8622,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8625,11 +8637,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8640,11 +8652,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8655,11 +8667,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8674,7 +8686,7 @@
       "lastUpdated": "2026-06-12",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 32,
+      "staleDays": 38,
       "status": "PROVEN"
     },
     {
@@ -8685,11 +8697,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8700,11 +8712,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8715,11 +8727,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8730,11 +8742,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8745,11 +8757,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8760,11 +8772,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8775,11 +8787,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8790,11 +8802,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8805,11 +8817,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8820,11 +8832,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -8859,7 +8871,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "COMPLETED"
     },
     {
@@ -8890,7 +8902,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "REFERENCE"
     },
     {
@@ -8921,7 +8933,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "REFERENCE"
     },
     {
@@ -8952,7 +8964,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "REFERENCE"
     },
     {
@@ -8985,7 +8997,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "REFERENCE"
     },
     {
@@ -9016,7 +9028,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 53,
+      "staleDays": 59,
       "status": "REFERENCE"
     },
     {
@@ -9048,7 +9060,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "REFERENCE"
     },
     {
@@ -9063,7 +9075,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "ACTIVE"
     },
     {
@@ -9074,11 +9086,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9089,11 +9101,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9104,11 +9116,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9119,11 +9131,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9134,11 +9146,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9166,7 +9178,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 106,
+      "staleDays": 112,
       "status": "ACTIVE"
     },
     {
@@ -9203,8 +9215,20 @@
       "lastUpdated": "2026-06-28",
       "owner": "gp-team",
       "path": "docs/runbooks/investment-rounds-enablement.md",
-      "staleDays": 16,
+      "staleDays": 22,
       "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/runbooks/marginal-moic-nonproduction-shadow-soak.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
     },
     {
       "docType": "doc",
@@ -9214,11 +9238,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9229,11 +9253,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9244,11 +9268,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9259,11 +9283,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9274,11 +9298,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9289,11 +9313,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9304,11 +9328,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9319,11 +9343,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9334,11 +9358,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9353,7 +9377,7 @@
       "lastUpdated": "2026-07-05",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 9,
+      "staleDays": 15,
       "status": "ACTIVE"
     },
     {
@@ -9364,11 +9388,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9379,11 +9403,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9394,11 +9418,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9409,11 +9433,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9424,11 +9448,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9439,11 +9463,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9457,7 +9481,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -9471,7 +9495,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -9485,7 +9509,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -9499,7 +9523,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "UNKNOWN"
     },
     {
@@ -9513,7 +9537,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -9527,7 +9551,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "UNKNOWN"
     },
     {
@@ -9538,11 +9562,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9553,11 +9577,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9568,11 +9592,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -9613,7 +9637,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "VERIFIED"
     },
     {
@@ -9961,7 +9985,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "DRAFT"
     },
     {
@@ -10159,7 +10183,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10241,7 +10265,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "VERIFIED"
     },
     {
@@ -10314,7 +10338,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "DRAFT"
     },
     {
@@ -10358,7 +10382,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "DRAFT"
     },
     {
@@ -10488,7 +10512,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "DRAFT"
     },
     {
@@ -10535,7 +10559,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "DRAFT"
     },
     {
@@ -10577,7 +10601,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 102,
+      "staleDays": 108,
       "status": "DRAFT"
     },
     {
@@ -10726,7 +10750,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10752,7 +10776,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10783,7 +10807,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10812,7 +10836,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10841,7 +10865,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10871,7 +10895,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10901,7 +10925,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10931,7 +10955,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 64,
+      "staleDays": 70,
       "status": "DRAFT"
     },
     {
@@ -10964,7 +10988,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 87,
+      "staleDays": 93,
       "status": "DRAFT"
     },
     {
@@ -10992,7 +11016,7 @@
         "severity": "high",
         "status": "VERIFIED",
         "superseded_by": null,
-        "test_file": null,
+        "test_file": "tests/regressions/REFL-039.test.ts",
         "title": "Transport failure must not invert model roles",
         "type": "reflection",
         "version": 1,
@@ -11064,11 +11088,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11079,11 +11103,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11094,11 +11118,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11125,7 +11149,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -11153,7 +11177,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -11182,7 +11206,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -11210,7 +11234,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -11238,7 +11262,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "ACTIVE"
     },
     {
@@ -11265,7 +11289,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 46,
+      "staleDays": 52,
       "status": "COMPLETE"
     },
     {
@@ -11306,7 +11330,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 37,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -11323,7 +11347,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 31,
+      "staleDays": 37,
       "status": "COMPLETE"
     },
     {
@@ -11352,7 +11376,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 36,
+      "staleDays": 42,
       "status": "ACTIVE"
     },
     {
@@ -11381,7 +11405,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 35,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -11449,7 +11473,7 @@
       "lastUpdated": "2026-06-21",
       "owner": "Core Team",
       "path": "docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md",
-      "staleDays": 23,
+      "staleDays": 29,
       "status": "DRAFT"
     },
     {
@@ -11503,7 +11527,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.3.md",
-      "staleDays": 21,
+      "staleDays": 27,
       "status": "HISTORICAL"
     },
     {
@@ -11521,7 +11545,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.4.md",
-      "staleDays": 21,
+      "staleDays": 27,
       "status": "DRAFT"
     },
     {
@@ -11590,7 +11614,7 @@
       "lastUpdated": "2026-06-28",
       "owner": "gp-team",
       "path": "docs/superpowers/plans/2026-06-28-investment-rounds-soak.md",
-      "staleDays": 16,
+      "staleDays": 22,
       "status": "ACTIVE"
     },
     {
@@ -11715,7 +11739,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 31,
+      "staleDays": 37,
       "status": "COMPLETE"
     },
     {
@@ -11744,7 +11768,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 36,
+      "staleDays": 42,
       "status": "ACTIVE"
     },
     {
@@ -11773,7 +11797,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 35,
+      "staleDays": 41,
       "status": "ACTIVE"
     },
     {
@@ -11820,7 +11844,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/superpowers/specs/2026-06-13-gp-trust-readiness-audit-design.md",
-      "staleDays": 31,
+      "staleDays": 37,
       "status": "ACTIVE"
     },
     {
@@ -11837,7 +11861,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md",
-      "staleDays": 23,
+      "staleDays": 29,
       "status": "DRAFT (red-team hardened 2026-06-21)"
     },
     {
@@ -11905,7 +11929,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 55,
+      "staleDays": 61,
       "status": "ACTIVE"
     },
     {
@@ -11916,11 +11940,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11931,11 +11955,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11946,11 +11970,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11961,11 +11985,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -11988,11 +12012,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12003,11 +12027,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12018,11 +12042,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12033,11 +12057,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12048,11 +12072,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12063,11 +12087,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12078,11 +12102,11 @@
         "status": "HISTORICAL"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "HISTORICAL"
     },
     {
@@ -12093,11 +12117,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12108,11 +12132,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12123,11 +12147,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12138,11 +12162,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12153,11 +12177,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12168,11 +12192,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12183,11 +12207,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12198,11 +12222,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12217,7 +12241,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 47,
+      "staleDays": 53,
       "status": "ACTIVE"
     },
     {
@@ -12263,7 +12287,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 197,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12274,11 +12298,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     },
     {
@@ -12289,15 +12313,15 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": false,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 176,
+      "staleDays": 182,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-07-14T00:00:00.000Z",
+  "generatedAt": "2026-07-20T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -13479,14 +13503,14 @@
       "REFERENCE": 8,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 135,
+      "UNKNOWN": 137,
       "VERIFIED": 10,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 40,
-    "stale_docs": 136,
-    "total_docs": 683
+    "missing_frontmatter": 42,
+    "stale_docs": 459,
+    "total_docs": 685
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,26 +1,26 @@
 ---
-last_updated: 2026-07-14
+last_updated: 2026-07-20
 ---
 
 # Staleness Report
 
-*Generated: 2026-07-14T00:00:00.000Z*
+*Generated: 2026-07-20T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 683 |
-| Stale Documents | 136 |
-| Missing Frontmatter | 40 |
+| Total Documents | 685 |
+| Stale Documents | 459 |
+| Missing Frontmatter | 42 |
 
 ### By Status
 
 | Status | Count |
 |--------|-------|
 | ACTIVE | 450 |
-| UNKNOWN | 135 |
+| UNKNOWN | 137 |
 | DRAFT | 34 |
 | HISTORICAL | 22 |
 | VERIFIED | 10 |
@@ -49,6 +49,7 @@ Documents that need review (older than their cadence threshold):
 | `.claude/artifacts/prC-storage-fund-investigation.md` | Never | 999 | No | Unassigned |
 | `CONTEXT.md` | Never | 999 | No | Unassigned |
 | `DIRECTORY_DELETION_INVESTIGATION.md` | Never | 999 | No | Unassigned |
+| `TODOS.md` | Never | 999 | No | Unassigned |
 | `docs/CA-PACING-ORACLE.md` | Never | 999 | No | Unassigned |
 | `docs/CRITICAL-REVIEW-secondary-surface-governance.md` | Never | 999 | No | Unassigned |
 | `docs/adr/ADR-020-analysis-cohort-boundary.md` | Never | 999 | No | Unassigned |
@@ -60,6 +61,7 @@ Documents that need review (older than their cadence threshold):
 | `docs/design/updog-design-philosophy-v3.1.1-implementation-notes.md` | Never | 999 | No | Unassigned |
 | `docs/phase2-calibration-benchmarks.md` | Never | 999 | No | Unassigned |
 | `docs/quarantine/2026-05-28-stabilization-triage.md` | Never | 999 | No | Unassigned |
+| `docs/runbooks/marginal-moic-nonproduction-shadow-soak.md` | Never | 999 | No | Unassigned |
 | `docs/skills/REFL-002-post-merge-jobs-not-validated-by-pr-ci.md` | Never | 999 | No | Unassigned |
 | `docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md` | Never | 999 | YES - verify! | Unassigned |
 | `docs/skills/REFL-004-schema-format-backward-compatibility.md` | Never | 999 | No | Unassigned |
@@ -94,31 +96,105 @@ Documents that need review (older than their cadence threshold):
 | `docs/superpowers/plans/2026-06-23-financial-actionability-p0.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/plans/2026-06-23-part-b-investment-rounds-ramp.md` | Never | 999 | No | Unassigned |
 | `docs/superpowers/plans/2026-06-24-pr-d-provenance-envelope-rounds-evidence.md` | Never | 999 | No | Unassigned |
-| `docs/superpowers/plans/2026-06-24-pr-e-moic-shadow-recording-canonical-route.md` | Never | 999 | No | Unassigned |
-| `docs/superpowers/plans/2026-06-25-h9-pr3-lp-package-export-revalidation.md` | Never | 999 | No | Unassigned |
 
-*...and 86 more stale documents.*
+*...and 409 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **.claude/plan.md** (197 days old)
-- [ ] **CHANGELOG.md** (55 days old)
-- [ ] **cheatsheets/daily-workflow.md** (102 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (176 days old)
-- [ ] **cheatsheets/pr-merge-verification.md** (99 days old)
-- [ ] **cheatsheets/schema-alignment.md** (176 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (176 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (176 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (176 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (176 days old)
+- [ ] **.claude/commands/retrospective.md** (182 days old)
+- [ ] **.claude/commands/session-learnings.md** (182 days old)
+- [ ] **.claude/commands/wshobson/deps-audit.md** (182 days old)
+- [ ] **.claude/integration-test-execution-summary.md** (182 days old)
+- [ ] **.claude/integration-test-final-report.md** (182 days old)
+- [ ] **.claude/integration-test-reenable-plan-v2.md** (182 days old)
+- [ ] **.claude/plan.md** (203 days old)
+- [ ] **.claude/prompts/integration-test-continuation-prompt.md** (182 days old)
+- [ ] **.claude/prompts/portfolio-intelligence-timeout-fix.md** (182 days old)
+- [ ] **.claude/prompts/week2.5-next-session-kickoff.md** (182 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v10.md** (182 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v2.md** (182 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v3.md** (182 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation.md** (182 days old)
+- [ ] **.claude/prompts/week2.5-phase4-next-steps.md** (182 days old)
+- [ ] **.claude/session-summary-portfolio-intelligence-implementation.md** (182 days old)
+- [ ] **.claude/sessions/PHASE4-CONTINUATION-KICKOFF.md** (182 days old)
+- [ ] **.claude/skills/README.md** (182 days old)
+- [ ] **.claude/skills/iterative-improvement.md** (182 days old)
+- [ ] **.claude/skills/task-decomposition.md** (182 days old)
+- [ ] **.claude/testing/rubric-calculation-engines.md** (182 days old)
+- [ ] **.claude/testing/scenario-comparison-manual-test-rubric.md** (182 days old)
+- [ ] **.claude/testing/seed-script-remaining-fixes.md** (182 days old)
+- [ ] **ANTI_PATTERNS.md** (182 days old)
+- [ ] **CHANGELOG.md** (61 days old)
+- [ ] **COMPREHENSIVE-WORKFLOW-GUIDE.md** (182 days old)
+- [ ] **ITERATION-A-QUICKSTART.md** (182 days old)
+- [ ] **MIGRATION-NATIVE-MEMORY.md** (182 days old)
+- [ ] **PRODUCTION_RUNBOOK.md** (182 days old)
+- [ ] **PROMPT_PATTERNS.md** (182 days old)
+- [ ] **cheatsheets/daily-workflow.md** (108 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (182 days old)
+- [ ] **cheatsheets/pr-merge-verification.md** (105 days old)
+- [ ] **cheatsheets/schema-alignment.md** (182 days old)
+- [ ] **docs/CA-IMPLEMENTATION-PLAN.md** (182 days old)
+- [ ] **docs/CA-SEMANTIC-LOCK.md** (182 days old)
+- [ ] **docs/DECISIONS.md** (182 days old)
+- [ ] **docs/DEPLOYMENT.md** (182 days old)
+- [ ] **docs/DEVELOPMENT_STRATEGY.md** (182 days old)
+- [ ] **docs/MILESTONE-XIRR-PHASE0-COMPLETE.md** (182 days old)
+- [ ] **docs/PRODUCTION_CHECKLIST.md** (182 days old)
+- [ ] **docs/RATE_LIMITING_SUMMARY.md** (182 days old)
+- [ ] **docs/SCENARIO_DEPLOY_GUIDE.md** (182 days old)
+- [ ] **docs/VERIFICATION_CHECKLIST.md** (182 days old)
+- [ ] **docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md** (182 days old)
+- [ ] **docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md** (182 days old)
+- [ ] **docs/adr/ADR-004-waterfall-names.md** (182 days old)
+- [ ] **docs/adr/ADR-008-capital-allocation-policy.md** (182 days old)
+- [ ] **docs/agent-2-mobile-executive-dashboard.md** (182 days old)
+- [ ] **docs/api/architecture/portfolio-route-api.md** (182 days old)
+- [ ] **docs/api/testing/portfolio-route-test-strategy.md** (182 days old)
+- [ ] **docs/behavioral-specs/time-travel-analytics-service-specs.md** (182 days old)
+- [ ] **docs/chaos-engineering/README.md** (182 days old)
+- [ ] **docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md** (182 days old)
+- [ ] **docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md** (182 days old)
+- [ ] **docs/deployment/ROLLBACK_PLAN.md** (182 days old)
+- [ ] **docs/deployment/STAGING_CHECKLIST.md** (182 days old)
+- [ ] **docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md** (182 days old)
+- [ ] **docs/deployment/STAGING_METRICS.md** (182 days old)
+- [ ] **docs/failure-triage.md** (182 days old)
+- [ ] **docs/forecasting/power-law-implementation.md** (182 days old)
+- [ ] **docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md** (182 days old)
+- [ ] **docs/foundation/PHASE2-ROADMAP.md** (182 days old)
+- [ ] **docs/foundation/PHASE3-KICKOFF.md** (182 days old)
+- [ ] **docs/foundation/PHASE4-KICKOFF.md** (182 days old)
+- [ ] **docs/integration/upstash-setup.md** (182 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (182 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (182 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (182 days old)
+- [ ] **docs/npm-bin-resolution-investigation.md** (182 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (182 days old)
+- [ ] **docs/observability/README.md** (182 days old)
+- [ ] **docs/phase0-xirr-analysis-eda20590.md** (182 days old)
+- [ ] **docs/phase1-1-1-analysis.md** (182 days old)
+- [ ] **docs/phase1-xirr-baseline-heatmap.md** (182 days old)
+- [ ] **docs/phase1b-waterfall-evaluator-hardening.md** (182 days old)
+- [ ] **docs/processes/CONTRIBUTING.md** (182 days old)
+- [ ] **docs/processes/code-review-checklist.md** (182 days old)
+- [ ] **docs/references/claude-agent-testing.md** (182 days old)
+- [ ] **docs/references/replit.md** (182 days old)
+- [ ] **docs/releases/stage-norm-phase5.md** (182 days old)
+- [ ] **docs/releases/stage-normalization-v3.4.md** (182 days old)
+- [ ] **docs/replit.md** (182 days old)
+- [ ] **docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md** (182 days old)
+- [ ] **docs/skills-application-log.md** (182 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)
 - [ ] **docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md** (999 days old)
 - [ ] **docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md** (999 days old)
-- [ ] **docs/xirr-consolidation-roadmap.md** (197 days old)
+- [ ] **docs/xirr-consolidation-roadmap.md** (203 days old)
+- [ ] **docs/xirr-excel-validation.md** (182 days old)
 
 ## Missing Frontmatter
 
@@ -127,6 +203,7 @@ Documents without proper YAML frontmatter:
 - [ ] `.claude/artifacts/prC-storage-fund-investigation.md`
 - [ ] `CONTEXT.md`
 - [ ] `DIRECTORY_DELETION_INVESTIGATION.md`
+- [ ] `TODOS.md`
 - [ ] `docs/CA-PACING-ORACLE.md`
 - [ ] `docs/CRITICAL-REVIEW-secondary-surface-governance.md`
 - [ ] `docs/adr/ADR-020-analysis-cohort-boundary.md`
@@ -138,6 +215,7 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/design/updog-design-philosophy-v3.1.1-implementation-notes.md`
 - [ ] `docs/phase2-calibration-benchmarks.md`
 - [ ] `docs/quarantine/2026-05-28-stabilization-triage.md`
+- [ ] `docs/runbooks/marginal-moic-nonproduction-shadow-soak.md`
 - [ ] `docs/skills/SKILLS_INDEX.md`
 - [ ] `docs/skills/WIZARD_INDEX.md`
 - [ ] `docs/superpowers/plans/2026-05-19-ca-period-truth-harness-remediation.md`

--- a/docs/runbooks/marginal-moic-nonproduction-shadow-soak.md
+++ b/docs/runbooks/marginal-moic-nonproduction-shadow-soak.md
@@ -1,0 +1,413 @@
+# Marginal MOIC Non-Production Shadow-Soak Runbook
+
+- Status: BLOCKED pending provider-native runtime and database identity proof
+- Production use: forbidden
+- Permitted mode: shadow only
+- Evidence classification: NON-PRODUCTION SOAK EVIDENCE ONLY
+
+This runbook may be executed only after the ADR-056 closeout and
+shadow-observability PRs are merged and a separate approval names the provider
+project, environment, deployment, backing database, deployed SHA, admin actor,
+pilot fund, configuration owner, rollback owner, UTC window, approved dates, log
+queries, and evidence store.
+
+URL inequality and `/healthz` are necessary but insufficient target proof. The
+secure approval record must include provider-native command or API output
+proving both the runtime and backing database are non-production. The
+identity-read mechanism is already known in this repository:
+`vercel inspect <deployment-alias>` for the runtime deployment, `railway status`
+with explicit `-p`/`-e`/`-s` for the worker environment, and the Neon
+project/branch ID for the backing database. Only the concrete soak-target and
+production reference IDs are deferred: they come from the Task 10 approval
+record and the secure prod-verification store and are never inlined into this
+repository. Absence of those captured IDs is a hard stop, not permission to
+infer them.
+
+Approval of this runbook's PR does not authorize a feature-flag change,
+reconciliation write, mode-row mutation, production action, on-mode transition,
+or release claim.
+
+## Required inputs
+
+Values come from the secure approval record or approved secret manager and must
+never be printed into a repository, issue, PR, or shared terminal transcript.
+
+```powershell
+$requiredNames = @(
+  'MOIC_SOAK_ENVIRONMENT',
+  'MOIC_SOAK_BASE_URL',
+  'MOIC_SOAK_EXPECTED_SHA',
+  'MOIC_SOAK_OBSERVABILITY_MERGE_SHA',
+  'MOIC_SOAK_PROVIDER_PROJECT_ID',
+  'MOIC_SOAK_PROVIDER_ENVIRONMENT_ID',
+  'MOIC_SOAK_PROVIDER_DEPLOYMENT_ID',
+  'MOIC_SOAK_DATABASE_ID',
+  'PRODUCTION_ORIGIN',
+  'PRODUCTION_PROVIDER_ENVIRONMENT_ID',
+  'PRODUCTION_PROVIDER_DEPLOYMENT_ID',
+  'PRODUCTION_DATABASE_ID',
+  'MOIC_SOAK_FUND_ID',
+  'MOIC_SOAK_AS_OF_DATES',
+  'MOIC_SOAK_CHECKPOINT_INDEX',
+  'MOIC_SOAK_USERNAME',
+  'MOIC_SOAK_PASSWORD',
+  'MOIC_SOAK_EVIDENCE_SALT'
+)
+$missing = $requiredNames | Where-Object {
+  [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+}
+if ($missing.Count -gt 0) {
+  throw "Missing required environment variables: $($missing -join ', ')"
+}
+```
+
+## Step 1: Target and ancestry preflight
+
+```powershell
+$environment = $env:MOIC_SOAK_ENVIRONMENT.Trim().ToLowerInvariant()
+if ($environment -notin @('local', 'staging')) {
+  throw 'MOIC_SOAK_ENVIRONMENT must be local or staging'
+}
+$baseUri = [Uri]$env:MOIC_SOAK_BASE_URL
+$productionUri = [Uri]$env:PRODUCTION_ORIGIN
+if (-not $baseUri.IsAbsoluteUri -or -not $productionUri.IsAbsoluteUri) {
+  throw 'Soak and production origins must be absolute URIs'
+}
+$baseAuthority = $baseUri.GetLeftPart([UriPartial]::Authority).TrimEnd('/')
+$productionAuthority = $productionUri.GetLeftPart([UriPartial]::Authority).TrimEnd('/')
+if ($baseAuthority -eq $productionAuthority) { throw 'Soak target equals production origin' }
+if ($environment -eq 'staging' -and $baseUri.Scheme -ne 'https') {
+  throw 'Shared staging must use HTTPS'
+}
+if ($environment -eq 'local' -and $baseUri.Host -notin @('localhost', '127.0.0.1')) {
+  throw 'Local target must use loopback'
+}
+if ($env:MOIC_SOAK_PROVIDER_ENVIRONMENT_ID -eq $env:PRODUCTION_PROVIDER_ENVIRONMENT_ID) {
+  throw 'Provider environment identity equals production'
+}
+if ($env:MOIC_SOAK_PROVIDER_DEPLOYMENT_ID -eq $env:PRODUCTION_PROVIDER_DEPLOYMENT_ID) {
+  throw 'Provider deployment identity equals production'
+}
+if ($env:MOIC_SOAK_DATABASE_ID -eq $env:PRODUCTION_DATABASE_ID) {
+  throw 'Backing database identity equals production'
+}
+foreach ($shaName in 'MOIC_SOAK_EXPECTED_SHA','MOIC_SOAK_OBSERVABILITY_MERGE_SHA') {
+  if ([Environment]::GetEnvironmentVariable($shaName) -notmatch '^[0-9a-fA-F]{40}$') {
+    throw "$shaName must be a full SHA"
+  }
+}
+git fetch origin main --prune
+git cat-file -e "$($env:MOIC_SOAK_EXPECTED_SHA)^{commit}"
+if ($LASTEXITCODE -ne 0) { throw 'Deployed SHA is not present in fetched repository history' }
+git merge-base --is-ancestor `
+  $env:MOIC_SOAK_OBSERVABILITY_MERGE_SHA `
+  $env:MOIC_SOAK_EXPECTED_SHA
+if ($LASTEXITCODE -ne 0) {
+  throw 'Observability merge is not an ancestor of the deployed SHA'
+}
+$baseUrl = $baseUri.AbsoluteUri.TrimEnd('/')
+if ($environment -eq 'staging') {
+  Resolve-DnsName $baseUri.DnsSafeHost -ErrorAction Stop | Out-Null
+}
+$health = Invoke-RestMethod -Method Get -Uri "$baseUrl/healthz"
+if ($health.status -ne 'ok' -or $health.commit_sha -ne $env:MOIC_SOAK_EXPECTED_SHA) {
+  throw 'Target health or deployed SHA does not match approval'
+}
+```
+
+Before this block, the operator must run and preserve the exact provider-native
+runtime and database identity commands from the secure approval record, using
+the known recipes (`vercel inspect`, `railway status -p/-e/-s`, Neon
+project/branch ID) to read the soak-target and production reference IDs, then
+confirm they differ. Environment-variable inequality is a secondary guard, not
+independent evidence. If those provider commands or their captured output are
+absent, stop.
+
+## Step 2: Fund and date validation and opaque fingerprints
+
+```powershell
+$fundId = 0
+if (-not [int]::TryParse($env:MOIC_SOAK_FUND_ID, [ref]$fundId) -or $fundId -le 0) {
+  throw 'MOIC_SOAK_FUND_ID must be a positive integer'
+}
+$dateTexts = @(
+  $env:MOIC_SOAK_AS_OF_DATES.Split(',') |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { $_ } |
+    Sort-Object -Unique
+)
+if ($dateTexts.Count -lt 3) { throw 'At least three distinct dates are required' }
+$asOfDates = foreach ($dateText in $dateTexts) {
+  $parsed = [datetime]::MinValue
+  if (-not [datetime]::TryParseExact(
+    $dateText,
+    'yyyy-MM-dd',
+    [Globalization.CultureInfo]::InvariantCulture,
+    [Globalization.DateTimeStyles]::None,
+    [ref]$parsed
+  )) { throw "Invalid soak date: $dateText" }
+  $parsed
+}
+$checkpointIndex = 0
+if (-not [int]::TryParse($env:MOIC_SOAK_CHECKPOINT_INDEX, [ref]$checkpointIndex) -or
+    $checkpointIndex -lt 0 -or $checkpointIndex -gt 4) {
+  throw 'MOIC_SOAK_CHECKPOINT_INDEX must be 0 through 4'
+}
+if ($env:MOIC_SOAK_EVIDENCE_SALT.Length -lt 32) {
+  throw 'Evidence salt must contain at least 32 characters'
+}
+function Get-OpaqueFingerprint([string]$value) {
+  $key = [Text.Encoding]::UTF8.GetBytes($env:MOIC_SOAK_EVIDENCE_SALT)
+  $hmac = [Security.Cryptography.HMACSHA256]::new($key)
+  try {
+    return [Convert]::ToHexString(
+      $hmac.ComputeHash([Text.Encoding]::UTF8.GetBytes($value))
+    ).ToLowerInvariant()
+  } finally {
+    $hmac.Dispose()
+  }
+}
+$targetFingerprint = Get-OpaqueFingerprint "$environment|$($env:MOIC_SOAK_PROVIDER_PROJECT_ID)|$baseAuthority"
+$fundFingerprint = Get-OpaqueFingerprint "$environment|$fundId"
+```
+
+Expected at runtime: validated fund/date/checkpoint inputs and opaque evidence
+identifiers; no raw target or fund identifiers leave the secure evidence store.
+
+## Step 3: Authentication and dormant-state proof
+
+```powershell
+$firstDate = $asOfDates[0].ToString('yyyy-MM-dd')
+$probeUri = "$baseUrl/api/funds/$fundId/moic/marginal-rankings?asOfDate=$firstDate"
+$unauth = Invoke-WebRequest -Method Get -Uri $probeUri -SkipHttpErrorCheck
+if ($unauth.StatusCode -ne 401) { throw 'Unauthenticated marginal probe must return 401' }
+
+$session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+$preAuthCsrf = Invoke-RestMethod -Method Get -Uri "$baseUrl/api/auth/csrf" -WebSession $session
+$loginBody = @{
+  username = $env:MOIC_SOAK_USERNAME
+  password = $env:MOIC_SOAK_PASSWORD
+} | ConvertTo-Json
+$login = Invoke-RestMethod -Method Post `
+  -Uri "$baseUrl/api/auth/login" `
+  -WebSession $session `
+  -Headers @{ 'X-CSRF-Token' = [string]$preAuthCsrf.csrfToken } `
+  -ContentType 'application/json' `
+  -Body $loginBody
+if ($login.user.role -ne 'admin') { throw 'Approved soak actor must be admin' }
+$sessionCsrf = Invoke-RestMethod -Method Get -Uri "$baseUrl/api/auth/csrf" -WebSession $session
+$csrfHeaders = @{ 'X-CSRF-Token' = [string]$sessionCsrf.csrfToken }
+
+$flagOnNoRow = Invoke-WebRequest -Method Get -Uri $probeUri -WebSession $session -SkipHttpErrorCheck
+if ($flagOnNoRow.StatusCode -ne 404) {
+  throw 'After approved non-production flag enablement, no-row probe must remain 404'
+}
+$planned = Invoke-RestMethod -Method Get `
+  -Uri "$baseUrl/api/funds/$fundId/moic/rankings?contract=v2" `
+  -WebSession $session
+if ($planned.contractVersion -ne '2.1.0' -or
+    $planned.modePreview.configuredMode -ne 'off' -or
+    $planned.modePreview.effectiveMode -ne 'off') {
+  throw 'Pilot fund is not dormant'
+}
+$expectedVersion = [int]$planned.modePreview.version
+```
+
+The provider-specific flag enable/redeploy occurs only after Task 10's approval
+and provider/data-plane proof, immediately before the no-row probe. Do not print
+login, CSRF, cookie, or session values.
+
+## Step 4: Reconciliation and shadow transition
+
+```powershell
+$reconciliationHeaders = @{
+  'X-CSRF-Token' = [string]$sessionCsrf.csrfToken
+  'Idempotency-Key' = "adr056-nn3-reconcile-$fundId-$([Guid]::NewGuid().ToString('N'))"
+}
+$reconciliation = Invoke-RestMethod -Method Post `
+  -Uri "$baseUrl/api/admin/funds/$fundId/moic/reconciliations" `
+  -WebSession $session `
+  -Headers $reconciliationHeaders `
+  -ContentType 'application/json' `
+  -Body '{}'
+$acceptedRunId = [long]::Parse(
+  [string]$reconciliation.runId,
+  [Globalization.CultureInfo]::InvariantCulture
+)
+
+$shadowHeaders = @{
+  'X-CSRF-Token' = [string]$sessionCsrf.csrfToken
+  'Idempotency-Key' = "adr056-nn3-shadow-$fundId-$([Guid]::NewGuid().ToString('N'))"
+}
+$shadowBody = @{
+  expectedVersion = $expectedVersion
+  configuredMode = 'shadow'
+  killSwitchActive = $false
+  acceptedReconciliationRunId = $acceptedRunId
+} | ConvertTo-Json
+$shadowMode = Invoke-RestMethod -Method Put `
+  -Uri "$baseUrl/api/admin/funds/$fundId/calculation-modes/fund-moic-rankings" `
+  -WebSession $session `
+  -Headers $shadowHeaders `
+  -ContentType 'application/json' `
+  -Body $shadowBody
+if ($shadowMode.configuredMode -ne 'shadow' -or
+    $shadowMode.effectiveMode -ne 'shadow' -or
+    $shadowMode.killSwitchActive -or
+    [string]::IsNullOrWhiteSpace($shadowMode.shadowStartedAt)) {
+  throw 'Mode update did not produce effective shadow with a start timestamp'
+}
+$shadowStartedAt = [datetimeoffset]::Parse(
+  [string]$shadowMode.shadowStartedAt,
+  [Globalization.CultureInfo]::InvariantCulture,
+  [Globalization.DateTimeStyles]::AssumeUniversal
+).ToUniversalTime()
+if ([Math]::Abs(([datetimeoffset]::UtcNow - $shadowStartedAt).TotalMinutes) -gt 5) {
+  throw 'shadowStartedAt is not anchored to the current transition'
+}
+$windowStartUtc = $shadowStartedAt
+$checkpointUtc = @(0, 1, 3, 5, 7) | ForEach-Object { $windowStartUtc.AddDays($_) }
+$shadowVersion = [int]$shadowMode.version
+```
+
+The observation clock is derived only from the server's returned
+`shadowStartedAt`, never from an operator-supplied earlier timestamp.
+
+## Step 5: Checkpoint continuity and probes
+
+```powershell
+$scheduledUtc = $checkpointUtc[$checkpointIndex]
+if ([Math]::Abs(([datetimeoffset]::UtcNow - $scheduledUtc).TotalMinutes) -gt 30) {
+  throw "Checkpoint $checkpointIndex is outside its 30-minute window"
+}
+$current = Invoke-RestMethod -Method Get `
+  -Uri "$baseUrl/api/funds/$fundId/moic/rankings?contract=v2" `
+  -WebSession $session
+$preview = $current.modePreview
+$currentShadowStartedAt = [datetimeoffset]::Parse(
+  [string]$preview.shadowStartedAt,
+  [Globalization.CultureInfo]::InvariantCulture,
+  [Globalization.DateTimeStyles]::AssumeUniversal
+).ToUniversalTime()
+if ($preview.configuredMode -ne 'shadow' -or
+    $preview.effectiveMode -ne 'shadow' -or
+    $preview.killSwitchActive -or
+    [int]$preview.version -ne $shadowVersion -or
+    $currentShadowStartedAt -ne $shadowStartedAt -or
+    -not $preview.currentSourceMatchesAccepted -or
+    $preview.unreconciledEditsPresent) {
+  throw 'Shadow mode, start clock, version, or accepted source changed; roll back and restart'
+}
+
+$probeReceipts = foreach ($dateText in $dateTexts) {
+  $requestId = "adr056-shadow-$checkpointIndex-$([Guid]::NewGuid().ToString('N'))"
+  $dated = Invoke-WebRequest -Method Get `
+    -Uri "$baseUrl/api/funds/$fundId/moic/marginal-rankings?asOfDate=$dateText" `
+    -WebSession $session `
+    -Headers @{ 'X-Request-ID' = $requestId }
+  $body = $dated.Content | ConvertFrom-Json
+  if ($dated.StatusCode -ne 200 -or
+      $body.contractVersion -ne 'marginal-reserve-rankings-v2' -or
+      $body.mode -ne 'shadow' -or
+      $body.actionability -ne 'non_actionable') {
+    throw "Shadow contract failed for $dateText"
+  }
+  [pscustomobject]@{
+    CheckpointIndex = $checkpointIndex
+    ScheduledUtc = $scheduledUtc.ToString('O')
+    AsOfDate = $dateText
+    RequestId = [string]$dated.Headers['X-Request-ID']
+    FactsInputHash = [string]$body.factsInputHash
+    AssumptionsHash = [string]$body.assumptionsHash
+  }
+}
+$probeReceipts
+```
+
+Rerun target/provider/database/SHA preflight and authentication in a fresh
+PowerShell 7 session before each checkpoint. Store receipts only in the approved
+external evidence store.
+
+## Step 6: Thresholds and stop conditions
+
+The runbook requires:
+
+- Five checkpoints at T+0, T+1d, T+3d, T+5d, and T+7d.
+- At least fifteen successful authenticated probes over at least three dates.
+- Unchanged `shadowStartedAt`, mode version, accepted source, and deployed SHA.
+- Every response is V2, `shadow`, and `non_actionable`.
+- Comparison-event count equals successful response count for the exclusive
+  pilot window using the approved saved query.
+- Zero marginal-route 5xx responses and zero unexplained server errors.
+- A checkpoint whose planned comparison basis is empty because the candidate
+  facts source is unavailable is not a clean probe: record it, treat a
+  persistently empty planned side as `annotation_required`, and do not count it
+  toward the fifteen-probe threshold.
+- Source-hash changes trigger rollback, a new accepted reconciliation, and a
+  newly approved seven-day window.
+- Every `annotation_required` result receives investment-team review inside the
+  approved log/evidence systems.
+- GitHub receives aggregates and opaque fingerprints only.
+
+## Step 7: Rollback
+
+Rollback may run days after the shadow transition in a fresh PowerShell 7
+session, so first re-run the Step 1 target/provider/database/SHA preflight and
+the Step 3 authentication to re-establish `$session` and `$sessionCsrf` before
+the block below.
+
+```powershell
+$current = Invoke-RestMethod -Method Get `
+  -Uri "$baseUrl/api/funds/$fundId/moic/rankings?contract=v2" `
+  -WebSession $session
+$version = [int]$current.modePreview.version
+$configured = [string]$current.modePreview.configuredMode
+if ($version -eq 0 -and $configured -eq 'off') {
+  Write-Output 'No mode row exists; disable the approved non-production flag now.'
+} elseif ($version -gt 0 -and $configured -eq 'shadow') {
+  $killHeaders = @{
+    'X-CSRF-Token' = [string]$sessionCsrf.csrfToken
+    'Idempotency-Key' = "adr056-nn3-kill-$fundId-$([Guid]::NewGuid().ToString('N'))"
+  }
+  $killBody = @{
+    expectedVersion = $version
+    configuredMode = 'shadow'
+    killSwitchActive = $true
+  } | ConvertTo-Json
+  $killed = Invoke-RestMethod -Method Put `
+    -Uri "$baseUrl/api/admin/funds/$fundId/calculation-modes/fund-moic-rankings" `
+    -WebSession $session `
+    -Headers $killHeaders `
+    -ContentType 'application/json' `
+    -Body $killBody
+  if ($killed.effectiveMode -ne 'off' -or -not $killed.killSwitchActive) {
+    throw 'Kill switch did not force effective off'
+  }
+  $offHeaders = @{
+    'X-CSRF-Token' = [string]$sessionCsrf.csrfToken
+    'Idempotency-Key' = "adr056-nn3-off-$fundId-$([Guid]::NewGuid().ToString('N'))"
+  }
+  $offBody = @{
+    expectedVersion = [int]$killed.version
+    configuredMode = 'off'
+    killSwitchActive = $true
+  } | ConvertTo-Json
+  $off = Invoke-RestMethod -Method Put `
+    -Uri "$baseUrl/api/admin/funds/$fundId/calculation-modes/fund-moic-rankings" `
+    -WebSession $session `
+    -Headers $offHeaders `
+    -ContentType 'application/json' `
+    -Body $offBody
+  if ($off.configuredMode -ne 'off' -or $off.effectiveMode -ne 'off') {
+    throw 'Stable off mode was not persisted'
+  }
+} elseif ($version -gt 0 -and $configured -eq 'off') {
+  Write-Output 'Mode row is already off; disable the approved non-production flag now.'
+} else {
+  throw "Unexpected rollback state version=$version mode=$configured; disable the non-production flag and stop"
+}
+```
+
+Execute the exact provider-native flag-disable and restart/redeploy commands
+from the secure approval record in every rollback branch, then require the
+marginal route to return 404. Preserve mode/idempotency rows for audit.

--- a/server/routes/fund-moic.ts
+++ b/server/routes/fund-moic.ts
@@ -48,6 +48,7 @@ import type { MarginalReserveRankingItemV1 } from '../../shared/contracts/margin
 import { MarginalReserveRankingsResponseV2Schema } from '../../shared/contracts/marginal-reserve-moic-v2.contract.js';
 import { buildMarginalReserveMoicInputs } from '../services/moic/marginal-reserve-moic-input-service.js';
 import { emitFundMoicFactsShadowTelemetry } from '../services/moic/fund-moic-facts-shadow-telemetry.js';
+import { emitMarginalReserveMoicShadowComparison } from '../services/moic/marginal-reserve-moic-shadow-service.js';
 
 const router = Router();
 
@@ -205,21 +206,28 @@ router.get(
         ? 'actionable'
         : 'non_actionable';
 
-    return res.json(
-      MarginalReserveRankingsResponseV2Schema.parse({
-        contractVersion: 'marginal-reserve-rankings-v2',
-        mode: modePreview.effectiveMode,
-        actionability: responseActionability,
+    const parsedResponse = MarginalReserveRankingsResponseV2Schema.parse({
+      contractVersion: 'marginal-reserve-rankings-v2',
+      mode: modePreview.effectiveMode,
+      actionability: responseActionability,
+      fundId,
+      asOfDate: parsedQuery.data.asOfDate,
+      factsInputHash: inputs.factsInputHash,
+      assumptionsHash: inputs.assumptionsHash,
+      rankings,
+      unavailable: [...inputs.unavailable].sort((left, right) => left.companyId - right.companyId),
+    });
+
+    if (modePreview.effectiveMode === 'shadow') {
+      emitMarginalReserveMoicShadowComparison({
         fundId,
-        asOfDate: parsedQuery.data.asOfDate,
-        factsInputHash: inputs.factsInputHash,
-        assumptionsHash: inputs.assumptionsHash,
-        rankings,
-        unavailable: [...inputs.unavailable].sort(
-          (left, right) => left.companyId - right.companyId
-        ),
-      })
-    );
+        plannedRankings: sources.candidate.rankings,
+        marginalRankings: parsedResponse.rankings,
+        unavailable: parsedResponse.unavailable,
+      });
+    }
+
+    return res.json(parsedResponse);
   })
 );
 

--- a/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
+++ b/tests/unit/routes/fund-moic-marginal-rankings.behavior.test.ts
@@ -2,6 +2,9 @@ import express, { type NextFunction, type Request, type Response } from 'express
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { errorHandler } from '../../../server/errors';
+import { requestId } from '../../../server/middleware/requestId';
+
 import type { MarginalReserveMoicInputV1 } from '../../../shared/contracts/marginal-reserve-moic-v1.contract';
 import { MarginalReserveRankingsResponseV2Schema } from '../../../shared/contracts/marginal-reserve-moic-v2.contract';
 
@@ -23,6 +26,7 @@ const svc = vi.hoisted(() => ({
   buildRoundsToModelEvidence: vi.fn(),
   resolveMoicActionability: vi.fn(),
   buildMarginalReserveMoicInputs: vi.fn(),
+  emitMarginalReserveMoicShadowComparison: vi.fn(),
 }));
 
 vi.mock('../../../server/services/fund-moic-ranking-service', async (importOriginal) => {
@@ -63,6 +67,10 @@ vi.mock('../../../server/services/moic/marginal-reserve-moic-input-service', () 
   buildMarginalReserveMoicInputs: svc.buildMarginalReserveMoicInputs,
 }));
 
+vi.mock('../../../server/services/moic/marginal-reserve-moic-shadow-service', () => ({
+  emitMarginalReserveMoicShadowComparison: svc.emitMarginalReserveMoicShadowComparison,
+}));
+
 vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
   return {
@@ -77,7 +85,30 @@ vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
 
 import fundMoicRouter from '../../../server/routes/fund-moic';
 
-const SOURCES = { source: 'shared-ranking-sources' };
+const PLANNED_RANKINGS = [
+  {
+    investmentId: '1',
+    rank: 1,
+    reservesMoic: {
+      value: 2,
+      description: 'planned-one',
+      formula: 'planned-one',
+    },
+  },
+  {
+    investmentId: '2',
+    rank: 2,
+    reservesMoic: {
+      value: 1.5,
+      description: 'planned-two',
+      formula: 'planned-two',
+    },
+  },
+];
+const SOURCES = {
+  source: 'shared-ranking-sources',
+  candidate: { rankings: PLANNED_RANKINGS },
+};
 const EVIDENCE = { coverage: { activeRoundCount: 1 } };
 
 function marginalInput(params: {
@@ -114,11 +145,10 @@ function marginalInput(params: {
 
 function buildApp() {
   const app = express();
+  app.use(requestId());
   app.use(express.json());
   app.use('/api', fundMoicRouter);
-  app.use((_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
-    res.status(500).json({ error: 'internal_error' })
-  );
+  app.use(errorHandler());
   return app;
 }
 
@@ -126,22 +156,22 @@ function getRankings(path = '/api/funds/1/moic/marginal-rankings?asOfDate=2026-0
   return request(buildApp()).get(path);
 }
 
-function inputAssembly(overrides: {
-  ready?: MarginalReserveMoicInputV1[];
-  unavailable?: Array<{ companyId: number; reasons: string[] }>;
-} = {}) {
+function inputAssembly(
+  overrides: {
+    ready?: MarginalReserveMoicInputV1[];
+    unavailable?: Array<{ companyId: number; reasons: string[] }>;
+  } = {}
+) {
   return {
-    ready:
-      overrides.ready ??
-      [
-        marginalInput({
-          companyId: 2,
-          exitValuation: '30000000',
-          readiness: { status: 'indicative', reasons: ['STALE_ASSUMPTION'] },
-        }),
-        marginalInput({ companyId: 1, exitValuation: '50000000' }),
-        marginalInput({ companyId: 4, exitValuation: '20000000' }),
-      ],
+    ready: overrides.ready ?? [
+      marginalInput({
+        companyId: 2,
+        exitValuation: '30000000',
+        readiness: { status: 'indicative', reasons: ['STALE_ASSUMPTION'] },
+      }),
+      marginalInput({ companyId: 1, exitValuation: '50000000' }),
+      marginalInput({ companyId: 4, exitValuation: '20000000' }),
+    ],
     unavailable: overrides.unavailable ?? [
       { companyId: 3, reasons: ['MISSING_CURRENT_OWNERSHIP'] },
     ],
@@ -156,6 +186,7 @@ function expectNoRouteReads() {
   expect(svc.buildRoundsToModelEvidence).toHaveBeenCalledTimes(0);
   expect(svc.resolveMoicActionability).toHaveBeenCalledTimes(0);
   expect(svc.buildMarginalReserveMoicInputs).toHaveBeenCalledTimes(0);
+  expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
 }
 
 beforeEach(() => {
@@ -200,6 +231,7 @@ describe('marginal reserve MOIC rankings route', () => {
     const response = await getRankings();
 
     expect(response.status).toBe(200);
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('preserves analyst universal safe-read access to another fund', async () => {
@@ -208,14 +240,13 @@ describe('marginal reserve MOIC rankings route', () => {
     const response = await getRankings();
 
     expect(response.status).toBe(200);
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('returns 404 without service reads when the server flag is off', async () => {
     featureState.enabled = false;
 
-    const response = await getRankings(
-      '/api/funds/1/moic/marginal-rankings?asOfDate=07-12-2026'
-    );
+    const response = await getRankings('/api/funds/1/moic/marginal-rankings?asOfDate=07-12-2026');
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({ error: 'not_found' });
@@ -249,6 +280,7 @@ describe('marginal reserve MOIC rankings route', () => {
     expect(svc.buildRoundsToModelEvidence).toHaveBeenCalledTimes(0);
     expect(svc.resolveMoicActionability).toHaveBeenCalledTimes(0);
     expect(svc.buildMarginalReserveMoicInputs).toHaveBeenCalledTimes(0);
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('returns sorted V2 shadow rankings as non-actionable even when H9 is actionable', async () => {
@@ -266,6 +298,24 @@ describe('marginal reserve MOIC rankings route', () => {
     ]);
     expect(parsed.unavailable).toEqual([{ companyId: 3, reasons: ['MISSING_CURRENT_OWNERSHIP'] }]);
     expect(parsed.rankings[0]?.result).not.toHaveProperty('companyId');
+
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(1);
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledWith({
+      fundId: 1,
+      plannedRankings: PLANNED_RANKINGS,
+      marginalRankings: parsed.rankings,
+      unavailable: parsed.unavailable,
+    });
+
+    const [emittedInput] = svc.emitMarginalReserveMoicShadowComparison.mock.calls[0];
+    expect(emittedInput.plannedRankings.length).toBeGreaterThan(0);
+    for (const planned of emittedInput.plannedRankings) {
+      expect(typeof planned.investmentId).toBe('string');
+      expect(planned.investmentId.length).toBeGreaterThan(0);
+    }
+    for (const marginal of emittedInput.marginalRankings) {
+      expect(typeof marginal.companyId).toBe('number');
+    }
   });
 
   it.each(['input_only', 'non_actionable', 'quarantined', 'unknown_legacy'] as const)(
@@ -280,6 +330,7 @@ describe('marginal reserve MOIC rankings route', () => {
         mode: 'on',
         actionability: 'non_actionable',
       });
+      expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
     }
   );
 
@@ -323,6 +374,7 @@ describe('marginal reserve MOIC rankings route', () => {
     expect(svc.resolveMoicActionability.mock.invocationCallOrder[0]).toBeLessThan(
       svc.buildMarginalReserveMoicInputs.mock.invocationCallOrder[0]
     );
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('keeps an empty ranking set non-actionable', async () => {
@@ -334,6 +386,7 @@ describe('marginal reserve MOIC rankings route', () => {
     const parsed = MarginalReserveRankingsResponseV2Schema.parse(response.body);
     expect(parsed.rankings).toEqual([]);
     expect(parsed.actionability).toBe('non_actionable');
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('keeps all-indicative rankings non-actionable', async () => {
@@ -356,6 +409,7 @@ describe('marginal reserve MOIC rankings route', () => {
     const parsed = MarginalReserveRankingsResponseV2Schema.parse(response.body);
     expect(parsed.rankings.map((ranking) => ranking.status)).toEqual(['indicative']);
     expect(parsed.actionability).toBe('non_actionable');
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('preserves sorted all-unavailable date-mismatch assembly as non-actionable', async () => {
@@ -375,9 +429,11 @@ describe('marginal reserve MOIC rankings route', () => {
     const parsed = MarginalReserveRankingsResponseV2Schema.parse(response.body);
     expect(parsed.rankings).toEqual([]);
     expect(parsed.unavailable.map((item) => item.companyId)).toEqual([1, 3]);
-    expect(parsed.unavailable.every((item) => item.reasons.includes('CURRENT_STATE_DATE_MISMATCH')))
-      .toBe(true);
+    expect(
+      parsed.unavailable.every((item) => item.reasons.includes('CURRENT_STATE_DATE_MISMATCH'))
+    ).toBe(true);
     expect(parsed.actionability).toBe('non_actionable');
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('propagates H9 failures to the existing 500 path without a V2 response', async () => {
@@ -386,13 +442,21 @@ describe('marginal reserve MOIC rankings route', () => {
     const response = await getRankings();
 
     expect(response.status).toBe(500);
-    expect(response.body).toEqual({ error: 'internal_error' });
+    expect(response.headers['x-request-id']).toEqual(expect.any(String));
+    expect(response.body).toEqual({
+      code: 'INTERNAL_ERROR',
+      message: 'Internal Server Error',
+      requestId: response.headers['x-request-id'],
+      ts: expect.any(String),
+    });
+    expect(response.body).not.toHaveProperty('contractVersion');
     expect(response.body).not.toHaveProperty('actionability');
     expect(svc.getFundMoicRankingSources).toHaveBeenCalledTimes(1);
     expect(svc.resolveFundCalculationMode).toHaveBeenCalledTimes(1);
     expect(svc.buildRoundsToModelEvidence).toHaveBeenCalledTimes(1);
     expect(svc.resolveMoicActionability).toHaveBeenCalledTimes(1);
     expect(svc.buildMarginalReserveMoicInputs).toHaveBeenCalledTimes(0);
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(0);
   });
 
   it('rejects a non-numeric fund ID with the sibling guard status', async () => {
@@ -403,5 +467,26 @@ describe('marginal reserve MOIC rankings route', () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({ error: 'Bad Request', message: 'Invalid fund ID' });
     expectNoRouteReads();
+  });
+
+  it('fails a shadow read closed through the shared error contract when comparison emission throws', async () => {
+    svc.resolveFundCalculationMode.mockResolvedValue({ effectiveMode: 'shadow' });
+    svc.emitMarginalReserveMoicShadowComparison.mockImplementationOnce(() => {
+      throw new Error('shadow comparison unavailable');
+    });
+
+    const response = await getRankings();
+
+    expect(response.status).toBe(500);
+    expect(response.headers['x-request-id']).toEqual(expect.any(String));
+    expect(response.body).toEqual({
+      code: 'INTERNAL_ERROR',
+      message: 'Internal Server Error',
+      requestId: response.headers['x-request-id'],
+      ts: expect.any(String),
+    });
+    expect(response.body).not.toHaveProperty('contractVersion');
+    expect(response.body).not.toHaveProperty('actionability');
+    expect(svc.emitMarginalReserveMoicShadowComparison).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Goal

Make ADR-056 NET-NEW #3 shadow reads emit the existing comparison artifact and publish a blocked non-production soak/rollback runbook.

## Scope

- one synchronous emitter call only for successful effective-shadow reads
- zero calls for off, on, denied, invalid, and H9-failure paths
- emitter failures use the shared normalized 500 contract and never return V2 success
- provider/runtime/database identity, deployed-SHA ancestry, server-anchored observation clock, checkpoints, evidence, stop, and rollback gates
- documentation index and deterministic discovery outputs

## Non-goals

- no committed flag-default change
- no environment or database mutation
- no on-mode transition
- no production or release action
- no schema, migration, consumer, policy, or response-contract change

## Verification

- focused marginal route/contract/input/shadow/mode/H9/policy/flag/error-contract tests
- full npm test (server + client shards, green; 2 pre-existing resource-ceiling flakes proven passing standalone)
- npm run check
- npm run lint (targeted on changed files; full sweep on CI)
- npm run policy:verify
- npm run phoenix:truth
- npm run docs:check-links
- npm run docs:routing:check
- npm run build

## Authority boundary

Merging this PR produces SHADOW_SOAK_READY; EXTERNAL_ACTIVATION_NOT_AUTHORIZED. It does not authorize any flag, environment, database, reconciliation, mode-row, fund, deployment, production, on-mode, or release mutation.