### PR TITLE
fix(db): unref pool health-check interval so it can't wedge Vercel Lambda

### DIFF
--- a/server/services/database-pool-manager.ts
+++ b/server/services/database-pool-manager.ts
@@ -397,6 +397,12 @@ export class DatabasePoolManager extends EventEmitter {
       this.updateMemoryMetrics(poolId);
     }, config.healthCheckIntervalMs);
 
+    // Never let the health-check timer keep the process alive. On serverless
+    // (Vercel Lambda) a referenced interval holds the event loop open, so the
+    // platform blocks every response until the 300s ceiling -> FUNCTION_INVOCATION_TIMEOUT
+    // on all routes once any request has created this pool.
+    interval.unref();
+
     this.healthCheckIntervals.set(poolId, interval);
   }
 


### PR DESCRIPTION
## Production outage fix

**Symptom:** every prod \`/api/*\` returns 504 \`FUNCTION_INVOCATION_TIMEOUT\` (health, csrf, login, readyz — all of them); static frontend serves fine. Confirmed 2026-07-26.

**Root cause:** \`DatabasePoolManager.startHealthMonitoring\` (\`server/services/database-pool-manager.ts\`) runs \`setInterval(checkPoolHealth, 60000)\` that was never \`.unref()\`'d. On Vercel Lambda a referenced timer keeps the event loop non-empty, so the platform holds every invocation open to the 300s ceiling → 504 on all routes once any request has created the \`streaming-monte-carlo\` pool (\`monte-carlo-service-unified.ts:360\`). That pool uses the Neon **WebSocket** driver, which cannot connect on serverless (\`All attempts to open a WebSocket ... fetch failed\`) — chronic since 2026-07-11 — so the timer is pure poison. Request-killing 300s timeouts began 2026-07-24T17:00, when the scheduled battery first exercised the streaming path in prod.

**Fix:** \`interval.unref()\` after the \`setInterval\`. The health check still runs opportunistically but never holds the process open. Universally correct (a background monitor should never keep a process alive); no behavior change off serverless.

**Evidence it's the trigger:** Vercel runtime errors show 2 clusters on \`/api/[...slug]\` — \`Database Pool Error\` (WS fetch failed, poolId \`streaming-monte-carlo\`, from \`checkPoolHealth\` on \`Timeout._onTimeout\`) and \`Vercel Runtime Timeout Error: Task timed out after 300 seconds\`.

Rollback does NOT help — the poison is in every recent build. This is the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)