### PR TITLE
feat(forecast): revise 0038 column set per 13.1 review (R1-R3)

### DIFF
--- a/migrations/0038_current_forecast_references.sql
+++ b/migrations/0038_current_forecast_references.sql
@@ -16,24 +16,25 @@ CREATE TABLE IF NOT EXISTS "current_forecast_references" (
   "methodology_version" text NOT NULL,
   "candidate" boolean NOT NULL DEFAULT true,
   "superseded_by_reference_id" integer,
-  "status" varchar(16) NOT NULL DEFAULT 'candidate',
   "reason" text,
   "created_by" integer,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   CONSTRAINT "current_forecast_references_fund_id_funds_id_fk"
     FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
   CONSTRAINT "current_forecast_references_superseded_by_fk"
     FOREIGN KEY ("superseded_by_reference_id") REFERENCES "public"."current_forecast_references"("id"),
   CONSTRAINT "current_forecast_references_fund_snapshot_fk"
-    FOREIGN KEY ("fund_snapshot_id") REFERENCES "public"."fund_snapshots"("id") ON DELETE cascade,
+    FOREIGN KEY ("fund_snapshot_id") REFERENCES "public"."fund_snapshots"("id"),
   CONSTRAINT "current_forecast_references_plan_version_fk"
     FOREIGN KEY ("current_plan_version_id") REFERENCES "public"."current_plan_versions"("id"),
   CONSTRAINT "current_forecast_references_facts_snapshot_fk"
     FOREIGN KEY ("financial_facts_snapshot_id") REFERENCES "public"."financial_facts_snapshots"("id"),
   CONSTRAINT "current_forecast_references_created_by_fk"
     FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
-  CONSTRAINT "current_forecast_references_status_check"
-    CHECK ("status" IN ('candidate','accepted','superseded'))
+  CONSTRAINT "current_forecast_references_fund_idempotency_unique"
+    UNIQUE ("fund_id", "idempotency_key")
 );
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_current_forecast_references_fund_created"

--- a/scripts/prod-schema-manifests/12-current-forecast-references.json
+++ b/scripts/prod-schema-manifests/12-current-forecast-references.json
@@ -34,19 +34,20 @@
           "type": "integer",
           "nullable": true
         },
-        { "name": "status", "type": "varchar", "nullable": false },
         { "name": "reason", "type": "text", "nullable": true },
         { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "idempotency_key", "type": "varchar", "nullable": false },
+        { "name": "request_hash", "type": "varchar", "nullable": false },
         { "name": "created_at", "type": "timestamptz", "nullable": false }
       ],
       "constraints": [
+        "current_forecast_references_fund_idempotency_unique",
         "current_forecast_references_fund_id_funds_id_fk",
         "current_forecast_references_superseded_by_fk",
         "current_forecast_references_fund_snapshot_fk",
         "current_forecast_references_plan_version_fk",
         "current_forecast_references_facts_snapshot_fk",
-        "current_forecast_references_created_by_fk",
-        "current_forecast_references_status_check"
+        "current_forecast_references_created_by_fk"
       ],
       "indexes": [
         "idx_current_forecast_references_fund_created",

--- a/shared/schema/current-forecast-references.ts
+++ b/shared/schema/current-forecast-references.ts
@@ -1,7 +1,6 @@
 import { sql } from 'drizzle-orm';
 import {
   boolean,
-  check,
   foreignKey,
   index,
   integer,
@@ -9,6 +8,7 @@ import {
   serial,
   text,
   timestamp,
+  unique,
   uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
@@ -26,10 +26,16 @@ import { users } from './user';
  * can serve a durable "held" pointer head instead of recomputing.
  *
  * Dormant in 13.1: no reader/writer/route consumes it yet (that is 13.1-svc).
- * `candidate = true` on create; an accepted served-pointer head is the single
- * non-superseded, non-candidate row per fund (partial unique index). FK names are
- * declared explicitly so the journaled migration (0038) and the Drizzle push
- * produce byte-identical catalog constraint names.
+ * Lifecycle is STRUCTURAL (13.1 review R1): `candidate = true` on create; an
+ * accepted served-pointer head is the single non-superseded, non-candidate row
+ * per fund (partial unique index); superseded rows carry the self-FK. There is
+ * deliberately no status enum column. Basis-pin FKs (snapshot, plan version,
+ * facts snapshot) are NO ACTION (R2): a pinned artifact cannot be deleted while
+ * referenced; only fund deletion cascades. Writers are idempotent through the
+ * fund-scoped idempotency unique (R3, `current_plan_versions` pattern, D13
+ * `runIdempotentCommand`). FK names are declared explicitly so the journaled
+ * migration (0038) and the Drizzle push produce byte-identical catalog
+ * constraint names.
  */
 export const currentForecastReferences = pgTable(
   'current_forecast_references',
@@ -47,9 +53,10 @@ export const currentForecastReferences = pgTable(
     methodologyVersion: text('methodology_version').notNull(),
     candidate: boolean('candidate').notNull().default(true),
     supersededByReferenceId: integer('superseded_by_reference_id'),
-    status: varchar('status', { length: 16 }).notNull().default('candidate'),
     reason: text('reason'),
     createdBy: integer('created_by'),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
@@ -67,7 +74,7 @@ export const currentForecastReferences = pgTable(
       columns: [table.fundSnapshotId],
       foreignColumns: [fundSnapshots.id],
       name: 'current_forecast_references_fund_snapshot_fk',
-    }).onDelete('cascade'),
+    }),
     planVersionFk: foreignKey({
       columns: [table.currentPlanVersionId],
       foreignColumns: [currentPlanVersions.id],
@@ -83,9 +90,9 @@ export const currentForecastReferences = pgTable(
       foreignColumns: [users.id],
       name: 'current_forecast_references_created_by_fk',
     }),
-    statusCheck: check(
-      'current_forecast_references_status_check',
-      sql`${table.status} IN ('candidate','accepted','superseded')`
+    fundIdempotencyUnique: unique('current_forecast_references_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
     ),
     fundCreatedIdx: index('idx_current_forecast_references_fund_created').on(
       table.fundId,


### PR DESCRIPTION
## Summary

Adjudicates the flagged open design note from Task 13.1-mig (#1190, issue #1172): the `current_forecast_references` column set was authored best-judgment and flagged "confirm before merge"; #1190 merged before the confirm landed, so this PR amends the **merged-but-never-applied** migration 0038 in place (human-gated apply; journal idx 39 unchanged; file already `@drift-patch`-marked). Review artifact: `.claude/artifacts/plan61-task13.1-review.md` (session-local).

- **R1 — drop `status` varchar(16) + CHECK.** Lifecycle is structural (`candidate` + supersession self-FK + accepted-head partial unique), matching `current_plan_versions`; the plan text defines acceptance via `candidate`/`cutover_reference_id` only, and a dual encoding can drift.
- **R2 — `fund_snapshot_id` FK `ON DELETE cascade` -> NO ACTION.** All three basis pins now uniformly block deletion of their pinned artifact; only `fund_id` cascades.
- **R3 — add `idempotency_key` varchar(128) + `request_hash` varchar(64) + `UNIQUE (fund_id, idempotency_key)`.** Zero-Tolerance mutation idempotency; enables D13 `runIdempotentCommand` (needs a unique conflict target) for the 13.1-svc shadow create-candidate (deterministic keys dedup corpus replays) and the admin route's required `Idempotency-Key`.

Drizzle mirror + manifest 12 updated in lockstep; byte parity re-proven by the Testcontainers prod-schema-clone lane.

## Verification

- `npm run check`: 0 new errors
- `npm run validate:schema-drift`: exit 0 (100 passes / 0 errors)
- Targeted: sentinels + substrate-widening + migration-ledger 20/20 green
- Pre-push related suite: 2,894 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkBQzihG4JJYWwGYvACk36