### PR TITLE
feat(forecast): current-forecast references + migration 0038 mirrors (PLAN_61 Task 13.1-mig)

### DIFF
--- a/migrations/0038_current_forecast_references.sql
+++ b/migrations/0038_current_forecast_references.sql
@@ -1,0 +1,74 @@
+-- @drift-patch
+-- Reason: Task 13 (R23/R24/R35) — append-only current-forecast reference pins for incident-held display,
+-- fund_calculation_modes activation event columns, and substrate-shadow representability widening.
+
+CREATE TABLE IF NOT EXISTS "current_forecast_references" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "calculation_key" text NOT NULL DEFAULT 'current_forecast',
+  "fund_snapshot_id" integer NOT NULL,
+  "current_plan_version_id" integer NOT NULL,
+  "financial_facts_snapshot_id" integer NOT NULL,
+  "input_hash" text NOT NULL,
+  "result_hash" text NOT NULL,
+  "assumptions_hash" text NOT NULL,
+  "engine_version" text NOT NULL,
+  "methodology_version" text NOT NULL,
+  "candidate" boolean NOT NULL DEFAULT true,
+  "superseded_by_reference_id" integer,
+  "status" varchar(16) NOT NULL DEFAULT 'candidate',
+  "reason" text,
+  "created_by" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "current_forecast_references_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "current_forecast_references_superseded_by_fk"
+    FOREIGN KEY ("superseded_by_reference_id") REFERENCES "public"."current_forecast_references"("id"),
+  CONSTRAINT "current_forecast_references_fund_snapshot_fk"
+    FOREIGN KEY ("fund_snapshot_id") REFERENCES "public"."fund_snapshots"("id") ON DELETE cascade,
+  CONSTRAINT "current_forecast_references_plan_version_fk"
+    FOREIGN KEY ("current_plan_version_id") REFERENCES "public"."current_plan_versions"("id"),
+  CONSTRAINT "current_forecast_references_facts_snapshot_fk"
+    FOREIGN KEY ("financial_facts_snapshot_id") REFERENCES "public"."financial_facts_snapshots"("id"),
+  CONSTRAINT "current_forecast_references_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "current_forecast_references_status_check"
+    CHECK ("status" IN ('candidate','accepted','superseded'))
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_current_forecast_references_fund_created"
+  ON "current_forecast_references" ("fund_id", "created_at" DESC);
+--> statement-breakpoint
+-- one accepted served-pointer head per fund (non-superseded, non-candidate)
+CREATE UNIQUE INDEX IF NOT EXISTS "current_forecast_references_fund_accepted_head_unique"
+  ON "current_forecast_references" ("fund_id")
+  WHERE "superseded_by_reference_id" IS NULL AND "candidate" = false;
+--> statement-breakpoint
+
+-- fund_calculation_modes activation event columns (R24/R35)
+ALTER TABLE "fund_calculation_modes" ADD COLUMN IF NOT EXISTS "activated_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "fund_calculation_modes" ADD COLUMN IF NOT EXISTS "cutover_reference_id" integer;
+--> statement-breakpoint
+ALTER TABLE "fund_calculation_modes"
+  ADD CONSTRAINT "fund_calculation_modes_cutover_reference_fk"
+  FOREIGN KEY ("cutover_reference_id") REFERENCES "public"."current_forecast_references"("id");
+--> statement-breakpoint
+
+-- substrate_shadow_reconciliations representability (R23/R35)
+ALTER TABLE "substrate_shadow_reconciliations"
+  DROP CONSTRAINT IF EXISTS "substrate_shadow_reconciliations_substrate_state_check";
+--> statement-breakpoint
+ALTER TABLE "substrate_shadow_reconciliations"
+  ADD CONSTRAINT "substrate_shadow_reconciliations_substrate_state_check"
+  CHECK ("substrate_state" IN ('available','indicative','unavailable','failed'));
+--> statement-breakpoint
+ALTER TABLE "substrate_shadow_reconciliations" ALTER COLUMN "result_hash" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "substrate_shadow_reconciliations"
+  ADD CONSTRAINT "substrate_shadow_reconciliations_result_hash_state_check"
+  CHECK ("result_hash" IS NOT NULL OR "substrate_state" IN ('unavailable','failed'));
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "substrate_shadow_reconciliations_fund_key_input_null_hash_unique"
+  ON "substrate_shadow_reconciliations" ("fund_id", "calculation_key", "input_hash")
+  WHERE "result_hash" IS NULL;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1784683827618,
       "tag": "0037_current_plans",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1784768956988,
+      "tag": "0038_current_forecast_references",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json
+++ b/scripts/prod-schema-manifests/09-substrate-shadow-reconciliations.json
@@ -22,7 +22,7 @@
           "nullable": false
         },
         { "name": "input_hash", "type": "text", "nullable": false },
-        { "name": "result_hash", "type": "text", "nullable": false },
+        { "name": "result_hash", "type": "text", "nullable": true },
         { "name": "assumptions_hash", "type": "text", "nullable": false },
         { "name": "mismatches", "type": "jsonb", "nullable": false },
         { "name": "observed_at", "type": "timestamptz", "nullable": false }

--- a/scripts/prod-schema-manifests/12-current-forecast-references.json
+++ b/scripts/prod-schema-manifests/12-current-forecast-references.json
@@ -1,0 +1,57 @@
+{
+  "name": "current-forecast-references",
+  "order": 12,
+  "description": "Append-only immutable current-forecast reference pins (basis + identity hashes) for post-cutover held display.",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0038_current_forecast_references.sql"],
+  "allowedCreateTables": ["current_forecast_references"],
+  "expectedTables": [
+    {
+      "name": "current_forecast_references",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "calculation_key", "type": "text", "nullable": false },
+        { "name": "fund_snapshot_id", "type": "integer", "nullable": false },
+        {
+          "name": "current_plan_version_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "financial_facts_snapshot_id",
+          "type": "integer",
+          "nullable": false
+        },
+        { "name": "input_hash", "type": "text", "nullable": false },
+        { "name": "result_hash", "type": "text", "nullable": false },
+        { "name": "assumptions_hash", "type": "text", "nullable": false },
+        { "name": "engine_version", "type": "text", "nullable": false },
+        { "name": "methodology_version", "type": "text", "nullable": false },
+        { "name": "candidate", "type": "boolean", "nullable": false },
+        {
+          "name": "superseded_by_reference_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "status", "type": "varchar", "nullable": false },
+        { "name": "reason", "type": "text", "nullable": true },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "current_forecast_references_fund_id_funds_id_fk",
+        "current_forecast_references_superseded_by_fk",
+        "current_forecast_references_fund_snapshot_fk",
+        "current_forecast_references_plan_version_fk",
+        "current_forecast_references_facts_snapshot_fk",
+        "current_forecast_references_created_by_fk",
+        "current_forecast_references_status_check"
+      ],
+      "indexes": [
+        "idx_current_forecast_references_fund_created",
+        "current_forecast_references_fund_accepted_head_unique"
+      ]
+    }
+  ]
+}

--- a/server/services/substrate-shadow-reconciliation-reader.ts
+++ b/server/services/substrate-shadow-reconciliation-reader.ts
@@ -110,7 +110,14 @@ async function queryShadowReconciliationRows(args: {
 
 function toObservation(
   row: SubstrateShadowReconciliation
-): ConstrainedReserveShadowReconciliationObservation {
+): ConstrainedReserveShadowReconciliationObservation | null {
+  // The value-producing constrained-reserve reader only ever sees rows with a
+  // result hash; the nullable `result_hash` column (migration 0038) belongs to
+  // the current-forecast shadow under a different calculation key. Skip any
+  // null-hash row defensively rather than fabricate a value.
+  if (row.resultHash === null) {
+    return null;
+  }
   return {
     id: row.id,
     fundId: row.fundId,
@@ -156,5 +163,10 @@ export async function readConstrainedReserveShadowReconciliations({
     MAX_SHADOW_RECONCILIATION_READ_LIMIT
   );
   const rows = await reader({ fundId, limit: boundedLimit });
-  return rows.map(toObservation);
+  return rows
+    .map(toObservation)
+    .filter(
+      (observation): observation is ConstrainedReserveShadowReconciliationObservation =>
+        observation !== null
+    );
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -49,6 +49,7 @@ export * from './schema/fund-moic-input-update-requests';
 export * from './schema/investment-rounds';
 export * from './schema/investment-round-model-overrides';
 export * from './schema/current-plans';
+export * from './schema/current-forecast-references';
 export * from './schemas/flags';
 export * from './schemas/reserve-approvals';
 

--- a/shared/schema/current-forecast-references.ts
+++ b/shared/schema/current-forecast-references.ts
@@ -1,0 +1,101 @@
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  check,
+  foreignKey,
+  index,
+  integer,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { currentPlanVersions } from './current-plans';
+import { financialFactsSnapshots } from './financial-facts-snapshots';
+import { funds, fundSnapshots } from './fund';
+import { users } from './user';
+
+/**
+ * Append-only immutable reference pins for the current-forecast (V2) calculation
+ * key (PLAN_61 Task 13, R23/R24/R35). Each row pins the exact basis
+ * (fund snapshot + accepted current-plan version + financial-facts snapshot) and
+ * identity hashes of one current-forecast evaluation so a post-cutover incident
+ * can serve a durable "held" pointer head instead of recomputing.
+ *
+ * Dormant in 13.1: no reader/writer/route consumes it yet (that is 13.1-svc).
+ * `candidate = true` on create; an accepted served-pointer head is the single
+ * non-superseded, non-candidate row per fund (partial unique index). FK names are
+ * declared explicitly so the journaled migration (0038) and the Drizzle push
+ * produce byte-identical catalog constraint names.
+ */
+export const currentForecastReferences = pgTable(
+  'current_forecast_references',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    calculationKey: text('calculation_key').notNull().default('current_forecast'),
+    fundSnapshotId: integer('fund_snapshot_id').notNull(),
+    currentPlanVersionId: integer('current_plan_version_id').notNull(),
+    financialFactsSnapshotId: integer('financial_facts_snapshot_id').notNull(),
+    inputHash: text('input_hash').notNull(),
+    resultHash: text('result_hash').notNull(),
+    assumptionsHash: text('assumptions_hash').notNull(),
+    engineVersion: text('engine_version').notNull(),
+    methodologyVersion: text('methodology_version').notNull(),
+    candidate: boolean('candidate').notNull().default(true),
+    supersededByReferenceId: integer('superseded_by_reference_id'),
+    status: varchar('status', { length: 16 }).notNull().default('candidate'),
+    reason: text('reason'),
+    createdBy: integer('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'current_forecast_references_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    supersededByFk: foreignKey({
+      columns: [table.supersededByReferenceId],
+      foreignColumns: [table.id],
+      name: 'current_forecast_references_superseded_by_fk',
+    }),
+    fundSnapshotFk: foreignKey({
+      columns: [table.fundSnapshotId],
+      foreignColumns: [fundSnapshots.id],
+      name: 'current_forecast_references_fund_snapshot_fk',
+    }).onDelete('cascade'),
+    planVersionFk: foreignKey({
+      columns: [table.currentPlanVersionId],
+      foreignColumns: [currentPlanVersions.id],
+      name: 'current_forecast_references_plan_version_fk',
+    }),
+    factsSnapshotFk: foreignKey({
+      columns: [table.financialFactsSnapshotId],
+      foreignColumns: [financialFactsSnapshots.id],
+      name: 'current_forecast_references_facts_snapshot_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'current_forecast_references_created_by_fk',
+    }),
+    statusCheck: check(
+      'current_forecast_references_status_check',
+      sql`${table.status} IN ('candidate','accepted','superseded')`
+    ),
+    fundCreatedIdx: index('idx_current_forecast_references_fund_created').on(
+      table.fundId,
+      table.createdAt.desc()
+    ),
+    fundAcceptedHeadUnique: uniqueIndex('current_forecast_references_fund_accepted_head_unique')
+      .on(table.fundId)
+      .where(sql`${table.supersededByReferenceId} IS NULL AND ${table.candidate} = false`),
+  })
+);
+
+export type CurrentForecastReferenceRow = typeof currentForecastReferences.$inferSelect;
+export type InsertCurrentForecastReferenceRow = typeof currentForecastReferences.$inferInsert;

--- a/shared/schema/fund-calculation-modes.ts
+++ b/shared/schema/fund-calculation-modes.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import {
   boolean,
   check,
+  foreignKey,
   index,
   integer,
   jsonb,
@@ -13,6 +14,7 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core';
 
+import { currentForecastReferences } from './current-forecast-references';
 import { funds } from './fund';
 import { reconciliationRuns } from './reconciliation-runs';
 import { users } from './user';
@@ -52,6 +54,11 @@ export const fundCalculationModes = pgTable(
     version: integer('version').notNull().default(1),
     updatedBy: integer('updated_by').references(() => users.id),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    // Activation event columns (PLAN_61 Task 13, R24/R35; migration 0038). Set
+    // atomically by the dormant activate command (13.1-svc); NULL pre-cutover.
+    // `cutoverReferenceId` is the served-pointer head advanced only while `on`.
+    activatedAt: timestamp('activated_at', { withTimezone: true }),
+    cutoverReferenceId: integer('cutover_reference_id'),
   },
   (table) => ({
     fundCalculationUnique: unique('fund_calculation_modes_fund_calculation_key_unique').on(
@@ -85,6 +92,11 @@ export const fundCalculationModes = pgTable(
       `
     ),
     versionCheck: check('fund_calculation_modes_version_check', sql`${table.version} >= 1`),
+    cutoverReferenceFk: foreignKey({
+      columns: [table.cutoverReferenceId],
+      foreignColumns: [currentForecastReferences.id],
+      name: 'fund_calculation_modes_cutover_reference_fk',
+    }),
   })
 );
 

--- a/shared/schema/index.ts
+++ b/shared/schema/index.ts
@@ -25,3 +25,4 @@ export * from './operating-objects';
 export * from './investment-rounds';
 export * from './investment-round-model-overrides';
 export * from './current-plans';
+export * from './current-forecast-references';

--- a/shared/schema/substrate-shadow-reconciliations.ts
+++ b/shared/schema/substrate-shadow-reconciliations.ts
@@ -10,6 +10,7 @@ import {
   text,
   timestamp,
   unique,
+  uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
 
@@ -51,7 +52,10 @@ export const substrateShadowReconciliations = pgTable(
     substrateState: varchar('substrate_state', { length: 16 }).notNull(),
     reconciliationStatus: varchar('reconciliation_status', { length: 16 }).notNull(),
     inputHash: text('input_hash').notNull(),
-    resultHash: text('result_hash').notNull(),
+    // Nullable since migration 0038 (R23/R35): the current-forecast shadow may
+    // record a non-value-producing observation (`unavailable`/`failed`) that has
+    // no result hash. The value-producing writer path still always sets it.
+    resultHash: text('result_hash'),
     assumptionsHash: text('assumptions_hash').notNull(),
     mismatches: jsonb('mismatches').notNull().$type<string[]>(),
     observedAt: timestamp('observed_at', { withTimezone: true }).notNull().defaultNow(),
@@ -65,9 +69,17 @@ export const substrateShadowReconciliations = pgTable(
       'substrate_shadow_reconciliations_effective_mode_check',
       sql`${table.effectiveMode} IN ('off','shadow','on')`
     ),
+    // Widened by migration 0038 (R23/R35): the current-forecast shadow adds the
+    // non-value-producing `unavailable`/`failed` states. The legacy substrate
+    // writer path stays constrained to `available`/`indicative` (regression test).
     substrateStateCheck: check(
       'substrate_shadow_reconciliations_substrate_state_check',
-      sql`${table.substrateState} IN ('available','indicative')`
+      sql`${table.substrateState} IN ('available','indicative','unavailable','failed')`
+    ),
+    // A missing result hash is only legal for the non-value-producing states.
+    resultHashStateCheck: check(
+      'substrate_shadow_reconciliations_result_hash_state_check',
+      sql`${table.resultHash} IS NOT NULL OR ${table.substrateState} IN ('unavailable','failed')`
     ),
     reconciliationStatusCheck: check(
       'substrate_shadow_reconciliations_reconciliation_status_check',
@@ -80,6 +92,13 @@ export const substrateShadowReconciliations = pgTable(
     fundKeyInputResultUnique: unique(
       'substrate_shadow_reconciliations_fund_key_input_result_unique'
     ).on(table.fundId, table.calculationKey, table.inputHash, table.resultHash),
+    // Null-hash rows cannot use the result-bearing unique above (NULL never
+    // conflicts), so dedupe them on (fund, key, input) via a partial unique index.
+    fundKeyInputNullHashUnique: uniqueIndex(
+      'substrate_shadow_reconciliations_fund_key_input_null_hash_unique'
+    )
+      .on(table.fundId, table.calculationKey, table.inputHash)
+      .where(sql`${table.resultHash} IS NULL`),
   })
 );
 

--- a/tests/e2e/qa-audit-latest-route-publish.spec.ts
+++ b/tests/e2e/qa-audit-latest-route-publish.spec.ts
@@ -189,6 +189,15 @@ async function installQaApiStubs(page: Page, scenario: FundsScenario) {
       return;
     }
 
+    if (request.method() === 'GET' && url.pathname === '/api/funds/1/current-plan-versions') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+      return;
+    }
+
     if (url.pathname === '/api/funds/1/results') {
       await route.fulfill({
         status: 200,

--- a/tests/e2e/route-fund-context-fidelity.spec.ts
+++ b/tests/e2e/route-fund-context-fidelity.spec.ts
@@ -362,6 +362,14 @@ async function installRouteFidelityApi(page: Page): Promise<RouteFidelityApiTrac
       return;
     }
 
+    if (
+      request.method() === 'GET' &&
+      url.pathname === `/api/funds/${FIDELITY_FUND.id}/current-plan-versions`
+    ) {
+      await fulfillJson(route, []);
+      return;
+    }
+
     if (request.method() === 'GET' && url.pathname === `/api/funds/${FIDELITY_FUND.id}/data`) {
       await fulfillJson(route, {
         fund: FIDELITY_FUND,

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -87,6 +87,8 @@ const SUBSTRATE_SHADOW_RECONCILIATION_MANIFEST_TABLES = [
 const FINANCIAL_FACTS_SNAPSHOT_MANIFEST_TABLES = ['financial_facts_snapshots'] as const;
 // M11 (11-current-plan-versions): immutable accepted current-plan versions (journal 0037).
 const CURRENT_PLAN_VERSIONS_MANIFEST_TABLES = ['current_plan_versions'] as const;
+// M12 (12-current-forecast-references): append-only current-forecast reference pins (journal 0038).
+const CURRENT_FORECAST_REFERENCES_MANIFEST_TABLES = ['current_forecast_references'] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
   'flags_state',
@@ -712,6 +714,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...SUBSTRATE_SHADOW_RECONCILIATION_MANIFEST_TABLES,
         ...FINANCIAL_FACTS_SNAPSHOT_MANIFEST_TABLES,
         ...CURRENT_PLAN_VERSIONS_MANIFEST_TABLES,
+        ...CURRENT_FORECAST_REFERENCES_MANIFEST_TABLES,
       ])
     );
 

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -48,6 +48,7 @@ const expectedJournaledDriftPatchFiles = [
   '0035_substrate_shadow_reconciliations.sql',
   '0036_financial_facts_snapshots.sql',
   '0037_current_plans.sql',
+  '0038_current_forecast_references.sql',
 ].sort();
 
 afterEach(() => {

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -94,6 +94,7 @@ describe('prod-schema manifest sentinels', () => {
       '09-substrate-shadow-reconciliations.json',
       '10-financial-facts-snapshots.json',
       '11-current-plan-versions.json',
+      '12-current-forecast-references.json',
     ]);
   });
 

--- a/tests/unit/schema/substrate-shadow-widening.test.ts
+++ b/tests/unit/schema/substrate-shadow-widening.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Substrate-shadow representability widening -- migration 0038 regression pin.
+ *
+ * Migration 0038 widens `substrate_shadow_reconciliations` so the NEW
+ * current-forecast shadow can record non-value-producing observations:
+ * `substrate_state` gains `unavailable`/`failed` and `result_hash` becomes
+ * nullable. This pins two invariants without a live DB:
+ *   1. the EXISTING substrate writer path stays constrained to
+ *      `available`/`indicative` (compile-time union) so it can never emit the
+ *      new states, and
+ *   2. the Drizzle table mirrors the migration -- `result_hash` is nullable and
+ *      the widened state CHECK plus the null-hash guard CHECK are declared.
+ */
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  substrateShadowReconciliations,
+  type InsertSubstrateShadowReconciliation,
+} from '@shared/schema';
+import type { SubstrateShadowReconciliationRecord } from '../../../server/services/constrained-reserve-substrate-shadow';
+
+// Compile-time guard: the value-producing writer union must EXCLUDE the new
+// non-value-producing states. If a future edit widens it, these stop compiling.
+type WriterState = SubstrateShadowReconciliationRecord['substrateState'];
+const writerStatesAreValueProducingOnly: [WriterState] extends ['available' | 'indicative']
+  ? true
+  : never = true;
+const writerHasNoNewStates: Exclude<WriterState, 'available' | 'indicative'> extends never
+  ? true
+  : never = true;
+
+describe('substrate-shadow representability widening (migration 0038)', () => {
+  const config = getTableConfig(substrateShadowReconciliations);
+
+  it('keeps the existing substrate writer path constrained to available|indicative', () => {
+    // Runtime mirror of the compile-time guards above.
+    expect(writerStatesAreValueProducingOnly).toBe(true);
+    expect(writerHasNoNewStates).toBe(true);
+  });
+
+  it('makes result_hash nullable at the Drizzle layer', () => {
+    const resultHash = config.columns.find((column) => column.name === 'result_hash');
+    expect(resultHash).toBeDefined();
+    expect(resultHash?.notNull).toBe(false);
+  });
+
+  it('declares the widened substrate_state and null-hash guard CHECK constraints', () => {
+    const checkNames = config.checks.map((check) => check.name);
+    expect(checkNames).toContain('substrate_shadow_reconciliations_substrate_state_check');
+    expect(checkNames).toContain('substrate_shadow_reconciliations_result_hash_state_check');
+  });
+
+  it('accepts a null result_hash for non-value-producing current-forecast rows', () => {
+    const unavailableRow: InsertSubstrateShadowReconciliation = {
+      fundId: 1,
+      calculationKey: 'current_forecast',
+      configuredMode: 'shadow',
+      effectiveMode: 'shadow',
+      killSwitchActive: false,
+      substrateState: 'unavailable',
+      reconciliationStatus: 'mismatch',
+      inputHash: 'input-abc',
+      resultHash: null,
+      assumptionsHash: 'assume-def',
+      mismatches: ['unavailable_expected'],
+    };
+    expect(unavailableRow.resultHash).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Dormant reference plane for the current-forecast (V2) calculation key — the **migration/schema half** of PLAN_61 Task 13.1 (13.1-mig). No reader, writer, route, or mode value is wired yet (that is 13.1-svc / 13.2). Migration 0038 is **authored + journaled (idx 39) but NEVER applied** — human-gated per repo policy.

## Migration 0038 (author-not-apply)
- New append-only `current_forecast_references` table: basis pins (fund snapshot + accepted current-plan version + financial-facts snapshot) + identity hashes, `candidate` flag, supersession self-FK, accepted-head partial unique index.
- `fund_calculation_modes` activation columns: `activated_at`, `cutover_reference_id` (+ FK to `current_forecast_references`).
- `substrate_shadow_reconciliations` representability widening: `substrate_state` gains `unavailable`/`failed`, `result_hash` nullable, null-hash guard CHECK + partial unique index (current-forecast shadow only).

## Drizzle mirrors + parity
- New `shared/schema/current-forecast-references.ts` (exported from both barrels), plus the substrate + `fund_calculation_modes` edits. FKs declared via explicit `foreignKey({name})` so the journaled migration and `pushSchema` produce **byte-identical catalog** constraint names.
- The value-producing substrate reader narrows the now-nullable `result_hash` (skips null-hash rows; those belong to a different calculation key).
- Prod-schema sync: new `12-current-forecast-references.json` manifest (+ sentinels pin, clone-test union); `09` result_hash nullability. The 64-char null-hash index is deliberately **not** a manifest sentinel (`loadIndexes` is not 63-byte-truncation-aware).

## Verification
- `npm run check`: 0 new TypeScript errors.
- `npm run validate:schema-drift`: exit 0 (ledger + surfaces clean).
- 69 tests green: new regression (`substrate-shadow-widening`) + existing substrate writer/reader/shadow (still constrained to `available`/`indicative`) + manifest sentinels / reconcile / mount-parity.
- Independent Drizzle↔SQL parity audit: **DRIFT 0** (migration-replay DB-A == `pushSchema` DB-B).
- The authoritative `prod-schema-clone` parity gate is Docker-gated (skipped on Windows) — **this PR's CI is the first place it runs.**

## Open decision (please confirm before merge)
Plan §3 pins `current_forecast_references` **semantics**, not a literal column list — the authored column set is best-judgment. Since 13.1-svc's reference/shadow services write to this table, please confirm the column set before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)