### PR TITLE
feat(forecast): dual-forecast serving adaptation for the governed current-forecast plane, dormant (PLAN_61 Task 13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added (2026-07-23)
+
+- **Current-forecast serving plane wired into the dual forecast, dormant
+  (PLAN_61 Task 13.2, ADR-060).** `metricsAggregator.getDualForecast` now
+  dispatches on the per-fund `current_forecast` mode resolution: `off`/`shadow`
+  serve the legacy composer byte-identically (snapshot-pinned), `on` serves the
+  V2 engine, and `held` serves exactly the pinned served-pointer reference with
+  the original basis hashes, a typed incident reason, and the age of the pinned
+  result - never the legacy lane post-cutover. Dual-forecast contract bumped to
+  v2 with an optional `currentForecastV2` block; the client renders a held
+  notice and the readiness rollup fails held/unavailable servings closed. All
+  funds still resolve `off` (no mode rows; `enable_current_forecast_v2` stays
+  default-off, now pinned by an activation-gate test).
+
 ### Added (2026-07-18)
 
 - **Ownership-aware position FMV is now consistent across current NAV surfaces

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8820,3 +8820,46 @@ unexplained divergences).
   produced nothing at all (thrown basis mismatch -> `failed`).
 
 ---
+
+## ADR-060: Dual-Forecast Contract v2 — Optional Serving Block Keeps `off` Byte-Identical (Demo Scope)
+
+**Date:** 2026-07-23 **Status:** [ACCEPTED] Accepted **Decision:** Task 13.2
+adapts the governed current-forecast plane into the live dual-forecast response
+by bumping `DUAL_FORECAST_CONTRACT_VERSION` to 2 with an OPTIONAL
+`currentForecastV2` block instead of a breaking reshape. The block is emitted
+ONLY when the resolved mode serves V2 (`status: 'live'`) or the pinned reference
+(`status: 'held'`); in `off`/`shadow` the payload stays byte-identical to
+version 1 (pinned by an off-mode serialization snapshot). `sources.current`
+widens to `projected_metrics_calculator | current_forecast_v2` so consumers can
+react to the response shape alone — the server-only flag is never exposed
+(`exposeToClient: false`).
+
+### Context
+
+The rollout table requires `off` byte-compatibility, `shadow` non-authority, and
+a `held` display carrying the ORIGINAL basis/version/hash plus a typed incident
+reason and the age of the pinned result. A versioned-but-additive contract lets
+one egress schema serve all four modes while the plane ships dormant (no mode
+rows exist; the flag is off; every fund resolves `off`).
+
+### Consequences
+
+- Serving dispatch lives in `MetricsAggregator.getDualForecast` through the 13.1
+  `dispatchCurrentForecastServing` seam; the route is unchanged and new mode
+  logic imports no protected module. The legacy composer is the ONLY lane that
+  invokes `ProjectedMetricsCalculator`; a consumer-level test pins that PMC is
+  never invoked post-cutover under kill.
+- Serving-time `shadow` performs NO observation write - the replay corpus is the
+  shadow evidence plane (13.1); the request path serves legacy unchanged.
+- `held` composes live construction/actual lanes with the pinned V2 payload (P1:
+  exactly `cutover_reference_id`); basis fields come from the reference row,
+  `held.reason` is the typed enum
+  `kill_switch | configured_off | configured_shadow | v2_runtime_failure`, and a
+  missing head surfaces `HELD_REFERENCE_MISSING` as an error envelope, never the
+  legacy response.
+- The V2 Current lane maps the engine's quarterly cumulative series
+  (`contributionsUsd` -> calledCapital, point-in-time `navUsd`, fund-level
+  `netIrr`) onto the existing per-quarter metrics; quarter 0 stays the as-of
+  actual, mirroring the legacy builder.
+
+---

--- a/client/src/components/dashboard/CurrentForecastHeldNotice.tsx
+++ b/client/src/components/dashboard/CurrentForecastHeldNotice.tsx
@@ -1,0 +1,29 @@
+import type { DualForecastCurrentForecastV2 } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
+import { buildHeldNotice } from '@/lib/dual-forecast-display';
+
+/**
+ * Held-serving disclosure (PLAN_61 Task 13.2, R24/D9): the current-forecast
+ * plane is serving the pinned reference forecast, not a live calculation.
+ * Renders only for a held block, with the typed incident reason and the age
+ * of the pinned result; muted styling per DESIGN.md - state disclosure, not
+ * an alarm surface.
+ */
+export function CurrentForecastHeldNotice({
+  block,
+}: {
+  block: DualForecastCurrentForecastV2 | null | undefined;
+}) {
+  const notice = buildHeldNotice(block);
+  if (notice === null) {
+    return null;
+  }
+
+  return (
+    <div role="status" className="mb-3 rounded-md border border-beige-200 bg-white px-3 py-2">
+      <p className="text-sm font-medium text-pov-charcoal">{notice.headline}</p>
+      <p className="mt-1 text-xs text-charcoal-600">
+        {notice.body} {notice.reason} {notice.age}. {notice.escalation}
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/dashboard/dual-forecast-dashboard.tsx
+++ b/client/src/components/dashboard/dual-forecast-dashboard.tsx
@@ -33,6 +33,7 @@ import {
   type ForecastMetricDrift,
   type TrustFilterKey,
 } from '@/lib/dual-forecast-display';
+import { CurrentForecastHeldNotice } from '@/components/dashboard/CurrentForecastHeldNotice';
 import { CurrentProjectionNotice } from '@/components/dashboard/CurrentProjectionNotice';
 import { FactsUnavailableNotice } from '@/components/dashboard/FactsUnavailableNotice';
 import { NavAttributionTable } from '@/components/dashboard/NavAttributionTable';
@@ -499,6 +500,7 @@ export default function DualForecastDashboard() {
               </CardDescription>
             </CardHeader>
             <CardContent>
+              <CurrentForecastHeldNotice block={dualForecast.currentForecastV2} />
               <CurrentProjectionNotice projection={dualForecast.currentProjection} />
               <ResponsiveContainer width="100%" height={300}>
                 <LineChart data={forecastData}>

--- a/client/src/lib/dual-forecast-display.ts
+++ b/client/src/lib/dual-forecast-display.ts
@@ -1,6 +1,8 @@
 import type {
   DualForecastActualsFacts,
   DualForecastActualsFactsCompany,
+  DualForecastCurrentForecastV2,
+  DualForecastHeldReason,
   DualForecastNavAnchor,
   DualForecastNavAnchoring,
   DualForecastPoint,
@@ -437,6 +439,58 @@ export function formatChipAriaLabel(count: number, key: TrustFilterKey): string 
 
 export function formatFactsFreshness(asOfDate: string, inputHash: string): string {
   return `Facts as of ${asOfDate} · input ${inputHash.slice(0, 8)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Held current-forecast disclosure (PLAN_61 Task 13.2, R24/D9)
+// ---------------------------------------------------------------------------
+
+export const CURRENT_FORECAST_HELD_NOTICE_COPY = {
+  headline: 'Current forecast is held',
+  body: 'Showing the pinned reference forecast, not a live calculation.',
+  escalation: 'Review before LP sharing.',
+} as const;
+
+/** Typed incident reason -> disclosure copy; the client reacts to the
+ * response shape only (the server flag is never exposed). */
+export const HELD_REASON_COPY: Record<DualForecastHeldReason, string> = {
+  kill_switch: 'The calculation kill switch is active.',
+  configured_off: 'The current-forecast calculation is switched off after cutover.',
+  configured_shadow: 'The current-forecast calculation is in shadow mode after cutover.',
+  v2_runtime_failure: 'The live calculation failed when this response was served.',
+};
+
+export function formatHeldAge(ageDays: number): string {
+  if (ageDays <= 0) {
+    return 'Pinned today';
+  }
+  return ageDays === 1 ? 'Pinned 1 day ago' : `Pinned ${ageDays} days ago`;
+}
+
+export interface HeldNotice {
+  headline: string;
+  body: string;
+  reason: string;
+  age: string;
+  escalation: string;
+}
+
+/** Null unless the response block is a genuine held serving (fail-quiet for
+ * absent block and for live V2 serving). */
+export function buildHeldNotice(
+  block: DualForecastCurrentForecastV2 | null | undefined
+): HeldNotice | null {
+  if (!block || block.status !== 'held' || block.held === null) {
+    return null;
+  }
+
+  return {
+    headline: CURRENT_FORECAST_HELD_NOTICE_COPY.headline,
+    body: CURRENT_FORECAST_HELD_NOTICE_COPY.body,
+    reason: HELD_REASON_COPY[block.held.reason],
+    age: formatHeldAge(block.held.ageDays),
+    escalation: CURRENT_FORECAST_HELD_NOTICE_COPY.escalation,
+  };
 }
 
 /**

--- a/client/src/pages/fund-model-results/readiness-rollup.ts
+++ b/client/src/pages/fund-model-results/readiness-rollup.ts
@@ -19,6 +19,7 @@
 
 import type { DecisionState } from '@/components/fund-results';
 import type { AllocationsResponse } from '@/components/portfolio/tabs/types';
+import { formatHeldAge, HELD_REASON_COPY } from '@/lib/dual-forecast-display';
 import type { DualForecastResponse } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
 import type { FundMoicRankingsResponseV2 } from '@shared/contracts/fund-moic-v2.contract';
 import type { FundResultsReadV1 } from '@shared/contracts/fund-results-v1.contract';
@@ -124,6 +125,48 @@ function deriveForecastSeed(input: ReadinessSourceInput<DualForecastResponse>): 
   const asOfDate = isoDateOnly(forecast.asOfDate);
   const details = forecast.warnings;
   const firstWarning = forecast.warnings[0] ?? null;
+
+  // Task 13.2 governed serving (R24/D9): a held current forecast is an
+  // incident state and dominates every downstream facts check - the row is
+  // pinned data, not a live calculation. Live V2 servings fail closed on
+  // unavailable/failed engine output and cap at indicative on indicative.
+  const served = forecast.currentForecastV2;
+  if (served !== undefined) {
+    if (served.status === 'held') {
+      return {
+        state: 'not_actionable',
+        stateLabel: 'Held',
+        primaryReason:
+          served.held === null
+            ? 'Current forecast is held'
+            : `Current forecast is held — ${HELD_REASON_COPY[served.held.reason]}`,
+        asOfDate: isoDateOnly(served.asOfDate),
+        ...(served.held === null ? {} : { blockedSummary: formatHeldAge(served.held.ageDays) }),
+        details,
+      };
+    }
+    if (served.engineStatus === 'unavailable' || served.engineStatus === 'failed') {
+      const detail = served.unavailableReasons[0]?.detail;
+      return {
+        state: 'not_actionable',
+        primaryReason:
+          detail === undefined
+            ? 'Current forecast unavailable'
+            : `Current forecast unavailable — ${detail}`,
+        asOfDate: isoDateOnly(served.asOfDate),
+        details,
+      };
+    }
+    if (served.engineStatus === 'indicative') {
+      return {
+        state: 'indicative',
+        primaryReason: 'Current forecast is indicative',
+        asOfDate: isoDateOnly(served.asOfDate),
+        details,
+      };
+    }
+    // engineStatus 'available': fall through to the facts-driven derivation.
+  }
 
   // Contract-documented facts-fetch failure: null facts/anchoring reads FAILED
   // (matches evidenceFromDualForecast, AMENDMENT 6).

--- a/server/services/current-forecast-calc-mode-resolver.ts
+++ b/server/services/current-forecast-calc-mode-resolver.ts
@@ -27,6 +27,13 @@ export const defaultCurrentForecastModeReader: CurrentForecastModeReader = (fund
       and(eq(row.fundId, fundId), eq(row.calculationKey, CURRENT_FORECAST_CALCULATION_KEY)),
   });
 
+/**
+ * Which post-cutover state produced a `held` resolution (13.2): the serving
+ * plane surfaces this as the incident/stale reason on the held display. Kill
+ * wins over the configured mode when both apply.
+ */
+export type CurrentForecastHeldReason = 'kill_switch' | 'configured_off' | 'configured_shadow';
+
 export interface CurrentForecastModeResolution {
   mode: CurrentForecastCalculationMode;
   /**
@@ -36,6 +43,8 @@ export interface CurrentForecastModeResolution {
    * serves exactly this pointer — never a "latest accepted" query.
    */
   cutoverReferenceId: number | null;
+  /** Present exactly when `mode` is `held`. */
+  heldReason?: CurrentForecastHeldReason;
 }
 
 /**
@@ -68,7 +77,12 @@ export async function resolveCurrentForecastModeResolution(
   if (!row?.killSwitchActive && row?.configuredMode === 'on') {
     return { mode: 'on', cutoverReferenceId };
   }
-  return { mode: 'held', cutoverReferenceId };
+  const heldReason: CurrentForecastHeldReason = row?.killSwitchActive
+    ? 'kill_switch'
+    : row?.configuredMode === 'shadow'
+      ? 'configured_shadow'
+      : 'configured_off';
+  return { mode: 'held', cutoverReferenceId, heldReason };
 }
 
 /** Bare-mode convenience wrapper over {@link resolveCurrentForecastModeResolution}. */

--- a/server/services/current-forecast-held-service.ts
+++ b/server/services/current-forecast-held-service.ts
@@ -1,0 +1,94 @@
+import { sql, type SQL } from 'drizzle-orm';
+
+import { db } from '../db';
+import {
+  CurrentForecastV2Schema,
+  type CurrentForecastV2,
+} from '../../shared/contracts/current-forecast-v2.contract';
+import {
+  getCurrentForecastReferenceById,
+  type CurrentForecastReferenceRecord,
+} from './current-forecast-reference-service';
+
+/**
+ * Held serving loader (PLAN_61 Task 13.2, P1/D9): resolve the pinned
+ * served-pointer head into the ORIGINAL forecast payload it named. A missing
+ * pointer head, missing snapshot, or contract-invalid payload throws - the
+ * route surfaces an error envelope; the legacy lane is never a fallback.
+ */
+
+export type CurrentForecastHeldDatabase = typeof db;
+
+export class CurrentForecastHeldError extends Error {
+  constructor(
+    readonly code: 'HELD_REFERENCE_MISSING',
+    message: string
+  ) {
+    super(message);
+    this.name = 'CurrentForecastHeldError';
+  }
+}
+
+export interface HeldCurrentForecast {
+  reference: CurrentForecastReferenceRecord;
+  forecast: CurrentForecastV2;
+}
+
+type SnapshotRow = { payload: unknown };
+
+async function executeRows<T>(
+  database: { execute: (query: SQL) => Promise<unknown> },
+  query: SQL
+): Promise<T[]> {
+  const result = (await database.execute(query)) as { rows: T[] };
+  return result.rows;
+}
+
+export async function loadHeldCurrentForecast(params: {
+  fundId: number;
+  referenceId: number;
+  database?: CurrentForecastHeldDatabase;
+}): Promise<HeldCurrentForecast> {
+  const database = params.database ?? db;
+
+  const reference = await getCurrentForecastReferenceById({
+    fundId: params.fundId,
+    referenceId: params.referenceId,
+    database,
+  });
+  if (!reference) {
+    throw new CurrentForecastHeldError(
+      'HELD_REFERENCE_MISSING',
+      `current-forecast reference ${params.referenceId} not found for fund ${params.fundId}`
+    );
+  }
+
+  const rows = await executeRows<SnapshotRow>(
+    database,
+    sql`
+      SELECT payload
+      FROM fund_snapshots
+      WHERE id = ${reference.fundSnapshotId}
+        AND fund_id = ${params.fundId}
+        AND type = 'CURRENT_FORECAST_V2'
+      LIMIT 1
+    `
+  );
+  const snapshot = rows[0];
+  if (!snapshot) {
+    throw new CurrentForecastHeldError(
+      'HELD_REFERENCE_MISSING',
+      `pinned snapshot ${reference.fundSnapshotId} for reference ${reference.id} not found for fund ${params.fundId}`
+    );
+  }
+
+  const parsed = CurrentForecastV2Schema.safeParse(snapshot.payload);
+  if (!parsed.success) {
+    throw new CurrentForecastHeldError(
+      'HELD_REFERENCE_MISSING',
+      `pinned snapshot ${reference.fundSnapshotId} payload failed the current-forecast-v2 contract`
+    );
+  }
+
+  return { reference, forecast: parsed.data };
+}

--- a/server/services/current-forecast-reference-service.ts
+++ b/server/services/current-forecast-reference-service.ts
@@ -235,6 +235,19 @@ async function loadReference(
 }
 
 /**
+ * Fund-scoped reference lookup by id for the held serving lane (13.2, P1):
+ * `held` loads EXACTLY the pointer head named by `cutover_reference_id`,
+ * never a latest-accepted query.
+ */
+export async function getCurrentForecastReferenceById(params: {
+  fundId: number;
+  referenceId: number;
+  database?: CurrentForecastReferenceDatabase;
+}): Promise<CurrentForecastReferenceRecord | null> {
+  return loadReference(params.database ?? db, params.fundId, params.referenceId);
+}
+
+/**
  * The accepted served-pointer head: the single non-superseded, non-candidate
  * row per fund (armed by the accepted-head partial unique from cutover onward).
  */

--- a/server/services/metrics-aggregator.ts
+++ b/server/services/metrics-aggregator.ts
@@ -24,7 +24,9 @@ import type {
   DualForecastActualsFacts,
   DualForecastActualsFactsCompany,
   DualForecastConfigMetadata,
+  DualForecastCurrentForecastV2,
   DualForecastCurrentProjection,
+  DualForecastHeldReason,
   DualForecastMetrics,
   DualForecastNavAnchor,
   DualForecastNavAnchorCompany,
@@ -32,6 +34,21 @@ import type {
   DualForecastPoint,
   DualForecastResponse,
 } from '@shared/contracts/dual-forecast/dual-forecast-response.contract';
+import type {
+  CurrentForecastSeriesPointV1,
+  CurrentForecastV2,
+} from '@shared/contracts/current-forecast-v2.contract';
+import {
+  dispatchCurrentForecastServing,
+  resolveCurrentForecastModeResolution,
+  type CurrentForecastModeResolution,
+} from './current-forecast-calc-mode-resolver';
+import { runCurrentForecastV2 } from './current-forecast-v2-service';
+import {
+  CurrentForecastHeldError,
+  loadHeldCurrentForecast,
+  type HeldCurrentForecast,
+} from './current-forecast-held-service';
 import { buildFundCompanyActualsFacts } from './fund-actuals/fund-company-actuals-facts-service';
 import { ActualMetricsCalculator, isLivePortfolioCompany } from './actual-metrics-calculator';
 import { ProjectedMetricsCalculator } from './projected-metrics-calculator';
@@ -82,6 +99,22 @@ type MetricsPortfolioCompany = PortfolioCompany & {
   investmentDate: Date | null;
   ownershipCurrentPct: string | null;
 };
+
+/** Mode-independent dual-forecast inputs shared by every serving lane (13.2). */
+interface DualForecastScaffold {
+  fund: MetricsFund;
+  effectiveFund: MetricsFund;
+  companies: MetricsPortfolioCompany[];
+  config: MetricsFundConfig;
+  metadata: DualForecastConfigMetadata;
+  warnings: string[];
+  actual: ActualMetrics;
+  actualsFacts: DualForecastActualsFacts | null;
+  navAnchoring: DualForecastNavAnchoring | null;
+  anchoredActual: ActualMetrics;
+  constructionStartIndex: number;
+  constructionForecast: ConstructionForecast;
+}
 
 const LEGACY_DEFAULT_TARGETS: MetricsFundConfig = {
   targetIRR: 0.25,
@@ -136,15 +169,37 @@ class InMemoryCache implements CacheClient {
   }
 }
 
+/**
+ * Injectable current-forecast serving seams (PLAN_61 Task 13.2). Production
+ * uses the governed defaults; unit tests inject fakes so no serving lane ever
+ * touches the database or the sanctioned V2 snapshot write.
+ */
+export interface CurrentForecastServingDeps {
+  resolveMode: (fundId: number) => Promise<CurrentForecastModeResolution>;
+  runV2: (fundId: number) => Promise<CurrentForecastV2>;
+  loadHeld: (fundId: number, referenceId: number) => Promise<HeldCurrentForecast>;
+  now: () => Date;
+}
+
+const defaultCurrentForecastServingDeps: CurrentForecastServingDeps = {
+  resolveMode: (fundId) => resolveCurrentForecastModeResolution(fundId),
+  // The sanctioned V2 run path persists its CURRENT_FORECAST_V2 fund snapshot.
+  runV2: (fundId) => runCurrentForecastV2({ fundId, clock: new Date().toISOString() }),
+  loadHeld: (fundId, referenceId) => loadHeldCurrentForecast({ fundId, referenceId }),
+  now: () => new Date(),
+};
+
 export class MetricsAggregator {
   private actualCalculator = new ActualMetricsCalculator();
   private projectedCalculator = new ProjectedMetricsCalculator();
   private varianceCalculator = new VarianceCalculator();
   private cache: CacheClient;
+  private currentForecastServing: CurrentForecastServingDeps;
 
-  constructor(cache?: CacheClient) {
+  constructor(cache?: CacheClient, currentForecastServing?: CurrentForecastServingDeps) {
     // Use provided cache or fallback to in-memory
     this.cache = cache || new InMemoryCache();
+    this.currentForecastServing = currentForecastServing ?? defaultCurrentForecastServingDeps;
   }
 
   /**
@@ -366,88 +421,34 @@ export class MetricsAggregator {
 
   /**
    * Get a dashboard-ready Construction Plan vs Current Forecast time series.
+   *
+   * Task 13.2: the current-forecast plane is mode-dispatched (R24/D9).
+   * `off`/`shadow` serve the legacy composer byte-identically (observation is
+   * the corpus plane, never this request path); `on` serves V2, degrading
+   * post-cutover to the pinned pointer head; `held` serves exactly that head
+   * (P1) and by construction never invokes the legacy PMC lane.
    */
   async getDualForecast(fundId: number): Promise<DualForecastResponse> {
-    const warnings: string[] = [];
-
     try {
-      const fundFromDb = await this.getFundForMetrics(fundId);
-      if (!fundFromDb) {
-        throw this.createError('INSUFFICIENT_DATA', `Fund ${fundId} not found`, 'aggregator');
-      }
-
-      const fund = fundFromDb as MetricsFund;
-      const companiesFromDb = await storage.getPortfolioCompanies(fundId);
-      const companies = companiesFromDb as MetricsPortfolioCompany[];
-      const { config, warnings: configWarnings, metadata } = await this.resolveFundConfig(fundId);
-      warnings.push(...configWarnings);
-
-      const effectiveFund: MetricsFund =
-        config.fundSizeOverride != null ? { ...fund, size: String(config.fundSizeOverride) } : fund;
-
-      const actual = await this.actualCalculator.calculate(fundId);
-      const actualsFacts = await this.fetchActualsFactsBlock(fundId, actual.asOfDate, warnings);
-      // PR-2 blend (ADR-029/030/032): a null facts block means no blend - the
-      // series keeps the legacy calculator NAV, disclosed via warnings.
-      const navAnchoring = this.buildNavAnchoring(companies, actualsFacts);
-      const anchoredActual = navAnchoring ? this.applyNavAnchoring(actual, navAnchoring) : actual;
-      const constructionStartIndex = this.getElapsedQuarterIndex(
-        effectiveFund.establishmentDate ?? effectiveFund.createdAt,
-        actual.asOfDate
-      );
-      const usesConstructionProjection = this.usesConstructionForecast(fund, companies);
-
-      let projected: ProjectedMetrics;
-      let currentProjectionStartIndex = 0;
-      let currentProjection: DualForecastCurrentProjection = {
-        status: 'projected',
-        fallbackReason: null,
-      };
-      try {
-        projected = await this.calculateProjectedMetrics(
-          fund,
-          effectiveFund,
-          companies,
-          config,
-          warnings
-        );
-        currentProjectionStartIndex = usesConstructionProjection ? constructionStartIndex + 1 : 0;
-      } catch (error) {
-        const fallbackReason = error instanceof Error ? error.message : 'Unknown error';
-        warnings.push(`Projected metrics calculation failed: ${fallbackReason}`);
-        projected = this.getDefaultProjectedMetrics(config);
-        currentProjection = { status: 'fallback_default', fallbackReason };
-      }
-
-      const constructionForecast = this.buildConstructionForecast(effectiveFund, config);
-      const series = this.buildDualForecastSeries(
-        anchoredActual,
-        projected,
-        constructionForecast,
-        toDecimal(effectiveFund.size),
-        config,
-        constructionStartIndex,
-        currentProjectionStartIndex
-      );
-
-      return {
-        fundId,
-        fundName: fund.name,
-        asOfDate: actual.asOfDate,
-        series,
-        sources: {
-          construction: 'construction_forecast_jcurve',
-          current: 'projected_metrics_calculator',
-          actual: 'actual_metrics_calculator',
-        },
-        config: metadata,
-        actualsFacts,
-        navAnchoring,
-        currentProjection,
-        warnings,
-      };
+      const resolution = await this.currentForecastServing.resolveMode(fundId);
+      return await dispatchCurrentForecastServing<DualForecastResponse>(resolution, {
+        runLegacy: () => this.buildLegacyDualForecast(fundId),
+        runV2: () => this.buildV2ServedDualForecast(fundId),
+        serveHeld: (referenceId) =>
+          this.buildHeldDualForecast(
+            fundId,
+            referenceId,
+            resolution.mode === 'on'
+              ? 'v2_runtime_failure'
+              : (resolution.heldReason ?? 'configured_off')
+          ),
+      });
     } catch (error) {
       console.error('Dual forecast aggregation failed:', error);
+
+      if (error instanceof CurrentForecastHeldError) {
+        throw this.createError('HELD_REFERENCE_MISSING', error.message, 'aggregator', error);
+      }
 
       if (this.isMetricsError(error)) {
         throw error;
@@ -460,6 +461,214 @@ export class MetricsAggregator {
         error
       );
     }
+  }
+
+  /**
+   * The pre-13.2 dual-forecast composer, verbatim (byte-identity pinned by the
+   * off-mode characterization snapshot). This is the ONLY lane that runs the
+   * contained ProjectedMetricsCalculator engine.
+   */
+  private async buildLegacyDualForecast(fundId: number): Promise<DualForecastResponse> {
+    const scaffold = await this.buildDualForecastScaffold(fundId);
+    const { fund, effectiveFund, companies, config, warnings } = scaffold;
+    const usesConstructionProjection = this.usesConstructionForecast(fund, companies);
+
+    let projected: ProjectedMetrics;
+    let currentProjectionStartIndex = 0;
+    let currentProjection: DualForecastCurrentProjection = {
+      status: 'projected',
+      fallbackReason: null,
+    };
+    try {
+      projected = await this.calculateProjectedMetrics(
+        fund,
+        effectiveFund,
+        companies,
+        config,
+        warnings
+      );
+      currentProjectionStartIndex = usesConstructionProjection
+        ? scaffold.constructionStartIndex + 1
+        : 0;
+    } catch (error) {
+      const fallbackReason = error instanceof Error ? error.message : 'Unknown error';
+      warnings.push(`Projected metrics calculation failed: ${fallbackReason}`);
+      projected = this.getDefaultProjectedMetrics(config);
+      currentProjection = { status: 'fallback_default', fallbackReason };
+    }
+
+    const series = this.buildDualForecastSeries(
+      scaffold.anchoredActual,
+      projected,
+      scaffold.constructionForecast,
+      toDecimal(effectiveFund.size),
+      config,
+      scaffold.constructionStartIndex,
+      currentProjectionStartIndex
+    );
+
+    return {
+      fundId,
+      fundName: fund.name,
+      asOfDate: scaffold.actual.asOfDate,
+      series,
+      sources: {
+        construction: 'construction_forecast_jcurve',
+        current: 'projected_metrics_calculator',
+        actual: 'actual_metrics_calculator',
+      },
+      config: scaffold.metadata,
+      actualsFacts: scaffold.actualsFacts,
+      navAnchoring: scaffold.navAnchoring,
+      currentProjection,
+      warnings,
+    };
+  }
+
+  /** `on` lane: the V2 engine result drives the Current series; PMC never runs. */
+  private async buildV2ServedDualForecast(fundId: number): Promise<DualForecastResponse> {
+    const scaffold = await this.buildDualForecastScaffold(fundId);
+    const forecast = await this.currentForecastServing.runV2(fundId);
+
+    return this.composeV2DualForecast(fundId, scaffold, forecast, {
+      status: 'live',
+      engineStatus: forecast.status,
+      asOfDate: forecast.asOfDate,
+      currentPlanVersionId: forecast.currentPlanVersionId,
+      financialFactsSnapshotId: forecast.financialFactsSnapshotId,
+      inputHash: forecast.inputHash,
+      resultHash: forecast.resultHash,
+      assumptionsHash: forecast.assumptionsHash,
+      engineVersion: forecast.engineVersion,
+      methodologyVersion: forecast.methodologyVersion,
+      unavailableReasons: forecast.unavailableReasons.map((reason) => ({
+        code: reason.code,
+        detail: reason.detail,
+      })),
+      held: null,
+    });
+  }
+
+  /**
+   * `held` lane (P1/D9): serve EXACTLY the pinned served-pointer head with its
+   * ORIGINAL basis/version/hashes from the reference row, the incident reason,
+   * and the age of the pinned result. A missing head throws - the route
+   * returns an error envelope, never the legacy response.
+   */
+  private async buildHeldDualForecast(
+    fundId: number,
+    referenceId: number,
+    reason: DualForecastHeldReason
+  ): Promise<DualForecastResponse> {
+    const scaffold = await this.buildDualForecastScaffold(fundId);
+    const { reference, forecast } = await this.currentForecastServing.loadHeld(fundId, referenceId);
+    const pinnedAtMs = new Date(reference.createdAt).getTime();
+    const ageDays = Math.max(
+      0,
+      Math.floor((this.currentForecastServing.now().getTime() - pinnedAtMs) / 86_400_000)
+    );
+
+    return this.composeV2DualForecast(fundId, scaffold, forecast, {
+      status: 'held',
+      engineStatus: forecast.status,
+      asOfDate: forecast.asOfDate,
+      currentPlanVersionId: String(reference.currentPlanVersionId),
+      financialFactsSnapshotId: String(reference.financialFactsSnapshotId),
+      inputHash: reference.inputHash,
+      resultHash: reference.resultHash,
+      assumptionsHash: reference.assumptionsHash,
+      engineVersion: reference.engineVersion,
+      methodologyVersion: reference.methodologyVersion,
+      unavailableReasons: forecast.unavailableReasons.map((unavailable) => ({
+        code: unavailable.code,
+        detail: unavailable.detail,
+      })),
+      held: { referenceId: reference.id, reason, pinnedAt: reference.createdAt, ageDays },
+    });
+  }
+
+  private composeV2DualForecast(
+    fundId: number,
+    scaffold: DualForecastScaffold,
+    forecast: CurrentForecastV2,
+    currentForecastV2: DualForecastCurrentForecastV2
+  ): DualForecastResponse {
+    const series = this.buildDualForecastSeriesFromV2(
+      scaffold.anchoredActual,
+      forecast,
+      scaffold.constructionForecast,
+      toDecimal(scaffold.effectiveFund.size),
+      scaffold.config,
+      scaffold.constructionStartIndex
+    );
+
+    return {
+      fundId,
+      fundName: scaffold.fund.name,
+      asOfDate: scaffold.actual.asOfDate,
+      series,
+      sources: {
+        construction: 'construction_forecast_jcurve',
+        current: 'current_forecast_v2',
+        actual: 'actual_metrics_calculator',
+      },
+      config: scaffold.metadata,
+      actualsFacts: scaffold.actualsFacts,
+      navAnchoring: scaffold.navAnchoring,
+      currentProjection: { status: 'projected', fallbackReason: null },
+      currentForecastV2,
+      warnings: scaffold.warnings,
+    };
+  }
+
+  /**
+   * The mode-independent dual-forecast inputs: fund, config, actuals, facts,
+   * NAV anchoring, and the construction lane. Extracted verbatim from the
+   * legacy composer; the off-mode byte snapshot pins the extraction.
+   */
+  private async buildDualForecastScaffold(fundId: number): Promise<DualForecastScaffold> {
+    const warnings: string[] = [];
+
+    const fundFromDb = await this.getFundForMetrics(fundId);
+    if (!fundFromDb) {
+      throw this.createError('INSUFFICIENT_DATA', `Fund ${fundId} not found`, 'aggregator');
+    }
+
+    const fund = fundFromDb as MetricsFund;
+    const companiesFromDb = await storage.getPortfolioCompanies(fundId);
+    const companies = companiesFromDb as MetricsPortfolioCompany[];
+    const { config, warnings: configWarnings, metadata } = await this.resolveFundConfig(fundId);
+    warnings.push(...configWarnings);
+
+    const effectiveFund: MetricsFund =
+      config.fundSizeOverride != null ? { ...fund, size: String(config.fundSizeOverride) } : fund;
+
+    const actual = await this.actualCalculator.calculate(fundId);
+    const actualsFacts = await this.fetchActualsFactsBlock(fundId, actual.asOfDate, warnings);
+    // PR-2 blend (ADR-029/030/032): a null facts block means no blend - the
+    // series keeps the legacy calculator NAV, disclosed via warnings.
+    const navAnchoring = this.buildNavAnchoring(companies, actualsFacts);
+    const anchoredActual = navAnchoring ? this.applyNavAnchoring(actual, navAnchoring) : actual;
+    const constructionStartIndex = this.getElapsedQuarterIndex(
+      effectiveFund.establishmentDate ?? effectiveFund.createdAt,
+      actual.asOfDate
+    );
+    const constructionForecast = this.buildConstructionForecast(effectiveFund, config);
+
+    return {
+      fund,
+      effectiveFund,
+      companies,
+      config,
+      metadata,
+      warnings,
+      actual,
+      actualsFacts,
+      navAnchoring,
+      anchoredActual,
+      constructionStartIndex,
+      constructionForecast,
+    };
   }
 
   /**
@@ -782,6 +991,86 @@ export class MetricsAggregator {
         variance: this.mapVariance(current, construction),
       };
     });
+  }
+
+  /**
+   * Task 13.2 sibling of {@link buildDualForecastSeries}: the Current lane
+   * comes from the V2 forecast's projected points (quarterly, cumulative
+   * money, point-in-time NAV) mapped in order onto quarters 1..N after the
+   * as-of quarter. Quarter 0 stays the as-of actual, exactly as the legacy
+   * builder does; the construction lane and variance reuse the same mappers.
+   */
+  private buildDualForecastSeriesFromV2(
+    actual: ActualMetrics,
+    forecast: CurrentForecastV2,
+    constructionForecast: ConstructionForecast,
+    fundSize: ReturnType<typeof toDecimal>,
+    config: MetricsFundConfig,
+    constructionStartIndex: number
+  ): DualForecastPoint[] {
+    const constructionLength = Math.min(
+      constructionForecast.jCurvePath.nav.length,
+      constructionForecast.jCurvePath.tvpi.length,
+      constructionForecast.jCurvePath.calls.length
+    );
+    const projectedPoints = forecast.series.filter((point) => point.source === 'projected');
+    const constructionRemainingLength = Math.max(1, constructionLength - constructionStartIndex);
+    const horizon = Math.max(1, Math.min(constructionRemainingLength, projectedPoints.length + 1));
+    const netIrr = forecast.netIrr === null ? null : Number(forecast.netIrr);
+
+    return Array.from({ length: horizon }, (_, quarterIndex) => {
+      const actualPoint = quarterIndex === 0 ? this.mapActualMetrics(actual) : null;
+      const construction = this.mapConstructionMetrics(
+        constructionForecast,
+        fundSize,
+        config,
+        constructionStartIndex + quarterIndex
+      );
+      const current =
+        actualPoint ?? this.mapV2PointMetrics(projectedPoints[quarterIndex - 1], netIrr);
+
+      return {
+        quarterIndex,
+        label: quarterIndex === 0 ? 'As of' : `Q+${quarterIndex}`,
+        date: this.addQuarters(actual.asOfDate, quarterIndex),
+        construction,
+        actual: actualPoint,
+        currentMode: quarterIndex === 0 ? ('actual' as const) : ('forecast' as const),
+        current,
+        variance: this.mapVariance(current, construction),
+      };
+    });
+  }
+
+  private mapV2PointMetrics(
+    point: CurrentForecastSeriesPointV1 | undefined,
+    netIrr: number | null
+  ): DualForecastMetrics {
+    if (!point) {
+      // Unreachable: the horizon caps at projectedPoints.length + 1.
+      return {
+        nav: 0,
+        calledCapital: 0,
+        distributions: 0,
+        tvpi: null,
+        dpi: null,
+        rvpi: null,
+        irr: netIrr,
+      };
+    }
+
+    const nav = Number(point.navUsd);
+    const calledCapital = Number(point.contributionsUsd);
+    const distributions = Number(point.distributionsUsd);
+    return {
+      nav,
+      calledCapital,
+      distributions,
+      tvpi: Number(point.tvpi),
+      dpi: Number(point.dpi),
+      rvpi: this.safeRatio(nav, calledCapital),
+      irr: netIrr,
+    };
   }
 
   /**

--- a/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
+++ b/shared/contracts/dual-forecast/dual-forecast-response.contract.ts
@@ -14,8 +14,12 @@ import {
  * freshness window is the disclosed 60s HTTP/client pair. If a later slice
  * adds server-side caching, the cache key MUST embed this constant so shape
  * changes and key bumps land in the same diff.
+ *
+ * Version 2 (PLAN_61 Task 13.2): optional `currentForecastV2` block plus the
+ * `current_forecast_v2` source. Absent block == legacy serving (off/shadow),
+ * keeping the version-1 payload byte-identical.
  */
-export const DUAL_FORECAST_CONTRACT_VERSION = 1;
+export const DUAL_FORECAST_CONTRACT_VERSION = 2;
 
 const PositiveIdSchema = z.number().int().positive();
 const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
@@ -41,7 +45,9 @@ export const DualForecastConfigMetadataSchema = z
 export const DualForecastSourceMetadataSchema = z
   .object({
     construction: z.literal('construction_forecast_jcurve'),
-    current: z.literal('projected_metrics_calculator'),
+    // Task 13.2: `current_forecast_v2` when the resolved mode serves V2 live
+    // or held; the legacy literal remains the off/shadow (dormant) value.
+    current: z.enum(['projected_metrics_calculator', 'current_forecast_v2']),
     actual: z.literal('actual_metrics_calculator'),
   })
   .strict();
@@ -199,6 +205,57 @@ export const DualForecastCurrentProjectionSchema = z
   })
   .strict();
 
+/**
+ * Task 13.2 (R24/D9): why the current-forecast plane is serving the pinned
+ * reference instead of a live V2 run. `kill_switch`/`configured_off`/
+ * `configured_shadow` are the post-cutover resolver states that must never
+ * re-enter legacy; `v2_runtime_failure` is the on-lane degrade.
+ */
+export const DualForecastHeldReasonSchema = z.enum([
+  'kill_switch',
+  'configured_off',
+  'configured_shadow',
+  'v2_runtime_failure',
+]);
+
+/** Held disclosure: the served-pointer head (P1), its incident reason, and
+ * the age of the pinned result - the display triple the plan requires. */
+export const DualForecastCurrentForecastHeldSchema = z
+  .object({
+    referenceId: PositiveIdSchema,
+    reason: DualForecastHeldReasonSchema,
+    /** `created_at` of the pinned reference row (when the result was produced). */
+    pinnedAt: z.string().datetime(),
+    ageDays: z.number().int().nonnegative(),
+  })
+  .strict();
+
+/**
+ * Governed current-forecast serving block (PLAN_61 Task 13.2). Present ONLY
+ * when the resolved mode serves V2 (`live`) or the pinned reference (`held`);
+ * absent in off/shadow so the legacy response stays byte-identical. Basis
+ * identifiers and hashes are the ORIGINAL values of the served result -
+ * for `held` that is the pinned reference's basis, not a recompute.
+ */
+export const DualForecastCurrentForecastV2Schema = z
+  .object({
+    status: z.enum(['live', 'held']),
+    engineStatus: z.enum(['available', 'indicative', 'unavailable', 'failed', 'held']),
+    asOfDate: IsoDateSchema,
+    currentPlanVersionId: z.string().min(1),
+    financialFactsSnapshotId: z.string().min(1),
+    inputHash: Sha256Schema,
+    resultHash: Sha256Schema.nullable(),
+    assumptionsHash: Sha256Schema,
+    engineVersion: z.string().min(1),
+    methodologyVersion: z.string().min(1),
+    unavailableReasons: z.array(
+      z.object({ code: z.string().min(1), detail: z.string().min(1) }).strict()
+    ),
+    held: DualForecastCurrentForecastHeldSchema.nullable(),
+  })
+  .strict();
+
 export const DualForecastResponseSchema = z
   .object({
     fundId: PositiveIdSchema,
@@ -210,6 +267,7 @@ export const DualForecastResponseSchema = z
     actualsFacts: DualForecastActualsFactsSchema.nullable(),
     navAnchoring: DualForecastNavAnchoringSchema.nullable(),
     currentProjection: DualForecastCurrentProjectionSchema,
+    currentForecastV2: DualForecastCurrentForecastV2Schema.optional(),
     warnings: z.array(z.string()),
   })
   .strict();
@@ -227,4 +285,7 @@ export type DualForecastTrustCounts = z.infer<typeof DualForecastTrustCountsSche
 export type DualForecastNavAnchorCompany = z.infer<typeof DualForecastNavAnchorCompanySchema>;
 export type DualForecastNavAnchoring = z.infer<typeof DualForecastNavAnchoringSchema>;
 export type DualForecastCurrentProjection = z.infer<typeof DualForecastCurrentProjectionSchema>;
+export type DualForecastHeldReason = z.infer<typeof DualForecastHeldReasonSchema>;
+export type DualForecastCurrentForecastHeld = z.infer<typeof DualForecastCurrentForecastHeldSchema>;
+export type DualForecastCurrentForecastV2 = z.infer<typeof DualForecastCurrentForecastV2Schema>;
 export type DualForecastResponse = z.infer<typeof DualForecastResponseSchema>;

--- a/shared/types/metrics.ts
+++ b/shared/types/metrics.ts
@@ -364,7 +364,13 @@ export interface UnifiedFundMetrics {
  */
 export interface MetricsCalculationError {
   /** Error code for programmatic handling */
-  code: 'INSUFFICIENT_DATA' | 'CALCULATION_FAILED' | 'ENGINE_ERROR' | 'CACHE_ERROR';
+  code:
+    | 'INSUFFICIENT_DATA'
+    | 'CALCULATION_FAILED'
+    | 'ENGINE_ERROR'
+    | 'CACHE_ERROR'
+    /** Task 13.2: held serving found no pointer head - error envelope, never legacy. */
+    | 'HELD_REFERENCE_MISSING';
 
   /** Human-readable error message */
   message: string;

--- a/tests/helpers/database-mock.ts
+++ b/tests/helpers/database-mock.ts
@@ -1027,6 +1027,9 @@ class DatabaseMock {
       users: createTableQuery('users'),
       investments: createTableQuery('investments'),
       investmentLots: createTableQuery('investment_lots'),
+      // Task 13.2: the current-forecast serving dispatch reads the per-key
+      // mode row on every dual-forecast request; unseeded funds resolve `off`.
+      fundCalculationModes: createTableQuery('fund_calculation_modes'),
     };
   }
 

--- a/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
+++ b/tests/unit/components/dashboard/dual-forecast-dashboard.test.tsx
@@ -699,6 +699,79 @@ describe('DualForecastDashboard', () => {
     expect(screen.getByText(/reason: projection engine timeout/i)).toBeInTheDocument();
   });
 
+  it('shows the held-forecast notice with the incident reason and age (Task 13.2)', async () => {
+    setActiveFundContext();
+    const payload = {
+      ...makePopulatedDualForecast(),
+      sources: {
+        construction: 'construction_forecast_jcurve',
+        current: 'current_forecast_v2',
+        actual: 'actual_metrics_calculator',
+      },
+      currentForecastV2: {
+        status: 'held',
+        engineStatus: 'available',
+        asOfDate: '2026-03-31',
+        currentPlanVersionId: '21',
+        financialFactsSnapshotId: '31',
+        inputHash: 'a'.repeat(64),
+        resultHash: 'b'.repeat(64),
+        assumptionsHash: 'c'.repeat(64),
+        engineVersion: 'current-forecast-v2-engine/1.0.0',
+        methodologyVersion: 'cohort-projection-v2/1.0.0',
+        unavailableReasons: [],
+        held: {
+          referenceId: 41,
+          reason: 'kill_switch',
+          pinnedAt: '2026-07-01T00:00:00.000Z',
+          ageDays: 21,
+        },
+      },
+    };
+    // Fixture guard: the ingress parse in useDualForecast must accept this.
+    expect(DualForecastResponseSchema.parse(payload)).toEqual(payload);
+    stubFetch({ forecast: { body: payload } });
+
+    renderWithQueryClient();
+
+    expect(await screen.findByText('Current forecast is held')).toBeInTheDocument();
+    expect(screen.getByText(/the calculation kill switch is active/i)).toBeInTheDocument();
+    expect(screen.getByText(/pinned 21 days ago/i)).toBeInTheDocument();
+  });
+
+  it('renders no held notice for a live V2 serving (Task 13.2)', async () => {
+    setActiveFundContext();
+    const payload = {
+      ...makePopulatedDualForecast(),
+      sources: {
+        construction: 'construction_forecast_jcurve',
+        current: 'current_forecast_v2',
+        actual: 'actual_metrics_calculator',
+      },
+      currentForecastV2: {
+        status: 'live',
+        engineStatus: 'available',
+        asOfDate: '2026-03-31',
+        currentPlanVersionId: '21',
+        financialFactsSnapshotId: '31',
+        inputHash: 'a'.repeat(64),
+        resultHash: 'b'.repeat(64),
+        assumptionsHash: 'c'.repeat(64),
+        engineVersion: 'current-forecast-v2-engine/1.0.0',
+        methodologyVersion: 'cohort-projection-v2/1.0.0',
+        unavailableReasons: [],
+        held: null,
+      },
+    };
+    expect(DualForecastResponseSchema.parse(payload)).toEqual(payload);
+    stubFetch({ forecast: { body: payload } });
+
+    renderWithQueryClient();
+
+    expect(await screen.findByText('Fund Value Forecast')).toBeInTheDocument();
+    expect(screen.queryByText('Current forecast is held')).toBeNull();
+  });
+
   it('shows fallback copy for a null fallbackReason without rendering the word null', async () => {
     setActiveFundContext();
     const payload = {

--- a/tests/unit/lib/dual-forecast-display.test.ts
+++ b/tests/unit/lib/dual-forecast-display.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   DualForecastActualsFactsSchema,
+  DualForecastCurrentForecastV2Schema,
   DualForecastNavAnchoringSchema,
   DualForecastPointSchema,
   type DualForecastActualsFacts,
   type DualForecastActualsFactsCompany,
+  type DualForecastCurrentForecastV2,
   type DualForecastNavAnchorCompany,
   type DualForecastNavAnchoring,
   type DualForecastPoint,
@@ -15,7 +17,11 @@ import {
   buildAttributionRows,
   buildAttributionSummary,
   buildForecastChartPoints,
+  buildHeldNotice,
   countNoFactsRows,
+  CURRENT_FORECAST_HELD_NOTICE_COPY,
+  formatHeldAge,
+  HELD_REASON_COPY,
   describeDriftDirection,
   filterAttributionRows,
   formatChipAriaLabel,
@@ -654,5 +660,78 @@ describe('disclosure formatters', () => {
     expect(formatFilterStatus(3, 12)).toBe('Showing 3 of 12 companies');
     expect(formatChipAriaLabel(9, 'PARTIAL')).toBe('Filter to 9 partial companies');
     expect(formatChipAriaLabel(2, 'NO_FACTS')).toBe('Filter to 2 no facts companies');
+  });
+});
+
+// ── Held current-forecast disclosure (PLAN_61 Task 13.2) ──
+
+function currentForecastV2Block(
+  overrides: Partial<DualForecastCurrentForecastV2> = {}
+): DualForecastCurrentForecastV2 {
+  return DualForecastCurrentForecastV2Schema.parse({
+    status: 'held',
+    engineStatus: 'available',
+    asOfDate: '2026-03-31',
+    currentPlanVersionId: '21',
+    financialFactsSnapshotId: '31',
+    inputHash: 'a'.repeat(64),
+    resultHash: 'b'.repeat(64),
+    assumptionsHash: 'c'.repeat(64),
+    engineVersion: 'current-forecast-v2-engine/1.0.0',
+    methodologyVersion: 'cohort-projection-v2/1.0.0',
+    unavailableReasons: [],
+    held: {
+      referenceId: 41,
+      reason: 'kill_switch',
+      pinnedAt: '2026-07-01T00:00:00.000Z',
+      ageDays: 21,
+    },
+    ...overrides,
+  });
+}
+
+describe('formatHeldAge', () => {
+  it('formats today, one day, and n days', () => {
+    expect(formatHeldAge(0)).toBe('Pinned today');
+    expect(formatHeldAge(1)).toBe('Pinned 1 day ago');
+    expect(formatHeldAge(21)).toBe('Pinned 21 days ago');
+  });
+});
+
+describe('buildHeldNotice', () => {
+  it('returns null when the block is absent or serving live', () => {
+    expect(buildHeldNotice(undefined)).toBeNull();
+    expect(buildHeldNotice(currentForecastV2Block({ status: 'live', held: null }))).toBeNull();
+  });
+
+  it('composes headline, typed reason copy, and age for a held block', () => {
+    const notice = buildHeldNotice(currentForecastV2Block());
+
+    expect(notice).toEqual({
+      headline: CURRENT_FORECAST_HELD_NOTICE_COPY.headline,
+      body: CURRENT_FORECAST_HELD_NOTICE_COPY.body,
+      reason: HELD_REASON_COPY.kill_switch,
+      age: 'Pinned 21 days ago',
+      escalation: CURRENT_FORECAST_HELD_NOTICE_COPY.escalation,
+    });
+  });
+
+  it('maps every held reason to distinct disclosure copy', () => {
+    const reasons = [
+      'kill_switch',
+      'configured_off',
+      'configured_shadow',
+      'v2_runtime_failure',
+    ] as const;
+    const copies = reasons.map((reason) => {
+      const notice = buildHeldNotice(
+        currentForecastV2Block({
+          held: { referenceId: 41, reason, pinnedAt: '2026-07-01T00:00:00.000Z', ageDays: 3 },
+        })
+      );
+      expect(notice?.reason).toBe(HELD_REASON_COPY[reason]);
+      return notice?.reason;
+    });
+    expect(new Set(copies).size).toBe(reasons.length);
   });
 });

--- a/tests/unit/pages/fund-model-results/readiness-rollup.test.tsx
+++ b/tests/unit/pages/fund-model-results/readiness-rollup.test.tsx
@@ -67,6 +67,39 @@ function dualForecastFixture(overrides: Partial<DualForecastResponse> = {}): Dua
   });
 }
 
+// ── Task 13.2 governed current-forecast serving fixtures ──
+
+function v2Sources() {
+  return {
+    construction: 'construction_forecast_jcurve',
+    current: 'current_forecast_v2',
+    actual: 'actual_metrics_calculator',
+  } as const;
+}
+
+function currentForecastV2Block(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'held',
+    engineStatus: 'available',
+    asOfDate: '2026-03-31',
+    currentPlanVersionId: '21',
+    financialFactsSnapshotId: '31',
+    inputHash: 'c'.repeat(64),
+    resultHash: 'd'.repeat(64),
+    assumptionsHash: 'e'.repeat(64),
+    engineVersion: 'current-forecast-v2-engine/1.0.0',
+    methodologyVersion: 'cohort-projection-v2/1.0.0',
+    unavailableReasons: [],
+    held: {
+      referenceId: 41,
+      reason: 'kill_switch',
+      pinnedAt: '2026-07-01T00:00:00.000Z',
+      ageDays: 21,
+    },
+    ...overrides,
+  };
+}
+
 function moicRanking(
   rank: number,
   rankability: 'actionable' | 'indicative' | 'not_actionable' | null,
@@ -480,6 +513,134 @@ describe('forecast row', () => {
 
     expect(row.state).toBe('not_actionable');
     expect(row.details).toEqual(['projection warning']);
+  });
+
+  it('a held current forecast fails closed with the incident reason and age (Task 13.2)', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          sources: v2Sources(),
+          currentForecastV2: currentForecastV2Block(),
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Held');
+    expect(row.primaryReason).toBe(
+      'Current forecast is held — The calculation kill switch is active.'
+    );
+    expect(row.blockedSummary).toBe('Pinned 21 days ago');
+    expect(row.asOfDate).toBe('2026-03-31');
+  });
+
+  it('held precedence beats every downstream facts check (Task 13.2)', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          sources: v2Sources(),
+          currentForecastV2: currentForecastV2Block({
+            held: {
+              referenceId: 41,
+              reason: 'v2_runtime_failure',
+              pinnedAt: '2026-07-01T00:00:00.000Z',
+              ageDays: 0,
+            },
+          }),
+          actualsFacts: null,
+          navAnchoring: null,
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('not_actionable');
+    expect(row.stateLabel).toBe('Held');
+    expect(row.primaryReason).toBe(
+      'Current forecast is held — The live calculation failed when this response was served.'
+    );
+    expect(row.blockedSummary).toBe('Pinned today');
+  });
+
+  it('a live V2 serving with engine status unavailable or failed is not decision-grade (Task 13.2)', () => {
+    const unavailable = rowByKey(
+      baseInputs({
+        forecast: data(
+          dualForecastFixture({
+            sources: v2Sources(),
+            currentForecastV2: currentForecastV2Block({
+              status: 'live',
+              held: null,
+              engineStatus: 'unavailable',
+              unavailableReasons: [
+                { code: 'FACTS_UNAVAILABLE', detail: 'No facts snapshot exists for this fund' },
+              ],
+            }),
+          })
+        ),
+      }),
+      'forecast'
+    );
+    expect(unavailable.state).toBe('not_actionable');
+    expect(unavailable.primaryReason).toBe(
+      'Current forecast unavailable — No facts snapshot exists for this fund'
+    );
+
+    const failed = rowByKey(
+      baseInputs({
+        forecast: data(
+          dualForecastFixture({
+            sources: v2Sources(),
+            currentForecastV2: currentForecastV2Block({
+              status: 'live',
+              held: null,
+              engineStatus: 'failed',
+            }),
+          })
+        ),
+      }),
+      'forecast'
+    );
+    expect(failed.state).toBe('not_actionable');
+    expect(failed.primaryReason).toBe('Current forecast unavailable');
+  });
+
+  it('a live indicative V2 serving reads at most indicative (Task 13.2)', () => {
+    const inputs = baseInputs({
+      forecast: data(
+        dualForecastFixture({
+          sources: v2Sources(),
+          currentForecastV2: currentForecastV2Block({
+            status: 'live',
+            held: null,
+            engineStatus: 'indicative',
+          }),
+        })
+      ),
+    });
+    const row = rowByKey(inputs, 'forecast');
+
+    expect(row.state).toBe('indicative');
+    expect(row.primaryReason).toBe('Current forecast is indicative');
+  });
+
+  it('a live available V2 serving keeps the existing facts-driven derivation (Task 13.2)', () => {
+    const withBlock = rowByKey(
+      baseInputs({
+        forecast: data(
+          dualForecastFixture({
+            sources: v2Sources(),
+            currentForecastV2: currentForecastV2Block({ status: 'live', held: null }),
+          })
+        ),
+      }),
+      'forecast'
+    );
+    const baseline = rowByKey(baseInputs(), 'forecast');
+
+    expect(withBlock.state).toBe(baseline.state);
+    expect(withBlock.primaryReason).toBe(baseline.primaryReason);
   });
 
   it('fails the empty facts universe closed (all-zero pinned UNAVAILABLE, AMENDMENT 8; F3)', () => {

--- a/tests/unit/routes/dual-forecast-route.test.ts
+++ b/tests/unit/routes/dual-forecast-route.test.ts
@@ -78,6 +78,48 @@ describe('dual forecast route', () => {
     expect(DualForecastResponseSchema.parse(payload)).toEqual(payload);
   });
 
+  it('accepts V2-served and held payloads under the bumped contract (Task 13.2 fixture guard)', () => {
+    const block = {
+      status: 'live',
+      engineStatus: 'available',
+      asOfDate: '2026-03-31',
+      currentPlanVersionId: '21',
+      financialFactsSnapshotId: '31',
+      inputHash: 'a'.repeat(64),
+      resultHash: 'b'.repeat(64),
+      assumptionsHash: 'c'.repeat(64),
+      engineVersion: 'current-forecast-v2-engine/1.0.0',
+      methodologyVersion: 'cohort-projection-v2/1.0.0',
+      unavailableReasons: [],
+      held: null,
+    };
+    const livePayload = {
+      ...dualForecastPayload(),
+      sources: {
+        construction: 'construction_forecast_jcurve',
+        current: 'current_forecast_v2',
+        actual: 'actual_metrics_calculator',
+      },
+      currentForecastV2: block,
+    };
+    expect(DualForecastResponseSchema.parse(livePayload)).toEqual(livePayload);
+
+    const heldPayload = {
+      ...livePayload,
+      currentForecastV2: {
+        ...block,
+        status: 'held',
+        held: {
+          referenceId: 41,
+          reason: 'kill_switch',
+          pinnedAt: '2026-07-01T00:00:00.000Z',
+          ageDays: 21,
+        },
+      },
+    };
+    expect(DualForecastResponseSchema.parse(heldPayload)).toEqual(heldPayload);
+  });
+
   it('returns the dual forecast for an authorized fund request', async () => {
     const response = await request(makeApp()).get('/api/funds/12/dual-forecast').expect(200);
 
@@ -133,6 +175,27 @@ describe('dual forecast route', () => {
     expect(response.body).toMatchObject({
       error: 'CONTRACT_VIOLATION',
       message: 'Dual forecast response failed contract validation',
+    });
+  });
+
+  it('a missing held pointer head returns an error envelope, never the legacy response', async () => {
+    // Task 13.2 (D9): the aggregator surfaces HELD_REFERENCE_MISSING when the
+    // pinned reference cannot be served; the route must emit the standard
+    // error envelope through the metrics-error branch - not fall back.
+    getDualForecastMock.mockRejectedValue({
+      code: 'HELD_REFERENCE_MISSING',
+      message: 'current-forecast reference 41 not found for fund 12',
+      component: 'aggregator',
+      timestamp: '2026-07-22T00:00:00.000Z',
+    });
+
+    const response = await request(makeApp()).get('/api/funds/12/dual-forecast').expect(500);
+
+    expect(response.body).toEqual({
+      error: 'HELD_REFERENCE_MISSING',
+      message: 'current-forecast reference 41 not found for fund 12',
+      component: 'aggregator',
+      timestamp: '2026-07-22T00:00:00.000Z',
     });
   });
 

--- a/tests/unit/services/__snapshots__/metrics-aggregator-dual-forecast.test.ts.snap
+++ b/tests/unit/services/__snapshots__/metrics-aggregator-dual-forecast.test.ts.snap
@@ -1,0 +1,186 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MetricsAggregator dual forecast > current-forecast serving modes (PLAN_61 Task 13.2) > off: the response is byte-identical to the legacy composer when no mode row exists 1`] = `
+"{
+  "fundId": 1,
+  "fundName": "Dual Forecast Fund",
+  "asOfDate": "2026-04-01T00:00:00.000Z",
+  "series": [
+    {
+      "quarterIndex": 0,
+      "label": "As of",
+      "date": "2026-04-01T00:00:00.000Z",
+      "construction": {
+        "nav": 47500000,
+        "calledCapital": 50000000,
+        "distributions": 0,
+        "tvpi": 0.95,
+        "dpi": 0,
+        "rvpi": 0.95,
+        "irr": 0.22
+      },
+      "actual": {
+        "nav": 30000000,
+        "calledCapital": 25000000,
+        "distributions": 2000000,
+        "tvpi": 1.28,
+        "dpi": 0.08,
+        "rvpi": 1.2,
+        "irr": 0.14
+      },
+      "currentMode": "actual",
+      "current": {
+        "nav": 30000000,
+        "calledCapital": 25000000,
+        "distributions": 2000000,
+        "tvpi": 1.28,
+        "dpi": 0.08,
+        "rvpi": 1.2,
+        "irr": 0.14
+      },
+      "variance": {
+        "nav": -17500000,
+        "calledCapital": -25000000,
+        "distributions": 2000000,
+        "tvpi": 0.33000000000000007,
+        "dpi": 0.08,
+        "rvpi": 0.25,
+        "irr": -0.07999999999999999
+      }
+    },
+    {
+      "quarterIndex": 1,
+      "label": "Q+1",
+      "date": "2026-07-01T00:00:00.000Z",
+      "construction": {
+        "nav": 52250000,
+        "calledCapital": 55000000,
+        "distributions": 0,
+        "tvpi": 0.95,
+        "dpi": 0,
+        "rvpi": 0.95,
+        "irr": 0.22
+      },
+      "actual": null,
+      "currentMode": "forecast",
+      "current": {
+        "nav": 36000000,
+        "calledCapital": 30000000,
+        "distributions": 3000000,
+        "tvpi": 1.3,
+        "dpi": 0.1,
+        "rvpi": 1.2,
+        "irr": 0.22
+      },
+      "variance": {
+        "nav": -16250000,
+        "calledCapital": -25000000,
+        "distributions": 3000000,
+        "tvpi": 0.3500000000000001,
+        "dpi": 0.1,
+        "rvpi": 0.25,
+        "irr": 0
+      }
+    },
+    {
+      "quarterIndex": 2,
+      "label": "Q+2",
+      "date": "2026-10-01T00:00:00.000Z",
+      "construction": {
+        "nav": 59363771.005187295,
+        "calledCapital": 60000000,
+        "distributions": 0,
+        "tvpi": 0.95,
+        "dpi": 0,
+        "rvpi": 0.9893961834197883,
+        "irr": 0.22
+      },
+      "actual": null,
+      "currentMode": "forecast",
+      "current": {
+        "nav": 44000000,
+        "calledCapital": 36000000,
+        "distributions": 5000000,
+        "tvpi": 1.3611111111111112,
+        "dpi": 0.1388888888888889,
+        "rvpi": 1.2222222222222223,
+        "irr": 0.22
+      },
+      "variance": {
+        "nav": -15363771.005187295,
+        "calledCapital": -24000000,
+        "distributions": 5000000,
+        "tvpi": 0.4111111111111112,
+        "dpi": 0.1388888888888889,
+        "rvpi": 0.23282603880243402,
+        "irr": 0
+      }
+    }
+  ],
+  "sources": {
+    "construction": "construction_forecast_jcurve",
+    "current": "projected_metrics_calculator",
+    "actual": "actual_metrics_calculator"
+  },
+  "config": {
+    "source": "published",
+    "version": 4,
+    "publishedAt": "2026-03-01T00:00:00.000Z",
+    "fallbackReason": null
+  },
+  "actualsFacts": {
+    "asOfDate": "2026-04-01",
+    "generatedAt": "2026-04-01T00:00:00.000Z",
+    "inputHash": "55ac3ae6700ef7021a5b9216b530de8f0faef40f5e672a00fc62e2d259f7d497",
+    "companies": [
+      {
+        "companyId": 10,
+        "companyName": "Northstar AI",
+        "trustState": "LIVE",
+        "planningFmvStatus": "active",
+        "currency": "USD",
+        "currencyStatus": "base_currency",
+        "activeRoundIds": [
+          5
+        ],
+        "supersedeLineage": [
+          {
+            "roundId": 5,
+            "supersedesRoundId": null
+          }
+        ],
+        "latestRoundDate": "2026-01-15",
+        "latestRoundValuation": "120000000.000000",
+        "latestPlanningFmvDate": "2026-03-01",
+        "latestPlanningFmvValue": "30000000.000000",
+        "warnings": []
+      }
+    ],
+    "warnings": []
+  },
+  "navAnchoring": {
+    "blendedNav": "30000000.000000",
+    "countsByTrustState": {
+      "LIVE": 1,
+      "PARTIAL": 0,
+      "UNAVAILABLE": 0,
+      "FAILED": 0
+    },
+    "companies": [
+      {
+        "companyId": 10,
+        "companyName": "Northstar AI",
+        "inNavUniverse": true,
+        "trustState": "LIVE",
+        "anchor": "planning_fmv",
+        "contribution": "30000000.000000"
+      }
+    ]
+  },
+  "currentProjection": {
+    "status": "projected",
+    "fallbackReason": null
+  },
+  "warnings": []
+}"
+`;

--- a/tests/unit/services/current-forecast-activation-gate.test.ts
+++ b/tests/unit/services/current-forecast-activation-gate.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Task 13 activation-ready gate assertions (PLAN_61, falsifiable per 13.2).
+ *
+ * This file pins gate item 1: the global flag exists, defaults OFF in every
+ * environment, and is never exposed to the client (the client reacts to the
+ * dual-forecast response shape only). The remaining gate items are pinned
+ * elsewhere and deliberately not duplicated here:
+ * - held-state map + kill switch on both sides of cutover:
+ *   tests/unit/services/current-forecast-calc-mode-resolver.test.ts
+ * - PMC never invoked post-cutover at the consumer level:
+ *   tests/unit/services/metrics-aggregator-dual-forecast.test.ts
+ * - replay corpus green per the three D1 criteria:
+ *   tests/unit/services/current-forecast-shadow-service.test.ts
+ *
+ * Actual flag and mode VALUES stay unchanged - this suite only proves the
+ * dormant posture is what the plan says it is.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+type FlagEntry = {
+  default: boolean;
+  description: string;
+  owner: string;
+  risk: string;
+  exposeToClient: boolean;
+  environments: Record<string, boolean>;
+  dependencies: unknown[];
+};
+
+async function loadRegistry(): Promise<Record<string, FlagEntry>> {
+  // The shared node setup mocks fs; go through the real module for this scan.
+  const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs');
+  const raw = readFileSync(join(process.cwd(), 'flags', 'registry.yaml'), 'utf8');
+  // Registry shape: { schema_version, flags: { <name>: entry }, deprecated }.
+  return (parse(raw) as { flags: Record<string, FlagEntry> }).flags;
+}
+
+describe('current-forecast activation gate: flag posture', () => {
+  it('enable_current_forecast_v2 exists, defaults off everywhere, and is server-only', async () => {
+    const registry = await loadRegistry();
+    const flag = registry['enable_current_forecast_v2'];
+
+    expect(flag).toBeDefined();
+    expect(flag?.default).toBe(false);
+    expect(flag?.exposeToClient).toBe(false);
+    expect(flag?.risk).toBe('high');
+    expect(flag?.environments).toEqual({
+      development: false,
+      staging: false,
+      production: false,
+    });
+  });
+});

--- a/tests/unit/services/current-forecast-calc-mode-resolver.test.ts
+++ b/tests/unit/services/current-forecast-calc-mode-resolver.test.ts
@@ -99,7 +99,7 @@ describe('resolveCurrentForecastModeResolution (R24/D9 held-state map)', () => {
         1,
         reader({ configuredMode: 'on', killSwitchActive: true, ...POST })
       )
-    ).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+    ).toEqual({ mode: 'held', cutoverReferenceId: 41, heldReason: 'kill_switch' });
   });
 
   it('post-cutover configured off resolves held', async () => {
@@ -108,7 +108,7 @@ describe('resolveCurrentForecastModeResolution (R24/D9 held-state map)', () => {
         1,
         reader({ configuredMode: 'off', killSwitchActive: false, ...POST })
       )
-    ).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+    ).toEqual({ mode: 'held', cutoverReferenceId: 41, heldReason: 'configured_off' });
   });
 
   it('post-cutover configured shadow resolves held', async () => {
@@ -117,7 +117,7 @@ describe('resolveCurrentForecastModeResolution (R24/D9 held-state map)', () => {
         1,
         reader({ configuredMode: 'shadow', killSwitchActive: false, ...POST })
       )
-    ).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+    ).toEqual({ mode: 'held', cutoverReferenceId: 41, heldReason: 'configured_shadow' });
   });
 
   it('held serves the served-pointer head from the mode row, not any other lookup', async () => {
@@ -130,7 +130,12 @@ describe('resolveCurrentForecastModeResolution (R24/D9 held-state map)', () => {
 
     const resolution = await resolveCurrentForecastModeResolution(1, modeReader);
 
-    expect(resolution).toEqual({ mode: 'held', cutoverReferenceId: 41 });
+    // Kill wins the reason ordering when both kill and configured-off apply.
+    expect(resolution).toEqual({
+      mode: 'held',
+      cutoverReferenceId: 41,
+      heldReason: 'kill_switch',
+    });
     expect(modeReader).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/services/current-forecast-held-service.test.ts
+++ b/tests/unit/services/current-forecast-held-service.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ENGINE_VERSION,
+  METHODOLOGY_VERSION,
+} from '../../../shared/contracts/current-forecast-v2.contract';
+import {
+  CurrentForecastHeldError,
+  loadHeldCurrentForecast,
+  type CurrentForecastHeldDatabase,
+} from '../../../server/services/current-forecast-held-service';
+
+const INPUT_HASH = 'a'.repeat(64);
+const RESULT_HASH = 'b'.repeat(64);
+const ASSUMPTIONS_HASH = 'c'.repeat(64);
+
+function referenceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 41,
+    fund_id: 7,
+    calculation_key: 'current_forecast',
+    fund_snapshot_id: 11,
+    current_plan_version_id: 21,
+    financial_facts_snapshot_id: 31,
+    input_hash: INPUT_HASH,
+    result_hash: RESULT_HASH,
+    assumptions_hash: ASSUMPTIONS_HASH,
+    engine_version: ENGINE_VERSION,
+    methodology_version: METHODOLOGY_VERSION,
+    candidate: false,
+    superseded_by_reference_id: null,
+    reason: null,
+    created_by: null,
+    request_hash: 'unused',
+    created_at: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function v2Payload(overrides: Record<string, unknown> = {}) {
+  return {
+    contractVersion: 'current-forecast-v2',
+    fundId: 7,
+    financialFactsSnapshotId: '31',
+    currentPlanVersionId: '21',
+    asOfDate: '2026-06-30',
+    status: 'available',
+    series: [],
+    remainingDeployableCapitalUsd: '1000000.000000',
+    committedCapitalUsd: '90000000.000000',
+    calledToDateUsd: '25000000.000000',
+    projectedFeesRemainingUsd: '2000000.000000',
+    recallableDistributionsUsd: '0.000000',
+    uncalledCapitalUsd: '65000000.000000',
+    netIrr: null,
+    inputHash: INPUT_HASH,
+    assumptionsHash: ASSUMPTIONS_HASH,
+    resultHash: RESULT_HASH,
+    engineVersion: ENGINE_VERSION,
+    methodologyVersion: METHODOLOGY_VERSION,
+    unavailableReasons: [],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function snapshotRow(overrides: Record<string, unknown> = {}) {
+  return {
+    payload: v2Payload(),
+    created_at: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeDatabase(executeRows: unknown[][]) {
+  const queue = [...executeRows];
+  const database = {
+    execute: vi.fn(async () => ({ rows: queue.shift() ?? [] })),
+  };
+  return { database: database as unknown as CurrentForecastHeldDatabase, raw: database };
+}
+
+describe('loadHeldCurrentForecast (P1: exactly the served-pointer head)', () => {
+  it('returns the pinned reference and its contract-parsed snapshot payload', async () => {
+    const { database } = makeDatabase([[referenceRow()], [snapshotRow()]]);
+
+    const held = await loadHeldCurrentForecast({ fundId: 7, referenceId: 41, database });
+
+    expect(held.reference).toMatchObject({
+      id: 41,
+      fundId: 7,
+      fundSnapshotId: 11,
+      inputHash: INPUT_HASH,
+      resultHash: RESULT_HASH,
+      assumptionsHash: ASSUMPTIONS_HASH,
+      engineVersion: ENGINE_VERSION,
+      methodologyVersion: METHODOLOGY_VERSION,
+      createdAt: '2026-07-01T00:00:00.000Z',
+    });
+    expect(held.forecast.status).toBe('available');
+    expect(held.forecast.resultHash).toBe(RESULT_HASH);
+  });
+
+  it('throws HELD_REFERENCE_MISSING when the pointer head row does not exist', async () => {
+    const { database } = makeDatabase([[]]);
+
+    await expect(
+      loadHeldCurrentForecast({ fundId: 7, referenceId: 41, database })
+    ).rejects.toMatchObject({
+      name: 'CurrentForecastHeldError',
+      code: 'HELD_REFERENCE_MISSING',
+    });
+  });
+
+  it('throws HELD_REFERENCE_MISSING when the pinned snapshot row is missing', async () => {
+    const { database } = makeDatabase([[referenceRow()], []]);
+
+    await expect(
+      loadHeldCurrentForecast({ fundId: 7, referenceId: 41, database })
+    ).rejects.toBeInstanceOf(CurrentForecastHeldError);
+  });
+
+  it('throws HELD_REFERENCE_MISSING when the pinned payload fails the V2 contract', async () => {
+    const { database } = makeDatabase([
+      [referenceRow()],
+      [snapshotRow({ payload: { not: 'a forecast' } })],
+    ]);
+
+    await expect(
+      loadHeldCurrentForecast({ fundId: 7, referenceId: 41, database })
+    ).rejects.toMatchObject({ code: 'HELD_REFERENCE_MISSING' });
+  });
+
+  it('scopes both loads to the fund (fund_id appears in each query)', async () => {
+    const { database, raw } = makeDatabase([[referenceRow()], [snapshotRow()]]);
+
+    await loadHeldCurrentForecast({ fundId: 7, referenceId: 41, database });
+
+    expect(raw.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
+++ b/tests/unit/services/metrics-aggregator-dual-forecast.test.ts
@@ -66,6 +66,7 @@ vi.mock(
 );
 
 import { MetricsAggregator } from '../../../server/services/metrics-aggregator';
+import { CurrentForecastHeldError } from '../../../server/services/current-forecast-held-service';
 import {
   buildFundCompanyActualsFactsFromRows,
   type FundCompanyActualsFactsRows,
@@ -1001,5 +1002,310 @@ describe('MetricsAggregator dual forecast', () => {
     );
     // The substituted default is non-actionable: future Current quarters are the zero default, not a forecast.
     expect(result.series[1]?.current.nav).toBe(0);
+  });
+
+  describe('current-forecast serving modes (PLAN_61 Task 13.2)', () => {
+    const V2_INPUT_HASH = 'd'.repeat(64);
+    const V2_RESULT_HASH = 'e'.repeat(64);
+    const V2_ASSUMPTIONS_HASH = 'f'.repeat(64);
+    const REF_INPUT_HASH = '1'.repeat(64);
+    const REF_RESULT_HASH = '2'.repeat(64);
+    const REF_ASSUMPTIONS_HASH = '3'.repeat(64);
+    const ENGINE_VERSION = 'current-forecast-v2-engine/1.0.0';
+    const METHODOLOGY_VERSION = 'cohort-projection-v2/1.0.0';
+
+    function v2Point(overrides: Record<string, unknown> = {}) {
+      return {
+        periodStart: '2026-04-01',
+        periodEnd: '2026-06-30',
+        source: 'projected',
+        deployedUsd: '24000000.000000',
+        contributionsUsd: '30000000.000000',
+        distributionsUsd: '3000000.000000',
+        navUsd: '36000000.000000',
+        tvpi: '1.300000000000',
+        dpi: '0.100000000000',
+        activeCompanyCount: 1,
+        projectedCohortCount: 2,
+        ...overrides,
+      };
+    }
+
+    function v2Forecast(overrides: Record<string, unknown> = {}) {
+      return {
+        contractVersion: 'current-forecast-v2',
+        fundId: 1,
+        financialFactsSnapshotId: '31',
+        currentPlanVersionId: '21',
+        asOfDate: '2026-03-31',
+        status: 'available',
+        series: [
+          v2Point({
+            periodStart: '2026-01-01',
+            periodEnd: '2026-03-31',
+            source: 'actual',
+            contributionsUsd: '25000000.000000',
+            distributionsUsd: '2000000.000000',
+            navUsd: '30000000.000000',
+            tvpi: '1.280000000000',
+            dpi: '0.080000000000',
+          }),
+          v2Point(),
+          v2Point({
+            periodStart: '2026-07-01',
+            periodEnd: '2026-09-30',
+            contributionsUsd: '36000000.000000',
+            distributionsUsd: '5000000.000000',
+            navUsd: '44000000.000000',
+            tvpi: '1.360000000000',
+            dpi: '0.140000000000',
+          }),
+        ],
+        remainingDeployableCapitalUsd: '54000000.000000',
+        committedCapitalUsd: '90000000.000000',
+        calledToDateUsd: '25000000.000000',
+        projectedFeesRemainingUsd: '2000000.000000',
+        recallableDistributionsUsd: '0.000000',
+        uncalledCapitalUsd: '65000000.000000',
+        netIrr: '0.210000000000',
+        inputHash: V2_INPUT_HASH,
+        assumptionsHash: V2_ASSUMPTIONS_HASH,
+        resultHash: V2_RESULT_HASH,
+        engineVersion: ENGINE_VERSION,
+        methodologyVersion: METHODOLOGY_VERSION,
+        unavailableReasons: [],
+        warnings: [],
+        ...overrides,
+      };
+    }
+
+    function heldReference(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 41,
+        fundId: 1,
+        calculationKey: 'current_forecast',
+        fundSnapshotId: 11,
+        currentPlanVersionId: 21,
+        financialFactsSnapshotId: 31,
+        inputHash: REF_INPUT_HASH,
+        resultHash: REF_RESULT_HASH,
+        assumptionsHash: REF_ASSUMPTIONS_HASH,
+        engineVersion: ENGINE_VERSION,
+        methodologyVersion: METHODOLOGY_VERSION,
+        candidate: false,
+        supersededByReferenceId: null,
+        reason: null,
+        createdBy: null,
+        createdAt: '2026-07-01T00:00:00.000Z',
+        ...overrides,
+      };
+    }
+
+    function servingDeps(overrides: Record<string, unknown> = {}) {
+      return {
+        resolveMode: vi.fn(async () => ({ mode: 'off', cutoverReferenceId: null })),
+        runV2: vi.fn(async () => v2Forecast()),
+        loadHeld: vi.fn(async () => ({ reference: heldReference(), forecast: v2Forecast() })),
+        now: () => new Date('2026-07-22T00:00:00.000Z'),
+        ...overrides,
+      };
+    }
+
+    it('off: the response is byte-identical to the legacy composer when no mode row exists', async () => {
+      const aggregator = new MetricsAggregator();
+      const result = await aggregator.getDualForecast(1);
+
+      // Byte pin (characterization, written against the pre-13.2 composer): the
+      // mode dispatch must keep this EXACT serialized output for funds with no
+      // current_forecast mode row - the dormant default for every fund today.
+      expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+      expect('currentForecastV2' in result).toBe(false);
+      expect(result.sources.current).toBe('projected_metrics_calculator');
+      // Pre-cutover the legacy lane still runs the contained PMC engine.
+      expect(projectedCalculateMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('shadow: serves the legacy response unchanged and never engages the V2 lane (non-authority)', async () => {
+      const offDeps = servingDeps();
+      const offResult = await new MetricsAggregator(undefined, offDeps).getDualForecast(1);
+
+      vi.clearAllMocks();
+      actualCalculateMock.mockResolvedValue(actualMetrics);
+      projectedCalculateMock.mockResolvedValue(projectedMetrics);
+      buildFundCompanyActualsFactsMock.mockResolvedValue(factsFixture);
+
+      const shadowDeps = servingDeps({
+        resolveMode: vi.fn(async () => ({ mode: 'shadow', cutoverReferenceId: null })),
+      });
+      const shadowResult = await new MetricsAggregator(undefined, shadowDeps).getDualForecast(1);
+
+      expect(JSON.stringify(shadowResult)).toBe(JSON.stringify(offResult));
+      expect('currentForecastV2' in shadowResult).toBe(false);
+      // Serving-time shadow never runs V2: observation is the corpus plane (13.1).
+      expect(shadowDeps.runV2).not.toHaveBeenCalled();
+      expect(shadowDeps.loadHeld).not.toHaveBeenCalled();
+      expect(projectedCalculateMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('on: serves the V2 current lane without ever invoking the legacy PMC engine', async () => {
+      const deps = servingDeps({
+        resolveMode: vi.fn(async () => ({ mode: 'on', cutoverReferenceId: 41 })),
+      });
+      const result = await new MetricsAggregator(undefined, deps).getDualForecast(1);
+
+      expect(projectedCalculateMock).not.toHaveBeenCalled();
+      expect(deps.runV2).toHaveBeenCalledWith(1);
+      expect(deps.loadHeld).not.toHaveBeenCalled();
+
+      expect(result.sources).toEqual({
+        construction: 'construction_forecast_jcurve',
+        current: 'current_forecast_v2',
+        actual: 'actual_metrics_calculator',
+      });
+      expect(result.currentProjection).toEqual({ status: 'projected', fallbackReason: null });
+      expect(result.currentForecastV2).toEqual({
+        status: 'live',
+        engineStatus: 'available',
+        asOfDate: '2026-03-31',
+        currentPlanVersionId: '21',
+        financialFactsSnapshotId: '31',
+        inputHash: V2_INPUT_HASH,
+        resultHash: V2_RESULT_HASH,
+        assumptionsHash: V2_ASSUMPTIONS_HASH,
+        engineVersion: ENGINE_VERSION,
+        methodologyVersion: METHODOLOGY_VERSION,
+        unavailableReasons: [],
+        held: null,
+      });
+
+      // Quarter 0 stays the as-of actual; forecast quarters map the V2
+      // projected points in order (cumulative money, point-in-time NAV).
+      expect(result.series).toHaveLength(3);
+      expect(result.series[0]).toMatchObject({ label: 'As of', currentMode: 'actual' });
+      expect(result.series[0]?.current).toEqual({
+        nav: 30_000_000,
+        calledCapital: 25_000_000,
+        distributions: 2_000_000,
+        tvpi: 1.28,
+        dpi: 0.08,
+        rvpi: 1.2,
+        irr: 0.14,
+      });
+      expect(result.series[1]?.actual).toBeNull();
+      expect(result.series[1]?.currentMode).toBe('forecast');
+      expect(result.series[1]?.current).toEqual({
+        nav: 36_000_000,
+        calledCapital: 30_000_000,
+        distributions: 3_000_000,
+        tvpi: 1.3,
+        dpi: 0.1,
+        rvpi: 1.2,
+        irr: 0.21,
+      });
+      expect(result.series[2]?.current).toMatchObject({
+        nav: 44_000_000,
+        calledCapital: 36_000_000,
+        distributions: 5_000_000,
+        tvpi: 1.36,
+        dpi: 0.14,
+        irr: 0.21,
+      });
+      expect(result.series[2]?.current.rvpi).toBeCloseTo(44 / 36, 12);
+      const point = result.series[1];
+      expect(point?.variance.nav).toBe((point?.current.nav ?? 0) - (point?.construction.nav ?? 0));
+
+      // The bumped contract accepts the V2-served payload end to end.
+      expect(DualForecastResponseSchema.parse(result)).toEqual(result);
+    });
+
+    it('on: a post-cutover V2 runtime failure degrades to the pinned reference, never legacy', async () => {
+      const deps = servingDeps({
+        resolveMode: vi.fn(async () => ({ mode: 'on', cutoverReferenceId: 41 })),
+        runV2: vi.fn(async () => {
+          throw new Error('engine down');
+        }),
+      });
+      const result = await new MetricsAggregator(undefined, deps).getDualForecast(1);
+
+      expect(projectedCalculateMock).not.toHaveBeenCalled();
+      expect(deps.loadHeld).toHaveBeenCalledWith(1, 41);
+      expect(result.currentForecastV2?.status).toBe('held');
+      expect(result.currentForecastV2?.held).toEqual({
+        referenceId: 41,
+        reason: 'v2_runtime_failure',
+        pinnedAt: '2026-07-01T00:00:00.000Z',
+        ageDays: 21,
+      });
+      expect(DualForecastResponseSchema.parse(result)).toEqual(result);
+    });
+
+    it('held: serves the pointer head with the original basis, incident reason, and age; PMC never runs', async () => {
+      const deps = servingDeps({
+        resolveMode: vi.fn(async () => ({
+          mode: 'held',
+          cutoverReferenceId: 41,
+          heldReason: 'kill_switch',
+        })),
+      });
+      const result = await new MetricsAggregator(undefined, deps).getDualForecast(1);
+
+      // Post-cutover kill: the contained PMC engine is NEVER invoked (D9).
+      expect(projectedCalculateMock).not.toHaveBeenCalled();
+      expect(deps.runV2).not.toHaveBeenCalled();
+      expect(deps.loadHeld).toHaveBeenCalledWith(1, 41);
+
+      expect(result.sources.current).toBe('current_forecast_v2');
+      // Basis/version/hash come from the pinned REFERENCE row (P1: the
+      // original accepted basis), not from any recompute.
+      expect(result.currentForecastV2).toEqual({
+        status: 'held',
+        engineStatus: 'available',
+        asOfDate: '2026-03-31',
+        currentPlanVersionId: '21',
+        financialFactsSnapshotId: '31',
+        inputHash: REF_INPUT_HASH,
+        resultHash: REF_RESULT_HASH,
+        assumptionsHash: REF_ASSUMPTIONS_HASH,
+        engineVersion: ENGINE_VERSION,
+        methodologyVersion: METHODOLOGY_VERSION,
+        unavailableReasons: [],
+        held: {
+          referenceId: 41,
+          reason: 'kill_switch',
+          pinnedAt: '2026-07-01T00:00:00.000Z',
+          ageDays: 21,
+        },
+      });
+      // The pinned payload still drives the forecast quarters.
+      expect(result.series[1]?.current).toMatchObject({
+        nav: 36_000_000,
+        calledCapital: 30_000_000,
+      });
+      expect(DualForecastResponseSchema.parse(result)).toEqual(result);
+    });
+
+    it('held: a missing pointer head is an error envelope, never the legacy response', async () => {
+      const deps = servingDeps({
+        resolveMode: vi.fn(async () => ({
+          mode: 'held',
+          cutoverReferenceId: 41,
+          heldReason: 'configured_off',
+        })),
+        loadHeld: vi.fn(async () => {
+          throw new CurrentForecastHeldError(
+            'HELD_REFERENCE_MISSING',
+            'reference 41 not found for fund 1'
+          );
+        }),
+      });
+
+      await expect(new MetricsAggregator(undefined, deps).getDualForecast(1)).rejects.toMatchObject(
+        {
+          code: 'HELD_REFERENCE_MISSING',
+          component: 'aggregator',
+        }
+      );
+      expect(projectedCalculateMock).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Final sub-slice of PLAN_61 Task 13: wires the `current_forecast` mode resolution into the live dual-forecast serving path (aggregator, contract, client) while everything ships dormant — no mode rows exist, `enable_current_forecast_v2` stays default-off, all funds resolve `off`.

Per the rollout table (plan §Task 13, sha `31931e6c`):
- **off**: byte-identical to the pre-13.2 composer — pinned by a serialization snapshot written against unmodified code before the refactor.
- **shadow**: serves legacy unchanged; the V2 seam is never engaged in the request path (observation is the corpus plane per 13.1's dispatch seam).
- **on**: V2 drives the Current series lane (`sources.current: current_forecast_v2`); post-cutover runtime failure degrades to the pinned reference, never legacy.
- **held**: serves EXACTLY the served-pointer head (P1) with the ORIGINAL reference basis/version/hashes, a typed incident reason (`kill_switch | configured_off | configured_shadow | v2_runtime_failure`), and the age of the pinned result. A missing head returns a `HELD_REFERENCE_MISSING` error envelope — never the legacy response (D9).

## Changes

- **Contract v2** (`dual-forecast-response.contract.ts`): optional `currentForecastV2` block + widened `sources.current` enum; absent block keeps v1 payloads byte-identical (ADR-060).
- **Aggregator**: `getDualForecast` dispatches through 13.1's `dispatchCurrentForecastServing`; injectable serving seams (`resolveMode`/`runV2`/`loadHeld`/`now`); legacy composer extracted verbatim as the only PMC-invoking lane; V2 quarterly-cumulative series mapped onto the existing per-quarter metrics.
- **Resolver**: additive `heldReason` on the held resolution (kill wins).
- **Held service** (new): fund-scoped load of the pinned reference + `CURRENT_FORECAST_V2` snapshot; `getCurrentForecastReferenceById` exported from the reference service.
- **Route**: source UNCHANGED — new error codes flow through the existing metrics-error envelope branch; egress parse stays fail-closed.
- **Client**: `CurrentForecastHeldNotice` (muted DESIGN.md styling) in the dual-forecast dashboard; held/age display helpers in `dual-forecast-display`; readiness rollup fails held/unavailable/failed servings closed and caps indicative.
- **Activation gate** (Task 13 exit, falsifiable): new test pins `enable_current_forecast_v2` default-off/server-only; held map + kill both sides pinned in resolver tests; corpus green pinned in shadow tests; consumer-level test proves `ProjectedMetricsCalculator` is never invoked post-cutover under kill.
- **Manifest untouched**: pre-activation, off/shadow still serve legacy, so `projected_metrics_calculator` / `metrics_aggregator_facade` stay allowlisted (D14 rule).

## Verification

- Plan's Task 13 verify block: server 60/60, client 109/109; `guard:legacy-calculation-consumers:check` pass (1473 files, no violations); `calc-gate` 20/20.
- MOIC mode-service characterization + golden + current-forecast key suites green; `substrate-shadow-widening` and `time-travel-current-forecast-v2-invisibility` green.
- Blast radius green: dashboard/page/readiness consumers, `wave1b-tail-api`, `h9-artifact-invalidation`, static-diag `wizard-to-results-e2e` (int config).
- `npm run check`: 0 new errors. Full sharded suite: server 7,781 passed (3 shards), client 1,523 passed (2 shards), 0 failures.
- No migration applied (0038 remains authored-not-applied), no DB writes, no flag or mode value flipped, activation never executed.

Refs #1172 (Task 13.2), #1171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkBQzihG4JJYWwGYvACk36