### PR TITLE
feat(observations): establish immutable financial evidence and identity (PLAN_61 Task 3)

### DIFF
--- a/migrations/0039_financial_observations.sql
+++ b/migrations/0039_financial_observations.sql
@@ -324,6 +324,7 @@ CREATE TABLE IF NOT EXISTS "working_value_selections" (
   CONSTRAINT "working_value_selections_superseded_fund_fk"
     FOREIGN KEY ("superseded_by_selection_id", "fund_id")
     REFERENCES "public"."working_value_selections"("id", "fund_id"),
+  CONSTRAINT "working_value_selections_id_fund_unique" UNIQUE ("id", "fund_id"),
   CONSTRAINT "working_value_selections_created_by_fk"
     FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
   CONSTRAINT "working_value_selections_consumer_check"

--- a/migrations/0039_financial_observations.sql
+++ b/migrations/0039_financial_observations.sql
@@ -1,0 +1,366 @@
+-- @drift-patch
+-- Reason: Task 3 (D3/D27/D30) — immutable financial evidence,
+-- identity, and import-foundation persistence + identity backfill.
+
+CREATE TABLE IF NOT EXISTS "source_artifacts" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "source_type" text NOT NULL,
+  "file_name" text,
+  "media_type" text NOT NULL,
+  "byte_count" integer NOT NULL,
+  "payload_sha256" varchar(64) NOT NULL,
+  "payload" bytea,
+  "purge_after" timestamp with time zone NOT NULL,
+  "retention_extended_until" timestamp with time zone,
+  "retention_extension_reason" text,
+  "purged_at" timestamp with time zone,
+  "created_by" integer,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "source_artifacts_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "source_artifacts_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "source_artifacts_source_type_check"
+    CHECK ("source_type" IN ('csv','xlsx','structured_paste','manual')),
+  CONSTRAINT "source_artifacts_payload_purged_check"
+    CHECK (("payload" IS NULL AND "purged_at" IS NOT NULL)
+      OR ("payload" IS NOT NULL AND "purged_at" IS NULL)),
+  CONSTRAINT "source_artifacts_id_fund_unique" UNIQUE ("id", "fund_id"),
+  CONSTRAINT "source_artifacts_fund_idempotency_unique"
+    UNIQUE ("fund_id", "idempotency_key")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_source_artifacts_fund_created"
+  ON "source_artifacts" ("fund_id", "created_at" DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_source_artifacts_purge_after"
+  ON "source_artifacts" ("purge_after")
+  WHERE "purged_at" IS NULL;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "import_mapping_profiles" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "name" text NOT NULL,
+  "source_type" text NOT NULL,
+  "domain" text NOT NULL,
+  "version" integer DEFAULT 1 NOT NULL,
+  "mappings" jsonb NOT NULL,
+  "identity_semantics_hash" varchar(64) NOT NULL,
+  "superseded_by_profile_id" integer,
+  "created_by" integer,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "import_mapping_profiles_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "import_mapping_profiles_superseded_fund_fk"
+    FOREIGN KEY ("superseded_by_profile_id", "fund_id")
+    REFERENCES "public"."import_mapping_profiles"("id", "fund_id"),
+  CONSTRAINT "import_mapping_profiles_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "import_mapping_profiles_source_type_check"
+    CHECK ("source_type" IN ('csv','xlsx','structured_paste','manual')),
+  CONSTRAINT "import_mapping_profiles_domain_check"
+    CHECK ("domain" IN ('ledger_event','valuation','ownership')),
+  CONSTRAINT "import_mapping_profiles_version_positive_check"
+    CHECK ("version" >= 1),
+  CONSTRAINT "import_mapping_profiles_id_fund_unique" UNIQUE ("id", "fund_id"),
+  CONSTRAINT "import_mapping_profiles_fund_idempotency_unique"
+    UNIQUE ("fund_id", "idempotency_key"),
+  CONSTRAINT "import_mapping_profiles_fund_name_version_unique"
+    UNIQUE ("fund_id", "name", "version")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "import_mapping_profiles_fund_name_head_unique"
+  ON "import_mapping_profiles" ("fund_id", "name")
+  WHERE "superseded_by_profile_id" IS NULL;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "import_batches" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "source_artifact_id" integer,
+  "mapping_profile_id" integer,
+  "status" text DEFAULT 'staged' NOT NULL,
+  "preview_hash" varchar(64),
+  "purge_after" timestamp with time zone NOT NULL,
+  "retention_extended_until" timestamp with time zone,
+  "retention_extension_reason" text,
+  "purged_at" timestamp with time zone,
+  "version" integer DEFAULT 1 NOT NULL,
+  "created_by" integer,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "import_batches_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "import_batches_source_artifact_fund_fk"
+    FOREIGN KEY ("source_artifact_id", "fund_id")
+    REFERENCES "public"."source_artifacts"("id", "fund_id"),
+  CONSTRAINT "import_batches_mapping_profile_fund_fk"
+    FOREIGN KEY ("mapping_profile_id", "fund_id")
+    REFERENCES "public"."import_mapping_profiles"("id", "fund_id"),
+  CONSTRAINT "import_batches_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "import_batches_status_check"
+    CHECK ("status" IN ('staged','partially_committed','committed','expired')),
+  CONSTRAINT "import_batches_id_fund_unique" UNIQUE ("id", "fund_id"),
+  CONSTRAINT "import_batches_fund_idempotency_unique"
+    UNIQUE ("fund_id", "idempotency_key")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_import_batches_fund_created"
+  ON "import_batches" ("fund_id", "created_at" DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_import_batches_purge_after"
+  ON "import_batches" ("purge_after")
+  WHERE "purged_at" IS NULL;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "company_identities" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "canonical_name" text NOT NULL,
+  "merged_into_identity_id" integer,
+  "source_portfolio_company_id" integer,
+  "created_by" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "company_identities_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "company_identities_merged_into_fk"
+    FOREIGN KEY ("merged_into_identity_id") REFERENCES "public"."company_identities"("id"),
+  CONSTRAINT "company_identities_source_portfolio_company_fk"
+    FOREIGN KEY ("source_portfolio_company_id") REFERENCES "public"."portfoliocompanies"("id"),
+  CONSTRAINT "company_identities_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "company_identities_no_self_merge_check"
+    CHECK ("merged_into_identity_id" IS NULL OR "merged_into_identity_id" <> "id"),
+  CONSTRAINT "company_identities_id_fund_unique" UNIQUE ("id", "fund_id")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "company_identities_source_pc_unique"
+  ON "company_identities" ("source_portfolio_company_id")
+  WHERE "source_portfolio_company_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_company_identities_fund"
+  ON "company_identities" ("fund_id");
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "company_external_identities" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "company_identity_id" integer NOT NULL,
+  "system" text NOT NULL,
+  "value" text NOT NULL,
+  "created_by" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "company_external_identities_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "company_external_identities_identity_fund_fk"
+    FOREIGN KEY ("company_identity_id", "fund_id")
+    REFERENCES "public"."company_identities"("id", "fund_id"),
+  CONSTRAINT "company_external_identities_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "company_external_identities_fund_system_value_unique"
+    UNIQUE ("fund_id", "system", "value")
+);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "portfolio_company_identity_links" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "portfolio_company_id" integer NOT NULL,
+  "company_identity_id" integer NOT NULL,
+  "link_type" text NOT NULL,
+  "active" boolean DEFAULT true NOT NULL,
+  "deactivated_at" timestamp with time zone,
+  "created_by" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "pc_identity_links_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "pc_identity_links_portfolio_company_fk"
+    FOREIGN KEY ("portfolio_company_id") REFERENCES "public"."portfoliocompanies"("id"),
+  CONSTRAINT "pc_identity_links_identity_fund_fk"
+    FOREIGN KEY ("company_identity_id", "fund_id")
+    REFERENCES "public"."company_identities"("id", "fund_id"),
+  CONSTRAINT "pc_identity_links_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "pc_identity_links_link_type_check"
+    CHECK ("link_type" IN ('backfill','operator_resolution','import_resolution')),
+  CONSTRAINT "pc_identity_links_active_deactivated_check"
+    CHECK (("active" AND "deactivated_at" IS NULL)
+      OR (NOT "active" AND "deactivated_at" IS NOT NULL))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "pc_identity_links_active_company_unique"
+  ON "portfolio_company_identity_links" ("portfolio_company_id")
+  WHERE "active" = true;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "source_observations" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "import_batch_id" integer,
+  "source_artifact_id" integer,
+  "mapping_profile_id" integer,
+  "company_identity_id" integer,
+  "domain" text NOT NULL,
+  "source_type" text NOT NULL,
+  "effective_date" date NOT NULL,
+  "normalized_payload" jsonb NOT NULL,
+  "observation_hash" varchar(64) NOT NULL,
+  "candidate_fingerprint" varchar(64) NOT NULL,
+  "source_locator" text,
+  "dependency_group_key" text,
+  "status" text DEFAULT 'staged' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "source_observations_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "source_observations_import_batch_fund_fk"
+    FOREIGN KEY ("import_batch_id", "fund_id")
+    REFERENCES "public"."import_batches"("id", "fund_id"),
+  CONSTRAINT "source_observations_source_artifact_fund_fk"
+    FOREIGN KEY ("source_artifact_id", "fund_id")
+    REFERENCES "public"."source_artifacts"("id", "fund_id"),
+  CONSTRAINT "source_observations_mapping_profile_fund_fk"
+    FOREIGN KEY ("mapping_profile_id", "fund_id")
+    REFERENCES "public"."import_mapping_profiles"("id", "fund_id"),
+  CONSTRAINT "source_observations_company_identity_fund_fk"
+    FOREIGN KEY ("company_identity_id", "fund_id")
+    REFERENCES "public"."company_identities"("id", "fund_id"),
+  CONSTRAINT "source_observations_domain_check"
+    CHECK ("domain" IN ('ledger_event','valuation','ownership')),
+  CONSTRAINT "source_observations_source_type_check"
+    CHECK ("source_type" IN ('csv','xlsx','structured_paste','manual')),
+  CONSTRAINT "source_observations_status_check"
+    CHECK ("status" IN ('staged','accepted','purged')),
+  CONSTRAINT "source_observations_id_fund_unique" UNIQUE ("id", "fund_id")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "source_observations_fund_hash_accepted_unique"
+  ON "source_observations" ("fund_id", "observation_hash")
+  WHERE "status" = 'accepted';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_source_observations_fund_effective_date"
+  ON "source_observations" ("fund_id", "effective_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_source_observations_fund_candidate_fingerprint"
+  ON "source_observations" ("fund_id", "candidate_fingerprint");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_source_observations_import_batch"
+  ON "source_observations" ("import_batch_id");
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "reconciliation_cases" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "import_batch_id" integer,
+  "source_observation_id" integer,
+  "case_type" text NOT NULL,
+  "status" text DEFAULT 'open' NOT NULL,
+  "observation_hash" varchar(64),
+  "candidate_fingerprint" varchar(64),
+  "resolution" jsonb,
+  "resolved_by" integer,
+  "resolved_at" timestamp with time zone,
+  "history" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "version" integer DEFAULT 1 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "reconciliation_cases_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "reconciliation_cases_import_batch_fund_fk"
+    FOREIGN KEY ("import_batch_id", "fund_id")
+    REFERENCES "public"."import_batches"("id", "fund_id"),
+  CONSTRAINT "reconciliation_cases_source_observation_fund_fk"
+    FOREIGN KEY ("source_observation_id", "fund_id")
+    REFERENCES "public"."source_observations"("id", "fund_id"),
+  CONSTRAINT "reconciliation_cases_resolved_by_fk"
+    FOREIGN KEY ("resolved_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "reconciliation_cases_case_type_check"
+    CHECK ("case_type" IN ('identity_resolution','observation_match')),
+  CONSTRAINT "reconciliation_cases_status_check"
+    CHECK ("status" IN ('open','resolved','expired_unresolved')),
+  CONSTRAINT "reconciliation_cases_resolved_fields_check"
+    CHECK (("status" = 'resolved'
+        AND "resolution" IS NOT NULL
+        AND "resolved_at" IS NOT NULL)
+      OR ("status" <> 'resolved'
+        AND "resolution" IS NULL
+        AND "resolved_at" IS NULL
+        AND "resolved_by" IS NULL))
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_reconciliation_cases_fund_status"
+  ON "reconciliation_cases" ("fund_id", "status");
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "working_value_selections" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "consumer" text NOT NULL,
+  "company_identity_id" integer,
+  "domain" text NOT NULL,
+  "measure_key" text NOT NULL,
+  "as_of_date" date NOT NULL,
+  "selected_observation_id" integer NOT NULL,
+  "is_default" boolean NOT NULL,
+  "reason" text,
+  "version" integer DEFAULT 1 NOT NULL,
+  "superseded_by_selection_id" integer,
+  "created_by" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "working_value_selections_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "working_value_selections_observation_fund_fk"
+    FOREIGN KEY ("selected_observation_id", "fund_id")
+    REFERENCES "public"."source_observations"("id", "fund_id"),
+  CONSTRAINT "working_value_selections_identity_fund_fk"
+    FOREIGN KEY ("company_identity_id", "fund_id")
+    REFERENCES "public"."company_identities"("id", "fund_id"),
+  CONSTRAINT "working_value_selections_superseded_fund_fk"
+    FOREIGN KEY ("superseded_by_selection_id", "fund_id")
+    REFERENCES "public"."working_value_selections"("id", "fund_id"),
+  CONSTRAINT "working_value_selections_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "working_value_selections_consumer_check"
+    CHECK ("consumer" IN ('forecast','reserve','economics','periodic_analysis')),
+  CONSTRAINT "working_value_selections_domain_check"
+    CHECK ("domain" IN ('ledger_event','valuation','ownership')),
+  CONSTRAINT "working_value_selections_deviation_reason_check"
+    CHECK ("is_default" OR "reason" IS NOT NULL)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "working_value_selections_scope_head_unique"
+  ON "working_value_selections"
+  ("fund_id", "consumer", "domain", "measure_key", "as_of_date", COALESCE("company_identity_id", 0))
+  WHERE "superseded_by_selection_id" IS NULL;
+--> statement-breakpoint
+
+INSERT INTO company_identities (fund_id, canonical_name, source_portfolio_company_id)
+SELECT pc.fund_id, pc.name, pc.id FROM portfoliocompanies pc
+WHERE pc.fund_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM company_identities ci WHERE ci.source_portfolio_company_id = pc.id);
+--> statement-breakpoint
+INSERT INTO portfolio_company_identity_links (fund_id, portfolio_company_id, company_identity_id, link_type, active)
+SELECT ci.fund_id, ci.source_portfolio_company_id, ci.id, 'backfill', true
+FROM company_identities ci
+WHERE ci.source_portfolio_company_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM portfolio_company_identity_links l
+                  WHERE l.portfolio_company_id = ci.source_portfolio_company_id);
+--> statement-breakpoint
+
+-- NULL-fund rows remain unlinked by design. Derivation query:
+-- SELECT count(*) FROM portfoliocompanies WHERE fund_id IS NULL
+DO $$
+DECLARE
+  unlinked_count integer;
+BEGIN
+  SELECT count(*) INTO unlinked_count FROM portfoliocompanies WHERE fund_id IS NULL;
+  RAISE NOTICE
+    'Task 3 identity backfill skipped % portfolio companies with NULL fund_id',
+    unlinked_count;
+END $$;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1784768956988,
       "tag": "0038_current_forecast_references",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1784839806903,
+      "tag": "0039_financial_observations",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/13-financial-observations.json
+++ b/scripts/prod-schema-manifests/13-financial-observations.json
@@ -340,6 +340,7 @@
         "working_value_selections_observation_fund_fk",
         "working_value_selections_identity_fund_fk",
         "working_value_selections_superseded_fund_fk",
+        "working_value_selections_id_fund_unique",
         "working_value_selections_created_by_fk",
         "working_value_selections_consumer_check",
         "working_value_selections_domain_check",

--- a/scripts/prod-schema-manifests/13-financial-observations.json
+++ b/scripts/prod-schema-manifests/13-financial-observations.json
@@ -1,0 +1,351 @@
+{
+  "name": "financial-observations",
+  "order": 13,
+  "description": "Immutable financial evidence, identity, reconciliation, and import-foundation persistence.",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0039_financial_observations.sql"],
+  "allowedCreateTables": [
+    "source_artifacts",
+    "import_mapping_profiles",
+    "import_batches",
+    "company_identities",
+    "company_external_identities",
+    "portfolio_company_identity_links",
+    "source_observations",
+    "reconciliation_cases",
+    "working_value_selections"
+  ],
+  "expectedTables": [
+    {
+      "name": "source_artifacts",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "source_type", "type": "text", "nullable": false },
+        { "name": "file_name", "type": "text", "nullable": true },
+        { "name": "media_type", "type": "text", "nullable": false },
+        { "name": "byte_count", "type": "integer", "nullable": false },
+        { "name": "payload_sha256", "type": "varchar", "nullable": false },
+        { "name": "payload", "type": "bytea", "nullable": true },
+        { "name": "purge_after", "type": "timestamptz", "nullable": false },
+        {
+          "name": "retention_extended_until",
+          "type": "timestamptz",
+          "nullable": true
+        },
+        {
+          "name": "retention_extension_reason",
+          "type": "text",
+          "nullable": true
+        },
+        { "name": "purged_at", "type": "timestamptz", "nullable": true },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "idempotency_key", "type": "varchar", "nullable": false },
+        { "name": "request_hash", "type": "varchar", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "source_artifacts_fund_id_funds_id_fk",
+        "source_artifacts_created_by_fk",
+        "source_artifacts_source_type_check",
+        "source_artifacts_payload_purged_check",
+        "source_artifacts_id_fund_unique",
+        "source_artifacts_fund_idempotency_unique"
+      ],
+      "indexes": [
+        "idx_source_artifacts_fund_created",
+        "idx_source_artifacts_purge_after"
+      ]
+    },
+    {
+      "name": "import_mapping_profiles",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "name", "type": "text", "nullable": false },
+        { "name": "source_type", "type": "text", "nullable": false },
+        { "name": "domain", "type": "text", "nullable": false },
+        { "name": "version", "type": "integer", "nullable": false },
+        { "name": "mappings", "type": "jsonb", "nullable": false },
+        {
+          "name": "identity_semantics_hash",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "superseded_by_profile_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "idempotency_key", "type": "varchar", "nullable": false },
+        { "name": "request_hash", "type": "varchar", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "import_mapping_profiles_fund_id_funds_id_fk",
+        "import_mapping_profiles_superseded_fund_fk",
+        "import_mapping_profiles_created_by_fk",
+        "import_mapping_profiles_source_type_check",
+        "import_mapping_profiles_domain_check",
+        "import_mapping_profiles_version_positive_check",
+        "import_mapping_profiles_id_fund_unique",
+        "import_mapping_profiles_fund_idempotency_unique",
+        "import_mapping_profiles_fund_name_version_unique"
+      ],
+      "indexes": ["import_mapping_profiles_fund_name_head_unique"]
+    },
+    {
+      "name": "import_batches",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "source_artifact_id", "type": "integer", "nullable": true },
+        { "name": "mapping_profile_id", "type": "integer", "nullable": true },
+        { "name": "status", "type": "text", "nullable": false },
+        { "name": "preview_hash", "type": "varchar", "nullable": true },
+        { "name": "purge_after", "type": "timestamptz", "nullable": false },
+        {
+          "name": "retention_extended_until",
+          "type": "timestamptz",
+          "nullable": true
+        },
+        {
+          "name": "retention_extension_reason",
+          "type": "text",
+          "nullable": true
+        },
+        { "name": "purged_at", "type": "timestamptz", "nullable": true },
+        { "name": "version", "type": "integer", "nullable": false },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "idempotency_key", "type": "varchar", "nullable": false },
+        { "name": "request_hash", "type": "varchar", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "import_batches_fund_id_funds_id_fk",
+        "import_batches_source_artifact_fund_fk",
+        "import_batches_mapping_profile_fund_fk",
+        "import_batches_created_by_fk",
+        "import_batches_status_check",
+        "import_batches_id_fund_unique",
+        "import_batches_fund_idempotency_unique"
+      ],
+      "indexes": [
+        "idx_import_batches_fund_created",
+        "idx_import_batches_purge_after"
+      ]
+    },
+    {
+      "name": "company_identities",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "canonical_name", "type": "text", "nullable": false },
+        {
+          "name": "merged_into_identity_id",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "source_portfolio_company_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "company_identities_fund_id_funds_id_fk",
+        "company_identities_merged_into_fk",
+        "company_identities_source_portfolio_company_fk",
+        "company_identities_created_by_fk",
+        "company_identities_no_self_merge_check",
+        "company_identities_id_fund_unique"
+      ],
+      "indexes": [
+        "company_identities_source_pc_unique",
+        "idx_company_identities_fund"
+      ]
+    },
+    {
+      "name": "company_external_identities",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        {
+          "name": "company_identity_id",
+          "type": "integer",
+          "nullable": false
+        },
+        { "name": "system", "type": "text", "nullable": false },
+        { "name": "value", "type": "text", "nullable": false },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "company_external_identities_fund_id_funds_id_fk",
+        "company_external_identities_identity_fund_fk",
+        "company_external_identities_created_by_fk",
+        "company_external_identities_fund_system_value_unique"
+      ],
+      "indexes": []
+    },
+    {
+      "name": "portfolio_company_identity_links",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        {
+          "name": "portfolio_company_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "company_identity_id",
+          "type": "integer",
+          "nullable": false
+        },
+        { "name": "link_type", "type": "text", "nullable": false },
+        { "name": "active", "type": "boolean", "nullable": false },
+        { "name": "deactivated_at", "type": "timestamptz", "nullable": true },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "pc_identity_links_fund_id_funds_id_fk",
+        "pc_identity_links_portfolio_company_fk",
+        "pc_identity_links_identity_fund_fk",
+        "pc_identity_links_created_by_fk",
+        "pc_identity_links_link_type_check",
+        "pc_identity_links_active_deactivated_check"
+      ],
+      "indexes": ["pc_identity_links_active_company_unique"]
+    },
+    {
+      "name": "source_observations",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "import_batch_id", "type": "integer", "nullable": true },
+        { "name": "source_artifact_id", "type": "integer", "nullable": true },
+        { "name": "mapping_profile_id", "type": "integer", "nullable": true },
+        {
+          "name": "company_identity_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "domain", "type": "text", "nullable": false },
+        { "name": "source_type", "type": "text", "nullable": false },
+        { "name": "effective_date", "type": "date", "nullable": false },
+        { "name": "normalized_payload", "type": "jsonb", "nullable": false },
+        { "name": "observation_hash", "type": "varchar", "nullable": false },
+        {
+          "name": "candidate_fingerprint",
+          "type": "varchar",
+          "nullable": false
+        },
+        { "name": "source_locator", "type": "text", "nullable": true },
+        { "name": "dependency_group_key", "type": "text", "nullable": true },
+        { "name": "status", "type": "text", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "source_observations_fund_id_funds_id_fk",
+        "source_observations_import_batch_fund_fk",
+        "source_observations_source_artifact_fund_fk",
+        "source_observations_mapping_profile_fund_fk",
+        "source_observations_company_identity_fund_fk",
+        "source_observations_domain_check",
+        "source_observations_source_type_check",
+        "source_observations_status_check",
+        "source_observations_id_fund_unique"
+      ],
+      "indexes": [
+        "source_observations_fund_hash_accepted_unique",
+        "idx_source_observations_fund_effective_date",
+        "idx_source_observations_fund_candidate_fingerprint",
+        "idx_source_observations_import_batch"
+      ]
+    },
+    {
+      "name": "reconciliation_cases",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "import_batch_id", "type": "integer", "nullable": true },
+        {
+          "name": "source_observation_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "case_type", "type": "text", "nullable": false },
+        { "name": "status", "type": "text", "nullable": false },
+        { "name": "observation_hash", "type": "varchar", "nullable": true },
+        {
+          "name": "candidate_fingerprint",
+          "type": "varchar",
+          "nullable": true
+        },
+        { "name": "resolution", "type": "jsonb", "nullable": true },
+        { "name": "resolved_by", "type": "integer", "nullable": true },
+        { "name": "resolved_at", "type": "timestamptz", "nullable": true },
+        { "name": "history", "type": "jsonb", "nullable": false },
+        { "name": "version", "type": "integer", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "reconciliation_cases_fund_id_funds_id_fk",
+        "reconciliation_cases_import_batch_fund_fk",
+        "reconciliation_cases_source_observation_fund_fk",
+        "reconciliation_cases_resolved_by_fk",
+        "reconciliation_cases_case_type_check",
+        "reconciliation_cases_status_check",
+        "reconciliation_cases_resolved_fields_check"
+      ],
+      "indexes": ["idx_reconciliation_cases_fund_status"]
+    },
+    {
+      "name": "working_value_selections",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "consumer", "type": "text", "nullable": false },
+        {
+          "name": "company_identity_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "domain", "type": "text", "nullable": false },
+        { "name": "measure_key", "type": "text", "nullable": false },
+        { "name": "as_of_date", "type": "date", "nullable": false },
+        {
+          "name": "selected_observation_id",
+          "type": "integer",
+          "nullable": false
+        },
+        { "name": "is_default", "type": "boolean", "nullable": false },
+        { "name": "reason", "type": "text", "nullable": true },
+        { "name": "version", "type": "integer", "nullable": false },
+        {
+          "name": "superseded_by_selection_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "working_value_selections_fund_id_funds_id_fk",
+        "working_value_selections_observation_fund_fk",
+        "working_value_selections_identity_fund_fk",
+        "working_value_selections_superseded_fund_fk",
+        "working_value_selections_created_by_fk",
+        "working_value_selections_consumer_check",
+        "working_value_selections_domain_check",
+        "working_value_selections_deviation_reason_check"
+      ],
+      "indexes": ["working_value_selections_scope_head_unique"]
+    }
+  ]
+}

--- a/shared/contracts/financial-facts-consumer-policies.ts
+++ b/shared/contracts/financial-facts-consumer-policies.ts
@@ -22,3 +22,15 @@ export const ConsumerEvaluationSchema = z
 export type FinancialFactsConsumerKey = z.infer<typeof FinancialFactsConsumerKeySchema>;
 export type ConsumerEvaluationReason = z.infer<typeof ConsumerEvaluationReasonSchema>;
 export type ConsumerEvaluation = z.infer<typeof ConsumerEvaluationSchema>;
+
+export const DEFAULT_SELECTION_RULE = 'latest_effective_dated_accepted_at_or_before_as_of' as const;
+
+export const CONSUMER_DEFAULT_SELECTION_RULES: Record<
+  FinancialFactsConsumerKey,
+  typeof DEFAULT_SELECTION_RULE
+> = {
+  forecast: DEFAULT_SELECTION_RULE,
+  reserve: DEFAULT_SELECTION_RULE,
+  economics: DEFAULT_SELECTION_RULE,
+  periodic_analysis: DEFAULT_SELECTION_RULE,
+};

--- a/shared/contracts/financial-observations/financial-observation.contract.ts
+++ b/shared/contracts/financial-observations/financial-observation.contract.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod';
+
+import { FinancialFactsConsumerKeySchema } from '../financial-facts-consumer-policies';
+
+export const FINANCIAL_OBSERVATION_SOURCES = ['csv', 'xlsx', 'structured_paste', 'manual'] as const;
+export const FINANCIAL_OBSERVATION_DOMAINS = ['ledger_event', 'valuation', 'ownership'] as const;
+export const SOURCE_OBSERVATION_STATUSES = ['staged', 'accepted', 'purged'] as const;
+export const IMPORT_BATCH_STATUSES = [
+  'staged',
+  'partially_committed',
+  'committed',
+  'expired',
+] as const;
+export const IDENTITY_LINK_TYPES = [
+  'backfill',
+  'operator_resolution',
+  'import_resolution',
+] as const;
+
+export const FinancialObservationSourceSchema = z.enum(FINANCIAL_OBSERVATION_SOURCES);
+export const FinancialObservationDomainSchema = z.enum(FINANCIAL_OBSERVATION_DOMAINS);
+export const SourceObservationStatusSchema = z.enum(SOURCE_OBSERVATION_STATUSES);
+export const ImportBatchStatusSchema = z.enum(IMPORT_BATCH_STATUSES);
+export const IdentityLinkTypeSchema = z.enum(IDENTITY_LINK_TYPES);
+export const Sha256HexSchema = z.string().regex(/^[a-f0-9]{64}$/);
+
+const PositiveIntegerSchema = z.number().int().positive();
+const NullablePositiveIntegerSchema = PositiveIntegerSchema.nullable();
+const CreatedAtSchema = z.string().datetime();
+
+export const SourceObservationV1Schema = z
+  .object({
+    id: PositiveIntegerSchema,
+    fundId: PositiveIntegerSchema,
+    importBatchId: NullablePositiveIntegerSchema,
+    sourceArtifactId: NullablePositiveIntegerSchema,
+    mappingProfileId: NullablePositiveIntegerSchema,
+    companyIdentityId: NullablePositiveIntegerSchema,
+    domain: FinancialObservationDomainSchema,
+    sourceType: FinancialObservationSourceSchema,
+    effectiveDate: z.string().date(),
+    normalizedPayload: z.record(z.string(), z.unknown()),
+    observationHash: Sha256HexSchema,
+    candidateFingerprint: Sha256HexSchema,
+    sourceLocator: z.string().min(1).nullable(),
+    dependencyGroupKey: z.string().min(1).nullable(),
+    status: SourceObservationStatusSchema,
+    createdAt: CreatedAtSchema,
+  })
+  .strict();
+
+export const WorkingValueSelectionV1Schema = z
+  .object({
+    id: PositiveIntegerSchema,
+    fundId: PositiveIntegerSchema,
+    consumer: FinancialFactsConsumerKeySchema,
+    companyIdentityId: NullablePositiveIntegerSchema,
+    domain: FinancialObservationDomainSchema,
+    measureKey: z.string().min(1),
+    asOfDate: z.string().date(),
+    selectedObservationId: PositiveIntegerSchema,
+    isDefault: z.boolean(),
+    reason: z.string().min(1).nullable(),
+    version: PositiveIntegerSchema,
+    supersededBySelectionId: NullablePositiveIntegerSchema,
+    createdBy: NullablePositiveIntegerSchema,
+    createdAt: CreatedAtSchema,
+  })
+  .strict();
+
+export const CompanyIdentityV1Schema = z
+  .object({
+    id: PositiveIntegerSchema,
+    fundId: PositiveIntegerSchema,
+    canonicalName: z.string().min(1),
+    mergedIntoIdentityId: NullablePositiveIntegerSchema,
+    sourcePortfolioCompanyId: NullablePositiveIntegerSchema,
+    createdBy: NullablePositiveIntegerSchema,
+    createdAt: CreatedAtSchema,
+  })
+  .strict();
+
+export const CompanyExternalIdentityV1Schema = z
+  .object({
+    id: PositiveIntegerSchema,
+    fundId: PositiveIntegerSchema,
+    companyIdentityId: PositiveIntegerSchema,
+    system: z.string().min(1),
+    value: z.string().min(1),
+    createdBy: NullablePositiveIntegerSchema,
+    createdAt: CreatedAtSchema,
+  })
+  .strict();
+
+export const PortfolioCompanyIdentityLinkV1Schema = z
+  .object({
+    id: PositiveIntegerSchema,
+    fundId: PositiveIntegerSchema,
+    portfolioCompanyId: PositiveIntegerSchema,
+    companyIdentityId: PositiveIntegerSchema,
+    linkType: IdentityLinkTypeSchema,
+    active: z.boolean(),
+    deactivatedAt: CreatedAtSchema.nullable(),
+    createdBy: NullablePositiveIntegerSchema,
+    createdAt: CreatedAtSchema,
+  })
+  .strict();
+
+export type SourceObservationV1 = z.infer<typeof SourceObservationV1Schema>;
+export type WorkingValueSelectionV1 = z.infer<typeof WorkingValueSelectionV1Schema>;
+export type CompanyIdentityV1 = z.infer<typeof CompanyIdentityV1Schema>;
+export type CompanyExternalIdentityV1 = z.infer<typeof CompanyExternalIdentityV1Schema>;
+export type PortfolioCompanyIdentityLinkV1 = z.infer<typeof PortfolioCompanyIdentityLinkV1Schema>;
+
+export interface MergeChainIdentity {
+  readonly mergedIntoIdentityId: number | null;
+}
+
+export function resolveIdentityMergeChain(
+  byId: ReadonlyMap<number, MergeChainIdentity>,
+  startId: number
+): number {
+  const visited = new Set<number>();
+  let currentId = startId;
+
+  while (true) {
+    if (visited.has(currentId)) {
+      throw new Error(`Company identity merge cycle detected at ${currentId}`);
+    }
+    visited.add(currentId);
+
+    const current = byId.get(currentId);
+    if (!current) {
+      throw new Error(`Company identity ${currentId} is missing from merge chain`);
+    }
+    if (current.mergedIntoIdentityId === null) {
+      return currentId;
+    }
+    currentId = current.mergedIntoIdentityId;
+  }
+}

--- a/shared/contracts/financial-observations/import-profile.contract.ts
+++ b/shared/contracts/financial-observations/import-profile.contract.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+import { canonicalSha256 } from '../../lib/canonical-hash';
+import {
+  FINANCIAL_OBSERVATION_DOMAINS,
+  FINANCIAL_OBSERVATION_SOURCES,
+  Sha256HexSchema,
+} from './financial-observation.contract';
+
+export const ALLOWED_MAPPING_TRANSFORMS = [
+  'trim',
+  'normalize_whitespace',
+  'parse_decimal',
+  'parse_date_iso',
+  'parse_date_us',
+  'negate',
+] as const;
+export const IDENTITY_TARGET_FIELDS = ['company_name', 'company_external_id'] as const;
+
+export const AllowedMappingTransformSchema = z.enum(ALLOWED_MAPPING_TRANSFORMS);
+export const MappingRuleV1Schema = z
+  .object({
+    sourceColumn: z.string().min(1),
+    targetField: z.string().min(1),
+    transforms: z.array(AllowedMappingTransformSchema),
+  })
+  .strict();
+
+export const ImportMappingProfileV1Schema = z
+  .object({
+    name: z.string().min(1),
+    sourceType: z.enum(FINANCIAL_OBSERVATION_SOURCES),
+    domain: z.enum(FINANCIAL_OBSERVATION_DOMAINS),
+    version: z.number().int().positive(),
+    mappings: z.array(MappingRuleV1Schema),
+    identitySemanticsHash: Sha256HexSchema,
+  })
+  .strict();
+
+export type MappingRuleV1 = z.infer<typeof MappingRuleV1Schema>;
+export type ImportMappingProfileV1 = z.infer<typeof ImportMappingProfileV1Schema>;
+
+const identityTargetFields = new Set<string>(IDENTITY_TARGET_FIELDS);
+
+export function buildIdentitySemanticsHash(mappings: readonly MappingRuleV1[]): string {
+  const identityMappings = mappings
+    .map((mapping) => MappingRuleV1Schema.parse(mapping))
+    .filter((mapping) => identityTargetFields.has(mapping.targetField))
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+
+  return canonicalSha256(identityMappings);
+}

--- a/shared/contracts/financial-observations/index.ts
+++ b/shared/contracts/financial-observations/index.ts
@@ -1,0 +1,3 @@
+export * from './financial-observation.contract';
+export * from './import-profile.contract';
+export * from './reconciliation.contract';

--- a/shared/contracts/financial-observations/reconciliation.contract.ts
+++ b/shared/contracts/financial-observations/reconciliation.contract.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+import { Sha256HexSchema } from './financial-observation.contract';
+
+export const RECONCILIATION_CASE_TYPES = ['identity_resolution', 'observation_match'] as const;
+export const RECONCILIATION_CASE_STATUSES = ['open', 'resolved', 'expired_unresolved'] as const;
+export const TERMINAL_RECONCILIATION_CASE_STATUSES = ['resolved', 'expired_unresolved'] as const;
+export const RECONCILIATION_RESOLUTION_ACTIONS = [
+  'confirm_match',
+  'create_identity',
+  'merge_identities',
+  'reject',
+] as const;
+
+export const ReconciliationCaseTypeSchema = z.enum(RECONCILIATION_CASE_TYPES);
+export const ReconciliationCaseStatusSchema = z.enum(RECONCILIATION_CASE_STATUSES);
+export const ReconciliationResolutionActionSchema = z.enum(RECONCILIATION_RESOLUTION_ACTIONS);
+
+export const ReconciliationResolutionV1Schema = z
+  .object({
+    action: ReconciliationResolutionActionSchema,
+    targetCompanyIdentityId: z.number().int().positive().nullable(),
+    memo: z.string().min(1),
+  })
+  .strict();
+
+export const ReconciliationCaseHistoryEntryV1Schema = z
+  .object({
+    at: z.string().datetime(),
+    event: z.enum(['opened', 'updated', 'resolved', 'expired_unresolved']),
+  })
+  .strict();
+
+export const ReconciliationCaseV1Schema = z
+  .object({
+    id: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    importBatchId: z.number().int().positive().nullable(),
+    sourceObservationId: z.number().int().positive().nullable(),
+    caseType: ReconciliationCaseTypeSchema,
+    status: ReconciliationCaseStatusSchema,
+    observationHash: Sha256HexSchema.nullable(),
+    candidateFingerprint: Sha256HexSchema.nullable(),
+    resolution: ReconciliationResolutionV1Schema.nullable(),
+    resolvedBy: z.number().int().positive().nullable(),
+    resolvedAt: z.string().datetime().nullable(),
+    history: z.array(ReconciliationCaseHistoryEntryV1Schema),
+    version: z.number().int().positive(),
+    createdAt: z.string().datetime(),
+  })
+  .strict();
+
+export type ReconciliationResolutionV1 = z.infer<typeof ReconciliationResolutionV1Schema>;
+export type ReconciliationCaseHistoryEntryV1 = z.infer<
+  typeof ReconciliationCaseHistoryEntryV1Schema
+>;
+export type ReconciliationCaseV1 = z.infer<typeof ReconciliationCaseV1Schema>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -49,6 +49,7 @@ export * from './schema/fund-moic-input-update-requests';
 export * from './schema/investment-rounds';
 export * from './schema/investment-round-model-overrides';
 export * from './schema/current-forecast-references';
+export * from './schema/financial-observations';
 export * from './schemas/flags';
 export * from './schemas/reserve-approvals';
 

--- a/shared/schema/financial-observations.ts
+++ b/shared/schema/financial-observations.ts
@@ -1,0 +1,572 @@
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  check,
+  customType,
+  date,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import type { MappingRuleV1 } from '../contracts/financial-observations/import-profile.contract';
+import type {
+  ReconciliationCaseHistoryEntryV1,
+  ReconciliationResolutionV1,
+} from '../contracts/financial-observations/reconciliation.contract';
+import { funds } from './fund';
+import { portfolioCompanies } from './portfolio';
+import { users } from './user';
+
+const bytea = customType<{ data: Buffer; notNull: false; default: false }>({
+  dataType() {
+    return 'bytea';
+  },
+  toDriver(value: unknown): Buffer {
+    return value as Buffer;
+  },
+  fromDriver(value: unknown): Buffer {
+    return value as Buffer;
+  },
+});
+
+export const sourceArtifacts = pgTable(
+  'source_artifacts',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    sourceType: text('source_type').notNull(),
+    fileName: text('file_name'),
+    mediaType: text('media_type').notNull(),
+    byteCount: integer('byte_count').notNull(),
+    payloadSha256: varchar('payload_sha256', { length: 64 }).notNull(),
+    payload: bytea('payload'),
+    purgeAfter: timestamp('purge_after', { withTimezone: true }).notNull(),
+    retentionExtendedUntil: timestamp('retention_extended_until', {
+      withTimezone: true,
+    }),
+    retentionExtensionReason: text('retention_extension_reason'),
+    purgedAt: timestamp('purged_at', { withTimezone: true }),
+    createdBy: integer('created_by'),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'source_artifacts_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'source_artifacts_created_by_fk',
+    }),
+    sourceTypeCheck: check(
+      'source_artifacts_source_type_check',
+      sql`${table.sourceType} IN ('csv','xlsx','structured_paste','manual')`
+    ),
+    payloadPurgedCheck: check(
+      'source_artifacts_payload_purged_check',
+      sql`(${table.payload} IS NULL AND ${table.purgedAt} IS NOT NULL)
+          OR (${table.payload} IS NOT NULL AND ${table.purgedAt} IS NULL)`
+    ),
+    idFundUnique: unique('source_artifacts_id_fund_unique').on(table.id, table.fundId),
+    fundIdempotencyUnique: unique('source_artifacts_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    fundCreatedIdx: index('idx_source_artifacts_fund_created').on(
+      table.fundId,
+      table.createdAt.desc()
+    ),
+    purgeAfterIdx: index('idx_source_artifacts_purge_after')
+      .on(table.purgeAfter)
+      .where(sql`${table.purgedAt} IS NULL`),
+  })
+);
+
+export const importMappingProfiles = pgTable(
+  'import_mapping_profiles',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    name: text('name').notNull(),
+    sourceType: text('source_type').notNull(),
+    domain: text('domain').notNull(),
+    version: integer('version').notNull().default(1),
+    mappings: jsonb('mappings').notNull().$type<MappingRuleV1[]>(),
+    identitySemanticsHash: varchar('identity_semantics_hash', { length: 64 }).notNull(),
+    supersededByProfileId: integer('superseded_by_profile_id'),
+    createdBy: integer('created_by'),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'import_mapping_profiles_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    supersededFundFk: foreignKey({
+      columns: [table.supersededByProfileId, table.fundId],
+      foreignColumns: [table.id, table.fundId],
+      name: 'import_mapping_profiles_superseded_fund_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'import_mapping_profiles_created_by_fk',
+    }),
+    sourceTypeCheck: check(
+      'import_mapping_profiles_source_type_check',
+      sql`${table.sourceType} IN ('csv','xlsx','structured_paste','manual')`
+    ),
+    domainCheck: check(
+      'import_mapping_profiles_domain_check',
+      sql`${table.domain} IN ('ledger_event','valuation','ownership')`
+    ),
+    versionPositiveCheck: check(
+      'import_mapping_profiles_version_positive_check',
+      sql`${table.version} >= 1`
+    ),
+    idFundUnique: unique('import_mapping_profiles_id_fund_unique').on(table.id, table.fundId),
+    fundIdempotencyUnique: unique('import_mapping_profiles_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    fundNameVersionUnique: unique('import_mapping_profiles_fund_name_version_unique').on(
+      table.fundId,
+      table.name,
+      table.version
+    ),
+    fundNameHeadUnique: uniqueIndex('import_mapping_profiles_fund_name_head_unique')
+      .on(table.fundId, table.name)
+      .where(sql`${table.supersededByProfileId} IS NULL`),
+  })
+);
+
+export const importBatches = pgTable(
+  'import_batches',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    sourceArtifactId: integer('source_artifact_id'),
+    mappingProfileId: integer('mapping_profile_id'),
+    status: text('status').notNull().default('staged'),
+    previewHash: varchar('preview_hash', { length: 64 }),
+    purgeAfter: timestamp('purge_after', { withTimezone: true }).notNull(),
+    retentionExtendedUntil: timestamp('retention_extended_until', {
+      withTimezone: true,
+    }),
+    retentionExtensionReason: text('retention_extension_reason'),
+    purgedAt: timestamp('purged_at', { withTimezone: true }),
+    version: integer('version').notNull().default(1),
+    createdBy: integer('created_by'),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'import_batches_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    sourceArtifactFundFk: foreignKey({
+      columns: [table.sourceArtifactId, table.fundId],
+      foreignColumns: [sourceArtifacts.id, sourceArtifacts.fundId],
+      name: 'import_batches_source_artifact_fund_fk',
+    }),
+    mappingProfileFundFk: foreignKey({
+      columns: [table.mappingProfileId, table.fundId],
+      foreignColumns: [importMappingProfiles.id, importMappingProfiles.fundId],
+      name: 'import_batches_mapping_profile_fund_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'import_batches_created_by_fk',
+    }),
+    statusCheck: check(
+      'import_batches_status_check',
+      sql`${table.status} IN ('staged','partially_committed','committed','expired')`
+    ),
+    idFundUnique: unique('import_batches_id_fund_unique').on(table.id, table.fundId),
+    fundIdempotencyUnique: unique('import_batches_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    fundCreatedIdx: index('idx_import_batches_fund_created').on(
+      table.fundId,
+      table.createdAt.desc()
+    ),
+    purgeAfterIdx: index('idx_import_batches_purge_after')
+      .on(table.purgeAfter)
+      .where(sql`${table.purgedAt} IS NULL`),
+  })
+);
+
+export const companyIdentities = pgTable(
+  'company_identities',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    canonicalName: text('canonical_name').notNull(),
+    mergedIntoIdentityId: integer('merged_into_identity_id'),
+    sourcePortfolioCompanyId: integer('source_portfolio_company_id'),
+    createdBy: integer('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'company_identities_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    mergedIntoFk: foreignKey({
+      columns: [table.mergedIntoIdentityId],
+      foreignColumns: [table.id],
+      name: 'company_identities_merged_into_fk',
+    }),
+    sourcePortfolioCompanyFk: foreignKey({
+      columns: [table.sourcePortfolioCompanyId],
+      foreignColumns: [portfolioCompanies.id],
+      name: 'company_identities_source_portfolio_company_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'company_identities_created_by_fk',
+    }),
+    noSelfMergeCheck: check(
+      'company_identities_no_self_merge_check',
+      sql`${table.mergedIntoIdentityId} IS NULL OR ${table.mergedIntoIdentityId} <> ${table.id}`
+    ),
+    idFundUnique: unique('company_identities_id_fund_unique').on(table.id, table.fundId),
+    sourcePortfolioCompanyUnique: uniqueIndex('company_identities_source_pc_unique')
+      .on(table.sourcePortfolioCompanyId)
+      .where(sql`${table.sourcePortfolioCompanyId} IS NOT NULL`),
+    fundIdx: index('idx_company_identities_fund').on(table.fundId),
+  })
+);
+
+export const companyExternalIdentities = pgTable(
+  'company_external_identities',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    companyIdentityId: integer('company_identity_id').notNull(),
+    system: text('system').notNull(),
+    value: text('value').notNull(),
+    createdBy: integer('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'company_external_identities_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    identityFundFk: foreignKey({
+      columns: [table.companyIdentityId, table.fundId],
+      foreignColumns: [companyIdentities.id, companyIdentities.fundId],
+      name: 'company_external_identities_identity_fund_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'company_external_identities_created_by_fk',
+    }),
+    fundSystemValueUnique: unique('company_external_identities_fund_system_value_unique').on(
+      table.fundId,
+      table.system,
+      table.value
+    ),
+  })
+);
+
+export const portfolioCompanyIdentityLinks = pgTable(
+  'portfolio_company_identity_links',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    portfolioCompanyId: integer('portfolio_company_id').notNull(),
+    companyIdentityId: integer('company_identity_id').notNull(),
+    linkType: text('link_type').notNull(),
+    active: boolean('active').notNull().default(true),
+    deactivatedAt: timestamp('deactivated_at', { withTimezone: true }),
+    createdBy: integer('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'pc_identity_links_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    portfolioCompanyFk: foreignKey({
+      columns: [table.portfolioCompanyId],
+      foreignColumns: [portfolioCompanies.id],
+      name: 'pc_identity_links_portfolio_company_fk',
+    }),
+    identityFundFk: foreignKey({
+      columns: [table.companyIdentityId, table.fundId],
+      foreignColumns: [companyIdentities.id, companyIdentities.fundId],
+      name: 'pc_identity_links_identity_fund_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'pc_identity_links_created_by_fk',
+    }),
+    linkTypeCheck: check(
+      'pc_identity_links_link_type_check',
+      sql`${table.linkType} IN ('backfill','operator_resolution','import_resolution')`
+    ),
+    activeDeactivatedCheck: check(
+      'pc_identity_links_active_deactivated_check',
+      sql`(${table.active} AND ${table.deactivatedAt} IS NULL)
+          OR (NOT ${table.active} AND ${table.deactivatedAt} IS NOT NULL)`
+    ),
+    activeCompanyUnique: uniqueIndex('pc_identity_links_active_company_unique')
+      .on(table.portfolioCompanyId)
+      .where(sql`${table.active} = true`),
+  })
+);
+
+export const sourceObservations = pgTable(
+  'source_observations',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    importBatchId: integer('import_batch_id'),
+    sourceArtifactId: integer('source_artifact_id'),
+    mappingProfileId: integer('mapping_profile_id'),
+    companyIdentityId: integer('company_identity_id'),
+    domain: text('domain').notNull(),
+    sourceType: text('source_type').notNull(),
+    effectiveDate: date('effective_date').notNull(),
+    normalizedPayload: jsonb('normalized_payload').notNull().$type<Record<string, unknown>>(),
+    observationHash: varchar('observation_hash', { length: 64 }).notNull(),
+    candidateFingerprint: varchar('candidate_fingerprint', { length: 64 }).notNull(),
+    sourceLocator: text('source_locator'),
+    dependencyGroupKey: text('dependency_group_key'),
+    status: text('status').notNull().default('staged'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'source_observations_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    importBatchFundFk: foreignKey({
+      columns: [table.importBatchId, table.fundId],
+      foreignColumns: [importBatches.id, importBatches.fundId],
+      name: 'source_observations_import_batch_fund_fk',
+    }),
+    sourceArtifactFundFk: foreignKey({
+      columns: [table.sourceArtifactId, table.fundId],
+      foreignColumns: [sourceArtifacts.id, sourceArtifacts.fundId],
+      name: 'source_observations_source_artifact_fund_fk',
+    }),
+    mappingProfileFundFk: foreignKey({
+      columns: [table.mappingProfileId, table.fundId],
+      foreignColumns: [importMappingProfiles.id, importMappingProfiles.fundId],
+      name: 'source_observations_mapping_profile_fund_fk',
+    }),
+    companyIdentityFundFk: foreignKey({
+      columns: [table.companyIdentityId, table.fundId],
+      foreignColumns: [companyIdentities.id, companyIdentities.fundId],
+      name: 'source_observations_company_identity_fund_fk',
+    }),
+    domainCheck: check(
+      'source_observations_domain_check',
+      sql`${table.domain} IN ('ledger_event','valuation','ownership')`
+    ),
+    sourceTypeCheck: check(
+      'source_observations_source_type_check',
+      sql`${table.sourceType} IN ('csv','xlsx','structured_paste','manual')`
+    ),
+    statusCheck: check(
+      'source_observations_status_check',
+      sql`${table.status} IN ('staged','accepted','purged')`
+    ),
+    idFundUnique: unique('source_observations_id_fund_unique').on(table.id, table.fundId),
+    fundHashAcceptedUnique: uniqueIndex('source_observations_fund_hash_accepted_unique')
+      .on(table.fundId, table.observationHash)
+      .where(sql`${table.status} = 'accepted'`),
+    fundEffectiveDateIdx: index('idx_source_observations_fund_effective_date').on(
+      table.fundId,
+      table.effectiveDate
+    ),
+    fundCandidateFingerprintIdx: index('idx_source_observations_fund_candidate_fingerprint').on(
+      table.fundId,
+      table.candidateFingerprint
+    ),
+    importBatchIdx: index('idx_source_observations_import_batch').on(table.importBatchId),
+  })
+);
+
+export const reconciliationCases = pgTable(
+  'reconciliation_cases',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    importBatchId: integer('import_batch_id'),
+    sourceObservationId: integer('source_observation_id'),
+    caseType: text('case_type').notNull(),
+    status: text('status').notNull().default('open'),
+    observationHash: varchar('observation_hash', { length: 64 }),
+    candidateFingerprint: varchar('candidate_fingerprint', { length: 64 }),
+    resolution: jsonb('resolution').$type<ReconciliationResolutionV1>(),
+    resolvedBy: integer('resolved_by'),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+    history: jsonb('history')
+      .notNull()
+      .default(sql`'[]'::jsonb`)
+      .$type<ReconciliationCaseHistoryEntryV1[]>(),
+    version: integer('version').notNull().default(1),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'reconciliation_cases_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    importBatchFundFk: foreignKey({
+      columns: [table.importBatchId, table.fundId],
+      foreignColumns: [importBatches.id, importBatches.fundId],
+      name: 'reconciliation_cases_import_batch_fund_fk',
+    }),
+    sourceObservationFundFk: foreignKey({
+      columns: [table.sourceObservationId, table.fundId],
+      foreignColumns: [sourceObservations.id, sourceObservations.fundId],
+      name: 'reconciliation_cases_source_observation_fund_fk',
+    }),
+    resolvedByFk: foreignKey({
+      columns: [table.resolvedBy],
+      foreignColumns: [users.id],
+      name: 'reconciliation_cases_resolved_by_fk',
+    }),
+    caseTypeCheck: check(
+      'reconciliation_cases_case_type_check',
+      sql`${table.caseType} IN ('identity_resolution','observation_match')`
+    ),
+    statusCheck: check(
+      'reconciliation_cases_status_check',
+      sql`${table.status} IN ('open','resolved','expired_unresolved')`
+    ),
+    resolvedFieldsCheck: check(
+      'reconciliation_cases_resolved_fields_check',
+      sql`(${table.status} = 'resolved'
+            AND ${table.resolution} IS NOT NULL
+            AND ${table.resolvedAt} IS NOT NULL)
+          OR (${table.status} <> 'resolved'
+            AND ${table.resolution} IS NULL
+            AND ${table.resolvedAt} IS NULL
+            AND ${table.resolvedBy} IS NULL)`
+    ),
+    fundStatusIdx: index('idx_reconciliation_cases_fund_status').on(table.fundId, table.status),
+  })
+);
+
+export const workingValueSelections = pgTable(
+  'working_value_selections',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    consumer: text('consumer').notNull(),
+    companyIdentityId: integer('company_identity_id'),
+    domain: text('domain').notNull(),
+    measureKey: text('measure_key').notNull(),
+    asOfDate: date('as_of_date').notNull(),
+    selectedObservationId: integer('selected_observation_id').notNull(),
+    isDefault: boolean('is_default').notNull(),
+    reason: text('reason'),
+    version: integer('version').notNull().default(1),
+    supersededBySelectionId: integer('superseded_by_selection_id'),
+    createdBy: integer('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'working_value_selections_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    observationFundFk: foreignKey({
+      columns: [table.selectedObservationId, table.fundId],
+      foreignColumns: [sourceObservations.id, sourceObservations.fundId],
+      name: 'working_value_selections_observation_fund_fk',
+    }),
+    identityFundFk: foreignKey({
+      columns: [table.companyIdentityId, table.fundId],
+      foreignColumns: [companyIdentities.id, companyIdentities.fundId],
+      name: 'working_value_selections_identity_fund_fk',
+    }),
+    supersededFundFk: foreignKey({
+      columns: [table.supersededBySelectionId, table.fundId],
+      foreignColumns: [table.id, table.fundId],
+      name: 'working_value_selections_superseded_fund_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'working_value_selections_created_by_fk',
+    }),
+    consumerCheck: check(
+      'working_value_selections_consumer_check',
+      sql`${table.consumer} IN ('forecast','reserve','economics','periodic_analysis')`
+    ),
+    domainCheck: check(
+      'working_value_selections_domain_check',
+      sql`${table.domain} IN ('ledger_event','valuation','ownership')`
+    ),
+    deviationReasonCheck: check(
+      'working_value_selections_deviation_reason_check',
+      sql`${table.isDefault} OR ${table.reason} IS NOT NULL`
+    ),
+    scopeHeadUnique: uniqueIndex('working_value_selections_scope_head_unique')
+      .on(
+        table.fundId,
+        table.consumer,
+        table.domain,
+        table.measureKey,
+        table.asOfDate,
+        sql`COALESCE(${table.companyIdentityId}, 0)`
+      )
+      .where(sql`${table.supersededBySelectionId} IS NULL`),
+  })
+);
+
+export type SourceArtifact = typeof sourceArtifacts.$inferSelect;
+export type InsertSourceArtifact = typeof sourceArtifacts.$inferInsert;
+export type ImportMappingProfile = typeof importMappingProfiles.$inferSelect;
+export type InsertImportMappingProfile = typeof importMappingProfiles.$inferInsert;
+export type ImportBatch = typeof importBatches.$inferSelect;
+export type InsertImportBatch = typeof importBatches.$inferInsert;
+export type CompanyIdentity = typeof companyIdentities.$inferSelect;
+export type InsertCompanyIdentity = typeof companyIdentities.$inferInsert;
+export type CompanyExternalIdentity = typeof companyExternalIdentities.$inferSelect;
+export type InsertCompanyExternalIdentity = typeof companyExternalIdentities.$inferInsert;
+export type PortfolioCompanyIdentityLink = typeof portfolioCompanyIdentityLinks.$inferSelect;
+export type InsertPortfolioCompanyIdentityLink = typeof portfolioCompanyIdentityLinks.$inferInsert;
+export type SourceObservation = typeof sourceObservations.$inferSelect;
+export type InsertSourceObservation = typeof sourceObservations.$inferInsert;
+export type ReconciliationCase = typeof reconciliationCases.$inferSelect;
+export type InsertReconciliationCase = typeof reconciliationCases.$inferInsert;
+export type WorkingValueSelection = typeof workingValueSelections.$inferSelect;
+export type InsertWorkingValueSelection = typeof workingValueSelections.$inferInsert;

--- a/shared/schema/financial-observations.ts
+++ b/shared/schema/financial-observations.ts
@@ -522,6 +522,7 @@ export const workingValueSelections = pgTable(
       foreignColumns: [table.id, table.fundId],
       name: 'working_value_selections_superseded_fund_fk',
     }),
+    idFundUnique: unique('working_value_selections_id_fund_unique').on(table.id, table.fundId),
     createdByFk: foreignKey({
       columns: [table.createdBy],
       foreignColumns: [users.id],

--- a/shared/schema/index.ts
+++ b/shared/schema/index.ts
@@ -26,3 +26,4 @@ export * from './investment-rounds';
 export * from './investment-round-model-overrides';
 export * from './current-plans';
 export * from './current-forecast-references';
+export * from './financial-observations';

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -89,6 +89,18 @@ const FINANCIAL_FACTS_SNAPSHOT_MANIFEST_TABLES = ['financial_facts_snapshots'] a
 const CURRENT_PLAN_VERSIONS_MANIFEST_TABLES = ['current_plan_versions'] as const;
 // M12 (12-current-forecast-references): append-only current-forecast reference pins (journal 0038).
 const CURRENT_FORECAST_REFERENCES_MANIFEST_TABLES = ['current_forecast_references'] as const;
+// M13 (13-financial-observations): immutable evidence, identity, and import foundation (journal 0039).
+const FINANCIAL_OBSERVATIONS_MANIFEST_TABLES = [
+  'source_artifacts',
+  'import_mapping_profiles',
+  'import_batches',
+  'company_identities',
+  'company_external_identities',
+  'portfolio_company_identity_links',
+  'source_observations',
+  'reconciliation_cases',
+  'working_value_selections',
+] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
   'flags_state',
@@ -715,6 +727,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...FINANCIAL_FACTS_SNAPSHOT_MANIFEST_TABLES,
         ...CURRENT_PLAN_VERSIONS_MANIFEST_TABLES,
         ...CURRENT_FORECAST_REFERENCES_MANIFEST_TABLES,
+        ...FINANCIAL_OBSERVATIONS_MANIFEST_TABLES,
       ])
     );
 
@@ -725,6 +738,94 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     expect(
       expectedConstraints.filter((constraintName) => !migratedConstraints.has(constraintName))
     ).toEqual([]);
+  });
+
+  it('replays the 0039 identity backfill without duplicates or operator-link resurrection', async () => {
+    expect(pool).toBeDefined();
+    const migration = await readFile(
+      path.join(process.cwd(), 'migrations', '0039_financial_observations.sql'),
+      'utf8'
+    );
+    const fundResult = await pool!.query<{ id: number }>(`
+      INSERT INTO funds (name, size, management_fee, carry_percentage, vintage_year)
+      VALUES ('Task 3 replay fund', 10000000, 0.02, 0.20, 2026)
+      RETURNING id
+    `);
+    const fundId = fundResult.rows[0]!.id;
+    const companyResult = await pool!.query<{ id: number; fund_id: number | null }>(
+      `
+        INSERT INTO portfoliocompanies
+          (fund_id, name, sector, stage, investment_amount)
+        VALUES
+          ($1, 'Task 3 linked company', 'software', 'seed', 100000),
+          (NULL, 'Task 3 NULL-fund company', 'software', 'seed', 100000)
+        RETURNING id, fund_id
+      `,
+      [fundId]
+    );
+    const linkedCompanyId = companyResult.rows.find((row) => row.fund_id === fundId)!.id;
+    const nullFundCompanyId = companyResult.rows.find((row) => row.fund_id === null)!.id;
+
+    await pool!.query(migration);
+
+    const identityCounts = await pool!.query<{
+      linked_count: string;
+      null_fund_count: string;
+    }>(
+      `
+        SELECT
+          count(*) FILTER (WHERE source_portfolio_company_id = $1) linked_count,
+          count(*) FILTER (WHERE source_portfolio_company_id = $2) null_fund_count
+        FROM company_identities
+      `,
+      [linkedCompanyId, nullFundCompanyId]
+    );
+    const linkCounts = await pool!.query<{ linked_count: string }>(
+      `
+        SELECT count(*) FILTER (WHERE portfolio_company_id = $1) linked_count
+        FROM portfolio_company_identity_links
+      `,
+      [linkedCompanyId]
+    );
+
+    expect(identityCounts.rows[0]).toEqual({
+      linked_count: '1',
+      null_fund_count: '0',
+    });
+    expect(linkCounts.rows[0]).toEqual({ linked_count: '1' });
+
+    await pool!.query(
+      `
+        UPDATE portfolio_company_identity_links
+        SET active = false, deactivated_at = now()
+        WHERE portfolio_company_id = $1
+      `,
+      [linkedCompanyId]
+    );
+    await pool!.query(migration);
+
+    const replayCounts = await pool!.query<{
+      identity_count: string;
+      link_count: string;
+      active_link_count: string;
+    }>(
+      `
+        SELECT
+          (SELECT count(*) FROM company_identities
+            WHERE source_portfolio_company_id = $1) identity_count,
+          (SELECT count(*) FROM portfolio_company_identity_links
+            WHERE portfolio_company_id = $1) link_count,
+          (SELECT count(*) FROM portfolio_company_identity_links
+            WHERE portfolio_company_id = $1 AND active) active_link_count
+      `,
+      [linkedCompanyId]
+    );
+
+    expect(replayCounts.rows[0]).toEqual({
+      identity_count: '1',
+      link_count: '1',
+      active_link_count: '0',
+    });
   });
 
   it('proves journal-built DB-A shape matches drizzle push DB-B where schemas overlap', async () => {

--- a/tests/unit/contract/financial-observations.contract.test.ts
+++ b/tests/unit/contract/financial-observations.contract.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONSUMER_DEFAULT_SELECTION_RULES,
+  DEFAULT_SELECTION_RULE,
+  FINANCIAL_FACTS_CONSUMER_KEYS,
+} from '@shared/contracts/financial-facts-consumer-policies';
+import {
+  FINANCIAL_OBSERVATION_DOMAINS,
+  FINANCIAL_OBSERVATION_SOURCES,
+  IDENTITY_LINK_TYPES,
+  IMPORT_BATCH_STATUSES,
+  SOURCE_OBSERVATION_STATUSES,
+  CompanyExternalIdentityV1Schema,
+  CompanyIdentityV1Schema,
+  PortfolioCompanyIdentityLinkV1Schema,
+  Sha256HexSchema,
+  SourceObservationV1Schema,
+  WorkingValueSelectionV1Schema,
+  resolveIdentityMergeChain,
+} from '@shared/contracts/financial-observations/financial-observation.contract';
+import {
+  ALLOWED_MAPPING_TRANSFORMS,
+  IDENTITY_TARGET_FIELDS,
+  ImportMappingProfileV1Schema,
+  MappingRuleV1Schema,
+  buildIdentitySemanticsHash,
+} from '@shared/contracts/financial-observations/import-profile.contract';
+import {
+  RECONCILIATION_CASE_STATUSES,
+  RECONCILIATION_CASE_TYPES,
+  RECONCILIATION_RESOLUTION_ACTIONS,
+  TERMINAL_RECONCILIATION_CASE_STATUSES,
+  ReconciliationCaseHistoryEntryV1Schema,
+  ReconciliationCaseV1Schema,
+  ReconciliationResolutionV1Schema,
+} from '@shared/contracts/financial-observations/reconciliation.contract';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+
+const sourceObservation = {
+  id: 1,
+  fundId: 2,
+  importBatchId: 3,
+  sourceArtifactId: 4,
+  mappingProfileId: 5,
+  companyIdentityId: 6,
+  domain: 'valuation',
+  sourceType: 'csv',
+  effectiveDate: '2026-07-23',
+  normalizedPayload: { fairValue: '1250000.00' },
+  observationHash: HASH_A,
+  candidateFingerprint: HASH_B,
+  sourceLocator: 'Sheet1!A2:D2',
+  dependencyGroupKey: null,
+  status: 'accepted',
+  createdAt: '2026-07-23T20:39:41.006Z',
+} as const;
+
+const workingValueSelection = {
+  id: 7,
+  fundId: 2,
+  consumer: 'forecast',
+  companyIdentityId: 6,
+  domain: 'valuation',
+  measureKey: 'fair_value',
+  asOfDate: '2026-07-23',
+  selectedObservationId: 1,
+  isDefault: false,
+  reason: 'IC-approved valuation override',
+  version: 1,
+  supersededBySelectionId: null,
+  createdBy: 8,
+  createdAt: '2026-07-23T20:39:41.006Z',
+} as const;
+
+const companyIdentity = {
+  id: 6,
+  fundId: 2,
+  canonicalName: 'Example Co',
+  mergedIntoIdentityId: null,
+  sourcePortfolioCompanyId: 9,
+  createdBy: 8,
+  createdAt: '2026-07-23T20:39:41.006Z',
+} as const;
+
+const companyExternalIdentity = {
+  id: 10,
+  fundId: 2,
+  companyIdentityId: 6,
+  system: 'carta',
+  value: 'company-123',
+  createdBy: 8,
+  createdAt: '2026-07-23T20:39:41.006Z',
+} as const;
+
+const portfolioCompanyIdentityLink = {
+  id: 11,
+  fundId: 2,
+  portfolioCompanyId: 9,
+  companyIdentityId: 6,
+  linkType: 'operator_resolution',
+  active: true,
+  deactivatedAt: null,
+  createdBy: 8,
+  createdAt: '2026-07-23T20:39:41.006Z',
+} as const;
+
+const mappingRule = {
+  sourceColumn: 'Company Name',
+  targetField: 'company_name',
+  transforms: ['trim', 'normalize_whitespace'],
+} as const;
+
+const importMappingProfile = {
+  name: 'Carta valuation export',
+  sourceType: 'csv',
+  domain: 'valuation',
+  version: 1,
+  mappings: [mappingRule],
+  identitySemanticsHash: HASH_A,
+} as const;
+
+const reconciliationResolution = {
+  action: 'confirm_match',
+  targetCompanyIdentityId: 6,
+  memo: 'Matched durable external identifier',
+} as const;
+
+const reconciliationHistoryEntry = {
+  at: '2026-07-23T20:39:41.006Z',
+  event: 'resolved',
+} as const;
+
+const reconciliationCase = {
+  id: 12,
+  fundId: 2,
+  importBatchId: 3,
+  sourceObservationId: 1,
+  caseType: 'identity_resolution',
+  status: 'resolved',
+  observationHash: HASH_A,
+  candidateFingerprint: HASH_B,
+  resolution: reconciliationResolution,
+  resolvedBy: 8,
+  resolvedAt: '2026-07-23T20:39:41.006Z',
+  history: [reconciliationHistoryEntry],
+  version: 1,
+  createdAt: '2026-07-23T20:39:41.006Z',
+} as const;
+
+describe('financial-observation contract constants', () => {
+  it('pins every persisted enum to its exact wire value list', () => {
+    expect(FINANCIAL_OBSERVATION_SOURCES).toEqual(['csv', 'xlsx', 'structured_paste', 'manual']);
+    expect(FINANCIAL_OBSERVATION_DOMAINS).toEqual(['ledger_event', 'valuation', 'ownership']);
+    expect(SOURCE_OBSERVATION_STATUSES).toEqual(['staged', 'accepted', 'purged']);
+    expect(IMPORT_BATCH_STATUSES).toEqual([
+      'staged',
+      'partially_committed',
+      'committed',
+      'expired',
+    ]);
+    expect(IDENTITY_LINK_TYPES).toEqual(['backfill', 'operator_resolution', 'import_resolution']);
+    expect(ALLOWED_MAPPING_TRANSFORMS).toEqual([
+      'trim',
+      'normalize_whitespace',
+      'parse_decimal',
+      'parse_date_iso',
+      'parse_date_us',
+      'negate',
+    ]);
+    expect(IDENTITY_TARGET_FIELDS).toEqual(['company_name', 'company_external_id']);
+    expect(RECONCILIATION_CASE_TYPES).toEqual(['identity_resolution', 'observation_match']);
+    expect(RECONCILIATION_CASE_STATUSES).toEqual(['open', 'resolved', 'expired_unresolved']);
+    expect(TERMINAL_RECONCILIATION_CASE_STATUSES).toEqual(['resolved', 'expired_unresolved']);
+    expect(RECONCILIATION_RESOLUTION_ACTIONS).toEqual([
+      'confirm_match',
+      'create_identity',
+      'merge_identities',
+      'reject',
+    ]);
+  });
+
+  it('accepts only lowercase 64-character SHA-256 hex strings', () => {
+    expect(Sha256HexSchema.parse(HASH_A)).toBe(HASH_A);
+    expect(Sha256HexSchema.safeParse('A'.repeat(64)).success).toBe(false);
+    expect(Sha256HexSchema.safeParse('a'.repeat(63)).success).toBe(false);
+    expect(Sha256HexSchema.safeParse(`${'a'.repeat(63)}g`).success).toBe(false);
+  });
+});
+
+describe('financial-observation object schemas', () => {
+  it('accepts the documented version-one objects', () => {
+    expect(SourceObservationV1Schema.parse(sourceObservation)).toEqual(sourceObservation);
+    expect(WorkingValueSelectionV1Schema.parse(workingValueSelection)).toEqual(
+      workingValueSelection
+    );
+    expect(CompanyIdentityV1Schema.parse(companyIdentity)).toEqual(companyIdentity);
+    expect(CompanyExternalIdentityV1Schema.parse(companyExternalIdentity)).toEqual(
+      companyExternalIdentity
+    );
+    expect(PortfolioCompanyIdentityLinkV1Schema.parse(portfolioCompanyIdentityLink)).toEqual(
+      portfolioCompanyIdentityLink
+    );
+    expect(MappingRuleV1Schema.parse(mappingRule)).toEqual(mappingRule);
+    expect(ImportMappingProfileV1Schema.parse(importMappingProfile)).toEqual(importMappingProfile);
+    expect(ReconciliationResolutionV1Schema.parse(reconciliationResolution)).toEqual(
+      reconciliationResolution
+    );
+    expect(ReconciliationCaseHistoryEntryV1Schema.parse(reconciliationHistoryEntry)).toEqual(
+      reconciliationHistoryEntry
+    );
+    expect(ReconciliationCaseV1Schema.parse(reconciliationCase)).toEqual(reconciliationCase);
+  });
+
+  it('rejects unknown keys on every object schema', () => {
+    const cases: ReadonlyArray<
+      readonly [{ safeParse(value: unknown): { success: boolean } }, object]
+    > = [
+      [SourceObservationV1Schema, sourceObservation],
+      [WorkingValueSelectionV1Schema, workingValueSelection],
+      [CompanyIdentityV1Schema, companyIdentity],
+      [CompanyExternalIdentityV1Schema, companyExternalIdentity],
+      [PortfolioCompanyIdentityLinkV1Schema, portfolioCompanyIdentityLink],
+      [MappingRuleV1Schema, mappingRule],
+      [ImportMappingProfileV1Schema, importMappingProfile],
+      [ReconciliationResolutionV1Schema, reconciliationResolution],
+      [ReconciliationCaseHistoryEntryV1Schema, reconciliationHistoryEntry],
+      [ReconciliationCaseV1Schema, reconciliationCase],
+    ];
+
+    for (const [schema, value] of cases) {
+      expect(schema.safeParse({ ...value, unexpected: true }).success).toBe(false);
+    }
+  });
+});
+
+describe('identity mapping semantics', () => {
+  const identityRule = {
+    sourceColumn: 'Company Name',
+    targetField: 'company_name',
+    transforms: ['trim', 'normalize_whitespace'],
+  } as const;
+  const externalIdRule = {
+    sourceColumn: 'Carta Company ID',
+    targetField: 'company_external_id',
+    transforms: ['trim'],
+  } as const;
+  const nonIdentityRule = {
+    sourceColumn: 'Fair Value',
+    targetField: 'fair_value',
+    transforms: ['trim', 'parse_decimal'],
+  } as const;
+
+  it('is stable under mapping-rule reorder', () => {
+    expect(buildIdentitySemanticsHash([identityRule, externalIdRule, nonIdentityRule])).toBe(
+      buildIdentitySemanticsHash([nonIdentityRule, externalIdRule, identityRule])
+    );
+  });
+
+  it('changes only when identity-bearing rules change', () => {
+    const baseline = buildIdentitySemanticsHash([identityRule, externalIdRule, nonIdentityRule]);
+    const identityChanged = buildIdentitySemanticsHash([
+      { ...identityRule, sourceColumn: 'Legal Company Name' },
+      externalIdRule,
+      nonIdentityRule,
+    ]);
+    const nonIdentityChanged = buildIdentitySemanticsHash([
+      identityRule,
+      externalIdRule,
+      { ...nonIdentityRule, sourceColumn: 'Current Fair Value' },
+    ]);
+
+    expect(identityChanged).not.toBe(baseline);
+    expect(nonIdentityChanged).toBe(baseline);
+  });
+
+  it('hashes SHA-like source strings directly without decimal-leaf mangling', () => {
+    const hexSourceRule = {
+      sourceColumn: 'e'.repeat(64),
+      targetField: 'company_external_id',
+      transforms: ['trim'],
+    } as const;
+
+    expect(buildIdentitySemanticsHash([hexSourceRule])).toBe(canonicalSha256([hexSourceRule]));
+  });
+});
+
+describe('company identity merge-chain resolution', () => {
+  it('returns the starting identity when it is already canonical', () => {
+    expect(resolveIdentityMergeChain(new Map([[1, { mergedIntoIdentityId: null }]]), 1)).toBe(1);
+  });
+
+  it('walks a merge chain to its canonical identity', () => {
+    expect(
+      resolveIdentityMergeChain(
+        new Map([
+          [1, { mergedIntoIdentityId: 2 }],
+          [2, { mergedIntoIdentityId: 3 }],
+          [3, { mergedIntoIdentityId: null }],
+        ]),
+        1
+      )
+    ).toBe(3);
+  });
+
+  it('throws on a merge cycle', () => {
+    expect(() =>
+      resolveIdentityMergeChain(
+        new Map([
+          [1, { mergedIntoIdentityId: 2 }],
+          [2, { mergedIntoIdentityId: 1 }],
+        ]),
+        1
+      )
+    ).toThrow(/cycle/i);
+  });
+});
+
+describe('financial-facts consumer selection defaults', () => {
+  it('keeps the frozen consumer key list and covers every key', () => {
+    expect(FINANCIAL_FACTS_CONSUMER_KEYS).toEqual([
+      'forecast',
+      'reserve',
+      'economics',
+      'periodic_analysis',
+    ]);
+    expect(CONSUMER_DEFAULT_SELECTION_RULES).toEqual({
+      forecast: DEFAULT_SELECTION_RULE,
+      reserve: DEFAULT_SELECTION_RULE,
+      economics: DEFAULT_SELECTION_RULE,
+      periodic_analysis: DEFAULT_SELECTION_RULE,
+    });
+    expect(DEFAULT_SELECTION_RULE).toBe('latest_effective_dated_accepted_at_or_before_as_of');
+  });
+});

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -49,6 +49,7 @@ const expectedJournaledDriftPatchFiles = [
   '0036_financial_facts_snapshots.sql',
   '0037_current_plans.sql',
   '0038_current_forecast_references.sql',
+  '0039_financial_observations.sql',
 ].sort();
 
 afterEach(() => {

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -95,6 +95,7 @@ describe('prod-schema manifest sentinels', () => {
       '10-financial-facts-snapshots.json',
       '11-current-plan-versions.json',
       '12-current-forecast-references.json',
+      '13-financial-observations.json',
     ]);
   });
 

--- a/tests/unit/schema/financial-observations-schema.test.ts
+++ b/tests/unit/schema/financial-observations-schema.test.ts
@@ -1,0 +1,391 @@
+// Default import on purpose: node-setup.ts vi.mock('fs') stubs named exports,
+// while its actual-module spread preserves `default` as the real fs module.
+import fs from 'node:fs';
+
+import { PgDialect, getTableConfig } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  FINANCIAL_OBSERVATION_DOMAINS,
+  FINANCIAL_OBSERVATION_SOURCES,
+  IDENTITY_LINK_TYPES,
+  IMPORT_BATCH_STATUSES,
+  SOURCE_OBSERVATION_STATUSES,
+} from '@shared/contracts/financial-observations/financial-observation.contract';
+import {
+  RECONCILIATION_CASE_STATUSES,
+  RECONCILIATION_CASE_TYPES,
+} from '@shared/contracts/financial-observations/reconciliation.contract';
+import { FINANCIAL_FACTS_CONSUMER_KEYS } from '@shared/contracts/financial-facts-consumer-policies';
+import * as runtimeSchema from '@shared/schema';
+import {
+  companyExternalIdentities,
+  companyIdentities,
+  importBatches,
+  importMappingProfiles,
+  portfolioCompanyIdentityLinks,
+  reconciliationCases,
+  sourceArtifacts,
+  sourceObservations,
+  workingValueSelections,
+} from '@shared/schema/financial-observations';
+
+const tableEntries = [
+  ['source_artifacts', sourceArtifacts],
+  ['import_mapping_profiles', importMappingProfiles],
+  ['import_batches', importBatches],
+  ['company_identities', companyIdentities],
+  ['company_external_identities', companyExternalIdentities],
+  ['portfolio_company_identity_links', portfolioCompanyIdentityLinks],
+  ['source_observations', sourceObservations],
+  ['reconciliation_cases', reconciliationCases],
+  ['working_value_selections', workingValueSelections],
+] as const;
+
+const tableConfigs = new Map(
+  tableEntries.map(([name, table]) => [name, getTableConfig(table)] as const)
+);
+const dialect = new PgDialect();
+
+function configFor(tableName: (typeof tableEntries)[number][0]) {
+  const config = tableConfigs.get(tableName);
+  if (!config) {
+    throw new Error(`Missing table config: ${tableName}`);
+  }
+  return config;
+}
+
+function constraintNames(tableName: (typeof tableEntries)[number][0]): string[] {
+  const config = configFor(tableName);
+  return [
+    ...config.foreignKeys.map((foreignKey) => foreignKey.getName()),
+    ...config.uniqueConstraints.map((constraint) => constraint.name),
+    ...config.checks.map((constraint) => constraint.name),
+  ];
+}
+
+function indexNames(tableName: (typeof tableEntries)[number][0]): string[] {
+  return configFor(tableName).indexes.map((index) => index.config.name);
+}
+
+function checkSql(tableName: (typeof tableEntries)[number][0], checkName: string): string {
+  const check = configFor(tableName).checks.find((candidate) => candidate.name === checkName);
+  if (!check) {
+    throw new Error(`Missing CHECK ${checkName}`);
+  }
+  return dialect.sqlToQuery(check.value).sql;
+}
+
+function quotedValues(values: readonly string[]): string {
+  return values.map((value) => `'${value}'`).join(',');
+}
+
+describe('financial observations Drizzle schema', () => {
+  it('exports all nine tables through the runtime schema barrel', () => {
+    expect(runtimeSchema.sourceArtifacts).toBe(sourceArtifacts);
+    expect(runtimeSchema.importMappingProfiles).toBe(importMappingProfiles);
+    expect(runtimeSchema.importBatches).toBe(importBatches);
+    expect(runtimeSchema.companyIdentities).toBe(companyIdentities);
+    expect(runtimeSchema.companyExternalIdentities).toBe(companyExternalIdentities);
+    expect(runtimeSchema.portfolioCompanyIdentityLinks).toBe(portfolioCompanyIdentityLinks);
+    expect(runtimeSchema.sourceObservations).toBe(sourceObservations);
+    expect(runtimeSchema.reconciliationCases).toBe(reconciliationCases);
+    expect(runtimeSchema.workingValueSelections).toBe(workingValueSelections);
+  });
+
+  it('fund-scopes every table with a required cascading fund FK', () => {
+    for (const [tableName] of tableEntries) {
+      const config = configFor(tableName);
+      const fundId = config.columns.find((column) => column.name === 'fund_id');
+      const fundFk = config.foreignKeys.find((foreignKey) =>
+        foreignKey.getName().endsWith('_fund_id_funds_id_fk')
+      );
+
+      expect(fundId?.notNull, `${tableName}.fund_id`).toBe(true);
+      expect(fundFk, `${tableName} fund FK`).toBeDefined();
+      expect(fundFk?.onDelete, `${tableName} fund FK delete action`).toBe('cascade');
+    }
+  });
+
+  it('uses plain composite unique constraints as every new-table FK target', () => {
+    const targetNames = [
+      'source_artifacts_id_fund_unique',
+      'import_mapping_profiles_id_fund_unique',
+      'import_batches_id_fund_unique',
+      'source_observations_id_fund_unique',
+      'company_identities_id_fund_unique',
+    ];
+    const actualNames = tableEntries.flatMap(([tableName]) =>
+      configFor(tableName).uniqueConstraints.map((constraint) => constraint.name)
+    );
+
+    expect(actualNames).toEqual(expect.arrayContaining(targetNames));
+    for (const name of targetNames) {
+      expect(tableEntries.flatMap(([tableName]) => indexNames(tableName))).not.toContain(name);
+    }
+  });
+
+  it('pins same-fund composite FKs across the evidence graph', () => {
+    const expectedByTable = {
+      import_mapping_profiles: ['import_mapping_profiles_superseded_fund_fk'],
+      import_batches: [
+        'import_batches_source_artifact_fund_fk',
+        'import_batches_mapping_profile_fund_fk',
+      ],
+      source_observations: [
+        'source_observations_import_batch_fund_fk',
+        'source_observations_source_artifact_fund_fk',
+        'source_observations_mapping_profile_fund_fk',
+        'source_observations_company_identity_fund_fk',
+      ],
+      reconciliation_cases: [
+        'reconciliation_cases_import_batch_fund_fk',
+        'reconciliation_cases_source_observation_fund_fk',
+      ],
+      working_value_selections: [
+        'working_value_selections_observation_fund_fk',
+        'working_value_selections_identity_fund_fk',
+        'working_value_selections_superseded_fund_fk',
+      ],
+      company_external_identities: ['company_external_identities_identity_fund_fk'],
+      portfolio_company_identity_links: ['pc_identity_links_identity_fund_fk'],
+    } as const;
+
+    for (const [tableName, names] of Object.entries(expectedByTable)) {
+      expect(
+        configFor(tableName as keyof typeof expectedByTable).foreignKeys.map((foreignKey) =>
+          foreignKey.getName()
+        )
+      ).toEqual(expect.arrayContaining([...names]));
+    }
+  });
+
+  it('keeps deliberate plain-FK exceptions for cross-fund merges and legacy companies', () => {
+    expect(constraintNames('company_identities')).toContain('company_identities_merged_into_fk');
+    expect(constraintNames('portfolio_company_identity_links')).toContain(
+      'pc_identity_links_portfolio_company_fk'
+    );
+  });
+
+  it('declares idempotency, accepted-head, selection-head, and identity uniqueness', () => {
+    expect(constraintNames('source_artifacts')).toContain(
+      'source_artifacts_fund_idempotency_unique'
+    );
+    expect(constraintNames('import_mapping_profiles')).toEqual(
+      expect.arrayContaining([
+        'import_mapping_profiles_fund_idempotency_unique',
+        'import_mapping_profiles_fund_name_version_unique',
+      ])
+    );
+    expect(constraintNames('import_batches')).toContain('import_batches_fund_idempotency_unique');
+    expect(constraintNames('company_external_identities')).toContain(
+      'company_external_identities_fund_system_value_unique'
+    );
+    expect(indexNames('import_mapping_profiles')).toContain(
+      'import_mapping_profiles_fund_name_head_unique'
+    );
+    expect(indexNames('source_observations')).toContain(
+      'source_observations_fund_hash_accepted_unique'
+    );
+    expect(indexNames('working_value_selections')).toContain(
+      'working_value_selections_scope_head_unique'
+    );
+    expect(indexNames('company_identities')).toContain('company_identities_source_pc_unique');
+    expect(indexNames('portfolio_company_identity_links')).toContain(
+      'pc_identity_links_active_company_unique'
+    );
+  });
+
+  it('pins append-only lineage and versioned supersession columns', () => {
+    expect(configFor('source_observations').columns.map((column) => column.name)).not.toContain(
+      'updated_at'
+    );
+    expect(constraintNames('import_mapping_profiles')).toContain(
+      'import_mapping_profiles_superseded_fund_fk'
+    );
+    expect(constraintNames('working_value_selections')).toContain(
+      'working_value_selections_superseded_fund_fk'
+    );
+    expect(
+      configFor('working_value_selections').columns.find((column) => column.name === 'version')
+        ?.notNull
+    ).toBe(true);
+  });
+
+  it('uses required varchar(64) columns for persisted SHA-256 hashes', () => {
+    const requiredHashes = {
+      source_artifacts: ['payload_sha256', 'request_hash'],
+      import_mapping_profiles: ['identity_semantics_hash', 'request_hash'],
+      source_observations: ['observation_hash', 'candidate_fingerprint'],
+    } as const;
+
+    for (const [tableName, columnNames] of Object.entries(requiredHashes)) {
+      const config = configFor(tableName as keyof typeof requiredHashes);
+      for (const columnName of columnNames) {
+        const column = config.columns.find((candidate) => candidate.name === columnName) as
+          { notNull: boolean; length?: number } | undefined;
+        expect(column?.notNull, `${tableName}.${columnName}`).toBe(true);
+        expect(column?.length, `${tableName}.${columnName} length`).toBe(64);
+      }
+    }
+  });
+
+  it('keeps the retention quartet on source artifacts and import batches', () => {
+    const retentionColumns = [
+      'purge_after',
+      'retention_extended_until',
+      'retention_extension_reason',
+      'purged_at',
+    ];
+
+    for (const tableName of ['source_artifacts', 'import_batches'] as const) {
+      expect(configFor(tableName).columns.map((column) => column.name)).toEqual(
+        expect.arrayContaining(retentionColumns)
+      );
+    }
+  });
+
+  it('declares selection, merge, and typed-link guards', () => {
+    expect(constraintNames('working_value_selections')).toContain(
+      'working_value_selections_deviation_reason_check'
+    );
+    expect(constraintNames('company_identities')).toContain(
+      'company_identities_no_self_merge_check'
+    );
+    expect(constraintNames('portfolio_company_identity_links')).toEqual(
+      expect.arrayContaining([
+        'pc_identity_links_link_type_check',
+        'pc_identity_links_active_deactivated_check',
+      ])
+    );
+  });
+
+  it('keeps every enum CHECK value list equal to its contract constant', () => {
+    expect(checkSql('source_artifacts', 'source_artifacts_source_type_check')).toContain(
+      `IN (${quotedValues(FINANCIAL_OBSERVATION_SOURCES)})`
+    );
+    expect(
+      checkSql('import_mapping_profiles', 'import_mapping_profiles_source_type_check')
+    ).toContain(`IN (${quotedValues(FINANCIAL_OBSERVATION_SOURCES)})`);
+    expect(checkSql('import_mapping_profiles', 'import_mapping_profiles_domain_check')).toContain(
+      `IN (${quotedValues(FINANCIAL_OBSERVATION_DOMAINS)})`
+    );
+    expect(checkSql('import_batches', 'import_batches_status_check')).toContain(
+      `IN (${quotedValues(IMPORT_BATCH_STATUSES)})`
+    );
+    expect(checkSql('source_observations', 'source_observations_source_type_check')).toContain(
+      `IN (${quotedValues(FINANCIAL_OBSERVATION_SOURCES)})`
+    );
+    expect(checkSql('source_observations', 'source_observations_domain_check')).toContain(
+      `IN (${quotedValues(FINANCIAL_OBSERVATION_DOMAINS)})`
+    );
+    expect(checkSql('source_observations', 'source_observations_status_check')).toContain(
+      `IN (${quotedValues(SOURCE_OBSERVATION_STATUSES)})`
+    );
+    expect(checkSql('reconciliation_cases', 'reconciliation_cases_case_type_check')).toContain(
+      `IN (${quotedValues(RECONCILIATION_CASE_TYPES)})`
+    );
+    expect(checkSql('reconciliation_cases', 'reconciliation_cases_status_check')).toContain(
+      `IN (${quotedValues(RECONCILIATION_CASE_STATUSES)})`
+    );
+    expect(
+      checkSql('working_value_selections', 'working_value_selections_consumer_check')
+    ).toContain(`IN (${quotedValues(FINANCIAL_FACTS_CONSUMER_KEYS)})`);
+    expect(checkSql('working_value_selections', 'working_value_selections_domain_check')).toContain(
+      `IN (${quotedValues(FINANCIAL_OBSERVATION_DOMAINS)})`
+    );
+    expect(
+      checkSql('portfolio_company_identity_links', 'pc_identity_links_link_type_check')
+    ).toContain(`IN (${quotedValues(IDENTITY_LINK_TYPES)})`);
+  });
+
+  it('keeps every table, constraint, and index identifier within PostgreSQL limit', () => {
+    const names = tableEntries.flatMap(([tableName]) => [
+      tableName,
+      ...constraintNames(tableName),
+      ...indexNames(tableName),
+    ]);
+
+    for (const name of names) {
+      expect(Buffer.byteLength(name, 'utf8'), name).toBeLessThanOrEqual(63);
+    }
+  });
+});
+
+describe('financial observations migration and production sync set', () => {
+  it('authors replay-safe journal migration 0039 in topological order', () => {
+    const migration = fs.readFileSync('migrations/0039_financial_observations.sql', 'utf8');
+    const expectedOrder = [
+      'source_artifacts',
+      'import_mapping_profiles',
+      'import_batches',
+      'company_identities',
+      'company_external_identities',
+      'portfolio_company_identity_links',
+      'source_observations',
+      'reconciliation_cases',
+      'working_value_selections',
+    ];
+
+    expect(migration).toContain('-- @drift-patch');
+    expect(migration).toContain('-- Reason: Task 3 (D3/D27/D30) — immutable financial evidence,');
+
+    let priorPosition = -1;
+    for (const tableName of expectedOrder) {
+      const marker = `CREATE TABLE IF NOT EXISTS "${tableName}"`;
+      const position = migration.indexOf(marker);
+      expect(position, marker).toBeGreaterThan(priorPosition);
+      priorPosition = position;
+    }
+
+    expect(migration).toContain(
+      'INSERT INTO company_identities (fund_id, canonical_name, source_portfolio_company_id)'
+    );
+    expect(migration).toContain(
+      'INSERT INTO portfolio_company_identity_links (fund_id, portfolio_company_id, company_identity_id, link_type, active)'
+    );
+    expect(migration).toContain(
+      'NOT EXISTS (SELECT 1 FROM company_identities ci WHERE ci.source_portfolio_company_id = pc.id)'
+    );
+    expect(migration).toMatch(
+      /NOT EXISTS \(SELECT 1 FROM portfolio_company_identity_links l\s+WHERE l\.portfolio_company_id = ci\.source_portfolio_company_id\)/
+    );
+    expect(migration).toContain('SELECT count(*) FROM portfoliocompanies WHERE fund_id IS NULL');
+    expect(migration).toMatch(/RAISE NOTICE/);
+  });
+
+  it('journals migration 0039 at idx 40', () => {
+    const journal = JSON.parse(fs.readFileSync('migrations/meta/_journal.json', 'utf8')) as {
+      entries: Array<{ idx: number; tag: string; breakpoints: boolean }>;
+    };
+
+    expect(journal.entries.at(-1)).toMatchObject({
+      idx: 40,
+      tag: '0039_financial_observations',
+      breakpoints: true,
+    });
+  });
+
+  it('keeps manifest constraint and index names byte-identical to migration DDL', () => {
+    const migration = fs.readFileSync('migrations/0039_financial_observations.sql', 'utf8');
+    const manifest = JSON.parse(
+      fs.readFileSync('scripts/prod-schema-manifests/13-financial-observations.json', 'utf8')
+    ) as {
+      expectedTables: Array<{
+        constraints: string[];
+        indexes: string[];
+      }>;
+    };
+    const migrationConstraints = [...migration.matchAll(/CONSTRAINT "([^"]+)"/g)].map(
+      (match) => match[1]
+    );
+    const migrationIndexes = [
+      ...migration.matchAll(/CREATE (?:UNIQUE )?INDEX IF NOT EXISTS "([^"]+)"/g),
+    ].map((match) => match[1]);
+    const manifestConstraints = manifest.expectedTables.flatMap((table) => table.constraints);
+    const manifestIndexes = manifest.expectedTables.flatMap((table) => table.indexes);
+
+    expect(new Set(manifestConstraints)).toEqual(new Set(migrationConstraints));
+    expect(new Set(manifestIndexes)).toEqual(new Set(migrationIndexes));
+  });
+});


### PR DESCRIPTION
## Summary

Wave C opener (child spec #1173, plan of record $Task 3). Establishes the immutable financial-evidence and identity persistence layer: schema + contracts + journaled migration **0039 (authored, NEVER applied — human-gated)**. No routes, no services, no flag or mode changes.

## Produces (9 tables, shared/schema/financial-observations.ts)

- `source_artifacts` — raw evidence bytes + SHA-256, retention quartet (`purge_after`, `retention_extended_until`, `retention_extension_reason`, `purged_at`), bidirectional payload/purge CHECK
- `import_mapping_profiles` — immutable versions; `(fund_id, name, version)` unique + active-head partial unique; `identity_semantics_hash`
- `import_batches` — status lifecycle incl. `expired`, preview hash, optimistic-lock `version`
- `source_observations` — immutable rows; `observation_hash` + `candidate_fingerprint`; accepted-hash partial unique (purged rows never block re-import)
- `reconciliation_cases` — lifecycle incl. terminal `expired_unresolved` (D3); resolution memo columns; append-only `history`; ETag `version`
- `working_value_selections` — append-only versioned with supersession (D30); deviation-requires-reason CHECK; typed-column scope-head partial unique (COALESCE expression, no writer-supplied scope string)
- `company_identities` (+`merged_into_identity_id` merge primitive, D27), `company_external_identities` (exact durable IDs, D31 alias target), `portfolio_company_identity_links` (typed links, one-active-link partial unique)

Cross-fund evidence graphs are relationally impossible: composite `(x_id, fund_id)` FKs to `(id, fund_id)` unique targets across all new-table edges. Deliberate exceptions: `merged_into_identity_id` is a plain self-FK (cross-fund merge IS the designed D27 reconciliation path for one real company held by two funds); `portfolio_company_id` FK stays plain (no alteration of legacy `portfoliocompanies`; fund coherence via backfill SQL + Task 6 service guards, D29).

## Migration 0039 + identity backfill

Journaled idx 40, `@drift-patch` + Reason, additive, topological DDL order, replay-safe. Backfill: one canonical identity per existing **fund-scoped portfolio-company row** — never deduplicated by name; `source_portfolio_company_id` partial unique is the replay anchor; link re-inserts are link-type-agnostic so operator relinks survive replay. NULL-fund companies stay unlinked (RAISE NOTICE + derivation query documented in the migration).

## D30 declaration

`shared/contracts/financial-facts-consumer-policies.ts`: additive `CONSUMER_DEFAULT_SELECTION_RULES` — all four consumers declare `latest_effective_dated_accepted_at_or_before_as_of`. `ConsumerEvaluationReasonSchema` deliberately untouched (reasons surfacing lands with Task 6's policy 1.0.1 bump, R34-p); frozen #1196 corpus surface unmodified.

## TDD evidence

Tests authored first against absent exports (phase-1 RED: unresolved imports), schema/contracts implemented (phase-2: contract/shape assertions green, migration fs assertions behavior-RED), then migration + sync set to full green. Implemented via Hermes pair lane (Codex owner + Claude reviewer) against a Codex-plan-reviewed brief; independent verification rerun in full afterward.

## Verification (local)

- Verify block: targeted schema+contract suites **26/26 PASS**; `validate:schema-drift` clean; `test:integration:phase0-dbproof` skips locally (no `TEST_DATABASE_URL`/Docker lane) — CI integration lane is the database proof
- `npm run check`: 0 new errors; `npm run lint` (eslint --max-warnings 0 + all guards): pass
- Frozen-corpus regression suites (5): **71 passed / 1 skipped**
- Full sharded suite: server 2507+2860+2480, client 790+733 — **9,370 passed, 0 failures**
- Sync set updated: journal, migration-ledger pin, manifest 13 (typed columns), sentinels pin, prod-schema-clone additions (0039 double-apply replay + backfill assertions — runs in the CI testcontainers lane; Windows-local skip)

## Boundaries honored

No migration applied to any database; no non-test DB writes; no flag/mode value changed; 0039 ships authored-not-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)