### PR TITLE
feat(forecast): current-forecast reference/shadow/held service plane, dormant (PLAN_61 Task 13.1-svc)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8666,8 +8666,8 @@ equal, `summaryValueDeltaPct` would return 0 with no error and no failing test.
 - Effective `off` returns 404. `shadow` computes rankings but is always
   `non_actionable`. `on` requires positive H9
   (`h9.actionability === 'actionable'`) and at least one actionable ranking;
-  otherwise it remains `non_actionable`. A thrown H9 resolution error remains
-  a 500 fail-closed path.
+  otherwise it remains `non_actionable`. A thrown H9 resolution error remains a
+  500 fail-closed path.
 - Access is limited by `isTeamMemberUser` before fund access is evaluated.
 - V1 remains exported for source compatibility only. The endpoint wire contract
   is no longer V1-compatible.
@@ -8675,8 +8675,8 @@ equal, `summaryValueDeltaPct` would return 0 with no error and no failing test.
   environment until BOTH `ENABLE_MARGINAL_RESERVE_MOIC` is enabled and a
   `fund_calculation_modes` row exists for the fund with
   `calculation_key='fund_moic_rankings_exit_probability'`, `configured_mode` of
-  `shadow` or `on`, and the kill switch off. No seed or migration creates such
-  a row.
+  `shadow` or `on`, and the kill switch off. No seed or migration creates such a
+  row.
 - The gating asymmetry with the sibling `/moic/rankings` route is deliberate:
   that route is mode-gated only, while this newer marginal-ranking surface also
   requires the server-only feature flag. Its sibling's `?contract=v1|v2`
@@ -8689,5 +8689,134 @@ equal, `summaryValueDeltaPct` would return 0 with no error and no failing test.
   deferred**, not complete.
 - No flag was enabled, no calculation-mode row was created or promoted, and no
   persistence or downstream financial surface changed.
+
+---
+
+## ADR-057: Current-Forecast Divergence-by-Design — Legacy Numeric Parity Is Not a Shadow Gate (Demo Scope)
+
+**Date:** 2026-07-22 **Status:** [ACCEPTED] Accepted **Decision:** The
+current-forecast shadow plane (PLAN_61 Task 13.1-svc,
+`server/services/current-forecast-shadow-service.ts`) defines "green" as:
+exact-basis replay reproduces the pinned `resultHash` for EVERY committed corpus
+base, at least 90% of evaluated bases produce an `available` value, and zero
+UNEXPLAINED divergences exist. Numeric parity against the legacy
+`ProjectedMetricsCalculator` lane is deliberately NOT a criterion.
+
+### Context
+
+The substrate-reserve shadow (ADR-050) gated promotion on parity between the
+legacy engine and the substrate for the SAME request. That model does not
+transfer to current-forecast: the Task 1 nondeterminism characterization
+established that the legacy dual-forecast lane is nondeterministic by design
+(fabricated construction inputs, wall-clock coupling), so byte-parity against it
+is unattainable and would institutionalize the fabrication it replaces. The V2
+engine (`runCohortProjectionV2`) is deterministic over a pinned basis (plan
+version + facts snapshot), so replay reproducibility is the correct trust
+signal.
+
+### Consequences
+
+- Trust rests on the committed replay corpus
+  (`tests/fixtures/current-forecast-replay-corpus/`): any engine drift fails the
+  pinned-hash reproduction test.
+- Divergence from the legacy lane is EXPECTED and auditable: reconciliation rows
+  carry typed mismatch reasons
+  (`legacy_fabrication_replaced|facts_gap|methodology_change|unavailable_expected`).
+  Per review pin P3, `unavailable` runs persist as
+  `reconciliation_status='mismatch'` with a typed reason (`facts_gap` when
+  facts-driven, else `unavailable_expected`); `failed` persists as `mismatch`
+  with NO typed reason — it is by definition an UNEXPLAINED divergence and
+  blocks green.
+- `evaluateCurrentForecastShadowGreen` is pure math over shadow outcomes; a
+  legacy-parity check can never be reintroduced into it without revisiting this
+  ADR.
+
+## ADR-058: Post-Cutover Held Semantics for current_forecast — the Served Pointer Is Live (D9) (Demo Scope)
+
+**Date:** 2026-07-22 **Status:** [ACCEPTED] Accepted **Decision:** The
+`current_forecast` calculation key diverges from every other key's kill/off
+semantics AFTER activation. Pre-cutover (`fund_calculation_modes.activated_at`
+IS NULL) the kill switch and off/unknown modes collapse to the legacy
+byte-compatible `off` path. Post-cutover, EVERY state other than effective `on`
+(kill switch, configured off, configured shadow, V2 serving failure) resolves
+`held`: the fund is served the pinned reference named by
+`fund_calculation_modes.cutover_reference_id`, and the legacy
+`ProjectedMetricsCalculator` lane is never re-entered.
+
+### Context
+
+Once a fund has cut over to V2, "off" has no safe meaning: falling back to the
+legacy lane would silently re-serve fabricated numbers, and serving nothing
+would blank a live reporting surface. The R24/D9 held state pins the last
+accepted evaluation instead. Resolver:
+`server/services/current-forecast-calc-mode-resolver.ts`
+(`resolveCurrentForecastModeResolution`, `dispatchCurrentForecastServing`).
+
+### The served pointer is LIVE (review pin P1)
+
+`fund_calculation_modes.cutover_reference_id` is the LIVE served-pointer head,
+mutated on every pointer-advance while the mode is `on`
+(`advanceCurrentForecastPointer`). It is NOT a frozen activation-time snapshot;
+the activation-time value remains recoverable via `activated_at` plus the
+`current_forecast_references` supersession chain. Pointer advance is by design —
+it must never later be "fixed" as a bug. `held` serves exactly this pointer and
+never a "latest accepted" query.
+
+### Activation atomicity (review pin P2)
+
+The dormant activation command (`activateCurrentForecast`, executed only by
+Task 23) flips the chosen candidate to `candidate = false` in the SAME atomic
+write as `activated_at` + `cutover_reference_id` + `configured_mode = 'on'`,
+arming the accepted-head partial unique
+(`current_forecast_references_fund_accepted_head_unique`) from cutover onward.
+Steady-state acceptance is single-clause (`candidate = false`, non-superseded);
+"named by `cutover_reference_id`" remains only as the transitional guard. The
+13.0 mode route refuses `off|shadow -> on` (`activation_command_required`): the
+ONLY path to `on` is the activation command, so the activation event is written
+in the same transaction by construction.
+
+### Consequences
+
+- Lifecycle reads use `candidate`/`superseded_by_reference_id` only — there is
+  no status column (13.1 review R1).
+- Reference rows are append-only; admin rollback
+  (`POST /api/admin/funds/:fundId/current-forecast/references`) clones a prior
+  reference into a NEW candidate rather than rewriting history.
+- A post-cutover incident (kill switch) keeps serving the held pointer; the
+  route back to `on` is a fresh green candidate plus the activation command, not
+  a mode-route write.
+
+## ADR-059: Migration 0038 Representability Delta vs ADR-050 — Widen substrate_state Only (Demo Scope)
+
+**Date:** 2026-07-22 **Status:** [ACCEPTED] Accepted **Decision:** Migration
+0038 widens the ADR-050 `substrate_shadow_reconciliations` ledger exactly far
+enough to represent the current-forecast shadow's non-value-producing
+observations, and no further: `substrate_state` gains `unavailable`/`failed`,
+`result_hash` becomes nullable with a guard CHECK
+(`result_hash IS NOT NULL OR substrate_state IN ('unavailable','failed')`) and a
+null-hash partial unique for dedup. `reconciliation_status` remains
+`match|mismatch` and `configured_mode`/`effective_mode` remain `off|shadow|on` —
+deliberately not widened.
+
+### Context
+
+ADR-050's ledger assumed every observation is value-producing (a substrate value
+reconciled against a legacy value). The current-forecast shadow must also
+durably record runs that produce no servable value (facts gaps, basis
+mismatches, engine failures) because the green decision counts them (coverage,
+unexplained divergences).
+
+### Consequences
+
+- Review pin P3: non-value-producing rows reuse `mismatch` + typed reason rather
+  than a widened status enum; `failed` is unexplained by definition.
+- Review pin P4: `held` is a resolver/serving state, never a ledger mode. The
+  current-forecast writer clamps mode values to `off|shadow|on`
+  (`assertLedgerMode`) and the legacy substrate writer path stays constrained to
+  `available`/`indicative`
+  (`tests/unit/schema/substrate-shadow-widening.test.ts`).
+- The engine still hashes unavailable result envelopes, so `unavailable` rows
+  normally CARRY a `result_hash`; the null-hash lane exists for runs that
+  produced nothing at all (thrown basis mismatch -> `failed`).
 
 ---

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -1325,6 +1325,56 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     notes:
       'Express middleware enforces fund access and admin role; route-policy verification allows this scoped admin financial-control API.',
   },
+  {
+    id: 'api:post:/api/admin/funds/:fundId/current-forecast/references',
+    method: 'POST',
+    path: '/api/admin/funds/:fundId/current-forecast/references',
+    lifecycle: 'durable_crud',
+    governanceRef: '/fund-model-results/:fundId',
+    surface: 'current-forecast-reference-admin-api',
+    owner: 'analytics',
+    telemetryKey: telemetryKeyForRoute(
+      'api.route',
+      '/api/admin/funds/:fundId/current-forecast/references'
+    ),
+    // TODO(13): replace with a current_forecast surface when the policy type supports it.
+    financialSurface: 'moic_reserves',
+    apiAuthBoundary: 'admin_only',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'fund_scope_and_idempotency_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+    staleBlocksExport: false,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+    notes:
+      'Idempotent admin override/rollback: clones an existing current-forecast reference into a new append-only candidate (PLAN_61 13.1-svc).',
+  },
+  {
+    id: 'api:post:/api/admin/funds/:fundId/current-forecast/activate',
+    method: 'POST',
+    path: '/api/admin/funds/:fundId/current-forecast/activate',
+    lifecycle: 'durable_crud',
+    governanceRef: '/fund-model-results/:fundId',
+    surface: 'current-forecast-activation-admin-api',
+    owner: 'analytics',
+    telemetryKey: telemetryKeyForRoute(
+      'api.route',
+      '/api/admin/funds/:fundId/current-forecast/activate'
+    ),
+    // TODO(13): replace with a current_forecast surface when the policy type supports it.
+    financialSurface: 'moic_reserves',
+    apiAuthBoundary: 'admin_only',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'admin_mode_update_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+    staleBlocksExport: false,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+    notes:
+      'DORMANT activation command (executed only by Task 23): atomically writes mode on + activated_at + cutover_reference_id + candidate flip.',
+  },
 ];
 
 export const EXPLICIT_API_ROUTE_POLICY_KEYS = new Set<string>(
@@ -1399,6 +1449,8 @@ export const COMMON_API_ROUTE_POLICY_IDS = {
     'api:post:/api/funds/:fundId/current-plan-versions',
     'api:post:/api/funds/:fundId/current-forecast/runs',
     'api:put:/api/admin/funds/:fundId/calculation-modes/current-forecast',
+    'api:post:/api/admin/funds/:fundId/current-forecast/references',
+    'api:post:/api/admin/funds/:fundId/current-forecast/activate',
   ],
   funds: ['client:/fund-setup'],
   'fund-metrics': ['client:/dashboard'],

--- a/server/routes/current-forecast.ts
+++ b/server/routes/current-forecast.ts
@@ -25,6 +25,12 @@ import {
   FundCalculationModeVersionConflictError,
   updateCurrentForecastCalculationMode,
 } from '../services/fund-calculation-mode-service';
+import {
+  CurrentForecastActivationBlockedError,
+  CurrentForecastReferenceError,
+  activateCurrentForecast,
+  createRollbackCurrentForecastReference,
+} from '../services/current-forecast-reference-service';
 
 const routeLog = createRouteLogger('current-forecast');
 const router = Router();
@@ -62,6 +68,20 @@ const CurrentForecastModeUpdateBodySchema = z
     expectedVersion: z.number().int().nonnegative(),
     configuredMode: z.enum(['off', 'shadow', 'on']),
     killSwitchActive: z.boolean().optional(),
+  })
+  .strict();
+
+const CurrentForecastReferenceBodySchema = z
+  .object({
+    sourceReferenceId: z.number().int().positive(),
+    reason: z.string().min(1),
+  })
+  .strict();
+
+const CurrentForecastActivateBodySchema = z
+  .object({
+    referenceId: z.number().int().positive(),
+    expectedVersion: z.number().int().nonnegative(),
   })
   .strict();
 
@@ -266,6 +286,17 @@ router.put(
       });
     }
 
+    // R22 refusal (13.1-svc): off|shadow -> on never goes through the mode
+    // route; only the activation command writes `on`, atomically with the
+    // activation event (activated_at + cutover_reference_id + candidate flip).
+    if (parsedBody.data.configuredMode === 'on') {
+      return res.status(409).json({
+        error: 'activation_command_required',
+        message:
+          'current-forecast cannot be set to on via the mode route; the activation command writes the cutover event atomically',
+      });
+    }
+
     try {
       const params: Parameters<typeof updateCurrentForecastCalculationMode>[0] = {
         fundId,
@@ -301,6 +332,118 @@ router.put(
       ) {
         return res.status(409).json({ error: error.code, message: error.message });
       }
+      throw error;
+    }
+  })
+);
+
+router.post(
+  '/admin/funds/:fundId/current-forecast/references',
+  currentForecastWriteLimiter,
+  requireAuth(),
+  validateFundIdParam,
+  requireFundAccess,
+  requireRole('admin'),
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = toNumber(req.params['fundId'], 'fundId', { integer: true, min: 1 });
+    const idempotencyKey = req.header('Idempotency-Key')?.trim();
+    if (!idempotencyKey) {
+      return res.status(428).json({
+        error: 'idempotency_key_required',
+        message: 'Idempotency-Key header is required',
+      });
+    }
+
+    const parsedBody = CurrentForecastReferenceBodySchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'invalid_reference_request',
+        message: 'Current forecast reference request is invalid',
+        details: parsedBody.error.format(),
+      });
+    }
+
+    try {
+      const result = await createRollbackCurrentForecastReference({
+        fundId,
+        sourceReferenceId: parsedBody.data.sourceReferenceId,
+        reason: parsedBody.data.reason,
+        idempotencyKey,
+        createdBy: actorId(req),
+      });
+      return res.status(200).json({ reference: result.row, replayed: result.replayed });
+    } catch (error) {
+      if (error instanceof CurrentForecastReferenceError) {
+        return res.status(error.status).json({ error: error.code, message: error.message });
+      }
+      if (respondToTypedError(error, res)) return;
+      throw error;
+    }
+  })
+);
+
+// DORMANT (PLAN_61 Task 13.1-svc): shipped unused; executed only by Task 23.
+router.post(
+  '/admin/funds/:fundId/current-forecast/activate',
+  currentForecastWriteLimiter,
+  requireAuth(),
+  validateFundIdParam,
+  requireFundAccess,
+  requireRole('admin'),
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = toNumber(req.params['fundId'], 'fundId', { integer: true, min: 1 });
+    const idempotencyKey = req.header('Idempotency-Key')?.trim();
+    if (!idempotencyKey) {
+      return res.status(428).json({
+        error: 'idempotency_key_required',
+        message: 'Idempotency-Key header is required',
+      });
+    }
+
+    const parsedBody = CurrentForecastActivateBodySchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'invalid_activation_request',
+        message: 'Current forecast activation request is invalid',
+        details: parsedBody.error.format(),
+      });
+    }
+
+    try {
+      const result = await activateCurrentForecast({
+        fundId,
+        referenceId: parsedBody.data.referenceId,
+        expectedVersion: parsedBody.data.expectedVersion,
+        idempotencyKey,
+        actorId: actorId(req),
+      });
+      return res.status(200).json({ ...result.response, replayed: result.replayed });
+    } catch (error) {
+      if (error instanceof FundCalculationModeVersionConflictError) {
+        return res.status(409).json({
+          error: error.code,
+          message: error.message,
+          expectedVersion: error.expectedVersion,
+          actualVersion: error.actualVersion,
+        });
+      }
+      if (error instanceof CurrentForecastActivationBlockedError) {
+        return res.status(409).json({
+          error: error.code,
+          message: error.message,
+          blockers: error.blockers,
+        });
+      }
+      if (error instanceof CurrentForecastReferenceError) {
+        return res.status(error.status).json({ error: error.code, message: error.message });
+      }
+      if (
+        error instanceof FundCalculationModeIdempotencyConflictError ||
+        error instanceof FundCalculationModeInProgressError
+      ) {
+        return res.status(409).json({ error: error.code, message: error.message });
+      }
+      if (respondToTypedError(error, res)) return;
       throw error;
     }
   })

--- a/server/services/current-forecast-calc-mode-resolver.ts
+++ b/server/services/current-forecast-calc-mode-resolver.ts
@@ -2,31 +2,121 @@ import { db } from '../db';
 
 export const CURRENT_FORECAST_CALCULATION_KEY = 'current_forecast';
 
-export type CurrentForecastCalculationMode = 'off' | 'shadow' | 'on';
+export type CurrentForecastCalculationMode = 'off' | 'shadow' | 'on' | 'held';
+
+export interface CurrentForecastModeRow {
+  configuredMode: string;
+  killSwitchActive: boolean;
+  activatedAt: Date | string | null;
+  cutoverReferenceId: number | null;
+}
 
 export type CurrentForecastModeReader = (
   fundId: number
-) => Promise<{ configuredMode: string; killSwitchActive: boolean } | null | undefined>;
+) => Promise<CurrentForecastModeRow | null | undefined>;
 
 export const defaultCurrentForecastModeReader: CurrentForecastModeReader = (fundId) =>
   db.query.fundCalculationModes.findFirst({
-    columns: { configuredMode: true, killSwitchActive: true },
+    columns: {
+      configuredMode: true,
+      killSwitchActive: true,
+      activatedAt: true,
+      cutoverReferenceId: true,
+    },
     where: (row, { and, eq }) =>
       and(eq(row.fundId, fundId), eq(row.calculationKey, CURRENT_FORECAST_CALCULATION_KEY)),
   });
 
+export interface CurrentForecastModeResolution {
+  mode: CurrentForecastCalculationMode;
+  /**
+   * P1 (13.1 adjudication): the LIVE served-pointer head from
+   * `fund_calculation_modes.cutover_reference_id`, advanced on every
+   * pointer-advance while `on`. Set post-cutover, null pre-cutover. `held`
+   * serves exactly this pointer — never a "latest accepted" query.
+   */
+  cutoverReferenceId: number | null;
+}
+
 /**
- * Resolve the current-forecast mode with a fail-safe off default.
- * TODO(13.1): map the held state once current_forecast_references exists.
+ * Resolve the current-forecast mode with the R24/D9 held-state map.
+ *
+ * Pre-cutover (`activatedAt` null): the kill switch and unknown/absent modes
+ * fail safe to the legacy byte-compatible `off` path. Post-cutover
+ * (`activatedAt` set): only effective `on` serves V2 live; EVERY other state
+ * (kill, off, configured shadow) resolves `held`, serving the pinned pointer
+ * head instead of ever re-entering the legacy lane.
  */
+export async function resolveCurrentForecastModeResolution(
+  fundId: number,
+  reader: CurrentForecastModeReader = defaultCurrentForecastModeReader
+): Promise<CurrentForecastModeResolution> {
+  const row = await reader(fundId);
+  const activated = row?.activatedAt !== null && row?.activatedAt !== undefined;
+
+  if (!activated) {
+    if (
+      !row?.killSwitchActive &&
+      (row?.configuredMode === 'shadow' || row?.configuredMode === 'on')
+    ) {
+      return { mode: row.configuredMode, cutoverReferenceId: null };
+    }
+    return { mode: 'off', cutoverReferenceId: null };
+  }
+
+  const cutoverReferenceId = row?.cutoverReferenceId ?? null;
+  if (!row?.killSwitchActive && row?.configuredMode === 'on') {
+    return { mode: 'on', cutoverReferenceId };
+  }
+  return { mode: 'held', cutoverReferenceId };
+}
+
+/** Bare-mode convenience wrapper over {@link resolveCurrentForecastModeResolution}. */
 export async function resolveCurrentForecastCalculationMode(
   fundId: number,
   reader: CurrentForecastModeReader = defaultCurrentForecastModeReader
 ): Promise<CurrentForecastCalculationMode> {
-  const mode = await reader(fundId);
-  if (mode?.killSwitchActive) return 'off';
-  if (mode?.configuredMode === 'shadow' || mode?.configuredMode === 'on') {
-    return mode.configuredMode;
+  return (await resolveCurrentForecastModeResolution(fundId, reader)).mode;
+}
+
+export interface CurrentForecastServingSeams<T> {
+  runLegacy: () => Promise<T>;
+  runV2: () => Promise<T>;
+  serveHeld: (cutoverReferenceId: number) => Promise<T>;
+}
+
+/**
+ * Map a mode resolution onto the serving lanes (13.2 consumer seam).
+ *
+ * `off`/`shadow` serve legacy (shadow observation is a separate plane); `on`
+ * serves V2, degrading to the held pointer head on a post-cutover V2 failure —
+ * never back to legacy (R24/D9). `held` serves the pointer head and by
+ * construction can never invoke the legacy `ProjectedMetricsCalculator` lane.
+ */
+export async function dispatchCurrentForecastServing<T>(
+  resolution: CurrentForecastModeResolution,
+  seams: CurrentForecastServingSeams<T>
+): Promise<T> {
+  switch (resolution.mode) {
+    case 'off':
+    case 'shadow':
+      return seams.runLegacy();
+    case 'on': {
+      if (resolution.cutoverReferenceId === null) {
+        return seams.runV2();
+      }
+      const cutoverReferenceId = resolution.cutoverReferenceId;
+      try {
+        return await seams.runV2();
+      } catch {
+        return seams.serveHeld(cutoverReferenceId);
+      }
+    }
+    case 'held': {
+      if (resolution.cutoverReferenceId === null) {
+        throw new Error('current-forecast held resolution has no served-pointer head');
+      }
+      return seams.serveHeld(resolution.cutoverReferenceId);
+    }
   }
-  return 'off';
 }

--- a/server/services/current-forecast-reference-service.ts
+++ b/server/services/current-forecast-reference-service.ts
@@ -1,0 +1,414 @@
+import { sql, type SQL } from 'drizzle-orm';
+
+import { db } from '../db';
+import { runIdempotentCommand } from '../lib/idempotent-command';
+import { CURRENT_FORECAST_CALCULATION_KEY } from './current-forecast-calc-mode-resolver';
+
+/**
+ * Append-only reference plane for the current-forecast calculation key
+ * (PLAN_61 Task 13.1-svc, R23/R24/R35). Lifecycle is STRUCTURAL (13.1 review
+ * R1): rows are created as `candidate = true`; the single accepted
+ * served-pointer head per fund is the non-superseded, non-candidate row
+ * (partial unique index), and supersession is the self-FK chain. All writers
+ * are fund-scoped idempotent through `runIdempotentCommand` (D13) and the
+ * `(fund_id, idempotency_key)` unique (R3).
+ */
+
+export const CURRENT_FORECAST_REFERENCE_CONTRACT_VERSION = 'current-forecast-reference-v1';
+
+export type CurrentForecastReferenceDatabase = typeof db;
+type Executor = {
+  execute: (query: SQL) => Promise<unknown>;
+};
+type ExecuteResult<T> = { rows: T[] };
+
+async function executeRows<T>(executor: Executor, query: SQL): Promise<T[]> {
+  const result = (await executor.execute(query)) as ExecuteResult<T>;
+  return result.rows;
+}
+
+export class CurrentForecastReferenceError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'CurrentForecastReferenceError';
+  }
+}
+
+export interface CurrentForecastReferenceBasis {
+  fundSnapshotId: number;
+  currentPlanVersionId: number;
+  financialFactsSnapshotId: number;
+  inputHash: string;
+  resultHash: string;
+  assumptionsHash: string;
+  engineVersion: string;
+  methodologyVersion: string;
+}
+
+export interface CurrentForecastReferenceRecord extends CurrentForecastReferenceBasis {
+  id: number;
+  fundId: number;
+  calculationKey: string;
+  candidate: boolean;
+  supersededByReferenceId: number | null;
+  reason: string | null;
+  createdBy: number | null;
+  createdAt: string;
+}
+
+/**
+ * Deterministic shadow create-candidate key: corpus replays of the same basis
+ * and result dedupe through `current_forecast_references_fund_idempotency_unique`.
+ */
+export function currentForecastReferenceIdempotencyKey(params: {
+  fundId: number;
+  inputHash: string;
+  resultHash: string;
+}): string {
+  return `cfref:${params.fundId}:${params.inputHash}:${params.resultHash}`;
+}
+
+type ReferenceRow = {
+  id: number;
+  fund_id: number;
+  calculation_key: string;
+  fund_snapshot_id: number;
+  current_plan_version_id: number;
+  financial_facts_snapshot_id: number;
+  input_hash: string;
+  result_hash: string;
+  assumptions_hash: string;
+  engine_version: string;
+  methodology_version: string;
+  candidate: boolean;
+  superseded_by_reference_id: number | null;
+  reason: string | null;
+  created_by: number | null;
+  request_hash: string;
+  created_at: Date | string;
+};
+
+const REFERENCE_COLUMNS = sql.raw(
+  [
+    'id',
+    'fund_id',
+    'calculation_key',
+    'fund_snapshot_id',
+    'current_plan_version_id',
+    'financial_facts_snapshot_id',
+    'input_hash',
+    'result_hash',
+    'assumptions_hash',
+    'engine_version',
+    'methodology_version',
+    'candidate',
+    'superseded_by_reference_id',
+    'reason',
+    'created_by',
+    'request_hash',
+    'created_at',
+  ].join(', ')
+);
+
+function toRecord(row: ReferenceRow): CurrentForecastReferenceRecord {
+  return {
+    id: row.id,
+    fundId: row.fund_id,
+    calculationKey: row.calculation_key,
+    fundSnapshotId: row.fund_snapshot_id,
+    currentPlanVersionId: row.current_plan_version_id,
+    financialFactsSnapshotId: row.financial_facts_snapshot_id,
+    inputHash: row.input_hash,
+    resultHash: row.result_hash,
+    assumptionsHash: row.assumptions_hash,
+    engineVersion: row.engine_version,
+    methodologyVersion: row.methodology_version,
+    candidate: row.candidate,
+    supersededByReferenceId: row.superseded_by_reference_id,
+    reason: row.reason,
+    createdBy: row.created_by,
+    createdAt:
+      row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+  };
+}
+
+export interface CreateCandidateCurrentForecastReferenceParams {
+  fundId: number;
+  basis: CurrentForecastReferenceBasis;
+  idempotencyKey: string;
+  reason?: string;
+  createdBy?: number | null;
+  /** Set by the rollback path so clones of different sources never replay each other. */
+  sourceReferenceId?: number;
+  database?: CurrentForecastReferenceDatabase;
+}
+
+/** Append-only create-candidate (`candidate = true`), idempotent via D13. */
+export async function createCandidateCurrentForecastReference(
+  params: CreateCandidateCurrentForecastReferenceParams
+): Promise<{ row: CurrentForecastReferenceRecord; replayed: boolean }> {
+  const database = params.database ?? db;
+  const reason = params.reason ?? null;
+  const createdBy = params.createdBy ?? null;
+  const { basis } = params;
+
+  const result = await runIdempotentCommand<CurrentForecastReferenceRecord>({
+    db: database,
+    fundId: params.fundId,
+    idempotencyKey: params.idempotencyKey,
+    contractVersion: CURRENT_FORECAST_REFERENCE_CONTRACT_VERSION,
+    request: {
+      fundId: params.fundId,
+      contractVersion: CURRENT_FORECAST_REFERENCE_CONTRACT_VERSION,
+      ...basis,
+      reason,
+      sourceReferenceId: params.sourceReferenceId ?? null,
+    },
+    insert: async (requestHash) => {
+      const rows = await executeRows<ReferenceRow>(
+        database,
+        sql`
+          INSERT INTO current_forecast_references
+            (fund_id, calculation_key, fund_snapshot_id, current_plan_version_id,
+             financial_facts_snapshot_id, input_hash, result_hash, assumptions_hash,
+             engine_version, methodology_version, candidate, reason, created_by,
+             idempotency_key, request_hash)
+          VALUES
+            (${params.fundId}, ${CURRENT_FORECAST_CALCULATION_KEY}, ${basis.fundSnapshotId},
+             ${basis.currentPlanVersionId}, ${basis.financialFactsSnapshotId},
+             ${basis.inputHash}, ${basis.resultHash}, ${basis.assumptionsHash},
+             ${basis.engineVersion}, ${basis.methodologyVersion}, true, ${reason},
+             ${createdBy}, ${params.idempotencyKey}, ${requestHash})
+          ON CONFLICT (fund_id, idempotency_key) DO NOTHING
+          RETURNING ${REFERENCE_COLUMNS}
+        `
+      );
+      const row = rows[0];
+      return row ? toRecord(row) : null;
+    },
+    loadExisting: async () => {
+      const rows = await executeRows<ReferenceRow>(
+        database,
+        sql`
+          SELECT ${REFERENCE_COLUMNS}
+          FROM current_forecast_references
+          WHERE fund_id = ${params.fundId}
+            AND idempotency_key = ${params.idempotencyKey}
+          LIMIT 1
+        `
+      );
+      const row = rows[0];
+      return row ? { row: toRecord(row), requestHash: row.request_hash } : null;
+    },
+  });
+
+  return result;
+}
+
+async function loadReference(
+  executor: Executor,
+  fundId: number,
+  referenceId: number
+): Promise<CurrentForecastReferenceRecord | null> {
+  const rows = await executeRows<ReferenceRow>(
+    executor,
+    sql`
+      SELECT ${REFERENCE_COLUMNS}
+      FROM current_forecast_references
+      WHERE fund_id = ${fundId}
+        AND id = ${referenceId}
+      LIMIT 1
+    `
+  );
+  const row = rows[0];
+  return row ? toRecord(row) : null;
+}
+
+/**
+ * The accepted served-pointer head: the single non-superseded, non-candidate
+ * row per fund (armed by the accepted-head partial unique from cutover onward).
+ */
+export async function getAcceptedCurrentForecastReferenceHead(params: {
+  fundId: number;
+  database?: CurrentForecastReferenceDatabase;
+}): Promise<CurrentForecastReferenceRecord | null> {
+  const database = params.database ?? db;
+  const rows = await executeRows<ReferenceRow>(
+    database,
+    sql`
+      SELECT ${REFERENCE_COLUMNS}
+      FROM current_forecast_references
+      WHERE fund_id = ${params.fundId}
+        AND superseded_by_reference_id IS NULL
+        AND candidate = false
+      LIMIT 1
+    `
+  );
+  const row = rows[0];
+  return row ? toRecord(row) : null;
+}
+
+type ModeRowForPointer = {
+  id: number;
+  configured_mode: string;
+  kill_switch_active: boolean;
+  activated_at: Date | string | null;
+  cutover_reference_id: number | null;
+  version: number;
+};
+
+async function lockCurrentForecastModeRow(
+  executor: Executor,
+  fundId: number
+): Promise<ModeRowForPointer | null> {
+  const rows = await executeRows<ModeRowForPointer>(
+    executor,
+    sql`
+      SELECT id, configured_mode, kill_switch_active, activated_at,
+             cutover_reference_id, version
+      FROM fund_calculation_modes
+      WHERE fund_id = ${fundId}
+        AND calculation_key = ${CURRENT_FORECAST_CALCULATION_KEY}
+      FOR UPDATE
+    `
+  );
+  return rows[0] ?? null;
+}
+
+/** Supersede the current accepted head (if any) with the incoming reference. */
+function supersedeAcceptedHead(executor: Executor, fundId: number, referenceId: number) {
+  return executor.execute(sql`
+    UPDATE current_forecast_references
+    SET superseded_by_reference_id = ${referenceId}
+    WHERE fund_id = ${fundId}
+      AND candidate = false
+      AND superseded_by_reference_id IS NULL
+      AND id <> ${referenceId}
+  `);
+}
+
+/**
+ * Advance the LIVE served pointer (P1) — legal ONLY while the mode row is
+ * effective `on` post-cutover. Supersedes the old head BEFORE flipping the new
+ * one (the accepted-head partial unique is checked per statement).
+ */
+export async function advanceCurrentForecastPointer(params: {
+  fundId: number;
+  referenceId: number;
+  actorId: number | null;
+  database?: CurrentForecastReferenceDatabase;
+}): Promise<{ cutoverReferenceId: number; version: number }> {
+  const database = params.database ?? db;
+
+  return database.transaction(async (tx) => {
+    const mode = await lockCurrentForecastModeRow(tx, params.fundId);
+    if (
+      !mode ||
+      mode.activated_at === null ||
+      mode.configured_mode !== 'on' ||
+      mode.kill_switch_active
+    ) {
+      throw new CurrentForecastReferenceError(
+        409,
+        'pointer_advance_requires_on',
+        'The current-forecast served pointer only advances while the mode is effective on post-cutover.'
+      );
+    }
+
+    const reference = await loadReference(tx, params.fundId, params.referenceId);
+    if (!reference) {
+      throw new CurrentForecastReferenceError(
+        404,
+        'reference_not_found',
+        `current_forecast_references row ${params.referenceId} does not exist for fund ${params.fundId}.`
+      );
+    }
+    if (reference.supersededByReferenceId !== null) {
+      throw new CurrentForecastReferenceError(
+        409,
+        'reference_superseded',
+        `Reference ${params.referenceId} is superseded and cannot become the served head.`
+      );
+    }
+    if (mode.cutover_reference_id === reference.id) {
+      return { cutoverReferenceId: reference.id, version: mode.version };
+    }
+
+    await supersedeAcceptedHead(tx, params.fundId, reference.id);
+    await tx.execute(sql`
+      UPDATE current_forecast_references
+      SET candidate = false
+      WHERE id = ${reference.id}
+    `);
+    const updated = await executeRows<{ cutover_reference_id: number; version: number }>(
+      tx,
+      sql`
+        UPDATE fund_calculation_modes
+        SET cutover_reference_id = ${reference.id},
+            version = version + 1,
+            updated_by = ${params.actorId},
+            updated_at = NOW()
+        WHERE id = ${mode.id}
+        RETURNING cutover_reference_id, version
+      `
+    );
+    const row = updated[0];
+    if (!row) {
+      throw new CurrentForecastReferenceError(
+        409,
+        'pointer_advance_conflict',
+        'The current-forecast mode row disappeared during pointer advance.'
+      );
+    }
+    return { cutoverReferenceId: row.cutover_reference_id, version: row.version };
+  });
+}
+
+/**
+ * Admin override/rollback (13.1-svc): clone an existing reference's basis and
+ * hashes into a NEW candidate row (append-only — the ledger never rewrites
+ * history). The clone re-enters the normal candidate lifecycle; it becomes the
+ * served head only through pointer advance or activation.
+ */
+export async function createRollbackCurrentForecastReference(params: {
+  fundId: number;
+  sourceReferenceId: number;
+  reason: string;
+  idempotencyKey: string;
+  createdBy: number | null;
+  database?: CurrentForecastReferenceDatabase;
+}): Promise<{ row: CurrentForecastReferenceRecord; replayed: boolean }> {
+  const database = params.database ?? db;
+
+  const source = await loadReference(database, params.fundId, params.sourceReferenceId);
+  if (!source) {
+    throw new CurrentForecastReferenceError(
+      404,
+      'reference_not_found',
+      `current_forecast_references row ${params.sourceReferenceId} does not exist for fund ${params.fundId}.`
+    );
+  }
+
+  return createCandidateCurrentForecastReference({
+    fundId: params.fundId,
+    basis: {
+      fundSnapshotId: source.fundSnapshotId,
+      currentPlanVersionId: source.currentPlanVersionId,
+      financialFactsSnapshotId: source.financialFactsSnapshotId,
+      inputHash: source.inputHash,
+      resultHash: source.resultHash,
+      assumptionsHash: source.assumptionsHash,
+      engineVersion: source.engineVersion,
+      methodologyVersion: source.methodologyVersion,
+    },
+    idempotencyKey: params.idempotencyKey,
+    reason: params.reason,
+    createdBy: params.createdBy,
+    sourceReferenceId: params.sourceReferenceId,
+    database,
+  });
+}

--- a/server/services/current-forecast-reference-service.ts
+++ b/server/services/current-forecast-reference-service.ts
@@ -1,8 +1,14 @@
 import { sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../db';
+import { canonicalSha256 } from '../../shared/lib/canonical-hash';
 import { runIdempotentCommand } from '../lib/idempotent-command';
 import { CURRENT_FORECAST_CALCULATION_KEY } from './current-forecast-calc-mode-resolver';
+import {
+  FundCalculationModeIdempotencyConflictError,
+  FundCalculationModeInProgressError,
+  FundCalculationModeVersionConflictError,
+} from './fund-calculation-mode-service';
 
 /**
  * Append-only reference plane for the current-forecast calculation key
@@ -410,5 +416,270 @@ export async function createRollbackCurrentForecastReference(params: {
     createdBy: params.createdBy,
     sourceReferenceId: params.sourceReferenceId,
     database,
+  });
+}
+
+export const CURRENT_FORECAST_ACTIVATE_ROUTE =
+  'POST /api/admin/funds/:fundId/current-forecast/activate';
+
+export class CurrentForecastActivationBlockedError extends Error {
+  readonly code = 'activation_blocked';
+
+  constructor(readonly blockers: string[]) {
+    super(`current-forecast activation is blocked: ${blockers.join(', ')}`);
+    this.name = 'CurrentForecastActivationBlockedError';
+  }
+}
+
+export type VerifyGreenCandidateFn = (params: {
+  executor: Executor;
+  fundId: number;
+  reference: CurrentForecastReferenceRecord;
+}) => Promise<string[]>;
+
+/**
+ * Default green-candidate verification against the durable ledgers: the
+ * reference must still be a live candidate, a fund-owned CURRENT_FORECAST_V2
+ * snapshot must exist, the exact basis hash must have a green shadow `match`
+ * replay, and the fund must carry zero `failed` shadow rows (P3: `failed` is by
+ * definition an UNEXPLAINED divergence and blocks green).
+ */
+export const verifyGreenCandidateWithLedger: VerifyGreenCandidateFn = async ({
+  executor,
+  fundId,
+  reference,
+}) => {
+  const blockers: string[] = [];
+
+  if (!reference.candidate || reference.supersededByReferenceId !== null) {
+    blockers.push('activation_requires_green_candidate');
+  }
+
+  const snapshots = await executeRows<{ id: number }>(
+    executor,
+    sql`
+      SELECT id
+      FROM fund_snapshots
+      WHERE fund_id = ${fundId}
+        AND type = 'CURRENT_FORECAST_V2'
+      LIMIT 1
+    `
+  );
+  if (snapshots.length === 0) {
+    blockers.push('current_forecast_snapshot_missing');
+  }
+
+  const matches = await executeRows<{ reconciliation_status: string }>(
+    executor,
+    sql`
+      SELECT reconciliation_status
+      FROM substrate_shadow_reconciliations
+      WHERE fund_id = ${fundId}
+        AND calculation_key = ${CURRENT_FORECAST_CALCULATION_KEY}
+        AND input_hash = ${reference.inputHash}
+        AND result_hash = ${reference.resultHash}
+      LIMIT 1
+    `
+  );
+  if (matches[0]?.reconciliation_status !== 'match') {
+    blockers.push('shadow_green_required');
+  }
+
+  const failed = await executeRows<{ id: number }>(
+    executor,
+    sql`
+      SELECT id
+      FROM substrate_shadow_reconciliations
+      WHERE fund_id = ${fundId}
+        AND calculation_key = ${CURRENT_FORECAST_CALCULATION_KEY}
+        AND substrate_state = 'failed'
+      LIMIT 1
+    `
+  );
+  if (failed.length > 0) {
+    blockers.push('unexplained_divergence_present');
+  }
+
+  return blockers;
+};
+
+export interface CurrentForecastActivationResponse {
+  calculationKey: string;
+  configuredMode: 'on';
+  activatedAt: string;
+  cutoverReferenceId: number;
+  version: number;
+}
+
+type ActivationLedgerRow = {
+  request_hash: string;
+  response_body: unknown;
+  status: 'pending' | 'completed';
+};
+
+function activationResponseFromLedger(value: unknown): CurrentForecastActivationResponse {
+  const parsed: unknown = typeof value === 'string' ? (JSON.parse(value) as unknown) : value;
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    (parsed as { calculationKey?: unknown }).calculationKey === CURRENT_FORECAST_CALCULATION_KEY &&
+    (parsed as { configuredMode?: unknown }).configuredMode === 'on'
+  ) {
+    return parsed as CurrentForecastActivationResponse;
+  }
+  throw new Error('Completed current-forecast activation ledger row has an invalid response body');
+}
+
+/**
+ * The DORMANT activation command (executed only by Task 23). One atomic
+ * transaction validates a green candidate then writes mode `on` +
+ * `activated_at` + `cutover_reference_id` AND flips the chosen candidate to
+ * `candidate = false` (P2) — arming the accepted-head partial unique. The mode
+ * route never writes `on` for this key; only this command does, so the
+ * activation event is by construction written in the same transaction.
+ */
+export async function activateCurrentForecast(params: {
+  fundId: number;
+  referenceId: number;
+  expectedVersion: number;
+  idempotencyKey: string;
+  actorId: number | null;
+  database?: CurrentForecastReferenceDatabase;
+  verifyGreenCandidate?: VerifyGreenCandidateFn;
+}): Promise<{ response: CurrentForecastActivationResponse; replayed: boolean }> {
+  const database = params.database ?? db;
+  const verifyGreenCandidate = params.verifyGreenCandidate ?? verifyGreenCandidateWithLedger;
+  const requestHash = canonicalSha256({
+    route: CURRENT_FORECAST_ACTIVATE_ROUTE,
+    fundId: params.fundId,
+    referenceId: params.referenceId,
+    expectedVersion: params.expectedVersion,
+  });
+
+  return database.transaction(async (tx) => {
+    const claimed = await executeRows<{ id: number }>(
+      tx,
+      sql`
+        INSERT INTO fund_calculation_mode_requests
+          (fund_id, calculation_key, idempotency_key, request_hash, created_by, status)
+        VALUES
+          (${params.fundId}, ${CURRENT_FORECAST_CALCULATION_KEY}, ${params.idempotencyKey}, ${requestHash}, ${params.actorId}, 'pending')
+        ON CONFLICT (fund_id, calculation_key, idempotency_key) DO NOTHING
+        RETURNING id
+      `
+    );
+    if (claimed.length === 0) {
+      const existing = await executeRows<ActivationLedgerRow>(
+        tx,
+        sql`
+          SELECT request_hash, response_body, status
+          FROM fund_calculation_mode_requests
+          WHERE fund_id = ${params.fundId}
+            AND calculation_key = ${CURRENT_FORECAST_CALCULATION_KEY}
+            AND idempotency_key = ${params.idempotencyKey}
+          LIMIT 1
+        `
+      );
+      const row = existing[0];
+      if (!row) {
+        throw new Error('Activation idempotency claim conflict did not return an existing request');
+      }
+      if (row.request_hash !== requestHash) {
+        throw new FundCalculationModeIdempotencyConflictError(
+          'Idempotency-Key reused with a different current-forecast activation request'
+        );
+      }
+      if (row.status !== 'completed' || row.response_body === null) {
+        throw new FundCalculationModeInProgressError();
+      }
+      return { response: activationResponseFromLedger(row.response_body), replayed: true };
+    }
+
+    const mode = await lockCurrentForecastModeRow(tx, params.fundId);
+    if (!mode) {
+      throw new FundCalculationModeVersionConflictError(params.expectedVersion, 0);
+    }
+    if (mode.version !== params.expectedVersion) {
+      throw new FundCalculationModeVersionConflictError(params.expectedVersion, mode.version);
+    }
+    if (mode.activated_at !== null) {
+      throw new CurrentForecastReferenceError(
+        409,
+        'already_activated',
+        `Fund ${params.fundId} current-forecast is already activated.`
+      );
+    }
+
+    const reference = await loadReference(tx, params.fundId, params.referenceId);
+    if (!reference) {
+      throw new CurrentForecastReferenceError(
+        404,
+        'reference_not_found',
+        `current_forecast_references row ${params.referenceId} does not exist for fund ${params.fundId}.`
+      );
+    }
+
+    const blockers = [
+      ...(mode.kill_switch_active ? ['kill_switch_active'] : []),
+      ...(await verifyGreenCandidate({ executor: tx, fundId: params.fundId, reference })),
+    ];
+    if (blockers.length > 0) {
+      throw new CurrentForecastActivationBlockedError(blockers);
+    }
+
+    await supersedeAcceptedHead(tx, params.fundId, reference.id);
+    await tx.execute(sql`
+      UPDATE current_forecast_references
+      SET candidate = false
+      WHERE id = ${reference.id}
+    `);
+    const updated = await executeRows<{
+      cutover_reference_id: number;
+      version: number;
+      activated_at: Date | string;
+    }>(
+      tx,
+      sql`
+        UPDATE fund_calculation_modes
+        SET configured_mode = 'on',
+            activated_at = NOW(),
+            cutover_reference_id = ${reference.id},
+            version = version + 1,
+            updated_by = ${params.actorId},
+            updated_at = NOW()
+        WHERE id = ${mode.id}
+        RETURNING cutover_reference_id, version, activated_at
+      `
+    );
+    const row = updated[0];
+    if (!row) {
+      throw new CurrentForecastReferenceError(
+        409,
+        'activation_conflict',
+        'The current-forecast mode row disappeared during activation.'
+      );
+    }
+
+    const response: CurrentForecastActivationResponse = {
+      calculationKey: CURRENT_FORECAST_CALCULATION_KEY,
+      configuredMode: 'on',
+      activatedAt:
+        row.activated_at instanceof Date
+          ? row.activated_at.toISOString()
+          : String(row.activated_at),
+      cutoverReferenceId: row.cutover_reference_id,
+      version: row.version,
+    };
+    await tx.execute(sql`
+      UPDATE fund_calculation_mode_requests
+      SET status = 'completed',
+          response_status = 200,
+          response_body = ${JSON.stringify(response)}::jsonb
+      WHERE fund_id = ${params.fundId}
+        AND calculation_key = ${CURRENT_FORECAST_CALCULATION_KEY}
+        AND idempotency_key = ${params.idempotencyKey}
+    `);
+
+    return { response, replayed: false };
   });
 }

--- a/server/services/current-forecast-shadow-service.ts
+++ b/server/services/current-forecast-shadow-service.ts
@@ -1,0 +1,345 @@
+import { db } from '../db';
+import { substrateShadowReconciliations } from '@shared/schema';
+import type { InsertSubstrateShadowReconciliation } from '../../shared/schema/substrate-shadow-reconciliations';
+import type { CurrentForecastV2 } from '../../shared/contracts/current-forecast-v2.contract';
+import { canonicalSha256 } from '../../shared/lib/canonical-hash';
+import {
+  CURRENT_FORECAST_CALCULATION_KEY,
+  type CurrentForecastModeResolution,
+} from './current-forecast-calc-mode-resolver';
+import {
+  createCandidateCurrentForecastReference,
+  currentForecastReferenceIdempotencyKey,
+} from './current-forecast-reference-service';
+
+/**
+ * Shadow evaluation plane for the current-forecast calculation key (PLAN_61
+ * Task 13.1-svc), modeled on `substrate-shadow-reconciliation-writer.ts`: runs
+ * V2 over the committed replay corpus and persists append-only reconciliation
+ * observations into `substrate_shadow_reconciliations`.
+ *
+ * Review pins honored here:
+ * - P3: non-value-producing runs persist as `reconciliation_status='mismatch'`
+ *   with a typed reason (`unavailable` -> `facts_gap`/`unavailable_expected`);
+ *   `failed` persists as `mismatch` with NO typed reason — it is by definition
+ *   an UNEXPLAINED divergence and blocks green.
+ * - P4: the writer never emits `configured_mode`/`effective_mode` outside
+ *   `off|shadow|on` ('held' is a resolver/serving state, not a ledger mode) —
+ *   enforced by {@link assertLedgerMode}.
+ * - D1 (divergence-by-design): legacy numeric parity is NOT a green criterion.
+ *   Green = exact-basis replay reproduces the pinned `resultHash` for every
+ *   base + >=90% available coverage + zero unexplained divergences.
+ */
+
+export const CURRENT_FORECAST_SHADOW_MISMATCH_REASONS = [
+  'legacy_fabrication_replaced',
+  'facts_gap',
+  'methodology_change',
+  'unavailable_expected',
+] as const;
+
+export type CurrentForecastShadowMismatchReason =
+  (typeof CURRENT_FORECAST_SHADOW_MISMATCH_REASONS)[number];
+
+type LedgerMode = 'off' | 'shadow' | 'on';
+
+/** P4 clamp: the substrate ledger mode CHECKs were deliberately not widened. */
+function assertLedgerMode(value: string): LedgerMode {
+  if (value !== 'off' && value !== 'shadow' && value !== 'on') {
+    throw new Error(`substrate ledger modes admit only off|shadow|on, got: ${value}`);
+  }
+  return value;
+}
+
+export interface CurrentForecastShadowModes {
+  configuredMode: LedgerMode;
+  effectiveMode: LedgerMode;
+  killSwitchActive: boolean;
+}
+
+export interface CurrentForecastShadowBaseExpectation {
+  status: 'available' | 'indicative' | 'unavailable' | 'failed';
+  inputHash: string | null;
+  resultHash: string | null;
+  methodologyVersion: string;
+  mismatchReasons: readonly CurrentForecastShadowMismatchReason[];
+}
+
+export interface CurrentForecastShadowBase {
+  name: string;
+  fundId: number;
+  referenceBasis: {
+    fundSnapshotId: number;
+    currentPlanVersionId: number;
+    financialFactsSnapshotId: number;
+  };
+  expected: CurrentForecastShadowBaseExpectation;
+}
+
+export interface CurrentForecastShadowOutcome {
+  baseName: string;
+  executed: boolean;
+  substrateState: 'available' | 'indicative' | 'unavailable' | 'failed' | null;
+  reconciliationStatus: 'match' | 'mismatch' | null;
+  replayConsistent: boolean;
+  mismatchReasons: CurrentForecastShadowMismatchReason[];
+  unexplained: boolean;
+}
+
+function skippedOutcome(baseName: string): CurrentForecastShadowOutcome {
+  return {
+    baseName,
+    executed: false,
+    substrateState: null,
+    reconciliationStatus: null,
+    replayConsistent: true,
+    mismatchReasons: [],
+    unexplained: false,
+  };
+}
+
+/**
+ * Deterministic identity for runs that produced no engine output at all (a
+ * thrown basis mismatch has no `inputHash`); keeps the NOT NULL hash columns
+ * honest and dedupes replays through the 0038 null-hash partial unique.
+ */
+function corpusRunIdentityHash(base: CurrentForecastShadowBase): string {
+  return canonicalSha256({
+    calculationKey: CURRENT_FORECAST_CALCULATION_KEY,
+    corpusBase: base.name,
+    fundId: base.fundId,
+  });
+}
+
+export interface BuildCurrentForecastShadowRecordParams {
+  base: CurrentForecastShadowBase;
+  result: CurrentForecastV2 | null;
+  error?: unknown;
+  modes: CurrentForecastShadowModes;
+}
+
+export function buildCurrentForecastShadowRecord(params: BuildCurrentForecastShadowRecordParams): {
+  record: InsertSubstrateShadowReconciliation;
+  outcome: CurrentForecastShadowOutcome;
+} {
+  const { base, result, error, modes } = params;
+  const configuredMode = assertLedgerMode(modes.configuredMode);
+  const effectiveMode = assertLedgerMode(modes.effectiveMode);
+
+  let substrateState: 'available' | 'indicative' | 'unavailable' | 'failed';
+  let resultHash: string | null;
+  let replayConsistent: boolean;
+  let mismatchReasons: CurrentForecastShadowMismatchReason[];
+
+  if (error !== undefined || result === null || result.status === 'failed') {
+    // P3: failed is by definition an UNEXPLAINED divergence — no typed reason.
+    substrateState = 'failed';
+    resultHash = null;
+    replayConsistent = false;
+    mismatchReasons = [];
+  } else if (result.status === 'unavailable') {
+    substrateState = 'unavailable';
+    // The engine still hashes the unavailable result envelope; persist it so
+    // replays dedupe through the result-bearing unique (null only when the
+    // engine truly produced nothing -- the 'failed' branch).
+    resultHash = result.resultHash;
+    replayConsistent = result.resultHash === base.expected.resultHash;
+    mismatchReasons = result.unavailableReasons.some(
+      (reason) => reason.code === 'FACTS_UNAVAILABLE'
+    )
+      ? ['facts_gap']
+      : ['unavailable_expected'];
+  } else if (result.status === 'available' || result.status === 'indicative') {
+    substrateState = result.status;
+    resultHash = result.resultHash;
+    replayConsistent = result.resultHash !== null && result.resultHash === base.expected.resultHash;
+    mismatchReasons = replayConsistent
+      ? []
+      : result.methodologyVersion !== base.expected.methodologyVersion
+        ? ['methodology_change']
+        : [];
+  } else {
+    // 'held' is a serving state; a shadow evaluation can never produce it.
+    throw new Error(`current-forecast shadow cannot record engine status: ${result.status}`);
+  }
+
+  const reconciliationStatus: 'match' | 'mismatch' =
+    substrateState === 'available' || substrateState === 'indicative'
+      ? replayConsistent
+        ? 'match'
+        : 'mismatch'
+      : 'mismatch';
+
+  const unexplained =
+    substrateState === 'failed' ||
+    (reconciliationStatus === 'mismatch' && mismatchReasons.length === 0);
+
+  const record: InsertSubstrateShadowReconciliation = {
+    fundId: base.fundId,
+    calculationKey: CURRENT_FORECAST_CALCULATION_KEY,
+    configuredMode,
+    effectiveMode,
+    killSwitchActive: modes.killSwitchActive,
+    substrateState,
+    reconciliationStatus,
+    inputHash: result?.inputHash ?? corpusRunIdentityHash(base),
+    resultHash,
+    assumptionsHash: result?.assumptionsHash ?? corpusRunIdentityHash(base),
+    mismatches: [...mismatchReasons],
+  };
+
+  return {
+    record,
+    outcome: {
+      baseName: base.name,
+      executed: true,
+      substrateState,
+      reconciliationStatus,
+      replayConsistent,
+      mismatchReasons,
+      unexplained,
+    },
+  };
+}
+
+/** Default append-only writer (substrate-writer shape: idempotent, no rethrow filtering). */
+export async function persistCurrentForecastShadowReconciliation(
+  record: InsertSubstrateShadowReconciliation
+): Promise<void> {
+  await db.insert(substrateShadowReconciliations).values(record).onConflictDoNothing();
+}
+
+export type PersistCurrentForecastShadowReconciliationFn = (
+  record: InsertSubstrateShadowReconciliation
+) => Promise<void>;
+
+export type CreateCurrentForecastReferenceFn = (params: {
+  fundId: number;
+  basis: {
+    fundSnapshotId: number;
+    currentPlanVersionId: number;
+    financialFactsSnapshotId: number;
+    inputHash: string;
+    resultHash: string;
+    assumptionsHash: string;
+    engineVersion: string;
+    methodologyVersion: string;
+  };
+  idempotencyKey: string;
+}) => Promise<unknown>;
+
+const defaultCreateReference: CreateCurrentForecastReferenceFn = (params) =>
+  createCandidateCurrentForecastReference(params);
+
+export interface RunCurrentForecastShadowBaseParams {
+  base: CurrentForecastShadowBase;
+  resolveMode: () => Promise<CurrentForecastModeResolution>;
+  runV2: () => Promise<CurrentForecastV2>;
+  persist?: PersistCurrentForecastShadowReconciliationFn;
+  createReference?: CreateCurrentForecastReferenceFn;
+}
+
+/**
+ * Evaluate one replay base under the shadow plane. Only a `shadow` resolution
+ * executes; `off`/`on`/`held` skip without persisting (P4: nothing outside the
+ * shadow lane ever reaches the ledger from here). A green (available + replay
+ * match) run creates the candidate reference under the deterministic
+ * `cfref:<fundId>:<inputHash>:<resultHash>` key.
+ */
+export async function runCurrentForecastShadowBase(
+  params: RunCurrentForecastShadowBaseParams
+): Promise<CurrentForecastShadowOutcome> {
+  const persist = params.persist ?? persistCurrentForecastShadowReconciliation;
+  const createReference = params.createReference ?? defaultCreateReference;
+
+  const resolution = await params.resolveMode();
+  if (resolution.mode !== 'shadow') {
+    return skippedOutcome(params.base.name);
+  }
+
+  let result: CurrentForecastV2 | null = null;
+  let caught: { error: unknown } | undefined;
+  try {
+    result = await params.runV2();
+  } catch (error) {
+    caught = { error };
+  }
+
+  const { record, outcome } = buildCurrentForecastShadowRecord({
+    base: params.base,
+    result,
+    ...(caught === undefined ? {} : { error: caught.error }),
+    modes: { configuredMode: 'shadow', effectiveMode: 'shadow', killSwitchActive: false },
+  });
+
+  await persist(record);
+
+  if (
+    outcome.substrateState === 'available' &&
+    outcome.reconciliationStatus === 'match' &&
+    result !== null &&
+    result.resultHash !== null
+  ) {
+    await createReference({
+      fundId: params.base.fundId,
+      basis: {
+        ...params.base.referenceBasis,
+        inputHash: result.inputHash,
+        resultHash: result.resultHash,
+        assumptionsHash: result.assumptionsHash,
+        engineVersion: result.engineVersion,
+        methodologyVersion: result.methodologyVersion,
+      },
+      idempotencyKey: currentForecastReferenceIdempotencyKey({
+        fundId: params.base.fundId,
+        inputHash: result.inputHash,
+        resultHash: result.resultHash,
+      }),
+    });
+  }
+
+  return outcome;
+}
+
+export interface CurrentForecastShadowGreenEvaluation {
+  green: boolean;
+  evaluatedCount: number;
+  availableCount: number;
+  availableCoverage: number;
+  replayInconsistent: string[];
+  unexplainedDivergences: string[];
+}
+
+/**
+ * D1 green criteria (legacy numeric parity deliberately absent): every
+ * evaluated base replays consistently, zero unexplained divergences, and
+ * >=90% of evaluated bases produced an `available` value.
+ */
+export function evaluateCurrentForecastShadowGreen(
+  outcomes: readonly CurrentForecastShadowOutcome[]
+): CurrentForecastShadowGreenEvaluation {
+  const evaluated = outcomes.filter((outcome) => outcome.executed);
+  const availableCount = evaluated.filter(
+    (outcome) => outcome.substrateState === 'available'
+  ).length;
+  const availableCoverage = evaluated.length === 0 ? 0 : availableCount / evaluated.length;
+  const replayInconsistent = evaluated
+    .filter((outcome) => !outcome.replayConsistent)
+    .map((outcome) => outcome.baseName);
+  const unexplainedDivergences = evaluated
+    .filter((outcome) => outcome.unexplained)
+    .map((outcome) => outcome.baseName);
+
+  return {
+    green:
+      evaluated.length > 0 &&
+      replayInconsistent.length === 0 &&
+      unexplainedDivergences.length === 0 &&
+      availableCoverage >= 0.9,
+    evaluatedCount: evaluated.length,
+    availableCount,
+    availableCoverage,
+    replayInconsistent,
+    unexplainedDivergences,
+  };
+}

--- a/shared/routes/api-route-manifest.ts
+++ b/shared/routes/api-route-manifest.ts
@@ -160,12 +160,14 @@ export const COMMON_API_ROUTE_MANIFEST = [
     migrationParity: { kind: 'c1', tables: ['current_plan_versions'] },
     schemaTables: [
       'current_plan_versions',
+      'current_forecast_references',
       'financial_facts_snapshots',
       'fund_snapshots',
       'fundconfigs',
       'funds',
       'fund_calculation_modes',
       'fund_calculation_mode_requests',
+      'substrate_shadow_reconciliations',
     ],
     owner: 'analytics',
     probe: {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -48,7 +48,6 @@ export * from './schema/fund-calculation-modes';
 export * from './schema/fund-moic-input-update-requests';
 export * from './schema/investment-rounds';
 export * from './schema/investment-round-model-overrides';
-export * from './schema/current-plans';
 export * from './schema/current-forecast-references';
 export * from './schemas/flags';
 export * from './schemas/reserve-approvals';

--- a/tests/fixtures/current-forecast-replay-corpus/case-blocked.json
+++ b/tests/fixtures/current-forecast-replay-corpus/case-blocked.json
@@ -1,0 +1,129 @@
+{
+  "name": "case-blocked",
+  "kind": "evaluate",
+  "sourceTruthCase": "CF-002",
+  "input": {
+    "fundId": 1,
+    "financialFactsSnapshotId": "31",
+    "currentPlanVersionId": "wrong-plan-version",
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "clock": "2026-07-22T03:00:00.000Z"
+  },
+  "plan": {
+    "contractVersion": "current-plan-version-v1",
+    "id": "current-plan-cf-002",
+    "fundId": 1,
+    "version": 1,
+    "sourceConfigId": 17,
+    "sourceConfigVersion": 3,
+    "sourceFactsSnapshotId": "31",
+    "deployableCapitalUsd": "8000000.000000",
+    "planTransformationVersion": "fund-config-to-current-plan/1.0.0",
+    "allocations": [],
+    "pacingAssumptions": {
+      "contractVersion": "current-plan-pacing-v1",
+      "deploymentQuarters": 1,
+      "quarterlyDeploymentPcts": ["1.000000000000"],
+      "followOnReservePct": "0.000000000000",
+      "annualFeeDragPct": "0.000000000000"
+    },
+    "cohortAssumptions": {
+      "contractVersion": "current-plan-cohort-v1",
+      "averageInitialCheckUsd": "1000000.000000",
+      "stageDistribution": [
+        {
+          "stage": "Seed",
+          "pct": "1.000000000000"
+        }
+      ],
+      "graduationMatrix": [
+        {
+          "fromStage": "Seed",
+          "toStage": "Seed",
+          "rate": "1.000000000000",
+          "quartersToGraduate": 0
+        }
+      ],
+      "exitAssumptions": [
+        {
+          "stage": "Seed",
+          "exitMultiple": "2.000000000000",
+          "quartersToExit": 4,
+          "failureRate": "0.000000000000"
+        }
+      ]
+    },
+    "reservePolicyVersion": "reserve-policy/1.0.0",
+    "assumptionsHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "supersedesVersionId": null,
+    "supersededByVersionId": null,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "facts": {
+    "id": 31,
+    "policyVersion": "financial-facts-policy/1.0.0",
+    "fundId": 1,
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "vehicleScope": "fund_all",
+    "vehicleIds": [11],
+    "selectionSetHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sourceFactsInputHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "snapshotInputHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consumerEvaluations": [],
+    "payload": {
+      "companyActuals": {
+        "fundId": 1,
+        "asOfDate": "2026-07-21",
+        "facts": [],
+        "inputHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "sourceObservationIds": [],
+      "workingValueSelectionIds": [],
+      "participationTermRefs": [],
+      "cashFlowSeries": {
+        "series": [
+          {
+            "eventType": "portfolio_investment",
+            "vehicleId": 11,
+            "perspective": "fund_gross",
+            "points": [
+              {
+                "eventId": 201,
+                "effectiveAt": "2026-07-01T00:00:00.000Z",
+                "amount": "8000000.000000"
+              }
+            ]
+          }
+        ],
+        "totals": {
+          "contributions": "0.000000",
+          "distributions": "0.000000",
+          "recallableDistributions": "0.000000"
+        },
+        "warnings": []
+      },
+      "marksSeries": {
+        "marks": [],
+        "periodNav": [],
+        "warnings": []
+      },
+      "vehicleRoster": []
+    },
+    "actorId": 7,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "expected": {
+    "status": "failed",
+    "inputHash": null,
+    "resultHash": null,
+    "mismatchReasons": [],
+    "methodologyVersion": "cohort-projection-v2/1.0.0"
+  },
+  "referenceBasis": {
+    "fundSnapshotId": 901,
+    "currentPlanVersionId": 911,
+    "financialFactsSnapshotId": 31
+  }
+}

--- a/tests/fixtures/current-forecast-replay-corpus/empty-facts.json
+++ b/tests/fixtures/current-forecast-replay-corpus/empty-facts.json
@@ -1,0 +1,116 @@
+{
+  "name": "empty-facts",
+  "kind": "evaluate",
+  "sourceTruthCase": "CF-001",
+  "input": {
+    "fundId": 1,
+    "financialFactsSnapshotId": "31",
+    "currentPlanVersionId": "current-plan-cf-001",
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "clock": "2026-07-22T03:00:00.000Z"
+  },
+  "plan": {
+    "contractVersion": "current-plan-version-v1",
+    "id": "current-plan-cf-001",
+    "fundId": 1,
+    "version": 1,
+    "sourceConfigId": 17,
+    "sourceConfigVersion": 3,
+    "sourceFactsSnapshotId": "31",
+    "deployableCapitalUsd": "0.000000",
+    "planTransformationVersion": "fund-config-to-current-plan/1.0.0",
+    "allocations": [],
+    "pacingAssumptions": {
+      "contractVersion": "current-plan-pacing-v1",
+      "deploymentQuarters": 1,
+      "quarterlyDeploymentPcts": ["1.000000000000"],
+      "followOnReservePct": "0.000000000000",
+      "annualFeeDragPct": "0.000000000000"
+    },
+    "cohortAssumptions": {
+      "contractVersion": "current-plan-cohort-v1",
+      "averageInitialCheckUsd": "0.000000",
+      "stageDistribution": [
+        {
+          "stage": "Seed",
+          "pct": "1.000000000000"
+        }
+      ],
+      "graduationMatrix": [
+        {
+          "fromStage": "Seed",
+          "toStage": "Seed",
+          "rate": "1.000000000000",
+          "quartersToGraduate": 0
+        }
+      ],
+      "exitAssumptions": [
+        {
+          "stage": "Seed",
+          "exitMultiple": "1.000000000000",
+          "quartersToExit": 1,
+          "failureRate": "0.000000000000"
+        }
+      ]
+    },
+    "reservePolicyVersion": "reserve-policy/1.0.0",
+    "assumptionsHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "supersedesVersionId": null,
+    "supersededByVersionId": null,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "facts": {
+    "id": 31,
+    "policyVersion": "financial-facts-policy/1.0.0",
+    "fundId": 1,
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "vehicleScope": "fund_all",
+    "vehicleIds": [11],
+    "selectionSetHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sourceFactsInputHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "snapshotInputHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consumerEvaluations": [],
+    "payload": {
+      "companyActuals": {
+        "fundId": 1,
+        "asOfDate": "2026-07-21",
+        "facts": [],
+        "inputHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "sourceObservationIds": [],
+      "workingValueSelectionIds": [],
+      "participationTermRefs": [],
+      "cashFlowSeries": {
+        "series": [],
+        "totals": {
+          "contributions": "0.000000",
+          "distributions": "0.000000",
+          "recallableDistributions": "0.000000"
+        },
+        "warnings": []
+      },
+      "marksSeries": {
+        "marks": [],
+        "periodNav": [],
+        "warnings": []
+      },
+      "vehicleRoster": []
+    },
+    "actorId": 7,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "expected": {
+    "status": "unavailable",
+    "inputHash": "f62025d800aca8ec9089fba6234c9e0d45ca48b474c87fda23a7eb29c6ef4ac1",
+    "resultHash": "dabca3814aff474b9df49862bf9330f0bdb635aeb73d217c31bf307b2f37c3e3",
+    "mismatchReasons": ["facts_gap"],
+    "methodologyVersion": "cohort-projection-v2/1.0.0"
+  },
+  "referenceBasis": {
+    "fundSnapshotId": 902,
+    "currentPlanVersionId": 912,
+    "financialFactsSnapshotId": 31
+  }
+}

--- a/tests/fixtures/current-forecast-replay-corpus/full-facts.json
+++ b/tests/fixtures/current-forecast-replay-corpus/full-facts.json
@@ -1,0 +1,129 @@
+{
+  "name": "full-facts",
+  "kind": "evaluate",
+  "sourceTruthCase": "CF-002",
+  "input": {
+    "fundId": 1,
+    "financialFactsSnapshotId": "31",
+    "currentPlanVersionId": "current-plan-cf-002",
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "clock": "2026-07-22T03:00:00.000Z"
+  },
+  "plan": {
+    "contractVersion": "current-plan-version-v1",
+    "id": "current-plan-cf-002",
+    "fundId": 1,
+    "version": 1,
+    "sourceConfigId": 17,
+    "sourceConfigVersion": 3,
+    "sourceFactsSnapshotId": "31",
+    "deployableCapitalUsd": "8000000.000000",
+    "planTransformationVersion": "fund-config-to-current-plan/1.0.0",
+    "allocations": [],
+    "pacingAssumptions": {
+      "contractVersion": "current-plan-pacing-v1",
+      "deploymentQuarters": 1,
+      "quarterlyDeploymentPcts": ["1.000000000000"],
+      "followOnReservePct": "0.000000000000",
+      "annualFeeDragPct": "0.000000000000"
+    },
+    "cohortAssumptions": {
+      "contractVersion": "current-plan-cohort-v1",
+      "averageInitialCheckUsd": "1000000.000000",
+      "stageDistribution": [
+        {
+          "stage": "Seed",
+          "pct": "1.000000000000"
+        }
+      ],
+      "graduationMatrix": [
+        {
+          "fromStage": "Seed",
+          "toStage": "Seed",
+          "rate": "1.000000000000",
+          "quartersToGraduate": 0
+        }
+      ],
+      "exitAssumptions": [
+        {
+          "stage": "Seed",
+          "exitMultiple": "2.000000000000",
+          "quartersToExit": 4,
+          "failureRate": "0.000000000000"
+        }
+      ]
+    },
+    "reservePolicyVersion": "reserve-policy/1.0.0",
+    "assumptionsHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "supersedesVersionId": null,
+    "supersededByVersionId": null,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "facts": {
+    "id": 31,
+    "policyVersion": "financial-facts-policy/1.0.0",
+    "fundId": 1,
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "vehicleScope": "fund_all",
+    "vehicleIds": [11],
+    "selectionSetHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sourceFactsInputHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "snapshotInputHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consumerEvaluations": [],
+    "payload": {
+      "companyActuals": {
+        "fundId": 1,
+        "asOfDate": "2026-07-21",
+        "facts": [],
+        "inputHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "sourceObservationIds": [],
+      "workingValueSelectionIds": [],
+      "participationTermRefs": [],
+      "cashFlowSeries": {
+        "series": [
+          {
+            "eventType": "portfolio_investment",
+            "vehicleId": 11,
+            "perspective": "fund_gross",
+            "points": [
+              {
+                "eventId": 201,
+                "effectiveAt": "2026-07-01T00:00:00.000Z",
+                "amount": "8000000.000000"
+              }
+            ]
+          }
+        ],
+        "totals": {
+          "contributions": "0.000000",
+          "distributions": "0.000000",
+          "recallableDistributions": "0.000000"
+        },
+        "warnings": []
+      },
+      "marksSeries": {
+        "marks": [],
+        "periodNav": [],
+        "warnings": []
+      },
+      "vehicleRoster": []
+    },
+    "actorId": 7,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "expected": {
+    "status": "available",
+    "inputHash": "bfb41e2cab582a0cbdbb317929c96692761b651ae5b4b24ca318b7b0d71280ee",
+    "resultHash": "4f68044925c16b678df52c0de890d58e78231a0091083fadde2c421dccb2ade3",
+    "mismatchReasons": [],
+    "methodologyVersion": "cohort-projection-v2/1.0.0"
+  },
+  "referenceBasis": {
+    "fundSnapshotId": 903,
+    "currentPlanVersionId": 913,
+    "financialFactsSnapshotId": 31
+  }
+}

--- a/tests/fixtures/current-forecast-replay-corpus/held.json
+++ b/tests/fixtures/current-forecast-replay-corpus/held.json
@@ -1,0 +1,129 @@
+{
+  "name": "held",
+  "kind": "held",
+  "sourceTruthCase": "CF-002",
+  "input": {
+    "fundId": 1,
+    "financialFactsSnapshotId": "31",
+    "currentPlanVersionId": "current-plan-cf-002",
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "clock": "2026-07-22T03:00:00.000Z"
+  },
+  "plan": {
+    "contractVersion": "current-plan-version-v1",
+    "id": "current-plan-cf-002",
+    "fundId": 1,
+    "version": 1,
+    "sourceConfigId": 17,
+    "sourceConfigVersion": 3,
+    "sourceFactsSnapshotId": "31",
+    "deployableCapitalUsd": "8000000.000000",
+    "planTransformationVersion": "fund-config-to-current-plan/1.0.0",
+    "allocations": [],
+    "pacingAssumptions": {
+      "contractVersion": "current-plan-pacing-v1",
+      "deploymentQuarters": 1,
+      "quarterlyDeploymentPcts": ["1.000000000000"],
+      "followOnReservePct": "0.000000000000",
+      "annualFeeDragPct": "0.000000000000"
+    },
+    "cohortAssumptions": {
+      "contractVersion": "current-plan-cohort-v1",
+      "averageInitialCheckUsd": "1000000.000000",
+      "stageDistribution": [
+        {
+          "stage": "Seed",
+          "pct": "1.000000000000"
+        }
+      ],
+      "graduationMatrix": [
+        {
+          "fromStage": "Seed",
+          "toStage": "Seed",
+          "rate": "1.000000000000",
+          "quartersToGraduate": 0
+        }
+      ],
+      "exitAssumptions": [
+        {
+          "stage": "Seed",
+          "exitMultiple": "2.000000000000",
+          "quartersToExit": 4,
+          "failureRate": "0.000000000000"
+        }
+      ]
+    },
+    "reservePolicyVersion": "reserve-policy/1.0.0",
+    "assumptionsHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "supersedesVersionId": null,
+    "supersededByVersionId": null,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "facts": {
+    "id": 31,
+    "policyVersion": "financial-facts-policy/1.0.0",
+    "fundId": 1,
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "vehicleScope": "fund_all",
+    "vehicleIds": [11],
+    "selectionSetHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sourceFactsInputHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "snapshotInputHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consumerEvaluations": [],
+    "payload": {
+      "companyActuals": {
+        "fundId": 1,
+        "asOfDate": "2026-07-21",
+        "facts": [],
+        "inputHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "sourceObservationIds": [],
+      "workingValueSelectionIds": [],
+      "participationTermRefs": [],
+      "cashFlowSeries": {
+        "series": [
+          {
+            "eventType": "portfolio_investment",
+            "vehicleId": 11,
+            "perspective": "fund_gross",
+            "points": [
+              {
+                "eventId": 201,
+                "effectiveAt": "2026-07-01T00:00:00.000Z",
+                "amount": "8000000.000000"
+              }
+            ]
+          }
+        ],
+        "totals": {
+          "contributions": "0.000000",
+          "distributions": "0.000000",
+          "recallableDistributions": "0.000000"
+        },
+        "warnings": []
+      },
+      "marksSeries": {
+        "marks": [],
+        "periodNav": [],
+        "warnings": []
+      },
+      "vehicleRoster": []
+    },
+    "actorId": 7,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "expected": {
+    "status": "available",
+    "inputHash": null,
+    "resultHash": null,
+    "mismatchReasons": [],
+    "methodologyVersion": "cohort-projection-v2/1.0.0"
+  },
+  "referenceBasis": {
+    "fundSnapshotId": 904,
+    "currentPlanVersionId": 914,
+    "financialFactsSnapshotId": 31
+  }
+}

--- a/tests/fixtures/current-forecast-replay-corpus/index.ts
+++ b/tests/fixtures/current-forecast-replay-corpus/index.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+
+import {
+  CurrentForecastV2InputSchema,
+  type CurrentForecastV2Input,
+} from '@shared/contracts/current-forecast-v2.contract';
+import {
+  CurrentPlanVersionV1Schema,
+  type CurrentPlanVersionV1,
+} from '@shared/contracts/current-plan-version-v1.contract';
+import {
+  FinancialFactsSnapshotV1Schema,
+  type FinancialFactsSnapshotV1,
+} from '@shared/contracts/financial-facts-snapshot-v1.contract';
+import { CURRENT_FORECAST_SHADOW_MISMATCH_REASONS } from '../../../server/services/current-forecast-shadow-service';
+
+import caseBlocked from './case-blocked.json';
+import emptyFacts from './empty-facts.json';
+import fullFacts from './full-facts.json';
+import held from './held.json';
+import indicative from './indicative.json';
+import partialFacts from './partial-facts.json';
+
+/**
+ * Committed deterministic replay corpus for the current-forecast shadow plane
+ * (PLAN_61 Task 13.1-svc). Bases are derived from the CF truth cases
+ * (`docs/current-forecast.truth-cases.json`) and span empty/partial/full
+ * facts, a case-blocked basis mismatch, and a held serving base. The pinned
+ * `expected.inputHash`/`expected.resultHash` values are the exact-basis replay
+ * contract: any engine drift fails the replay-reproduction test.
+ */
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+
+const ExpectationSchema = z
+  .object({
+    status: z.enum(['available', 'indicative', 'unavailable', 'failed']),
+    inputHash: Sha256Schema.nullable(),
+    resultHash: Sha256Schema.nullable(),
+    methodologyVersion: z.string().min(1),
+    mismatchReasons: z.array(z.enum(CURRENT_FORECAST_SHADOW_MISMATCH_REASONS)),
+  })
+  .strict();
+
+const ReferenceBasisSchema = z
+  .object({
+    fundSnapshotId: z.number().int().positive(),
+    currentPlanVersionId: z.number().int().positive(),
+    financialFactsSnapshotId: z.number().int().positive(),
+  })
+  .strict();
+
+const CorpusFileSchema = z
+  .object({
+    name: z.string().min(1),
+    kind: z.enum(['evaluate', 'held']),
+    sourceTruthCase: z.string().regex(/^CF-00[1-8]$/),
+    input: z.unknown(),
+    plan: z.unknown(),
+    facts: z.unknown(),
+    referenceBasis: ReferenceBasisSchema,
+    expected: ExpectationSchema,
+  })
+  .strict();
+
+const FactsEnvelopeSchema = z
+  .object({
+    id: z.number().int().positive(),
+  })
+  .passthrough();
+
+export interface CurrentForecastReplayCorpusEntry {
+  name: string;
+  kind: 'evaluate' | 'held';
+  sourceTruthCase: string;
+  input: CurrentForecastV2Input;
+  plan: CurrentPlanVersionV1;
+  facts: FinancialFactsSnapshotV1 & { readonly id: number };
+  referenceBasis: z.infer<typeof ReferenceBasisSchema>;
+  expected: z.infer<typeof ExpectationSchema>;
+}
+
+function loadEntry(raw: unknown): CurrentForecastReplayCorpusEntry {
+  const file = CorpusFileSchema.parse(raw);
+  const input = CurrentForecastV2InputSchema.parse(file.input);
+  const plan = CurrentPlanVersionV1Schema.parse(file.plan);
+  const factsEnvelope = FactsEnvelopeSchema.parse(file.facts);
+  const { id, ...factsWithoutId } = factsEnvelope;
+  const facts = { ...FinancialFactsSnapshotV1Schema.parse(factsWithoutId), id };
+
+  return {
+    name: file.name,
+    kind: file.kind,
+    sourceTruthCase: file.sourceTruthCase,
+    input,
+    plan,
+    facts,
+    referenceBasis: file.referenceBasis,
+    expected: file.expected,
+  };
+}
+
+export const CURRENT_FORECAST_REPLAY_CORPUS: CurrentForecastReplayCorpusEntry[] = [
+  fullFacts,
+  indicative,
+  partialFacts,
+  emptyFacts,
+  caseBlocked,
+  held,
+].map(loadEntry);

--- a/tests/fixtures/current-forecast-replay-corpus/indicative.json
+++ b/tests/fixtures/current-forecast-replay-corpus/indicative.json
@@ -1,0 +1,157 @@
+{
+  "name": "indicative",
+  "kind": "evaluate",
+  "sourceTruthCase": "CF-008",
+  "input": {
+    "fundId": 1,
+    "financialFactsSnapshotId": "31",
+    "currentPlanVersionId": "current-plan-cf-008",
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "clock": "2026-07-22T03:00:00.000Z"
+  },
+  "plan": {
+    "contractVersion": "current-plan-version-v1",
+    "id": "current-plan-cf-008",
+    "fundId": 1,
+    "version": 1,
+    "sourceConfigId": 17,
+    "sourceConfigVersion": 3,
+    "sourceFactsSnapshotId": "31",
+    "deployableCapitalUsd": "3000000.000000",
+    "planTransformationVersion": "fund-config-to-current-plan/1.0.0",
+    "allocations": [],
+    "pacingAssumptions": {
+      "contractVersion": "current-plan-pacing-v1",
+      "deploymentQuarters": 2,
+      "quarterlyDeploymentPcts": ["0.500000000000", "0.500000000000"],
+      "followOnReservePct": "0.000000000000",
+      "annualFeeDragPct": "0.000000000000"
+    },
+    "cohortAssumptions": {
+      "contractVersion": "current-plan-cohort-v1",
+      "averageInitialCheckUsd": "500000.000000",
+      "stageDistribution": [
+        {
+          "stage": "Seed",
+          "pct": "0.500000000000"
+        },
+        {
+          "stage": "Series A",
+          "pct": "0.500000000000"
+        }
+      ],
+      "graduationMatrix": [
+        {
+          "fromStage": "Seed",
+          "toStage": "Seed",
+          "rate": "1.000000000000",
+          "quartersToGraduate": 0
+        },
+        {
+          "fromStage": "Series A",
+          "toStage": "Series A",
+          "rate": "1.000000000000",
+          "quartersToGraduate": 0
+        }
+      ],
+      "exitAssumptions": [
+        {
+          "stage": "Seed",
+          "exitMultiple": "1.000000000000",
+          "quartersToExit": 2,
+          "failureRate": "0.000000000000"
+        },
+        {
+          "stage": "Series A",
+          "exitMultiple": "1.000000000000",
+          "quartersToExit": 3,
+          "failureRate": "0.000000000000"
+        }
+      ]
+    },
+    "reservePolicyVersion": "reserve-policy/1.0.0",
+    "assumptionsHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "supersedesVersionId": null,
+    "supersededByVersionId": null,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "facts": {
+    "id": 31,
+    "policyVersion": "financial-facts-policy/1.0.0",
+    "fundId": 1,
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "vehicleScope": "fund_all",
+    "vehicleIds": [11],
+    "selectionSetHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sourceFactsInputHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "snapshotInputHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consumerEvaluations": [],
+    "payload": {
+      "companyActuals": {
+        "fundId": 1,
+        "asOfDate": "2026-07-21",
+        "facts": [],
+        "inputHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "sourceObservationIds": [],
+      "workingValueSelectionIds": [],
+      "participationTermRefs": [],
+      "cashFlowSeries": {
+        "series": [
+          {
+            "eventType": "lp_capital_call",
+            "vehicleId": 11,
+            "perspective": "lp_net",
+            "points": [
+              {
+                "eventId": 801,
+                "effectiveAt": "2026-07-01T00:00:00.000Z",
+                "amount": "1000000.000000"
+              }
+            ]
+          },
+          {
+            "eventType": "portfolio_investment",
+            "vehicleId": 11,
+            "perspective": "fund_gross",
+            "points": [
+              {
+                "eventId": 802,
+                "effectiveAt": "2026-07-01T00:00:00.000Z",
+                "amount": "1000000.000000"
+              }
+            ]
+          }
+        ],
+        "totals": {
+          "contributions": "1000000.000000",
+          "distributions": "0.000000",
+          "recallableDistributions": "0.000000"
+        },
+        "warnings": []
+      },
+      "marksSeries": {
+        "marks": [],
+        "periodNav": [],
+        "warnings": []
+      },
+      "vehicleRoster": []
+    },
+    "actorId": 7,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "expected": {
+    "status": "indicative",
+    "inputHash": "7c6dad15d16041c1d1d2c74ec81e51ca53315f31ebbedac4057e077cd6250c49",
+    "resultHash": "ef11e6a144782cdf4f28be5a040467a0d9f79835be5b363f54b056ef6294dc39",
+    "mismatchReasons": [],
+    "methodologyVersion": "cohort-projection-v2/1.0.0"
+  },
+  "referenceBasis": {
+    "fundSnapshotId": 905,
+    "currentPlanVersionId": 915,
+    "financialFactsSnapshotId": 31
+  }
+}

--- a/tests/fixtures/current-forecast-replay-corpus/partial-facts.json
+++ b/tests/fixtures/current-forecast-replay-corpus/partial-facts.json
@@ -1,0 +1,115 @@
+{
+  "name": "partial-facts",
+  "kind": "evaluate",
+  "sourceTruthCase": "CF-004",
+  "input": {
+    "fundId": 1,
+    "financialFactsSnapshotId": "31",
+    "currentPlanVersionId": "current-plan-cf-004",
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "clock": "2026-07-22T03:00:00.000Z"
+  },
+  "plan": {
+    "contractVersion": "current-plan-version-v1",
+    "id": "current-plan-cf-004",
+    "fundId": 1,
+    "version": 1,
+    "sourceConfigId": 17,
+    "sourceConfigVersion": 3,
+    "sourceFactsSnapshotId": "31",
+    "deployableCapitalUsd": "8000000.000000",
+    "planTransformationVersion": "fund-config-to-current-plan/1.0.0",
+    "allocations": [],
+    "pacingAssumptions": {
+      "contractVersion": "current-plan-pacing-v1",
+      "deploymentQuarters": 1,
+      "quarterlyDeploymentPcts": ["1.000000000000"],
+      "followOnReservePct": "0.000000000000",
+      "annualFeeDragPct": "0.000000000000"
+    },
+    "cohortAssumptions": {
+      "contractVersion": "current-plan-cohort-v1",
+      "averageInitialCheckUsd": "1000000.000000",
+      "stageDistribution": [
+        {
+          "stage": "Series A",
+          "pct": "1.000000000000"
+        }
+      ],
+      "graduationMatrix": [],
+      "exitAssumptions": []
+    },
+    "reservePolicyVersion": "reserve-policy/1.0.0",
+    "assumptionsHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "supersedesVersionId": null,
+    "supersededByVersionId": null,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "facts": {
+    "id": 31,
+    "policyVersion": "financial-facts-policy/1.0.0",
+    "fundId": 1,
+    "asOfDate": "2026-07-21",
+    "knowledgeCutoff": "2026-07-22T02:00:00.000Z",
+    "vehicleScope": "fund_all",
+    "vehicleIds": [11],
+    "selectionSetHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sourceFactsInputHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "snapshotInputHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consumerEvaluations": [],
+    "payload": {
+      "companyActuals": {
+        "fundId": 1,
+        "asOfDate": "2026-07-21",
+        "facts": [],
+        "inputHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "sourceObservationIds": [],
+      "workingValueSelectionIds": [],
+      "participationTermRefs": [],
+      "cashFlowSeries": {
+        "series": [
+          {
+            "eventType": "portfolio_investment",
+            "vehicleId": 11,
+            "perspective": "fund_gross",
+            "points": [
+              {
+                "eventId": 401,
+                "effectiveAt": "2026-07-01T00:00:00.000Z",
+                "amount": "2000000.000000"
+              }
+            ]
+          }
+        ],
+        "totals": {
+          "contributions": "0.000000",
+          "distributions": "0.000000",
+          "recallableDistributions": "0.000000"
+        },
+        "warnings": []
+      },
+      "marksSeries": {
+        "marks": [],
+        "periodNav": [],
+        "warnings": []
+      },
+      "vehicleRoster": []
+    },
+    "actorId": 7,
+    "createdAt": "2026-07-22T02:00:00.000Z"
+  },
+  "expected": {
+    "status": "unavailable",
+    "inputHash": "10e7ff7f6014db18563fbfe3a1dada0ab4af1413f3844d5d0461ce900359e044",
+    "resultHash": "dca6e02bce9837c4a3bf55145bb9159a9863f63d7a2818bd2d98ab49db2dd375",
+    "mismatchReasons": ["unavailable_expected"],
+    "methodologyVersion": "cohort-projection-v2/1.0.0"
+  },
+  "referenceBasis": {
+    "fundSnapshotId": 906,
+    "currentPlanVersionId": 916,
+    "financialFactsSnapshotId": 31
+  }
+}

--- a/tests/unit/routes/current-forecast-mode.behavior.test.ts
+++ b/tests/unit/routes/current-forecast-mode.behavior.test.ts
@@ -104,6 +104,17 @@ describe('current-forecast calculation mode route', () => {
     expect(svc.updateCurrentForecastCalculationMode).not.toHaveBeenCalled();
   });
 
+  it('refuses off|shadow -> on: only the activation command may write on', async () => {
+    const response = await put({
+      key: 'forecast-on',
+      body: { expectedVersion: 0, configuredMode: 'on' },
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({ error: 'activation_command_required' });
+    expect(svc.updateCurrentForecastCalculationMode).not.toHaveBeenCalled();
+  });
+
   it('writes off mode and returns the preview with replay status', async () => {
     const response = await put({ key: '  forecast-off  ' });
 

--- a/tests/unit/routes/current-forecast-references.behavior.test.ts
+++ b/tests/unit/routes/current-forecast-references.behavior.test.ts
@@ -1,0 +1,249 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  user: null as null | { id: number; role: string; fundIds: number[] },
+}));
+const svc = vi.hoisted(() => ({
+  createRollbackCurrentForecastReference: vi.fn(),
+  activateCurrentForecast: vi.fn(),
+}));
+
+vi.mock('../../../server/services/current-forecast-reference-service', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../server/services/current-forecast-reference-service')
+    >();
+  return {
+    ...actual,
+    createRollbackCurrentForecastReference: svc.createRollbackCurrentForecastReference,
+    activateCurrentForecast: svc.activateCurrentForecast,
+  };
+});
+
+vi.mock('../../../server/lib/auth/jwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../server/lib/auth/jwt')>();
+  return {
+    ...actual,
+    requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
+      if (!authState.user) return res.sendStatus(401);
+      (req as Request & { user: unknown }).user = { ...authState.user };
+      next();
+    },
+  };
+});
+
+import {
+  CurrentForecastActivationBlockedError,
+  CurrentForecastReferenceError,
+} from '../../../server/services/current-forecast-reference-service';
+import { FundCalculationModeVersionConflictError } from '../../../server/services/fund-calculation-mode-service';
+import currentForecastRouter from '../../../server/routes/current-forecast';
+
+const ADMIN = { id: 101, role: 'admin', fundIds: [1] };
+
+const referenceRecord = {
+  id: 50,
+  fundId: 1,
+  calculationKey: 'current_forecast',
+  fundSnapshotId: 11,
+  currentPlanVersionId: 21,
+  financialFactsSnapshotId: 31,
+  inputHash: 'a'.repeat(64),
+  resultHash: 'b'.repeat(64),
+  assumptionsHash: 'c'.repeat(64),
+  engineVersion: 'current-forecast-v2-engine/1.0.0',
+  methodologyVersion: 'cohort-projection-v2/1.0.0',
+  candidate: true,
+  supersededByReferenceId: null,
+  reason: 'roll back to pre-incident head',
+  createdBy: 101,
+  createdAt: '2026-07-22T00:00:00.000Z',
+};
+
+const activationResponse = {
+  calculationKey: 'current_forecast',
+  configuredMode: 'on',
+  activatedAt: '2026-07-22T00:00:00.000Z',
+  cutoverReferenceId: 50,
+  version: 4,
+};
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', currentForecastRouter);
+  app.use((_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
+    res.status(500).json({ error: 'internal_error' })
+  );
+  return app;
+}
+
+function post(path: string, options: { key?: string; body?: unknown } = {}) {
+  const req = request(buildApp()).post(path);
+  if (options.key !== undefined) req.set('Idempotency-Key', options.key);
+  return req.send(options.body ?? {});
+}
+
+const REFERENCES_PATH = '/api/admin/funds/1/current-forecast/references';
+const ACTIVATE_PATH = '/api/admin/funds/1/current-forecast/activate';
+const validReferencesBody = { sourceReferenceId: 40, reason: 'roll back to pre-incident head' };
+const validActivateBody = { referenceId: 50, expectedVersion: 3 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = ADMIN;
+  svc.createRollbackCurrentForecastReference.mockResolvedValue({
+    row: referenceRecord,
+    replayed: false,
+  });
+  svc.activateCurrentForecast.mockResolvedValue({
+    response: activationResponse,
+    replayed: false,
+  });
+});
+
+describe('POST /api/admin/funds/:fundId/current-forecast/references', () => {
+  it('requires the admin role', async () => {
+    authState.user = { id: 102, role: 'analyst', fundIds: [1] };
+
+    const response = await post(REFERENCES_PATH, { key: 'ref-role', body: validReferencesBody });
+
+    expect(response.status).toBe(403);
+    expect(svc.createRollbackCurrentForecastReference).not.toHaveBeenCalled();
+  });
+
+  it('returns 428 when Idempotency-Key is missing', async () => {
+    const response = await post(REFERENCES_PATH, { body: validReferencesBody });
+
+    expect(response.status).toBe(428);
+    expect(response.body).toEqual({
+      error: 'idempotency_key_required',
+      message: 'Idempotency-Key header is required',
+    });
+    expect(svc.createRollbackCurrentForecastReference).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body is invalid', async () => {
+    const response = await post(REFERENCES_PATH, {
+      key: 'ref-invalid',
+      body: { ...validReferencesBody, unexpected: true },
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'invalid_reference_request' });
+    expect(svc.createRollbackCurrentForecastReference).not.toHaveBeenCalled();
+  });
+
+  it('creates the rollback candidate and returns it with replay status', async () => {
+    const response = await post(REFERENCES_PATH, {
+      key: '  ref-happy  ',
+      body: validReferencesBody,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ reference: referenceRecord, replayed: false });
+    expect(svc.createRollbackCurrentForecastReference).toHaveBeenCalledWith({
+      fundId: 1,
+      sourceReferenceId: 40,
+      reason: 'roll back to pre-incident head',
+      idempotencyKey: 'ref-happy',
+      createdBy: 101,
+    });
+  });
+
+  it('maps reference_not_found to 404', async () => {
+    svc.createRollbackCurrentForecastReference.mockRejectedValue(
+      new CurrentForecastReferenceError(404, 'reference_not_found', 'missing reference')
+    );
+
+    const response = await post(REFERENCES_PATH, { key: 'ref-404', body: validReferencesBody });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'reference_not_found', message: 'missing reference' });
+  });
+});
+
+describe('POST /api/admin/funds/:fundId/current-forecast/activate', () => {
+  it('requires the admin role', async () => {
+    authState.user = { id: 102, role: 'analyst', fundIds: [1] };
+
+    const response = await post(ACTIVATE_PATH, { key: 'act-role', body: validActivateBody });
+
+    expect(response.status).toBe(403);
+    expect(svc.activateCurrentForecast).not.toHaveBeenCalled();
+  });
+
+  it('returns 428 when Idempotency-Key is missing', async () => {
+    const response = await post(ACTIVATE_PATH, { body: validActivateBody });
+
+    expect(response.status).toBe(428);
+    expect(svc.activateCurrentForecast).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body is invalid', async () => {
+    const response = await post(ACTIVATE_PATH, {
+      key: 'act-invalid',
+      body: { referenceId: 50 },
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'invalid_activation_request' });
+    expect(svc.activateCurrentForecast).not.toHaveBeenCalled();
+  });
+
+  it('activates and returns the activation event with replay status', async () => {
+    const response = await post(ACTIVATE_PATH, { key: 'act-happy', body: validActivateBody });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ...activationResponse, replayed: false });
+    expect(svc.activateCurrentForecast).toHaveBeenCalledWith({
+      fundId: 1,
+      referenceId: 50,
+      expectedVersion: 3,
+      idempotencyKey: 'act-happy',
+      actorId: 101,
+    });
+  });
+
+  it('maps a version conflict to 409', async () => {
+    svc.activateCurrentForecast.mockRejectedValue(
+      new FundCalculationModeVersionConflictError(3, 5)
+    );
+
+    const response = await post(ACTIVATE_PATH, { key: 'act-conflict', body: validActivateBody });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: 'stale_expected_version',
+      expectedVersion: 3,
+      actualVersion: 5,
+    });
+  });
+
+  it('maps activation blockers to 409 with the blocker list', async () => {
+    svc.activateCurrentForecast.mockRejectedValue(
+      new CurrentForecastActivationBlockedError(['shadow_green_required'])
+    );
+
+    const response = await post(ACTIVATE_PATH, { key: 'act-blocked', body: validActivateBody });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: 'activation_blocked',
+      blockers: ['shadow_green_required'],
+    });
+  });
+
+  it('maps already_activated to 409', async () => {
+    svc.activateCurrentForecast.mockRejectedValue(
+      new CurrentForecastReferenceError(409, 'already_activated', 'already activated')
+    );
+
+    const response = await post(ACTIVATE_PATH, { key: 'act-twice', body: validActivateBody });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual({ error: 'already_activated', message: 'already activated' });
+  });
+});

--- a/tests/unit/services/current-forecast-calc-mode-resolver.test.ts
+++ b/tests/unit/services/current-forecast-calc-mode-resolver.test.ts
@@ -1,17 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   CURRENT_FORECAST_CALCULATION_KEY,
+  dispatchCurrentForecastServing,
   resolveCurrentForecastCalculationMode,
+  resolveCurrentForecastModeResolution,
   type CurrentForecastModeReader,
+  type CurrentForecastModeRow,
 } from '../../../server/services/current-forecast-calc-mode-resolver';
 
 const reader =
-  (row: { configuredMode: string; killSwitchActive: boolean } | null): CurrentForecastModeReader =>
+  (row: CurrentForecastModeRow | null): CurrentForecastModeReader =>
   async () =>
     row;
 
-describe('resolveCurrentForecastCalculationMode', () => {
+/** Pre-cutover: no activation event has been written. */
+const PRE = { activatedAt: null, cutoverReferenceId: null };
+/** Post-cutover: activation pinned reference 41 as the served-pointer head. */
+const POST = { activatedAt: new Date('2026-07-01T00:00:00Z'), cutoverReferenceId: 41 };
+
+describe('resolveCurrentForecastCalculationMode (pre-cutover legacy map)', () => {
   it('defaults to off when no row exists', async () => {
     expect(await resolveCurrentForecastCalculationMode(1, reader(null))).toBe('off');
   });
@@ -20,7 +28,7 @@ describe('resolveCurrentForecastCalculationMode', () => {
     expect(
       await resolveCurrentForecastCalculationMode(
         1,
-        reader({ configuredMode: 'shadow', killSwitchActive: false })
+        reader({ configuredMode: 'shadow', killSwitchActive: false, ...PRE })
       )
     ).toBe('shadow');
   });
@@ -29,16 +37,16 @@ describe('resolveCurrentForecastCalculationMode', () => {
     expect(
       await resolveCurrentForecastCalculationMode(
         1,
-        reader({ configuredMode: 'on', killSwitchActive: false })
+        reader({ configuredMode: 'on', killSwitchActive: false, ...PRE })
       )
     ).toBe('on');
   });
 
-  it('collapses to off when the kill switch is active', async () => {
+  it('collapses to off when the kill switch is active pre-cutover', async () => {
     expect(
       await resolveCurrentForecastCalculationMode(
         1,
-        reader({ configuredMode: 'on', killSwitchActive: true })
+        reader({ configuredMode: 'on', killSwitchActive: true, ...PRE })
       )
     ).toBe('off');
   });
@@ -47,12 +55,161 @@ describe('resolveCurrentForecastCalculationMode', () => {
     expect(
       await resolveCurrentForecastCalculationMode(
         1,
-        reader({ configuredMode: 'bogus', killSwitchActive: false })
+        reader({ configuredMode: 'bogus', killSwitchActive: false, ...PRE })
       )
     ).toBe('off');
   });
 
   it('exposes the current-forecast calculation key', () => {
     expect(CURRENT_FORECAST_CALCULATION_KEY).toBe('current_forecast');
+  });
+});
+
+describe('resolveCurrentForecastModeResolution (R24/D9 held-state map)', () => {
+  it('pre-cutover kill resolves off with no pointer', async () => {
+    expect(
+      await resolveCurrentForecastModeResolution(
+        1,
+        reader({ configuredMode: 'on', killSwitchActive: true, ...PRE })
+      )
+    ).toEqual({ mode: 'off', cutoverReferenceId: null });
+  });
+
+  it('pre-cutover shadow resolves shadow', async () => {
+    expect(
+      await resolveCurrentForecastModeResolution(
+        1,
+        reader({ configuredMode: 'shadow', killSwitchActive: false, ...PRE })
+      )
+    ).toEqual({ mode: 'shadow', cutoverReferenceId: null });
+  });
+
+  it('post-cutover effective on resolves on and carries the pointer head', async () => {
+    expect(
+      await resolveCurrentForecastModeResolution(
+        1,
+        reader({ configuredMode: 'on', killSwitchActive: false, ...POST })
+      )
+    ).toEqual({ mode: 'on', cutoverReferenceId: 41 });
+  });
+
+  it('post-cutover kill resolves held, never legacy off', async () => {
+    expect(
+      await resolveCurrentForecastModeResolution(
+        1,
+        reader({ configuredMode: 'on', killSwitchActive: true, ...POST })
+      )
+    ).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+  });
+
+  it('post-cutover configured off resolves held', async () => {
+    expect(
+      await resolveCurrentForecastModeResolution(
+        1,
+        reader({ configuredMode: 'off', killSwitchActive: false, ...POST })
+      )
+    ).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+  });
+
+  it('post-cutover configured shadow resolves held', async () => {
+    expect(
+      await resolveCurrentForecastModeResolution(
+        1,
+        reader({ configuredMode: 'shadow', killSwitchActive: false, ...POST })
+      )
+    ).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+  });
+
+  it('held serves the served-pointer head from the mode row, not any other lookup', async () => {
+    const modeReader = vi.fn(async (): Promise<CurrentForecastModeRow> => ({
+      configuredMode: 'off',
+      killSwitchActive: true,
+      activatedAt: '2026-07-01T00:00:00Z',
+      cutoverReferenceId: 41,
+    }));
+
+    const resolution = await resolveCurrentForecastModeResolution(1, modeReader);
+
+    expect(resolution).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+    expect(modeReader).toHaveBeenCalledTimes(1);
+  });
+
+  it('legacy wrapper surfaces held post-cutover', async () => {
+    expect(
+      await resolveCurrentForecastCalculationMode(
+        1,
+        reader({ configuredMode: 'off', killSwitchActive: false, ...POST })
+      )
+    ).toBe('held');
+  });
+});
+
+describe('dispatchCurrentForecastServing', () => {
+  const seams = () => ({
+    runLegacy: vi.fn(async () => 'legacy' as const),
+    runV2: vi.fn(async () => 'v2' as const),
+    serveHeld: vi.fn(async () => 'held' as const),
+  });
+
+  it('off serves the legacy lane', async () => {
+    const s = seams();
+
+    await expect(
+      dispatchCurrentForecastServing({ mode: 'off', cutoverReferenceId: null }, s)
+    ).resolves.toBe('legacy');
+    expect(s.runV2).not.toHaveBeenCalled();
+    expect(s.serveHeld).not.toHaveBeenCalled();
+  });
+
+  it('shadow serves the legacy lane (observation is a separate plane)', async () => {
+    const s = seams();
+
+    await expect(
+      dispatchCurrentForecastServing({ mode: 'shadow', cutoverReferenceId: null }, s)
+    ).resolves.toBe('legacy');
+  });
+
+  it('held serves the pointer head and NEVER invokes the legacy calculator', async () => {
+    const s = seams();
+
+    await expect(
+      dispatchCurrentForecastServing({ mode: 'held', cutoverReferenceId: 41 }, s)
+    ).resolves.toBe('held');
+    expect(s.serveHeld).toHaveBeenCalledWith(41);
+    // ProjectedMetricsCalculator seam: post-cutover under kill the legacy lane
+    // must never run (R24/D9); the resolver yields held and dispatch pins it.
+    expect(s.runLegacy).not.toHaveBeenCalled();
+    expect(s.runV2).not.toHaveBeenCalled();
+  });
+
+  it('post-cutover V2 failure degrades to held, never legacy', async () => {
+    const s = seams();
+    s.runV2.mockRejectedValueOnce(new Error('v2 exploded'));
+
+    await expect(
+      dispatchCurrentForecastServing({ mode: 'on', cutoverReferenceId: 41 }, s)
+    ).resolves.toBe('held');
+    expect(s.serveHeld).toHaveBeenCalledWith(41);
+    expect(s.runLegacy).not.toHaveBeenCalled();
+  });
+
+  it('pre-cutover on with a V2 failure rethrows (no pointer to hold on, no legacy fallback)', async () => {
+    const s = seams();
+    s.runV2.mockRejectedValueOnce(new Error('v2 exploded'));
+
+    await expect(
+      dispatchCurrentForecastServing({ mode: 'on', cutoverReferenceId: null }, s)
+    ).rejects.toThrow('v2 exploded');
+    expect(s.runLegacy).not.toHaveBeenCalled();
+    expect(s.serveHeld).not.toHaveBeenCalled();
+  });
+
+  it('held with a missing pointer head throws instead of falling back', async () => {
+    const s = seams();
+
+    await expect(
+      dispatchCurrentForecastServing({ mode: 'held', cutoverReferenceId: null }, s)
+    ).rejects.toThrow(/served-pointer head/);
+    expect(s.runLegacy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/current-forecast-reference-service.test.ts
+++ b/tests/unit/services/current-forecast-reference-service.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import { IdempotentCommandError } from '../../../server/lib/idempotent-command';
+import {
+  CURRENT_FORECAST_REFERENCE_CONTRACT_VERSION,
+  CurrentForecastReferenceError,
+  advanceCurrentForecastPointer,
+  createCandidateCurrentForecastReference,
+  createRollbackCurrentForecastReference,
+  currentForecastReferenceIdempotencyKey,
+  getAcceptedCurrentForecastReferenceHead,
+  type CurrentForecastReferenceBasis,
+  type CurrentForecastReferenceDatabase,
+} from '../../../server/services/current-forecast-reference-service';
+
+const INPUT_HASH = 'a'.repeat(64);
+const RESULT_HASH = 'b'.repeat(64);
+const ASSUMPTIONS_HASH = 'c'.repeat(64);
+
+const basis: CurrentForecastReferenceBasis = {
+  fundSnapshotId: 11,
+  currentPlanVersionId: 21,
+  financialFactsSnapshotId: 31,
+  inputHash: INPUT_HASH,
+  resultHash: RESULT_HASH,
+  assumptionsHash: ASSUMPTIONS_HASH,
+  engineVersion: 'current-forecast-v2-engine/1.0.0',
+  methodologyVersion: 'cohort-projection-v2/1.0.0',
+};
+
+function snakeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 42,
+    fund_id: 7,
+    calculation_key: 'current_forecast',
+    fund_snapshot_id: 11,
+    current_plan_version_id: 21,
+    financial_facts_snapshot_id: 31,
+    input_hash: INPUT_HASH,
+    result_hash: RESULT_HASH,
+    assumptions_hash: ASSUMPTIONS_HASH,
+    engine_version: 'current-forecast-v2-engine/1.0.0',
+    methodology_version: 'cohort-projection-v2/1.0.0',
+    candidate: true,
+    superseded_by_reference_id: null,
+    reason: null,
+    created_by: null,
+    idempotency_key: 'key-1',
+    request_hash: 'unused',
+    created_at: '2026-07-20T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeDatabase(executeRows: unknown[][]) {
+  const queue = [...executeRows];
+  const tx = {
+    execute: vi.fn(async () => ({ rows: queue.shift() ?? [] })),
+  };
+  const database = {
+    execute: vi.fn(async () => ({ rows: queue.shift() ?? [] })),
+    transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+      callback(tx)
+    ),
+  };
+  return {
+    database: database as unknown as CurrentForecastReferenceDatabase,
+    tx,
+    database_raw: database,
+  };
+}
+
+function expectedRequestHash(extra: Record<string, unknown> = {}) {
+  return canonicalSha256({
+    fundId: 7,
+    contractVersion: CURRENT_FORECAST_REFERENCE_CONTRACT_VERSION,
+    ...basis,
+    reason: null,
+    sourceReferenceId: null,
+    ...extra,
+  });
+}
+
+describe('currentForecastReferenceIdempotencyKey', () => {
+  it('builds the deterministic cfref key', () => {
+    expect(
+      currentForecastReferenceIdempotencyKey({
+        fundId: 7,
+        inputHash: INPUT_HASH,
+        resultHash: RESULT_HASH,
+      })
+    ).toBe(`cfref:7:${INPUT_HASH}:${RESULT_HASH}`);
+  });
+});
+
+describe('createCandidateCurrentForecastReference', () => {
+  it('inserts a candidate row and returns the mapped record', async () => {
+    const { database, database_raw } = makeDatabase([[snakeRow()]]);
+
+    const result = await createCandidateCurrentForecastReference({
+      fundId: 7,
+      basis,
+      idempotencyKey: 'key-1',
+      database,
+    });
+
+    expect(result.replayed).toBe(false);
+    expect(result.row).toMatchObject({
+      id: 42,
+      fundId: 7,
+      calculationKey: 'current_forecast',
+      candidate: true,
+      supersededByReferenceId: null,
+      inputHash: INPUT_HASH,
+      resultHash: RESULT_HASH,
+    });
+    expect(database_raw.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays an existing row when the same request is re-issued', async () => {
+    const { database } = makeDatabase([[], [snakeRow({ request_hash: expectedRequestHash() })]]);
+
+    const result = await createCandidateCurrentForecastReference({
+      fundId: 7,
+      basis,
+      idempotencyKey: 'key-1',
+      database,
+    });
+
+    expect(result.replayed).toBe(true);
+    expect(result.row.id).toBe(42);
+  });
+
+  it('rejects idempotency-key reuse with a different request', async () => {
+    const { database } = makeDatabase([[], [snakeRow({ request_hash: 'f'.repeat(64) })]]);
+
+    await expect(
+      createCandidateCurrentForecastReference({
+        fundId: 7,
+        basis,
+        idempotencyKey: 'key-1',
+        database,
+      })
+    ).rejects.toMatchObject({
+      name: 'IdempotentCommandError',
+      code: 'IDEMPOTENCY_KEY_REUSE',
+    });
+    expect(IdempotentCommandError).toBeDefined();
+  });
+});
+
+describe('getAcceptedCurrentForecastReferenceHead', () => {
+  it('returns null when no accepted head exists', async () => {
+    const { database } = makeDatabase([[]]);
+
+    expect(await getAcceptedCurrentForecastReferenceHead({ fundId: 7, database })).toBeNull();
+  });
+
+  it('returns the mapped accepted head', async () => {
+    const { database } = makeDatabase([[snakeRow({ candidate: false })]]);
+
+    const head = await getAcceptedCurrentForecastReferenceHead({ fundId: 7, database });
+
+    expect(head).toMatchObject({ id: 42, candidate: false, supersededByReferenceId: null });
+  });
+});
+
+describe('advanceCurrentForecastPointer', () => {
+  const eligibleModeRow = {
+    id: 9,
+    configured_mode: 'on',
+    kill_switch_active: false,
+    activated_at: '2026-07-01T00:00:00.000Z',
+    cutover_reference_id: 41,
+    version: 3,
+  };
+
+  it('supersedes the old head, flips the target, and advances the pointer in one tx', async () => {
+    const { database, tx } = makeDatabase([
+      [eligibleModeRow],
+      [snakeRow({ id: 42 })],
+      [],
+      [],
+      [{ cutover_reference_id: 42, version: 4 }],
+    ]);
+
+    const result = await advanceCurrentForecastPointer({
+      fundId: 7,
+      referenceId: 42,
+      actorId: 101,
+      database,
+    });
+
+    expect(result).toEqual({ cutoverReferenceId: 42, version: 4 });
+    expect(tx.execute).toHaveBeenCalledTimes(5);
+  });
+
+  it('is a no-op when the target is already the served head', async () => {
+    const { database, tx } = makeDatabase([
+      [{ ...eligibleModeRow, cutover_reference_id: 42 }],
+      [snakeRow({ id: 42, candidate: false })],
+    ]);
+
+    const result = await advanceCurrentForecastPointer({
+      fundId: 7,
+      referenceId: 42,
+      actorId: 101,
+      database,
+    });
+
+    expect(result).toEqual({ cutoverReferenceId: 42, version: 3 });
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['kill switch active', { ...eligibleModeRow, kill_switch_active: true }],
+    ['configured shadow', { ...eligibleModeRow, configured_mode: 'shadow' }],
+    ['not activated', { ...eligibleModeRow, activated_at: null }],
+  ])('refuses to advance when %s', async (_label, modeRow) => {
+    const { database, tx } = makeDatabase([[modeRow]]);
+
+    await expect(
+      advanceCurrentForecastPointer({ fundId: 7, referenceId: 42, actorId: 101, database })
+    ).rejects.toMatchObject({
+      name: 'CurrentForecastReferenceError',
+      code: 'pointer_advance_requires_on',
+    });
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to advance when no mode row exists', async () => {
+    const { database } = makeDatabase([[]]);
+
+    await expect(
+      advanceCurrentForecastPointer({ fundId: 7, referenceId: 42, actorId: 101, database })
+    ).rejects.toMatchObject({ code: 'pointer_advance_requires_on' });
+  });
+
+  it('refuses a missing reference', async () => {
+    const { database } = makeDatabase([[eligibleModeRow], []]);
+
+    await expect(
+      advanceCurrentForecastPointer({ fundId: 7, referenceId: 42, actorId: 101, database })
+    ).rejects.toMatchObject({ code: 'reference_not_found', status: 404 });
+  });
+
+  it('refuses a superseded reference', async () => {
+    const { database } = makeDatabase([
+      [eligibleModeRow],
+      [snakeRow({ id: 42, superseded_by_reference_id: 43 })],
+    ]);
+
+    await expect(
+      advanceCurrentForecastPointer({ fundId: 7, referenceId: 42, actorId: 101, database })
+    ).rejects.toMatchObject({ code: 'reference_superseded', status: 409 });
+    expect(CurrentForecastReferenceError).toBeDefined();
+  });
+});
+
+describe('createRollbackCurrentForecastReference', () => {
+  it('clones the source basis into a new candidate under the caller key', async () => {
+    const sourceRow = snakeRow({ id: 40, candidate: false, superseded_by_reference_id: 41 });
+    const insertedRow = snakeRow({
+      id: 50,
+      idempotency_key: 'admin-rollback-1',
+      reason: 'roll back to pre-incident head',
+    });
+    const { database, database_raw } = makeDatabase([[sourceRow], [insertedRow]]);
+
+    const result = await createRollbackCurrentForecastReference({
+      fundId: 7,
+      sourceReferenceId: 40,
+      reason: 'roll back to pre-incident head',
+      idempotencyKey: 'admin-rollback-1',
+      createdBy: 101,
+      database,
+    });
+
+    expect(result.replayed).toBe(false);
+    expect(result.row).toMatchObject({
+      id: 50,
+      candidate: true,
+      reason: 'roll back to pre-incident head',
+    });
+    expect(database_raw.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('404s when the source reference does not exist for the fund', async () => {
+    const { database } = makeDatabase([[]]);
+
+    await expect(
+      createRollbackCurrentForecastReference({
+        fundId: 7,
+        sourceReferenceId: 40,
+        reason: 'nope',
+        idempotencyKey: 'admin-rollback-2',
+        createdBy: 101,
+        database,
+      })
+    ).rejects.toMatchObject({ code: 'reference_not_found', status: 404 });
+  });
+});

--- a/tests/unit/services/current-forecast-reference-service.test.ts
+++ b/tests/unit/services/current-forecast-reference-service.test.ts
@@ -3,13 +3,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
 import { IdempotentCommandError } from '../../../server/lib/idempotent-command';
 import {
+  CURRENT_FORECAST_ACTIVATE_ROUTE,
   CURRENT_FORECAST_REFERENCE_CONTRACT_VERSION,
   CurrentForecastReferenceError,
+  activateCurrentForecast,
   advanceCurrentForecastPointer,
   createCandidateCurrentForecastReference,
   createRollbackCurrentForecastReference,
   currentForecastReferenceIdempotencyKey,
   getAcceptedCurrentForecastReferenceHead,
+  verifyGreenCandidateWithLedger,
   type CurrentForecastReferenceBasis,
   type CurrentForecastReferenceDatabase,
 } from '../../../server/services/current-forecast-reference-service';
@@ -299,5 +302,299 @@ describe('createRollbackCurrentForecastReference', () => {
         database,
       })
     ).rejects.toMatchObject({ code: 'reference_not_found', status: 404 });
+  });
+});
+
+describe('activateCurrentForecast', () => {
+  const dormantModeRow = {
+    id: 9,
+    configured_mode: 'shadow',
+    kill_switch_active: false,
+    activated_at: null,
+    cutover_reference_id: null,
+    version: 3,
+  };
+  const verifyGreen = () => vi.fn(async () => [] as string[]);
+
+  function activationRequestHash() {
+    return canonicalSha256({
+      route: CURRENT_FORECAST_ACTIVATE_ROUTE,
+      fundId: 7,
+      referenceId: 42,
+      expectedVersion: 3,
+    });
+  }
+
+  it('atomically writes on + activated_at + pointer and flips the candidate (P2)', async () => {
+    const { database, tx } = makeDatabase([
+      [{ id: 1 }],
+      [dormantModeRow],
+      [snakeRow({ id: 42 })],
+      [],
+      [],
+      [
+        {
+          cutover_reference_id: 42,
+          version: 4,
+          activated_at: '2026-07-22T00:00:00.000Z',
+        },
+      ],
+      [],
+    ]);
+
+    const result = await activateCurrentForecast({
+      fundId: 7,
+      referenceId: 42,
+      expectedVersion: 3,
+      idempotencyKey: 'activate-1',
+      actorId: 101,
+      database,
+      verifyGreenCandidate: verifyGreen(),
+    });
+
+    expect(result.replayed).toBe(false);
+    expect(result.response).toEqual({
+      calculationKey: 'current_forecast',
+      configuredMode: 'on',
+      activatedAt: '2026-07-22T00:00:00.000Z',
+      cutoverReferenceId: 42,
+      version: 4,
+    });
+    // claim, lock, reference load, supersede, candidate flip, mode update,
+    // ledger completion -- ALL on the one transaction (P2 atomicity).
+    expect(tx.execute).toHaveBeenCalledTimes(7);
+  });
+
+  it('replays a completed activation without re-writing', async () => {
+    const stored = {
+      calculationKey: 'current_forecast',
+      configuredMode: 'on',
+      activatedAt: '2026-07-22T00:00:00.000Z',
+      cutoverReferenceId: 42,
+      version: 4,
+    };
+    const { database, tx } = makeDatabase([
+      [],
+      [
+        {
+          request_hash: activationRequestHash(),
+          response_body: stored,
+          status: 'completed',
+        },
+      ],
+    ]);
+
+    const result = await activateCurrentForecast({
+      fundId: 7,
+      referenceId: 42,
+      expectedVersion: 3,
+      idempotencyKey: 'activate-1',
+      actorId: 101,
+      database,
+      verifyGreenCandidate: verifyGreen(),
+    });
+
+    expect(result.replayed).toBe(true);
+    expect(result.response).toEqual(stored);
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects idempotency-key reuse with a different activation request', async () => {
+    const { database } = makeDatabase([
+      [],
+      [{ request_hash: 'different', response_body: null, status: 'completed' }],
+    ]);
+
+    await expect(
+      activateCurrentForecast({
+        fundId: 7,
+        referenceId: 42,
+        expectedVersion: 3,
+        idempotencyKey: 'activate-1',
+        actorId: 101,
+        database,
+        verifyGreenCandidate: verifyGreen(),
+      })
+    ).rejects.toMatchObject({ name: 'FundCalculationModeIdempotencyConflictError' });
+  });
+
+  it('throws a version conflict on a stale expectedVersion', async () => {
+    const { database } = makeDatabase([[{ id: 1 }], [{ ...dormantModeRow, version: 5 }]]);
+
+    await expect(
+      activateCurrentForecast({
+        fundId: 7,
+        referenceId: 42,
+        expectedVersion: 3,
+        idempotencyKey: 'activate-2',
+        actorId: 101,
+        database,
+        verifyGreenCandidate: verifyGreen(),
+      })
+    ).rejects.toMatchObject({ name: 'FundCalculationModeVersionConflictError' });
+  });
+
+  it('refuses to activate twice', async () => {
+    const { database } = makeDatabase([
+      [{ id: 1 }],
+      [{ ...dormantModeRow, activated_at: '2026-07-01T00:00:00.000Z' }],
+    ]);
+
+    await expect(
+      activateCurrentForecast({
+        fundId: 7,
+        referenceId: 42,
+        expectedVersion: 3,
+        idempotencyKey: 'activate-3',
+        actorId: 101,
+        database,
+        verifyGreenCandidate: verifyGreen(),
+      })
+    ).rejects.toMatchObject({ code: 'already_activated', status: 409 });
+  });
+
+  it('blocks on green-candidate blockers without writing', async () => {
+    const { database, tx } = makeDatabase([[{ id: 1 }], [dormantModeRow], [snakeRow({ id: 42 })]]);
+
+    await expect(
+      activateCurrentForecast({
+        fundId: 7,
+        referenceId: 42,
+        expectedVersion: 3,
+        idempotencyKey: 'activate-4',
+        actorId: 101,
+        database,
+        verifyGreenCandidate: vi.fn(async () => ['shadow_green_required']),
+      })
+    ).rejects.toMatchObject({
+      name: 'CurrentForecastActivationBlockedError',
+      blockers: ['shadow_green_required'],
+    });
+    expect(tx.execute).toHaveBeenCalledTimes(3);
+  });
+
+  it('includes kill_switch_active among activation blockers', async () => {
+    const { database } = makeDatabase([
+      [{ id: 1 }],
+      [{ ...dormantModeRow, kill_switch_active: true }],
+      [snakeRow({ id: 42 })],
+    ]);
+
+    await expect(
+      activateCurrentForecast({
+        fundId: 7,
+        referenceId: 42,
+        expectedVersion: 3,
+        idempotencyKey: 'activate-5',
+        actorId: 101,
+        database,
+        verifyGreenCandidate: verifyGreen(),
+      })
+    ).rejects.toMatchObject({
+      name: 'CurrentForecastActivationBlockedError',
+      blockers: ['kill_switch_active'],
+    });
+  });
+
+  it('404s a missing reference', async () => {
+    const { database } = makeDatabase([[{ id: 1 }], [dormantModeRow], []]);
+
+    await expect(
+      activateCurrentForecast({
+        fundId: 7,
+        referenceId: 42,
+        expectedVersion: 3,
+        idempotencyKey: 'activate-6',
+        actorId: 101,
+        database,
+        verifyGreenCandidate: verifyGreen(),
+      })
+    ).rejects.toMatchObject({ code: 'reference_not_found', status: 404 });
+  });
+});
+
+describe('verifyGreenCandidateWithLedger', () => {
+  const candidateReference = {
+    id: 42,
+    fundId: 7,
+    calculationKey: 'current_forecast',
+    fundSnapshotId: 11,
+    currentPlanVersionId: 21,
+    financialFactsSnapshotId: 31,
+    inputHash: INPUT_HASH,
+    resultHash: RESULT_HASH,
+    assumptionsHash: ASSUMPTIONS_HASH,
+    engineVersion: 'current-forecast-v2-engine/1.0.0',
+    methodologyVersion: 'cohort-projection-v2/1.0.0',
+    candidate: true,
+    supersededByReferenceId: null,
+    reason: null,
+    createdBy: null,
+    createdAt: '2026-07-20T00:00:00.000Z',
+  };
+
+  function makeExecutor(executeRows: unknown[][]) {
+    const queue = [...executeRows];
+    return { execute: vi.fn(async () => ({ rows: queue.shift() ?? [] })) };
+  }
+
+  it('returns no blockers for a green candidate', async () => {
+    const executor = makeExecutor([[{ id: 5 }], [{ reconciliation_status: 'match' }], []]);
+
+    expect(
+      await verifyGreenCandidateWithLedger({
+        executor,
+        fundId: 7,
+        reference: candidateReference,
+      })
+    ).toEqual([]);
+  });
+
+  it('flags a non-candidate or superseded reference', async () => {
+    const executor = makeExecutor([[{ id: 5 }], [{ reconciliation_status: 'match' }], []]);
+
+    expect(
+      await verifyGreenCandidateWithLedger({
+        executor,
+        fundId: 7,
+        reference: { ...candidateReference, candidate: false },
+      })
+    ).toContain('activation_requires_green_candidate');
+  });
+
+  it('flags a missing CURRENT_FORECAST_V2 snapshot', async () => {
+    const executor = makeExecutor([[], [{ reconciliation_status: 'match' }], []]);
+
+    expect(
+      await verifyGreenCandidateWithLedger({
+        executor,
+        fundId: 7,
+        reference: candidateReference,
+      })
+    ).toContain('current_forecast_snapshot_missing');
+  });
+
+  it('flags a basis hash with no green shadow match', async () => {
+    const executor = makeExecutor([[{ id: 5 }], [], []]);
+
+    expect(
+      await verifyGreenCandidateWithLedger({
+        executor,
+        fundId: 7,
+        reference: candidateReference,
+      })
+    ).toContain('shadow_green_required');
+  });
+
+  it('flags unexplained divergences (failed shadow rows block green, P3)', async () => {
+    const executor = makeExecutor([[{ id: 5 }], [{ reconciliation_status: 'match' }], [{ id: 8 }]]);
+
+    expect(
+      await verifyGreenCandidateWithLedger({
+        executor,
+        fundId: 7,
+        reference: candidateReference,
+      })
+    ).toContain('unexplained_divergence_present');
   });
 });

--- a/tests/unit/services/current-forecast-shadow-service.test.ts
+++ b/tests/unit/services/current-forecast-shadow-service.test.ts
@@ -1,0 +1,456 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { insert, values, onConflictDoNothing } = vi.hoisted(() => {
+  const onConflictDoNothing = vi.fn(() => Promise.resolve({ rowsAffected: 0 }));
+  const values = vi.fn(() => ({ onConflictDoNothing }));
+  const insert = vi.fn(() => ({ values }));
+  return { insert, values, onConflictDoNothing };
+});
+
+vi.mock('../../../server/db', () => ({ db: { insert } }));
+
+import { runCohortProjectionV2 } from '@shared/core/cohorts/CohortProjectionV2';
+import { substrateShadowReconciliations } from '../../../shared/schema';
+import {
+  buildCurrentForecastShadowRecord,
+  evaluateCurrentForecastShadowGreen,
+  persistCurrentForecastShadowReconciliation,
+  runCurrentForecastShadowBase,
+  type CurrentForecastShadowBase,
+  type CurrentForecastShadowModes,
+  type CurrentForecastShadowOutcome,
+} from '../../../server/services/current-forecast-shadow-service';
+import {
+  CURRENT_FORECAST_REPLAY_CORPUS,
+  type CurrentForecastReplayCorpusEntry,
+} from '../../fixtures/current-forecast-replay-corpus';
+
+const SHADOW_MODES: CurrentForecastShadowModes = {
+  configuredMode: 'shadow',
+  effectiveMode: 'shadow',
+  killSwitchActive: false,
+};
+
+function corpusEntry(name: string): CurrentForecastReplayCorpusEntry {
+  const entry = CURRENT_FORECAST_REPLAY_CORPUS.find((candidate) => candidate.name === name);
+  if (!entry) throw new Error(`Missing corpus entry ${name}`);
+  return entry;
+}
+
+function toShadowBase(entry: CurrentForecastReplayCorpusEntry): CurrentForecastShadowBase {
+  return {
+    name: entry.name,
+    fundId: entry.input.fundId,
+    referenceBasis: entry.referenceBasis,
+    expected: entry.expected,
+  };
+}
+
+function runEngine(entry: CurrentForecastReplayCorpusEntry) {
+  return runCohortProjectionV2(entry.input, entry.plan, entry.facts);
+}
+
+const shadowResolution = async () => ({ mode: 'shadow' as const, cutoverReferenceId: null });
+const heldResolution = async () => ({ mode: 'held' as const, cutoverReferenceId: 41 });
+
+function outcomeFixture(
+  overrides: Partial<CurrentForecastShadowOutcome> = {}
+): CurrentForecastShadowOutcome {
+  return {
+    baseName: 'fixture',
+    executed: true,
+    substrateState: 'available',
+    reconciliationStatus: 'match',
+    replayConsistent: true,
+    mismatchReasons: [],
+    unexplained: false,
+    ...overrides,
+  };
+}
+
+describe('current-forecast replay corpus', () => {
+  it('loads six schema-validated bases with exactly one held base', () => {
+    expect(CURRENT_FORECAST_REPLAY_CORPUS).toHaveLength(6);
+    expect(
+      CURRENT_FORECAST_REPLAY_CORPUS.filter((entry) => entry.kind === 'held').map((e) => e.name)
+    ).toEqual(['held']);
+    expect(CURRENT_FORECAST_REPLAY_CORPUS.map((entry) => entry.name).sort()).toEqual([
+      'case-blocked',
+      'empty-facts',
+      'full-facts',
+      'held',
+      'indicative',
+      'partial-facts',
+    ]);
+  });
+
+  it('exact-basis replay reproduces the pinned hashes for every value-bearing base', () => {
+    for (const entry of CURRENT_FORECAST_REPLAY_CORPUS) {
+      if (entry.kind !== 'evaluate' || entry.name === 'case-blocked') continue;
+      const result = runEngine(entry);
+      expect({
+        name: entry.name,
+        status: result.status,
+        inputHash: result.inputHash,
+        resultHash: result.resultHash,
+      }).toEqual({
+        name: entry.name,
+        status: entry.expected.status,
+        inputHash: entry.expected.inputHash,
+        resultHash: entry.expected.resultHash,
+      });
+    }
+  });
+
+  it('the case-blocked base fails with a basis mismatch', () => {
+    expect(() => runEngine(corpusEntry('case-blocked'))).toThrowError(
+      /currentPlanVersionId must identify the supplied plan/
+    );
+  });
+});
+
+describe('buildCurrentForecastShadowRecord', () => {
+  it('maps an available replay match to match with no reasons', () => {
+    const entry = corpusEntry('full-facts');
+    const { record, outcome } = buildCurrentForecastShadowRecord({
+      base: toShadowBase(entry),
+      result: runEngine(entry),
+      modes: SHADOW_MODES,
+    });
+
+    expect(record).toMatchObject({
+      fundId: entry.input.fundId,
+      calculationKey: 'current_forecast',
+      configuredMode: 'shadow',
+      effectiveMode: 'shadow',
+      substrateState: 'available',
+      reconciliationStatus: 'match',
+      inputHash: entry.expected.inputHash,
+      resultHash: entry.expected.resultHash,
+      mismatches: [],
+    });
+    expect(outcome).toMatchObject({
+      executed: true,
+      replayConsistent: true,
+      unexplained: false,
+    });
+  });
+
+  it('maps an indicative replay match to match', () => {
+    const entry = corpusEntry('indicative');
+    const { record, outcome } = buildCurrentForecastShadowRecord({
+      base: toShadowBase(entry),
+      result: runEngine(entry),
+      modes: SHADOW_MODES,
+    });
+
+    expect(record.substrateState).toBe('indicative');
+    expect(record.reconciliationStatus).toBe('match');
+    expect(outcome.unexplained).toBe(false);
+  });
+
+  it('flags an unexplained divergence when the hash drifts under the same methodology', () => {
+    const entry = corpusEntry('full-facts');
+    const base = toShadowBase(entry);
+    const { record, outcome } = buildCurrentForecastShadowRecord({
+      base: {
+        ...base,
+        expected: { ...base.expected, resultHash: 'f'.repeat(64) },
+      },
+      result: runEngine(entry),
+      modes: SHADOW_MODES,
+    });
+
+    expect(record.reconciliationStatus).toBe('mismatch');
+    expect(record.mismatches).toEqual([]);
+    expect(outcome).toMatchObject({ replayConsistent: false, unexplained: true });
+  });
+
+  it('types a hash drift under a different pinned methodology as methodology_change', () => {
+    const entry = corpusEntry('full-facts');
+    const base = toShadowBase(entry);
+    const { record, outcome } = buildCurrentForecastShadowRecord({
+      base: {
+        ...base,
+        expected: {
+          ...base.expected,
+          resultHash: 'f'.repeat(64),
+          methodologyVersion: 'cohort-projection-v1/9.9.9',
+        },
+      },
+      result: runEngine(entry),
+      modes: SHADOW_MODES,
+    });
+
+    expect(record.reconciliationStatus).toBe('mismatch');
+    expect(record.mismatches).toEqual(['methodology_change']);
+    expect(outcome).toMatchObject({ replayConsistent: false, unexplained: false });
+  });
+
+  it('persists a facts-driven unavailable run as mismatch + facts_gap (P3)', () => {
+    const entry = corpusEntry('empty-facts');
+    const { record, outcome } = buildCurrentForecastShadowRecord({
+      base: toShadowBase(entry),
+      result: runEngine(entry),
+      modes: SHADOW_MODES,
+    });
+
+    expect(record).toMatchObject({
+      substrateState: 'unavailable',
+      reconciliationStatus: 'mismatch',
+      mismatches: ['facts_gap'],
+      resultHash: entry.expected.resultHash,
+    });
+    expect(outcome).toMatchObject({ replayConsistent: true, unexplained: false });
+  });
+
+  it('persists an expected non-facts unavailable run as mismatch + unavailable_expected (P3)', () => {
+    const entry = corpusEntry('partial-facts');
+    const { record, outcome } = buildCurrentForecastShadowRecord({
+      base: toShadowBase(entry),
+      result: runEngine(entry),
+      modes: SHADOW_MODES,
+    });
+
+    expect(record.substrateState).toBe('unavailable');
+    expect(record.mismatches).toEqual(['unavailable_expected']);
+    expect(outcome.unexplained).toBe(false);
+  });
+
+  it('persists a thrown run as failed + mismatch with NO typed reason (unexplained, P3)', () => {
+    const entry = corpusEntry('case-blocked');
+    const { record, outcome } = buildCurrentForecastShadowRecord({
+      base: toShadowBase(entry),
+      result: null,
+      error: new Error('basis mismatch'),
+      modes: SHADOW_MODES,
+    });
+
+    expect(record).toMatchObject({
+      substrateState: 'failed',
+      reconciliationStatus: 'mismatch',
+      resultHash: null,
+      mismatches: [],
+    });
+    expect(record.inputHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(outcome).toMatchObject({ replayConsistent: false, unexplained: true });
+  });
+
+  it('never emits a ledger mode outside off|shadow|on (P4)', () => {
+    const entry = corpusEntry('full-facts');
+
+    expect(() =>
+      buildCurrentForecastShadowRecord({
+        base: toShadowBase(entry),
+        result: runEngine(entry),
+        modes: { ...SHADOW_MODES, effectiveMode: 'held' as never },
+      })
+    ).toThrowError(/off\|shadow\|on/);
+  });
+});
+
+describe('runCurrentForecastShadowBase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips without persisting when the resolution is held', async () => {
+    const entry = corpusEntry('held');
+    const persist = vi.fn();
+    const createReference = vi.fn();
+
+    const outcome = await runCurrentForecastShadowBase({
+      base: toShadowBase(entry),
+      resolveMode: heldResolution,
+      runV2: async () => runEngine(entry),
+      persist,
+      createReference,
+    });
+
+    expect(outcome).toMatchObject({ executed: false, substrateState: null });
+    expect(persist).not.toHaveBeenCalled();
+    expect(createReference).not.toHaveBeenCalled();
+  });
+
+  it('persists one record and creates the candidate reference on an available match', async () => {
+    const entry = corpusEntry('full-facts');
+    const persist = vi.fn();
+    const createReference = vi.fn();
+
+    const outcome = await runCurrentForecastShadowBase({
+      base: toShadowBase(entry),
+      resolveMode: shadowResolution,
+      runV2: async () => runEngine(entry),
+      persist,
+      createReference,
+    });
+
+    expect(outcome).toMatchObject({ executed: true, reconciliationStatus: 'match' });
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(createReference).toHaveBeenCalledTimes(1);
+    expect(createReference).toHaveBeenCalledWith({
+      fundId: entry.input.fundId,
+      basis: {
+        ...entry.referenceBasis,
+        inputHash: entry.expected.inputHash,
+        resultHash: entry.expected.resultHash,
+        assumptionsHash: expect.stringMatching(/^[a-f0-9]{64}$/) as unknown as string,
+        engineVersion: 'current-forecast-v2-engine/1.0.0',
+        methodologyVersion: 'cohort-projection-v2/1.0.0',
+      },
+      idempotencyKey: `cfref:${entry.input.fundId}:${entry.expected.inputHash}:${entry.expected.resultHash}`,
+    });
+  });
+
+  it('persists but does not create a reference for unavailable and failed runs', async () => {
+    const persist = vi.fn();
+    const createReference = vi.fn();
+
+    for (const name of ['empty-facts', 'case-blocked'] as const) {
+      const entry = corpusEntry(name);
+      await runCurrentForecastShadowBase({
+        base: toShadowBase(entry),
+        resolveMode: shadowResolution,
+        runV2: async () => runEngine(entry),
+        persist,
+        createReference,
+      });
+    }
+
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(createReference).not.toHaveBeenCalled();
+  });
+
+  it('evaluates the full corpus with zero unexplained divergences outside case-blocked', async () => {
+    const outcomes: CurrentForecastShadowOutcome[] = [];
+    for (const entry of CURRENT_FORECAST_REPLAY_CORPUS) {
+      outcomes.push(
+        await runCurrentForecastShadowBase({
+          base: toShadowBase(entry),
+          resolveMode: entry.kind === 'held' ? heldResolution : shadowResolution,
+          runV2: async () => runEngine(entry),
+          persist: vi.fn(),
+          createReference: vi.fn(),
+        })
+      );
+    }
+
+    const executed = outcomes.filter((outcome) => outcome.executed);
+    expect(executed).toHaveLength(5);
+    expect(executed.filter((outcome) => outcome.unexplained).map((o) => o.baseName)).toEqual([
+      'case-blocked',
+    ]);
+    expect(
+      executed
+        .filter((outcome) => outcome.baseName !== 'case-blocked')
+        .every((outcome) => outcome.replayConsistent)
+    ).toBe(true);
+  });
+});
+
+describe('evaluateCurrentForecastShadowGreen (D1: legacy parity is not a criterion)', () => {
+  it('is green for fully available replay-consistent outcomes', () => {
+    const outcomes = Array.from({ length: 10 }, (_unused, index) =>
+      outcomeFixture({ baseName: `base-${index}` })
+    );
+
+    expect(evaluateCurrentForecastShadowGreen(outcomes)).toMatchObject({
+      green: true,
+      evaluatedCount: 10,
+      availableCount: 10,
+      availableCoverage: 1,
+    });
+  });
+
+  it('blocks green on a single unexplained divergence', () => {
+    const outcomes = [
+      ...Array.from({ length: 9 }, (_unused, index) => outcomeFixture({ baseName: `ok-${index}` })),
+      outcomeFixture({
+        baseName: 'broken',
+        substrateState: 'failed',
+        reconciliationStatus: 'mismatch',
+        replayConsistent: false,
+        unexplained: true,
+      }),
+    ];
+
+    const evaluation = evaluateCurrentForecastShadowGreen(outcomes);
+    expect(evaluation.green).toBe(false);
+    expect(evaluation.unexplainedDivergences).toEqual(['broken']);
+  });
+
+  it('holds the >=90% available coverage boundary', () => {
+    const explainedUnavailable = (name: string) =>
+      outcomeFixture({
+        baseName: name,
+        substrateState: 'unavailable',
+        reconciliationStatus: 'mismatch',
+        mismatchReasons: ['unavailable_expected'],
+      });
+
+    const nineOfTen = [
+      ...Array.from({ length: 9 }, (_unused, index) => outcomeFixture({ baseName: `ok-${index}` })),
+      explainedUnavailable('gap-0'),
+    ];
+    expect(evaluateCurrentForecastShadowGreen(nineOfTen)).toMatchObject({
+      green: true,
+      availableCoverage: 0.9,
+    });
+
+    const eightOfTen = [
+      ...Array.from({ length: 8 }, (_unused, index) => outcomeFixture({ baseName: `ok-${index}` })),
+      explainedUnavailable('gap-0'),
+      explainedUnavailable('gap-1'),
+    ];
+    expect(evaluateCurrentForecastShadowGreen(eightOfTen).green).toBe(false);
+  });
+
+  it('blocks green on any replay-inconsistent value-bearing base even when explained', () => {
+    const outcomes = [
+      ...Array.from({ length: 19 }, (_unused, index) =>
+        outcomeFixture({ baseName: `ok-${index}` })
+      ),
+      outcomeFixture({
+        baseName: 'drifted',
+        reconciliationStatus: 'mismatch',
+        replayConsistent: false,
+        mismatchReasons: ['methodology_change'],
+      }),
+    ];
+
+    const evaluation = evaluateCurrentForecastShadowGreen(outcomes);
+    expect(evaluation.green).toBe(false);
+    expect(evaluation.replayInconsistent).toEqual(['drifted']);
+    expect(evaluation.unexplainedDivergences).toEqual([]);
+  });
+
+  it('is never green over zero evaluated outcomes', () => {
+    expect(evaluateCurrentForecastShadowGreen([]).green).toBe(false);
+    expect(evaluateCurrentForecastShadowGreen([outcomeFixture({ executed: false })]).green).toBe(
+      false
+    );
+  });
+});
+
+describe('persistCurrentForecastShadowReconciliation (default writer)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('issues insert(table).values(record).onConflictDoNothing() exactly once', async () => {
+    const entry = corpusEntry('full-facts');
+    const { record } = buildCurrentForecastShadowRecord({
+      base: toShadowBase(entry),
+      result: runEngine(entry),
+      modes: SHADOW_MODES,
+    });
+
+    await persistCurrentForecastShadowReconciliation(record);
+
+    expect(insert).toHaveBeenCalledOnce();
+    expect(insert).toHaveBeenCalledWith(substrateShadowReconciliations);
+    expect(values).toHaveBeenCalledOnce();
+    expect(values).toHaveBeenCalledWith(record);
+    expect(onConflictDoNothing).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Delivers the DORMANT service plane for the `current_forecast` calculation key (PLAN_61 Task 13.1-svc), stacking on 13.1-mig (#1190/#1191):

- **Held-state resolver** (`current-forecast-calc-mode-resolver.ts`): R24/D9 state map. Pre-cutover: kill/off -> `off`, shadow -> `shadow`, on -> `on`. Post-cutover: only effective `on` serves V2; every other state resolves `held`, serving the served-pointer head. `dispatchCurrentForecastServing` pins post-cutover V2 failure -> held (never legacy) and that the legacy `ProjectedMetricsCalculator` lane is never invoked under post-cutover kill.
- **Reference service** (`current-forecast-reference-service.ts`): append-only create-candidate on `runIdempotentCommand` (D13), accepted-head read, pointer advance (only while effective `on` post-cutover), admin rollback clone, and the DORMANT activation command.
- **Shadow service** (`current-forecast-shadow-service.ts`): runs V2 over the committed replay corpus, persists reconciliations with typed mismatch reasons, green = exact-basis replay reproduces resultHash + >=90% available coverage + zero unexplained divergences. Legacy numeric parity is NOT a criterion (ADR-057).
- **Replay corpus** (`tests/fixtures/current-forecast-replay-corpus/`): six deterministic bases derived from the CF truth cases (empty/partial/full facts, indicative, case-blocked, held) with pinned engine hashes.
- **Dormant admin routes**: `POST .../current-forecast/references` (rollback clone) and `POST .../current-forecast/activate` (executed only by Task 23), full auth chain + Idempotency-Key (428), synced into route manifest schemaTables + policy registry. The 13.0 mode route now refuses `off|shadow -> on` (`activation_command_required`).
- **ADR-057/058/059** + runtime-barrel dedup of the doubled `./schema/current-plans` star export.

## Review-pin conformance (2026-07-22 adjudication, BINDING)

| Pin | Implementation |
| --- | --- |
| P1 — `cutover_reference_id` is the LIVE served head | `advanceCurrentForecastPointer` mutates it on every advance while `on`; held serves exactly this pointer, never a latest-accepted query; stated verbatim in ADR-058 |
| P2 — activation flips candidate in the same atomic write | `activateCurrentForecast` supersedes the prior head, flips `candidate=false`, and writes `on` + `activated_at` + `cutover_reference_id` in ONE transaction (test pins all 7 statements on one tx) |
| P3 — unavailable/failed persist as `mismatch` + typed reason | `buildCurrentForecastShadowRecord`: unavailable -> `facts_gap`/`unavailable_expected`; `failed` -> no typed reason, unexplained, blocks green |
| P4 — ledger modes never leave `off\|shadow\|on` | `assertLedgerMode` clamp + test; only `shadow` resolutions execute, so records are always shadow/shadow |
| Idempotency | Reference writers on `runIdempotentCommand`; shadow create-candidate uses deterministic `cfref:<fundId>:<inputHash>:<resultHash>` keys; admin routes require `Idempotency-Key` |

## Attestations

- NO migration applied (`db:push`/`db:migrate` never run; 0038 remains authored-not-applied)
- NO database written; all tests are DB-free (injected seams/fakes)
- NO flag or mode value flipped anywhere
- The activation command ships dormant and was never executed
- MOIC mode-service behavior byte-untouched (characterization + golden suites green)
- Existing substrate shadow writer/reader still emit only `available`/`indicative` (regression green)

## Verification

- Verify set (7 files): 93/93 green
- `guard:legacy-calculation-consumers:check`: pass (1471 files, no violations)
- `calc-gate`: 20/20 green; `npm run check`: 0 new errors; `validate:schema-drift`: 100 passes, 0 errors; `policy:verify`: 87 entries pass
- Full suite (sharded, TZ=UTC): server 7,763 passed (3 shards), client 1,512 passed (2 shards), 0 failures

## Residuals

- The mode route still blocks `off -> shadow` for `current_forecast` (strategy `validateAccepted` returns `accepted_reconciliation_required`; source wiring to references is a later task alongside the `unavailable_until_task_13_1` source-hash placeholder).
- Client adapter is Task 13.2 (out of scope here).

Merging is the user's action; auto-merge deliberately NOT armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkBQzihG4JJYWwGYvACk36