### PR TITLE
feat(forecast): current-plan review & acceptance panel (PLAN_61 Task 12.3)

### DIFF
--- a/client/src/components/fund-results/CurrentPlanAcceptancePanel.tsx
+++ b/client/src/components/fund-results/CurrentPlanAcceptancePanel.tsx
@@ -1,0 +1,165 @@
+import type { CurrentPlanVersionV1 } from '@shared/contracts/current-plan-version-v1.contract';
+import { Button } from '@/components/ui/button';
+import { useCurrentPlanVersions } from '@/hooks/useCurrentPlanVersions';
+import { cn } from '@/lib/utils';
+import {
+  diagnosticAlertClasses,
+  formatDateOrFallback,
+} from '@/pages/fund-model-results/formatters';
+
+export interface CurrentPlanAcceptancePanelProps {
+  fundId: number | null;
+}
+
+function formatMoneyString(value: string): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(Number(value));
+}
+
+function formatRatioAsPercent(value: string): string {
+  return `${(Number(value) * 100).toFixed(2)}%`;
+}
+
+function ReviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 py-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+      <dt className="text-sm font-medium text-charcoal-500">{label}</dt>
+      <dd className="text-sm text-charcoal sm:text-right">{value}</dd>
+    </div>
+  );
+}
+
+function HeadPlanReview({ headVersion }: { headVersion: CurrentPlanVersionV1 }) {
+  return (
+    <div className="space-y-5">
+      <dl className="divide-y divide-beige-100 font-poppins">
+        <ReviewRow
+          label="Source configuration"
+          value={`Config #${headVersion.sourceConfigId} v${headVersion.sourceConfigVersion}`}
+        />
+        <ReviewRow
+          label="Facts provenance"
+          value={`Facts snapshot: ${headVersion.sourceFactsSnapshotId}`}
+        />
+        <ReviewRow
+          label="Assumptions hash"
+          value={`${headVersion.assumptionsHash.slice(0, 12)}…`}
+        />
+        <ReviewRow label="Plan version" value={`Plan version ${headVersion.version}`} />
+        <ReviewRow
+          label="Derived"
+          value={`Derived ${formatDateOrFallback(headVersion.createdAt)}`}
+        />
+        <ReviewRow
+          label="Deployable capital"
+          value={formatMoneyString(headVersion.deployableCapitalUsd)}
+        />
+      </dl>
+
+      <div className="rounded-md border border-beige-200 bg-beige-50 p-4 font-poppins">
+        <p className="text-xs font-medium uppercase tracking-wide text-charcoal-500">
+          Compiled annual fee drag
+        </p>
+        <p className="mt-1 text-2xl font-semibold text-charcoal">
+          {formatRatioAsPercent(headVersion.pacingAssumptions.annualFeeDragPct)}
+        </p>
+      </div>
+
+      <dl className="grid gap-3 font-poppins sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-md border border-beige-200 p-3">
+          <dt className="text-xs text-charcoal-500">Deployment quarters</dt>
+          <dd className="mt-1 font-medium text-charcoal">
+            {headVersion.pacingAssumptions.deploymentQuarters}
+          </dd>
+        </div>
+        <div className="rounded-md border border-beige-200 p-3">
+          <dt className="text-xs text-charcoal-500">Allocations</dt>
+          <dd className="mt-1 font-medium text-charcoal">{headVersion.allocations.length}</dd>
+        </div>
+        <div className="rounded-md border border-beige-200 p-3">
+          <dt className="text-xs text-charcoal-500">Portfolio stages</dt>
+          <dd className="mt-1 font-medium text-charcoal">
+            {headVersion.cohortAssumptions.stageDistribution.length}
+          </dd>
+        </div>
+        <div className="rounded-md border border-beige-200 p-3">
+          <dt className="text-xs text-charcoal-500">Exit assumptions</dt>
+          <dd className="mt-1 font-medium text-charcoal">
+            {headVersion.cohortAssumptions.exitAssumptions.length}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function CurrentPlanAcceptanceContent({ fundId }: { fundId: number }) {
+  const { headVersion, isLoading, error, mint } = useCurrentPlanVersions(fundId);
+
+  return (
+    <section
+      aria-labelledby="current-plan-review-heading"
+      className={cn('rounded-lg border border-beige-200 bg-white p-6', 'space-y-5')}
+    >
+      <div>
+        <h2 id="current-plan-review-heading" className="font-inter text-lg font-bold text-charcoal">
+          Current Plan Review
+        </h2>
+        <p className="mt-1 text-sm text-charcoal-500 font-poppins">
+          Review the assumptions and source evidence compiled into the current plan.
+        </p>
+      </div>
+
+      {isLoading && <p className="text-sm text-charcoal-500 font-poppins">Loading current plan…</p>}
+      {error && (
+        <p
+          role="alert"
+          className={cn(
+            'rounded-md border p-3 text-sm font-poppins text-charcoal',
+            diagnosticAlertClasses('danger')
+          )}
+        >
+          {error.message}
+        </p>
+      )}
+      {mint.error && (
+        <p
+          role="alert"
+          className={cn(
+            'rounded-md border p-3 text-sm font-poppins text-charcoal',
+            diagnosticAlertClasses('danger')
+          )}
+        >
+          {mint.error.message}
+        </p>
+      )}
+      {!isLoading && !error && headVersion === null && (
+        <div className="space-y-3 font-poppins">
+          <p className="text-sm text-charcoal-500">
+            No current plan has been derived from the published configuration yet.
+          </p>
+          <Button type="button" onClick={() => mint.mutate()} disabled={mint.isPending}>
+            {mint.isPending ? 'Deriving…' : 'Derive initial plan'}
+          </Button>
+        </div>
+      )}
+      {!isLoading && !error && headVersion && (
+        <div className="space-y-5">
+          <HeadPlanReview headVersion={headVersion} />
+          <div className="flex justify-end">
+            <Button type="button" onClick={() => mint.mutate()} disabled={mint.isPending}>
+              {mint.isPending ? 'Working…' : 'Accept & mint new plan version'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function CurrentPlanAcceptancePanel({ fundId }: CurrentPlanAcceptancePanelProps) {
+  return fundId == null ? null : <CurrentPlanAcceptanceContent fundId={fundId} />;
+}

--- a/client/src/components/fund-results/index.ts
+++ b/client/src/components/fund-results/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { FundModelScorecard } from './FundModelScorecard';
+export { CurrentPlanAcceptancePanel } from './CurrentPlanAcceptancePanel';
 export { ReserveAllocationBreakdown } from './ReserveAllocationBreakdown';
 export {
   ScenarioComparisonTable,
@@ -27,6 +28,7 @@ export {
 } from './financial-evidence';
 
 export type { FundModelScorecardProps } from './FundModelScorecard';
+export type { CurrentPlanAcceptancePanelProps } from './CurrentPlanAcceptancePanel';
 export type { ReserveAllocationBreakdownProps } from './ReserveAllocationBreakdown';
 export type { ScenarioComparisonTableProps } from './ScenarioComparisonTable';
 export type { CrossSetScenarioComparisonTableProps } from './CrossSetScenarioComparisonTable';

--- a/client/src/hooks/useCurrentPlanVersions.ts
+++ b/client/src/hooks/useCurrentPlanVersions.ts
@@ -1,0 +1,60 @@
+import type { UseMutationResult } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CurrentPlanVersionV1 } from '@shared/contracts/current-plan-version-v1.contract';
+import { apiRequest } from '@/lib/queryClient';
+
+export const currentPlanVersionsQueryKey = (fundId: number | undefined) =>
+  ['current-plan-versions', fundId ?? null] as const;
+
+export interface MintCurrentPlanVersionInput {
+  asOfDate?: string;
+}
+
+interface CurrentPlanVersionsResult {
+  versions: CurrentPlanVersionV1[];
+  headVersion: CurrentPlanVersionV1 | null;
+  isLoading: boolean;
+  error: Error | null;
+  mint: UseMutationResult<CurrentPlanVersionV1, Error, MintCurrentPlanVersionInput | void>;
+}
+
+export function useCurrentPlanVersions(fundId: number | undefined): CurrentPlanVersionsResult {
+  const queryClient = useQueryClient();
+  const query = useQuery<CurrentPlanVersionV1[], Error>({
+    queryKey: currentPlanVersionsQueryKey(fundId),
+    enabled: fundId != null,
+    queryFn: () =>
+      apiRequest<CurrentPlanVersionV1[]>('GET', `/api/funds/${fundId}/current-plan-versions`),
+  });
+  const mint = useMutation<CurrentPlanVersionV1, Error, MintCurrentPlanVersionInput | void>({
+    mutationFn: (input) => {
+      if (fundId == null) {
+        throw new Error('No fund ID available');
+      }
+
+      const asOfDate = input?.asOfDate;
+      return apiRequest<CurrentPlanVersionV1>(
+        'POST',
+        `/api/funds/${fundId}/current-plan-versions`,
+        { ...(asOfDate != null && { asOfDate }) },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'Idempotency-Key': crypto.randomUUID(),
+          },
+        }
+      );
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: currentPlanVersionsQueryKey(fundId) }),
+  });
+  const versions = query.data ?? [];
+
+  return {
+    versions,
+    headVersion: versions.find((version) => version.supersededByVersionId === null) ?? null,
+    isLoading: query.isLoading,
+    error: query.error,
+    mint,
+  };
+}

--- a/client/src/pages/fund-model-results.tsx
+++ b/client/src/pages/fund-model-results.tsx
@@ -12,7 +12,7 @@
 
 import { useRef, useEffect, useState } from 'react';
 import { useRoute } from 'wouter';
-import { FinancialEvidenceDrawer } from '@/components/fund-results';
+import { CurrentPlanAcceptancePanel, FinancialEvidenceDrawer } from '@/components/fund-results';
 import { QuarterlyReviewTrace } from '@/features/analytics-parity/QuarterlyReviewTrace';
 import type {
   ScorecardPayload,
@@ -212,6 +212,8 @@ function FundModelResultsPage() {
       <PublishHistoryCard historyState={historyState} />
 
       <PublishComparisonCard comparisonState={comparisonState} />
+
+      <CurrentPlanAcceptancePanel fundId={routeFundNumber} />
 
       <QuarterlyReviewTrace
         results={results}

--- a/tests/integration/wizard-to-results-e2e.test.ts
+++ b/tests/integration/wizard-to-results-e2e.test.ts
@@ -111,6 +111,15 @@ vi.mock('@/hooks/use-scenario-set-list', () => ({
     error: new Error('scenario set list unavailable'),
   }),
 }));
+vi.mock('@/hooks/useCurrentPlanVersions', () => ({
+  useCurrentPlanVersions: () => ({
+    versions: [],
+    headVersion: null,
+    isLoading: true,
+    error: null,
+    mint: { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, error: null },
+  }),
+}));
 
 vi.mock('@/stores/useFundSelector', () => ({
   useFundSelector: (selector: (s: typeof mockFundState) => unknown) => selector(mockFundState),

--- a/tests/unit/components/fund-results/CurrentPlanAcceptancePanel.test.tsx
+++ b/tests/unit/components/fund-results/CurrentPlanAcceptancePanel.test.tsx
@@ -1,0 +1,184 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CurrentPlanVersionV1Schema,
+  PLAN_TRANSFORMATION_VERSION,
+} from '@shared/contracts/current-plan-version-v1.contract';
+import { CurrentPlanAcceptancePanel } from '@/components/fund-results/CurrentPlanAcceptancePanel';
+import { ApiError, apiRequest } from '@/lib/queryClient';
+
+vi.mock('@/lib/queryClient', async (orig) => {
+  const actual = await orig<typeof import('@/lib/queryClient')>();
+  return { ...actual, apiRequest: vi.fn() };
+});
+
+const mockApi = vi.mocked(apiRequest);
+
+const headFixture = CurrentPlanVersionV1Schema.parse({
+  contractVersion: 'current-plan-version-v1',
+  id: 'plan-version-2',
+  fundId: 7,
+  version: 2,
+  sourceConfigId: 11,
+  sourceConfigVersion: 3,
+  sourceFactsSnapshotId: 'facts-snapshot-23',
+  deployableCapitalUsd: '9000000.000000',
+  planTransformationVersion: PLAN_TRANSFORMATION_VERSION,
+  allocations: [
+    {
+      allocationId: 'seed-allocation',
+      name: 'Seed',
+      stageFocus: 'Seed',
+      initialCapitalUsd: '6000000.000000',
+      followOnCapitalUsd: '3000000.000000',
+      avgInitialCheckUsd: '1000000.000000',
+      pacingQuarters: 8,
+      followOnStrategy: 'maintain_ownership',
+      followOnParticipationPct: '0.500000000000',
+    },
+  ],
+  pacingAssumptions: {
+    contractVersion: 'current-plan-pacing-v1',
+    deploymentQuarters: 2,
+    quarterlyDeploymentPcts: ['0.500000000000', '0.500000000000'],
+    followOnReservePct: '0.333333333333',
+    annualFeeDragPct: '0.020000000000',
+  },
+  cohortAssumptions: {
+    contractVersion: 'current-plan-cohort-v1',
+    averageInitialCheckUsd: '1000000.000000',
+    stageDistribution: [
+      { stage: 'Seed', pct: '0.600000000000' },
+      { stage: 'Series A', pct: '0.400000000000' },
+    ],
+    graduationMatrix: [
+      {
+        fromStage: 'Seed',
+        toStage: 'Series A',
+        rate: '0.750000000000',
+        quartersToGraduate: 4,
+      },
+    ],
+    exitAssumptions: [
+      {
+        stage: 'Seed',
+        exitMultiple: '3.000000000000',
+        quartersToExit: 20,
+        failureRate: '0.250000000000',
+      },
+    ],
+  },
+  reservePolicyVersion: 'reserve-policy/1.0.0',
+  assumptionsHash: 'a'.repeat(64),
+  supersedesVersionId: 'plan-version-1',
+  supersededByVersionId: null,
+  createdAt: '2026-07-22T05:07:50.303Z',
+});
+
+function wrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('CurrentPlanAcceptancePanel', () => {
+  beforeEach(() => mockApi.mockReset());
+
+  it('renders nothing without a fund ID', () => {
+    const { container } = render(<CurrentPlanAcceptancePanel fundId={null} />, {
+      wrapper: wrapper(),
+    });
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+
+  it('shows the head plan fee, deployable capital, and source provenance', async () => {
+    mockApi.mockResolvedValue([headFixture] as never);
+
+    render(<CurrentPlanAcceptancePanel fundId={7} />, { wrapper: wrapper() });
+
+    expect(screen.getByText('Current Plan Review')).toBeInTheDocument();
+    expect(await screen.findByText('2.00%')).toBeInTheDocument();
+    expect(screen.getByText('$9,000,000')).toBeInTheDocument();
+    expect(screen.getByText('Config #11 v3')).toBeInTheDocument();
+    expect(screen.getByText('Facts snapshot: facts-snapshot-23')).toBeInTheDocument();
+  });
+
+  it('offers to derive the initial plan when no current plan exists', async () => {
+    mockApi.mockResolvedValueOnce([] as never).mockResolvedValueOnce(headFixture as never);
+
+    render(<CurrentPlanAcceptancePanel fundId={7} />, { wrapper: wrapper() });
+
+    const deriveButton = await screen.findByRole('button', { name: /derive initial plan/i });
+    fireEvent.click(deriveButton);
+
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith(
+        'POST',
+        '/api/funds/7/current-plan-versions',
+        {},
+        {
+          headers: expect.objectContaining({
+            'Idempotency-Key': expect.any(String),
+          }),
+        }
+      )
+    );
+  });
+
+  it('accepts the reviewed plan by minting a new version', async () => {
+    mockApi
+      .mockResolvedValueOnce([headFixture] as never)
+      .mockResolvedValueOnce(headFixture as never);
+
+    render(<CurrentPlanAcceptancePanel fundId={7} />, { wrapper: wrapper() });
+
+    const acceptButton = await screen.findByRole('button', {
+      name: /accept & mint new plan version/i,
+    });
+    fireEvent.click(acceptButton);
+
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith(
+        'POST',
+        '/api/funds/7/current-plan-versions',
+        {},
+        {
+          headers: expect.objectContaining({
+            'Idempotency-Key': expect.any(String),
+          }),
+        }
+      )
+    );
+  });
+
+  it('shows the typed route message when minting fails', async () => {
+    mockApi
+      .mockResolvedValueOnce([headFixture] as never)
+      .mockRejectedValueOnce(
+        new ApiError(
+          422,
+          'FEE_PROFILE_ABSENT: fund has no fee tiers configured',
+          'FEE_PROFILE_ABSENT'
+        )
+      );
+
+    render(<CurrentPlanAcceptancePanel fundId={7} />, { wrapper: wrapper() });
+
+    const acceptButton = await screen.findByRole('button', {
+      name: /accept & mint new plan version/i,
+    });
+    fireEvent.click(acceptButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'FEE_PROFILE_ABSENT: fund has no fee tiers configured'
+    );
+  });
+});

--- a/tests/unit/hooks/useCurrentPlanVersions.test.tsx
+++ b/tests/unit/hooks/useCurrentPlanVersions.test.tsx
@@ -1,0 +1,200 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CurrentPlanVersionV1Schema,
+  PLAN_TRANSFORMATION_VERSION,
+  type CurrentPlanVersionV1,
+} from '@shared/contracts/current-plan-version-v1.contract';
+import {
+  currentPlanVersionsQueryKey,
+  useCurrentPlanVersions,
+} from '@/hooks/useCurrentPlanVersions';
+import { apiRequest } from '@/lib/queryClient';
+
+vi.mock('@/lib/queryClient', async (orig) => {
+  const actual = await orig<typeof import('@/lib/queryClient')>();
+  return { ...actual, apiRequest: vi.fn() };
+});
+
+const mockApi = vi.mocked(apiRequest);
+
+interface VersionFixtureOptions {
+  id: string;
+  version: number;
+  supersedesVersionId: string | null;
+  supersededByVersionId: string | null;
+}
+
+function versionFixture({
+  id,
+  version,
+  supersedesVersionId,
+  supersededByVersionId,
+}: VersionFixtureOptions): CurrentPlanVersionV1 {
+  return CurrentPlanVersionV1Schema.parse({
+    contractVersion: 'current-plan-version-v1',
+    id,
+    fundId: 7,
+    version,
+    sourceConfigId: 11,
+    sourceConfigVersion: 3,
+    sourceFactsSnapshotId: 'facts-snapshot-23',
+    deployableCapitalUsd: '9000000.000000',
+    planTransformationVersion: PLAN_TRANSFORMATION_VERSION,
+    allocations: [
+      {
+        allocationId: 'seed-allocation',
+        name: 'Seed',
+        stageFocus: 'Seed',
+        initialCapitalUsd: '6000000.000000',
+        followOnCapitalUsd: '3000000.000000',
+        avgInitialCheckUsd: '1000000.000000',
+        pacingQuarters: 8,
+        followOnStrategy: 'maintain_ownership',
+        followOnParticipationPct: '0.500000000000',
+      },
+    ],
+    pacingAssumptions: {
+      contractVersion: 'current-plan-pacing-v1',
+      deploymentQuarters: 2,
+      quarterlyDeploymentPcts: ['0.500000000000', '0.500000000000'],
+      followOnReservePct: '0.333333333333',
+      annualFeeDragPct: '0.020000000000',
+    },
+    cohortAssumptions: {
+      contractVersion: 'current-plan-cohort-v1',
+      averageInitialCheckUsd: '1000000.000000',
+      stageDistribution: [
+        { stage: 'Seed', pct: '0.600000000000' },
+        { stage: 'Series A', pct: '0.400000000000' },
+      ],
+      graduationMatrix: [
+        {
+          fromStage: 'Seed',
+          toStage: 'Series A',
+          rate: '0.750000000000',
+          quartersToGraduate: 4,
+        },
+      ],
+      exitAssumptions: [
+        {
+          stage: 'Seed',
+          exitMultiple: '3.000000000000',
+          quartersToExit: 20,
+          failureRate: '0.250000000000',
+        },
+      ],
+    },
+    reservePolicyVersion: 'reserve-policy/1.0.0',
+    assumptionsHash: 'a'.repeat(64),
+    supersedesVersionId,
+    supersededByVersionId,
+    createdAt: '2026-07-22T05:07:50.303Z',
+  });
+}
+
+function wrapper(queryClient?: QueryClient) {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useCurrentPlanVersions', () => {
+  beforeEach(() => mockApi.mockReset());
+
+  it('fetches plan versions and identifies the non-superseded head', async () => {
+    const superseded = versionFixture({
+      id: 'plan-version-1',
+      version: 1,
+      supersedesVersionId: null,
+      supersededByVersionId: 'plan-version-2',
+    });
+    const head = versionFixture({
+      id: 'plan-version-2',
+      version: 2,
+      supersedesVersionId: 'plan-version-1',
+      supersededByVersionId: null,
+    });
+    mockApi.mockResolvedValue([superseded, head] as never);
+
+    const { result } = renderHook(() => useCurrentPlanVersions(7), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockApi).toHaveBeenCalledWith('GET', '/api/funds/7/current-plan-versions');
+    expect(result.current.versions).toEqual([superseded, head]);
+    expect(result.current.headVersion).toEqual(head);
+  });
+
+  it('returns a null head when the plan-version list is empty', async () => {
+    mockApi.mockResolvedValue([] as never);
+
+    const { result } = renderHook(() => useCurrentPlanVersions(7), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.versions).toEqual([]);
+    expect(result.current.headVersion).toBeNull();
+  });
+
+  it('does not fetch plan versions without a fund ID', () => {
+    const { result } = renderHook(() => useCurrentPlanVersions(undefined), {
+      wrapper: wrapper(),
+    });
+
+    expect(mockApi).not.toHaveBeenCalled();
+    expect(result.current.versions).toEqual([]);
+  });
+
+  it('builds a stable query key with a nullable missing fund ID', () => {
+    expect(currentPlanVersionsQueryKey(7)).toEqual(['current-plan-versions', 7]);
+    expect(currentPlanVersionsQueryKey(undefined)).toEqual(['current-plan-versions', null]);
+  });
+
+  it('mints a plan version with an idempotency key and invalidates the fund query', async () => {
+    const minted = versionFixture({
+      id: 'plan-version-1',
+      version: 1,
+      supersedesVersionId: null,
+      supersededByVersionId: null,
+    });
+    mockApi.mockResolvedValueOnce([] as never).mockResolvedValueOnce(minted as never);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCurrentPlanVersions(7), {
+      wrapper: wrapper(queryClient),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await result.current.mint.mutateAsync();
+
+    expect(mockApi).toHaveBeenCalledWith(
+      'POST',
+      '/api/funds/7/current-plan-versions',
+      {},
+      {
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'Idempotency-Key': expect.any(String),
+        }),
+      }
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: currentPlanVersionsQueryKey(7),
+    });
+  });
+});

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -52,6 +52,15 @@ vi.mock('@/hooks/use-moic', () => ({
     error: new Error('rankings unavailable'),
   }),
 }));
+vi.mock('@/hooks/useCurrentPlanVersions', () => ({
+  useCurrentPlanVersions: () => ({
+    versions: [],
+    headVersion: null,
+    isLoading: true,
+    error: null,
+    mint: { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, error: null },
+  }),
+}));
 vi.mock('@/components/portfolio/tabs/hooks/useLatestAllocations', () => ({
   useLatestAllocations: () => ({
     isSuccess: false,


### PR DESCRIPTION
## Task 12.3 — R28 plan-acceptance UI (client-only, shadow-safe)

Part of PLAN_61 Rev 3 Wave B (milestone #1, child #1172). Adds the thin plan review/acceptance panel on the fund-model-results (forecast) spoke. Consumes **only** the already-merged Task 12.2 endpoints; no server, schema, migration, or feature-flag changes.

### What
- **`useCurrentPlanVersions` hook** — `GET /api/funds/:fundId/current-plan-versions` → `CurrentPlanVersionV1[]`, derives the head (non-superseded) version, plus a `mint` mutation (`POST` with `Idempotency-Key`, invalidates the query on success).
- **`CurrentPlanAcceptancePanel`** — renders the head plan's derived assumptions with source-config/facts provenance, the **compiled annual fee-drag** value prominently, and an assumption summary; an empty **"Derive initial plan"** state; an **"Accept & mint new plan version"** action; and accessible alerts that surface the 12.2 typed route error codes (`FEE_PROFILE_ABSENT`, `PLAN_DERIVATION_INCOMPLETE`, …). Mounted after `PublishComparisonCard`.
- **Client tests** in `tests/unit/**` for the hook and panel; the page test mocks the hook to stay QueryClient-free.

### Design
Charcoal/beige presson vocabulary, shared `Button`, semantic `dl`/`role="alert"`, disabled pending states — DESIGN.md v3.1.1.

### Verification (local)
- `tests/unit/hooks/useCurrentPlanVersions.test.tsx` + `tests/unit/components/fund-results/CurrentPlanAcceptancePanel.test.tsx` → 10 passed
- Regressed page test fixed: `tests/unit/pages/fund-model-results.test.tsx` → 65 passed
- Full **client** project (both shards) → 1512 passed, 0 failed
- `npm run check` → 0 new TypeScript errors (0/0); ESLint clean on changed files

Money/ratio values are decimal strings end-to-end; the panel formats for display only and never round-trips them into requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)