### PR TITLE
feat(imports): V2 normalization for CSV and manual financial input (PLAN_61 Task 5a)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8863,3 +8863,54 @@ rows exist; the flag is off; every fund resolves `off`).
   actual, mirroring the legacy builder.
 
 ---
+
+## ADR-061: V2 Normalization — Two-Key Identity and Descriptor-Excluded Fingerprint (PLAN_61 Task 5a)
+
+**Date:** 2026-07-23 **Status:** [ACCEPTED] Accepted **Decision:** The V2
+CSV/manual normalization layer derives two independent keys from every staged
+observation. `observationHash = canonicalSha256(normalizedPayload)` is the FULL
+identity (economics + descriptor + transaction discriminator) and drives hard
+dedup via `source_observations_fund_hash_accepted_unique`.
+`candidateFingerprint = canonicalSha256(economicPreimage)` is the ECONOMIC
+identity: it EXCLUDES the `descriptor` sub-object and `schemaVersion`, INCLUDES
+the `externalRef` discriminator plus a dedicated `fingerprintVersion` tag, and
+drives soft `observation_match` lookup via
+`idx_source_observations_fund_candidate_fingerprint`. Equivalent CSV and manual
+inputs converge on equal `normalizedPayload` and equal `candidateFingerprint`;
+byte-identical `observationHash` across modes is NOT asserted (defect D15) — the
+executable spec asserts derivation (`hash === canonicalSha256(payload)`) and
+payload equality, not cross-mode digest identity.
+
+### Context
+
+Field selection is the load-bearing, non-derivable decision the future
+reconciliation/commit path (Task 6) depends on: a descriptor-only edit must
+reuse the existing economic identity (same fingerprint, different hash), while a
+same-amount/same-date pair of distinct wires must stay distinct (different
+fingerprint via `externalRef`). The corpus test
+`tests/unit/services/financial-observations/normalization-service.test.ts` is
+the executable spec (cases 11 and 12 pin these two properties; case 6 pins that
+a durable external identity holds the fingerprint stable across differing
+display names).
+
+### Consequences
+
+- No adapter may inject a financial assumption: formulas, malformed
+  numbers/dates, inferred FX, defaulted currency, and out-of-range values are
+  rejected (preview outcome `rejected`, distinct from the DB
+  `staged|accepted|purged` status). Currency is USD-only and explicit; `fxRate`
+  is the definitional constant `1.000000000000` when absent, never an inferred
+  conversion.
+- Company identity is a STRUCTURED object (`{kind:'external',system,externalId}`
+  or `{kind:'name',canonicalName}`), object-hashed to avoid delimiter collisions
+  — never a delimiter-joined string.
+- Decimal precision is a fixed per-field policy (`amount`/`postMoneyValuation`
+  6dp, `fxRate`/`ownershipPct` 12dp), never inferred from a key-name regex;
+  `MONEY_LEAF_KEY`/`RATIO_LEAF_KEY` stay assertion-only. Hashing uses plain
+  `canonicalSha256`; the decimal invariant is asserted on a numeric-only
+  projection (never over free text — `canonicalizeDecimalLeaves` false-positives
+  on real names/memos containing `/e[+-]?\d/`).
+- One CSV tokenizer (`server/lib/csv-tokenizer.ts`) serves both the byte-frozen
+  V1 lane and the V2 raw lane (defect D10); no `csv-parse` dependency. No
+  migration, no route, no schema change — the layer ships as a pure, executable
+  reference spec ahead of the ingestion service.

--- a/server/lib/csv-tokenizer.ts
+++ b/server/lib/csv-tokenizer.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared CSV tokenizer.
+ *
+ * Single hand-rolled CSV tokenizer consumed by BOTH the V1 import lane
+ * (`server/services/lp-reporting/import-reconciliation-service.ts`) and the V2
+ * financial-observations normalization adapters. Extracted from the V1 service
+ * without behavior change (PLAN_61 Wave C, Task 5a, defect D10): there is
+ * exactly one tokenizer and no `csv-parse` dependency.
+ *
+ * The V1 lane trims every cell (`splitCsvLine`). The V2 lane must NOT inherit
+ * implicit trimming, so it consumes the raw variants and decides whitespace
+ * handling only through declared mapping transforms.
+ *
+ * @module server/lib/csv-tokenizer
+ */
+
+const BOM_CHAR = String.fromCharCode(0xfeff);
+
+/**
+ * Split a single CSV line into raw cells. Handles double-quoted fields and
+ * escaped quotes (`""`). Does NOT trim cells — callers decide.
+ */
+export function splitCsvLineRaw(line: string): string[] {
+  const cells: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      cells.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  cells.push(current);
+  return cells;
+}
+
+/**
+ * V1 line splitter: raw split with every cell trimmed. Byte-identical to the
+ * original `import-reconciliation-service.ts` behavior.
+ */
+export function splitCsvLine(line: string): string[] {
+  return splitCsvLineRaw(line).map((c) => c.trim());
+}
+
+/**
+ * V1 buffer parser: strips an optional UTF-8 BOM, splits on CRLF/LF, drops
+ * empty lines, snake_cases the header, trims every cell. Byte-identical to the
+ * original V1 implementation.
+ */
+export function parseCsvBuffer(buffer: Buffer): { header: string[]; rows: string[][] } {
+  const raw = buffer.toString('utf8');
+  const text = raw.startsWith(BOM_CHAR) ? raw.slice(1) : raw;
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length === 0) {
+    return { header: [], rows: [] };
+  }
+  const header = splitCsvLine(lines[0]!).map((h) => h.toLowerCase().replace(/[\s-]/g, '_'));
+  const rows = lines.slice(1).map((l) => splitCsvLine(l));
+  return { header, rows };
+}
+
+/**
+ * V2 buffer parser: identical pipeline and header canonicalization as
+ * `parseCsvBuffer`, but ROW cells are left untrimmed so the normalization layer
+ * controls whitespace exclusively through declared transforms.
+ */
+export function parseCsvBufferRaw(buffer: Buffer): { header: string[]; rows: string[][] } {
+  const raw = buffer.toString('utf8');
+  const text = raw.startsWith(BOM_CHAR) ? raw.slice(1) : raw;
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length === 0) {
+    return { header: [], rows: [] };
+  }
+  const header = splitCsvLine(lines[0]!).map((h) => h.toLowerCase().replace(/[\s-]/g, '_'));
+  const rows = lines.slice(1).map((l) => splitCsvLineRaw(l));
+  return { header, rows };
+}
+
+/**
+ * Map header tokens through an alias table. Used by the V1 Notion export path.
+ */
+export function normalizeHeaders(header: string[], mapping: Record<string, string>): string[] {
+  return header.map((h) => mapping[h] ?? h);
+}
+
+/**
+ * Canonicalize a single lookup token to the same snake_case form the header
+ * receives inside `parseCsvBuffer`. Lets a mapping profile's display-text
+ * `sourceColumn` (e.g. "Company Name") resolve against a normalized header.
+ */
+export function normalizeHeaderToken(token: string): string {
+  return token.trim().toLowerCase().replace(/[\s-]/g, '_');
+}
+
+/** Count double-quote characters in a physical line. */
+export function countQuoteChars(line: string): number {
+  let count = 0;
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] === '"') {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * True when any physical line (after BOM strip + newline split, non-empty) has
+ * an odd number of quote characters, i.e. a quoted field spans a newline. The
+ * V1 tokenizer silently mis-splits such input; the V2 lane rejects it.
+ */
+export function hasEmbeddedQuotedNewline(buffer: Buffer): boolean {
+  const raw = buffer.toString('utf8');
+  const text = raw.startsWith(BOM_CHAR) ? raw.slice(1) : raw;
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  return lines.some((line) => countQuoteChars(line) % 2 === 1);
+}

--- a/server/services/financial-observations/csv-adapter.ts
+++ b/server/services/financial-observations/csv-adapter.ts
@@ -1,0 +1,259 @@
+/**
+ * CSV adapter (PLAN_61 Wave C, Task 5a).
+ *
+ * Turns a CSV buffer plus a mapping profile into per-row normalized
+ * observations, using the shared CSV tokenizer (defect D10) and the shared
+ * normalization service. Batch-level structural problems (profile/header
+ * mismatch, embedded newline, row overflow) reject the whole batch; per-row
+ * problems mark that row's candidate `rejected`.
+ *
+ * @module server/services/financial-observations/csv-adapter
+ */
+
+import {
+  hasEmbeddedQuotedNewline,
+  normalizeHeaderToken,
+  parseCsvBufferRaw,
+} from '../../lib/csv-tokenizer';
+
+import type { FinancialObservationDomain } from '@shared/contracts/financial-observations/financial-observation.contract';
+import type {
+  ImportMappingProfileV1,
+  MappingRuleV1,
+} from '@shared/contracts/financial-observations/import-profile.contract';
+import type {
+  ManualEntryV2,
+  MeasureKeyV2,
+  NormalizationIssue,
+  NormalizedCandidateV2,
+  NormalizationResultV2,
+} from '@shared/contracts/financial-observations/normalization.contract';
+import { MAX_NORMALIZATION_ROWS } from '@shared/contracts/financial-observations/normalization.contract';
+
+import { applyMappingTransforms, normalizeObservation } from './normalization-service';
+
+export interface NormalizeCsvArgs {
+  buffer: Buffer;
+  profile: ImportMappingProfileV1;
+  /** Target domain for this batch; must match the profile's domain. */
+  domain: FinancialObservationDomain;
+  /** Reserved for future cross-fund detection; not persisted here. */
+  fundId: number;
+}
+
+function batchReject(code: NormalizationIssue['code'], message: string): NormalizationResultV2 {
+  return { outcome: 'rejected', issues: [{ code, message }], candidates: [] };
+}
+
+/** Assign a transformed cell to its ManualEntryV2 target field. */
+function assignTargetField(entry: MutableEntry, targetField: string, value: string): void {
+  switch (targetField) {
+    case 'measure_key':
+      entry.measureKey = value as MeasureKeyV2;
+      break;
+    case 'effective_date':
+      entry.effectiveDate = value;
+      break;
+    case 'currency':
+      entry.currency = value;
+      break;
+    case 'fx_rate':
+      entry.fxRate = value;
+      break;
+    case 'amount':
+      entry.amount = value;
+      break;
+    case 'post_money_valuation':
+      entry.postMoneyValuation = value;
+      break;
+    case 'valuation_basis':
+      entry.valuationBasis = value;
+      break;
+    case 'ownership_pct':
+      entry.ownershipPct = value;
+      break;
+    case 'external_ref':
+      entry.externalRef = value;
+      break;
+    case 'company_name':
+      entry.companyName = value;
+      break;
+    case 'company_external_system':
+      entry.externalSystem = value;
+      break;
+    case 'company_external_value':
+      entry.externalValue = value;
+      break;
+    case 'memo':
+    case 'description':
+    case 'note':
+    case 'label':
+    case 'source_label': {
+      const key = targetField === 'source_label' ? 'sourceLabel' : targetField;
+      entry.descriptor = { ...entry.descriptor, [key]: value };
+      break;
+    }
+    default:
+      // Unknown target fields are ignored (forward-compatible profiles).
+      break;
+  }
+}
+
+interface MutableEntry {
+  measureKey?: MeasureKeyV2;
+  companyName?: string;
+  externalSystem?: string;
+  externalValue?: string;
+  effectiveDate?: string;
+  currency?: string;
+  fxRate?: string;
+  amount?: string;
+  postMoneyValuation?: string;
+  valuationBasis?: string;
+  ownershipPct?: string;
+  externalRef?: string;
+  descriptor?: Record<string, string>;
+}
+
+function toManualEntry(
+  entry: MutableEntry,
+  domain: FinancialObservationDomain,
+  row: number
+): ManualEntryV2 {
+  const manual: ManualEntryV2 = {
+    domain,
+    measureKey: (entry.measureKey ?? 'initial_investment') as MeasureKeyV2,
+    sourceLocator: `csv:row:${row}`,
+  };
+  if (entry.externalSystem !== undefined && entry.externalValue !== undefined) {
+    manual.companyExternalId = { system: entry.externalSystem, value: entry.externalValue };
+  }
+  if (entry.companyName !== undefined) manual.companyName = entry.companyName;
+  if (entry.effectiveDate !== undefined) manual.effectiveDate = entry.effectiveDate;
+  if (entry.currency !== undefined) manual.currency = entry.currency;
+  if (entry.fxRate !== undefined) manual.fxRate = entry.fxRate;
+  if (entry.amount !== undefined) manual.amount = entry.amount;
+  if (entry.postMoneyValuation !== undefined) manual.postMoneyValuation = entry.postMoneyValuation;
+  if (entry.valuationBasis !== undefined) manual.valuationBasis = entry.valuationBasis;
+  if (entry.ownershipPct !== undefined) manual.ownershipPct = entry.ownershipPct;
+  if (entry.externalRef !== undefined) manual.externalRef = entry.externalRef;
+  if (entry.descriptor !== undefined) manual.descriptor = entry.descriptor;
+  return manual;
+}
+
+export function normalizeCsvObservations(args: NormalizeCsvArgs): NormalizationResultV2 {
+  const { buffer, profile, domain } = args;
+
+  // --- Batch-level structural gates ---------------------------------------
+  if (profile.sourceType !== 'csv') {
+    return batchReject(
+      'PROFILE_SOURCE_MISMATCH',
+      `Profile sourceType "${profile.sourceType}" is not "csv".`
+    );
+  }
+  if (profile.domain !== domain) {
+    return batchReject(
+      'PROFILE_DOMAIN_MISMATCH',
+      `Profile domain "${profile.domain}" does not match batch domain "${domain}".`
+    );
+  }
+
+  const seenTargets = new Set<string>();
+  for (const rule of profile.mappings) {
+    if (seenTargets.has(rule.targetField)) {
+      return batchReject(
+        'PROFILE_DUPLICATE_TARGET',
+        `Duplicate targetField "${rule.targetField}" in mapping profile.`
+      );
+    }
+    seenTargets.add(rule.targetField);
+  }
+
+  if (hasEmbeddedQuotedNewline(buffer)) {
+    return batchReject(
+      'EMBEDDED_LINE_BREAK_UNSUPPORTED',
+      'A quoted field spans a newline; not supported.'
+    );
+  }
+
+  const { header, rows } = parseCsvBufferRaw(buffer);
+
+  if (rows.length > MAX_NORMALIZATION_ROWS) {
+    return batchReject(
+      'ROW_LIMIT_EXCEEDED',
+      `Row count ${rows.length} exceeds the limit of ${MAX_NORMALIZATION_ROWS}.`
+    );
+  }
+
+  const dupHeader = firstDuplicate(header);
+  if (dupHeader !== null) {
+    return batchReject('DUPLICATE_HEADER', `Duplicate normalized header "${dupHeader}".`);
+  }
+
+  // --- Column resolution --------------------------------------------------
+  const columnIndex = new Map<string, number>();
+  for (const rule of profile.mappings) {
+    const token = normalizeHeaderToken(rule.sourceColumn);
+    const idx = header.indexOf(token);
+    if (idx < 0) {
+      return batchReject(
+        'UNMAPPED_REQUIRED_COLUMN',
+        `Mapped column "${rule.sourceColumn}" (${token}) is absent from the header.`
+      );
+    }
+    columnIndex.set(rule.targetField, idx);
+  }
+
+  // --- Per-row normalization ----------------------------------------------
+  const candidates: NormalizedCandidateV2[] = [];
+  for (let r = 0; r < rows.length; r++) {
+    const cells = rows[r]!;
+    const rowNumber = r + 1;
+    const rowIssues: NormalizationIssue[] = [];
+    const entry: MutableEntry = {};
+
+    for (const rule of profile.mappings) {
+      const idx = columnIndex.get(rule.targetField)!;
+      const raw = cells[idx] ?? '';
+      const result = applyMappingTransforms(raw, rule.transforms as MappingRuleV1['transforms']);
+      if (!result.ok) {
+        rowIssues.push({
+          code: result.code,
+          message: `Column "${rule.sourceColumn}" row ${rowNumber}: ${result.code}.`,
+          field: rule.targetField,
+          row: rowNumber,
+        });
+      } else {
+        assignTargetField(entry, rule.targetField, result.value);
+      }
+    }
+
+    if (rowIssues.length > 0) {
+      candidates.push({ outcome: 'rejected', issues: rowIssues });
+      continue;
+    }
+
+    const candidate = normalizeObservation(toManualEntry(entry, domain, rowNumber));
+    candidates.push(withRow(candidate, rowNumber));
+  }
+
+  return { outcome: 'staged', issues: [], candidates };
+}
+
+function withRow(candidate: NormalizedCandidateV2, row: number): NormalizedCandidateV2 {
+  if (candidate.outcome === 'staged') {
+    return candidate;
+  }
+  return { ...candidate, issues: candidate.issues.map((i) => ({ ...i, row })) };
+}
+
+function firstDuplicate(values: readonly string[]): string | null {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      return value;
+    }
+    seen.add(value);
+  }
+  return null;
+}

--- a/server/services/financial-observations/manual-entry-adapter.ts
+++ b/server/services/financial-observations/manual-entry-adapter.ts
@@ -1,0 +1,27 @@
+/**
+ * Manual-entry adapter (PLAN_61 Wave C, Task 5a).
+ *
+ * Normalizes a typed manual observation. No transforms are applied: the entry
+ * is already typed, so it flows straight through the shared normalization path,
+ * guaranteeing equivalence with the CSV adapter by construction.
+ *
+ * This adapter is also the seam canonical direct writes will use (Tasks 9-11)
+ * to synthesize `sourceType: 'manual'` observations in-transaction. Here it is
+ * built only; no route or database wiring.
+ *
+ * @module server/services/financial-observations/manual-entry-adapter
+ */
+
+import type {
+  ManualEntryV2,
+  NormalizedCandidateV2,
+} from '@shared/contracts/financial-observations/normalization.contract';
+
+import { normalizeObservation } from './normalization-service';
+
+export function normalizeManualObservation(entry: ManualEntryV2): NormalizedCandidateV2 {
+  return normalizeObservation({
+    ...entry,
+    sourceLocator: entry.sourceLocator ?? 'manual',
+  });
+}

--- a/server/services/financial-observations/normalization-service.ts
+++ b/server/services/financial-observations/normalization-service.ts
@@ -1,0 +1,432 @@
+/**
+ * Financial-observations V2 normalization service (PLAN_61 Wave C, Task 5a).
+ *
+ * Pure, deterministic normalization of a single financial observation. Both the
+ * CSV adapter and the manual-entry adapter converge on `normalizeObservation`,
+ * so equivalent CSV and manual inputs produce equal typed `normalizedPayload`
+ * and equal `candidateFingerprint` by construction.
+ *
+ * No database access, no route, no feature flag. No adapter may inject a
+ * financial assumption: formulas, malformed numbers/dates, inferred FX,
+ * defaulted currency, and out-of-range values are all rejected.
+ *
+ * @module server/services/financial-observations/normalization-service
+ */
+
+import { Decimal } from '@shared/lib/decimal-config';
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+import { assertDecimalStringLeaves, toFixedDecimalString } from '@shared/lib/decimal-string';
+
+import type { AllowedMappingTransform } from '@shared/contracts/financial-observations/import-profile.contract';
+import type {
+  CompanyIdentityDescriptorV2,
+  ManualEntryV2,
+  NormalizationIssue,
+  NormalizationIssueCode,
+  NormalizedCandidateV2,
+} from '@shared/contracts/financial-observations/normalization.contract';
+import {
+  DOMAIN_MEASURE_MATRIX,
+  FINGERPRINT_VERSION,
+  MAX_TEXT_FIELD_LENGTH,
+  NORMALIZED_PAYLOAD_SCHEMA_VERSION,
+  PAYLOAD_DECIMAL_POLICY,
+} from '@shared/contracts/financial-observations/normalization.contract';
+
+// ============================================================================
+// Transform applier
+// ============================================================================
+
+export type TransformResult =
+  { ok: true; value: string } | { ok: false; code: NormalizationIssueCode };
+
+/** Grouping is either full 3-digit groups or no commas at all. */
+const GROUPED_DECIMAL_REGEX = /^-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?$/;
+const PLAIN_DECIMAL_REGEX = /^-?\d+(?:\.\d+)?$/;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const US_DATE_REGEX = /^(0?[1-9]|1[0-2])\/(0?[1-9]|[12]\d|3[01])\/\d{4}$/;
+/** Formula-injection shapes: leading =, +, @, tab, CR, or a signed formula. */
+const FORMULA_PREFIX_REGEX = /^[=+@\t\r]|^-[=+@]/;
+
+function isRealYmd(year: number, month: number, day: number): boolean {
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  return dt.getUTCFullYear() === year && dt.getUTCMonth() === month - 1 && dt.getUTCDate() === day;
+}
+
+function isRealIsoDate(value: string): boolean {
+  if (!ISO_DATE_REGEX.test(value)) {
+    return false;
+  }
+  const [y, m, d] = value.split('-').map((part) => Number.parseInt(part, 10));
+  return isRealYmd(y!, m!, d!);
+}
+
+/**
+ * Apply the declared transform chain to a raw CSV cell, in order. A leading
+ * formula-injection shape is rejected first, before any transform runs.
+ */
+export function applyMappingTransforms(
+  raw: string,
+  transforms: readonly AllowedMappingTransform[]
+): TransformResult {
+  if (FORMULA_PREFIX_REGEX.test(raw)) {
+    return { ok: false, code: 'FORMULA_REJECTED' };
+  }
+
+  let value = raw;
+  for (const transform of transforms) {
+    switch (transform) {
+      case 'trim':
+        value = value.trim();
+        break;
+      case 'normalize_whitespace':
+        value = value.replace(/\s+/g, ' ').trim();
+        break;
+      case 'parse_decimal': {
+        let candidate = value.trim();
+        if (candidate.startsWith('$')) {
+          candidate = candidate.slice(1);
+        }
+        if (!GROUPED_DECIMAL_REGEX.test(candidate)) {
+          return { ok: false, code: 'MALFORMED_NUMBER' };
+        }
+        value = candidate.replace(/,/g, '');
+        break;
+      }
+      case 'parse_date_iso': {
+        const candidate = value.trim();
+        if (!isRealIsoDate(candidate)) {
+          return { ok: false, code: 'MALFORMED_DATE' };
+        }
+        value = candidate;
+        break;
+      }
+      case 'parse_date_us': {
+        const candidate = value.trim();
+        const match = US_DATE_REGEX.exec(candidate);
+        if (!match) {
+          return { ok: false, code: 'MALFORMED_DATE' };
+        }
+        const month = Number.parseInt(match[1]!, 10);
+        const day = Number.parseInt(match[2]!, 10);
+        const year = Number.parseInt(candidate.slice(-4), 10);
+        if (!isRealYmd(year, month, day)) {
+          return { ok: false, code: 'MALFORMED_DATE' };
+        }
+        value = `${year.toString().padStart(4, '0')}-${month
+          .toString()
+          .padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
+        break;
+      }
+      case 'negate': {
+        const candidate = value.trim();
+        if (!PLAIN_DECIMAL_REGEX.test(candidate)) {
+          return { ok: false, code: 'MALFORMED_NUMBER' };
+        }
+        value = candidate.startsWith('-') ? candidate.slice(1) : `-${candidate}`;
+        break;
+      }
+      default: {
+        // Exhaustiveness guard: the allowlist is closed, so this is unreachable.
+        transform satisfies never;
+        return { ok: false, code: 'MALFORMED_NUMBER' };
+      }
+    }
+  }
+  return { ok: true, value };
+}
+
+// ============================================================================
+// Normalization
+// ============================================================================
+
+const USD_FX_RATE = toFixedDecimalString('1', PAYLOAD_DECIMAL_POLICY.fxRate);
+
+function isBlank(value: string | null | undefined): boolean {
+  return value === null || value === undefined || value.trim() === '';
+}
+
+function canonicalizeName(name: string): string {
+  return name.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+type FormatResult = { ok: true; value: string } | { ok: false; code: NormalizationIssueCode };
+
+/** Format a plain decimal string to fixed places; excess non-zero precision is rejected. */
+function formatDecimalField(raw: string, places: number): FormatResult {
+  let decimal: Decimal;
+  try {
+    decimal = new Decimal(raw);
+  } catch {
+    return { ok: false, code: 'MALFORMED_NUMBER' };
+  }
+  if (!decimal.isFinite()) {
+    return { ok: false, code: 'MALFORMED_NUMBER' };
+  }
+  const fixed = decimal.toFixed(places);
+  if (!new Decimal(fixed).equals(decimal)) {
+    return { ok: false, code: 'PRECISION_EXCEEDED' };
+  }
+  return { ok: true, value: fixed };
+}
+
+function issue(code: NormalizationIssueCode, message: string, field?: string): NormalizationIssue {
+  return field === undefined ? { code, message } : { code, message, field };
+}
+
+/**
+ * Normalize one typed observation. Returns a preview candidate: `staged` with a
+ * payload and both hashes, or `rejected` with issues and no hashes.
+ */
+export function normalizeObservation(input: ManualEntryV2): NormalizedCandidateV2 {
+  const issues: NormalizationIssue[] = [];
+  const domainRule = DOMAIN_MEASURE_MATRIX[input.domain];
+
+  // --- Identity -----------------------------------------------------------
+  let companyIdentity: CompanyIdentityDescriptorV2 | null = null;
+  if (input.companyExternalId) {
+    companyIdentity = {
+      kind: 'external',
+      system: input.companyExternalId.system,
+      externalId: input.companyExternalId.value,
+    };
+  } else if (!isBlank(input.companyName)) {
+    companyIdentity = { kind: 'name', canonicalName: canonicalizeName(input.companyName!) };
+  } else {
+    issues.push(issue('IDENTITY_REQUIRED', 'A company name or external id is required.'));
+  }
+
+  // --- Transaction date ---------------------------------------------------
+  if (isBlank(input.effectiveDate)) {
+    issues.push(
+      issue('MISSING_TRANSACTION_DATE', 'A transaction date is required.', 'effectiveDate')
+    );
+  } else if (!isRealIsoDate(input.effectiveDate!.trim())) {
+    issues.push(
+      issue(
+        'MALFORMED_DATE',
+        `effectiveDate "${input.effectiveDate}" is not a real YYYY-MM-DD date.`,
+        'effectiveDate'
+      )
+    );
+  }
+
+  // --- Currency -----------------------------------------------------------
+  if (isBlank(input.currency)) {
+    issues.push(
+      issue(
+        'CURRENCY_REQUIRED',
+        'Currency must be stated explicitly; it is never defaulted.',
+        'currency'
+      )
+    );
+  } else if (input.currency!.trim().toUpperCase() !== 'USD') {
+    issues.push(
+      issue(
+        'NON_USD_VALUE_UNSUPPORTED',
+        `Currency "${input.currency}" is not supported; only USD.`,
+        'currency'
+      )
+    );
+  }
+
+  // --- FX rate ------------------------------------------------------------
+  if (!isBlank(input.fxRate)) {
+    if (isBlank(input.currency)) {
+      issues.push(
+        issue(
+          'INFERRED_FX_REJECTED',
+          'An FX rate without an explicit currency is rejected.',
+          'fxRate'
+        )
+      );
+    } else {
+      try {
+        if (!new Decimal(input.fxRate!).equals(1)) {
+          issues.push(
+            issue(
+              'INFERRED_FX_REJECTED',
+              'A non-unity FX rate is rejected; only USD at 1.0 is supported.',
+              'fxRate'
+            )
+          );
+        }
+      } catch {
+        issues.push(
+          issue('MALFORMED_NUMBER', `fxRate "${input.fxRate}" is not a decimal.`, 'fxRate')
+        );
+      }
+    }
+  }
+
+  // --- Domain / measure / value matrix ------------------------------------
+  const measures = domainRule.measures as readonly string[];
+  if (!measures.includes(input.measureKey)) {
+    issues.push(
+      issue(
+        'MEASURE_DOMAIN_MISMATCH',
+        `measureKey "${input.measureKey}" is not valid for domain "${input.domain}".`,
+        'measureKey'
+      )
+    );
+  }
+  for (const forbidden of domainRule.forbiddenValues as readonly string[]) {
+    if (!isBlank((input as Record<string, unknown>)[forbidden] as string | undefined)) {
+      issues.push(
+        issue(
+          'VALUE_DOMAIN_MISMATCH',
+          `Field "${forbidden}" is not allowed for domain "${input.domain}".`,
+          forbidden
+        )
+      );
+    }
+  }
+
+  // --- Economic value -----------------------------------------------------
+  const requiredField = domainRule.requiredValue;
+  const rawValue = (input as Record<string, unknown>)[requiredField] as string | undefined;
+  let formattedValue: string | null = null;
+  if (isBlank(rawValue)) {
+    issues.push(
+      issue(
+        'MISSING_ECONOMIC_VALUE',
+        `Field "${requiredField}" is required for domain "${input.domain}".`,
+        requiredField
+      )
+    );
+  } else {
+    const places = PAYLOAD_DECIMAL_POLICY[requiredField as keyof typeof PAYLOAD_DECIMAL_POLICY];
+    const formatted = formatDecimalField(rawValue!.trim(), places);
+    if (!formatted.ok) {
+      issues.push(
+        issue(
+          formatted.code,
+          `Field "${requiredField}" value "${rawValue}" is invalid.`,
+          requiredField
+        )
+      );
+    } else {
+      formattedValue = formatted.value;
+      if (input.domain === 'ownership') {
+        const pct = new Decimal(formatted.value);
+        if (pct.lessThan(0) || pct.greaterThan(100)) {
+          issues.push(
+            issue(
+              'OWNERSHIP_OUT_OF_RANGE',
+              `ownershipPct "${rawValue}" must be within [0, 100].`,
+              'ownershipPct'
+            )
+          );
+        }
+      }
+    }
+  }
+
+  // --- Text length --------------------------------------------------------
+  const textFields: Array<[string, string | undefined]> = [
+    ['companyName', input.companyName],
+    ['descriptor.memo', input.descriptor?.memo],
+    ['descriptor.description', input.descriptor?.description],
+    ['descriptor.note', input.descriptor?.note],
+    ['descriptor.label', input.descriptor?.label],
+    ['descriptor.sourceLabel', input.descriptor?.sourceLabel],
+  ];
+  for (const [field, text] of textFields) {
+    if (text !== undefined && text.length > MAX_TEXT_FIELD_LENGTH) {
+      issues.push(
+        issue(
+          'TEXT_LENGTH_EXCEEDED',
+          `Field "${field}" exceeds ${MAX_TEXT_FIELD_LENGTH} characters.`,
+          field
+        )
+      );
+    }
+  }
+
+  if (issues.length > 0 || companyIdentity === null || formattedValue === null) {
+    return { outcome: 'rejected', issues };
+  }
+
+  // --- Payload assembly (single canonical path) ---------------------------
+  const effectiveDate = input.effectiveDate!.trim();
+  const externalRef = isBlank(input.externalRef) ? null : input.externalRef!.trim();
+  const descriptor = buildDescriptor(input.descriptor);
+
+  const valuationBasis =
+    input.domain === 'valuation' && !isBlank(input.valuationBasis)
+      ? input.valuationBasis!.trim()
+      : undefined;
+
+  const economic: Record<string, unknown> = {};
+  economic[requiredField] = formattedValue;
+  if (valuationBasis !== undefined) {
+    economic['valuationBasis'] = valuationBasis;
+  }
+
+  const normalizedPayload: Record<string, unknown> = {
+    schemaVersion: NORMALIZED_PAYLOAD_SCHEMA_VERSION,
+    domain: input.domain,
+    measureKey: input.measureKey,
+    companyIdentity,
+    effectiveDate,
+    currency: 'USD',
+    fxRate: USD_FX_RATE,
+    ...economic,
+    externalRef,
+    ...(descriptor !== undefined && { descriptor }),
+  };
+
+  // Decimal invariant: assert only the numeric projection (P2 — never assert
+  // decimal-string shape over free text such as company names or memos).
+  assertDecimalStringLeaves(numericProjection(normalizedPayload, requiredField));
+
+  const fingerprintPreimage: Record<string, unknown> = {
+    fingerprintVersion: FINGERPRINT_VERSION,
+    domain: input.domain,
+    measureKey: input.measureKey,
+    companyIdentity,
+    effectiveDate,
+    currency: 'USD',
+    fxRate: USD_FX_RATE,
+    ...economic,
+    externalRef,
+  };
+
+  const observationHash = canonicalSha256(normalizedPayload);
+  const candidateFingerprint = canonicalSha256(fingerprintPreimage);
+
+  return {
+    outcome: 'staged',
+    issues: [],
+    normalizedPayload,
+    observationHash,
+    candidateFingerprint,
+    effectiveDate,
+    ...(input.sourceLocator !== undefined && { sourceLocator: input.sourceLocator }),
+  };
+}
+
+function buildDescriptor(
+  descriptor: ManualEntryV2['descriptor']
+): Record<string, string> | undefined {
+  if (!descriptor) {
+    return undefined;
+  }
+  const out: Record<string, string> = {};
+  for (const key of ['memo', 'description', 'note', 'label', 'sourceLabel'] as const) {
+    const value = descriptor[key];
+    if (!isBlank(value)) {
+      out[key] = value!.trim();
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function numericProjection(
+  payload: Record<string, unknown>,
+  requiredField: string
+): Record<string, unknown> {
+  const projection: Record<string, unknown> = { fxRate: payload['fxRate'] };
+  projection[requiredField] = payload[requiredField];
+  return projection;
+}

--- a/server/services/lp-reporting/import-reconciliation-service.ts
+++ b/server/services/lp-reporting/import-reconciliation-service.ts
@@ -16,6 +16,8 @@ import { randomUUID } from 'node:crypto';
 
 import { Decimal } from '@shared/lib/decimal-config';
 import { canonicalSha256 } from '@shared/lib/canonical-hash';
+
+import { parseCsvBuffer, normalizeHeaders } from '../../lib/csv-tokenizer';
 import type {
   ImportDryRunResponse,
   ImportError,
@@ -114,53 +116,9 @@ export function computeSourceRowHash(input: {
 // CSV / NOTION PARSING
 // ============================================================================
 
-/**
- * Minimal CSV splitter. Handles double-quoted fields and escaped quotes.
- * Sufficient for fixture parsing in Phase 0; production import in Phase 1
- * may swap this for a hardened parser if necessary.
- */
-function splitCsvLine(line: string): string[] {
-  const cells: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (inQuotes) {
-      if (ch === '"' && line[i + 1] === '"') {
-        current += '"';
-        i++;
-      } else if (ch === '"') {
-        inQuotes = false;
-      } else {
-        current += ch;
-      }
-    } else if (ch === '"') {
-      inQuotes = true;
-    } else if (ch === ',') {
-      cells.push(current);
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  cells.push(current);
-  return cells.map((c) => c.trim());
-}
-
-const BOM_CHAR = String.fromCharCode(0xfeff);
-
-function parseCsvBuffer(buffer: Buffer): { header: string[]; rows: string[][] } {
-  // Strip optional UTF-8 BOM at the start of the file.
-  const raw = buffer.toString('utf8');
-  const text = raw.startsWith(BOM_CHAR) ? raw.slice(1) : raw;
-  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
-  if (lines.length === 0) {
-    return { header: [], rows: [] };
-  }
-  const header = splitCsvLine(lines[0]!).map((h) => h.toLowerCase().replace(/[\s-]/g, '_'));
-  const rows = lines.slice(1).map((l) => splitCsvLine(l));
-  return { header, rows };
-}
+// The CSV tokenizer (splitCsvLine/parseCsvBuffer/normalizeHeaders) lives in the
+// shared module `server/lib/csv-tokenizer` so the V1 lane and the V2
+// financial-observations adapters use exactly one implementation (defect D10).
 
 /**
  * Notion CSV exports use Title Case headers with spaces. Normalize to
@@ -182,10 +140,6 @@ const NOTION_HEADER_MAP: Record<string, string> = {
   description: 'description',
   notes: 'description',
 };
-
-function normalizeHeaders(header: string[], mapping: Record<string, string>): string[] {
-  return header.map((h) => mapping[h] ?? h);
-}
 
 function parseOptionalPositiveInteger(
   raw: string | undefined,

--- a/shared/contracts/financial-observations/financial-observation.contract.ts
+++ b/shared/contracts/financial-observations/financial-observation.contract.ts
@@ -19,6 +19,8 @@ export const IDENTITY_LINK_TYPES = [
 
 export const FinancialObservationSourceSchema = z.enum(FINANCIAL_OBSERVATION_SOURCES);
 export const FinancialObservationDomainSchema = z.enum(FINANCIAL_OBSERVATION_DOMAINS);
+export type FinancialObservationSource = z.infer<typeof FinancialObservationSourceSchema>;
+export type FinancialObservationDomain = z.infer<typeof FinancialObservationDomainSchema>;
 export const SourceObservationStatusSchema = z.enum(SOURCE_OBSERVATION_STATUSES);
 export const ImportBatchStatusSchema = z.enum(IMPORT_BATCH_STATUSES);
 export const IdentityLinkTypeSchema = z.enum(IDENTITY_LINK_TYPES);

--- a/shared/contracts/financial-observations/import-profile.contract.ts
+++ b/shared/contracts/financial-observations/import-profile.contract.ts
@@ -18,6 +18,7 @@ export const ALLOWED_MAPPING_TRANSFORMS = [
 export const IDENTITY_TARGET_FIELDS = ['company_name', 'company_external_id'] as const;
 
 export const AllowedMappingTransformSchema = z.enum(ALLOWED_MAPPING_TRANSFORMS);
+export type AllowedMappingTransform = z.infer<typeof AllowedMappingTransformSchema>;
 export const MappingRuleV1Schema = z
   .object({
     sourceColumn: z.string().min(1),

--- a/shared/contracts/financial-observations/index.ts
+++ b/shared/contracts/financial-observations/index.ts
@@ -1,3 +1,4 @@
 export * from './financial-observation.contract';
 export * from './import-profile.contract';
+export * from './normalization.contract';
 export * from './reconciliation.contract';

--- a/shared/contracts/financial-observations/normalization.contract.ts
+++ b/shared/contracts/financial-observations/normalization.contract.ts
@@ -1,0 +1,216 @@
+import { z } from 'zod';
+
+import {
+  FinancialObservationDomainSchema,
+  Sha256HexSchema,
+} from './financial-observation.contract';
+import { MappingRuleV1Schema } from './import-profile.contract';
+
+/**
+ * V2 normalization contract (PLAN_61 Wave C, Task 5a).
+ *
+ * Deterministic normalization of CSV and manual financial inputs into a typed
+ * `normalizedPayload` plus a two-key identity (`observationHash`,
+ * `candidateFingerprint`). Pure reference layer: no route consumes it yet
+ * (Tasks 6 and 9-11 wire against this frozen shape). Additive to the V1
+ * `csv | notion` import contract, which is unchanged.
+ */
+
+export const IMPORT_V2_CONTRACT_VERSION = 'import-v2' as const;
+
+/** Fingerprint preimage algorithm version. Bump when the economic subset changes. */
+export const FINGERPRINT_VERSION = 1 as const;
+
+/** normalizedPayload schema version. Bump when the payload shape changes. */
+export const NORMALIZED_PAYLOAD_SCHEMA_VERSION = 1 as const;
+
+/** Maximum rows a single CSV normalization batch will process. */
+export const MAX_NORMALIZATION_ROWS = 5000;
+
+/** Maximum length of any free-text field (descriptor / display name). */
+export const MAX_TEXT_FIELD_LENGTH = 2000;
+
+export const MEASURE_KEYS_V2 = [
+  'initial_investment',
+  'follow_on_investment',
+  'capital_contribution',
+  'ownership_stake',
+  'post_money_valuation',
+] as const;
+export const MeasureKeyV2Schema = z.enum(MEASURE_KEYS_V2);
+export type MeasureKeyV2 = z.infer<typeof MeasureKeyV2Schema>;
+
+/**
+ * Decimal precision by payload field. Precision is fixed per field here, never
+ * inferred from a key-name regex, so future renames cannot silently change the
+ * financial precision of a value.
+ */
+export const PAYLOAD_DECIMAL_POLICY = {
+  amount: 6,
+  postMoneyValuation: 6,
+  fxRate: 12,
+  ownershipPct: 12,
+} as const;
+export type PayloadDecimalField = keyof typeof PAYLOAD_DECIMAL_POLICY;
+
+/**
+ * Domain -> measure/value compatibility. Enforced in both directions so a
+ * ledger row cannot carry a valuation measure and a valuation cannot carry a
+ * ledger amount.
+ */
+export const DOMAIN_MEASURE_MATRIX = {
+  ledger_event: {
+    measures: ['initial_investment', 'follow_on_investment', 'capital_contribution'],
+    requiredValue: 'amount',
+    forbiddenValues: ['postMoneyValuation', 'valuationBasis', 'ownershipPct'],
+  },
+  valuation: {
+    measures: ['post_money_valuation'],
+    requiredValue: 'postMoneyValuation',
+    forbiddenValues: ['amount', 'ownershipPct'],
+  },
+  ownership: {
+    measures: ['ownership_stake'],
+    requiredValue: 'ownershipPct',
+    forbiddenValues: ['amount', 'postMoneyValuation', 'valuationBasis'],
+  },
+} as const;
+
+export const NORMALIZATION_ISSUE_CODES = [
+  // Row-level
+  'MISSING_TRANSACTION_DATE',
+  'MALFORMED_DATE',
+  'MALFORMED_NUMBER',
+  'PRECISION_EXCEEDED',
+  'FORMULA_REJECTED',
+  'CURRENCY_REQUIRED',
+  'NON_USD_VALUE_UNSUPPORTED',
+  'INFERRED_FX_REJECTED',
+  'MISSING_ECONOMIC_VALUE',
+  'MEASURE_DOMAIN_MISMATCH',
+  'VALUE_DOMAIN_MISMATCH',
+  'OWNERSHIP_OUT_OF_RANGE',
+  'IDENTITY_REQUIRED',
+  'TEXT_LENGTH_EXCEEDED',
+  // Batch-level
+  'ROW_LIMIT_EXCEEDED',
+  'PROFILE_SOURCE_MISMATCH',
+  'PROFILE_DOMAIN_MISMATCH',
+  'PROFILE_DUPLICATE_TARGET',
+  'DUPLICATE_HEADER',
+  'UNMAPPED_REQUIRED_COLUMN',
+  'EMBEDDED_LINE_BREAK_UNSUPPORTED',
+] as const;
+export const NormalizationIssueCodeSchema = z.enum(NORMALIZATION_ISSUE_CODES);
+export type NormalizationIssueCode = z.infer<typeof NormalizationIssueCodeSchema>;
+
+export const NORMALIZATION_OUTCOMES = ['staged', 'rejected'] as const;
+export const NormalizationOutcomeSchema = z.enum(NORMALIZATION_OUTCOMES);
+export type NormalizationOutcome = z.infer<typeof NormalizationOutcomeSchema>;
+
+export const NormalizationIssueSchema = z
+  .object({
+    code: NormalizationIssueCodeSchema,
+    message: z.string().min(1),
+    field: z.string().min(1).optional(),
+    row: z.number().int().positive().optional(),
+  })
+  .strict();
+export type NormalizationIssue = z.infer<typeof NormalizationIssueSchema>;
+
+/** Structured company identity. Object-hashed; no delimiter collisions. */
+export const CompanyIdentityDescriptorV2Schema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('external'),
+      system: z.string().min(1),
+      externalId: z.string().min(1),
+    })
+    .strict(),
+  z.object({ kind: z.literal('name'), canonicalName: z.string().min(1) }).strict(),
+]);
+export type CompanyIdentityDescriptorV2 = z.infer<typeof CompanyIdentityDescriptorV2Schema>;
+
+export const ObservationDescriptorV2Schema = z
+  .object({
+    memo: z.string().optional(),
+    description: z.string().optional(),
+    note: z.string().optional(),
+    label: z.string().optional(),
+    sourceLabel: z.string().optional(),
+  })
+  .strict();
+export type ObservationDescriptorV2 = z.infer<typeof ObservationDescriptorV2Schema>;
+
+/** Typed manual entry. The future direct-write seam synthesizes this shape. */
+export const ManualEntryV2Schema = z
+  .object({
+    domain: FinancialObservationDomainSchema,
+    measureKey: MeasureKeyV2Schema,
+    companyName: z.string().optional(),
+    companyExternalId: z
+      .object({ system: z.string().min(1), value: z.string().min(1) })
+      .strict()
+      .optional(),
+    effectiveDate: z.string().optional(),
+    currency: z.string().optional(),
+    fxRate: z.string().optional(),
+    amount: z.string().optional(),
+    postMoneyValuation: z.string().optional(),
+    valuationBasis: z.string().optional(),
+    ownershipPct: z.string().optional(),
+    externalRef: z.string().nullable().optional(),
+    descriptor: ObservationDescriptorV2Schema.optional(),
+    sourceLocator: z.string().optional(),
+  })
+  .strict();
+export type ManualEntryV2 = z.infer<typeof ManualEntryV2Schema>;
+
+export const NormalizationCsvRequestV2Schema = z
+  .object({
+    contractVersion: z.literal(IMPORT_V2_CONTRACT_VERSION),
+    mode: z.literal('csv'),
+    fundId: z.number().int().positive(),
+    domain: FinancialObservationDomainSchema,
+    profile: z.object({ mappings: z.array(MappingRuleV1Schema) }).passthrough(),
+    csv: z.string(),
+  })
+  .strict();
+
+export const NormalizationManualRequestV2Schema = z
+  .object({
+    contractVersion: z.literal(IMPORT_V2_CONTRACT_VERSION),
+    mode: z.literal('manual'),
+    fundId: z.number().int().positive(),
+    entry: ManualEntryV2Schema,
+  })
+  .strict();
+
+export const NormalizationRequestV2Schema = z.discriminatedUnion('mode', [
+  NormalizationCsvRequestV2Schema,
+  NormalizationManualRequestV2Schema,
+]);
+export type NormalizationRequestV2 = z.infer<typeof NormalizationRequestV2Schema>;
+
+export const NormalizedCandidateV2Schema = z
+  .object({
+    outcome: NormalizationOutcomeSchema,
+    issues: z.array(NormalizationIssueSchema),
+    normalizedPayload: z.record(z.string(), z.unknown()).optional(),
+    observationHash: Sha256HexSchema.optional(),
+    candidateFingerprint: Sha256HexSchema.optional(),
+    effectiveDate: z.string().date().optional(),
+    sourceLocator: z.string().optional(),
+  })
+  .strict();
+export type NormalizedCandidateV2 = z.infer<typeof NormalizedCandidateV2Schema>;
+
+/** Batch result: a fatal batch-level rejection carries issues and no candidates. */
+export const NormalizationResultV2Schema = z
+  .object({
+    outcome: NormalizationOutcomeSchema,
+    issues: z.array(NormalizationIssueSchema),
+    candidates: z.array(NormalizedCandidateV2Schema),
+  })
+  .strict();
+export type NormalizationResultV2 = z.infer<typeof NormalizationResultV2Schema>;

--- a/tests/fixtures/financial-observations/equivalence-corpus.ts
+++ b/tests/fixtures/financial-observations/equivalence-corpus.ts
@@ -1,0 +1,663 @@
+/**
+ * Golden equivalence corpus (PLAN_61 Wave C, Task 5a).
+ *
+ * 12 event types, each expressed as equivalent CSV and manual variants, with
+ * pinned dispositions and hash relationships. Values are grounded in the real
+ * Press On Ventures fund files (Venture Pipeline, LPs x Funds); values marked
+ * `// illustrative` are synthetic.
+ *
+ * Fixture only: no database, no route. Consumed by
+ * `tests/unit/services/financial-observations/normalization-service.test.ts`.
+ */
+
+import type { FinancialObservationDomain } from '@shared/contracts/financial-observations/financial-observation.contract';
+import {
+  buildIdentitySemanticsHash,
+  type ImportMappingProfileV1,
+  type MappingRuleV1,
+} from '@shared/contracts/financial-observations/import-profile.contract';
+import type {
+  ManualEntryV2,
+  NormalizationIssueCode,
+} from '@shared/contracts/financial-observations/normalization.contract';
+
+export const CORPUS_FUND_ID = 1;
+
+export type CsvVariant = { kind: 'csv'; header: string; row: string };
+export type ManualVariant = { kind: 'manual'; entry: ManualEntryV2 };
+export type Variant = CsvVariant | ManualVariant;
+
+export type CorpusAssertion =
+  | { assert: 'staged'; variant: string }
+  | { assert: 'rejected'; variant: string; issueCodes: NormalizationIssueCode[] }
+  | { assert: 'noIssues'; variant: string }
+  | { assert: 'payloadEqual'; left: string; right: string }
+  | { assert: 'payloadDiffer'; left: string; right: string }
+  | { assert: 'fingerprintEqual'; left: string; right: string }
+  | { assert: 'fingerprintDiffer'; left: string; right: string }
+  | { assert: 'hashEqual'; left: string; right: string }
+  | { assert: 'hashDiffer'; left: string; right: string }
+  | { assert: 'payloadPinned'; variant: string; expected: Record<string, unknown> };
+
+export interface EquivalenceCase {
+  readonly id: number;
+  readonly name: string;
+  readonly domain: FinancialObservationDomain;
+  readonly profile: ImportMappingProfileV1;
+  readonly variants: Record<string, Variant>;
+  readonly assertions: readonly CorpusAssertion[];
+}
+
+// ---------------------------------------------------------------------------
+// Profiles
+// ---------------------------------------------------------------------------
+
+function profile(
+  name: string,
+  domain: FinancialObservationDomain,
+  mappings: MappingRuleV1[]
+): ImportMappingProfileV1 {
+  return {
+    name,
+    sourceType: 'csv',
+    domain,
+    version: 1,
+    mappings,
+    identitySemanticsHash: buildIdentitySemanticsHash(mappings),
+  };
+}
+
+const LEDGER_MAPPINGS: MappingRuleV1[] = [
+  { sourceColumn: 'company_name', targetField: 'company_name', transforms: ['trim'] },
+  { sourceColumn: 'measure_key', targetField: 'measure_key', transforms: ['trim'] },
+  { sourceColumn: 'effective_date', targetField: 'effective_date', transforms: ['parse_date_iso'] },
+  { sourceColumn: 'currency', targetField: 'currency', transforms: ['trim'] },
+  { sourceColumn: 'amount', targetField: 'amount', transforms: ['parse_decimal'] },
+  { sourceColumn: 'external_ref', targetField: 'external_ref', transforms: ['trim'] },
+  { sourceColumn: 'memo', targetField: 'memo', transforms: ['trim'] },
+];
+const LEDGER_HEADER = 'company_name,measure_key,effective_date,currency,amount,external_ref,memo';
+const LEDGER_PROFILE = profile('ledger-v2', 'ledger_event', LEDGER_MAPPINGS);
+
+const LEDGER_FX_MAPPINGS: MappingRuleV1[] = [
+  ...LEDGER_MAPPINGS,
+  { sourceColumn: 'fx_rate', targetField: 'fx_rate', transforms: ['trim'] },
+];
+const LEDGER_FX_HEADER = `${LEDGER_HEADER},fx_rate`;
+const LEDGER_FX_PROFILE = profile('ledger-fx-v2', 'ledger_event', LEDGER_FX_MAPPINGS);
+
+const VALUATION_MAPPINGS: MappingRuleV1[] = [
+  { sourceColumn: 'company_name', targetField: 'company_name', transforms: ['trim'] },
+  { sourceColumn: 'measure_key', targetField: 'measure_key', transforms: ['trim'] },
+  { sourceColumn: 'effective_date', targetField: 'effective_date', transforms: ['parse_date_iso'] },
+  { sourceColumn: 'currency', targetField: 'currency', transforms: ['trim'] },
+  {
+    sourceColumn: 'post_money_valuation',
+    targetField: 'post_money_valuation',
+    transforms: ['parse_decimal'],
+  },
+  { sourceColumn: 'valuation_basis', targetField: 'valuation_basis', transforms: ['trim'] },
+  { sourceColumn: 'external_ref', targetField: 'external_ref', transforms: ['trim'] },
+];
+const VALUATION_HEADER =
+  'company_name,measure_key,effective_date,currency,post_money_valuation,valuation_basis,external_ref';
+const VALUATION_PROFILE = profile('valuation-v2', 'valuation', VALUATION_MAPPINGS);
+
+const OWNERSHIP_MAPPINGS: MappingRuleV1[] = [
+  { sourceColumn: 'company_name', targetField: 'company_name', transforms: ['trim'] },
+  { sourceColumn: 'measure_key', targetField: 'measure_key', transforms: ['trim'] },
+  { sourceColumn: 'effective_date', targetField: 'effective_date', transforms: ['parse_date_iso'] },
+  { sourceColumn: 'currency', targetField: 'currency', transforms: ['trim'] },
+  { sourceColumn: 'ownership_pct', targetField: 'ownership_pct', transforms: ['parse_decimal'] },
+  { sourceColumn: 'external_ref', targetField: 'external_ref', transforms: ['trim'] },
+];
+const OWNERSHIP_HEADER =
+  'company_name,measure_key,effective_date,currency,ownership_pct,external_ref';
+const OWNERSHIP_PROFILE = profile('ownership-v2', 'ownership', OWNERSHIP_MAPPINGS);
+
+const EXTERNAL_MAPPINGS: MappingRuleV1[] = [
+  {
+    sourceColumn: 'company_external_system',
+    targetField: 'company_external_system',
+    transforms: ['trim'],
+  },
+  {
+    sourceColumn: 'company_external_value',
+    targetField: 'company_external_value',
+    transforms: ['trim'],
+  },
+  { sourceColumn: 'measure_key', targetField: 'measure_key', transforms: ['trim'] },
+  { sourceColumn: 'effective_date', targetField: 'effective_date', transforms: ['parse_date_iso'] },
+  { sourceColumn: 'currency', targetField: 'currency', transforms: ['trim'] },
+  { sourceColumn: 'amount', targetField: 'amount', transforms: ['parse_decimal'] },
+  { sourceColumn: 'external_ref', targetField: 'external_ref', transforms: ['trim'] },
+  { sourceColumn: 'source_label', targetField: 'source_label', transforms: ['trim'] },
+];
+const EXTERNAL_HEADER =
+  'company_external_system,company_external_value,measure_key,effective_date,currency,amount,external_ref,source_label';
+const EXTERNAL_PROFILE = profile('ledger-external-v2', 'ledger_event', EXTERNAL_MAPPINGS);
+
+// ---------------------------------------------------------------------------
+// Helpers for canonical manual entries
+// ---------------------------------------------------------------------------
+
+function ledgerManual(over: Partial<ManualEntryV2>): ManualEntryV2 {
+  return {
+    domain: 'ledger_event',
+    measureKey: 'initial_investment',
+    currency: 'USD',
+    effectiveDate: '2023-01-15',
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+export const EQUIVALENCE_CASES: readonly EquivalenceCase[] = [
+  // 1. Initial investment — Jon Victor SPV Three initial $100,000
+  {
+    id: 1,
+    name: 'initial investment',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,initial_investment,2023-01-15,USD,"100,000.00",wire-001,initial check',
+      },
+      manual: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'Jon Victor SPV Three',
+          measureKey: 'initial_investment',
+          amount: '100000.00',
+          externalRef: 'wire-001',
+          descriptor: { memo: 'initial check' },
+        }),
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'csv' },
+      { assert: 'staged', variant: 'manual' },
+      { assert: 'payloadEqual', left: 'csv', right: 'manual' },
+      { assert: 'fingerprintEqual', left: 'csv', right: 'manual' },
+      {
+        assert: 'payloadPinned',
+        variant: 'manual',
+        expected: {
+          schemaVersion: 1,
+          domain: 'ledger_event',
+          measureKey: 'initial_investment',
+          companyIdentity: { kind: 'name', canonicalName: 'jon victor spv three' },
+          effectiveDate: '2023-01-15',
+          currency: 'USD',
+          fxRate: '1.000000000000',
+          amount: '100000.000000',
+          externalRef: 'wire-001',
+          descriptor: { memo: 'initial check' },
+        },
+      },
+    ],
+  },
+
+  // 2. Follow-on — Jon Victor SPV Three follow-on $25,040
+  {
+    id: 2,
+    name: 'follow-on investment',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,follow_on_investment,2023-06-01,USD,"25,040.00",wire-002,follow on',
+      },
+      manual: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'Jon Victor SPV Three',
+          measureKey: 'follow_on_investment',
+          effectiveDate: '2023-06-01',
+          amount: '25040',
+          externalRef: 'wire-002',
+          descriptor: { memo: 'follow on' },
+        }),
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'csv' },
+      { assert: 'staged', variant: 'manual' },
+      { assert: 'payloadEqual', left: 'csv', right: 'manual' },
+      { assert: 'fingerprintEqual', left: 'csv', right: 'manual' },
+    ],
+  },
+
+  // 3. Valuation mark — Puzzle Medical Devices Series A $100m post-money
+  {
+    id: 3,
+    name: 'valuation mark',
+    domain: 'valuation',
+    profile: VALUATION_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: VALUATION_HEADER,
+        row: 'Puzzle Medical Devices,post_money_valuation,2023-04-01,USD,100000000,priced_round,mark-001',
+      },
+      manual: {
+        kind: 'manual',
+        entry: {
+          domain: 'valuation',
+          measureKey: 'post_money_valuation',
+          companyName: 'Puzzle Medical Devices',
+          effectiveDate: '2023-04-01',
+          currency: 'USD',
+          postMoneyValuation: '100000000',
+          valuationBasis: 'priced_round',
+          externalRef: 'mark-001',
+        },
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'csv' },
+      { assert: 'staged', variant: 'manual' },
+      { assert: 'payloadEqual', left: 'csv', right: 'manual' },
+      { assert: 'fingerprintEqual', left: 'csv', right: 'manual' },
+      {
+        assert: 'payloadPinned',
+        variant: 'manual',
+        expected: {
+          schemaVersion: 1,
+          domain: 'valuation',
+          measureKey: 'post_money_valuation',
+          companyIdentity: { kind: 'name', canonicalName: 'puzzle medical devices' },
+          effectiveDate: '2023-04-01',
+          currency: 'USD',
+          fxRate: '1.000000000000',
+          postMoneyValuation: '100000000.000000',
+          valuationBasis: 'priced_round',
+          externalRef: 'mark-001',
+        },
+      },
+    ],
+  },
+
+  // 4. Ownership update — Get Globy seed SPV stake (8% // illustrative)
+  {
+    id: 4,
+    name: 'ownership update',
+    domain: 'ownership',
+    profile: OWNERSHIP_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: OWNERSHIP_HEADER,
+        row: 'Get Globy,ownership_stake,2023-02-01,USD,8,own-001',
+      }, // illustrative
+      manual: {
+        kind: 'manual',
+        entry: {
+          domain: 'ownership',
+          measureKey: 'ownership_stake',
+          companyName: 'Get Globy',
+          effectiveDate: '2023-02-01',
+          currency: 'USD',
+          ownershipPct: '8', // illustrative
+          externalRef: 'own-001',
+        },
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'csv' },
+      { assert: 'staged', variant: 'manual' },
+      { assert: 'payloadEqual', left: 'csv', right: 'manual' },
+      { assert: 'fingerprintEqual', left: 'csv', right: 'manual' },
+      {
+        assert: 'payloadPinned',
+        variant: 'manual',
+        expected: {
+          schemaVersion: 1,
+          domain: 'ownership',
+          measureKey: 'ownership_stake',
+          companyIdentity: { kind: 'name', canonicalName: 'get globy' },
+          effectiveDate: '2023-02-01',
+          currency: 'USD',
+          fxRate: '1.000000000000',
+          ownershipPct: '8.000000000000',
+          externalRef: 'own-001',
+        },
+      },
+    ],
+  },
+
+  // 5. Cash-flow event — David Morris SPV Three initial $50,000 call
+  {
+    id: 5,
+    name: 'cash-flow event',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'David Morris,capital_contribution,2023-03-01,USD,"50,000.00",call-001,capital call',
+      },
+      manual: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'David Morris',
+          measureKey: 'capital_contribution',
+          effectiveDate: '2023-03-01',
+          amount: '50000',
+          externalRef: 'call-001',
+          descriptor: { memo: 'capital call' },
+        }),
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'csv' },
+      { assert: 'staged', variant: 'manual' },
+      { assert: 'payloadEqual', left: 'csv', right: 'manual' },
+      { assert: 'fingerprintEqual', left: 'csv', right: 'manual' },
+    ],
+  },
+
+  // 6. External identity — same carta id, differing display names
+  {
+    id: 6,
+    name: 'external identity',
+    domain: 'ledger_event',
+    profile: EXTERNAL_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: EXTERNAL_HEADER,
+        row: 'carta,cmp_puzzle,initial_investment,2023-03-01,USD,500000,ref6,Puzzle Medical Devices',
+      }, // illustrative
+      manual: {
+        kind: 'manual',
+        entry: {
+          domain: 'ledger_event',
+          measureKey: 'initial_investment',
+          companyExternalId: { system: 'carta', value: 'cmp_puzzle' }, // illustrative
+          effectiveDate: '2023-03-01',
+          currency: 'USD',
+          amount: '500000',
+          externalRef: 'ref6',
+          descriptor: { sourceLabel: 'Puzzle Medical Devices' },
+        },
+      },
+      altName: {
+        kind: 'manual',
+        entry: {
+          domain: 'ledger_event',
+          measureKey: 'initial_investment',
+          companyExternalId: { system: 'carta', value: 'cmp_puzzle' }, // illustrative
+          effectiveDate: '2023-03-01',
+          currency: 'USD',
+          amount: '500000',
+          externalRef: 'ref6',
+          descriptor: { sourceLabel: 'Puzzle Med Inc' },
+        },
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'csv' },
+      { assert: 'staged', variant: 'manual' },
+      { assert: 'staged', variant: 'altName' },
+      { assert: 'payloadEqual', left: 'csv', right: 'manual' },
+      { assert: 'fingerprintEqual', left: 'csv', right: 'manual' },
+      // differing display name: same economic identity, different full hash
+      { assert: 'fingerprintEqual', left: 'manual', right: 'altName' },
+      { assert: 'hashDiffer', left: 'manual', right: 'altName' },
+      {
+        assert: 'payloadPinned',
+        variant: 'manual',
+        expected: {
+          schemaVersion: 1,
+          domain: 'ledger_event',
+          measureKey: 'initial_investment',
+          companyIdentity: { kind: 'external', system: 'carta', externalId: 'cmp_puzzle' },
+          effectiveDate: '2023-03-01',
+          currency: 'USD',
+          fxRate: '1.000000000000',
+          amount: '500000.000000',
+          externalRef: 'ref6',
+          descriptor: { sourceLabel: 'Puzzle Medical Devices' },
+        },
+      },
+    ],
+  },
+
+  // 7. Number formats — three spellings of $100,000 normalize identically
+  {
+    id: 7,
+    name: 'number formats',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      comma: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,initial_investment,2023-01-15,USD,"100,000.00",wire-001,initial check',
+      },
+      plain: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,initial_investment,2023-01-15,USD,100000,wire-001,initial check',
+      },
+      dollar: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,initial_investment,2023-01-15,USD,"$100,000.00",wire-001,initial check',
+      },
+      manual: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'Jon Victor SPV Three',
+          measureKey: 'initial_investment',
+          amount: '100000',
+          externalRef: 'wire-001',
+          descriptor: { memo: 'initial check' },
+        }),
+      },
+      malformed: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,initial_investment,2023-01-15,USD,"1,23",wire-001,initial check',
+      },
+    },
+    assertions: [
+      { assert: 'payloadEqual', left: 'comma', right: 'plain' },
+      { assert: 'payloadEqual', left: 'plain', right: 'dollar' },
+      { assert: 'payloadEqual', left: 'dollar', right: 'manual' },
+      { assert: 'rejected', variant: 'malformed', issueCodes: ['MALFORMED_NUMBER'] },
+    ],
+  },
+
+  // 8. Explicit USD FX = 1.0 — no warning
+  {
+    id: 8,
+    name: 'explicit usd fx',
+    domain: 'ledger_event',
+    profile: LEDGER_FX_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: LEDGER_FX_HEADER,
+        row: 'David Morris,follow_on_investment,2023-07-01,USD,"12,520.00",fx-001,follow on,1.0',
+      },
+      manual: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'David Morris',
+          measureKey: 'follow_on_investment',
+          effectiveDate: '2023-07-01',
+          amount: '12520',
+          externalRef: 'fx-001',
+          fxRate: '1.0',
+          descriptor: { memo: 'follow on' },
+        }),
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'csv' },
+      { assert: 'noIssues', variant: 'csv' },
+      { assert: 'staged', variant: 'manual' },
+      { assert: 'noIssues', variant: 'manual' },
+      { assert: 'payloadEqual', left: 'csv', right: 'manual' },
+      { assert: 'fingerprintEqual', left: 'csv', right: 'manual' },
+    ],
+  },
+
+  // 9. Non-USD rejection — EUR blocked
+  {
+    id: 9,
+    name: 'non-usd rejection',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'David Morris,capital_contribution,2023-03-01,EUR,"50,000.00",call-001,capital call',
+      },
+      manual: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'David Morris',
+          measureKey: 'capital_contribution',
+          effectiveDate: '2023-03-01',
+          currency: 'EUR',
+          amount: '50000',
+          externalRef: 'call-001',
+          descriptor: { memo: 'capital call' },
+        }),
+      },
+    },
+    assertions: [
+      { assert: 'rejected', variant: 'csv', issueCodes: ['NON_USD_VALUE_UNSUPPORTED'] },
+      { assert: 'rejected', variant: 'manual', issueCodes: ['NON_USD_VALUE_UNSUPPORTED'] },
+    ],
+  },
+
+  // 10. Reordered columns — identical payload, fingerprint, and hash
+  {
+    id: 10,
+    name: 'reordered columns',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      baseline: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,initial_investment,2023-01-15,USD,"100,000.00",wire-001,initial check',
+      },
+      reordered: {
+        kind: 'csv',
+        header: 'memo,amount,external_ref,currency,effective_date,measure_key,company_name',
+        row: 'initial check,"100,000.00",wire-001,USD,2023-01-15,initial_investment,Jon Victor SPV Three',
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'baseline' },
+      { assert: 'staged', variant: 'reordered' },
+      { assert: 'payloadEqual', left: 'baseline', right: 'reordered' },
+      { assert: 'fingerprintEqual', left: 'baseline', right: 'reordered' },
+      { assert: 'hashEqual', left: 'baseline', right: 'reordered' },
+    ],
+  },
+
+  // 11. Description change — same fingerprint, different hash
+  {
+    id: 11,
+    name: 'description change',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      csv: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,initial_investment,2023-01-15,USD,"100,000.00",wire-001,initial check',
+      },
+      manual: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'Jon Victor SPV Three',
+          measureKey: 'initial_investment',
+          amount: '100000',
+          externalRef: 'wire-001',
+          descriptor: { memo: 'initial check' },
+        }),
+      },
+      altMemo: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'Jon Victor SPV Three',
+          measureKey: 'initial_investment',
+          amount: '100000',
+          externalRef: 'wire-001',
+          descriptor: { memo: 'revised note' },
+        }),
+      },
+    },
+    assertions: [
+      { assert: 'fingerprintEqual', left: 'csv', right: 'altMemo' },
+      { assert: 'hashDiffer', left: 'csv', right: 'altMemo' },
+      { assert: 'payloadDiffer', left: 'csv', right: 'altMemo' },
+    ],
+  },
+
+  // 12. Same amount+date, distinct transactions — externalRef discriminates
+  {
+    id: 12,
+    name: 'same amount and date, distinct transactions',
+    domain: 'ledger_event',
+    profile: LEDGER_PROFILE,
+    variants: {
+      wireA: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,follow_on_investment,2023-06-01,USD,"25,040.00",wire-A,follow on',
+      },
+      wireB: {
+        kind: 'csv',
+        header: LEDGER_HEADER,
+        row: 'Jon Victor SPV Three,follow_on_investment,2023-06-01,USD,"25,040.00",wire-B,follow on',
+      },
+      refBlank: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'Jon Victor SPV Three',
+          measureKey: 'follow_on_investment',
+          effectiveDate: '2023-06-01',
+          amount: '25040',
+          externalRef: '',
+          descriptor: { memo: 'follow on' },
+        }),
+      },
+      refAbsent: {
+        kind: 'manual',
+        entry: ledgerManual({
+          companyName: 'Jon Victor SPV Three',
+          measureKey: 'follow_on_investment',
+          effectiveDate: '2023-06-01',
+          amount: '25040',
+          descriptor: { memo: 'follow on' },
+        }),
+      },
+    },
+    assertions: [
+      { assert: 'staged', variant: 'wireA' },
+      { assert: 'staged', variant: 'wireB' },
+      { assert: 'fingerprintDiffer', left: 'wireA', right: 'wireB' },
+      { assert: 'hashDiffer', left: 'wireA', right: 'wireB' },
+      // blank and absent externalRef both normalize to null → identical
+      { assert: 'payloadEqual', left: 'refBlank', right: 'refAbsent' },
+      { assert: 'fingerprintEqual', left: 'refBlank', right: 'refAbsent' },
+    ],
+  },
+];

--- a/tests/unit/services/financial-observations/normalization-service.test.ts
+++ b/tests/unit/services/financial-observations/normalization-service.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalSha256 } from '@shared/lib/canonical-hash';
+import {
+  FINGERPRINT_VERSION,
+  type ImportMappingProfileV1,
+  type ManualEntryV2,
+  type MappingRuleV1,
+  type NormalizedCandidateV2,
+} from '@shared/contracts/financial-observations';
+import { buildIdentitySemanticsHash } from '@shared/contracts/financial-observations/import-profile.contract';
+
+import {
+  applyMappingTransforms,
+  normalizeObservation,
+} from '@/server/services/financial-observations/normalization-service';
+import { normalizeCsvObservations } from '@/server/services/financial-observations/csv-adapter';
+import { normalizeManualObservation } from '@/server/services/financial-observations/manual-entry-adapter';
+import {
+  CORPUS_FUND_ID,
+  EQUIVALENCE_CASES,
+  type EquivalenceCase,
+  type Variant,
+} from '../../../fixtures/financial-observations/equivalence-corpus';
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+function runVariant(caseObj: EquivalenceCase, variant: Variant): NormalizedCandidateV2 {
+  if (variant.kind === 'manual') {
+    return normalizeManualObservation(variant.entry);
+  }
+  const buffer = Buffer.from(`${variant.header}\n${variant.row}\n`, 'utf8');
+  const result = normalizeCsvObservations({
+    buffer,
+    profile: caseObj.profile,
+    domain: caseObj.domain,
+    fundId: CORPUS_FUND_ID,
+  });
+  return result.candidates[0] ?? { outcome: result.outcome, issues: result.issues };
+}
+
+function runCase(caseObj: EquivalenceCase): Record<string, NormalizedCandidateV2> {
+  const out: Record<string, NormalizedCandidateV2> = {};
+  for (const [key, variant] of Object.entries(caseObj.variants)) {
+    out[key] = runVariant(caseObj, variant);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Corpus assertions
+// ---------------------------------------------------------------------------
+
+describe('equivalence corpus', () => {
+  for (const caseObj of EQUIVALENCE_CASES) {
+    it(`case ${caseObj.id}: ${caseObj.name}`, () => {
+      const results = runCase(caseObj);
+      for (const a of caseObj.assertions) {
+        switch (a.assert) {
+          case 'staged':
+            expect(results[a.variant]!.outcome, `${a.variant} staged`).toBe('staged');
+            break;
+          case 'rejected': {
+            const r = results[a.variant]!;
+            expect(r.outcome, `${a.variant} rejected`).toBe('rejected');
+            const codes = r.issues.map((i) => i.code);
+            for (const code of a.issueCodes) {
+              expect(codes, `${a.variant} carries ${code}`).toContain(code);
+            }
+            break;
+          }
+          case 'noIssues':
+            expect(results[a.variant]!.issues, `${a.variant} no issues`).toEqual([]);
+            break;
+          case 'payloadEqual':
+            expect(results[a.left]!.normalizedPayload).toEqual(results[a.right]!.normalizedPayload);
+            break;
+          case 'payloadDiffer':
+            expect(results[a.left]!.normalizedPayload).not.toEqual(
+              results[a.right]!.normalizedPayload
+            );
+            break;
+          case 'fingerprintEqual':
+            expect(results[a.left]!.candidateFingerprint).toBe(
+              results[a.right]!.candidateFingerprint
+            );
+            break;
+          case 'fingerprintDiffer':
+            expect(results[a.left]!.candidateFingerprint).not.toBe(
+              results[a.right]!.candidateFingerprint
+            );
+            break;
+          case 'hashEqual':
+            expect(results[a.left]!.observationHash).toBe(results[a.right]!.observationHash);
+            break;
+          case 'hashDiffer':
+            expect(results[a.left]!.observationHash).not.toBe(results[a.right]!.observationHash);
+            break;
+          case 'payloadPinned':
+            expect(results[a.variant]!.normalizedPayload).toEqual(a.expected);
+            break;
+          default: {
+            a satisfies never;
+            throw new Error('unknown assertion');
+          }
+        }
+      }
+    });
+  }
+
+  it('exit gate: every csv/manual pair has equal payload and fingerprint', () => {
+    let pairs = 0;
+    for (const caseObj of EQUIVALENCE_CASES) {
+      const results = runCase(caseObj);
+      const csv = results.csv;
+      const manual = results.manual;
+      if (csv?.outcome === 'staged' && manual?.outcome === 'staged') {
+        pairs++;
+        expect(csv.normalizedPayload, `case ${caseObj.id} payload`).toEqual(
+          manual.normalizedPayload
+        );
+        expect(csv.candidateFingerprint, `case ${caseObj.id} fingerprint`).toBe(
+          manual.candidateFingerprint
+        );
+      }
+    }
+    expect(pairs).toBeGreaterThanOrEqual(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hash derivation (D15: derivation asserted, cross-mode byte-identity not a gate)
+// ---------------------------------------------------------------------------
+
+describe('hash derivation', () => {
+  function preimageFromPayload(payload: Record<string, unknown>): Record<string, unknown> {
+    const {
+      schemaVersion: _schemaVersion,
+      descriptor: _descriptor,
+      ...economicAndIdentity
+    } = payload;
+    return { fingerprintVersion: FINGERPRINT_VERSION, ...economicAndIdentity };
+  }
+
+  it('observationHash and candidateFingerprint derive from their exact preimages', () => {
+    for (const caseObj of EQUIVALENCE_CASES) {
+      const results = runCase(caseObj);
+      for (const [key, candidate] of Object.entries(results)) {
+        if (candidate.outcome !== 'staged') continue;
+        const payload = candidate.normalizedPayload!;
+        expect(candidate.observationHash, `${caseObj.id}.${key} hash`).toBe(
+          canonicalSha256(payload)
+        );
+        expect(candidate.candidateFingerprint, `${caseObj.id}.${key} fp`).toBe(
+          canonicalSha256(preimageFromPayload(payload))
+        );
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative gating — one per issue code
+// ---------------------------------------------------------------------------
+
+function baseLedger(over: Partial<ManualEntryV2>): ManualEntryV2 {
+  return {
+    domain: 'ledger_event',
+    measureKey: 'initial_investment',
+    companyName: 'Acme',
+    effectiveDate: '2023-01-15',
+    currency: 'USD',
+    amount: '1000',
+    ...over,
+  };
+}
+
+function csvProfile(
+  mappings: MappingRuleV1[],
+  over: Partial<ImportMappingProfileV1> = {}
+): ImportMappingProfileV1 {
+  return {
+    name: 'neg',
+    sourceType: 'csv',
+    domain: 'ledger_event',
+    version: 1,
+    mappings,
+    identitySemanticsHash: buildIdentitySemanticsHash(mappings),
+    ...over,
+  };
+}
+
+const NEG_MAPPINGS: MappingRuleV1[] = [
+  { sourceColumn: 'company_name', targetField: 'company_name', transforms: ['trim'] },
+  { sourceColumn: 'measure_key', targetField: 'measure_key', transforms: ['trim'] },
+  { sourceColumn: 'effective_date', targetField: 'effective_date', transforms: ['parse_date_iso'] },
+  { sourceColumn: 'currency', targetField: 'currency', transforms: ['trim'] },
+  { sourceColumn: 'amount', targetField: 'amount', transforms: ['parse_decimal'] },
+];
+const NEG_HEADER = 'company_name,measure_key,effective_date,currency,amount';
+
+function csvRows(
+  header: string,
+  rows: string[],
+  domain: EquivalenceCase['domain'] = 'ledger_event',
+  profile = csvProfile(NEG_MAPPINGS)
+) {
+  const buffer = Buffer.from([header, ...rows].join('\n'), 'utf8');
+  return normalizeCsvObservations({ buffer, profile, domain, fundId: 1 });
+}
+
+describe('negative gating', () => {
+  it('MISSING_TRANSACTION_DATE', () => {
+    const r = normalizeObservation(baseLedger({ effectiveDate: undefined }));
+    expect(r.outcome).toBe('rejected');
+    expect(r.issues.map((i) => i.code)).toContain('MISSING_TRANSACTION_DATE');
+  });
+
+  it('MALFORMED_DATE', () => {
+    const r = normalizeObservation(baseLedger({ effectiveDate: '2023-13-40' }));
+    expect(r.issues.map((i) => i.code)).toContain('MALFORMED_DATE');
+  });
+
+  it('MALFORMED_NUMBER', () => {
+    const r = normalizeObservation(baseLedger({ amount: 'not-a-number' }));
+    expect(r.issues.map((i) => i.code)).toContain('MALFORMED_NUMBER');
+  });
+
+  it('PRECISION_EXCEEDED', () => {
+    const r = normalizeObservation(baseLedger({ amount: '1.0000001' }));
+    expect(r.issues.map((i) => i.code)).toContain('PRECISION_EXCEEDED');
+  });
+
+  it('FORMULA_REJECTED', () => {
+    const result = csvRows(NEG_HEADER, ['Acme,initial_investment,2023-01-15,USD,=1+1']);
+    expect(result.candidates[0]!.issues.map((i) => i.code)).toContain('FORMULA_REJECTED');
+  });
+
+  it('CURRENCY_REQUIRED', () => {
+    const r = normalizeObservation(baseLedger({ currency: undefined }));
+    expect(r.issues.map((i) => i.code)).toContain('CURRENCY_REQUIRED');
+  });
+
+  it('NON_USD_VALUE_UNSUPPORTED', () => {
+    const r = normalizeObservation(baseLedger({ currency: 'EUR' }));
+    expect(r.issues.map((i) => i.code)).toContain('NON_USD_VALUE_UNSUPPORTED');
+  });
+
+  it('INFERRED_FX_REJECTED — non-unity fx', () => {
+    const r = normalizeObservation(baseLedger({ fxRate: '1.5' }));
+    expect(r.issues.map((i) => i.code)).toContain('INFERRED_FX_REJECTED');
+  });
+
+  it('INFERRED_FX_REJECTED — fx without currency', () => {
+    const r = normalizeObservation(baseLedger({ currency: undefined, fxRate: '1.0' }));
+    expect(r.issues.map((i) => i.code)).toContain('INFERRED_FX_REJECTED');
+  });
+
+  it('MISSING_ECONOMIC_VALUE', () => {
+    const r = normalizeObservation(baseLedger({ amount: undefined }));
+    expect(r.issues.map((i) => i.code)).toContain('MISSING_ECONOMIC_VALUE');
+  });
+
+  it('MEASURE_DOMAIN_MISMATCH', () => {
+    const r = normalizeObservation(baseLedger({ measureKey: 'ownership_stake' }));
+    expect(r.issues.map((i) => i.code)).toContain('MEASURE_DOMAIN_MISMATCH');
+  });
+
+  it('VALUE_DOMAIN_MISMATCH', () => {
+    const r = normalizeObservation(baseLedger({ postMoneyValuation: '100' }));
+    expect(r.issues.map((i) => i.code)).toContain('VALUE_DOMAIN_MISMATCH');
+  });
+
+  it('OWNERSHIP_OUT_OF_RANGE', () => {
+    const r = normalizeObservation({
+      domain: 'ownership',
+      measureKey: 'ownership_stake',
+      companyName: 'Acme',
+      effectiveDate: '2023-01-15',
+      currency: 'USD',
+      ownershipPct: '150',
+    });
+    expect(r.issues.map((i) => i.code)).toContain('OWNERSHIP_OUT_OF_RANGE');
+  });
+
+  it('IDENTITY_REQUIRED', () => {
+    const r = normalizeObservation(baseLedger({ companyName: undefined }));
+    expect(r.issues.map((i) => i.code)).toContain('IDENTITY_REQUIRED');
+  });
+
+  it('TEXT_LENGTH_EXCEEDED', () => {
+    const r = normalizeObservation(baseLedger({ descriptor: { memo: 'x'.repeat(2001) } }));
+    expect(r.issues.map((i) => i.code)).toContain('TEXT_LENGTH_EXCEEDED');
+  });
+
+  it('ROW_LIMIT_EXCEEDED', () => {
+    const rows = Array.from({ length: 5001 }, () => 'Acme,initial_investment,2023-01-15,USD,1000');
+    const result = csvRows(NEG_HEADER, rows);
+    expect(result.outcome).toBe('rejected');
+    expect(result.issues.map((i) => i.code)).toContain('ROW_LIMIT_EXCEEDED');
+  });
+
+  it('PROFILE_SOURCE_MISMATCH', () => {
+    const result = csvRows(
+      NEG_HEADER,
+      ['Acme,initial_investment,2023-01-15,USD,1000'],
+      'ledger_event',
+      csvProfile(NEG_MAPPINGS, { sourceType: 'manual' })
+    );
+    expect(result.issues.map((i) => i.code)).toContain('PROFILE_SOURCE_MISMATCH');
+  });
+
+  it('PROFILE_DOMAIN_MISMATCH', () => {
+    const result = csvRows(
+      NEG_HEADER,
+      ['Acme,initial_investment,2023-01-15,USD,1000'],
+      'ledger_event',
+      csvProfile(NEG_MAPPINGS, { domain: 'valuation' })
+    );
+    expect(result.issues.map((i) => i.code)).toContain('PROFILE_DOMAIN_MISMATCH');
+  });
+
+  it('PROFILE_DUPLICATE_TARGET', () => {
+    const dup = [
+      ...NEG_MAPPINGS,
+      { sourceColumn: 'amount2', targetField: 'amount', transforms: ['parse_decimal'] as const },
+    ];
+    const result = csvRows(
+      NEG_HEADER,
+      ['Acme,initial_investment,2023-01-15,USD,1000'],
+      'ledger_event',
+      csvProfile(dup as MappingRuleV1[])
+    );
+    expect(result.issues.map((i) => i.code)).toContain('PROFILE_DUPLICATE_TARGET');
+  });
+
+  it('DUPLICATE_HEADER', () => {
+    const result = csvRows('company_name,amount,amount', ['Acme,1000,2000']);
+    expect(result.issues.map((i) => i.code)).toContain('DUPLICATE_HEADER');
+  });
+
+  it('UNMAPPED_REQUIRED_COLUMN', () => {
+    const result = csvRows('company_name,measure_key,effective_date,currency', [
+      'Acme,initial_investment,2023-01-15,USD',
+    ]);
+    expect(result.issues.map((i) => i.code)).toContain('UNMAPPED_REQUIRED_COLUMN');
+  });
+
+  it('EMBEDDED_LINE_BREAK_UNSUPPORTED', () => {
+    const buffer = Buffer.from(
+      `${NEG_HEADER}\nAcme,initial_investment,2023-01-15,USD,"10\n00"\n`,
+      'utf8'
+    );
+    const result = normalizeCsvObservations({
+      buffer,
+      profile: csvProfile(NEG_MAPPINGS),
+      domain: 'ledger_event',
+      fundId: 1,
+    });
+    expect(result.issues.map((i) => i.code)).toContain('EMBEDDED_LINE_BREAK_UNSUPPORTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe('determinism', () => {
+  it('structured external identity avoids delimiter collision', () => {
+    const a = normalizeObservation(
+      baseLedger({ companyName: undefined, companyExternalId: { system: 'a:b', value: 'c' } })
+    );
+    const b = normalizeObservation(
+      baseLedger({ companyName: undefined, companyExternalId: { system: 'a', value: 'b:c' } })
+    );
+    expect(a.outcome).toBe('staged');
+    expect(b.outcome).toBe('staged');
+    expect(a.candidateFingerprint).not.toBe(b.candidateFingerprint);
+  });
+
+  it('transform application is order-dependent and repeatable', () => {
+    const first = applyMappingTransforms(' 1,000.00 ', ['trim', 'parse_decimal']);
+    const second = applyMappingTransforms(' 1,000.00 ', ['trim', 'parse_decimal']);
+    expect(first).toEqual({ ok: true, value: '1000.00' });
+    expect(second).toEqual(first);
+    const negated = applyMappingTransforms('1000', ['parse_decimal', 'negate']);
+    expect(negated).toEqual({ ok: true, value: '-1000' });
+  });
+
+  it('decimal precision follows the per-field policy', () => {
+    const money = normalizeObservation(baseLedger({ amount: '1000' }));
+    expect(money.normalizedPayload!.amount).toBe('1000.000000');
+    expect(money.normalizedPayload!.fxRate).toBe('1.000000000000');
+    const ownership = normalizeObservation({
+      domain: 'ownership',
+      measureKey: 'ownership_stake',
+      companyName: 'Acme',
+      effectiveDate: '2023-01-15',
+      currency: 'USD',
+      ownershipPct: '8',
+    });
+    expect(ownership.normalizedPayload!.ownershipPct).toBe('8.000000000000');
+  });
+});


### PR DESCRIPTION
## Summary

PLAN_61 Wave C, Task 5a (child spec #1173). Introduces a **pure, deterministic V2 normalization layer** for CSV and manual financial input, built on **one shared CSV tokenizer** consumed by both the byte-frozen V1 import lane and the new V2 adapters. No migration, no route, no schema change — the layer ships as an executable reference spec ahead of the ingestion service (Tasks 6, 9-11 wire against this frozen shape).

**Exit gate satisfied:** equivalent CSV and manual inputs normalize to **equal typed `normalizedPayload` and equal `candidateFingerprint`**; no adapter can inject a financial assumption (formulas, malformed numbers/dates, inferred FX, defaulted currency, out-of-range values all rejected); **V1 behavior unchanged**. Byte-identical `observationHash` across modes is deliberately not asserted (defect D15) — the corpus asserts derivation (`hash === canonicalSha256(payload)`) and payload equality instead.

## What changed

- **`server/lib/csv-tokenizer.ts`** (new) — extracted `splitCsvLine`/`parseCsvBuffer`/`normalizeHeaders` from `import-reconciliation-service` (defect D10, one tokenizer, no `csv-parse`). Adds untrimmed raw variants + header-token/embedded-newline helpers for the V2 lane. V1 output byte-identical.
- **`server/services/financial-observations/normalization-service.ts`** (new) — deterministic transform applier (six-transform allowlist), domain/measure/value matrix, USD-only explicit currency with definitional `fxRate`, structured company identity (object-hashed, no delimiter collisions), per-field decimal policy (no silent rounding), two-key derivation.
- **`csv-adapter.ts` / `manual-entry-adapter.ts`** (new) — converge on one assembly path so equivalence holds by construction. The manual adapter is the future direct-write seam (built, not wired).
- **`shared/contracts/financial-observations/normalization.contract.ts`** (new) — additive V2 schemas (`contractVersion: import-v2`), issue codes, decimal policy, matrix; barrel-exported. V1 `csv | notion` contract untouched.
- **Equivalence corpus** (12 event types grounded in the real fund files) + Vitest pinning every disposition, hash relationship, and negative gate.
- **DECISIONS.md** — ADR-061 (fingerprint field selection).

## Verification

- Task 5a verify block green; V1 reconciliation + adversarial + dry-run contract suites green **unchanged** (byte-frozen).
- `npm run check` 0 new TS errors; `guardrails:check` pass (incl. decimal-string-laundering); `lint` clean; `policy:verify` unchanged at 89 entries (no route).
- **Full sharded suite green**: server ~7,900 tests, client ~1,500 tests, 0 failures.

## Scope guarantees

No migration (tail stays 0039), no schema, no route, no flag/mode change, V1 contract byte-frozen. User-owned worktree dirt untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)