### PR TITLE
feat(imports): retain source artifacts and immutable mapping profiles

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,11 @@ import { isPublicApiPath } from './lib/public-api-boundary.js';
 import { errorHandler } from './errors.js';
 import { requireCsrf } from './lib/auth/csrf.js';
 import { mountCommonRoutes } from './routes/mount-common-routes.js';
+import {
+  ARTIFACT_MAX_BYTES,
+  ARTIFACT_RAW_MEDIA_TYPES,
+  isArtifactUploadRequest,
+} from './services/financial-observations/source-artifact-service.js';
 
 export function makeApp() {
   const app = express();
@@ -74,7 +79,7 @@ export function makeApp() {
       res.setHeader('Access-Control-Allow-Credentials', 'true');
       res.setHeader(
         'Access-Control-Allow-Headers',
-        'content-type, authorization, x-csrf-token, x-request-id, if-match, idempotency-key'
+        'content-type, authorization, x-csrf-token, x-request-id, if-match, idempotency-key, x-artifact-file-name, x-artifact-source-type'
       );
       res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
     }
@@ -86,10 +91,26 @@ export function makeApp() {
   const rateLimitWindowMs = Number(process.env['RATE_LIMIT_WINDOW_MS'] || '60000');
   const rateLimitMax = Number(process.env['RATE_LIMIT_MAX'] || '60');
 
+  const artifactRawParser = express.raw({
+    type: [...ARTIFACT_RAW_MEDIA_TYPES],
+    limit: ARTIFACT_MAX_BYTES,
+  });
+  const artifactRawMediaTypes = new Set<string>(ARTIFACT_RAW_MEDIA_TYPES);
+
+  // Deliberate single-route transport exception: only exact artifact POSTs
+  // may enter the raw parser before mutation Content-Type enforcement.
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    return isArtifactUploadRequest(req) ? artifactRawParser(req, res, next) : next();
+  });
+
   // Content-Type validation for mutations
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (['POST', 'PUT', 'PATCH'].includes(req.method)) {
       const ct = ((req.headers['content-type'] as string) || '').toLowerCase();
+      const mediaType = ct.split(';', 1)[0]?.trim() ?? '';
+      if (isArtifactUploadRequest(req) && artifactRawMediaTypes.has(mediaType)) {
+        return next();
+      }
       if (!ct.startsWith('application/json')) {
         return res.status(415).json({
           error: 'unsupported_media_type',

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -616,6 +616,16 @@ const LP_REPORTING_ADDITIONAL_ROUTE_POLICY_GROUPS = [
     exportPolicy: 'not_exportable',
     provenanceRequired: true,
   },
+  {
+    governanceRef: '/lp-reporting/imports',
+    routes: [
+      ['POST', '/api/funds/:fundId/imports/artifacts'],
+      ['POST', '/api/funds/:fundId/imports/mapping-profiles'],
+    ],
+    workflowRequirement: 'fund_scope_and_idempotency_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+  },
 ] satisfies ReadonlyArray<LpReportingRoutePolicyGroup>;
 
 const LP_REPORTING_ADDITIONAL_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] =

--- a/server/routes/lp-reporting/imports.ts
+++ b/server/routes/lp-reporting/imports.ts
@@ -46,6 +46,21 @@ import {
   ImportCommitError,
 } from '../../services/lp-reporting/import-commit-service';
 import { invalidateH9Artifacts } from '../../services/h9-artifact-invalidation-service';
+import {
+  ARTIFACT_RAW_MEDIA_TYPES,
+  createSourceArtifact,
+  SourceArtifactJsonEnvelopeSchema,
+  SourceArtifactResponseSchema,
+} from '../../services/financial-observations/source-artifact-service';
+import {
+  createMappingProfileVersion,
+  MappingProfileResponseSchema,
+} from '../../services/financial-observations/mapping-profile-service';
+import {
+  FINANCIAL_OBSERVATION_DOMAINS,
+  FINANCIAL_OBSERVATION_SOURCES,
+  MappingRuleV1Schema,
+} from '@shared/contracts/financial-observations';
 
 const router = Router();
 
@@ -75,6 +90,34 @@ const importLimiter = rateLimit({
     return userId !== undefined ? `lp-reporting-import:${userId}` : 'lp-reporting-import:anon';
   },
 });
+
+const importArtifactLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'TOO_MANY_REQUESTS',
+    message: 'Artifact and mapping-profile imports are limited to 100 requests per hour per user.',
+  },
+  keyGenerator: (req: Request) => {
+    const userId = req.user?.id;
+    return userId !== undefined ? `lp-reporting-artifact:${userId}` : 'lp-reporting-artifact:anon';
+  },
+});
+
+const idempotencyKeySchema = z.string().min(1).max(128);
+const rawArtifactSourceTypeSchema = z.enum(['csv', 'xlsx']);
+const rawArtifactMediaTypes = new Set<string>(ARTIFACT_RAW_MEDIA_TYPES);
+const mappingProfileBodySchema = z
+  .object({
+    name: z.string().min(1),
+    sourceType: z.enum(FINANCIAL_OBSERVATION_SOURCES),
+    domain: z.enum(FINANCIAL_OBSERVATION_DOMAINS),
+    mappings: z.array(MappingRuleV1Schema),
+    supersedesProfileId: z.number().int().positive().nullable(),
+  })
+  .strict();
 
 function decodePayload(payload: string): Buffer {
   return Buffer.from(payload, 'base64');
@@ -126,6 +169,57 @@ function sendCommitError(res: Response, err: unknown): Response {
   return res.status(500).json({
     error: 'IMPORT_COMMIT_FAILED',
     message,
+  });
+}
+
+function requestHeader(req: Request, name: string): string | undefined {
+  return firstString(req.headers[name.toLowerCase()]);
+}
+
+function parseIdempotencyKey(req: Request): z.SafeParseReturnType<string, string> {
+  return idempotencyKeySchema.safeParse(requestHeader(req, 'idempotency-key'));
+}
+
+function decodeArtifactFileName(req: Request): string | null {
+  const rawFileName = requestHeader(req, 'x-artifact-file-name');
+  if (rawFileName === undefined) return null;
+
+  const encodedFileName = rawFileName.replace(/^UTF-8''/i, '');
+  try {
+    return decodeURIComponent(encodedFileName);
+  } catch {
+    throw new ImportCommitError(
+      400,
+      'INVALID_ARTIFACT_FILE_NAME',
+      'X-Artifact-File-Name must use valid RFC 8187 percent-encoding.'
+    );
+  }
+}
+
+function baseMediaType(req: Request): string {
+  return (requestHeader(req, 'content-type') ?? '').split(';', 1)[0]!.trim().toLowerCase();
+}
+
+function sendV2ImportError(res: Response, error: unknown): Response {
+  if (typeof error === 'object' && error !== null) {
+    const candidate = error as { status?: unknown; statusCode?: unknown; code?: unknown };
+    const status =
+      typeof candidate.status === 'number'
+        ? candidate.status
+        : typeof candidate.statusCode === 'number'
+          ? candidate.statusCode
+          : null;
+    if (status !== null) {
+      return res.status(status).json({
+        error: typeof candidate.code === 'string' ? candidate.code : 'IMPORT_REQUEST_FAILED',
+        message: error instanceof Error ? error.message : 'Import request failed.',
+      });
+    }
+  }
+
+  return res.status(500).json({
+    error: 'IMPORT_REQUEST_FAILED',
+    message: error instanceof Error ? error.message : 'Unknown error',
   });
 }
 
@@ -253,6 +347,121 @@ router.post(
       return res.status(validated.insertedCount > 0 ? 201 : 200).json(validated);
     } catch (err) {
       return sendCommitError(res, err);
+    }
+  }
+);
+
+router.post(
+  '/api/funds/:fundId/imports/artifacts',
+  requireAuth(),
+  requireFundAccess,
+  importArtifactLimiter,
+  async (req: Request, res: Response) => {
+    const parsedIdempotencyKey = parseIdempotencyKey(req);
+    if (!parsedIdempotencyKey.success) {
+      return res.status(400).json({
+        error: 'INVALID_IDEMPOTENCY_KEY',
+        message: 'Idempotency-Key must contain 1 to 128 characters.',
+      });
+    }
+
+    try {
+      let mediaType = baseMediaType(req);
+      let sourceType: (typeof FINANCIAL_OBSERVATION_SOURCES)[number];
+      let fileName: string | null;
+      let payload: Buffer;
+
+      if (rawArtifactMediaTypes.has(mediaType)) {
+        const parsedSourceType = rawArtifactSourceTypeSchema.safeParse(
+          requestHeader(req, 'x-artifact-source-type')
+        );
+        if (!parsedSourceType.success) {
+          return res.status(400).json({
+            error: 'INVALID_ARTIFACT_SOURCE_TYPE',
+            message: 'X-Artifact-Source-Type must be csv or xlsx.',
+          });
+        }
+        if (!Buffer.isBuffer(req.body)) {
+          return res.status(400).json({
+            error: 'INVALID_ARTIFACT_BODY',
+            message: 'Raw artifact requests must contain byte payloads.',
+          });
+        }
+        sourceType = parsedSourceType.data;
+        fileName = decodeArtifactFileName(req);
+        payload = req.body;
+      } else {
+        // The contract caps characters at 200,000. The upstream JSON parser
+        // separately enforces its byte limit, so multibyte envelopes can fail earlier.
+        const parsedBody = SourceArtifactJsonEnvelopeSchema.safeParse(req.body);
+        if (!parsedBody.success) {
+          return res.status(400).json({
+            error: 'INVALID_ARTIFACT_BODY',
+            message: 'JSON artifact body is invalid.',
+            issues: parsedBody.error.issues,
+          });
+        }
+        sourceType = parsedBody.data.sourceType;
+        fileName = parsedBody.data.fileName;
+        mediaType = 'application/json';
+        payload = Buffer.from(parsedBody.data.content, 'utf8');
+      }
+
+      const result = SourceArtifactResponseSchema.parse(
+        await createSourceArtifact({
+          fundId: parseFundId(req),
+          sourceType,
+          fileName,
+          mediaType,
+          payload,
+          actorId: resolveAuthenticatedUserId(req),
+          idempotencyKey: parsedIdempotencyKey.data,
+        })
+      );
+      const { replayed, ...response } = result;
+      return res.status(replayed ? 200 : 201).json(response);
+    } catch (error) {
+      return sendV2ImportError(res, error);
+    }
+  }
+);
+
+router.post(
+  '/api/funds/:fundId/imports/mapping-profiles',
+  requireAuth(),
+  requireFundAccess,
+  importArtifactLimiter,
+  async (req: Request, res: Response) => {
+    const parsedIdempotencyKey = parseIdempotencyKey(req);
+    if (!parsedIdempotencyKey.success) {
+      return res.status(400).json({
+        error: 'INVALID_IDEMPOTENCY_KEY',
+        message: 'Idempotency-Key must contain 1 to 128 characters.',
+      });
+    }
+
+    const parsedBody = mappingProfileBodySchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'INVALID_MAPPING_PROFILE_BODY',
+        message: 'Mapping-profile body is invalid.',
+        issues: parsedBody.error.issues,
+      });
+    }
+
+    try {
+      const result = MappingProfileResponseSchema.parse(
+        await createMappingProfileVersion({
+          fundId: parseFundId(req),
+          ...parsedBody.data,
+          actorId: resolveAuthenticatedUserId(req),
+          idempotencyKey: parsedIdempotencyKey.data,
+        })
+      );
+      const { replayed, ...response } = result;
+      return res.status(replayed ? 200 : 201).json(response);
+    } catch (error) {
+      return sendV2ImportError(res, error);
     }
   }
 );

--- a/server/server.ts
+++ b/server/server.ts
@@ -34,6 +34,12 @@ import { installRumIngressGuards } from './routes/metrics-rum-ingress.js';
 import type { Providers } from './providers.js';
 import { isPublicApiPath } from './lib/public-api-boundary.js';
 import { requireCsrf } from './lib/auth/csrf.js';
+import {
+  ARTIFACT_MAX_BYTES,
+  ARTIFACT_RAW_MEDIA_TYPES,
+  isArtifactUploadRequest,
+  isMappingProfileCreateRequest,
+} from './services/financial-observations/source-artifact-service.js';
 
 export { isPublicApiPath } from './lib/public-api-boundary.js';
 
@@ -122,6 +128,8 @@ export async function createServer(
         'X-Request-ID',
         'If-Match',
         'Idempotency-Key',
+        'X-Artifact-File-Name',
+        'X-Artifact-Source-Type',
       ],
       exposedHeaders: ['X-Request-ID', 'RateLimit-Limit', 'RateLimit-Remaining', 'RateLimit-Reset'],
     })
@@ -131,6 +139,13 @@ export async function createServer(
 
   // Body parsing with size limits and CSP report support
   const bodyLimit = config.BODY_LIMIT;
+  const artifactRawParser = express.raw({
+    type: [...ARTIFACT_RAW_MEDIA_TYPES],
+    limit: ARTIFACT_MAX_BYTES,
+  });
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    return isArtifactUploadRequest(req) ? artifactRawParser(req, res, next) : next();
+  });
   app.use(
     bodyParser['json']({
       limit: bodyLimit,
@@ -300,6 +315,12 @@ export async function createServer(
 
   // Apply idempotency middleware to mutation endpoints
   app.use('/api', (req: Request, res: Response, next: NextFunction) => {
+    const fullApiRequest = { method: req.method, path: `/api${req.path}` };
+    // D13: these V2 commands compare service request hashes so a changed
+    // payload reusing the same key returns 409 instead of middleware cache replay.
+    if (isArtifactUploadRequest(fullApiRequest) || isMappingProfileCreateRequest(fullApiRequest)) {
+      return next();
+    }
     if (
       ['POST', 'PUT', 'PATCH'].includes(req.method) &&
       (req.path.includes('/reserves/calculate') ||

--- a/server/services/financial-observations/mapping-profile-service.ts
+++ b/server/services/financial-observations/mapping-profile-service.ts
@@ -1,0 +1,302 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../../db';
+import { runIdempotentCommand } from '../../lib/idempotent-command';
+import type {
+  FINANCIAL_OBSERVATION_DOMAINS,
+  FINANCIAL_OBSERVATION_SOURCES,
+} from '../../../shared/contracts/financial-observations';
+import {
+  buildIdentitySemanticsHash,
+  ImportMappingProfileV1Schema,
+  MappingRuleV1Schema,
+  type MappingRuleV1,
+} from '../../../shared/contracts/financial-observations';
+import {
+  importMappingProfiles,
+  type ImportMappingProfile,
+} from '../../../shared/schema/financial-observations';
+
+export const MAPPING_PROFILE_CONTRACT_VERSION = '1.0.0';
+
+export const MappingProfileResponseSchema = ImportMappingProfileV1Schema.extend({
+  id: z.number().int().positive(),
+  fundId: z.number().int().positive(),
+  supersededByProfileId: z.number().int().positive().nullable(),
+  createdAt: z.string().datetime(),
+  replayed: z.boolean(),
+}).strict();
+
+export type MappingProfileResponse = z.infer<typeof MappingProfileResponseSchema>;
+export type FinancialObservationSource = (typeof FINANCIAL_OBSERVATION_SOURCES)[number];
+export type FinancialObservationDomain = (typeof FINANCIAL_OBSERVATION_DOMAINS)[number];
+
+type MappingProfileDatabase = typeof db;
+
+export type MappingProfileServiceErrorCode =
+  | 'INVALID_MAPPINGS'
+  | 'PROFILE_NOT_FOUND'
+  | 'PROFILE_SUPERSEDED'
+  | 'PROFILE_HEAD_CONFLICT'
+  | 'PROFILE_NAME_ACTIVE_CONFLICT';
+
+export class MappingProfileServiceError extends Error {
+  readonly statusCode: number;
+
+  constructor(
+    readonly status: number,
+    readonly code: MappingProfileServiceErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'MappingProfileServiceError';
+    this.statusCode = status;
+  }
+}
+
+export interface CreateMappingProfileVersionInput {
+  fundId: number;
+  name: string;
+  sourceType: FinancialObservationSource;
+  domain: FinancialObservationDomain;
+  mappings: MappingRuleV1[];
+  supersedesProfileId: number | null;
+  actorId: number | null;
+  idempotencyKey: string;
+  database?: MappingProfileDatabase;
+}
+
+interface PostgresConstraintError {
+  code?: unknown;
+  constraint?: unknown;
+}
+
+function isActiveNameConflict(error: unknown): boolean {
+  const candidate = error as PostgresConstraintError;
+  return (
+    candidate?.code === '23505' &&
+    candidate.constraint === 'import_mapping_profiles_fund_name_head_unique'
+  );
+}
+
+function mappingProfileFromRow(
+  row: ImportMappingProfile,
+  replayed: boolean
+): MappingProfileResponse {
+  return MappingProfileResponseSchema.parse({
+    id: row.id,
+    fundId: row.fundId,
+    name: row.name,
+    sourceType: row.sourceType,
+    domain: row.domain,
+    version: row.version,
+    mappings: row.mappings,
+    identitySemanticsHash: row.identitySemanticsHash,
+    supersededByProfileId: row.supersededByProfileId,
+    createdAt: row.createdAt.toISOString(),
+    replayed,
+  });
+}
+
+function parseMappings(mappings: readonly MappingRuleV1[]): MappingRuleV1[] {
+  try {
+    return mappings.map((mapping) => MappingRuleV1Schema.parse(mapping));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new MappingProfileServiceError(
+        400,
+        'INVALID_MAPPINGS',
+        'Mappings contain an invalid source, target, or transform.'
+      );
+    }
+    throw error;
+  }
+}
+
+function profileMatchesSupersession(
+  prior: ImportMappingProfile,
+  input: CreateMappingProfileVersionInput
+): boolean {
+  return (
+    prior.name === input.name &&
+    prior.sourceType === input.sourceType &&
+    prior.domain === input.domain &&
+    prior.supersededByProfileId === null
+  );
+}
+
+export async function createMappingProfileVersion(
+  input: CreateMappingProfileVersionInput
+): Promise<MappingProfileResponse> {
+  const database = input.database ?? db;
+  const mappings = parseMappings(input.mappings);
+  const identitySemanticsHash = buildIdentitySemanticsHash(mappings);
+
+  const result = await runIdempotentCommand<ImportMappingProfile>({
+    db: database,
+    fundId: input.fundId,
+    idempotencyKey: input.idempotencyKey,
+    contractVersion: MAPPING_PROFILE_CONTRACT_VERSION,
+    request: {
+      fundId: input.fundId,
+      contractVersion: MAPPING_PROFILE_CONTRACT_VERSION,
+      name: input.name,
+      sourceType: input.sourceType,
+      domain: input.domain,
+      mappings,
+      supersedesProfileId: input.supersedesProfileId,
+      actorId: input.actorId,
+    },
+    loadExisting: async () => {
+      const [existing] = await database
+        .select()
+        .from(importMappingProfiles)
+        .where(
+          and(
+            eq(importMappingProfiles.fundId, input.fundId),
+            eq(importMappingProfiles.idempotencyKey, input.idempotencyKey)
+          )
+        )
+        .limit(1);
+      return existing ? { row: existing, requestHash: existing.requestHash } : null;
+    },
+    insert: async (requestHash) => {
+      try {
+        return await database.transaction(async (transaction) => {
+          if (input.supersedesProfileId === null) {
+            const [inserted] = await transaction
+              .insert(importMappingProfiles)
+              .values({
+                fundId: input.fundId,
+                name: input.name,
+                sourceType: input.sourceType,
+                domain: input.domain,
+                version: 1,
+                mappings,
+                identitySemanticsHash,
+                supersededByProfileId: null,
+                createdBy: input.actorId,
+                idempotencyKey: input.idempotencyKey,
+                requestHash,
+              })
+              .onConflictDoNothing({
+                target: [importMappingProfiles.fundId, importMappingProfiles.idempotencyKey],
+              })
+              .returning();
+            return inserted ?? null;
+          }
+
+          // A completed supersession makes its predecessor non-head. Detect the
+          // service-owned replay first so the predecessor validation cannot mask it.
+          const [idempotentReplay] = await transaction
+            .select()
+            .from(importMappingProfiles)
+            .where(
+              and(
+                eq(importMappingProfiles.fundId, input.fundId),
+                eq(importMappingProfiles.idempotencyKey, input.idempotencyKey)
+              )
+            )
+            .limit(1);
+          if (idempotentReplay) return null;
+
+          const [prior] = await transaction
+            .select()
+            .from(importMappingProfiles)
+            .where(
+              and(
+                eq(importMappingProfiles.id, input.supersedesProfileId),
+                eq(importMappingProfiles.fundId, input.fundId)
+              )
+            )
+            .limit(1);
+          if (!prior) {
+            throw new MappingProfileServiceError(
+              404,
+              'PROFILE_NOT_FOUND',
+              'Mapping profile was not found in this fund.'
+            );
+          }
+          if (!profileMatchesSupersession(prior, input)) {
+            throw new MappingProfileServiceError(
+              409,
+              'PROFILE_SUPERSEDED',
+              'Mapping profile is not the active compatible head.'
+            );
+          }
+
+          const [inserted] = await transaction
+            .insert(importMappingProfiles)
+            .values({
+              fundId: input.fundId,
+              name: input.name,
+              sourceType: input.sourceType,
+              domain: input.domain,
+              version: prior.version + 1,
+              mappings,
+              identitySemanticsHash,
+              supersededByProfileId: prior.id,
+              createdBy: input.actorId,
+              idempotencyKey: input.idempotencyKey,
+              requestHash,
+            })
+            .onConflictDoNothing({
+              target: [importMappingProfiles.fundId, importMappingProfiles.idempotencyKey],
+            })
+            .returning();
+          if (!inserted) return null;
+
+          const [superseded] = await transaction
+            .update(importMappingProfiles)
+            .set({ supersededByProfileId: inserted.id })
+            .where(
+              and(
+                eq(importMappingProfiles.id, prior.id),
+                eq(importMappingProfiles.fundId, input.fundId),
+                isNull(importMappingProfiles.supersededByProfileId)
+              )
+            )
+            .returning({ id: importMappingProfiles.id });
+          if (!superseded) {
+            throw new MappingProfileServiceError(
+              409,
+              'PROFILE_HEAD_CONFLICT',
+              'Mapping profile head changed while creating a successor.'
+            );
+          }
+
+          const [promoted] = await transaction
+            .update(importMappingProfiles)
+            .set({ supersededByProfileId: null })
+            .where(
+              and(
+                eq(importMappingProfiles.id, inserted.id),
+                eq(importMappingProfiles.fundId, input.fundId)
+              )
+            )
+            .returning();
+          if (!promoted) {
+            throw new MappingProfileServiceError(
+              409,
+              'PROFILE_HEAD_CONFLICT',
+              'Mapping profile successor could not be promoted to head.'
+            );
+          }
+          return promoted;
+        });
+      } catch (error) {
+        if (isActiveNameConflict(error)) {
+          throw new MappingProfileServiceError(
+            409,
+            'PROFILE_NAME_ACTIVE_CONFLICT',
+            'An active mapping profile already uses this name.'
+          );
+        }
+        throw error;
+      }
+    },
+  });
+
+  return mappingProfileFromRow(result.row, result.replayed);
+}

--- a/server/services/financial-observations/source-artifact-service.ts
+++ b/server/services/financial-observations/source-artifact-service.ts
@@ -1,0 +1,197 @@
+import { createHash } from 'node:crypto';
+
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../../db';
+import { runIdempotentCommand } from '../../lib/idempotent-command';
+import type { FINANCIAL_OBSERVATION_SOURCES } from '../../../shared/contracts/financial-observations';
+import { FinancialObservationSourceSchema } from '../../../shared/contracts/financial-observations';
+import {
+  sourceArtifacts,
+  type SourceArtifact,
+} from '../../../shared/schema/financial-observations';
+
+export const ARTIFACT_MAX_BYTES = 4 * 1024 * 1024;
+export const ARTIFACT_RETENTION_DAYS = 400;
+export const ARTIFACT_RAW_MEDIA_TYPES = [
+  'application/octet-stream',
+  'text/csv',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+] as const;
+export const SOURCE_ARTIFACT_CONTRACT_VERSION = '1.0.0';
+
+interface RouteRequestShape {
+  method: string;
+  path: string;
+}
+
+export function isArtifactUploadRequest(request: RouteRequestShape): boolean {
+  return (
+    request.method === 'POST' && /^\/api\/funds\/[^/]+\/imports\/artifacts\/?$/.test(request.path)
+  );
+}
+
+export function isMappingProfileCreateRequest(request: RouteRequestShape): boolean {
+  return (
+    request.method === 'POST' &&
+    /^\/api\/funds\/[^/]+\/imports\/mapping-profiles\/?$/.test(request.path)
+  );
+}
+
+export const SourceArtifactJsonEnvelopeSchema = z
+  .object({
+    sourceType: z.enum(['structured_paste', 'manual']),
+    fileName: z.string().nullable(),
+    content: z.string().max(200_000),
+  })
+  .strict();
+
+export const SourceArtifactResponseSchema = z
+  .object({
+    id: z.number().int().positive(),
+    fundId: z.number().int().positive(),
+    sourceType: FinancialObservationSourceSchema,
+    fileName: z.string().nullable(),
+    mediaType: z.string().min(1),
+    byteCount: z.number().int().nonnegative(),
+    payloadSha256: z.string().regex(/^[a-f0-9]{64}$/),
+    purgeAfter: z.string().datetime(),
+    createdBy: z.number().int().positive().nullable(),
+    createdAt: z.string().datetime(),
+    replayed: z.boolean(),
+  })
+  .strict();
+
+export type SourceArtifactJsonEnvelope = z.infer<typeof SourceArtifactJsonEnvelopeSchema>;
+export type SourceArtifactResponse = z.infer<typeof SourceArtifactResponseSchema>;
+export type FinancialObservationSource = (typeof FINANCIAL_OBSERVATION_SOURCES)[number];
+
+type SourceArtifactDatabase = typeof db;
+
+export type SourceArtifactServiceErrorCode = 'EMPTY_ARTIFACT' | 'ARTIFACT_TOO_LARGE';
+
+export class SourceArtifactServiceError extends Error {
+  readonly statusCode: number;
+
+  constructor(
+    readonly status: number,
+    readonly code: SourceArtifactServiceErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'SourceArtifactServiceError';
+    this.statusCode = status;
+  }
+}
+
+export interface CreateSourceArtifactInput {
+  fundId: number;
+  sourceType: FinancialObservationSource;
+  fileName: string | null;
+  mediaType: string;
+  payload: Buffer;
+  actorId: number | null;
+  idempotencyKey: string;
+  database?: SourceArtifactDatabase;
+  now?: Date;
+}
+
+function sourceArtifactFromRow(row: SourceArtifact, replayed: boolean): SourceArtifactResponse {
+  return SourceArtifactResponseSchema.parse({
+    id: row.id,
+    fundId: row.fundId,
+    sourceType: row.sourceType,
+    fileName: row.fileName,
+    mediaType: row.mediaType,
+    byteCount: row.byteCount,
+    payloadSha256: row.payloadSha256,
+    purgeAfter: row.purgeAfter.toISOString(),
+    createdBy: row.createdBy,
+    createdAt: row.createdAt.toISOString(),
+    replayed,
+  });
+}
+
+export async function createSourceArtifact(
+  input: CreateSourceArtifactInput
+): Promise<SourceArtifactResponse> {
+  if (input.payload.byteLength === 0) {
+    throw new SourceArtifactServiceError(
+      400,
+      'EMPTY_ARTIFACT',
+      'Artifact payload must not be empty.'
+    );
+  }
+  if (input.payload.byteLength > ARTIFACT_MAX_BYTES) {
+    throw new SourceArtifactServiceError(
+      413,
+      'ARTIFACT_TOO_LARGE',
+      `Artifact payload must not exceed ${ARTIFACT_MAX_BYTES} bytes.`
+    );
+  }
+
+  const database = input.database ?? db;
+  const now = input.now ?? new Date();
+  const byteCount = input.payload.byteLength;
+  const payloadSha256 = createHash('sha256').update(input.payload).digest('hex');
+  const purgeAfter = new Date(now.getTime() + ARTIFACT_RETENTION_DAYS * 86_400_000);
+
+  const result = await runIdempotentCommand<SourceArtifact>({
+    db: database,
+    fundId: input.fundId,
+    idempotencyKey: input.idempotencyKey,
+    contractVersion: SOURCE_ARTIFACT_CONTRACT_VERSION,
+    request: {
+      fundId: input.fundId,
+      contractVersion: SOURCE_ARTIFACT_CONTRACT_VERSION,
+      sourceType: input.sourceType,
+      fileName: input.fileName,
+      mediaType: input.mediaType,
+      payloadSha256,
+      byteCount,
+      actorId: input.actorId,
+    },
+    loadExisting: async () => {
+      const [existing] = await database
+        .select()
+        .from(sourceArtifacts)
+        .where(
+          and(
+            eq(sourceArtifacts.fundId, input.fundId),
+            eq(sourceArtifacts.idempotencyKey, input.idempotencyKey)
+          )
+        )
+        .limit(1);
+      return existing ? { row: existing, requestHash: existing.requestHash } : null;
+    },
+    insert: async (requestHash) => {
+      const [inserted] = await database
+        .insert(sourceArtifacts)
+        .values({
+          fundId: input.fundId,
+          sourceType: input.sourceType,
+          fileName: input.fileName,
+          mediaType: input.mediaType,
+          byteCount,
+          payloadSha256,
+          payload: input.payload,
+          purgeAfter,
+          retentionExtendedUntil: null,
+          retentionExtensionReason: null,
+          purgedAt: null,
+          createdBy: input.actorId,
+          idempotencyKey: input.idempotencyKey,
+          requestHash,
+          createdAt: now,
+        })
+        .onConflictDoNothing({
+          target: [sourceArtifacts.fundId, sourceArtifacts.idempotencyKey],
+        })
+        .returning();
+      return inserted ?? null;
+    },
+  });
+
+  return sourceArtifactFromRow(result.row, result.replayed);
+}

--- a/shared/routes/api-route-manifest.ts
+++ b/shared/routes/api-route-manifest.ts
@@ -823,7 +823,13 @@ export const COMMON_API_ROUTE_MANIFEST = [
     financial: true,
     migrationParity: {
       kind: 'c1',
-      tables: ['evidence_records', 'lp_report_packages', 'lp_report_package_exports'],
+      tables: [
+        'evidence_records',
+        'lp_report_packages',
+        'lp_report_package_exports',
+        'source_artifacts',
+        'import_mapping_profiles',
+      ],
     },
     schemaTables: [
       'cash_flow_events',
@@ -832,6 +838,8 @@ export const COMMON_API_ROUTE_MANIFEST = [
       'portfoliocompanies',
       'users',
       'lp_fund_commitments',
+      'source_artifacts',
+      'import_mapping_profiles',
       'evidence_records',
       'lp_report_packages',
       'lp_report_package_exports',

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -96,6 +96,8 @@ const LP_REPORTING_ROUTE_POLICY_KEYS = [
   'POST /api/funds/:fundId/imports/valuation-marks/dry-run',
   'POST /api/funds/:fundId/imports/ledger/commit',
   'POST /api/funds/:fundId/imports/valuation-marks/commit',
+  'POST /api/funds/:fundId/imports/artifacts',
+  'POST /api/funds/:fundId/imports/mapping-profiles',
 ] as const;
 
 type LpReportingPolicyExpectation = Pick<
@@ -227,6 +229,17 @@ const LP_REPORTING_ADDITIONAL_POLICY_GROUPS: ReadonlyArray<{
     ],
     expected: {
       workflowRequirement: 'clean_preview_hash_fund_references_and_source_hashes_verified',
+      exportPolicy: 'not_exportable',
+      provenanceRequired: true,
+    },
+  },
+  {
+    keys: [
+      'POST /api/funds/:fundId/imports/artifacts',
+      'POST /api/funds/:fundId/imports/mapping-profiles',
+    ],
+    expected: {
+      workflowRequirement: 'fund_scope_and_idempotency_verified',
       exportPolicy: 'not_exportable',
       provenanceRequired: true,
     },
@@ -430,7 +443,7 @@ describe('route policy coverage', () => {
   });
 
   it('covers every LP-reporting metric-run and import route', () => {
-    expect(LP_REPORTING_ROUTE_POLICY_KEYS).toHaveLength(28);
+    expect(LP_REPORTING_ROUTE_POLICY_KEYS).toHaveLength(30);
 
     const declaredRoutes = [
       ...declaredRoutePolicyKeys('server/routes/lp-reporting/metric-runs.ts'),

--- a/tests/unit/routes/lp-reporting/imports-routes.test.ts
+++ b/tests/unit/routes/lp-reporting/imports-routes.test.ts
@@ -44,7 +44,15 @@ const commitServiceMock = vi.hoisted(() => {
   };
 });
 
-vi.mock('../../../../server/lib/auth/jwt', () => ({
+const sourceArtifactServiceMock = vi.hoisted(() => ({
+  createSourceArtifact: vi.fn(),
+}));
+const mappingProfileServiceMock = vi.hoisted(() => ({
+  createMappingProfileVersion: vi.fn(),
+}));
+
+vi.mock('../../../../server/lib/auth/jwt', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../server/lib/auth/jwt')>()),
   requireAuth: () => (req: Request, res: Response, next: NextFunction) => {
     if (!authState.authenticated) {
       return res.sendStatus(401);
@@ -78,9 +86,35 @@ vi.mock('../../../../server/lib/auth/jwt', () => ({
   },
 }));
 
+vi.mock('../../../../server/lib/auth/csrf', () => ({
+  requireCsrf: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
 vi.mock('../../../../server/services/lp-reporting/import-commit-service', () => commitServiceMock);
+vi.mock(
+  '../../../../server/services/financial-observations/source-artifact-service',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('../../../../server/services/financial-observations/source-artifact-service')
+    >()),
+    createSourceArtifact: sourceArtifactServiceMock.createSourceArtifact,
+  })
+);
+vi.mock(
+  '../../../../server/services/financial-observations/mapping-profile-service',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('../../../../server/services/financial-observations/mapping-profile-service')
+    >()),
+    createMappingProfileVersion: mappingProfileServiceMock.createMappingProfileVersion,
+  })
+);
 
 import importsRouter from '../../../../server/routes/lp-reporting/imports';
+import {
+  ARTIFACT_MAX_BYTES,
+  ARTIFACT_RAW_MEDIA_TYPES,
+} from '../../../../server/services/financial-observations/source-artifact-service';
 
 const FIXTURES_DIR = path.join(process.cwd(), 'tests', 'fixtures', 'lp-reporting');
 const ledgerCsvBase64 = fs
@@ -106,6 +140,7 @@ function buildValuationCsvWithFutureMark(): string {
 
 function buildApp(): express.Express {
   const app = express();
+  app.use(express.raw({ type: [...ARTIFACT_RAW_MEDIA_TYPES], limit: ARTIFACT_MAX_BYTES }));
   app.use(express.json({ limit: '512kb' }));
   app.use(importsRouter);
   return app;
@@ -115,12 +150,57 @@ beforeEach(() => {
   authState.authenticated = true;
   authState.userId = nextUserId++;
   authState.fundIds = [1, 2];
+  sourceArtifactServiceMock.createSourceArtifact.mockImplementation(
+    async (input: {
+      fundId: number;
+      sourceType: string;
+      fileName: string | null;
+      mediaType: string;
+      payload: Buffer;
+      actorId: number | null;
+    }) => ({
+      id: 101,
+      fundId: input.fundId,
+      sourceType: input.sourceType,
+      fileName: input.fileName,
+      mediaType: input.mediaType,
+      byteCount: input.payload.byteLength,
+      payloadSha256: 'a'.repeat(64),
+      purgeAfter: '2027-08-27T22:46:12.807Z',
+      createdBy: input.actorId,
+      createdAt: '2026-07-23T22:46:12.807Z',
+      replayed: false,
+    })
+  );
+  mappingProfileServiceMock.createMappingProfileVersion.mockImplementation(
+    async (input: {
+      fundId: number;
+      name: string;
+      sourceType: string;
+      domain: string;
+      mappings: unknown[];
+    }) => ({
+      id: 201,
+      fundId: input.fundId,
+      name: input.name,
+      sourceType: input.sourceType,
+      domain: input.domain,
+      version: 1,
+      mappings: input.mappings,
+      identitySemanticsHash: 'b'.repeat(64),
+      supersededByProfileId: null,
+      createdAt: '2026-07-23T22:46:12.807Z',
+      replayed: false,
+    })
+  );
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   commitServiceMock.commitLedgerImport.mockReset();
   commitServiceMock.commitValuationMarkImport.mockReset();
+  sourceArtifactServiceMock.createSourceArtifact.mockReset();
+  mappingProfileServiceMock.createMappingProfileVersion.mockReset();
 });
 
 describe('POST /api/funds/:fundId/imports/ledger/dry-run', () => {
@@ -336,6 +416,227 @@ describe('POST /api/funds/:fundId/imports/valuation-marks/dry-run', () => {
   });
 });
 
+describe('POST /api/funds/:fundId/imports/artifacts', () => {
+  it('returns 401 when unauthenticated and 403 on cross-fund access', async () => {
+    authState.authenticated = false;
+    const unauthenticated = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('Idempotency-Key', 'artifact-unauthenticated')
+      .send(Buffer.from('raw'));
+    expect(unauthenticated.status).toBe(401);
+
+    authState.authenticated = true;
+    const crossFund = await request(buildApp())
+      .post('/api/funds/99/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('Idempotency-Key', 'artifact-cross-fund')
+      .send(Buffer.from('raw'));
+    expect(crossFund.status).toBe(403);
+  });
+
+  it('rejects missing or invalid idempotency and source-type headers', async () => {
+    const missingKey = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .send(Buffer.from('raw'));
+    expect(missingKey.status).toBe(400);
+    expect(missingKey.body.error).toBe('INVALID_IDEMPOTENCY_KEY');
+
+    const longKey = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('Idempotency-Key', 'x'.repeat(129))
+      .send(Buffer.from('raw'));
+    expect(longKey.status).toBe(400);
+    expect(longKey.body.error).toBe('INVALID_IDEMPOTENCY_KEY');
+
+    const invalidSource = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'manual')
+      .set('Idempotency-Key', 'artifact-invalid-source')
+      .send(Buffer.from('raw'));
+    expect(invalidSource.status).toBe(400);
+    expect(invalidSource.body.error).toBe('INVALID_ARTIFACT_SOURCE_TYPE');
+  });
+
+  it('decodes an RFC 8187 filename and stores only raw payload metadata', async () => {
+    const response = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'text/csv')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('X-Artifact-File-Name', "UTF-8''Quarterly%20Marks.csv")
+      .set('Idempotency-Key', 'artifact-rfc8187')
+      .send(Buffer.from('company,value\nAcme,100\n'));
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      id: 101,
+      fileName: 'Quarterly Marks.csv',
+      mediaType: 'text/csv',
+    });
+    expect(response.body).not.toHaveProperty('payload');
+    expect(response.body).not.toHaveProperty('replayed');
+    expect(sourceArtifactServiceMock.createSourceArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: 'Quarterly Marks.csv',
+        sourceType: 'csv',
+        payload: Buffer.from('company,value\nAcme,100\n'),
+      })
+    );
+  });
+
+  it('rejects a malformed RFC 8187 filename', async () => {
+    const response = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('X-Artifact-File-Name', "UTF-8''bad%ZZ.csv")
+      .set('Idempotency-Key', 'artifact-malformed-name')
+      .send(Buffer.from('raw'));
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('INVALID_ARTIFACT_FILE_NAME');
+    expect(sourceArtifactServiceMock.createSourceArtifact).not.toHaveBeenCalled();
+  });
+
+  it('accepts a JSON envelope and rejects content over 200,000 characters', async () => {
+    const accepted = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Idempotency-Key', 'artifact-manual')
+      .send({ sourceType: 'manual', fileName: null, content: 'manual observation' });
+    expect(accepted.status).toBe(201);
+    expect(sourceArtifactServiceMock.createSourceArtifact).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sourceType: 'manual',
+        fileName: null,
+        mediaType: 'application/json',
+        payload: Buffer.from('manual observation'),
+      })
+    );
+
+    const oversized = await request(buildApp())
+      .post('/api/funds/1/imports/artifacts')
+      .set('Idempotency-Key', 'artifact-oversized-json')
+      .send({ sourceType: 'manual', fileName: null, content: 'x'.repeat(200_001) });
+    expect(oversized.status).toBe(400);
+    expect(oversized.body.error).toBe('INVALID_ARTIFACT_BODY');
+  });
+});
+
+describe('POST /api/funds/:fundId/imports/mapping-profiles', () => {
+  const mappingBody = {
+    name: 'Quarterly marks',
+    sourceType: 'csv',
+    domain: 'valuation',
+    mappings: [{ sourceColumn: 'Company', targetField: 'company_name', transforms: ['trim'] }],
+    supersedesProfileId: null,
+  };
+
+  it('returns 401 when unauthenticated and 403 on cross-fund access', async () => {
+    authState.authenticated = false;
+    const unauthenticated = await request(buildApp())
+      .post('/api/funds/1/imports/mapping-profiles')
+      .set('Idempotency-Key', 'mapping-unauthenticated')
+      .send(mappingBody);
+    expect(unauthenticated.status).toBe(401);
+
+    authState.authenticated = true;
+    const crossFund = await request(buildApp())
+      .post('/api/funds/99/imports/mapping-profiles')
+      .set('Idempotency-Key', 'mapping-cross-fund')
+      .send(mappingBody);
+    expect(crossFund.status).toBe(403);
+  });
+
+  it('creates a mapping profile and rejects disallowed transforms', async () => {
+    const created = await request(buildApp())
+      .post('/api/funds/1/imports/mapping-profiles')
+      .set('Idempotency-Key', 'mapping-create')
+      .send(mappingBody);
+    expect(created.status).toBe(201);
+    expect(created.body).toMatchObject({
+      id: 201,
+      name: 'Quarterly marks',
+      identitySemanticsHash: 'b'.repeat(64),
+    });
+    expect(created.body).not.toHaveProperty('replayed');
+
+    const invalid = await request(buildApp())
+      .post('/api/funds/1/imports/mapping-profiles')
+      .set('Idempotency-Key', 'mapping-invalid')
+      .send({
+        ...mappingBody,
+        mappings: [
+          { sourceColumn: 'Company', targetField: 'company_name', transforms: ['uppercase'] },
+        ],
+      });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body.error).toBe('INVALID_MAPPING_PROFILE_BODY');
+    expect(mappingProfileServiceMock.createMappingProfileVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the 100/hour/user V2 limiter across artifact and mapping routes', async () => {
+    authState.userId = nextUserId++;
+    const app = buildApp();
+    for (let index = 0; index < 50; index += 1) {
+      const artifact = await request(app)
+        .post('/api/funds/1/imports/artifacts')
+        .set('Content-Type', 'application/octet-stream')
+        .set('X-Artifact-Source-Type', 'csv')
+        .set('Idempotency-Key', `artifact-rate-${index}`)
+        .send(Buffer.from('raw'));
+      expect(artifact.status).toBe(201);
+
+      const mapping = await request(app)
+        .post('/api/funds/1/imports/mapping-profiles')
+        .set('Idempotency-Key', `mapping-rate-${index}`)
+        .send(mappingBody);
+      expect(mapping.status).toBe(201);
+    }
+
+    const limited = await request(app)
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('Idempotency-Key', 'artifact-rate-limited')
+      .send(Buffer.from('raw'));
+    expect(limited.status).toBe(429);
+    expect(limited.body.error).toBe('TOO_MANY_REQUESTS');
+  });
+});
+
+describe('makeApp artifact raw-parser boundary', () => {
+  it('accepts exactly 4 MiB and rejects 4 MiB plus one byte', async () => {
+    authState.userId = nextUserId++;
+    const { makeApp } = await import('../../../../server/app');
+    const app = makeApp();
+
+    const accepted = await request(app)
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('Idempotency-Key', 'artifact-boundary-accepted')
+      .send(Buffer.alloc(ARTIFACT_MAX_BYTES));
+    expect(accepted.status).toBeGreaterThanOrEqual(200);
+    expect(accepted.status).toBeLessThan(300);
+    expect(accepted.body.byteCount).toBe(ARTIFACT_MAX_BYTES);
+
+    const rejected = await request(app)
+      .post('/api/funds/1/imports/artifacts')
+      .set('Content-Type', 'application/octet-stream')
+      .set('X-Artifact-Source-Type', 'csv')
+      .set('Idempotency-Key', 'artifact-boundary-rejected')
+      .send(Buffer.alloc(ARTIFACT_MAX_BYTES + 1));
+    expect(rejected.status).toBe(413);
+  });
+});
+
 describe('DB-write absence -- no INSERT runs during dry-run', () => {
   it('the imports router does NOT import the db module', () => {
     const routerSource = fs.readFileSync(
@@ -380,12 +681,17 @@ describe('Source grep -- bounded commit endpoints, no /api/public', () => {
     expect(routerSource).not.toMatch(/\/api\/public/);
   });
 
-  it('uses /api/funds/:fundId/imports prefix only', () => {
-    const matches =
-      routerSource.match(/router\.(post|get|put|delete|patch)\(\s*['"]([^'"]+)['"]/g) ?? [];
-    expect(matches.length).toBeGreaterThan(0);
-    for (const m of matches) {
-      expect(m).toMatch(/\/api\/funds\/:fundId\/imports\/[^/]+\/(dry-run|commit)/);
-    }
+  it('declares exactly the four frozen V1 routes and two V2 creation routes', () => {
+    const paths = [
+      ...routerSource.matchAll(/router\.(?:post|get|put|delete|patch)\(\s*['"]([^'"]+)['"]/g),
+    ].map((match) => match[1]);
+    expect(paths).toEqual([
+      '/api/funds/:fundId/imports/ledger/dry-run',
+      '/api/funds/:fundId/imports/valuation-marks/dry-run',
+      '/api/funds/:fundId/imports/ledger/commit',
+      '/api/funds/:fundId/imports/valuation-marks/commit',
+      '/api/funds/:fundId/imports/artifacts',
+      '/api/funds/:fundId/imports/mapping-profiles',
+    ]);
   });
 });

--- a/tests/unit/services/financial-observations/mapping-profile-service.test.ts
+++ b/tests/unit/services/financial-observations/mapping-profile-service.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from 'vitest';
+
+import type { db } from '../../../../server/db';
+import {
+  createMappingProfileVersion,
+  MappingProfileServiceError,
+} from '../../../../server/services/financial-observations/mapping-profile-service';
+import type { MappingRuleV1 } from '../../../../shared/contracts/financial-observations';
+import {
+  importMappingProfiles,
+  type ImportMappingProfile,
+} from '../../../../shared/schema/financial-observations';
+
+type MappingProfileDatabase = typeof db;
+
+function queryRows<T>(rows: readonly T[]) {
+  const values = [...rows];
+  return {
+    limit: (count: number) => Promise.resolve(values.slice(0, count)),
+  };
+}
+
+class FakeMappingProfileDb {
+  readonly rows: ImportMappingProfile[] = [];
+  readonly statementOrder: string[] = [];
+  readonly selectResults: ImportMappingProfile[][] = [];
+  casSucceeds = true;
+  promoteSucceeds = true;
+  rejectInsertWith: Error | null = null;
+  private nextId = 1;
+  private lastInsertedId: number | null = null;
+
+  asDatabase(): MappingProfileDatabase {
+    return this as unknown as MappingProfileDatabase;
+  }
+
+  transaction<T>(operation: (transaction: MappingProfileDatabase) => Promise<T>): Promise<T> {
+    const rowsBefore = this.rows.map((row) => ({ ...row, mappings: [...row.mappings] }));
+    const orderLength = this.statementOrder.length;
+    return operation(this.asDatabase()).catch((error: unknown) => {
+      this.rows.splice(0, this.rows.length, ...rowsBefore);
+      this.statementOrder.splice(orderLength);
+      throw error;
+    });
+  }
+
+  select() {
+    return {
+      from: (table: unknown) => ({
+        where: (_condition: unknown) => {
+          const queued =
+            this.selectResults.shift() ?? (table === importMappingProfiles ? this.rows : []);
+          return queryRows(queued);
+        },
+      }),
+    };
+  }
+
+  insert(table: unknown) {
+    return {
+      values: (values: Omit<ImportMappingProfile, 'id' | 'createdAt'> & { createdAt?: Date }) => ({
+        onConflictDoNothing: (_options: unknown) => ({
+          returning: async () => {
+            if (table !== importMappingProfiles) return [];
+            if (this.rejectInsertWith) throw this.rejectInsertWith;
+            const conflict = this.rows.some(
+              (row) => row.fundId === values.fundId && row.idempotencyKey === values.idempotencyKey
+            );
+            if (conflict) return [];
+
+            const inserted = {
+              id: this.nextId++,
+              createdAt: values.createdAt ?? new Date('2026-07-23T22:46:12.807Z'),
+              ...values,
+            } as ImportMappingProfile;
+            this.rows.push(inserted);
+            this.lastInsertedId = inserted.id;
+            this.statementOrder.push(
+              inserted.supersededByProfileId === null ? 'insert-head' : 'insert-non-head'
+            );
+            return [inserted];
+          },
+        }),
+      }),
+    };
+  }
+
+  update(table: unknown) {
+    return {
+      set: (values: Partial<ImportMappingProfile>) => ({
+        where: (_condition: unknown) => ({
+          returning: async () => {
+            if (table !== importMappingProfiles) return [];
+            if (values.supersededByProfileId === null) {
+              this.statementOrder.push('promote-successor');
+              if (!this.promoteSucceeds) return [];
+              const successor = this.rows.find((row) => row.id === this.lastInsertedId);
+              if (!successor) return [];
+              Object.assign(successor, values);
+              return [successor];
+            }
+
+            this.statementOrder.push('cas-repoint-prior');
+            if (!this.casSucceeds) return [];
+            const prior = this.rows.find(
+              (row) => row.id !== this.lastInsertedId && row.supersededByProfileId === null
+            );
+            if (!prior) return [];
+            Object.assign(prior, values);
+            return [prior];
+          },
+        }),
+      }),
+    };
+  }
+
+  seed(row: ImportMappingProfile): void {
+    this.rows.push(row);
+    this.nextId = Math.max(this.nextId, row.id + 1);
+  }
+}
+
+const identityMappings: MappingRuleV1[] = [
+  { sourceColumn: 'Company', targetField: 'company_name', transforms: ['trim'] },
+  {
+    sourceColumn: 'Company ID',
+    targetField: 'company_external_id',
+    transforms: ['normalize_whitespace'],
+  },
+  { sourceColumn: 'Value', targetField: 'fair_value', transforms: ['parse_decimal'] },
+];
+
+function profileInput(
+  database: MappingProfileDatabase,
+  overrides: Partial<Parameters<typeof createMappingProfileVersion>[0]> = {}
+) {
+  return {
+    fundId: 1,
+    name: 'Quarterly marks',
+    sourceType: 'csv' as const,
+    domain: 'valuation' as const,
+    mappings: identityMappings,
+    supersedesProfileId: null,
+    actorId: 7,
+    idempotencyKey: 'profile-key',
+    database,
+    ...overrides,
+  };
+}
+
+function storedProfile(overrides: Partial<ImportMappingProfile> = {}): ImportMappingProfile {
+  return {
+    id: 10,
+    fundId: 1,
+    name: 'Quarterly marks',
+    sourceType: 'csv',
+    domain: 'valuation',
+    version: 1,
+    mappings: identityMappings,
+    identitySemanticsHash: 'a'.repeat(64),
+    supersededByProfileId: null,
+    createdBy: 7,
+    idempotencyKey: 'prior-key',
+    requestHash: 'b'.repeat(64),
+    createdAt: new Date('2026-07-22T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('createMappingProfileVersion', () => {
+  it('surfaces a disallowed transform as a 400 service error', async () => {
+    const fakeDb = new FakeMappingProfileDb();
+
+    const error = await createMappingProfileVersion(
+      profileInput(fakeDb.asDatabase(), {
+        mappings: [
+          {
+            sourceColumn: 'Company',
+            targetField: 'company_name',
+            transforms: ['uppercase'],
+          },
+        ] as never,
+      })
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(MappingProfileServiceError);
+    expect(error).toMatchObject({ status: 400, statusCode: 400, code: 'INVALID_MAPPINGS' });
+    expect(fakeDb.rows).toHaveLength(0);
+  });
+
+  it('supersedes the current head by inserting non-head, CAS-repointing, then promoting', async () => {
+    const fakeDb = new FakeMappingProfileDb();
+    const prior = storedProfile();
+    fakeDb.seed(prior);
+    fakeDb.selectResults.push([], [prior]);
+
+    const successor = await createMappingProfileVersion(
+      profileInput(fakeDb.asDatabase(), {
+        supersedesProfileId: prior.id,
+        idempotencyKey: 'successor-key',
+      })
+    );
+
+    expect(fakeDb.statementOrder).toEqual([
+      'insert-non-head',
+      'cas-repoint-prior',
+      'promote-successor',
+    ]);
+    expect(successor).toMatchObject({
+      version: 2,
+      supersededByProfileId: null,
+      replayed: false,
+    });
+    expect(fakeDb.rows.find((row) => row.id === prior.id)?.supersededByProfileId).toBe(
+      successor.id
+    );
+    expect(fakeDb.rows.filter((row) => row.supersededByProfileId === null)).toHaveLength(1);
+  });
+
+  it('returns 404 when the superseded profile is absent from the fund-scoped lookup', async () => {
+    const fakeDb = new FakeMappingProfileDb();
+    fakeDb.selectResults.push([], []);
+
+    await expect(
+      createMappingProfileVersion(
+        profileInput(fakeDb.asDatabase(), {
+          supersedesProfileId: 999,
+          idempotencyKey: 'cross-fund-key',
+        })
+      )
+    ).rejects.toMatchObject({
+      status: 404,
+      code: 'PROFILE_NOT_FOUND',
+    });
+    expect(fakeDb.rows).toHaveLength(0);
+  });
+
+  it('rejects a non-head predecessor', async () => {
+    const fakeDb = new FakeMappingProfileDb();
+    const prior = storedProfile({ supersededByProfileId: 11 });
+    fakeDb.seed(prior);
+    fakeDb.selectResults.push([], [prior]);
+
+    await expect(
+      createMappingProfileVersion(
+        profileInput(fakeDb.asDatabase(), {
+          supersedesProfileId: prior.id,
+          idempotencyKey: 'non-head-key',
+        })
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'PROFILE_SUPERSEDED',
+    });
+  });
+
+  it('rolls back and returns PROFILE_HEAD_CONFLICT when the CAS loses', async () => {
+    const fakeDb = new FakeMappingProfileDb();
+    const prior = storedProfile();
+    fakeDb.seed(prior);
+    fakeDb.selectResults.push([], [prior]);
+    fakeDb.casSucceeds = false;
+
+    await expect(
+      createMappingProfileVersion(
+        profileInput(fakeDb.asDatabase(), {
+          supersedesProfileId: prior.id,
+          idempotencyKey: 'cas-loser-key',
+        })
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'PROFILE_HEAD_CONFLICT',
+    });
+    expect(fakeDb.rows).toEqual([prior]);
+  });
+
+  it('maps the active-name partial unique violation to PROFILE_NAME_ACTIVE_CONFLICT', async () => {
+    const fakeDb = new FakeMappingProfileDb();
+    const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), {
+      code: '23505',
+      constraint: 'import_mapping_profiles_fund_name_head_unique',
+    });
+    fakeDb.rejectInsertWith = pgError;
+
+    await expect(
+      createMappingProfileVersion(profileInput(fakeDb.asDatabase()))
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'PROFILE_NAME_ACTIVE_CONFLICT',
+    });
+  });
+
+  it('preserves the identity hash for unchanged identity mappings and changes it for identity drift', async () => {
+    const unchangedDb = new FakeMappingProfileDb();
+    const initial = await createMappingProfileVersion(
+      profileInput(unchangedDb.asDatabase(), { idempotencyKey: 'initial-key' })
+    );
+    const initialRow = unchangedDb.rows[0];
+    expect(initialRow).toBeDefined();
+    unchangedDb.selectResults.push([], [initialRow!]);
+
+    const unchanged = await createMappingProfileVersion(
+      profileInput(unchangedDb.asDatabase(), {
+        supersedesProfileId: initial.id,
+        idempotencyKey: 'unchanged-key',
+        mappings: [
+          ...identityMappings.slice(0, 2),
+          { sourceColumn: 'NAV', targetField: 'fair_value', transforms: ['parse_decimal'] },
+        ],
+      })
+    );
+    expect(unchanged.identitySemanticsHash).toBe(initial.identitySemanticsHash);
+
+    const changedDb = new FakeMappingProfileDb();
+    const changedPrior = storedProfile({
+      id: 20,
+      identitySemanticsHash: initial.identitySemanticsHash,
+    });
+    changedDb.seed(changedPrior);
+    changedDb.selectResults.push([], [changedPrior]);
+    const changed = await createMappingProfileVersion(
+      profileInput(changedDb.asDatabase(), {
+        supersedesProfileId: changedPrior.id,
+        idempotencyKey: 'changed-key',
+        mappings: [
+          {
+            sourceColumn: 'Legal Name',
+            targetField: 'company_name',
+            transforms: ['trim'],
+          },
+          identityMappings[1]!,
+        ],
+      })
+    );
+    expect(changed.identitySemanticsHash).not.toBe(initial.identitySemanticsHash);
+  });
+
+  it('replays the same supersession request after the predecessor is no longer head', async () => {
+    const fakeDb = new FakeMappingProfileDb();
+    const prior = storedProfile();
+    fakeDb.seed(prior);
+    fakeDb.selectResults.push([], [prior]);
+    const input = profileInput(fakeDb.asDatabase(), {
+      supersedesProfileId: prior.id,
+      idempotencyKey: 'replay-successor-key',
+    });
+
+    const created = await createMappingProfileVersion(input);
+    const storedSuccessor = fakeDb.rows.find((row) => row.id === created.id);
+    expect(storedSuccessor).toBeDefined();
+    fakeDb.selectResults.push([storedSuccessor!], [storedSuccessor!]);
+
+    const replayed = await createMappingProfileVersion(input);
+
+    expect(replayed).toEqual({ ...created, replayed: true });
+    expect(fakeDb.rows).toHaveLength(2);
+  });
+});

--- a/tests/unit/services/financial-observations/source-artifact-service.test.ts
+++ b/tests/unit/services/financial-observations/source-artifact-service.test.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import type { db } from '../../../../server/db';
+import {
+  ARTIFACT_MAX_BYTES,
+  ARTIFACT_RETENTION_DAYS,
+  createSourceArtifact,
+} from '../../../../server/services/financial-observations/source-artifact-service';
+import {
+  sourceArtifacts,
+  type SourceArtifact,
+} from '../../../../shared/schema/financial-observations';
+
+type SourceArtifactDatabase = typeof db;
+
+function queryRows<T>(rows: readonly T[]) {
+  const values = [...rows];
+  return {
+    limit: (count: number) => Promise.resolve(values.slice(0, count)),
+  };
+}
+
+class FakeSourceArtifactDb {
+  readonly rows: SourceArtifact[] = [];
+  successfulInserts = 0;
+
+  constructor(private readonly createdAt = new Date('2026-07-23T22:46:12.807Z')) {}
+
+  asDatabase(): SourceArtifactDatabase {
+    return this as unknown as SourceArtifactDatabase;
+  }
+
+  select() {
+    return {
+      from: (table: unknown) => ({
+        where: (_condition: unknown) =>
+          queryRows(table === sourceArtifacts ? this.rows : ([] as SourceArtifact[])),
+      }),
+    };
+  }
+
+  insert(table: unknown) {
+    return {
+      values: (values: Omit<SourceArtifact, 'id' | 'createdAt'> & { createdAt?: Date }) => ({
+        onConflictDoNothing: (_options: unknown) => ({
+          returning: async () => {
+            if (table !== sourceArtifacts) return [];
+            const conflict = this.rows.some(
+              (row) => row.fundId === values.fundId && row.idempotencyKey === values.idempotencyKey
+            );
+            if (conflict) return [];
+
+            const inserted = {
+              id: this.rows.length + 1,
+              createdAt: values.createdAt ?? this.createdAt,
+              ...values,
+            } as SourceArtifact;
+            this.rows.push(inserted);
+            this.successfulInserts += 1;
+            return [inserted];
+          },
+        }),
+      }),
+    };
+  }
+}
+
+const now = new Date('2026-07-23T22:46:12.807Z');
+
+function artifactInput(
+  database: SourceArtifactDatabase,
+  payload = Buffer.from('company,value\nAcme,100\n')
+) {
+  return {
+    fundId: 1,
+    sourceType: 'csv' as const,
+    fileName: 'fund.csv',
+    mediaType: 'text/csv',
+    payload,
+    actorId: 7,
+    idempotencyKey: 'artifact-key',
+    database,
+    now,
+  };
+}
+
+describe('createSourceArtifact', () => {
+  it('replays the same artifact without creating a second row', async () => {
+    const fakeDb = new FakeSourceArtifactDb(now);
+    const input = artifactInput(fakeDb.asDatabase());
+
+    const created = await createSourceArtifact(input);
+    const replayed = await createSourceArtifact(input);
+
+    expect(created.replayed).toBe(false);
+    expect(replayed).toEqual({ ...created, replayed: true });
+    expect(fakeDb.rows).toHaveLength(1);
+    expect(fakeDb.successfulInserts).toBe(1);
+  });
+
+  it('rejects reuse of an idempotency key with different payload bytes', async () => {
+    const fakeDb = new FakeSourceArtifactDb(now);
+    await createSourceArtifact(artifactInput(fakeDb.asDatabase(), Buffer.from('first')));
+
+    await expect(
+      createSourceArtifact(artifactInput(fakeDb.asDatabase(), Buffer.from('second')))
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'IDEMPOTENCY_KEY_REUSE',
+    });
+    expect(fakeDb.rows).toHaveLength(1);
+  });
+
+  it('rejects empty and oversized payloads with HTTP-shaped errors', async () => {
+    const fakeDb = new FakeSourceArtifactDb(now);
+
+    await expect(
+      createSourceArtifact(artifactInput(fakeDb.asDatabase(), Buffer.alloc(0)))
+    ).rejects.toMatchObject({
+      status: 400,
+      statusCode: 400,
+      code: 'EMPTY_ARTIFACT',
+    });
+    await expect(
+      createSourceArtifact(artifactInput(fakeDb.asDatabase(), Buffer.alloc(ARTIFACT_MAX_BYTES + 1)))
+    ).rejects.toMatchObject({
+      status: 413,
+      statusCode: 413,
+      code: 'ARTIFACT_TOO_LARGE',
+    });
+    expect(fakeDb.rows).toHaveLength(0);
+  });
+
+  it('hashes raw bytes, records byte count and retention, and omits payload from response', async () => {
+    const fakeDb = new FakeSourceArtifactDb(now);
+    const payload = Buffer.from([0x00, 0xff, 0x10, 0x80]);
+
+    const result = await createSourceArtifact(artifactInput(fakeDb.asDatabase(), payload));
+
+    expect(result).toMatchObject({
+      byteCount: 4,
+      payloadSha256: createHash('sha256').update(payload).digest('hex'),
+      purgeAfter: new Date(now.getTime() + ARTIFACT_RETENTION_DAYS * 86_400_000).toISOString(),
+      createdAt: now.toISOString(),
+      replayed: false,
+    });
+    expect(result).not.toHaveProperty('payload');
+    expect(fakeDb.rows[0]?.payload).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## PLAN_61 Wave C — Task 4: Raw-artifact and immutable mapping-profile APIs

Child spec #1173. Retains raw source artifacts and immutable mapping profiles behind idempotent, fund-scoped APIs. No migration (tail stays 0039); V1 import lane byte-frozen.

### New endpoints (existing `lp-reporting/imports` router)
- `POST /api/funds/:fundId/imports/artifacts` — stores raw source bytes with SHA-256 digest, byte count, and a 400-day retention window (D3). A route-scoped `express.raw` parser (4 MiB — R25 Vercel cap) carries binary uploads past the JSON content-type gate in **both** `makeApp` (Vercel/prod) and `registerRoutes` (Docker/Railway). Metadata rides in `X-Artifact-Source-Type`, `X-Artifact-File-Name` (RFC 8187), `Idempotency-Key`. A JSON envelope (`.max(200_000)` chars) covers paste/manual input.
- `POST /api/funds/:fundId/imports/mapping-profiles` — mints immutable, versioned profiles. Supersession is the one allowed mutation, implemented with an **insert-non-head → CAS-repoint prior → promote successor** choreography (mirrors `current-plan-version-service`) so exact idempotent replay and concurrent-head races stay deterministic.

### Correctness
- Both commands run through `runIdempotentCommand` (D13): identical keys replay, changed payloads return 409 `IDEMPOTENCY_KEY_REUSE`.
- The two V2 routes are excluded from the Docker/Railway header-only `withIdempotency` middleware — otherwise a changed payload reusing a key would get a cached 200 replay and bypass the service's 409.
- Cross-fund `supersedesProfileId` → 404 (fund-scoped WHERE, no widening of `fund-scoped-ownership`). Disallowed transforms → 400. Raw bytes hashed with `createHash('sha256')` (never `canonicalizeDecimalLeaves`). Spreadsheet formulas never evaluated.
- New `importArtifactLimiter` (100/hr/user) on V2 routes; V1 `importLimiter` (20/hr) untouched.

### Plan Review Gate
Codex read-only review surfaced 10 defects in the draft plan; all adjudicated against source and folded in before implementation — notably the supersession replay-safety pattern, the `withIdempotency` bypass, and the deterministically-failing route-shape test guard (now an explicit 6-route allowlist).

### Verification (all green, run independently)
- Targeted suites 71/71 — includes the exit-gate 4 MiB boundary pair (4 MiB accepted, 4 MiB + 1 → 413) through the composed `makeApp` stack, plus `mount-parity-migrations` and `route-policy-coverage`.
- `policy:verify` (89 entries), `guardrails:check`, `check` (0 new TS errors), eslint (0).
- V1 freeze proof: #1195 adversarial import suite (35) + corpus suites green.
- Full sharded suite: server 1/3–3/3 and client 1/2–2/2 all passing.

No migration applied; no flag/mode changed; V1 import contract byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
