### PR TITLE
feat(forecast): current_forecast calculation-mode write plane, dormant (PLAN_61 Task 13.0)

### DIFF
--- a/flags/registry.yaml
+++ b/flags/registry.yaml
@@ -488,6 +488,19 @@ flags:
     dependencies: []
     expiresAt: null
 
+  enable_current_forecast_v2:
+    default: false
+    description: 'Current Forecast V2 dual-forecast adapter (PLAN_61 Task 13)'
+    owner: 'gp-team'
+    risk: high
+    exposeToClient: false
+    environments:
+      development: false
+      staging: false
+      production: false
+    dependencies: []
+    expiresAt: null
+
   enable_portfolio_intelligence:
     default: false
     description: 'Gates Portfolio Intelligence prototype endpoints that remain fail-closed until backed by computed financial data'

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -1300,6 +1300,31 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     notes:
       'Express middleware enforces fund access and admin role; route-policy verification allows this scoped admin financial-control API.',
   },
+  {
+    id: 'api:put:/api/admin/funds/:fundId/calculation-modes/current-forecast',
+    method: 'PUT',
+    path: '/api/admin/funds/:fundId/calculation-modes/current-forecast',
+    lifecycle: 'durable_crud',
+    governanceRef: '/fund-model-results/:fundId',
+    surface: 'current-forecast-mode-admin-api',
+    owner: 'analytics',
+    telemetryKey: telemetryKeyForRoute(
+      'api.route',
+      '/api/admin/funds/:fundId/calculation-modes/current-forecast'
+    ),
+    // TODO(13): replace with a current_forecast surface when the policy type supports it.
+    financialSurface: 'moic_reserves',
+    apiAuthBoundary: 'admin_only',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'admin_mode_update_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+    staleBlocksExport: false,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+    notes:
+      'Express middleware enforces fund access and admin role; route-policy verification allows this scoped admin financial-control API.',
+  },
 ];
 
 export const EXPLICIT_API_ROUTE_POLICY_KEYS = new Set<string>(
@@ -1373,6 +1398,7 @@ export const COMMON_API_ROUTE_POLICY_IDS = {
     'api:get:/api/funds/:fundId/current-plan-versions',
     'api:post:/api/funds/:fundId/current-plan-versions',
     'api:post:/api/funds/:fundId/current-forecast/runs',
+    'api:put:/api/admin/funds/:fundId/calculation-modes/current-forecast',
   ],
   funds: ['client:/fund-setup'],
   'fund-metrics': ['client:/dashboard'],

--- a/server/routes/current-forecast.ts
+++ b/server/routes/current-forecast.ts
@@ -4,7 +4,7 @@ import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 
 import { toNumber } from '@shared/number';
-import { requireAuth, requireFundAccess } from '../lib/auth/jwt.js';
+import { requireAuth, requireFundAccess, requireRole } from '../lib/auth/jwt.js';
 import { FundScopeError } from '../lib/fund-scoped-ownership';
 import { IdempotentCommandError } from '../lib/idempotent-command';
 import { handleNumberParseError } from '../lib/number-parse-error';
@@ -18,6 +18,13 @@ import {
   CurrentForecastV2ServiceError,
   runCurrentForecastV2,
 } from '../services/current-forecast-v2-service';
+import {
+  FundCalculationModeBlockedError,
+  FundCalculationModeIdempotencyConflictError,
+  FundCalculationModeInProgressError,
+  FundCalculationModeVersionConflictError,
+  updateCurrentForecastCalculationMode,
+} from '../services/fund-calculation-mode-service';
 
 const routeLog = createRouteLogger('current-forecast');
 const router = Router();
@@ -47,6 +54,14 @@ const RunCurrentForecastV2BodySchema = z
     currentPlanVersionId: z.string().optional(),
     financialFactsSnapshotId: z.string().optional(),
     clock: z.string().datetime().optional(),
+  })
+  .strict();
+
+const CurrentForecastModeUpdateBodySchema = z
+  .object({
+    expectedVersion: z.number().int().nonnegative(),
+    configuredMode: z.enum(['off', 'shadow', 'on']),
+    killSwitchActive: z.boolean().optional(),
   })
   .strict();
 
@@ -220,6 +235,72 @@ router.post(
       return res.status(200).json(forecast);
     } catch (error) {
       if (respondToTypedError(error, res)) return;
+      throw error;
+    }
+  })
+);
+
+router.put(
+  '/admin/funds/:fundId/calculation-modes/current-forecast',
+  currentForecastWriteLimiter,
+  requireAuth(),
+  validateFundIdParam,
+  requireFundAccess,
+  requireRole('admin'),
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = toNumber(req.params['fundId'], 'fundId', { integer: true, min: 1 });
+    const idempotencyKey = req.header('Idempotency-Key')?.trim();
+    if (!idempotencyKey) {
+      return res.status(428).json({
+        error: 'idempotency_key_required',
+        message: 'Idempotency-Key header is required',
+      });
+    }
+
+    const parsedBody = CurrentForecastModeUpdateBodySchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'invalid_mode_update',
+        message: 'Current forecast calculation mode update payload is invalid',
+        details: parsedBody.error.format(),
+      });
+    }
+
+    try {
+      const params: Parameters<typeof updateCurrentForecastCalculationMode>[0] = {
+        fundId,
+        expectedVersion: parsedBody.data.expectedVersion,
+        configuredMode: parsedBody.data.configuredMode,
+        idempotencyKey,
+        actorId: actorId(req),
+        ...(parsedBody.data.killSwitchActive !== undefined && {
+          killSwitchActive: parsedBody.data.killSwitchActive,
+        }),
+      };
+      const result = await updateCurrentForecastCalculationMode(params);
+      return res.status(200).json({ ...result.response, replayed: result.replayed });
+    } catch (error) {
+      if (error instanceof FundCalculationModeVersionConflictError) {
+        return res.status(409).json({
+          error: error.code,
+          message: error.message,
+          expectedVersion: error.expectedVersion,
+          actualVersion: error.actualVersion,
+        });
+      }
+      if (error instanceof FundCalculationModeBlockedError) {
+        return res.status(409).json({
+          error: error.code,
+          message: error.message,
+          blockers: error.blockers,
+        });
+      }
+      if (
+        error instanceof FundCalculationModeIdempotencyConflictError ||
+        error instanceof FundCalculationModeInProgressError
+      ) {
+        return res.status(409).json({ error: error.code, message: error.message });
+      }
       throw error;
     }
   })

--- a/server/services/current-forecast-calc-mode-resolver.ts
+++ b/server/services/current-forecast-calc-mode-resolver.ts
@@ -1,0 +1,32 @@
+import { db } from '../db';
+
+export const CURRENT_FORECAST_CALCULATION_KEY = 'current_forecast';
+
+export type CurrentForecastCalculationMode = 'off' | 'shadow' | 'on';
+
+export type CurrentForecastModeReader = (
+  fundId: number
+) => Promise<{ configuredMode: string; killSwitchActive: boolean } | null | undefined>;
+
+export const defaultCurrentForecastModeReader: CurrentForecastModeReader = (fundId) =>
+  db.query.fundCalculationModes.findFirst({
+    columns: { configuredMode: true, killSwitchActive: true },
+    where: (row, { and, eq }) =>
+      and(eq(row.fundId, fundId), eq(row.calculationKey, CURRENT_FORECAST_CALCULATION_KEY)),
+  });
+
+/**
+ * Resolve the current-forecast mode with a fail-safe off default.
+ * TODO(13.1): map the held state once current_forecast_references exists.
+ */
+export async function resolveCurrentForecastCalculationMode(
+  fundId: number,
+  reader: CurrentForecastModeReader = defaultCurrentForecastModeReader
+): Promise<CurrentForecastCalculationMode> {
+  const mode = await reader(fundId);
+  if (mode?.killSwitchActive) return 'off';
+  if (mode?.configuredMode === 'shadow' || mode?.configuredMode === 'on') {
+    return mode.configuredMode;
+  }
+  return 'off';
+}

--- a/server/services/fund-calculation-mode-service.ts
+++ b/server/services/fund-calculation-mode-service.ts
@@ -17,9 +17,13 @@ import {
 import { invalidateH9Artifacts } from './h9-artifact-invalidation-service';
 import { reconciliationRuns } from '../../shared/schema';
 import { buildRoundsToModelEvidence } from './rounds-to-model-evidence-service';
+import { CURRENT_FORECAST_CALCULATION_KEY } from './current-forecast-calc-mode-resolver';
 
 const MODE_ROUTE = 'PUT /api/admin/funds/:fundId/calculation-modes/fund-moic-rankings';
+const CURRENT_FORECAST_MODE_ROUTE =
+  'PUT /api/admin/funds/:fundId/calculation-modes/current-forecast';
 export const MOIC_MODE_RESIDENCY_DAYS_REQUIRED = 7;
+const CURRENT_FORECAST_MODE_RESIDENCY_DAYS_REQUIRED = MOIC_MODE_RESIDENCY_DAYS_REQUIRED;
 
 export type FundCalculationConfiguredMode = 'off' | 'shadow' | 'on';
 export type FundCalculationEffectiveMode = 'off' | 'shadow' | 'on';
@@ -129,6 +133,10 @@ type ReconciliationRow = {
 };
 
 export type AcceptedRef = ReconciliationRow;
+
+type CurrentForecastModeSources = {
+  sourceInputHash: string;
+};
 
 export interface CalculationModeStrategy<TSources> {
   calculationKey: string;
@@ -685,6 +693,25 @@ const moicCalculationModeStrategy: CalculationModeStrategy<FundMoicRankingSource
   postCommit: invalidateH9Artifacts,
 };
 
+const currentForecastCalculationModeStrategy: CalculationModeStrategy<CurrentForecastModeSources> =
+  {
+    calculationKey: CURRENT_FORECAST_CALCULATION_KEY,
+    modeRoute: CURRENT_FORECAST_MODE_ROUTE,
+    residencyDaysRequired: CURRENT_FORECAST_MODE_RESIDENCY_DAYS_REQUIRED,
+    loadSources: async () => ({
+      sourceInputHash: canonicalSha256({
+        calculationKey: CURRENT_FORECAST_CALCULATION_KEY,
+        referenceStatus: 'unavailable_until_task_13_1',
+      }),
+    }),
+    sourceInputHash: (sources) => sources.sourceInputHash,
+    factsAvailable: () => true,
+    sourceBlockers: () => [],
+    validateAccepted: () => ['accepted_reconciliation_required'],
+    loadCompletedAccepted: async () => null,
+    postCommit: () => Promise.resolve(),
+  };
+
 function validateOnTransition<TSources>(
   strategy: CalculationModeStrategy<TSources>,
   params: {
@@ -977,4 +1004,12 @@ export async function updateFundMoicCalculationMode(
     response: result.response as FundCalculationModePreview,
     replayed: result.replayed,
   };
+}
+
+export async function updateCurrentForecastCalculationMode(
+  params: UpdateFundCalculationModeParams<CurrentForecastModeSources>
+): Promise<{ response: GenericFundCalculationModePreview; replayed: boolean }> {
+  // Transitional schema alias: last_moic_source_input_hash stores the accepted
+  // source hash for whichever calculation key owns the row until Task 13.1.
+  return updateFundCalculationMode(currentForecastCalculationModeStrategy, params);
 }

--- a/server/services/fund-calculation-mode-service.ts
+++ b/server/services/fund-calculation-mode-service.ts
@@ -49,6 +49,21 @@ export interface FundCalculationModePreview {
   version: number;
 }
 
+interface GenericFundCalculationModePreview {
+  calculationKey: string;
+  configuredMode: FundCalculationConfiguredMode;
+  effectiveMode: FundCalculationEffectiveMode;
+  killSwitchActive: boolean;
+  shadowStartedAt: string | null;
+  eligibleAt: string | null;
+  residencyDaysRequired: number;
+  residencyStatus: FundCalculationResidencyStatus;
+  currentSourceMatchesAccepted: boolean;
+  unreconciledEditsPresent: boolean;
+  blockers: FundCalculationModeBlocker[];
+  version: number;
+}
+
 export class FundCalculationModeVersionConflictError extends Error {
   readonly code = 'stale_expected_version';
 
@@ -88,8 +103,8 @@ export class FundCalculationModeInProgressError extends Error {
   }
 }
 
-type FundCalculationModeDatabase = typeof db;
-type FundCalculationModeTransaction = Parameters<
+export type FundCalculationModeDatabase = typeof db;
+export type FundCalculationModeTransaction = Parameters<
   Parameters<FundCalculationModeDatabase['transaction']>[0]
 >[0];
 type ExecuteResult<T> = { rows: T[] };
@@ -112,6 +127,25 @@ type ReconciliationRow = {
   candidate_material?: boolean;
   requested_at?: Date | string;
 };
+
+export type AcceptedRef = ReconciliationRow;
+
+export interface CalculationModeStrategy<TSources> {
+  calculationKey: string;
+  modeRoute: string;
+  residencyDaysRequired: number;
+  loadSources(fundId: number, database: FundCalculationModeDatabase, now: Date): Promise<TSources>;
+  sourceInputHash(sources: TSources): string;
+  factsAvailable(sources: TSources): boolean;
+  sourceBlockers(sources: TSources): FundCalculationModeBlocker[];
+  validateAccepted(accepted: AcceptedRef | null, sources: TSources): FundCalculationModeBlocker[];
+  loadCompletedAccepted(
+    tx: FundCalculationModeTransaction,
+    fundId: number,
+    acceptedId: number
+  ): Promise<AcceptedRef | null>;
+  postCommit(fundId: number): Promise<void>;
+}
 
 type AcceptedMoicReconciliationRow = {
   id?: number;
@@ -385,17 +419,20 @@ export function toH9SnapshotColumns(result: MoicActionabilityResult) {
   };
 }
 
-function requestHashFor(params: {
-  fundId: number;
-  expectedVersion: number;
-  configuredMode: FundCalculationConfiguredMode;
-  killSwitchActive: boolean | null;
-  acceptedReconciliationRunId: number | null;
-}): string {
+function requestHashFor<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: {
+    fundId: number;
+    expectedVersion: number;
+    configuredMode: FundCalculationConfiguredMode;
+    killSwitchActive: boolean | null;
+    acceptedReconciliationRunId: number | null;
+  }
+): string {
   return canonicalSha256({
-    route: MODE_ROUTE,
+    route: strategy.modeRoute,
     fundId: params.fundId,
-    calculationKey: FUND_MOIC_CALCULATION_KEY,
+    calculationKey: strategy.calculationKey,
     expectedVersion: params.expectedVersion,
     configuredMode: params.configuredMode,
     killSwitchActive: params.killSwitchActive,
@@ -403,34 +440,40 @@ function requestHashFor(params: {
   });
 }
 
-function responseFromLedger(value: unknown): FundCalculationModePreview {
+function responseFromLedger<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  value: unknown
+): GenericFundCalculationModePreview {
   const parsed: unknown = typeof value === 'string' ? (JSON.parse(value) as unknown) : value;
   if (
     typeof parsed === 'object' &&
     parsed !== null &&
-    (parsed as { calculationKey?: unknown }).calculationKey === FUND_MOIC_CALCULATION_KEY &&
+    (parsed as { calculationKey?: unknown }).calculationKey === strategy.calculationKey &&
     typeof (parsed as { version?: unknown }).version === 'number'
   ) {
-    return parsed as FundCalculationModePreview;
+    return parsed as GenericFundCalculationModePreview;
   }
 
   throw new Error('Completed MOIC mode idempotency row has an invalid response body');
 }
 
-async function claimOrReplay(params: {
-  tx: FundCalculationModeTransaction;
-  fundId: number;
-  idempotencyKey: string;
-  requestHash: string;
-  actorId: number | null;
-}): Promise<{ claimed: true } | { claimed: false; response: FundCalculationModePreview }> {
+async function claimOrReplay<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: {
+    tx: FundCalculationModeTransaction;
+    fundId: number;
+    idempotencyKey: string;
+    requestHash: string;
+    actorId: number | null;
+  }
+): Promise<{ claimed: true } | { claimed: false; response: GenericFundCalculationModePreview }> {
   const claimed = await executeRows<{ id: number }>(
     params.tx,
     sql`
       INSERT INTO fund_calculation_mode_requests
         (fund_id, calculation_key, idempotency_key, request_hash, created_by, status)
       VALUES
-        (${params.fundId}, ${FUND_MOIC_CALCULATION_KEY}, ${params.idempotencyKey}, ${params.requestHash}, ${params.actorId}, 'pending')
+        (${params.fundId}, ${strategy.calculationKey}, ${params.idempotencyKey}, ${params.requestHash}, ${params.actorId}, 'pending')
       ON CONFLICT (fund_id, calculation_key, idempotency_key) DO NOTHING
       RETURNING id
     `
@@ -450,7 +493,7 @@ async function claimOrReplay(params: {
       SELECT request_hash, response_body, status
       FROM fund_calculation_mode_requests
       WHERE fund_id = ${params.fundId}
-        AND calculation_key = ${FUND_MOIC_CALCULATION_KEY}
+        AND calculation_key = ${strategy.calculationKey}
         AND idempotency_key = ${params.idempotencyKey}
       LIMIT 1
     `
@@ -469,7 +512,7 @@ async function claimOrReplay(params: {
     throw new FundCalculationModeInProgressError();
   }
 
-  return { claimed: false, response: responseFromLedger(row.response_body) };
+  return { claimed: false, response: responseFromLedger(strategy, row.response_body) };
 }
 
 function toDate(value: Date | string | null): Date | null {
@@ -495,19 +538,33 @@ function sourceBlockers(sources: FundMoicRankingSources): FundCalculationModeBlo
   return blockers;
 }
 
-function buildModePreview(params: {
-  row: ModeRow | null;
-  sources: FundMoicRankingSources;
-  now: Date;
-}): FundCalculationModePreview {
+function strategySourceBlockers<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  sources: TSources
+): FundCalculationModeBlocker[] {
+  const blockers = strategy.sourceBlockers(sources);
+  if (!strategy.factsAvailable(sources) && !blockers.includes('facts_unavailable')) {
+    return ['facts_unavailable', ...blockers];
+  }
+  return blockers;
+}
+
+function buildModePreview<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: {
+    row: ModeRow | null;
+    sources: TSources;
+    now: Date;
+  }
+): GenericFundCalculationModePreview {
   const configuredMode = params.row?.configured_mode ?? 'off';
   const killSwitchActive = params.row?.kill_switch_active ?? false;
   const shadowStartedDate = toDate(params.row?.shadow_started_at ?? null);
   const eligibleDate = shadowStartedDate
-    ? addDays(shadowStartedDate, MOIC_MODE_RESIDENCY_DAYS_REQUIRED)
+    ? addDays(shadowStartedDate, strategy.residencyDaysRequired)
     : null;
   const currentSourceMatchesAccepted =
-    params.row?.last_moic_source_input_hash === params.sources.moicSourceInputHash;
+    params.row?.last_moic_source_input_hash === strategy.sourceInputHash(params.sources);
   const unreconciledEditsPresent = Boolean(
     params.row?.last_moic_source_input_hash && !currentSourceMatchesAccepted
   );
@@ -531,16 +588,16 @@ function buildModePreview(params: {
   if (configuredMode !== 'off' && residencyStatus === 'pending') {
     blockers.push('shadow_residency_pending');
   }
-  blockers.push(...sourceBlockers(params.sources));
+  blockers.push(...strategySourceBlockers(strategy, params.sources));
 
   return {
-    calculationKey: FUND_MOIC_CALCULATION_KEY,
+    calculationKey: strategy.calculationKey,
     configuredMode,
     effectiveMode: killSwitchActive ? 'off' : configuredMode,
     killSwitchActive,
     shadowStartedAt: shadowStartedDate?.toISOString() ?? null,
     eligibleAt: eligibleDate?.toISOString() ?? null,
-    residencyDaysRequired: MOIC_MODE_RESIDENCY_DAYS_REQUIRED,
+    residencyDaysRequired: strategy.residencyDaysRequired,
     residencyStatus,
     currentSourceMatchesAccepted,
     unreconciledEditsPresent,
@@ -549,7 +606,8 @@ function buildModePreview(params: {
   };
 }
 
-async function loadModeRow(
+async function loadModeRow<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
   executor: Pick<FundCalculationModeTransaction, 'execute'>,
   fundId: number,
   lock: boolean
@@ -563,7 +621,7 @@ async function loadModeRow(
                  last_candidate_output_hash, version
           FROM fund_calculation_modes
           WHERE fund_id = ${fundId}
-            AND calculation_key = ${FUND_MOIC_CALCULATION_KEY}
+            AND calculation_key = ${strategy.calculationKey}
           FOR UPDATE
         `
       : sql`
@@ -572,7 +630,7 @@ async function loadModeRow(
                  last_candidate_output_hash, version
           FROM fund_calculation_modes
           WHERE fund_id = ${fundId}
-            AND calculation_key = ${FUND_MOIC_CALCULATION_KEY}
+            AND calculation_key = ${strategy.calculationKey}
           LIMIT 1
         `
   );
@@ -613,38 +671,57 @@ function validateAcceptedReconciliation(params: {
   return [];
 }
 
-function validateOnTransition(params: {
-  accepted: ReconciliationRow | null;
-  nextKillSwitchActive: boolean;
-  shadowStartedAt: Date | null;
-  sources: FundMoicRankingSources;
-  now: Date;
-}): FundCalculationModeBlocker[] {
+const moicCalculationModeStrategy: CalculationModeStrategy<FundMoicRankingSources> = {
+  calculationKey: FUND_MOIC_CALCULATION_KEY,
+  modeRoute: MODE_ROUTE,
+  residencyDaysRequired: MOIC_MODE_RESIDENCY_DAYS_REQUIRED,
+  loadSources: (fundId, database, now) =>
+    getFundMoicRankingSources(fundId, database, undefined, now),
+  sourceInputHash: (sources) => sources.moicSourceInputHash,
+  factsAvailable: (sources) => sources.factsSource.status === 'available',
+  sourceBlockers,
+  validateAccepted: (accepted, sources) => validateAcceptedReconciliation({ accepted, sources }),
+  loadCompletedAccepted: loadCompletedReconciliation,
+  postCommit: invalidateH9Artifacts,
+};
+
+function validateOnTransition<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: {
+    accepted: AcceptedRef | null;
+    nextKillSwitchActive: boolean;
+    shadowStartedAt: Date | null;
+    sources: TSources;
+    now: Date;
+  }
+): FundCalculationModeBlocker[] {
   const blockers: FundCalculationModeBlocker[] = [];
   if (params.nextKillSwitchActive) {
     blockers.push('kill_switch_active');
   }
-  blockers.push(...validateAcceptedReconciliation(params));
+  blockers.push(...strategy.validateAccepted(params.accepted, params.sources));
   if (
     !params.shadowStartedAt ||
-    params.now.getTime() <
-      addDays(params.shadowStartedAt, MOIC_MODE_RESIDENCY_DAYS_REQUIRED).getTime()
+    params.now.getTime() < addDays(params.shadowStartedAt, strategy.residencyDaysRequired).getTime()
   ) {
     blockers.push('shadow_residency_pending');
   }
-  blockers.push(...sourceBlockers(params.sources));
+  blockers.push(...strategySourceBlockers(strategy, params.sources));
   return [...new Set(blockers)].sort();
 }
 
-async function insertModeRow(params: {
-  tx: FundCalculationModeTransaction;
-  fundId: number;
-  configuredMode: FundCalculationConfiguredMode;
-  killSwitchActive: boolean;
-  shadowStartedAt: Date | null;
-  accepted: ReconciliationRow | null;
-  actorId: number | null;
-}): Promise<ModeRow> {
+async function insertModeRow<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: {
+    tx: FundCalculationModeTransaction;
+    fundId: number;
+    configuredMode: FundCalculationConfiguredMode;
+    killSwitchActive: boolean;
+    shadowStartedAt: Date | null;
+    accepted: AcceptedRef | null;
+    actorId: number | null;
+  }
+): Promise<ModeRow> {
   const rows = await executeRows<ModeRow>(
     params.tx,
     sql`
@@ -654,7 +731,7 @@ async function insertModeRow(params: {
          last_candidate_output_hash, version, updated_by, updated_at)
       VALUES (
         ${params.fundId},
-        ${FUND_MOIC_CALCULATION_KEY},
+        ${strategy.calculationKey},
         ${params.configuredMode},
         ${params.killSwitchActive},
         ${params.shadowStartedAt},
@@ -679,15 +756,18 @@ async function insertModeRow(params: {
   return inserted;
 }
 
-async function updateModeRow(params: {
-  tx: FundCalculationModeTransaction;
-  row: ModeRow;
-  configuredMode: FundCalculationConfiguredMode;
-  killSwitchActive: boolean;
-  shadowStartedAt: Date | null;
-  accepted: ReconciliationRow | null;
-  actorId: number | null;
-}): Promise<ModeRow> {
+async function updateModeRow<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: {
+    tx: FundCalculationModeTransaction;
+    row: ModeRow;
+    configuredMode: FundCalculationConfiguredMode;
+    killSwitchActive: boolean;
+    shadowStartedAt: Date | null;
+    accepted: AcceptedRef | null;
+    actorId: number | null;
+  }
+): Promise<ModeRow> {
   const rows = await executeRows<ModeRow>(
     params.tx,
     sql`
@@ -702,6 +782,7 @@ async function updateModeRow(params: {
           updated_by = ${params.actorId},
           updated_at = NOW()
       WHERE id = ${params.row.id}
+        AND calculation_key = ${strategy.calculationKey}
       RETURNING id, configured_mode, kill_switch_active, shadow_started_at,
                 last_reconciliation_run_id, last_moic_source_input_hash,
                 last_candidate_output_hash, version
@@ -715,20 +796,35 @@ async function updateModeRow(params: {
   return updated;
 }
 
-export async function resolveFundCalculationMode(params: {
+type ResolveFundCalculationModeParams<TSources> = {
   fundId: number;
-  sources?: FundMoicRankingSources;
+  sources?: TSources;
   database?: FundCalculationModeDatabase;
   now?: Date;
-}): Promise<FundCalculationModePreview> {
-  const database = params.database ?? db;
-  const sources = params.sources ?? (await getFundMoicRankingSources(params.fundId, database));
-  const row = await loadModeRow(database as never, params.fundId, false);
+};
 
-  return buildModePreview({ row, sources, now: params.now ?? new Date() });
+async function resolveFundCalculationModeGeneric<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: ResolveFundCalculationModeParams<TSources>
+): Promise<GenericFundCalculationModePreview> {
+  const database = params.database ?? db;
+  const now = params.now ?? new Date();
+  const sources = params.sources ?? (await strategy.loadSources(params.fundId, database, now));
+  const row = await loadModeRow(strategy, database as never, params.fundId, false);
+
+  return buildModePreview(strategy, { row, sources, now });
 }
 
-export async function updateFundMoicCalculationMode(params: {
+export async function resolveFundCalculationMode(
+  params: ResolveFundCalculationModeParams<FundMoicRankingSources>
+): Promise<FundCalculationModePreview> {
+  return resolveFundCalculationModeGeneric(
+    moicCalculationModeStrategy,
+    params
+  ) as Promise<FundCalculationModePreview>;
+}
+
+type UpdateFundCalculationModeParams<TSources> = {
   fundId: number;
   expectedVersion: number;
   configuredMode: FundCalculationConfiguredMode;
@@ -737,13 +833,18 @@ export async function updateFundMoicCalculationMode(params: {
   idempotencyKey: string;
   actorId: number | null;
   database?: FundCalculationModeDatabase;
-  sources?: FundMoicRankingSources;
+  sources?: TSources;
   now?: Date;
-}): Promise<{ response: FundCalculationModePreview; replayed: boolean }> {
+};
+
+async function updateFundCalculationMode<TSources>(
+  strategy: CalculationModeStrategy<TSources>,
+  params: UpdateFundCalculationModeParams<TSources>
+): Promise<{ response: GenericFundCalculationModePreview; replayed: boolean }> {
   const database = params.database ?? db;
-  const sources = params.sources ?? (await getFundMoicRankingSources(params.fundId, database));
   const now = params.now ?? new Date();
-  const requestHash = requestHashFor({
+  const sources = params.sources ?? (await strategy.loadSources(params.fundId, database, now));
+  const requestHash = requestHashFor(strategy, {
     fundId: params.fundId,
     expectedVersion: params.expectedVersion,
     configuredMode: params.configuredMode,
@@ -752,7 +853,7 @@ export async function updateFundMoicCalculationMode(params: {
   });
 
   const result = await database.transaction(async (tx) => {
-    const claim = await claimOrReplay({
+    const claim = await claimOrReplay(strategy, {
       tx,
       fundId: params.fundId,
       idempotencyKey: params.idempotencyKey,
@@ -763,7 +864,7 @@ export async function updateFundMoicCalculationMode(params: {
       return { response: claim.response, replayed: true };
     }
 
-    const existing = await loadModeRow(tx, params.fundId, true);
+    const existing = await loadModeRow(strategy, tx, params.fundId, true);
     if (!existing && params.expectedVersion !== 0) {
       throw new FundCalculationModeVersionConflictError(params.expectedVersion, 0);
     }
@@ -772,7 +873,7 @@ export async function updateFundMoicCalculationMode(params: {
     }
 
     const nextKillSwitchActive = params.killSwitchActive ?? existing?.kill_switch_active ?? false;
-    let accepted: ReconciliationRow | null =
+    let accepted: AcceptedRef | null =
       existing?.last_reconciliation_run_id &&
       existing.last_moic_source_input_hash &&
       existing.last_candidate_output_hash
@@ -787,12 +888,12 @@ export async function updateFundMoicCalculationMode(params: {
       params.acceptedReconciliationRunId !== undefined &&
       params.acceptedReconciliationRunId !== null
     ) {
-      accepted = await loadCompletedReconciliation(
+      accepted = await strategy.loadCompletedAccepted(
         tx,
         params.fundId,
         params.acceptedReconciliationRunId
       );
-      const blockers = validateAcceptedReconciliation({ accepted, sources });
+      const blockers = strategy.validateAccepted(accepted, sources);
       if (blockers.length > 0) {
         throw new FundCalculationModeBlockedError(blockers);
       }
@@ -800,7 +901,7 @@ export async function updateFundMoicCalculationMode(params: {
 
     let nextShadowStartedAt: Date | null = null;
     if (params.configuredMode === 'shadow') {
-      const blockers = validateAcceptedReconciliation({ accepted, sources });
+      const blockers = strategy.validateAccepted(accepted, sources);
       if (blockers.length > 0) {
         throw new FundCalculationModeBlockedError(blockers);
       }
@@ -816,7 +917,7 @@ export async function updateFundMoicCalculationMode(params: {
 
     if (params.configuredMode === 'on') {
       const shadowStartedAt = toDate(existing?.shadow_started_at ?? null);
-      const blockers = validateOnTransition({
+      const blockers = validateOnTransition(strategy, {
         accepted,
         nextKillSwitchActive,
         shadowStartedAt,
@@ -830,7 +931,7 @@ export async function updateFundMoicCalculationMode(params: {
     }
 
     const row = existing
-      ? await updateModeRow({
+      ? await updateModeRow(strategy, {
           tx,
           row: existing,
           configuredMode: params.configuredMode,
@@ -839,7 +940,7 @@ export async function updateFundMoicCalculationMode(params: {
           accepted,
           actorId: params.actorId,
         })
-      : await insertModeRow({
+      : await insertModeRow(strategy, {
           tx,
           fundId: params.fundId,
           configuredMode: params.configuredMode,
@@ -849,21 +950,31 @@ export async function updateFundMoicCalculationMode(params: {
           actorId: params.actorId,
         });
 
-    const response = buildModePreview({ row, sources, now });
+    const response = buildModePreview(strategy, { row, sources, now });
     await tx.execute(sql`
       UPDATE fund_calculation_mode_requests
       SET status = 'completed',
           response_status = 200,
           response_body = ${JSON.stringify(response)}::jsonb
       WHERE fund_id = ${params.fundId}
-        AND calculation_key = ${FUND_MOIC_CALCULATION_KEY}
+        AND calculation_key = ${strategy.calculationKey}
         AND idempotency_key = ${params.idempotencyKey}
     `);
 
     return { response, replayed: false };
   });
   if (!result.replayed) {
-    await invalidateH9Artifacts(params.fundId);
+    await strategy.postCommit(params.fundId);
   }
   return result;
+}
+
+export async function updateFundMoicCalculationMode(
+  params: UpdateFundCalculationModeParams<FundMoicRankingSources>
+): Promise<{ response: FundCalculationModePreview; replayed: boolean }> {
+  const result = await updateFundCalculationMode(moicCalculationModeStrategy, params);
+  return {
+    response: result.response as FundCalculationModePreview,
+    replayed: result.replayed,
+  };
 }

--- a/shared/routes/api-route-manifest.ts
+++ b/shared/routes/api-route-manifest.ts
@@ -164,6 +164,8 @@ export const COMMON_API_ROUTE_MANIFEST = [
       'fund_snapshots',
       'fundconfigs',
       'funds',
+      'fund_calculation_modes',
+      'fund_calculation_mode_requests',
     ],
     owner: 'analytics',
     probe: {

--- a/tests/unit/routes/current-forecast-mode.behavior.test.ts
+++ b/tests/unit/routes/current-forecast-mode.behavior.test.ts
@@ -1,0 +1,120 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  user: null as null | { id: number; role: string; fundIds: number[] },
+}));
+const svc = vi.hoisted(() => ({ updateCurrentForecastCalculationMode: vi.fn() }));
+
+vi.mock('../../../server/services/fund-calculation-mode-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../server/services/fund-calculation-mode-service')>();
+  return {
+    ...actual,
+    updateCurrentForecastCalculationMode: svc.updateCurrentForecastCalculationMode,
+  };
+});
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
+      if (!authState.user) return res.sendStatus(401);
+      (req as Request & { user: unknown }).user = { ...authState.user };
+      next();
+    },
+  };
+});
+
+import currentForecastRouter from '../../../server/routes/current-forecast';
+
+const preview = {
+  calculationKey: 'current_forecast',
+  configuredMode: 'off',
+  effectiveMode: 'off',
+  killSwitchActive: false,
+  shadowStartedAt: null,
+  eligibleAt: null,
+  residencyDaysRequired: 7,
+  residencyStatus: 'not_applicable',
+  currentSourceMatchesAccepted: false,
+  unreconciledEditsPresent: false,
+  blockers: [],
+  version: 1,
+};
+const validBody = { expectedVersion: 0, configuredMode: 'off' };
+const ADMIN = { id: 101, role: 'admin', fundIds: [1] };
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', currentForecastRouter);
+  app.use((_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
+    res.status(500).json({ error: 'internal_error' })
+  );
+  return app;
+}
+
+function put(options: { key?: string; body?: unknown } = {}) {
+  const req = request(buildApp()).put('/api/admin/funds/1/calculation-modes/current-forecast');
+  if (options.key !== undefined) req.set('Idempotency-Key', options.key);
+  return req.send(options.body ?? validBody);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = ADMIN;
+  svc.updateCurrentForecastCalculationMode.mockResolvedValue({
+    response: preview,
+    replayed: false,
+  });
+});
+
+describe('current-forecast calculation mode route', () => {
+  it('requires the admin role', async () => {
+    authState.user = { id: 102, role: 'analyst', fundIds: [1] };
+
+    const response = await put({ key: 'forecast-role' });
+
+    expect(response.status).toBe(403);
+    expect(svc.updateCurrentForecastCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('returns 428 when Idempotency-Key is missing', async () => {
+    const response = await put();
+
+    expect(response.status).toBe(428);
+    expect(response.body).toEqual({
+      error: 'idempotency_key_required',
+      message: 'Idempotency-Key header is required',
+    });
+    expect(svc.updateCurrentForecastCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body is invalid', async () => {
+    const response = await put({
+      key: 'forecast-invalid',
+      body: { expectedVersion: 0, configuredMode: 'off', unexpected: true },
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'invalid_mode_update' });
+    expect(svc.updateCurrentForecastCalculationMode).not.toHaveBeenCalled();
+  });
+
+  it('writes off mode and returns the preview with replay status', async () => {
+    const response = await put({ key: '  forecast-off  ' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ...preview, replayed: false });
+    expect(svc.updateCurrentForecastCalculationMode).toHaveBeenCalledWith({
+      fundId: 1,
+      expectedVersion: 0,
+      configuredMode: 'off',
+      idempotencyKey: 'forecast-off',
+      actorId: 101,
+    });
+  });
+});

--- a/tests/unit/routes/current-forecast.contract.test.ts
+++ b/tests/unit/routes/current-forecast.contract.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../server/lib/auth/jwt', () => ({
     if (!authState.fundAccess) return res.sendStatus(403);
     next();
   },
+  requireRole: () => (_req: Request, _res: Response, next: NextFunction) => next(),
 }));
 
 vi.mock('../../../server/services/current-plan-version-service', () => {

--- a/tests/unit/services/current-forecast-calc-mode-resolver.test.ts
+++ b/tests/unit/services/current-forecast-calc-mode-resolver.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CURRENT_FORECAST_CALCULATION_KEY,
+  resolveCurrentForecastCalculationMode,
+  type CurrentForecastModeReader,
+} from '../../../server/services/current-forecast-calc-mode-resolver';
+
+const reader =
+  (row: { configuredMode: string; killSwitchActive: boolean } | null): CurrentForecastModeReader =>
+  async () =>
+    row;
+
+describe('resolveCurrentForecastCalculationMode', () => {
+  it('defaults to off when no row exists', async () => {
+    expect(await resolveCurrentForecastCalculationMode(1, reader(null))).toBe('off');
+  });
+
+  it('returns shadow when configuredMode is shadow', async () => {
+    expect(
+      await resolveCurrentForecastCalculationMode(
+        1,
+        reader({ configuredMode: 'shadow', killSwitchActive: false })
+      )
+    ).toBe('shadow');
+  });
+
+  it('returns on when configuredMode is on', async () => {
+    expect(
+      await resolveCurrentForecastCalculationMode(
+        1,
+        reader({ configuredMode: 'on', killSwitchActive: false })
+      )
+    ).toBe('on');
+  });
+
+  it('collapses to off when the kill switch is active', async () => {
+    expect(
+      await resolveCurrentForecastCalculationMode(
+        1,
+        reader({ configuredMode: 'on', killSwitchActive: true })
+      )
+    ).toBe('off');
+  });
+
+  it('fails safe to off on an unexpected configuredMode', async () => {
+    expect(
+      await resolveCurrentForecastCalculationMode(
+        1,
+        reader({ configuredMode: 'bogus', killSwitchActive: false })
+      )
+    ).toBe('off');
+  });
+
+  it('exposes the current-forecast calculation key', () => {
+    expect(CURRENT_FORECAST_CALCULATION_KEY).toBe('current_forecast');
+  });
+});

--- a/tests/unit/services/fund-calculation-mode-service.current-forecast.test.ts
+++ b/tests/unit/services/fund-calculation-mode-service.current-forecast.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CURRENT_FORECAST_CALCULATION_KEY } from '../../../server/services/current-forecast-calc-mode-resolver';
+import { updateCurrentForecastCalculationMode } from '../../../server/services/fund-calculation-mode-service';
+
+const now = new Date('2026-07-22T12:00:00.000Z');
+
+function modeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    configured_mode: 'off',
+    kill_switch_active: false,
+    shadow_started_at: null,
+    last_reconciliation_run_id: null,
+    last_moic_source_input_hash: null,
+    last_candidate_output_hash: null,
+    version: 1,
+    ...overrides,
+  };
+}
+
+function makeDatabase(executeRows: unknown[][]) {
+  const queue = [...executeRows];
+  const tx = {
+    execute: vi.fn(async () => ({ rows: queue.shift() ?? [] })),
+  };
+  const database = {
+    execute: vi.fn(async () => ({ rows: queue.shift() ?? [] })),
+    transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+      callback(tx)
+    ),
+  };
+
+  return { database, tx };
+}
+
+describe('current-forecast calculation mode service', () => {
+  it('creates the current_forecast row in off mode at version 1', async () => {
+    const { database, tx } = makeDatabase([[{ id: 100 }], [], [modeRow()], []]);
+
+    const result = await updateCurrentForecastCalculationMode({
+      fundId: 7,
+      expectedVersion: 0,
+      configuredMode: 'off',
+      idempotencyKey: 'forecast-off-1',
+      actorId: 42,
+      database: database as never,
+      now,
+    });
+
+    expect(result).toEqual({
+      response: {
+        calculationKey: CURRENT_FORECAST_CALCULATION_KEY,
+        configuredMode: 'off',
+        effectiveMode: 'off',
+        killSwitchActive: false,
+        shadowStartedAt: null,
+        eligibleAt: null,
+        residencyDaysRequired: 7,
+        residencyStatus: 'not_applicable',
+        currentSourceMatchesAccepted: false,
+        unreconciledEditsPresent: false,
+        blockers: [],
+        version: 1,
+      },
+      replayed: false,
+    });
+    expect(tx.execute).toHaveBeenCalledTimes(4);
+  });
+});

--- a/tests/unit/services/fund-calculation-mode-service.golden.test.ts
+++ b/tests/unit/services/fund-calculation-mode-service.golden.test.ts
@@ -1,0 +1,154 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import { updateFundMoicCalculationMode } from '../../../server/services/fund-calculation-mode-service';
+import type { FundMoicRankingSources } from '../../../server/services/fund-moic-ranking-service';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+
+const ROUTE = 'PUT /api/admin/funds/:fundId/calculation-modes/fund-moic-rankings';
+const CALCULATION_KEY = 'fund_moic_rankings_exit_probability';
+const GOLDEN_REQUEST_HASH = '7ab56e0b229a66f10e55cd72ac7492c26c1b795924f6a95d8ba964389ddfdc5b';
+const NOW = new Date('2026-06-24T12:00:00.000Z');
+const dialect = new PgDialect();
+
+function sourceBundle(): FundMoicRankingSources {
+  return {
+    legacy: {
+      fundId: 7,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt: NOW.toISOString(),
+      rankings: [],
+    },
+    candidate: {
+      fundId: 7,
+      provenance: {
+        source: 'portfolio_companies',
+        calculation: 'reserves_moic_rankings',
+        metricBasis: 'planned_reserves',
+        sourceRecordCount: 1,
+      },
+      generatedAt: NOW.toISOString(),
+      rankings: [],
+    },
+    moicInputSummary: {
+      sourceVersion: 'moic-round-fmv-facts-v2',
+      explicitExitProbabilityCount: 1,
+      defaultedExitProbabilityCount: 0,
+      activationBlockingDefaultedExitProbabilityCount: 0,
+      explicitReserveExitMultipleCount: 1,
+      defaultedReserveExitMultipleCount: 0,
+      activationBlockingDefaultedReserveExitMultipleCount: 0,
+    },
+    moicSourceInputHash: 'source-hash-a',
+    factsSource: {
+      status: 'available',
+      response: {
+        fundId: 7,
+        asOfDate: '2026-07-13',
+        facts: [],
+        inputHash: 'f'.repeat(64),
+        generatedAt: '2026-07-13T00:00:00.000Z',
+      },
+    },
+  };
+}
+
+function makeDatabase(executeRows: unknown[][]) {
+  const queue = [...executeRows];
+  const executed: Array<{ sql: string; params: unknown[] }> = [];
+  const tx = {
+    execute: vi.fn(async (query: SQL) => {
+      executed.push(dialect.sqlToQuery(query));
+      return { rows: queue.shift() ?? [] };
+    }),
+  };
+  const database = {
+    transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+      callback(tx)
+    ),
+  };
+
+  return { database, executed };
+}
+
+describe('fund calculation mode service MOIC golden contract', () => {
+  it('preserves the request hash and response bytes for a representative shadow update', async () => {
+    const requestPreimage = {
+      route: ROUTE,
+      fundId: 7,
+      calculationKey: CALCULATION_KEY,
+      expectedVersion: 0,
+      configuredMode: 'shadow',
+      killSwitchActive: null,
+      acceptedReconciliationRunId: 55,
+    } as const;
+    const { database, executed } = makeDatabase([
+      [{ id: 100 }],
+      [],
+      [
+        {
+          id: 55,
+          candidate_input_hash: 'source-hash-a',
+          candidate_output_hash: 'candidate-output-a',
+        },
+      ],
+      [
+        {
+          id: 1,
+          configured_mode: 'shadow',
+          kill_switch_active: false,
+          shadow_started_at: NOW,
+          last_reconciliation_run_id: 55,
+          last_moic_source_input_hash: 'source-hash-a',
+          last_candidate_output_hash: 'candidate-output-a',
+          version: 1,
+        },
+      ],
+      [],
+    ]);
+
+    const result = await updateFundMoicCalculationMode({
+      fundId: 7,
+      expectedVersion: 0,
+      configuredMode: 'shadow',
+      acceptedReconciliationRunId: 55,
+      idempotencyKey: 'golden-idempotency-key',
+      actorId: 42,
+      database: database as never,
+      sources: sourceBundle(),
+      now: NOW,
+    });
+
+    expect(canonicalSha256(requestPreimage)).toBe(GOLDEN_REQUEST_HASH);
+    expect(executed[0]?.params).toEqual([
+      7,
+      CALCULATION_KEY,
+      'golden-idempotency-key',
+      GOLDEN_REQUEST_HASH,
+      42,
+    ]);
+    expect(result.response).toEqual({
+      calculationKey: CALCULATION_KEY,
+      configuredMode: 'shadow',
+      effectiveMode: 'shadow',
+      killSwitchActive: false,
+      shadowStartedAt: '2026-06-24T12:00:00.000Z',
+      eligibleAt: '2026-07-01T12:00:00.000Z',
+      residencyDaysRequired: 7,
+      residencyStatus: 'pending',
+      currentSourceMatchesAccepted: true,
+      unreconciledEditsPresent: false,
+      blockers: ['shadow_residency_pending'],
+      version: 1,
+    });
+    expect(JSON.stringify(result.response)).toBe(
+      '{"calculationKey":"fund_moic_rankings_exit_probability","configuredMode":"shadow","effectiveMode":"shadow","killSwitchActive":false,"shadowStartedAt":"2026-06-24T12:00:00.000Z","eligibleAt":"2026-07-01T12:00:00.000Z","residencyDaysRequired":7,"residencyStatus":"pending","currentSourceMatchesAccepted":true,"unreconciledEditsPresent":false,"blockers":["shadow_residency_pending"],"version":1}'
+    );
+  });
+});


### PR DESCRIPTION
## Task 13.0 — R22 mode-write plane (dormant; MOIC byte-untouched)

PLAN_61 Rev 3 Wave B (milestone #1, child #1172), first of Task 13's three sub-slices. Parameterizes the fund calculation-mode service by calculation key so a second key, `current_forecast`, can be written through the same mechanics — **without changing MOIC behavior**. Ships fully dormant: default-off flag, `on`/`shadow` for `current_forecast` blocked (no acceptance/activation plane exists until 13.1/13.2). No migration, no client, no flag/mode value flipped.

### 13.0a — byte-preserving strategy extraction (refactor)
Extracts `CalculationModeStrategy<TSources>` from the MOIC mode-write service (claim/replay ledger, mode-row CRUD, optimistic version, residency clock become generic; MOIC constants, `sourceBlockers`, acceptance policy, and the `invalidateH9Artifacts` post-commit become `moicCalculationModeStrategy`). `updateFundMoicCalculationMode` / `resolveFundCalculationMode` stay as thin wrappers. The two existing MOIC characterization suites are **untouched**, and a new golden test pins the exact request-hash preimage and response-body bytes.

### 13.0b — the `current_forecast` key (dormant)
- `enable_current_forecast_v2` flag — `default: false`, `exposeToClient: false`, `risk: high`.
- `current-forecast-calc-mode-resolver.ts` — per-key resolver (kill/absent → off; held-state map is `TODO(13.1)`).
- `currentForecastCalculationModeStrategy` + `updateCurrentForecastCalculationMode` reusing the shared mechanics; acceptance is dormant (blocks shadow/on until the reference plane lands in 13.1).
- Admin route `PUT /api/admin/funds/:fundId/calculation-modes/current-forecast` on the existing current-forecast router (`requireAuth → requireFundAccess → requireRole('admin')`, `Idempotency-Key` required), plus route-manifest `schemaTables`, a route-policy `admin_only` governance entry, and its policy-group membership.

### Verification (local)
- Core: 49 tests green incl. **both** MOIC characterization suites unchanged (service 14 + route 17), golden byte/hash test, new `current_forecast` service/resolver/route tests.
- Blast radius: flag-registry parity, route/mount parity, route-policy coverage → 43 green.
- `npm run policy:verify` → PASS (85 entries); `npm run validate:schema-drift` → clean; `npm run guard:legacy-calculation-consumers:check` → clean; `npm run check` → 0 new TypeScript errors.
- The 6 other mode-service consumers compile against the preserved public API (repo-wide typecheck 0/0).

Activation is Task 23 (human-gated); nothing here is switched on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)