### PR TITLE
fix(monte-carlo): disable streaming engine (Neon WS pool) on Vercel serverless

### DIFF
--- a/server/services/monte-carlo-service-unified.ts
+++ b/server/services/monte-carlo-service-unified.ts
@@ -503,6 +503,10 @@ export class UnifiedMonteCarloService {
     const explicit = process.env['ENABLE_STREAMING_MONTE_CARLO'];
     if (explicit === '1') return true;
     if (explicit === '0') return false;
+    // Serverless (Vercel Lambda) cannot open the Neon WebSocket pool the streaming
+    // engine depends on; creating it wedges the function's event loop until the 300s
+    // ceiling, 504-ing every route. Off by default there unless explicitly enabled.
+    if (process.env['VERCEL']) return false;
     return process.env['NODE_ENV'] === 'production';
   }
 


### PR DESCRIPTION
## Production outage — real fix (follow-up to #1208)

#1208 (`interval.unref()`) was necessary but **insufficient**: prod `/api/*` still 504s with `Task timed out after 300 seconds`. Runtime logs on the #1208 deploy confirm cold start logs `streamingEnabled: true`, then the `streaming-monte-carlo` Neon **WebSocket** pool fails (`fetch failed`) and the Lambda wedges to the 300s ceiling.

**Root cause:** `shouldEnableStreaming()` defaults **on** when `NODE_ENV=production`, so every cold Vercel Lambda constructs `UnifiedMonteCarloService` → `initializePooling()` → a Neon WS `Pool` + health monitor. The WS can't connect on serverless; the failing `acquireConnection` + neon's internal retry timers keep the event loop alive to 300s → 504 on every route (even no-DB `/api/auth/csrf`). The pool's pending I/O is the poison, not just the health-check timer #1208 fixed.

**Fix:** gate streaming off when `process.env.VERCEL` is set. Explicit `ENABLE_STREAMING_MONTE_CARLO=1/0` still overrides; non-serverless prod unchanged. The traditional in-process engine is the built-in fallback (already used whenever streaming is disabled).

Deterministic at the code level (independent of Vercel env-var propagation). Produces a fresh production build on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)